### PR TITLE
Changed HTTP header response to use Gerrit Build Version

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -47,7 +47,7 @@ func init() {
 		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s)",
 			ServerName, BuildVersionString, BuildNumberString, VersionCommitSHA)
 
-		VersionString = fmt.Sprintf("%s/%.2f", ServerName, VersionNumber)
+		VersionString = fmt.Sprintf("%s/%s", ServerName, BuildVersionString)
 	} else {
 		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s)", ServerName, GitBranch, GitCommit, GitDirty)
 		VersionString = fmt.Sprintf("%s/unofficial", ServerName)


### PR DESCRIPTION
For release builds the HTTP header was using a literal float value for the release version.
Changed to use the Gerrit build release version which is printed to SG stderr on startup
fixes issue #543 
