### PR TITLE
return JSON on delete

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/admin_api.go
@@ -51,6 +51,7 @@ func (h *handler) handleDeleteDB() error {
 	if !h.server.RemoveDatabase(h.db.Name) {
 		return base.HTTPErrorf(http.StatusNotFound, "missing")
 	}
+	h.response.Write([]byte("{}"))
 	return nil
 }
 


### PR DESCRIPTION
This just returns an empty JSON object on DB delete, which allows PouchDB tests to pass.
