### PR TITLE
removed additional 'shift' previously added as it was an incorrect fix f...

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -98,7 +98,7 @@ while [ "$1" != "" ]; do
             exit 1
             ;;
     esac
-    shift 2
+    shift
 done
 
 # If OS and VER were not provided on the command line get them for current env


### PR DESCRIPTION
...or the original issue that was caused by not using  '=' between a parameter key and value

Fixes issue #547 
