### PR TITLE
Added a stub handler for attempts to create a DB on the public API

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -142,6 +142,18 @@ func (h *handler) handleGetDB() error {
 	return nil
 }
 
+// Stub handler for hadling create DB on the public API returns HTTP status 412
+// if the db exists, and 403 if it doesn't.
+// fixes issue #562
+func (h *handler) handleCreateTarget() error {
+	dbname := h.PathVar("targetdb")
+	if _, err := h.server.GetDatabase(dbname); err != nil {
+		return base.HTTPErrorf(http.StatusForbidden, "does not exist")
+	} else {
+		return base.HTTPErrorf(http.StatusPreconditionFailed, "exists")
+	}
+}
+
 func (h *handler) handleEFC() error { // Handles _ensure_full_commit.
 	// no-op. CouchDB's replicator sends this, so don't barf. Status must be 201.
 	h.writeJSONStatus(http.StatusCreated, db.Body{

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api.go
@@ -148,9 +148,9 @@ func (h *handler) handleGetDB() error {
 func (h *handler) handleCreateTarget() error {
 	dbname := h.PathVar("targetdb")
 	if _, err := h.server.GetDatabase(dbname); err != nil {
-		return base.HTTPErrorf(http.StatusForbidden, "does not exist")
+		return base.HTTPErrorf(http.StatusForbidden, "Creating a DB over the public API is unsupported")
 	} else {
-		return base.HTTPErrorf(http.StatusPreconditionFailed, "exists")
+		return base.HTTPErrorf(http.StatusPreconditionFailed, "Database already exists")
 	}
 }
 

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -1612,3 +1612,14 @@ func TestStarAccess(t *testing.T) {
 	assert.Equals(t, changes.Results[0].ID, "doc3")
 	assert.Equals(t, since, db.SequenceID{Seq: 3})
 }
+
+// Test for issue #562
+func TestCreateTarget(t *testing.T) {
+	var rt restTester
+	//Attempt to create existing target DB on public API
+	response := rt.sendRequest("PUT", "/db/", "")
+	assertStatus(t, response, 412)
+	//Attempt to create new target DB on public API
+	response = rt.sendRequest("PUT", "/foo/", "")
+	assertStatus(t, response, 403)
+}

--- a/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/routing.go
@@ -92,6 +92,11 @@ func CreatePublicHandler(sc *ServerContext) http.Handler {
 		(*handler).handleSessionPOST)).Methods("POST")
 	dbr.Handle("/_session", makeHandler(sc, regularPrivs,
 		(*handler).handleSessionDELETE)).Methods("DELETE")
+	// The routine below is part of the CouchDB REST API, users can't create DB's via the pblic API
+	// but if the client set the 'createTarget' property of the Replicatior SG should return HTTP status 412
+	// if the db exists, and 403 if it doesn't.
+	r.Handle("/{targetdb:"+dbRegex+"}/",
+		makeHandler(sc, publicPrivs, (*handler).handleCreateTarget)).Methods("PUT")
 	return wrapRouter(sc, regularPrivs, r)
 }
 


### PR DESCRIPTION
return a 412 if the db exists, and a 403 if it doesn't. fixes issue #562
