### PR TITLE
Add webhook support

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/crud.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/crud.go
@@ -615,6 +615,11 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 	revChannels := doc.History[newRevID].Channels
 	db.revisionCache.Put(body, encodeRevisions(history), revChannels)
 
+	// Raise event
+	if db.EventMgr.HasHandlerForEvent(DocumentChange) {
+		db.EventMgr.RaiseDocumentChangeEvent(body, revChannels)
+	}
+
 	// Now that the document has successfully been stored, we can make other db changes:
 	base.LogTo("CRUD", "Stored doc %q / %q", docid, newRevID)
 

--- a/src/github.com/couchbaselabs/sync_gateway/db/database.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/database.go
@@ -40,7 +40,8 @@ type DatabaseContext struct {
 	autoImport         bool                    // Add sync data to new untracked docs?
 	Shadower           *Shadower               // Tracks an external Couchbase bucket
 	revisionCache      *RevisionCache          // Cache of recently-accessed doc revisions
-	changeCache        changeCache
+	changeCache        changeCache             //
+	EventMgr           *EventManager           // Manages notification events
 }
 
 const DefaultRevsLimit = 1000
@@ -94,6 +95,9 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool) (*Da
 		autoImport: autoImport,
 	}
 	context.revisionCache = NewRevisionCache(RevisionCacheCapacity, context.revCacheLoader)
+
+	context.EventMgr = NewEventManager()
+
 	var err error
 	context.sequences, err = newSequenceAllocator(bucket)
 	if err != nil {

--- a/src/github.com/couchbaselabs/sync_gateway/db/event.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event.go
@@ -38,7 +38,7 @@ type AsyncEvent struct {
 	EventImpl
 }
 
-func (ae *AsyncEvent) Synchronous() bool {
+func (ae AsyncEvent) Synchronous() bool {
 	return false
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/db/event.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event.go
@@ -1,0 +1,159 @@
+package db
+
+import (
+	"errors"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"github.com/couchbaselabs/walrus"
+	"github.com/robertkrimen/otto"
+	"strconv"
+)
+
+// Event type
+type EventType uint8
+
+const (
+	DocumentChange EventType = iota
+	UserAdd
+)
+
+// An event that can be raised during SG processing.
+type Event interface {
+	Synchronous() bool
+	EventType() EventType
+}
+
+type EventImpl struct {
+	eventType EventType
+}
+
+func (e *EventImpl) EventType() EventType {
+	return e.eventType
+}
+
+// Currently the AsyncEvent type only manages the Synchronous() check.  Future enhancements
+// around async processing would leverage this type.
+type AsyncEvent struct {
+	EventImpl
+}
+
+func (ae *AsyncEvent) Synchronous() bool {
+	return false
+}
+
+// DocumentChangeEvent is raised when a document has been successfully written to the backing
+// data store.  Event has the document body and channel set as properties.
+type DocumentChangeEvent struct {
+	AsyncEvent
+	Doc      Body
+	Channels base.Set
+}
+
+// Javascript function handling for events
+const kTaskCacheSize = 4
+
+type ResponseType uint8
+
+const (
+	StringResponse ResponseType = iota
+	JSObjectResponse
+)
+
+// A compiled JavaScript event function.
+type jsEventTask struct {
+	walrus.JSRunner
+	responseType ResponseType
+}
+
+// Compiles a JavaScript event function to a jsEventTask object.
+func newJsEventTask(funcSource string) (walrus.JSServerTask, error) {
+	eventTask := &jsEventTask{}
+	err := eventTask.Init(funcSource)
+	if err != nil {
+		return nil, err
+	}
+
+	eventTask.After = func(result otto.Value, err error) (interface{}, error) {
+		nativeValue, _ := result.Export()
+		/*
+			switch nativeValue := nativeValue.(type) {
+			case string:
+				stringResult = nativeValue
+				eventTask.responseType = StringResponse
+			case interface{}:
+				resultBytes, marshErr := json.Marshal(nativeValue)
+				if marshErr != nil {
+					err = marshErr
+				} else {
+					stringResult = string(resultBytes)
+					eventTask.responseType = JSObjectResponse
+				}
+			}
+		*/
+		return nativeValue, err
+	}
+
+	return eventTask, nil
+}
+
+//////// JSEventFunction
+
+// A thread-safe wrapper around a jsEventTask, i.e. an event function.
+type JSEventFunction struct {
+	*walrus.JSServer
+}
+
+func NewJSEventFunction(fnSource string) *JSEventFunction {
+
+	base.LogTo("Events", "Creating new JSEventFunction")
+	return &JSEventFunction{
+		JSServer: walrus.NewJSServer(fnSource, kTaskCacheSize,
+			func(fnSource string) (walrus.JSServerTask, error) {
+				return newJsEventTask(fnSource)
+			}),
+	}
+}
+
+// Calls a jsEventFunction returning an interface{}
+func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
+
+	var err error
+	var result interface{}
+
+	// Different events send different parameters
+	switch event := event.(type) {
+
+	case *DocumentChangeEvent:
+		result, err = ef.Call(event.Doc)
+	}
+
+	if err != nil {
+		base.Warn("Error calling function - function processing aborted: %v", err)
+		return "", err
+	}
+
+	return result, err
+}
+
+// Calls a jsEventFunction returning bool.
+func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
+
+	result, err := ef.CallFunction(event)
+	if err != nil {
+		return false, err
+	}
+
+	switch result := result.(type) {
+	case bool:
+		return result, nil
+	case string:
+		boolResult, err := strconv.ParseBool(result)
+		if err != nil {
+			return false, err
+		}
+		return boolResult, nil
+	default:
+		base.Warn("Event validate function returned non-boolean result %v", result)
+		return false, errors.New("Validate function returned non-boolean value.")
+	}
+
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event.go
@@ -1,0 +1,165 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"github.com/couchbaselabs/walrus"
+	"github.com/robertkrimen/otto"
+	"strconv"
+)
+
+// Event type
+type EventType uint8
+
+const (
+	DocumentChange EventType = iota
+	UserAdd
+)
+
+// An event that can be raised during SG processing.
+type Event interface {
+	Synchronous() bool
+	EventType() EventType
+	String() string
+}
+
+type EventImpl struct {
+	eventType EventType
+}
+
+func (e *EventImpl) EventType() EventType {
+	return e.eventType
+}
+
+// Currently the AsyncEvent type only manages the Synchronous() check.  Future enhancements
+// around async processing would leverage this type.
+type AsyncEvent struct {
+	EventImpl
+}
+
+func (ae *AsyncEvent) Synchronous() bool {
+	return false
+}
+
+// DocumentChangeEvent is raised when a document has been successfully written to the backing
+// data store.  Event has the document body and channel set as properties.
+type DocumentChangeEvent struct {
+	AsyncEvent
+	Doc      Body
+	Channels base.Set
+}
+
+func (dce *DocumentChangeEvent) String() string {
+	return fmt.Sprintf("Document change event for doc id: %s", dce.Doc["_id"])
+}
+
+// Javascript function handling for events
+const kTaskCacheSize = 4
+
+type ResponseType uint8
+
+const (
+	StringResponse ResponseType = iota
+	JSObjectResponse
+)
+
+// A compiled JavaScript event function.
+type jsEventTask struct {
+	walrus.JSRunner
+	responseType ResponseType
+}
+
+// Compiles a JavaScript event function to a jsEventTask object.
+func newJsEventTask(funcSource string) (walrus.JSServerTask, error) {
+	eventTask := &jsEventTask{}
+	err := eventTask.Init(funcSource)
+	if err != nil {
+		return nil, err
+	}
+
+	eventTask.After = func(result otto.Value, err error) (interface{}, error) {
+		nativeValue, _ := result.Export()
+		/*
+			switch nativeValue := nativeValue.(type) {
+			case string:
+				stringResult = nativeValue
+				eventTask.responseType = StringResponse
+			case interface{}:
+				resultBytes, marshErr := json.Marshal(nativeValue)
+				if marshErr != nil {
+					err = marshErr
+				} else {
+					stringResult = string(resultBytes)
+					eventTask.responseType = JSObjectResponse
+				}
+			}
+		*/
+		return nativeValue, err
+	}
+
+	return eventTask, nil
+}
+
+//////// JSEventFunction
+
+// A thread-safe wrapper around a jsEventTask, i.e. an event function.
+type JSEventFunction struct {
+	*walrus.JSServer
+}
+
+func NewJSEventFunction(fnSource string) *JSEventFunction {
+
+	base.LogTo("Events", "Creating new JSEventFunction")
+	return &JSEventFunction{
+		JSServer: walrus.NewJSServer(fnSource, kTaskCacheSize,
+			func(fnSource string) (walrus.JSServerTask, error) {
+				return newJsEventTask(fnSource)
+			}),
+	}
+}
+
+// Calls a jsEventFunction returning an interface{}
+func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
+
+	var err error
+	var result interface{}
+
+	// Different events send different parameters
+	switch event := event.(type) {
+
+	case *DocumentChangeEvent:
+		result, err = ef.Call(event.Doc)
+	}
+
+	if err != nil {
+		base.Warn("Error calling function - function processing aborted: %v", err)
+		return "", err
+	}
+
+	return result, err
+}
+
+// Calls a jsEventFunction returning bool.
+func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
+
+	result, err := ef.CallFunction(event)
+	if err != nil {
+		return false, err
+	}
+
+	switch result := result.(type) {
+	case bool:
+		return result, nil
+	case string:
+		boolResult, err := strconv.ParseBool(result)
+		if err != nil {
+			return false, err
+		}
+		return boolResult, nil
+	default:
+		base.Warn("Event validate function returned non-boolean result %v", result)
+		return false, errors.New("Validate function returned non-boolean value.")
+	}
+
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"github.com/couchbaselabs/sync_gateway/base"
 	"github.com/couchbaselabs/walrus"
 	"github.com/robertkrimen/otto"
