### PR TITLE
Removed setting of optional parameter Timeout on http.Client

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/event_handler.go
@@ -91,7 +91,7 @@ func (wh *Webhook) HandleEvent(event Event) {
 		return
 	}
 
-	client := http.Client{Timeout: wh.timeout}
+	client := http.Client{} //{Timeout: wh.timeout} re-instate once Jenkins build has been upgraded to go 1.3
 	resp, err := client.Post(wh.url, contentType, payload)
 	if err != nil {
 		base.Warn("Error attempting to post to url %s: %s", wh.url, err)


### PR DESCRIPTION
as this requires go 1.3 and currently breaks Jenkins builds as these are still on go 1.2. Jenkins will be upgraded before the SG 1.1.0 release at which time this call can be re-instated. Issue #605 tracks the re-instatement.
