### PR TITLE
Reject document bodies for PUT/POST that contain user defined top level properties starting with '_'

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -474,6 +474,12 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 			return
 		}
 
+		//Reject bodies containing user special properties for compatibility with CouchDB
+		if containsUserSpecialProperties(body) {
+			err = base.HTTPErrorf(400, "user defined top level properties beginning with '_' are not allowed in document body")
+			return
+		}
+
 		// Determine which is the current "winning" revision (it's not necessarily the new one):
 		newRevID = body["_rev"].(string)
 		parentRevID = doc.History[newRevID].Parent

--- a/src/github.com/couchbaselabs/sync_gateway/db/revision.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revision.go
@@ -136,6 +136,15 @@ func stripSpecialProperties(body Body) Body {
 	return stripped
 }
 
+func containsUserSpecialProperties(body Body) bool {
+	for key, _ := range body {
+		if key[0] == '_' && key != "_id" && key != "_rev" && key != "_deleted" && key != "_attachments" && key != "_revisions" {
+			return true
+		}
+	}
+	return false
+}
+
 func canonicalEncoding(body Body) []byte {
 	encoded, err := json.Marshal(body) //FIX: Use canonical JSON encoder
 	if err != nil {


### PR DESCRIPTION
fixes issue #507
