### PR TITLE
Feature/issue 482

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -616,18 +616,8 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 	db.revisionCache.Put(body, encodeRevisions(history), revChannels)
 
 	// Raise event
-	if db.EventMgr.HasHandlerForEvent(DocumentCommit) {
-		// todo: refactor to reuse the oldDoc that was used during sync function execution
-		// Get the parent revision
-		var oldJsonBytes []byte
-		var err error
-		oldJsonBytes, err = db.getAncestorJSON(doc, doc.CurrentRev)
-		if err != nil {
-			base.Warn("Error retrieving ancestor JSON for event handling - event not raised")
-		} else {
-			oldJson := string(oldJsonBytes)
-			db.EventMgr.RaiseDocumentCommitEvent(body, oldJson, revChannels)
-		}
+	if db.EventMgr.HasHandlerForEvent(DocumentChange) {
+		db.EventMgr.RaiseDocumentChangeEvent(body, revChannels)
 	}
 
 	// Now that the document has successfully been stored, we can make other db changes:

--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -615,6 +615,9 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 	revChannels := doc.History[newRevID].Channels
 	db.revisionCache.Put(body, encodeRevisions(history), revChannels)
 
+	// TODO EVENT
+	db.EventMgr.RaiseDocumentCommitEvent(body, revChannels)
+
 	// Now that the document has successfully been stored, we can make other db changes:
 	base.LogTo("CRUD", "Stored doc %q / %q", docid, newRevID)
 

--- a/src/github.com/couchbaselabs/sync_gateway/db/database.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/database.go
@@ -40,7 +40,8 @@ type DatabaseContext struct {
 	autoImport         bool                    // Add sync data to new untracked docs?
 	Shadower           *Shadower               // Tracks an external Couchbase bucket
 	revisionCache      *RevisionCache          // Cache of recently-accessed doc revisions
-	changeCache        changeCache
+	changeCache        changeCache             //
+	EventMgr           *EventManager           // Manages notification events
 }
 
 const DefaultRevsLimit = 1000
@@ -94,6 +95,9 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool) (*Da
 		autoImport: autoImport,
 	}
 	context.revisionCache = NewRevisionCache(RevisionCacheCapacity, context.revCacheLoader)
