### PR TITLE
DCP support for Sync Gateway

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
@@ -10,12 +10,15 @@
 package base
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/couchbase/gomemcached"
 	"github.com/couchbase/gomemcached/client"
 	"github.com/couchbaselabs/go-couchbase"
+	"github.com/couchbaselabs/go-couchbase/cbdatasource"
 	"github.com/couchbaselabs/walrus"
 )
 
@@ -32,13 +35,14 @@ type AuthHandler couchbase.AuthHandler
 
 // Full specification of how to connect to a bucket
 type BucketSpec struct {
-	Server, PoolName, BucketName string
-	Auth                         AuthHandler
+	Server, PoolName, BucketName, FeedType string
+	Auth                                   AuthHandler
 }
 
 // Implementation of walrus.Bucket that talks to a Couchbase server
 type couchbaseBucket struct {
 	*couchbase.Bucket
+	spec BucketSpec // keep a copy of the BucketSpec for DCP usage
 }
 
 type couchbaseFeedImpl struct {
@@ -53,6 +57,10 @@ func (feed *couchbaseFeedImpl) Events() <-chan walrus.TapEvent {
 func (bucket couchbaseBucket) GetName() string {
 	return bucket.Name
 }
+
+/*func (bucket couchbaseBucket) GetUUID() string {
+	return bucket.Bucket.UUID
+}*/
 
 func (bucket couchbaseBucket) Write(k string, flags int, exp int, v interface{}, opt walrus.WriteOptions) (err error) {
 	return bucket.Bucket.Write(k, flags, exp, v, couchbase.WriteOptions(opt))
@@ -77,6 +85,23 @@ func (bucket couchbaseBucket) View(ddoc, name string, params map[string]interfac
 }
 
 func (bucket couchbaseBucket) StartTapFeed(args walrus.TapArguments) (walrus.TapFeed, error) {
+	// Use tap only when it's explicitly requested, or if DCP isn't supported
+	if bucket.spec.FeedType == "tap" {
+		LogTo("Feed", "Using TAP feed for bucket: %q (based on feed_type specified in config file", bucket.GetName())
+		return bucket.StartCouchbaseTapFeed(args)
+	} else {
+		feed, err := bucket.StartDCPFeed(args)
+		if err != nil {
+			Warn("Unable to start DCP feed - reverting to using TAP feed: %s", err)
+			return bucket.StartCouchbaseTapFeed(args)
+		} else {
+			LogTo("Feed", "Using DCP feed for bucket: %q", bucket.GetName())
+			return feed, nil
+		}
+	}
+}
+
+func (bucket couchbaseBucket) StartCouchbaseTapFeed(args walrus.TapArguments) (walrus.TapFeed, error) {
 	cbArgs := memcached.TapArguments{
 		Backfill: args.Backfill,
 		Dump:     args.Dump,
@@ -105,6 +130,123 @@ func (bucket couchbaseBucket) StartTapFeed(args walrus.TapArguments) (walrus.Tap
 	return &impl, nil
 }
 
+// Start cbdatasource-based DCP feed.  Supports
+func (bucket couchbaseBucket) StartDCPFeed(args walrus.TapArguments) (walrus.TapFeed, error) {
+
+	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
+	// reusing the bucket connection we've already established.
+	urls := []string{bucket.spec.Server}
+	poolName := bucket.spec.PoolName
+	if poolName == "" {
+		poolName = "default"
+	}
+	bucketName := bucket.spec.BucketName
+
+	vbucketIdsArr := []uint16(nil) // nil means get all the vbuckets.
+
+	receiver := NewDCPReceiver()
+
+	maxVbno, err := bucket.getMaxVbno()
+	if err != nil {
+		return nil, err
+	}
+
+	startSeqnos := make(map[uint16]uint64, maxVbno)
+	vbuuids := make(map[uint16]uint64, maxVbno)
+
+	// GetStatsVbSeqno retrieves high sequence number for each vbucket, to enable starting
+	// DCP stream from that position.  Also being used as a check on whether the server supports
+	// DCP.
+	statsUuids, highSeqnos, err := bucket.GetStatsVbSeqno(maxVbno)
+	if err != nil {
+		return nil, errors.New("Error retrieving stats-vbseqno - DCP not supported")
+	}
+
+	if args.Backfill == walrus.TapNoBackfill {
+		// For non-backfill, use vbucket uuids, high sequence numbers
+		LogTo("Feed+", "Seeding seqnos: %v", highSeqnos)
+		vbuuids = statsUuids
+		startSeqnos = highSeqnos
+	}
+	receiver.SeedSeqnos(vbuuids, startSeqnos)
+
+	// Auth handler for DCP connection needs to support bucket name defaults
+	username, password := "", ""
+	if bucket.spec.Auth != nil {
+		username, password, _ = bucket.spec.Auth.GetCredentials()
+	}
+	auth := &dcpAuth{username, password, bucketName}
+
+	LogTo("Feed+", "Connecting to new bucket datasource.  URLs:%s, pool:%s, name:%s, auth:%s", urls, poolName, bucketName, auth)
+	bds, err := cbdatasource.NewBucketDataSource(urls, poolName, bucketName, "", vbucketIdsArr, auth, receiver, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make(chan walrus.TapEvent)
+	impl := couchbaseDCPFeedImpl{bds, events}
+
+	if err = bds.Start(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for dcpEvent := range receiver.EventFeed {
+			events <- dcpEvent
+		}
+	}()
+
+	return &impl, nil
+}
+
+func (bucket couchbaseBucket) GetStatsVbSeqno(maxVbno uint16) (map[uint16]uint64, map[uint16]uint64, error) {
+
+	stats := bucket.Bucket.GetStats("vbucket-seqno")
+	if len(stats) == 0 {
+		// If vbucket-seqno map is empty, bucket doesn't support DCP
+		return nil, nil, errors.New("vbucket-seqno call returned empty map.")
+	}
+
+	uuids := make(map[uint16]uint64, maxVbno)
+	highSeqnos := make(map[uint16]uint64, maxVbno)
+
+	// GetStats response is in the form map[serverURI]map[]
+	for _, serverMap := range stats {
+		for i := uint16(0); i < maxVbno; i++ {
+			// stats come map with keys in format:
+			//   vb_nn:uuid
+			//   vb_nn:high_seqno
+			//   vb_nn:abs_high_seqno
+			//   vb_nn:purge_seqno
+			uuidKey := fmt.Sprintf("vb_%d:uuid", i)
+			highSeqnoKey := fmt.Sprintf("vb_%d:high_seqno", i)
+
+			highSeqno, err := strconv.ParseUint(serverMap[highSeqnoKey], 10, 64)
+			if err == nil && highSeqno > 0 {
+				highSeqnos[i] = highSeqno
+				uuid, err := strconv.ParseUint(serverMap[uuidKey], 10, 64)
+				if err == nil {
+					uuids[i] = uuid
+				}
+			}
+		}
+		break
+	}
+	return uuids, highSeqnos, nil
+}
+
+func (bucket couchbaseBucket) getMaxVbno() (uint16, error) {
+
+	var maxVbno uint16
+	vbsMap := bucket.Bucket.VBServerMap()
+	if vbsMap == nil || vbsMap.VBucketMap == nil {
+		return 0, errors.New("Error retrieving VBServerMap")
+	}
+	maxVbno = uint16(len(vbsMap.VBucketMap))
+
+	return maxVbno, nil
+}
+
 func (bucket couchbaseBucket) Dump() {
 	Warn("Dump not implemented for couchbaseBucket")
 }
@@ -125,8 +267,9 @@ func GetCouchbaseBucket(spec BucketSpec) (bucket Bucket, err error) {
 	}
 	cbbucket, err := pool.GetBucket(spec.BucketName)
 	if err == nil {
-		bucket = couchbaseBucket{cbbucket}
+		bucket = couchbaseBucket{cbbucket, spec}
 	}
+
 	return
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/base/dcp_feed.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/dcp_feed.go
@@ -1,0 +1,193 @@
+//  Copyright (c) 2014 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package base
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/couchbase/gomemcached"
+	"github.com/couchbaselabs/go-couchbase/cbdatasource"
+	"github.com/couchbaselabs/walrus"
+)
+
+type couchbaseDCPFeedImpl struct {
+	bds    cbdatasource.BucketDataSource
+	events <-chan walrus.TapEvent
+}
+
+func (feed *couchbaseDCPFeedImpl) Events() <-chan walrus.TapEvent {
+	return feed.events
+}
+
+func (feed *couchbaseDCPFeedImpl) Close() error {
+	return feed.bds.Close()
+}
+
+// Implementation of couchbase.AuthHandler for use by cbdatasource during bucket connect.
+type dcpAuth struct {
+	Username, Password, BucketName string
+}
+
+// GetCredentials is based on approach used in go-couchbase pools.go authHandler().
+func (a dcpAuth) GetCredentials() (string, string, string) {
+	if a.Username == "" {
+		return a.BucketName, "", a.BucketName
+	} else {
+		return a.Username, a.Password, a.BucketName
+	}
+}
+
+// DCPReceiver implements cbdatasource.Receiver to manage updates coming from a
+// cbdatasource BucketDataSource.  See go-couchbase/cbdatasource for
+// additional details
+type DCPReceiver struct {
+	m         sync.Mutex
+	seqs      map[uint16]uint64 // To track max seq #'s we received per vbucketId.
+	meta      map[uint16][]byte // To track metadata blob's per vbucketId.
+	EventFeed <-chan walrus.TapEvent
+	output    chan walrus.TapEvent // Same as EventFeed but writeably-typed
+}
+
+func NewDCPReceiver() *DCPReceiver {
+	r := &DCPReceiver{
+		output: make(chan walrus.TapEvent, 10),
+	}
+	r.EventFeed = r.output
+	return r
+}
+
+func (r *DCPReceiver) OnError(err error) {
+	Warn("Feed", "Error processing DCP stream: %v", err)
+}
+
+func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
+	req *gomemcached.MCRequest) error {
+	r.updateSeq(vbucketId, seq)
+	r.output <- makeFeedEvent(req, vbucketId)
+	return nil
+}
+
+func (r *DCPReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
+	req *gomemcached.MCRequest) error {
+	r.updateSeq(vbucketId, seq)
+	r.output <- makeFeedEvent(req, vbucketId)
+	return nil
+}
+
+func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16) walrus.TapEvent {
+	// not currently doing rq.Extras handling (as in gocouchbase/upr_feed, makeUprEvent) as SG doesn't use
+	// expiry/flags information, and snapshot handling is done by cbdatasource and sent as
+	// SnapshotStart, SnapshotEnd
+	event := walrus.TapEvent{
+		Opcode:   walrus.TapOpcode(rq.Opcode),
+		Key:      rq.Key,
+		Value:    rq.Body,
+		Sequence: rq.Cas,
+	}
+	return event
+}
+
+func (r *DCPReceiver) SnapshotStart(vbucketId uint16,
+	snapStart, snapEnd uint64, snapType uint32) error {
+	// TODO: On snapshot start, could persist high sequence information when in a bucket shadowing
+	// scenario, to support restart.  Not yet implemented due to concerns about impact of persistence
+	// on the shadowing DCP feed, as the SnapshotStart gets issued per vbucket.  It's not clear that the
+	// performance benefit on SG restart outweighs the performance impact during regular processing.
+	return nil
+}
+
+// SetMetaData and GetMetaData used internally by cbdatasource.  Expects send/recieve of opaque
+// []byte data.  cbdatasource is multithreaded so need to manage synchronization
+func (r *DCPReceiver) SetMetaData(vbucketId uint16, value []byte) error {
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if r.meta == nil {
+		r.meta = make(map[uint16][]byte)
+	}
+	r.meta[vbucketId] = value
+
+	return nil
+}
+
+func (r *DCPReceiver) GetMetaData(vbucketId uint16) (
+	value []byte, lastSeq uint64, err error) {
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	value = []byte(nil)
+	if r.meta != nil {
+		value = r.meta[vbucketId]
+	}
+
+	if r.seqs != nil {
+		lastSeq = r.seqs[vbucketId]
+	}
+
+	return value, lastSeq, nil
+}
+
+// Until we have CBL client support for rollback, we just rollback the sequence for the
+// vbucket to unblock the DCP stream.
+func (r *DCPReceiver) Rollback(vbucketId uint16, rollbackSeq uint64) error {
+	Warn("DCP Rollback request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x", vbucketId, rollbackSeq)
+	r.updateSeq(vbucketId, rollbackSeq)
+	return nil
+}
+
+func (r *DCPReceiver) updateSeq(vbucketId uint16, seq uint64) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if r.seqs == nil {
+		r.seqs = make(map[uint16]uint64)
+	}
+	if r.seqs[vbucketId] < seq {
+		r.seqs[vbucketId] = seq // Remember the max seq for GetMetaData().
+	}
+}
+
+// Seeds the sequence numbers returned by GetMetadata to support starting DCP from a particular
+// sequence.
+func (r *DCPReceiver) SeedSeqnos(uuids map[uint16]uint64, seqs map[uint16]uint64) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// Set the high seqnos as-is
+	r.seqs = seqs
+
+	// For metadata, we need to do more work to build metadata based on uuid and map values.  This
+	// isn't strictly to the design of cbdatasource.Receiver, which intends metadata to be opaque, but
+	// is required in order to have the BucketDataSource start the UPRStream as needed.
+	// The implementation has been reviewed with the cbdatasource owners and they agree this is a
+	// reasonable approach, as the structure of VBucketMetaData is expected to rarely change.
+	for vbucketId, uuid := range uuids {
+		failOver := make([][]uint64, 1)
+		failOverEntry := []uint64{uuid, 0}
+		failOver[0] = failOverEntry
+		metadata := &cbdatasource.VBucketMetaData{
+			SeqStart:    seqs[vbucketId],
+			SeqEnd:      uint64(0xFFFFFFFFFFFFFFFF),
+			SnapStart:   seqs[vbucketId],
+			SnapEnd:     seqs[vbucketId],
+			FailOverLog: failOver,
+		}
+		buf, err := json.Marshal(metadata)
+		if err == nil {
+			if r.meta == nil {
+				r.meta = make(map[uint16][]byte)
+			}
+			r.meta[vbucketId] = buf
+		}
+	}
+}

--- a/src/github.com/couchbaselabs/sync_gateway/base/dcp_feed.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/dcp_feed.go
@@ -36,7 +36,14 @@ type dcpAuth struct {
 	Username, Password, BucketName string
 }
 
-// GetCredentials is based on approach used in go-couchbase pools.go authHandler().
+// GetCredentials is used when cbdatasource makes a new bucket connection, based on approach we're
+// using for our other bucket connections (via go-couchbase pools.go authHandler()).
+// Background: After hitting an auth issue when connecting to a new cbdatasource bucket with the
+// standard username/password authenticator, I talked to Steve Yen and he tipped me off about the
+// default bucketname-as-username handling, and figured out that go-couchbase was doing that for us
+// for our usual bucket handling.
+// Reviewed with Steve and he said that the auth handling in couchbase server is undergoing changes
+// as part of Sherlock, so we may need to revisit once they've stabilized on an approach.
 func (a dcpAuth) GetCredentials() (string, string, string) {
 	if a.Username == "" {
 		return a.BucketName, "", a.BucketName

--- a/src/github.com/couchbaselabs/sync_gateway/rest/config.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/config.go
@@ -82,6 +82,7 @@ type DbConfig struct {
 	ImportDocs    interface{}                    `json:"import_docs,omitempty"`    // false, true, or "continuous"
 	Shadow        *ShadowConfig                  `json:"shadow,omitempty"`         // External bucket to shadow
 	EventHandlers *EventHandlerConfig            `json:"event_handlers,omitempty"` // Event handlers (webhook)
+	FeedType      string                         `json:"feed_type,omitempty"`      // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -102,6 +103,7 @@ type ShadowConfig struct {
 	Username     string  `json:"username,omitempty"`     // Username for authenticating to server
 	Password     string  `json:"password,omitempty"`     // Password for authenticating to server
 	Doc_id_regex *string `json:"doc_id_regex,omitempty"` // Optional regex that doc IDs must match
+	FeedType     string  `json:"feed_type,omitempty"`    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
 }
 
 type EventHandlerConfig struct {
@@ -168,12 +170,12 @@ func (dbConfig *DbConfig) setup(name string) error {
 
 // Implementation of AuthHandler interface for DbConfig
 func (dbConfig *DbConfig) GetCredentials() (string, string, string) {
-	return dbConfig.Username, dbConfig.Password, ""
+	return dbConfig.Username, dbConfig.Password, *dbConfig.Bucket
 }
 
 // Implementation of AuthHandler interface for ShadowConfig
 func (shadowConfig *ShadowConfig) GetCredentials() (string, string, string) {
-	return shadowConfig.Username, shadowConfig.Password, ""
+	return shadowConfig.Username, shadowConfig.Password, shadowConfig.Bucket
 }
 
 // Reads a ServerConfig from raw data

--- a/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/server_context.go
@@ -186,11 +186,14 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 		return nil, fmt.Errorf("Unrecognized value for ImportDocs: %#v", config.ImportDocs)
 	}
 
+	feedType := strings.ToLower(config.FeedType)
+
 	// Connect to the bucket and add the database:
 	spec := base.BucketSpec{
 		Server:     server,
 		PoolName:   pool,
 		BucketName: bucketName,
+		FeedType:   feedType,
 	}
 	if config.Username != "" {
 		spec.Auth = config
@@ -318,6 +321,7 @@ func (sc *ServerContext) startShadowing(dbcontext *db.DatabaseContext, shadow *S
 		Server:     *shadow.Server,
 		PoolName:   "default",
 		BucketName: shadow.Bucket,
+		FeedType:   shadow.FeedType,
 	}
 	if shadow.Pool != nil {
 		spec.PoolName = *shadow.Pool


### PR DESCRIPTION
PR for #404.

Adds support for using the Couchbase Server DCP feed instead of the TAP feed when available.  Uses the cbdatasource library from go-couchbase for interaction with the DCP feed, which handles cluster rebalancing and bucket failover.  Recommendation from Steve Yen is that cbdatasource needs to manage it's own connection, so we're not reusing SG's existing bucket connection for the DCP feed.  This requires that bucket auth information is passed to cbdatasource when initializing the DCP feed, so we're now saving the bucket spec along with the bucket to have that available on feed startup.

For standard feed usage, SG will make a stats vbseqno call to the server to identify the high sequence number in each bucket, and use that to start a DCP feed listening for new revisions.

For shadowing usage, SG starts from seq=0 and processes all data on startup. An enhancement to support resuming from the latest is possible by persisting DCP sequence info on snapshot end/start, but I've got concerns about whether the performance impact to the shadower feed of persisting sequence information on every vbucket snapshot.  A similar problem is being discussed in the context of #525 (how to efficiently persist the latest sequence information for all vbuckets), so I plan to revisit once that's completed.

By default, SG will attempt to use a DCP feed when working with a Couchbase bucket.  If DCP isn't supported for the bucket, it reverts to the TAP feed.  To force usage of TAP, users can set the property 'feed_type':'tap' in the database definition in the sync gateway config file.
