### PR TITLE
Use Facebook ID instead of email to register users

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/auth/auth.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/auth.go
@@ -255,3 +255,19 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) Us
 	}
 	return user
 }
+
+// Registers a new user account based on the given verified email address.
+// Username will be the same as the verified email address. Password will be random.
+// The user will have access to no channels.
+func (auth *Authenticator) RegisterNewUser(username, email string) (User, error) {
+	user, err := auth.NewUser(username, base.GenerateRandomSecret(), base.Set{})
+	if err != nil {
+		return nil, err
+	}
+	user.SetEmail(email)
+	err = auth.Save(user)
+	if err != nil {
+		return nil, err
+	}
+	return user, err
+}

--- a/src/github.com/couchbaselabs/sync_gateway/auth/auth_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/auth/auth_test.go
@@ -375,3 +375,36 @@ func TestRoleInheritance(t *testing.T) {
 	assert.True(t, user2.CanSeeChannel("hoopy"))
 	assert.Equals(t, user2.AuthorizeAllChannels(ch.SetOf("britain", "dull", "hoopiest")), nil)
 }
+
+func TestRegisterUser(t *testing.T) {
+	// Register user based on name, email
+	auth := NewAuthenticator(gTestBucket, nil)
+	user, err := auth.RegisterNewUser("ValidName", "foo@example.com")
+	assert.Equals(t, user.Name(), "ValidName")
+	assert.Equals(t, user.Email(), "foo@example.com")
+	assert.Equals(t, err, nil)
+
+	// verify retrieval by username
+	user, err = auth.GetUser("ValidName")
+	assert.Equals(t, user.Name(), "ValidName")
+	assert.Equals(t, err, nil)
+
+	// verify retrieval by email
+	user, err = auth.GetUserByEmail("foo@example.com")
+	assert.Equals(t, user.Name(), "ValidName")
+	assert.Equals(t, err, nil)
+
+	// Register user based on email, retrieve based on username, email
+	user, err = auth.RegisterNewUser("bar@example.com", "bar@example.com")
+	assert.Equals(t, user.Name(), "bar@example.com")
+	assert.Equals(t, user.Email(), "bar@example.com")
+	assert.Equals(t, err, nil)
+
+	user, err = auth.GetUser("UnknownName")
+	assert.Equals(t, user, nil)
+	assert.Equals(t, err, nil)
+
+	user, err = auth.GetUserByEmail("bar@example.com")
+	assert.Equals(t, user.Name(), "bar@example.com")
+	assert.Equals(t, err, nil)
+}

--- a/src/github.com/couchbaselabs/sync_gateway/rest/facebook.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/facebook.go
@@ -41,7 +41,7 @@ func (h *handler) handleFacebookPOST() error {
 	}
 
 	createUserIfNeeded := h.server.config.Facebook.Register
-	return h.makeSessionFromEmail(facebookResponse.Email, createUserIfNeeded)
+	return h.makeSessionFromNameAndEmail(facebookResponse.Id, facebookResponse.Email, createUserIfNeeded)
 
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/handler.go
@@ -360,22 +360,6 @@ func (h *handler) getBasicAuth() (username string, password string) {
 	return
 }
 
-// Registers a new user account based on the given verified email address.
-// Username will be the same as the verified email address. Password will be random.
-// The user will have access to no channels.
-func (h *handler) registerNewUser(email string) (auth.User, error) {
-	user, err := h.db.Authenticator().NewUser(email, base.GenerateRandomSecret(), base.Set{})
-	if err != nil {
-		return nil, err
-	}
-	user.SetEmail(email)
-	err = h.db.Authenticator().Save(user)
-	if err != nil {
-		return nil, err
-	}
-	return user, err
-}
-
 //////// RESPONSES:
 
 func (h *handler) setHeader(name string, value string) {


### PR DESCRIPTION
Issue #493

Switch Facebook-based user creation to set name=ID instead of name=email, to support continued authentication of users who change their Facebook email.

For backwards compatibility with users created prior to this change, the Facebook auth flow still tries to get a user based on email when it can't find one using ID.

Changed RegisterNewUser into an authenticator method instead of a handler method for easier testability.