+
+	context.EventMgr = NewEventManager()
+
 	var err error
 	context.sequences, err = newSequenceAllocator(bucket)
 	if err != nil {

--- a/src/github.com/couchbaselabs/sync_gateway/db/event-manager.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event-manager.go
@@ -1,0 +1,213 @@
+package db
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"net/http"
+	"regexp"
+)
+
+// Event type
+type EventType uint8
+
+const (
+	DocumentCommit EventType = iota
+	UserAdd
+)
+
+// EventManager
+// EventManager manages the configured set of event listeners.  Incoming events are just dumped in the
+// eventChannel to minimize time spent blocking whatever process is raising the event.
+//
+// EventCoordinator goroutine works the event channel and sends events to the appropriate listener channels
+
+type EventManager struct {
+	activeEventTypes map[EventType]bool
+	eventHandlers    []EventHandler
+	eventChannel     chan Event
+}
+
+func NewEventManager() *EventManager {
+
+	em := &EventManager{
+		eventHandlers: make([]EventHandler, 0),
+	}
+
+	// create channel for incoming events
+	em.eventChannel = make(chan Event)
+
+	// TODO: retrieve handlers from config
+	/*
+		myWebHook, err := NewWebhook("http://localhost:8081/echo", "")
+		if err == nil {
+			em.eventHandlers = append(em.eventHandlers, myWebHook)
+		}
+		myOtherWebHook, err := NewWebhook("http://localhost:8081/test", "")
+		if err == nil {
+			em.eventHandlers = append(em.eventHandlers, myOtherWebHook)
+		}
+	*/
+
+	em.activeEventTypes = make(map[EventType]bool)
+	em.activeEventTypes[DocumentCommit] = true
+
+	// Start incoming event queue worker go routine
+	go func() {
+		for event := range em.eventChannel {
+
+			// send event to all handlers
+			for _, handler := range em.eventHandlers {
+
+				base.LogTo("Events", "Event queue worker sending event to: %s", handler)
+				handler.HandleEvent(event)
+			}
+		}
+	}()
+
+	return em
+}
+
+func (em *EventManager) RegisterEventHandler(handler EventHandler) {
+	em.eventHandlers = append(em.eventHandlers, handler)
+
+	base.LogTo("Events", "Registered event handler")
+}
+
+func (em *EventManager) HasHandlerForEvent(eventType EventType) bool {
+
+	// TODO EVENT: activeEvents might be getting stored somewhere less redundant
+	return em.activeEventTypes[eventType]
+}
+
+func (em *EventManager) RaiseDocumentCommitEvent(body Body, channels base.Set) {
+
+	if !em.activeEventTypes[DocumentCommit] {
+		return
+	}
+	event := &DocumentCommitEvent{
+		body:     body,
+		channels: channels}
+
+	base.LogTo("Events", "event type: %d", event.EventType())
+	em.eventChannel <- event
+
+	base.LogTo("Events", "Document commit event %s added to event channel", body["_id"])
+
+}
+
+// Event
+// TODO: move to event.go?
+type Event interface {
+	// TODO EVENT: get rid of EventType and just use type check
+	EventType() EventType
+}
+
+type DocumentCommitEvent struct {
+	eventType EventType
+	body      Body
+	channels  base.Set
+}
+
+func (d DocumentCommitEvent) EventType() EventType {
+	return DocumentCommit
+}
+
+// EventHandler interface represents an instance of an event handler defined in the database config
+type EventHandler interface {
+	HandleEvent(event Event) error
+}
+
+// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
+type Webhook struct {
+	url          string
+	channelRegex *regexp.Regexp
+}
+
+func NewWebhook(url string, channelRegexString string) (Webhook, error) {
+
+	base.LogTo("Events", "Creating webhook for %s", url)
+
+	var err error
+	wh := Webhook{
+		url: url,
+	}
+
+	if channelRegexString != "" {
+		wh.channelRegex, err = regexp.Compile(channelRegexString)
+		if err != nil {
+			base.LogTo("Events", "Invalid channel expression: %s - webhook not loaded", channelRegexString)
+			return wh, err
+		}
+	}
+	return wh, err
+}
+
+func (wh Webhook) HandleEvent(event Event) error {
+
+	base.LogTo("Events", "Starting handler for event.")
+	// TODO return error
+	if !wh.handlesEvent(event) {
+
+		base.LogTo("Events", "Webhook handler doesn't handle event %s", event)
+		return nil
+	}
+
+	switch event := event.(type) {
+	case *DocumentCommitEvent:
+		// start a goroutine to perform the HTTP POST
+		go func() {
+
+			// transform body if map function provided
+
+			// post to URL
+			jsonOut, err := json.Marshal(event.body)
+			if err != nil {
+				base.Warn("Couldn't serialize event JSON for %v", event.body)
+				return
+			}
+			resp, err := http.Post(wh.url, "application/json", bytes.NewBuffer(jsonOut))
+			if err != nil {
+				base.LogTo("Events", "Error posting to webhook %s", err)
+				return
+			}
+
+			base.LogTo("Events", "Handler ran for event.  Doc with id %s posted to URL %s, got status %s",
+				event.body["_id"], wh.url, resp.Status)
+		}()
+	}
+
+	return nil
+
+}
+
+// HandlesEvent checks whether the incoming event type is handled by the webhook listener, and
+// if so, that the set of channels on the document associated with the event match the channel regex
+// in the webhook definition.
+func (wh Webhook) handlesEvent(event Event) bool {
+
+	dceEvent := event.(*DocumentCommitEvent)
+
+	base.LogTo("Events", "Type assertion to DocumentCommitEvent for %s, %s", event, dceEvent)
+
+	if event, ok := event.(*DocumentCommitEvent); !ok {
+
+		base.LogTo("Events", "Webhook only supports DocumentCommitEvent")
+		return false
+	} else {
+		matchesChannel := false
+		// If no regex is specified, no channel matching required
+		if wh.channelRegex == nil {
+			matchesChannel = true
+		} else {
+			for channel, _ := range event.channels {
+				if wh.channelRegex.MatchString(channel) {
+					matchesChannel = true
+					break
+				}
+			}
+		}
+		return matchesChannel
+	}
+
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event.go
@@ -1,0 +1,183 @@
+package db
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"github.com/couchbaselabs/walrus"
+	"github.com/robertkrimen/otto"
+	"strconv"
+)
+
+// Event type
+type EventType uint8
+
+const (
+	DocumentCommit EventType = iota
+	UserAdd
+)
+
+// Event
+type Event interface {
+	Synchronous() bool
+	EventType() EventType
+}
+
+type EventImpl struct {
+	eventType EventType
+}
+
+func (e *EventImpl) EventType() EventType {
+	return e.eventType
+}
+
+type AsyncEvent struct {
+	EventImpl
+}
+
+func (ae *AsyncEvent) Synchronous() bool {
+	return false
+}
+
+type DocumentCommitEvent struct {
+	AsyncEvent
+	Doc      Body     `json:"doc,omitempty"`
+	OldDoc   string   `json:"oldDoc,omitempty"`
+	Channels base.Set `json:"channels,omitempty"`
+}
+
+/*
+func (d DocumentCommitEvent) EventType() EventType {
+	return DocumentCommit
+}
+*/
+// Transform function handling
+const kTaskCacheSize = 4
+
+type ResponseType uint8
+
+const (
+	StringResponse ResponseType = iota
+	JSObjectResponse
+)
+
+// A compiled JavaScript event function.
+type jsEventTask struct {
+	walrus.JSRunner
+	responseType ResponseType
+}
+
+// Compiles a JavaScript event function to a jsEventTask object.
+func newJsEventTask(funcSource string) (walrus.JSServerTask, error) {
+	eventTask := &jsEventTask{}
+	err := eventTask.Init(funcSource)
+	if err != nil {
+		return nil, err
+	}
+
+	eventTask.After = func(result otto.Value, err error) (interface{}, error) {
+		nativeValue, _ := result.Export()
+		/*
+			switch nativeValue := nativeValue.(type) {
+			case string:
+				stringResult = nativeValue
+				eventTask.responseType = StringResponse
+			case interface{}:
+				resultBytes, marshErr := json.Marshal(nativeValue)
+				if marshErr != nil {
+					err = marshErr
+				} else {
+					stringResult = string(resultBytes)
+					eventTask.responseType = JSObjectResponse
+				}
+			}
+		*/
+		return nativeValue, err
+	}
+
+	return eventTask, nil
+}
+
+//////// JSEventFunction
+
+// A thread-safe wrapper around a jsEventTask, i.e. an event function.
+type JSEventFunction struct {
+	*walrus.JSServer
+}
+
+func NewJSEventFunction(fnSource string) *JSEventFunction {
+
+	return &JSEventFunction{
+		JSServer: walrus.NewJSServer(fnSource, kTaskCacheSize,
+			func(fnSource string) (walrus.JSServerTask, error) {
+				return newJsEventTask(fnSource)
+			}),
+	}
+}
+
+// Calls a jsMapTask.
+func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
+
+	var err error
+	var result interface{}
+
+	// Different events send different parameters
+	switch event := event.(type) {
+
+	case *DocumentCommitEvent:
+		result, err = ef.Call(event.Doc, event.OldDoc)
+	}
+
+	if err != nil {
+		base.Warn("Error calling function - function processing aborted: %v", err)
+		return "", err
+	}
+
+	return result, err
+}
+
+func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
+
+	result, err := ef.CallFunction(event)
+	if err != nil {
+		return false, err
+	}
+
+	switch result := result.(type) {
+	case bool:
+		return result, nil
+	case string:
+		boolResult, err := strconv.ParseBool(result)
+		if err != nil {
+			return false, err
+		}
+		return boolResult, nil
+	default:
+		base.Warn("Event validate function returned non-boolean result %v", result)
+		return false, errors.New("Validate function returned non-boolean value.")
+	}
+
+}
+
+func (ef *JSEventFunction) CallTransformFunction(event Event) (string, ResponseType, error) {
+
+	result, err := ef.CallFunction(event)
+
+	var stringResult string
+	var responseType ResponseType
+	switch result := result.(type) {
+	case string:
+		stringResult = result
+		responseType = StringResponse
+	case interface{}:
+		resultBytes, marshErr := json.Marshal(result)
+		if marshErr != nil {
+			err = marshErr
+		} else {
+			stringResult = string(resultBytes)
+			responseType = JSObjectResponse
+		}
+	}
+
+	return stringResult, responseType, err
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
@@ -7,191 +7,89 @@ import (
 	"fmt"
 	"github.com/couchbaselabs/sync_gateway/base"
 	"net/http"
-	"regexp"
 )
 
 // EventHandler interface represents an instance of an event handler defined in the database config
 type EventHandler interface {
-	HandleEvent(event Event) error
+	HandleEvent(event Event)
 }
 
 type AsyncEventHandler struct{}
 
-func (a *AsyncEventHandler) MapPayload(body Body, mapFunction string) (Body, error) {
-	var err error
-	return body, err
-}
-
 // Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
 type Webhook struct {
 	AsyncEventHandler
-	url          string
-	channelRegex *regexp.Regexp
-	transformFn  *JSEventFunction
+	url    string
+	filter *JSEventFunction
 }
 
-func NewWebhook(url string, channelRegexString string, transformFnString string) (*Webhook, error) {
-
-	base.LogTo("Events", "Creating webhook for %s", url)
+// Creates a new webhook handler based on the url and filter function.
+func NewWebhook(url string, filterFnString string) (*Webhook, error) {
 
 	var err error
+
+	if url == "" {
+		err = errors.New("url parameter must be defined for webhook events.")
+		return nil, err
+	}
+
 	wh := &Webhook{
 		url: url,
 	}
-
-	if channelRegexString != "" {
-		wh.channelRegex, err = regexp.Compile(channelRegexString)
-		if err != nil {
-			base.LogTo("Events", "Invalid channel expression: %s - webhook not loaded", channelRegexString)
-			return wh, err
-		}
+	if filterFnString != "" {
+		wh.filter = NewJSEventFunction(filterFnString)
 	}
 
-	if transformFnString != "" {
-		wh.transformFn = NewJSEventFunction(transformFnString)
-	}
 	return wh, err
 }
 
-func (wh *Webhook) HandleEvent(event Event) error {
+// Performs an HTTP POST to the url defined for the handler.  If a filter function is defined,
+// calls it to determine whether to POST.  The payload for the POST is depends
+// on the event type.
+func (wh *Webhook) HandleEvent(event Event) {
 
-	var err error
-
-	// Check whether the webhook should handle this event
-	if !wh.handlesEvent(event) {
-		return nil
-	}
-
-	// start a goroutine to perform the HTTP POST
-	// TODO: consider just returning this function, and let the EventManager coordinate
-	// go routine execution, to support throttling if needed
-
-	go func() {
-
-		var payload *bytes.Buffer
-		var contentType string
-
-		if wh.transformFn != nil {
-			// If transform function is defined, use it to build the response
-			result, responseType, err := wh.transformFn.CallTransformFunction(event)
-			if err != nil {
-				base.Warn("Error running wehbook transform function: %v", err)
-			}
-			switch responseType {
-			case StringResponse:
-				// If function returns string, send as-is.  If empty string, cancel http POST.
-				if result == "" {
-					return
-				}
-				//TODO: do we need to handle urlencoding of the payload here, in case
-				// function hasn't?
-				contentType = "application/x-www-form-urlencoded"
-				payload = bytes.NewBufferString(result)
-			case JSObjectResponse:
-				contentType = "application/json"
-				payload = bytes.NewBufferString(result)
-			}
-		} else {
-			// If no transform function defined, the response depends on event type
-			switch event := event.(type) {
-			case *DocumentCommitEvent:
-				// for DocumentCommitEvent, return new document body
-				jsonOut, err := json.Marshal(event.Doc)
-				if err != nil {
-					base.Warn("Error marshalling JSON for event, cancelled webhook POST: %v", err)
-					return
-				}
-				contentType = "application/json"
-				payload = bytes.NewBuffer(jsonOut)
-			default:
-				err = errors.New("Webhook invoked for unsupported event type.")
-				return
-			}
+	var payload *bytes.Buffer
+	var contentType string
+	if wh.filter != nil {
+		// If filter function is defined, use it to determine whether to post
+		success, err := wh.filter.CallValidateFunction(event)
+		if err != nil {
+			base.Warn("Error calling webhook filter function: %v", err)
 		}
 
-		resp, err := http.Post(wh.url, contentType, payload)
-		if err != nil {
-			base.LogTo("Events", "Error posting to webhook %s", err)
+		// If filter returns false, cancel webhook post
+		if !success {
 			return
 		}
-
-		base.LogTo("Events+", "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
-			payload, wh.url, resp.Status)
-	}()
-
-	return err
-
-}
-
-// HandlesEvent checks whether the incoming event type is handled by the webhook listener, and
-// if so, that the set of channels on the document associated with the event match the channel regex
-// in the webhook definition.
-func (wh *Webhook) handlesEvent(event Event) bool {
-
-	if event, ok := event.(*DocumentCommitEvent); !ok {
-		base.LogTo("Events", "Webhook only supports DocumentCommitEvent")
-		return false
-	} else {
-		matchesChannel := false
-		// If no regex is specified, no channel matching required
-		if wh.channelRegex == nil {
-			matchesChannel = true
-		} else {
-			for channel, _ := range event.Channels {
-				if wh.channelRegex.MatchString(channel) {
-					matchesChannel = true
-					break
-				}
-			}
-		}
-		return matchesChannel
 	}
+
+	// Different events post different content by default
+	switch event := event.(type) {
+	case *DocumentChangeEvent:
+		// for DocumentChangeEvent, post document body
+		jsonOut, err := json.Marshal(event.Doc)
+		if err != nil {
+			base.Warn("Error marshalling doc for webhook post")
+			return
+		}
+		contentType = "application/json"
+		payload = bytes.NewBuffer(jsonOut)
+	default:
+		base.Warn("Webhook invoked for unsupported event type.")
+		return
+	}
+
+	resp, err := http.Post(wh.url, contentType, payload)
+	if err != nil {
+		base.Warn("Error attempting to post to url %s: %s", wh.url, err)
+		return
+	}
+
+	base.LogTo("Events+", "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
+		payload, wh.url, resp.Status)
 
 }
 
 func (wh *Webhook) String() string {
 	return fmt.Sprintf("Webhook handler [%s]", wh.url)
-}
-
-// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
-type CustomEventHandler struct {
-	AsyncEventHandler
-	handleEventFn *JSEventFunction
-}
-
-func NewCustomEventHandler(handleEventFn string) (*CustomEventHandler, error) {
-
-	base.LogTo("Events", "Creating custom handler")
-
-	handleFunction := NewJSEventFunction(handleEventFn)
-
-	handler := &CustomEventHandler{
-		handleEventFn: handleFunction,
-	}
-
-	return handler, nil
-}
-
-func (ch *CustomEventHandler) HandleEvent(event Event) error {
-
-	var err error
-	switch event := event.(type) {
-	case *DocumentCommitEvent:
-		// start a goroutine to execute the custom function
-		// TODO: consider just returning this function, and let the EventManager coordinate
-		// go routine execution, to support throttling if needed
-		go func() {
-
-			ch.handleEventFn.CallFunction(event)
-
-		}()
-	}
-
-	return err
-
-}
-
-func (ch *CustomEventHandler) String() string {
-	//TODO: add a 'name' property to handlers for better diagnostics?
-	return fmt.Sprintf("Custom event handler")
 }

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
@@ -1,0 +1,197 @@
+package db
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"net/http"
+	"regexp"
+)
+
+// EventHandler interface represents an instance of an event handler defined in the database config
+type EventHandler interface {
+	HandleEvent(event Event) error
+}
+
+type AsyncEventHandler struct{}
+
+func (a *AsyncEventHandler) MapPayload(body Body, mapFunction string) (Body, error) {
+	var err error
+	return body, err
+}
+
+// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
+type Webhook struct {
+	AsyncEventHandler
+	url          string
+	channelRegex *regexp.Regexp
+	transformFn  *JSEventFunction
+}
+
+func NewWebhook(url string, channelRegexString string, transformFnString string) (*Webhook, error) {
+
+	base.LogTo("Events", "Creating webhook for %s", url)
+
+	var err error
+	wh := &Webhook{
+		url: url,
+	}
+
+	if channelRegexString != "" {
+		wh.channelRegex, err = regexp.Compile(channelRegexString)
+		if err != nil {
+			base.LogTo("Events", "Invalid channel expression: %s - webhook not loaded", channelRegexString)
+			return wh, err
+		}
+	}
+
+	if transformFnString != "" {
+		wh.transformFn = NewJSEventFunction(transformFnString)
+	}
+	return wh, err
+}
+
+func (wh *Webhook) HandleEvent(event Event) error {
+
+	var err error
+
+	// Check whether the webhook should handle this event
+	if !wh.handlesEvent(event) {
+		return nil
+	}
+
+	// start a goroutine to perform the HTTP POST
+	// TODO: consider just returning this function, and let the EventManager coordinate
+	// go routine execution, to support throttling if needed
+
+	go func() {
+
+		var payload *bytes.Buffer
+		var contentType string
+
+		if wh.transformFn != nil {
+			// If transform function is defined, use it to build the response
+			result, responseType, err := wh.transformFn.CallTransformFunction(event)
+			if err != nil {
+				base.Warn("Error running wehbook transform function: %v", err)
+			}
+			switch responseType {
+			case StringResponse:
+				// If function returns string, send as-is.  If empty string, cancel http POST.
+				if result == "" {
+					return
+				}
+				//TODO: do we need to handle urlencoding of the payload here, in case
+				// function hasn't?
+				contentType = "application/x-www-form-urlencoded"
+				payload = bytes.NewBufferString(result)
+			case JSObjectResponse:
+				contentType = "application/json"
+				payload = bytes.NewBufferString(result)
+			}
+		} else {
+			// If no transform function defined, the response depends on event type
+			switch event := event.(type) {
+			case *DocumentCommitEvent:
+				// for DocumentCommitEvent, return new document body
+				jsonOut, err := json.Marshal(event.Doc)
+				if err != nil {
+					base.Warn("Error marshalling JSON for event, cancelled webhook POST: %v", err)
+					return
+				}
+				contentType = "application/json"
+				payload = bytes.NewBuffer(jsonOut)
+			default:
+				err = errors.New("Webhook invoked for unsupported event type.")
+				return
+			}
+		}
+
+		resp, err := http.Post(wh.url, contentType, payload)
+		if err != nil {
+			base.LogTo("Events", "Error posting to webhook %s", err)
+			return
+		}
+
+		base.LogTo("Events+", "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
+			payload, wh.url, resp.Status)
+	}()
+
+	return err
+
+}
+
+// HandlesEvent checks whether the incoming event type is handled by the webhook listener, and
+// if so, that the set of channels on the document associated with the event match the channel regex
+// in the webhook definition.
+func (wh *Webhook) handlesEvent(event Event) bool {
+
+	if event, ok := event.(*DocumentCommitEvent); !ok {
+		base.LogTo("Events", "Webhook only supports DocumentCommitEvent")
+		return false
+	} else {
+		matchesChannel := false
+		// If no regex is specified, no channel matching required
+		if wh.channelRegex == nil {
+			matchesChannel = true
+		} else {
+			for channel, _ := range event.Channels {
+				if wh.channelRegex.MatchString(channel) {
+					matchesChannel = true
+					break
+				}
+			}
+		}
+		return matchesChannel
+	}
+
+}
+
+func (wh *Webhook) String() string {
+	return fmt.Sprintf("Webhook handler [%s]", wh.url)
+}
+
+// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
+type CustomEventHandler struct {
+	AsyncEventHandler
+	handleEventFn *JSEventFunction
+}
+
+func NewCustomEventHandler(handleEventFn string) (*CustomEventHandler, error) {
+
+	base.LogTo("Events", "Creating custom handler")
+
+	handleFunction := NewJSEventFunction(handleEventFn)
+
+	handler := &CustomEventHandler{
+		handleEventFn: handleFunction,
+	}
+
+	return handler, nil
+}
+
+func (ch *CustomEventHandler) HandleEvent(event Event) error {
+
+	var err error
+	switch event := event.(type) {
+	case *DocumentCommitEvent:
+		// start a goroutine to execute the custom function
+		// TODO: consider just returning this function, and let the EventManager coordinate
+		// go routine execution, to support throttling if needed
+		go func() {
+
+			ch.handleEventFn.CallFunction(event)
+
+		}()
+	}
+
+	return err
+
+}
+
+func (ch *CustomEventHandler) String() string {
+	//TODO: add a 'name' property to handlers for better diagnostics?
+	return fmt.Sprintf("Custom event handler")
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
@@ -1,69 +1,36 @@
 package db
 
 import (
-	"bytes"
-	"encoding/json"
 	"github.com/couchbaselabs/sync_gateway/base"
-	"net/http"
-	"regexp"
 )
 
-// Event type
-type EventType uint8
-
-const (
-	DocumentCommit EventType = iota
-	UserAdd
-)
-
-// EventManager
 // EventManager manages the configured set of event listeners.  Incoming events are just dumped in the
 // eventChannel to minimize time spent blocking whatever process is raising the event.
-//
-// EventCoordinator goroutine works the event channel and sends events to the appropriate listener channels
-
+// The event queue worker goroutine works the event channel and sends events to the appropriate listener channels
 type EventManager struct {
 	activeEventTypes  map[EventType]bool
-	eventHandlers     []EventHandler
+	eventHandlers     map[EventType][]EventHandler
 	asyncEventChannel chan Event
 }
 
 func NewEventManager() *EventManager {
 
 	em := &EventManager{
-		eventHandlers: make([]EventHandler, 0),
+		eventHandlers: make(map[EventType][]EventHandler, 0),
 	}
 
 	// create channel for incoming asynchronous events
-	em.eventChannel = make(chan Event)
-
-	// TODO: retrieve handlers from config
-	/*
-		myWebHook, err := NewWebhook("http://localhost:8081/echo", "")
-		if err == nil {
-			em.eventHandlers = append(em.eventHandlers, myWebHook)
-		}
-		myOtherWebHook, err := NewWebhook("http://localhost:8081/test", "")
-		if err == nil {
-			em.eventHandlers = append(em.eventHandlers, myOtherWebHook)
-		}
-	*/
+	em.asyncEventChannel = make(chan Event)
 
 	em.activeEventTypes = make(map[EventType]bool)
-	em.activeEventTypes[DocumentCommit] = true
 
-	// Start incoming event queue worker go routine
+	// Start event queue worker go routine
 	go func() {
 		for event := range em.asyncEventChannel {
-
 			// send event to all registered handlers
-			for _, handler := range em.eventHandlers {
-
+			for _, handler := range em.eventHandlers[event.EventType()] {
 				base.LogTo("Events", "Event queue worker sending event to: %s", handler)
-
-				if handler.HandlesEvent(event) {
-					handler.HandleEvent(event)
-				}
+				handler.HandleEvent(event)
 			}
 		}
 	}()
@@ -71,10 +38,10 @@ func NewEventManager() *EventManager {
 	return em
 }
 
-func (em *EventManager) RegisterEventHandler(handler EventHandler) {
-	em.eventHandlers = append(em.eventHandlers, handler)
-
-	base.LogTo("Events", "Registered event handler")
+func (em *EventManager) RegisterEventHandler(handler EventHandler, eventType EventType) {
+	em.eventHandlers[eventType] = append(em.eventHandlers[eventType], handler)
+	em.activeEventTypes[eventType] = true
+	base.LogTo("Events", "Registered event handler: %v", handler)
 }
 
 func (em *EventManager) HasHandlerForEvent(eventType EventType) bool {
@@ -84,130 +51,24 @@ func (em *EventManager) HasHandlerForEvent(eventType EventType) bool {
 
 }
 
-func (em *EventManager) raiseAsyncEvent(event Event) {
-	em.asyncEventChannel <- event
-	base.LogTo("Events", "%s added to event channel", event.EventType())
+func (em *EventManager) raiseEvent(event Event) bool {
+	if !event.Synchronous() {
+		em.asyncEventChannel <- event
+	}
+	// TODO: handling for synchronous events
+	return true
 }
 
-func (em *EventManager) RaiseDocumentCommitEvent(body Body, channels base.Set) {
+func (em *EventManager) RaiseDocumentCommitEvent(body Body, oldBody string, channels base.Set) {
 
 	if !em.activeEventTypes[DocumentCommit] {
 		return
 	}
+
 	event := &DocumentCommitEvent{
-		body:     body,
-		channels: channels}
-	em.raiseAsyncEvent(event)
-
-}
-
-// Event
-// TODO: move to event.go?
-type Event interface {
-	// TODO EVENT: get rid of EventType and just use type check
-	EventType() EventType
-}
-
-type DocumentCommitEvent struct {
-	eventType EventType
-	body      Body
-	channels  base.Set
-}
-
-func (d DocumentCommitEvent) EventType() EventType {
-	return DocumentCommit
-}
-
-// EventHandler interface represents an instance of an event handler defined in the database config
-type EventHandler interface {
-	HandleEvent(event Event) error
-}
-
-// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
-type Webhook struct {
-	url          string
-	channelRegex *regexp.Regexp
-}
-
-func NewWebhook(url string, channelRegexString string) (Webhook, error) {
-
-	base.LogTo("Events", "Creating webhook for %s", url)
-
-	var err error
-	wh := Webhook{
-		url: url,
-	}
-
-	if channelRegexString != "" {
-		wh.channelRegex, err = regexp.Compile(channelRegexString)
-		if err != nil {
-			base.LogTo("Events", "Invalid channel expression: %s - webhook not loaded", channelRegexString)
-			return wh, err
-		}
-	}
-	return wh, err
-}
-
-func (wh Webhook) HandleEvent(event Event) error {
-
-	switch event := event.(type) {
-	case *DocumentCommitEvent:
-		// start a goroutine to perform the HTTP POST
-
-		// TODO: consider just returning this function, and let the EventManager coordinate
-		// go routine execution, to support throttling if needed
-		go func() {
-
-			// transform body if map function provided
-
-			// post to URL
-			jsonOut, err := json.Marshal(event.body)
-			if err != nil {
-				base.Warn("Couldn't serialize event JSON for %v", event.body)
-				return err
-			}
-			resp, err := http.Post(wh.url, "application/json", bytes.NewBuffer(jsonOut))
-			if err != nil {
-				base.LogTo("Events", "Error posting to webhook %s", err)
-				return err
-			}
-
-			base.LogTo("Events", "Webhook handler ran for event.  Doc with id %s posted to URL %s, got status %s",
-				event.body["_id"], wh.url, resp.Status)
-		}()
-	}
-
-	return nil
-
-}
-
-// HandlesEvent checks whether the incoming event type is handled by the webhook listener, and
-// if so, that the set of channels on the document associated with the event match the channel regex
-// in the webhook definition.
-func (wh Webhook) HandlesEvent(event Event) bool {
-
-	dceEvent := event.(*DocumentCommitEvent)
-
-	base.LogTo("Events", "Type assertion to DocumentCommitEvent for %s, %s", event, dceEvent)
-
-	if event, ok := event.(*DocumentCommitEvent); !ok {
-
-		base.LogTo("Events", "Webhook only supports DocumentCommitEvent")
-		return false
-	} else {
-		matchesChannel := false
-		// If no regex is specified, no channel matching required
-		if wh.channelRegex == nil {
-			matchesChannel = true
-		} else {
-			for channel, _ := range event.channels {
-				if wh.channelRegex.MatchString(channel) {
-					matchesChannel = true
-					break
-				}
-			}
-		}
-		return matchesChannel
-	}
+		Doc:      body,
+		OldDoc:   oldBody,
+		Channels: channels}
+	em.raiseEvent(event)
 
 }

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
@@ -13,40 +13,43 @@ import (
 	"time"
 )
 
-const testLiveHTTP = true
+// Webhook tests use an HTTP listener.  Use of this listener is disabled by default, to avoid
+// port conflicts/permission issues when running tests on a non-dev machine.
+const testLiveHTTP = false
 
-type OfflineHook struct {
-	webhook *Webhook
-}
-
+// Testing handler tracks recieved events in ResultChannel
 type TestingHandler struct {
 	receivedType  EventType
 	payload       Body
-	ResultChannel chan Body
+	ResultChannel chan Body // channel for tracking async results
 	HandledEvent  EventType
+	handleDelay   int // long running handler execution
 }
 
-func (th *TestingHandler) HandleEvent(event Event) error {
+func (th *TestingHandler) HandleEvent(event Event) {
 
-	if dceEvent, ok := event.(*DocumentCommitEvent); ok {
+	if th.handleDelay > 0 {
+		time.Sleep(time.Duration(th.handleDelay) * time.Millisecond)
+	}
+	if dceEvent, ok := event.(*DocumentChangeEvent); ok {
 		th.ResultChannel <- dceEvent.Doc
 	}
-	return nil
+	return
 }
 
 func (th *TestingHandler) SetChannel(channel chan Body) {
 	th.ResultChannel = channel
 }
 
-func TestDocumentCommitEvent(t *testing.T) {
+func TestDocumentChangeEvent(t *testing.T) {
 
 	em := NewEventManager()
 
+	// Setup test data
 	ids := make([]string, 20)
 	for i := 0; i < 20; i++ {
 		ids[i] = fmt.Sprintf("%d", i)
 	}
-
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
 			"_id":   ids[i],
@@ -60,30 +63,26 @@ func TestDocumentCommitEvent(t *testing.T) {
 		}
 		return testBody, channelSet
 	}
-
 	resultChannel := make(chan Body, 10)
-
-	testHandler := &TestingHandler{HandledEvent: DocumentCommit}
+	//Setup test handler
+	testHandler := &TestingHandler{HandledEvent: DocumentChange}
 	testHandler.SetChannel(resultChannel)
-	fmt.Println("channel: %s", testHandler.ResultChannel)
-	em.RegisterEventHandler(testHandler, DocumentCommit)
-
-	fmt.Println("Registered Event handler, raising 10 events...")
+	em.RegisterEventHandler(testHandler, DocumentChange)
+	//Raise events
 	for i := 0; i < 10; i++ {
 		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
+		em.RaiseDocumentChangeEvent(body, channels)
 	}
 	// wait for Event Manager queue worker to process
 	time.Sleep(10 * time.Millisecond)
 
-	fmt.Println("Channel size after adds: %d", len(resultChannel))
 	assert.True(t, len(resultChannel) == 10)
 
 }
 
-func TestCustomEvent(t *testing.T) {
+// Test sending many events with slow-running execution to validate they get processed in parallel
+func TestSlowExecutionProcessing(t *testing.T) {
 
-	fmt.Println("Creating event manager")
 	em := NewEventManager()
 
 	ids := make([]string, 20)
@@ -105,23 +104,58 @@ func TestCustomEvent(t *testing.T) {
 		return testBody, channelSet
 	}
 
-	resultChannel := make(chan Body, 10)
-
-	testHandler := &TestingHandler{HandledEvent: DocumentCommit}
+	resultChannel := make(chan Body, 101000)
+	testHandler := &TestingHandler{HandledEvent: DocumentChange, handleDelay: 500}
 	testHandler.SetChannel(resultChannel)
-	fmt.Println("channel: %s", testHandler.ResultChannel)
-	em.RegisterEventHandler(testHandler, DocumentCommit)
+	em.RegisterEventHandler(testHandler, DocumentChange)
 
-	fmt.Println("Registered Event handler")
+	for i := 0; i < 100000; i++ {
+		body, channels := eventForTest(i % 10)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(750 * time.Millisecond)
+
+	assert.True(t, len(resultChannel) == 100000)
+
+}
+
+func TestCustomHandler(t *testing.T) {
+
+	em := NewEventManager()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 20)
+
+	testHandler := &TestingHandler{HandledEvent: DocumentChange}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+
 	for i := 0; i < 10; i++ {
-		fmt.Println("raising event %d", i)
 		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
+		em.RaiseDocumentChangeEvent(body, channels)
 	}
 	// wait for Event Manager queue worker to process
 	time.Sleep(50 * time.Millisecond)
 
-	fmt.Println("Channel size after adds: %d", len(resultChannel))
 	assert.True(t, len(resultChannel) == 10)
 
 }
@@ -156,39 +190,40 @@ func TestUnhandledEvent(t *testing.T) {
 	testHandler.SetChannel(resultChannel)
 	em.RegisterEventHandler(testHandler, UserAdd)
 
-	// send DocumentCommit events to handler
+	// send DocumentChange events to handler
 	for i := 0; i < 10; i++ {
 		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
+		em.RaiseDocumentChangeEvent(body, channels)
 	}
 	// Wait for Event Manager queue worker to process
 	time.Sleep(50 * time.Millisecond)
 
-	fmt.Println("Channel size after adds: %d", len(resultChannel))
 	// Validate that no events were handled
 	assert.True(t, len(resultChannel) == 0)
 
 }
 
-func InitWebhookTest() (*int, *float64) {
+func InitWebhookTest() (*int, *float64, *[][]byte) {
 
 	// Uses counter and sum values for simplified tracking of POST requests recieved by HTTP
 	// TODO:  enhance by adding listener for /count, /sum, /reset endpoints, and leave
 	// all management within the function, instead of sharing pointer references around
 	counter := 0
 	sum := 0.0
+	var payloads [][]byte
 	// Start HTTP listener for webhook calls
 	go func() {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			r.ParseForm()
 
+			fmt.Println("Handling event")
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				log.Printf("Error trying to read body: %s", err)
 			}
 
 			if len(body) > 0 {
-				log.Printf("Handled request with body: %s", body)
+				payloads = append(payloads, body)
 				var payload map[string]interface{}
 				json.Unmarshal(body, &payload)
 				floatValue, ok := payload["value"].(float64)
@@ -206,13 +241,12 @@ func InitWebhookTest() (*int, *float64) {
 			}
 
 			fmt.Fprintf(w, "OK")
-
 			counter++
 
 		})
 		http.ListenAndServe(":8081", nil)
 	}()
-	return &counter, &sum
+	return &counter, &sum, &payloads
 }
 
 func TestWebhook(t *testing.T) {
@@ -220,9 +254,7 @@ func TestWebhook(t *testing.T) {
 	if !testLiveHTTP {
 		return
 	}
-
-	count, sum := InitWebhookTest()
-
+	count, sum, payloads := InitWebhookTest()
 	ids := make([]string, 20)
 	for i := 0; i < 20; i++ {
 		ids[i] = fmt.Sprintf("%d", i)
@@ -242,92 +274,53 @@ func TestWebhook(t *testing.T) {
 		return testBody, channelSet
 	}
 
-	// Test basic webhook (no channels, no transform)
+	// Test basic webhook
 	em := NewEventManager()
-	webhookHandler, _ := NewWebhook("http://localhost:8081/echo", "", "")
-	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	webhookHandler, _ := NewWebhook("http://localhost:8081/echo", "")
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
+		em.RaiseDocumentChangeEvent(body, channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equals(t, *count, 10)
 
-	// Test webhook filtering by channels
+	// Test webhook filter function
 	*count, *sum = 0, 0.0
 	em = NewEventManager()
-	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "Even", "")
-	em.RegisterEventHandler(webhookHandler, DocumentCommit)
-	for i := 0; i < 10; i++ {
-		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
-	}
-	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 5)
-
-	// Test webhook filtering by channels (regex)
-	*count, *sum = 0, 0.0
-	em = NewEventManager()
-	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "E.", "")
-	em.RegisterEventHandler(webhookHandler, DocumentCommit)
-	for i := 0; i < 10; i++ {
-		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
-	}
-	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 5)
-	assert.Equals(t, *sum, 20.0)
-
-	// Test webhook filtering by transform
-	*count, *sum = 0, 0.0
-	em = NewEventManager()
-	transformFunction := `function(doc) {
+	filterFunction := `function(doc) {
 							if (doc.value < 6) {
-								return '';
+								return false;
 							} else {
-								return doc;
+								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "", transformFunction)
-	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", filterFunction)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
+		em.RaiseDocumentChangeEvent(body, channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equals(t, *count, 4)
 
-	// Test webhook transform that returns string, verify HTTP post as form data
-	*count, *sum = 0, 0.0
+	// Validate payload
+	fmt.Println("RESET HERE")
+	*count, *sum, *payloads = 0, 0.0, nil
 	em = NewEventManager()
-	transformFunction = `function(doc) {
-							output = "value=" + doc.value;
-							return output;
-							}`
-	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "", transformFunction)
-	em.RegisterEventHandler(webhookHandler, DocumentCommit)
-	for i := 0; i < 10; i++ {
-		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
-	}
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "")
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	body, channels := eventForTest(0)
+	em.RaiseDocumentChangeEvent(body, channels)
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 10)
-	assert.Equals(t, *sum, 45.0)
+	receivedPayload := string((*payloads)[0])
+	fmt.Println("payload:", receivedPayload)
+	assert.Equals(t, string((*payloads)[0]), `{"_id":"0","value":0}`)
+	assert.Equals(t, *count, 1)
 
 }
 
-// Test custom event handler
-func TestCustomHandler(t *testing.T) {
-	em := NewEventManager()
-
-	// write handler that does simple logging
-	customFn := `function(doc) {
-						log("Received doc with id" + doc._id)
-						return;
-						}`
-
-	customHandler, _ := NewCustomEventHandler(customFn)
-	em.RegisterEventHandler(customHandler, DocumentCommit)
+func TestUnavailableWebhook(t *testing.T) {
 
 	ids := make([]string, 20)
 	for i := 0; i < 20; i++ {
@@ -348,94 +341,14 @@ func TestCustomHandler(t *testing.T) {
 		return testBody, channelSet
 	}
 
+	// Test unreachable webhook
+	em := NewEventManager()
+	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "")
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, channels := eventForTest(i)
-		em.RaiseDocumentCommitEvent(body, body, channels)
+		em.RaiseDocumentChangeEvent(body, channels)
 	}
+
 	time.Sleep(50 * time.Millisecond)
-
-}
-
-// Test transform returning string
-func TestTransformFunctionReturningString(t *testing.T) {
-	eventFunction := `function(doc) {
-						return 'hello';}`
-	transformer := NewJSEventFunction(eventFunction)
-	dce := &DocumentCommitEvent{
-		Doc: Body{"input": "a1"},
-	}
-	returnString, responseType, err := transformer.CallTransformFunction(dce)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, responseType, StringResponse)
-	assert.Equals(t, returnString, "hello")
-}
-
-// Test transform returning js object (as JSON string)
-func TestTransformFunctionReturningObject(t *testing.T) {
-	eventFunction := `function(doc) {
-						var jsobj = new Object();
-						jsobj.val = "hello";
-						return jsobj;}`
-	transformer := NewJSEventFunction(eventFunction)
-	dce := &DocumentCommitEvent{
-		Doc: Body{"input": "a1"},
-	}
-	returnString, responseType, err := transformer.CallTransformFunction(dce)
-
-	assert.Equals(t, responseType, JSObjectResponse)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, returnString, `{"val":"hello"}`)
-}
-
-// Test that input parameters are available for transformation by function
-func TestTransformFunctionFromInput(t *testing.T) {
-	eventFunction := `function(doc, oldDoc) {
-						var jsobj = new Object();
-						jsobj.new = doc.value;
-						jsobj.old = oldDoc.value;
-						return jsobj;}`
-	transformer := NewJSEventFunction(eventFunction)
-	dce := &DocumentCommitEvent{
-		Doc:    Body{"new": "123", "value": "a1"},
-		OldDoc: Body{"old": "123", "value": "a0"},
-	}
-	returnString, responseType, err := transformer.CallTransformFunction(dce)
-
-	assert.Equals(t, responseType, JSObjectResponse)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, returnString, `{"new":"a1","old":"a0"}`)
-}
-
-// Test that function runner supports functionswith subset of parameters
-func TestTransformFunctionWithSingleParamFunction(t *testing.T) {
-	eventFunction := `function(doc) {
-						var jsobj = new Object();
-						jsobj.id = doc.id;
-						return jsobj;}`
-	transformer := NewJSEventFunction(eventFunction)
-	dce := &DocumentCommitEvent{
-		Doc:    Body{"id": "123", "input": "a1"},
-		OldDoc: Body{"id": "456", "input": "a0"},
-	}
-	returnString, responseType, err := transformer.CallTransformFunction(dce)
-
-	assert.Equals(t, responseType, JSObjectResponse)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, returnString, `{"id":"123"}`)
-}
-
-// Test that a malformed function returns error without panic
-func TestTransformFunctionMalformedFunction(t *testing.T) {
-
-	eventFunction := `function(doc) {
-		var jsobj =`
-	transformer := NewJSEventFunction(eventFunction)
-
-	dce := &DocumentCommitEvent{
-		Doc: Body{"id": "123", "input": "a1"},
-	}
-	returnString, _, err := transformer.CallTransformFunction(dce)
-
-	assert.Equals(t, err != nil, true)
-	assert.Equals(t, returnString, "")
 }

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
@@ -1,57 +1,441 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/couchbaselabs/go.assert"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
 	"testing"
+	"time"
+)
+
+const testLiveHTTP = true
+
+type OfflineHook struct {
+	webhook *Webhook
 }
 
-func EventManagerTest(t *testing.T) {
+type TestingHandler struct {
+	receivedType  EventType
+	payload       Body
+	ResultChannel chan Body
+	HandledEvent  EventType
+}
+
+func (th *TestingHandler) HandleEvent(event Event) error {
+
+	if dceEvent, ok := event.(*DocumentCommitEvent); ok {
+		th.ResultChannel <- dceEvent.Doc
+	}
+	return nil
+}
+
+func (th *TestingHandler) SetChannel(channel chan Body) {
+	th.ResultChannel = channel
+}
+
+func TestDocumentCommitEvent(t *testing.T) {
+
+	em := NewEventManager()
+
 	ids := make([]string, 20)
 	for i := 0; i < 20; i++ {
 		ids[i] = fmt.Sprintf("%d", i)
 	}
 
-	revForTest := func(i int) (Body, Body, base.Set) {
-		body := Body{
-			"_id":  ids[i],
-			"_rev": "x",
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
 		}
-		history := Body{"start": i}
-		return body, history, nil
-	}
-	verify := func(body Body, history Body, channels base.Set, i int) {
-		if body == nil {
-			t.Fatalf("nil body at #%d", i)
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
 		}
-		assert.True(t, body != nil)
-		assert.Equals(t, body["_id"], ids[i])
-		assert.True(t, history != nil)
-		assert.Equals(t, history["start"], i)
-		assert.DeepEquals(t, channels, base.Set(nil))
+		return testBody, channelSet
 	}
 
-	cache := NewRevisionCache(10, nil)
+	resultChannel := make(chan Body, 10)
+
+	testHandler := &TestingHandler{HandledEvent: DocumentCommit}
+	testHandler.SetChannel(resultChannel)
+	fmt.Println("channel: %s", testHandler.ResultChannel)
+	em.RegisterEventHandler(testHandler, DocumentCommit)
+
+	fmt.Println("Registered Event handler, raising 10 events...")
 	for i := 0; i < 10; i++ {
-		body, history, channels := revForTest(i)
-		cache.Put(body, history, channels)
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(10 * time.Millisecond)
+
+	fmt.Println("Channel size after adds: %d", len(resultChannel))
+	assert.True(t, len(resultChannel) == 10)
+
+}
+
+func TestCustomEvent(t *testing.T) {
+
+	fmt.Println("Creating event manager")
+	em := NewEventManager()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 10)
+
+	testHandler := &TestingHandler{HandledEvent: DocumentCommit}
+	testHandler.SetChannel(resultChannel)
+	fmt.Println("channel: %s", testHandler.ResultChannel)
+	em.RegisterEventHandler(testHandler, DocumentCommit)
+
+	fmt.Println("Registered Event handler")
+	for i := 0; i < 10; i++ {
+		fmt.Println("raising event %d", i)
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(50 * time.Millisecond)
+
+	fmt.Println("Channel size after adds: %d", len(resultChannel))
+	assert.True(t, len(resultChannel) == 10)
+
+}
+
+func TestUnhandledEvent(t *testing.T) {
+
+	em := NewEventManager()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 10)
+
+	// create handler for UserAdd events
+	testHandler := &TestingHandler{HandledEvent: UserAdd}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, UserAdd)
+
+	// send DocumentCommit events to handler
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	// Wait for Event Manager queue worker to process
+	time.Sleep(50 * time.Millisecond)
+
+	fmt.Println("Channel size after adds: %d", len(resultChannel))
+	// Validate that no events were handled
+	assert.True(t, len(resultChannel) == 0)
+
+}
+
+func InitWebhookTest() (*int, *float64) {
+
+	// Uses counter and sum values for simplified tracking of POST requests recieved by HTTP
+	// TODO:  enhance by adding listener for /count, /sum, /reset endpoints, and leave
+	// all management within the function, instead of sharing pointer references around
+	counter := 0
+	sum := 0.0
+	// Start HTTP listener for webhook calls
+	go func() {
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			r.ParseForm()
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				log.Printf("Error trying to read body: %s", err)
+			}
+
+			if len(body) > 0 {
+				log.Printf("Handled request with body: %s", body)
+				var payload map[string]interface{}
+				json.Unmarshal(body, &payload)
+				floatValue, ok := payload["value"].(float64)
+				if ok {
+					sum = sum + floatValue
+				}
+			}
+
+			if len(r.Form) > 0 {
+				log.Printf("Handled request with form: %v", r.Form)
+				floatValue, err := strconv.ParseFloat(r.Form.Get("value"), 64)
+				if err == nil {
+					sum = sum + floatValue
+				}
+			}
+
+			fmt.Fprintf(w, "OK")
+
+			counter++
+
+		})
+		http.ListenAndServe(":8081", nil)
+	}()
+	return &counter, &sum
+}
+
+func TestWebhook(t *testing.T) {
+
+	if !testLiveHTTP {
+		return
+	}
+
+	count, sum := InitWebhookTest()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	// Test basic webhook (no channels, no transform)
+	em := NewEventManager()
+	webhookHandler, _ := NewWebhook("http://localhost:8081/echo", "", "")
+	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 10)
+
+	// Test webhook filtering by channels
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "Even", "")
+	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 5)
+
+	// Test webhook filtering by channels (regex)
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "E.", "")
+	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 5)
+	assert.Equals(t, *sum, 20.0)
+
+	// Test webhook filtering by transform
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	transformFunction := `function(doc) {
+							if (doc.value < 6) {
+								return '';
+							} else {
+								return doc;
+							}
+							}`
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "", transformFunction)
+	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 4)
+
+	// Test webhook transform that returns string, verify HTTP post as form data
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	transformFunction = `function(doc) {
+							output = "value=" + doc.value;
+							return output;
+							}`
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "", transformFunction)
+	em.RegisterEventHandler(webhookHandler, DocumentCommit)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 10)
+	assert.Equals(t, *sum, 45.0)
+
+}
+
+// Test custom event handler
+func TestCustomHandler(t *testing.T) {
+	em := NewEventManager()
+
+	// write handler that does simple logging
+	customFn := `function(doc) {
+						log("Received doc with id" + doc._id)
+						return;
+						}`
+
+	customHandler, _ := NewCustomEventHandler(customFn)
+	em.RegisterEventHandler(customHandler, DocumentCommit)
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
 	}
 
 	for i := 0; i < 10; i++ {
-		body, history, channels, _ := cache.Get(ids[i], "x")
-		verify(body, history, channels, i)
+		body, channels := eventForTest(i)
+		em.RaiseDocumentCommitEvent(body, body, channels)
 	}
