### PR TITLE
render JSON to clients that don't handle multipart

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -524,7 +524,11 @@ func TestOpenRevs(t *testing.T) {
 	response := rt.sendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 
-	response = rt.sendRequest("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "")
+
+	reqHeaders := map[string]string{
+		"Accept": "application/json",
+	}
+	response = rt.sendRequestWithHeaders("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "", reqHeaders)
 	assertStatus(t, response, 200)
 	assert.Equals(t, response.Body.String(), `[
 {"_id":"or1","_rev":"12-abc","_revisions":{"ids":["abc","eleven","ten","nine"],"start":12},"n":1}

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -513,6 +513,25 @@ func TestRevsDiff(t *testing.T) {
 		"rd9": RevDiffResponse{"missing": []string{"1-a", "2-b", "3-c"}}})
 }
 
+func TestOpenRevs(t *testing.T) {
+	var rt restTester
+
+	// Create some docs:
+	input := `{"new_edits":false, "docs": [
+                    {"_id": "or1", "_rev": "12-abc", "n": 1,
+                     "_revisions": {"start": 12, "ids": ["abc", "eleven", "ten", "nine"]}}
+              ]}`
+	response := rt.sendRequest("POST", "/db/_bulk_docs", input)
+	assertStatus(t, response, 201)
+
+	response = rt.sendRequest("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "")
+	assertStatus(t, response, 200)
+	assert.Equals(t, response.Body.String(), `[
+{"_id":"or1","_rev":"12-abc","_revisions":{"ids":["abc","eleven","ten","nine"],"start":12},"n":1}
+,{"missing":"10-ten"}
+]`)
+}
+
 func TestLocalDocs(t *testing.T) {
 	var rt restTester
 	response := rt.sendRequest("GET", "/db/_local/loc1", "")

--- a/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
@@ -75,17 +75,34 @@ func (h *handler) handleGetDoc() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "bad open_revs")
 		}
 
-		err = h.writeMultipart("mixed", func(writer *multipart.Writer) error {
+		if h.requestAccepts("multipart/") && !h.requestAccepts("application/json") {
+			err = h.writeMultipart("mixed", func(writer *multipart.Writer) error {
+				for _, revid := range revids {
+					revBody, err := h.db.GetRev(docid, revid, includeRevs, attachmentsSince)
+					if err != nil {
+						revBody = db.Body{"missing": revid} //TODO: More specific error
+					}
+					h.db.WriteRevisionAsPart(revBody, err != nil, false, writer)
+				}
+				return nil
+			})
+			return err
+		} else {
+			base.LogTo("HTTP", "Fallback to non-multipart for open_revs")
+			h.setHeader("Content-Type", "application/json")
+			h.response.Write([]byte(`[` + "\n"))
+			seperator := []byte(``);
 			for _, revid := range revids {
 				revBody, err := h.db.GetRev(docid, revid, includeRevs, attachmentsSince)
 				if err != nil {
 					revBody = db.Body{"missing": revid} //TODO: More specific error
 				}
-				h.db.WriteRevisionAsPart(revBody, err != nil, false, writer)
+				h.response.Write(seperator)
+				seperator = []byte(",")
+				h.addJSON(revBody);
 			}
-			return nil
-		})
-		return err
+			h.response.Write([]byte(`]`))
+		}
 	}
 	return nil
 }

--- a/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/doc_api.go
@@ -75,7 +75,7 @@ func (h *handler) handleGetDoc() error {
 			return base.HTTPErrorf(http.StatusBadRequest, "bad open_revs")
 		}
 
-		if h.requestAccepts("multipart/") && !h.requestAccepts("application/json") {
+		if h.requestAccepts("multipart/") {
 			err = h.writeMultipart("mixed", func(writer *multipart.Writer) error {
 				for _, revid := range revids {
 					revBody, err := h.db.GetRev(docid, revid, includeRevs, attachmentsSince)
@@ -88,18 +88,18 @@ func (h *handler) handleGetDoc() error {
 			})
 			return err
 		} else {
-			base.LogTo("HTTP", "Fallback to non-multipart for open_revs")
+			base.LogTo("HTTP+", "Fallback to non-multipart for open_revs")
 			h.setHeader("Content-Type", "application/json")
 			h.response.Write([]byte(`[` + "\n"))
-			seperator := []byte(``);
+			separator := []byte(``)
 			for _, revid := range revids {
 				revBody, err := h.db.GetRev(docid, revid, includeRevs, attachmentsSince)
 				if err != nil {
 					revBody = db.Body{"missing": revid} //TODO: More specific error
 				}
-				h.response.Write(seperator)
-				seperator = []byte(",")
-				h.addJSON(revBody);
+				h.response.Write(separator)
+				separator = []byte(",")
+				h.addJSON(revBody)
 			}
 			h.response.Write([]byte(`]`))
 		}


### PR DESCRIPTION
PouchDB accepts JSON for document requests with `open_revs=["1-list","2-of","3-revs"]` but not multipart. Sync Gateway only provides multipart. This patch falls back to JSON for clients that need it.

@adamcfraser there is some logic duplication, but maybe not enough to factor out. I'm happy to rework the patch to remove the duplication if you have a preference how.

@snej @tleyden @hideki the risk factor with this patch is that it might start serving non-multipart to clients that accept multipart. I tried to test against CBL-iOS but wasn't able to get it to do a request that uses `open_revs`. I grepped the codebase for `open_revs` but both iOS and Android only mention it in their HTTP router.

Which leaves me with the question of: if none of our clients ever make this request, why do we have it in Sync Gateway? I must be wrong and the clients do use this endpoint, and for whatever reason I'm just not finding it in the code.

So once we have determined how to test that this patch doesn't negatively impact existing clients, I'll be ready to merge it.