@@ -20,6 +21,7 @@ const (
 type Event interface {
 	Synchronous() bool
 	EventType() EventType
+	String() string
 }
 
 type EventImpl struct {
@@ -46,6 +48,10 @@ type DocumentChangeEvent struct {
 	AsyncEvent
 	Doc      Body
 	Channels base.Set
+}
+
+func (dce *DocumentChangeEvent) String() string {
+	return fmt.Sprintf("Document change event for doc id: %s", dce.Doc["_id"])
 }
 
 // Javascript function handling for events

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"net/http"
+	"time"
+)
+
+// EventHandler interface represents an instance of an event handler defined in the database config
+type EventHandler interface {
+	HandleEvent(event Event)
+	String() string
+}
+
+type AsyncEventHandler struct{}
+
+// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
+type Webhook struct {
+	AsyncEventHandler
+	url     string
+	filter  *JSEventFunction
+	timeout time.Duration
+}
+
+// default HTTP post timeout
+const kDefaultWebhookTimeout = 60
+
+// Creates a new webhook handler based on the url and filter function.
+func NewWebhook(url string, filterFnString string, timeout uint64) (*Webhook, error) {
+
+	var err error
+
+	if url == "" {
+		err = errors.New("url parameter must be defined for webhook events.")
+		return nil, err
+	}
+
+	wh := &Webhook{
+		url: url,
+	}
+	if filterFnString != "" {
+		wh.filter = NewJSEventFunction(filterFnString)
+	}
+
+	if timeout != 0 {
+		wh.timeout = time.Duration(timeout) * time.Second
+	} else {
+		wh.timeout = time.Duration(kDefaultWebhookTimeout) * time.Second
+	}
+
+	return wh, err
+}
+
+// Performs an HTTP POST to the url defined for the handler.  If a filter function is defined,
+// calls it to determine whether to POST.  The payload for the POST is depends
+// on the event type.
+func (wh *Webhook) HandleEvent(event Event) {
+
+	var payload *bytes.Buffer
+	var contentType string
+	if wh.filter != nil {
+		// If filter function is defined, use it to determine whether to post
+		success, err := wh.filter.CallValidateFunction(event)
+		if err != nil {
+			base.Warn("Error calling webhook filter function: %v", err)
+		}
+
+		// If filter returns false, cancel webhook post
+		if !success {
+			return
+		}
+	}
+
+	// Different events post different content by default
+	switch event := event.(type) {
+	case *DocumentChangeEvent:
+		// for DocumentChangeEvent, post document body
+		jsonOut, err := json.Marshal(event.Doc)
+		if err != nil {
+			base.Warn("Error marshalling doc for webhook post")
+			return
+		}
+		contentType = "application/json"
+		payload = bytes.NewBuffer(jsonOut)
+	default:
+		base.Warn("Webhook invoked for unsupported event type.")
+		return
+	}
+
+	client := http.Client{Timeout: wh.timeout}
+	resp, err := client.Post(wh.url, contentType, payload)
+	if err != nil {
+		base.Warn("Error attempting to post to url %s: %s", wh.url, err)
+		return
+	}
+
+	base.LogTo("Events+", "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
+		payload, wh.url, resp.Status)
+
+}
+
+func (wh *Webhook) String() string {
+	return fmt.Sprintf("Webhook handler [%s]", wh.url)
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
@@ -1,0 +1,95 @@
+package db
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"net/http"
+)
+
+// EventHandler interface represents an instance of an event handler defined in the database config
+type EventHandler interface {
+	HandleEvent(event Event)
+}
+
+type AsyncEventHandler struct{}
+
+// Webhook is an implementation of EventHandler that sends an asynchronous HTTP POST
+type Webhook struct {
+	AsyncEventHandler
+	url    string
+	filter *JSEventFunction
+}
+
+// Creates a new webhook handler based on the url and filter function.
+func NewWebhook(url string, filterFnString string) (*Webhook, error) {
+
+	var err error
+
+	if url == "" {
+		err = errors.New("url parameter must be defined for webhook events.")
+		return nil, err
+	}
+
+	wh := &Webhook{
+		url: url,
+	}
+	if filterFnString != "" {
+		wh.filter = NewJSEventFunction(filterFnString)
+	}
+
+	return wh, err
+}
+
+// Performs an HTTP POST to the url defined for the handler.  If a filter function is defined,
+// calls it to determine whether to POST.  The payload for the POST is depends
+// on the event type.
+func (wh *Webhook) HandleEvent(event Event) {
+
+	var payload *bytes.Buffer
+	var contentType string
+	if wh.filter != nil {
+		// If filter function is defined, use it to determine whether to post
+		success, err := wh.filter.CallValidateFunction(event)
+		if err != nil {
+			base.Warn("Error calling webhook filter function: %v", err)
+		}
+
+		// If filter returns false, cancel webhook post
+		if !success {
+			return
+		}
+	}
+
+	// Different events post different content by default
+	switch event := event.(type) {
+	case *DocumentChangeEvent:
+		// for DocumentChangeEvent, post document body
+		jsonOut, err := json.Marshal(event.Doc)
+		if err != nil {
+			base.Warn("Error marshalling doc for webhook post")
+			return
+		}
+		contentType = "application/json"
+		payload = bytes.NewBuffer(jsonOut)
+	default:
+		base.Warn("Webhook invoked for unsupported event type.")
+		return
+	}
+
+	resp, err := http.Post(wh.url, contentType, payload)
+	if err != nil {
+		base.Warn("Error attempting to post to url %s: %s", wh.url, err)
+		return
+	}
+
+	base.LogTo("Events+", "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
+		payload, wh.url, resp.Status)
+
+}
+
+func (wh *Webhook) String() string {
+	return fmt.Sprintf("Webhook handler [%s]", wh.url)
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"github.com/couchbaselabs/sync_gateway/base"
+	"sync"
+	"time"
+)
+
+// EventManager routes raised events to corresponding event handlers.  Incoming events are just dumped in the
+// eventChannel to minimize time spent blocking whatever process is raising the event.
+// The event queue worker goroutine works the event channel and sends events to the appropriate handlers
+type EventManager struct {
+	activeEventTypes   map[EventType]bool
+	eventHandlers      map[EventType][]EventHandler
+	asyncEventChannel  chan Event
+	activeCountChannel chan bool
+}
+
+const kMaxActiveEvents = 500 // number of events that are processed concurrently
+const kEventWaitTime = 5     // time (ms) to wait before dropping event, when at max events
+
+// Creates a new event manager.  Sets up the event channel for async events, and the goroutine to
+// monitor and process that channel.
+func NewEventManager() *EventManager {
+
+	em := &EventManager{
+		eventHandlers: make(map[EventType][]EventHandler, 0),
+	}
+	// Create channel for queued asynchronous events.
+	em.activeEventTypes = make(map[EventType]bool)
+	return em
+}
+
+// Starts the listener queue for the event manager
+func (em *EventManager) Start(maxProcesses uint, waitTime int) {
+
+	if maxProcesses == 0 {
+		maxProcesses = kMaxActiveEvents
+	}
+	if waitTime < 0 {
+		waitTime = kEventWaitTime
+	}
+
+	base.LogTo("Events", "Starting event manager with max processes:%d, wait time:%d ms", maxProcesses, waitTime)
+	// activeCountChannel limits the number of concurrent events being processed
+	em.activeCountChannel = make(chan bool, maxProcesses)
+
+	// asyncEventChannel stores the incoming events.  It's set to 3x activeCountChannel, to
+	// handle temporary spikes in event inflow
+	em.asyncEventChannel = make(chan Event, 3*maxProcesses)
+
+	// Start the event channel worker go routine.  If activeCountChannel is not full, spawns a new
+	// goroutine to process the event.  When the activeCountChannel is full, waits for
+	// (waitTime) milliseconds before cancelling the event.  When asyncEventChannel is full, the raiseEvent
+	// method will block for (waitTime).
+	// Default value of (waitTime) is 5 ms.
+	go func() {
+		for event := range em.asyncEventChannel {
+			select {
+			case em.activeCountChannel <- true:
+				// Spawn a go routine to process the event
+				go func(event Event) {
+					defer func() { <-em.activeCountChannel }()
+					base.LogTo("Events+", "Processing event: %s", event.String())
+					// Send event to all registered handlers concurrently.  WaitGroup blocks
+					// until all are finished
+					var wg sync.WaitGroup
+					for _, handler := range em.eventHandlers[event.EventType()] {
+						base.LogTo("Events+", "Event queue worker sending event %s to: %s", event.String(), handler)
+						wg.Add(1)
+						go func(event Event, handler EventHandler) {
+							defer wg.Done()
+							//TODO: Currently we're not tracking success/fail from event handlers.  When this
+							// is needed, could pass a channel to HandleEvent for tracking results
+							handler.HandleEvent(event)
+						}(event, handler)
+					}
+					wg.Wait()
+				}(event)
+			case <-time.After(time.Duration(waitTime) * time.Millisecond):
+				// We've hit the maximum number of concurrent event processing routines - ignore event and log error
+				base.Warn("Event queue full - discarding event: %s", event.String())
+			}
+		}
+	}()
+
+}
+
+// Register a new event handler to the EventManager.  The event manager will route events of
+// type eventType to the handler.
+func (em *EventManager) RegisterEventHandler(handler EventHandler, eventType EventType) {
+	em.eventHandlers[eventType] = append(em.eventHandlers[eventType], handler)
+	em.activeEventTypes[eventType] = true
+	base.LogTo("Events", "Registered event handler: %v", handler)
+}
+
+// Checks whether a handler of the given type has been registered to the event manager.
+func (em *EventManager) HasHandlerForEvent(eventType EventType) bool {
+	return em.activeEventTypes[eventType]
+}
+
+// Adds async events to the channel for processing
+func (em *EventManager) raiseEvent(event Event) {
+	if !event.Synchronous() {
+		em.asyncEventChannel <- event
+	}
+	// TODO: handling for synchronous events
+}
+
+// Raises a document change event based on the the document body and channel set.  If the
+// event manager doesn't have a listener for this event, ignores.
+func (em *EventManager) RaiseDocumentChangeEvent(body Body, channels base.Set) {
+
+	if !em.activeEventTypes[DocumentChange] {
+		return
+	}
+	event := &DocumentChangeEvent{
+		Doc:      body,
+		Channels: channels}
+
+	em.raiseEvent(event)
+
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"github.com/couchbaselabs/sync_gateway/base"
+)
+
+// EventManager routes raised events to corresponding event handlers.  Incoming events are just dumped in the
+// eventChannel to minimize time spent blocking whatever process is raising the event.
+// The event queue worker goroutine works the event channel and sends events to the appropriate handlers
+type EventManager struct {
+	activeEventTypes  map[EventType]bool
+	eventHandlers     map[EventType][]EventHandler
+	asyncEventChannel chan Event
+}
+
+// Creates a new event manager.  Sets up the event channel for async events, and the goroutine to
+// monitor and process that channel.
+func NewEventManager() *EventManager {
+
+	em := &EventManager{
+		eventHandlers: make(map[EventType][]EventHandler, 0),
+	}
+
+	// Create channel for queued asynchronous events.
+	em.asyncEventChannel = make(chan Event, 500)
+
+	em.activeEventTypes = make(map[EventType]bool)
+
+	// Start event channel worker go routine
+	go func() {
+		for event := range em.asyncEventChannel {
+			// send event to all registered handlers
+			for _, handler := range em.eventHandlers[event.EventType()] {
+				base.LogTo("Events+", "Event queue worker sending event to: %s", handler)
+				//TODO: currently we're not tracking success/fail from event handlers.  When this
+				// is needed, could pass a channel to HandleEvent for tracking results
+				go handler.HandleEvent(event)
+			}
+		}
+	}()
+
+	return em
+}
+
+// Register a new event handler to the EventManger.  The event manager will route events of
+// type eventType to the handler.
+func (em *EventManager) RegisterEventHandler(handler EventHandler, eventType EventType) {
+	em.eventHandlers[eventType] = append(em.eventHandlers[eventType], handler)
+	em.activeEventTypes[eventType] = true
+	base.LogTo("Events", "Registered event handler: %v", handler)
+}
+
+// Checks whether a handler of the given type has been registered to the event manager.
+func (em *EventManager) HasHandlerForEvent(eventType EventType) bool {
+	return em.activeEventTypes[eventType]
+}
+
+// Adds async events to the channel for processing
+func (em *EventManager) raiseEvent(event Event) {
+	if !event.Synchronous() {
+		em.asyncEventChannel <- event
+	}
+	// TODO: handling for synchronous events
+}
+
+// Raises a document change event based on the the document body and channel set.  If the
+// event manager doesn't have a listener for this event, ignores.
+func (em *EventManager) RaiseDocumentChangeEvent(body Body, channels base.Set) {
+
+	if !em.activeEventTypes[DocumentChange] {
+		return
+	}
+	event := &DocumentChangeEvent{
+		Doc:      body,
+		Channels: channels}
+
+	em.raiseEvent(event)
+
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
@@ -2,16 +2,22 @@ package db
 
 import (
 	"github.com/couchbaselabs/sync_gateway/base"
+	"sync"
+	"time"
 )
 
 // EventManager routes raised events to corresponding event handlers.  Incoming events are just dumped in the
 // eventChannel to minimize time spent blocking whatever process is raising the event.
 // The event queue worker goroutine works the event channel and sends events to the appropriate handlers
 type EventManager struct {
-	activeEventTypes  map[EventType]bool
-	eventHandlers     map[EventType][]EventHandler
-	asyncEventChannel chan Event
+	activeEventTypes   map[EventType]bool
+	eventHandlers      map[EventType][]EventHandler
+	asyncEventChannel  chan Event
+	activeCountChannel chan bool
 }
+
+const kMaxActiveEvents = 500 // number of events that are processed concurrently
+const kEventWaitTime = 5     // time (ms) to wait before dropping event, when at max events
 
 // Creates a new event manager.  Sets up the event channel for async events, and the goroutine to
 // monitor and process that channel.
@@ -20,29 +26,67 @@ func NewEventManager() *EventManager {
 	em := &EventManager{
 		eventHandlers: make(map[EventType][]EventHandler, 0),
 	}
-
 	// Create channel for queued asynchronous events.
-	em.asyncEventChannel = make(chan Event, 500)
-
 	em.activeEventTypes = make(map[EventType]bool)
+	return em
+}
 
-	// Start event channel worker go routine
+// Starts the listener queue for the event manager
+func (em *EventManager) Start(maxProcesses uint, waitTime int) {
+
+	if maxProcesses == 0 {
+		maxProcesses = kMaxActiveEvents
+	}
+	if waitTime < 0 {
+		waitTime = kEventWaitTime
+	}
+
+	base.LogTo("Events", "Starting event manager with max processes:%d, wait time:%d ms", maxProcesses, waitTime)
+	// activeCountChannel limits the number of concurrent events being processed
+	em.activeCountChannel = make(chan bool, maxProcesses)
+
+	// asyncEventChannel stores the incoming events.  It's set to 3x activeCountChannel, to
+	// handle temporary spikes in event inflow
+	em.asyncEventChannel = make(chan Event, 3*maxProcesses)
+
+	// Start the event channel worker go routine.  If activeCountChannel is not full, spawns a new
+	// goroutine to process the event.  When the activeCountChannel is full, waits for
+	// (waitTime) milliseconds before cancelling the event.  When asyncEventChannel is full, the raiseEvent
+	// method will block for (waitTime).
+	// Default value of (waitTime) is 5 ms.
 	go func() {
 		for event := range em.asyncEventChannel {
-			// send event to all registered handlers
-			for _, handler := range em.eventHandlers[event.EventType()] {
-				base.LogTo("Events+", "Event queue worker sending event to: %s", handler)
-				//TODO: currently we're not tracking success/fail from event handlers.  When this
-				// is needed, could pass a channel to HandleEvent for tracking results
-				go handler.HandleEvent(event)
+			select {
+			case em.activeCountChannel <- true:
+				// Spawn a go routine to process the event
+				go func(event Event) {
+					defer func() { <-em.activeCountChannel }()
+					base.LogTo("Events+", "Processing event: %s", event.String())
+					// Send event to all registered handlers concurrently.  WaitGroup blocks
+					// until all are finished
+					var wg sync.WaitGroup
+					for _, handler := range em.eventHandlers[event.EventType()] {
+						base.LogTo("Events+", "Event queue worker sending event %s to: %s", event.String(), handler)
+						wg.Add(1)
+						go func(event Event, handler EventHandler) {
+							defer wg.Done()
+							//TODO: Currently we're not tracking success/fail from event handlers.  When this
+							// is needed, could pass a channel to HandleEvent for tracking results
+							handler.HandleEvent(event)
+						}(event, handler)
+					}
+					wg.Wait()
+				}(event)
+			case <-time.After(time.Duration(waitTime) * time.Millisecond):
+				// We've hit the maximum number of concurrent event processing routines - ignore event and log error
+				base.Warn("Event queue full - discarding event: %s", event.String())
 			}
 		}
 	}()
 
-	return em
 }
 
-// Register a new event handler to the EventManger.  The event manager will route events of
+// Register a new event handler to the EventManager.  The event manager will route events of
 // type eventType to the handler.
 func (em *EventManager) RegisterEventHandler(handler EventHandler, eventType EventType) {
 	em.eventHandlers[eventType] = append(em.eventHandlers[eventType], handler)

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager.go
@@ -53,12 +53,12 @@ func (em *EventManager) Start(maxProcesses uint, waitTime int) {
 	// handle temporary spikes in event inflow
 	em.asyncEventChannel = make(chan Event, 3*maxProcesses)
 
-	// Start the event channel worker go routine.  If activeCountChannel is not full, spawns a new
-	// goroutine to process the event.  When the activeCountChannel is full, blocks.
+	// Start the event channel worker go routine, which will work the event queue and spawn goroutines to process the
+	// event.  Blocks if the activeCountChannel is full, to prevent spawning more than cap(activeCountChannel)
+	// goroutines.
 	go func() {
 		for event := range em.asyncEventChannel {
 			em.activeCountChannel <- true
-			// Spawn a go routine to process the event
 			go em.ProcessEvent(event)
 		}
 	}()

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
@@ -1,0 +1,413 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/couchbaselabs/go.assert"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// Webhook tests use an HTTP listener.  Use of this listener is disabled by default, to avoid
+// port conflicts/permission issues when running tests on a non-dev machine.
+const testLiveHTTP = false
+
+// Testing handler tracks recieved events in ResultChannel
+type TestingHandler struct {
+	receivedType  EventType
+	payload       Body
+	ResultChannel chan Body // channel for tracking async results
+	HandledEvent  EventType
+	handleDelay   int // long running handler execution
+}
+
+func (th *TestingHandler) HandleEvent(event Event) {
+
+	if th.handleDelay > 0 {
+		time.Sleep(time.Duration(th.handleDelay) * time.Millisecond)
+	}
+	if dceEvent, ok := event.(*DocumentChangeEvent); ok {
+		th.ResultChannel <- dceEvent.Doc
+	}
+	return
+}
+
+func (th *TestingHandler) SetChannel(channel chan Body) {
+	th.ResultChannel = channel
+}
+
+func (th *TestingHandler) String() string {
+	return "Testing Handler"
+}
+
+func TestDocumentChangeEvent(t *testing.T) {
+
+	em := NewEventManager()
+	em.Start(0, -1)
+
+	// Setup test data
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+	resultChannel := make(chan Body, 10)
+	//Setup test handler
+	testHandler := &TestingHandler{HandledEvent: DocumentChange}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+	//Raise events
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(10 * time.Millisecond)
+
+	assert.True(t, len(resultChannel) == 10)
+
+}
+
+// Test sending many events with slow-running execution to validate they get dropped after hitting
+// the max concurrent goroutines
+func TestSlowExecutionProcessing(t *testing.T) {
+
+	em := NewEventManager()
+	em.Start(0, -1)
+
+	base.LogKeys["Events"] = true
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 100)
+	testHandler := &TestingHandler{HandledEvent: DocumentChange, handleDelay: 500}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+
+	for i := 0; i < 20; i++ {
+		body, channels := eventForTest(i % 10)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(2000 * time.Millisecond)
+	fmt.Println("resultChannel:", len(resultChannel))
+
+	assert.True(t, len(resultChannel) == 20)
+
+}
+
+func TestCustomHandler(t *testing.T) {
+
+	em := NewEventManager()
+	em.Start(0, -1)
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 20)
+
+	testHandler := &TestingHandler{HandledEvent: DocumentChange}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, len(resultChannel) == 10)
+
+}
+
+func TestUnhandledEvent(t *testing.T) {
+
+	em := NewEventManager()
+	em.Start(0, -1)
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 10)
+
+	// create handler for UserAdd events
+	testHandler := &TestingHandler{HandledEvent: UserAdd}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, UserAdd)
+
+	// send DocumentChange events to handler
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// Wait for Event Manager queue worker to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Validate that no events were handled
+	assert.True(t, len(resultChannel) == 0)
+
+}
+
+func InitWebhookTest() (*int, *float64, *[][]byte) {
+
+	// Uses counter and sum values for simplified tracking of POST requests recieved by HTTP
+	// TODO:  enhance by adding listener for /count, /sum, /reset endpoints, and leave
+	// all management within the function, instead of sharing pointer references around
+	counter := 0
+	sum := 0.0
+	var payloads [][]byte
+	// Start HTTP listener for webhook calls
+	go func() {
+		http.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(1 * time.Second)
+			counter++
+			fmt.Fprintf(w, "OK")
+		})
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			r.ParseForm()
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				log.Printf("Error trying to read body: %s", err)
+			}
+
+			if len(body) > 0 {
+				payloads = append(payloads, body)
+				var payload map[string]interface{}
+				json.Unmarshal(body, &payload)
+				floatValue, ok := payload["value"].(float64)
+				if ok {
+					sum = sum + floatValue
+				}
+			}
+
+			if len(r.Form) > 0 {
+				log.Printf("Handled request with form: %v", r.Form)
+				floatValue, err := strconv.ParseFloat(r.Form.Get("value"), 64)
+				if err == nil {
+					sum = sum + floatValue
+				}
+			}
+
+			fmt.Fprintf(w, "OK")
+			counter++
+
+		})
+		http.ListenAndServe(":8081", nil)
+	}()
+	return &counter, &sum, &payloads
+}
+
+func TestWebhook(t *testing.T) {
+
+	if !testLiveHTTP {
+		return
+	}
+	count, sum, payloads := InitWebhookTest()
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	// Test basic webhook
+	em := NewEventManager()
+	em.Start(0, -1)
+	webhookHandler, _ := NewWebhook("http://localhost:8081/echo", "", 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 10)
+
+	// Test webhook filter function
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	em.Start(0, -1)
+	filterFunction := `function(doc) {
+							if (doc.value < 6) {
+								return false;
+							} else {
+								return true;
+							}
+							}`
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", filterFunction, 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 4)
+
+	// Validate payload
+	fmt.Println("RESET HERE")
+	*count, *sum, *payloads = 0, 0.0, nil
+	em = NewEventManager()
+	em.Start(0, -1)
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "", 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	body, channels := eventForTest(0)
+	em.RaiseDocumentChangeEvent(body, channels)
+	time.Sleep(50 * time.Millisecond)
+	receivedPayload := string((*payloads)[0])
+	fmt.Println("payload:", receivedPayload)
+	assert.Equals(t, string((*payloads)[0]), `{"_id":"0","value":0}`)
+	assert.Equals(t, *count, 1)
+
+	// Test fast fill, fast webhook
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	em.Start(5, -1)
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "", 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 100; i++ {
+		body, channels := eventForTest(i % 10)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(5 * time.Second)
+	assert.Equals(t, *count, 100)
+
+	// Test queue full, slow webhook.  Drops events
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	em.Start(5, -1)
+	webhookHandler, _ = NewWebhook("http://localhost:8081/slow", "", 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 100; i++ {
+		body, channels := eventForTest(i % 10)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(5 * time.Second)
+	assert.Equals(t, *count, 5)
+
+	// Test queue full, slow webhook, long wait time.  Throttles events
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	em.Start(5, 1100)
+	webhookHandler, _ = NewWebhook("http://localhost:8081/slow", "", 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 100; i++ {
+		body, channels := eventForTest(i % 10)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(10 * time.Second)
+	assert.Equals(t, *count, 100)
+
+}
+
+func TestUnavailableWebhook(t *testing.T) {
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	// Test unreachable webhook
+	em := NewEventManager()
+	em.Start(0, -1)
+	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "", 0)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}

--- a/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_manager_test.go
@@ -1,0 +1,354 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/couchbaselabs/go.assert"
+	"github.com/couchbaselabs/sync_gateway/base"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// Webhook tests use an HTTP listener.  Use of this listener is disabled by default, to avoid
+// port conflicts/permission issues when running tests on a non-dev machine.
+const testLiveHTTP = false
+
+// Testing handler tracks recieved events in ResultChannel
+type TestingHandler struct {
+	receivedType  EventType
+	payload       Body
+	ResultChannel chan Body // channel for tracking async results
+	HandledEvent  EventType
+	handleDelay   int // long running handler execution
+}
+
+func (th *TestingHandler) HandleEvent(event Event) {
+
+	if th.handleDelay > 0 {
+		time.Sleep(time.Duration(th.handleDelay) * time.Millisecond)
+	}
+	if dceEvent, ok := event.(*DocumentChangeEvent); ok {
+		th.ResultChannel <- dceEvent.Doc
+	}
+	return
+}
+
+func (th *TestingHandler) SetChannel(channel chan Body) {
+	th.ResultChannel = channel
+}
+
+func TestDocumentChangeEvent(t *testing.T) {
+
+	em := NewEventManager()
+
+	// Setup test data
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+	resultChannel := make(chan Body, 10)
+	//Setup test handler
+	testHandler := &TestingHandler{HandledEvent: DocumentChange}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+	//Raise events
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(10 * time.Millisecond)
+
+	assert.True(t, len(resultChannel) == 10)
+
+}
+
+// Test sending many events with slow-running execution to validate they get processed in parallel
+func TestSlowExecutionProcessing(t *testing.T) {
+
+	em := NewEventManager()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 101000)
+	testHandler := &TestingHandler{HandledEvent: DocumentChange, handleDelay: 500}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+
+	for i := 0; i < 100000; i++ {
+		body, channels := eventForTest(i % 10)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(750 * time.Millisecond)
+
+	assert.True(t, len(resultChannel) == 100000)
+
+}
+
+func TestCustomHandler(t *testing.T) {
+
+	em := NewEventManager()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 20)
+
+	testHandler := &TestingHandler{HandledEvent: DocumentChange}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, DocumentChange)
+
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// wait for Event Manager queue worker to process
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, len(resultChannel) == 10)
+
+}
+
+func TestUnhandledEvent(t *testing.T) {
+
+	em := NewEventManager()
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	resultChannel := make(chan Body, 10)
+
+	// create handler for UserAdd events
+	testHandler := &TestingHandler{HandledEvent: UserAdd}
+	testHandler.SetChannel(resultChannel)
+	em.RegisterEventHandler(testHandler, UserAdd)
+
+	// send DocumentChange events to handler
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	// Wait for Event Manager queue worker to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Validate that no events were handled
+	assert.True(t, len(resultChannel) == 0)
+
+}
+
+func InitWebhookTest() (*int, *float64, *[][]byte) {
+
+	// Uses counter and sum values for simplified tracking of POST requests recieved by HTTP
+	// TODO:  enhance by adding listener for /count, /sum, /reset endpoints, and leave
+	// all management within the function, instead of sharing pointer references around
+	counter := 0
+	sum := 0.0
+	var payloads [][]byte
+	// Start HTTP listener for webhook calls
+	go func() {
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			r.ParseForm()
+
+			fmt.Println("Handling event")
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				log.Printf("Error trying to read body: %s", err)
+			}
+
+			if len(body) > 0 {
+				payloads = append(payloads, body)
+				var payload map[string]interface{}
+				json.Unmarshal(body, &payload)
+				floatValue, ok := payload["value"].(float64)
+				if ok {
+					sum = sum + floatValue
+				}
+			}
+
+			if len(r.Form) > 0 {
+				log.Printf("Handled request with form: %v", r.Form)
+				floatValue, err := strconv.ParseFloat(r.Form.Get("value"), 64)
+				if err == nil {
+					sum = sum + floatValue
+				}
+			}
+
+			fmt.Fprintf(w, "OK")
+			counter++
+
+		})
+		http.ListenAndServe(":8081", nil)
+	}()
+	return &counter, &sum, &payloads
+}
+
+func TestWebhook(t *testing.T) {
+
+	if !testLiveHTTP {
+		return
+	}
+	count, sum, payloads := InitWebhookTest()
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	// Test basic webhook
+	em := NewEventManager()
+	webhookHandler, _ := NewWebhook("http://localhost:8081/echo", "")
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 10)
+
+	// Test webhook filter function
+	*count, *sum = 0, 0.0
+	em = NewEventManager()
+	filterFunction := `function(doc) {
+							if (doc.value < 6) {
+								return false;
+							} else {
+								return true;
+							}
+							}`
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", filterFunction)
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+	time.Sleep(50 * time.Millisecond)
+	assert.Equals(t, *count, 4)
+
+	// Validate payload
+	fmt.Println("RESET HERE")
+	*count, *sum, *payloads = 0, 0.0, nil
+	em = NewEventManager()
+	webhookHandler, _ = NewWebhook("http://localhost:8081/echo", "")
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	body, channels := eventForTest(0)
+	em.RaiseDocumentChangeEvent(body, channels)
+	time.Sleep(50 * time.Millisecond)
+	receivedPayload := string((*payloads)[0])
+	fmt.Println("payload:", receivedPayload)
+	assert.Equals(t, string((*payloads)[0]), `{"_id":"0","value":0}`)
+	assert.Equals(t, *count, 1)
+
+}
+
+func TestUnavailableWebhook(t *testing.T) {
+
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	eventForTest := func(i int) (Body, base.Set) {
+		testBody := Body{
+			"_id":   ids[i],
+			"value": i,
+		}
+		var channelSet base.Set
+		if i%2 == 0 {
+			channelSet = base.SetFromArray([]string{"Even"})
+		} else {
+			channelSet = base.SetFromArray([]string{"Odd"})
+		}
+		return testBody, channelSet
+	}
+
+	// Test unreachable webhook
+	em := NewEventManager()
+	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "")
+	em.RegisterEventHandler(webhookHandler, DocumentChange)
+	for i := 0; i < 10; i++ {
+		body, channels := eventForTest(i)
+		em.RaiseDocumentChangeEvent(body, channels)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -69,18 +69,19 @@ type ServerConfig struct {
 
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
-	name       string                         `json:"name"`                  // Database name in REST API (stored as key in JSON)
-	Server     *string                        `json:"server"`                // Couchbase (or Walrus) server URL, default "http://localhost:8091"
-	Username   string                         `json:"username,omitempty"`    // Username for authenticating to server
-	Password   string                         `json:"password,omitempty"`    // Password for authenticating to server
-	Bucket     *string                        `json:"bucket"`                // Bucket name on server; defaults to same as 'name'
-	Pool       *string                        `json:"pool"`                  // Couchbase pool name, default "default"
-	Sync       *string                        `json:"sync"`                  // Sync function defines which users can see which data
-	Users      map[string]*db.PrincipalConfig `json:"users,omitempty"`       // Initial user accounts
-	Roles      map[string]*db.PrincipalConfig `json:"roles,omitempty"`       // Initial roles
-	RevsLimit  *uint32                        `json:"revs_limit,omitempty"`  // Max depth a document's revision tree can grow to
-	ImportDocs interface{}                    `json:"import_docs,omitempty"` // false, true, or "continuous"
-	Shadow     *ShadowConfig                  `json:"shadow,omitempty"`      // External bucket to shadow
+	name          string                         `json:"name"`                     // Database name in REST API (stored as key in JSON)
+	Server        *string                        `json:"server"`                   // Couchbase (or Walrus) server URL, default "http://localhost:8091"
+	Username      string                         `json:"username,omitempty"`       // Username for authenticating to server
+	Password      string                         `json:"password,omitempty"`       // Password for authenticating to server
+	Bucket        *string                        `json:"bucket"`                   // Bucket name on server; defaults to same as 'name'
+	Pool          *string                        `json:"pool"`                     // Couchbase pool name, default "default"
+	Sync          *string                        `json:"sync"`                     // Sync function defines which users can see which data
+	Users         map[string]*db.PrincipalConfig `json:"users,omitempty"`          // Initial user accounts
+	Roles         map[string]*db.PrincipalConfig `json:"roles,omitempty"`          // Initial roles
+	RevsLimit     *uint32                        `json:"revs_limit,omitempty"`     // Max depth a document's revision tree can grow to
+	ImportDocs    interface{}                    `json:"import_docs,omitempty"`    // false, true, or "continuous"
+	Shadow        *ShadowConfig                  `json:"shadow,omitempty"`         // External bucket to shadow
+	EventHandlers *EventHandlerConfig            `json:"eventHandlers, omitempty"` // Event handlers (webhook)
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -101,6 +102,16 @@ type ShadowConfig struct {
 	Username     string  `json:"username,omitempty"`     // Username for authenticating to server
 	Password     string  `json:"password,omitempty"`     // Password for authenticating to server
 	Doc_id_regex *string `json:"doc_id_regex,omitempty"` // Optional regex that doc IDs must match
+}
+
+type EventHandlerConfig struct {
+	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
+}
+
+type EventConfig struct {
+	HandlerType string `json:"handler"`          // Handler type
+	Url         string `json:"url,omitempty"`    // Url (webhook)
+	Filter      string `json:"filter,omitempty"` // Filter function (webhook)
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -81,7 +81,7 @@ type DbConfig struct {
 	RevsLimit     *uint32                        `json:"revs_limit,omitempty"`     // Max depth a document's revision tree can grow to
 	ImportDocs    interface{}                    `json:"import_docs,omitempty"`    // false, true, or "continuous"
 	Shadow        *ShadowConfig                  `json:"shadow,omitempty"`         // External bucket to shadow
-	EventHandlers *EventHandlerConfig            `json:"eventHandlers, omitempty"` // Event handlers (webhook)
+	EventHandlers *EventHandlerConfig            `json:"event_handlers,omitempty"` // Event handlers (webhook)
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -105,13 +105,16 @@ type ShadowConfig struct {
 }
 
 type EventHandlerConfig struct {
+	MaxEventProc    uint           `json:"max_processes,omitempty"`    // Max concurrent event handling goroutines
+	WaitForProcess  string         `json:"wait_for_process,omitempty"` // Max wait time when event queue is full (ms)
 	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
 }
 
 type EventConfig struct {
-	HandlerType string `json:"handler"`          // Handler type
-	Url         string `json:"url,omitempty"`    // Url (webhook)
-	Filter      string `json:"filter,omitempty"` // Filter function (webhook)
+	HandlerType string `json:"handler"`           // Handler type
+	Url         string `json:"url,omitempty"`     // Url (webhook)
+	Filter      string `json:"filter,omitempty"`  // Filter function (webhook)
+	Timeout     uint64 `json:"timeout,omitempty"` // Timeout (webhook)
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -69,18 +69,19 @@ type ServerConfig struct {
 
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
-	name       string                         `json:"name"`                  // Database name in REST API (stored as key in JSON)
-	Server     *string                        `json:"server"`                // Couchbase (or Walrus) server URL, default "http://localhost:8091"
-	Username   string                         `json:"username,omitempty"`    // Username for authenticating to server
-	Password   string                         `json:"password,omitempty"`    // Password for authenticating to server
-	Bucket     *string                        `json:"bucket"`                // Bucket name on server; defaults to same as 'name'
-	Pool       *string                        `json:"pool"`                  // Couchbase pool name, default "default"
-	Sync       *string                        `json:"sync"`                  // Sync function defines which users can see which data
-	Users      map[string]*db.PrincipalConfig `json:"users,omitempty"`       // Initial user accounts
-	Roles      map[string]*db.PrincipalConfig `json:"roles,omitempty"`       // Initial roles
-	RevsLimit  *uint32                        `json:"revs_limit,omitempty"`  // Max depth a document's revision tree can grow to
-	ImportDocs interface{}                    `json:"import_docs,omitempty"` // false, true, or "continuous"
-	Shadow     *ShadowConfig                  `json:"shadow,omitempty"`      // External bucket to shadow
+	name          string                         `json:"name"`                     // Database name in REST API (stored as key in JSON)
+	Server        *string                        `json:"server"`                   // Couchbase (or Walrus) server URL, default "http://localhost:8091"
+	Username      string                         `json:"username,omitempty"`       // Username for authenticating to server
+	Password      string                         `json:"password,omitempty"`       // Password for authenticating to server
+	Bucket        *string                        `json:"bucket"`                   // Bucket name on server; defaults to same as 'name'
+	Pool          *string                        `json:"pool"`                     // Couchbase pool name, default "default"
+	Sync          *string                        `json:"sync"`                     // Sync function defines which users can see which data
+	Users         map[string]*db.PrincipalConfig `json:"users,omitempty"`          // Initial user accounts
+	Roles         map[string]*db.PrincipalConfig `json:"roles,omitempty"`          // Initial roles
+	RevsLimit     *uint32                        `json:"revs_limit,omitempty"`     // Max depth a document's revision tree can grow to
+	ImportDocs    interface{}                    `json:"import_docs,omitempty"`    // false, true, or "continuous"
+	Shadow        *ShadowConfig                  `json:"shadow,omitempty"`         // External bucket to shadow
+	EventHandlers *EventHandlerConfig            `json:"event_handlers,omitempty"` // Event handlers (webhook)
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -101,6 +102,19 @@ type ShadowConfig struct {
 	Username     string  `json:"username,omitempty"`     // Username for authenticating to server
 	Password     string  `json:"password,omitempty"`     // Password for authenticating to server
 	Doc_id_regex *string `json:"doc_id_regex,omitempty"` // Optional regex that doc IDs must match
+}
+
+type EventHandlerConfig struct {
+	MaxEventProc    uint           `json:"max_processes,omitempty"`    // Max concurrent event handling goroutines
+	WaitForProcess  string         `json:"wait_for_process,omitempty"` // Max wait time when event queue is full (ms)
+	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
+}
+
+type EventConfig struct {
+	HandlerType string `json:"handler"`           // Handler type
+	Url         string `json:"url,omitempty"`     // Url (webhook)
+	Filter      string `json:"filter,omitempty"`  // Filter function (webhook)
+	Timeout     uint64 `json:"timeout,omitempty"` // Timeout (webhook)
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
@@ -12,10 +12,12 @@ package rest
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -242,6 +244,24 @@ func (sc *ServerContext) AddDatabaseFromConfig(config *DbConfig) (*db.DatabaseCo
 		}
 	}
 
+	// Initialize event handlers, if any:
+	if config.EventHandlers != nil {
+		// Process document commit event handlers
+		if err = sc.processEventHandlersForEvent(config.EventHandlers.DocumentChanged, db.DocumentChange, dbcontext); err != nil {
+			return nil, err
+		}
+		// WaitForProcess uses string, to support both omitempty and zero values
+		customWaitTime := int64(-1)
+		if config.EventHandlers.WaitForProcess != "" {
+			customWaitTime, err = strconv.ParseInt(config.EventHandlers.WaitForProcess, 10, 0)
+			if err != nil {
+				customWaitTime = -1
+				base.Warn("Error parsing wait_for_process from config, using default %s", err)
+			}
+		}
+		dbcontext.EventMgr.Start(config.EventHandlers.MaxEventProc, int(customWaitTime))
+	}
+
 	// Register it so HTTP handlers can find it:
 	if err := sc.registerDatabase(dbcontext); err != nil {
 		dbcontext.Close()
@@ -249,6 +269,25 @@ func (sc *ServerContext) AddDatabaseFromConfig(config *DbConfig) (*db.DatabaseCo
 	}
 	sc.setDatabaseConfig(config.name, config)
 	return dbcontext, nil
+}
+
+func (sc *ServerContext) processEventHandlersForEvent(events []*EventConfig, eventType db.EventType, dbcontext *db.DatabaseContext) error {
+
+	for _, event := range events {
+		switch event.HandlerType {
+		case "webhook":
+			wh, err := db.NewWebhook(event.Url, event.Filter, event.Timeout)
+			if err != nil {
+				base.Warn("Error creating webhook %v", err)
+				return err
+			}
+			dbcontext.EventMgr.RegisterEventHandler(wh, eventType)
+		default:
+			return errors.New(fmt.Sprintf("Unknown event handler type %s", event.HandlerType))
+		}
+
+	}
+	return nil
 }
 
 func (sc *ServerContext) applySyncFunction(dbcontext *db.DatabaseContext, syncFn string) error {


### PR DESCRIPTION
Initial support for webhooks.  Implementation is built to support additional events and event handlers in future.  Currently only one event is being raised - a DocumentCommitEvent, after a doc is successfully updated in updateDoc.

EventManager maintains a channel (eventChannel) for raised events.  The only synchronous activity on the main document update go routine is to add the event to the EventManager channel.

EventManager has a go routine that works the eventChannel.  For each event, it passes the event to each registered eventHandler.  Each eventHandler creates a go routine for their own processing (for webhook, it's making an HTTP POST).

eventHandlers are defined in config.  Currently the only supported eventHandler type is webhook.