+	time.Sleep(50 * time.Millisecond)
 
-	for i := 10; i < 13; i++ {
-		body, history, channels := revForTest(i)
-		cache.Put(body, history, channels)
-	}
+}
 
-	for i := 0; i < 3; i++ {
-		body, _, _, _ := cache.Get(ids[i], "x")
-		assert.True(t, body == nil)
+// Test transform returning string
+func TestTransformFunctionReturningString(t *testing.T) {
+	eventFunction := `function(doc) {
+						return 'hello';}`
+	transformer := NewJSEventFunction(eventFunction)
+	dce := &DocumentCommitEvent{
+		Doc: Body{"input": "a1"},
 	}
-	for i := 3; i < 13; i++ {
-		body, history, channels, _ := cache.Get(ids[i], "x")
-		verify(body, history, channels, i)
+	returnString, responseType, err := transformer.CallTransformFunction(dce)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, responseType, StringResponse)
+	assert.Equals(t, returnString, "hello")
+}
+
+// Test transform returning js object (as JSON string)
+func TestTransformFunctionReturningObject(t *testing.T) {
+	eventFunction := `function(doc) {
+						var jsobj = new Object();
+						jsobj.val = "hello";
+						return jsobj;}`
+	transformer := NewJSEventFunction(eventFunction)
+	dce := &DocumentCommitEvent{
+		Doc: Body{"input": "a1"},
 	}
+	returnString, responseType, err := transformer.CallTransformFunction(dce)
+
+	assert.Equals(t, responseType, JSObjectResponse)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, returnString, `{"val":"hello"}`)
+}
+
+// Test that input parameters are available for transformation by function
+func TestTransformFunctionFromInput(t *testing.T) {
+	eventFunction := `function(doc, oldDoc) {
+						var jsobj = new Object();
+						jsobj.new = doc.value;
+						jsobj.old = oldDoc.value;
+						return jsobj;}`
+	transformer := NewJSEventFunction(eventFunction)
+	dce := &DocumentCommitEvent{
+		Doc:    Body{"new": "123", "value": "a1"},
+		OldDoc: Body{"old": "123", "value": "a0"},
+	}
+	returnString, responseType, err := transformer.CallTransformFunction(dce)
+
+	assert.Equals(t, responseType, JSObjectResponse)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, returnString, `{"new":"a1","old":"a0"}`)
+}
+
+// Test that function runner supports functionswith subset of parameters
+func TestTransformFunctionWithSingleParamFunction(t *testing.T) {
+	eventFunction := `function(doc) {
+						var jsobj = new Object();
+						jsobj.id = doc.id;
+						return jsobj;}`
+	transformer := NewJSEventFunction(eventFunction)
+	dce := &DocumentCommitEvent{
+		Doc:    Body{"id": "123", "input": "a1"},
+		OldDoc: Body{"id": "456", "input": "a0"},
+	}
+	returnString, responseType, err := transformer.CallTransformFunction(dce)
+
+	assert.Equals(t, responseType, JSObjectResponse)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, returnString, `{"id":"123"}`)
+}
+
+// Test that a malformed function returns error without panic
+func TestTransformFunctionMalformedFunction(t *testing.T) {
+
+	eventFunction := `function(doc) {
+		var jsobj =`
+	transformer := NewJSEventFunction(eventFunction)
+
+	dce := &DocumentCommitEvent{
+		Doc: Body{"id": "123", "input": "a1"},
+	}
+	returnString, _, err := transformer.CallTransformFunction(dce)
+
+	assert.Equals(t, err != nil, true)
+	assert.Equals(t, returnString, "")
 }

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+}
+
+func EventManagerTest(t *testing.T) {
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	revForTest := func(i int) (Body, Body, base.Set) {
+		body := Body{
+			"_id":  ids[i],
+			"_rev": "x",
+		}
+		history := Body{"start": i}
+		return body, history, nil
+	}
+	verify := func(body Body, history Body, channels base.Set, i int) {
+		if body == nil {
+			t.Fatalf("nil body at #%d", i)
+		}
+		assert.True(t, body != nil)
+		assert.Equals(t, body["_id"], ids[i])
+		assert.True(t, history != nil)
+		assert.Equals(t, history["start"], i)
+		assert.DeepEquals(t, channels, base.Set(nil))
+	}
+
+	cache := NewRevisionCache(10, nil)
+	for i := 0; i < 10; i++ {
+		body, history, channels := revForTest(i)
+		cache.Put(body, history, channels)
+	}
+
+	for i := 0; i < 10; i++ {
+		body, history, channels, _ := cache.Get(ids[i], "x")
+		verify(body, history, channels, i)
+	}
+
+	for i := 10; i < 13; i++ {
+		body, history, channels := revForTest(i)
+		cache.Put(body, history, channels)
+	}
+
+	for i := 0; i < 3; i++ {
+		body, _, _, _ := cache.Get(ids[i], "x")
+		assert.True(t, body == nil)
+	}
+	for i := 3; i < 13; i++ {
+		body, history, channels, _ := cache.Get(ids[i], "x")
+		verify(body, history, channels, i)
+	}
+}

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -69,18 +69,19 @@ type ServerConfig struct {
 
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
-	name       string                         `json:"name"`                  // Database name in REST API (stored as key in JSON)
-	Server     *string                        `json:"server"`                // Couchbase (or Walrus) server URL, default "http://localhost:8091"
-	Username   string                         `json:"username,omitempty"`    // Username for authenticating to server
-	Password   string                         `json:"password,omitempty"`    // Password for authenticating to server
-	Bucket     *string                        `json:"bucket"`                // Bucket name on server; defaults to same as 'name'
-	Pool       *string                        `json:"pool"`                  // Couchbase pool name, default "default"
-	Sync       *string                        `json:"sync"`                  // Sync function defines which users can see which data
-	Users      map[string]*db.PrincipalConfig `json:"users,omitempty"`       // Initial user accounts
-	Roles      map[string]*db.PrincipalConfig `json:"roles,omitempty"`       // Initial roles
-	RevsLimit  *uint32                        `json:"revs_limit,omitempty"`  // Max depth a document's revision tree can grow to
-	ImportDocs interface{}                    `json:"import_docs,omitempty"` // false, true, or "continuous"
-	Shadow     *ShadowConfig                  `json:"shadow,omitempty"`      // External bucket to shadow
+	name          string                         `json:"name"`                     // Database name in REST API (stored as key in JSON)
+	Server        *string                        `json:"server"`                   // Couchbase (or Walrus) server URL, default "http://localhost:8091"
+	Username      string                         `json:"username,omitempty"`       // Username for authenticating to server
+	Password      string                         `json:"password,omitempty"`       // Password for authenticating to server
+	Bucket        *string                        `json:"bucket"`                   // Bucket name on server; defaults to same as 'name'
+	Pool          *string                        `json:"pool"`                     // Couchbase pool name, default "default"
+	Sync          *string                        `json:"sync"`                     // Sync function defines which users can see which data
+	Users         map[string]*db.PrincipalConfig `json:"users,omitempty"`          // Initial user accounts
+	Roles         map[string]*db.PrincipalConfig `json:"roles,omitempty"`          // Initial roles
+	RevsLimit     *uint32                        `json:"revs_limit,omitempty"`     // Max depth a document's revision tree can grow to
+	ImportDocs    interface{}                    `json:"import_docs,omitempty"`    // false, true, or "continuous"
+	Shadow        *ShadowConfig                  `json:"shadow,omitempty"`         // External bucket to shadow
+	EventHandlers *EventConfig                   `json:"eventHandlers, omitempty"` // Event handlers (webhook)
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -101,6 +102,17 @@ type ShadowConfig struct {
 	Username     string  `json:"username,omitempty"`     // Username for authenticating to server
 	Password     string  `json:"password,omitempty"`     // Password for authenticating to server
 	Doc_id_regex *string `json:"doc_id_regex,omitempty"` // Optional regex that doc IDs must match
+}
+
+type EventConfig struct {
+	TestWH   string           `json:"testwh"`             // test
+	Webhooks []*WebhookConfig `json:"webhooks,omitempty"` // Webhook events
+}
+
+type WebhookConfig struct {
+	Url          string  `json:"url"`                    //url
+	Channels     *string `json:"channels,omitempty"`     // channels
+	TransformMap *string `json:"transformMap,omitempty"` // map
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -81,7 +81,7 @@ type DbConfig struct {
 	RevsLimit     *uint32                        `json:"revs_limit,omitempty"`     // Max depth a document's revision tree can grow to
 	ImportDocs    interface{}                    `json:"import_docs,omitempty"`    // false, true, or "continuous"
 	Shadow        *ShadowConfig                  `json:"shadow,omitempty"`         // External bucket to shadow
-	EventHandlers *EventConfig                   `json:"eventHandlers, omitempty"` // Event handlers (webhook)
+	EventHandlers *EventHandlerConfig            `json:"eventHandlers, omitempty"` // Event handlers (webhook)
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -104,15 +104,24 @@ type ShadowConfig struct {
 	Doc_id_regex *string `json:"doc_id_regex,omitempty"` // Optional regex that doc IDs must match
 }
 
+type EventHandlerConfig struct {
+	DocumentCommitEvent *EventConfig `json:"document_commit_event,omitempty"` // Document Commit
+	UserCommitEvent     *EventConfig `json:"user_commit_event,omitempty"`     // User Commit
+}
+
 type EventConfig struct {
-	TestWH   string           `json:"testwh"`             // test
-	Webhooks []*WebhookConfig `json:"webhooks,omitempty"` // Webhook events
+	Webhooks []*WebhookConfig     `json:"webhooks,omitempty"` // Webhook events
+	Custom   []*CustomEventConfig `json:"custom, omitempty"`  // Custom events
 }
 
 type WebhookConfig struct {
-	Url          string  `json:"url"`                    //url
-	Channels     *string `json:"channels,omitempty"`     // channels
-	TransformMap *string `json:"transformMap,omitempty"` // map
+	Url       string  `json:"url"`                 // url
+	Channels  *string `json:"channels,omitempty"`  // channels
+	Transform *string `json:"transform,omitempty"` // map
+}
+
+type CustomEventConfig struct {
+	HandleEventFn *string `json:"handleFn, omitEmpty"`
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -105,23 +105,13 @@ type ShadowConfig struct {
 }
 
 type EventHandlerConfig struct {
-	DocumentCommitEvent *EventConfig `json:"document_commit_event,omitempty"` // Document Commit
-	UserCommitEvent     *EventConfig `json:"user_commit_event,omitempty"`     // User Commit
+	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
 }
 
 type EventConfig struct {
-	Webhooks []*WebhookConfig     `json:"webhooks,omitempty"` // Webhook events
-	Custom   []*CustomEventConfig `json:"custom, omitempty"`  // Custom events
-}
-
-type WebhookConfig struct {
-	Url       string  `json:"url"`                 // url
-	Channels  *string `json:"channels,omitempty"`  // channels
-	Transform *string `json:"transform,omitempty"` // map
-}
-
-type CustomEventConfig struct {
-	HandleEventFn *string `json:"handleFn, omitEmpty"`
+	HandlerType string `json:"handler"`          // Handler type
+	Url         string `json:"url,omitempty"`    // Url (webhook)
+	Filter      string `json:"filter,omitempty"` // Filter function (webhook)
 }
 
 func (dbConfig *DbConfig) setup(name string) error {


### PR DESCRIPTION
Webhook initial implementation

Adds event handling infrastructure, with specific support for the `document_change` event, and the `webhook` event handler.

Adds the following components:

`event_manager` (event_manager.go) : maintains the set of registered event handlers, and routes events to the appropriate handlers
`event` (event.go): an event raised during Sync Gateway processing.  In this commit only the DocumentChange event is included.  
`event_handler`: a component that can receive an event, and perform some operation based on the event type.  In this commit the only supported handler is the webhook handler

A webhook handler registered for the document_changed event posts the body of the changed document to the url provided.  A filter function can be defined to only post a subset of changed documents.

Webhook handlers are registered in the Sync Gateway config file, in a new eventHandlers section, following the format:

```
 "eventHandlers": {
          "document_changed": [
            {"handler": "webhook",
             "url": "http://localhost:8081/filtered",
             "filter": `function(doc) {
                  if (doc.type=="interesting") {
                    return true;
                  }
                  return false;
                }`
            },
          ]
        }
```

Config parameter information
`handler`: Handler type.  'webhook' is the only currently supported handler type
`url`: URL to post the document 
`filter`: javascript function taking the document as input, and returning boolean.  The webhook handler cancels the HTTP Post if the handler returns false.
