### PR TITLE
By default system runs processes with root as the working directory, to ...

### DIFF
--- a/service/script_templates/systemd_sync_gateway.tpl
+++ b/service/script_templates/systemd_sync_gateway.tpl
@@ -11,6 +11,7 @@ Environment=\"LOGS=${LOGS_TEMPLATE_VAR}\"
 Environment=\"NAME=${SERVICE_NAME}\"
 Type=simple
 User=${RUNAS_TEMPLATE_VAR}
+WorkingDirectory=${RUNBASE_TEMPLATE_VAR}
 ExecStartPre=/bin/mkdir -p ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/mkdir -p ${RUNBASE_TEMPLATE_VAR}/data


### PR DESCRIPTION
...force sync_gateway to run from the runtime user home dir added the following to the service template:

WorkingDirectory=${RUNBASE_TEMPLATE_VAR}

fixes issur #569 
