### PR TITLE
Send appropriate event opcodes to SG when working DCP stream

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/bucket.go
@@ -115,7 +115,6 @@ func (bucket couchbaseBucket) StartCouchbaseTapFeed(args walrus.TapArguments) (w
 	tapFeed := couchbaseFeedImpl{cbFeed, events}
 	go func() {
 		for cbEvent := range cbFeed.C {
-			LogTo("FeedTiming", "Got TAP Event %s", cbEvent)
 			events <- walrus.TapEvent{
 				Opcode:   walrus.TapOpcode(cbEvent.Opcode),
 				Expiry:   cbEvent.Expiry,
@@ -194,7 +193,7 @@ func (bucket couchbaseBucket) StartDCPFeed(args walrus.TapArguments) (walrus.Tap
 	}
 
 	go func() {
-		for dcpEvent := range dcpReceiver.EventFeed {
+		for dcpEvent := range dcpReceiver.GetEventFeed() {
 			events <- dcpEvent
 		}
 	}()

--- a/src/github.com/couchbaselabs/sync_gateway/base/dcp_feed.go
+++ b/src/github.com/couchbaselabs/sync_gateway/base/dcp_feed.go
@@ -52,6 +52,15 @@ func (a dcpAuth) GetCredentials() (string, string, string) {
 	}
 }
 
+type Receiver interface {
+	cbdatasource.Receiver
+	SeedSeqnos(map[uint16]uint64, map[uint16]uint64)
+	GetEventFeed() <-chan walrus.TapEvent
+	SetEventFeed(chan walrus.TapEvent)
+	GetOutput() chan walrus.TapEvent
+	updateSeq(vbucketId uint16, seq uint64)
+}
+
 // DCPReceiver implements cbdatasource.Receiver to manage updates coming from a
 // cbdatasource BucketDataSource.  See go-couchbase/cbdatasource for
 // additional details
@@ -59,16 +68,35 @@ type DCPReceiver struct {
 	m         sync.Mutex
 	seqs      map[uint16]uint64 // To track max seq #'s we received per vbucketId.
 	meta      map[uint16][]byte // To track metadata blob's per vbucketId.
-	EventFeed <-chan walrus.TapEvent
+	eventFeed <-chan walrus.TapEvent
 	output    chan walrus.TapEvent // Same as EventFeed but writeably-typed
 }
 
-func NewDCPReceiver() *DCPReceiver {
+func NewDCPReceiver() Receiver {
 	r := &DCPReceiver{
 		output: make(chan walrus.TapEvent, 10),
 	}
-	r.EventFeed = r.output
+	r.eventFeed = r.output
+	//r.SetEventFeed(r.GetOutput())
+
+	if LogKeys["DCP"] {
+		LogTo("DCP", "Using DCP Logging Receiver")
+		logRec := &DCPLoggingReceiver{rec: r}
+		return logRec
+	}
 	return r
+}
+
+func (r *DCPReceiver) SetEventFeed(c chan walrus.TapEvent) {
+	r.output = c
+}
+
+func (r *DCPReceiver) GetEventFeed() <-chan walrus.TapEvent {
+	return r.eventFeed
+}
+
+func (r *DCPReceiver) GetOutput() chan walrus.TapEvent {
+	return r.output
 }
 
 func (r *DCPReceiver) OnError(err error) {
@@ -78,23 +106,23 @@ func (r *DCPReceiver) OnError(err error) {
 func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
 	r.updateSeq(vbucketId, seq)
-	r.output <- makeFeedEvent(req, vbucketId)
+	r.output <- makeFeedEvent(req, vbucketId, walrus.TapMutation)
 	return nil
 }
 
 func (r *DCPReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
 	r.updateSeq(vbucketId, seq)
-	r.output <- makeFeedEvent(req, vbucketId)
+	r.output <- makeFeedEvent(req, vbucketId, walrus.TapDeletion)
 	return nil
 }
 
-func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16) walrus.TapEvent {
+func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16, opcode walrus.TapOpcode) walrus.TapEvent {
 	// not currently doing rq.Extras handling (as in gocouchbase/upr_feed, makeUprEvent) as SG doesn't use
 	// expiry/flags information, and snapshot handling is done by cbdatasource and sent as
 	// SnapshotStart, SnapshotEnd
 	event := walrus.TapEvent{
-		Opcode:   walrus.TapOpcode(rq.Opcode),
+		Opcode:   opcode,
 		Key:      rq.Key,
 		Value:    rq.Body,
 		Sequence: rq.Cas,
@@ -197,4 +225,72 @@ func (r *DCPReceiver) SeedSeqnos(uuids map[uint16]uint64, seqs map[uint16]uint64
 			r.meta[vbucketId] = buf
 		}
 	}
+}
+
+// DCPReceiver implements cbdatasource.Receiver to manage updates coming from a
+// cbdatasource BucketDataSource.  See go-couchbase/cbdatasource for
+// additional details
+type DCPLoggingReceiver struct {
+	rec Receiver
+}
+
+func (r *DCPLoggingReceiver) OnError(err error) {
+	LogTo("DCP", "OnError: %v", err)
+	r.rec.OnError(err)
+}
+
+func (r *DCPLoggingReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
+	req *gomemcached.MCRequest) error {
+	LogTo("DCP", "DataUpdate:%d, %s, %d, %v", vbucketId, key, seq, req)
+	return r.rec.DataUpdate(vbucketId, key, seq, req)
+}
+
+func (r *DCPLoggingReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
+	req *gomemcached.MCRequest) error {
+	LogTo("DCP", "DataDelete:%d, %s, %d, %v", vbucketId, key, seq, req)
+	return r.rec.DataDelete(vbucketId, key, seq, req)
+}
+
+func (r *DCPLoggingReceiver) Rollback(vbucketId uint16, rollbackSeq uint64) error {
+	LogTo("DCP", "Rollback:%d, %d", vbucketId, rollbackSeq)
+	return r.rec.Rollback(vbucketId, rollbackSeq)
+}
+
+func (r *DCPLoggingReceiver) SetMetaData(vbucketId uint16, value []byte) error {
+
+	LogTo("DCP", "SetMetaData:%d, %s", vbucketId, value)
+	return r.rec.SetMetaData(vbucketId, value)
+}
+
+func (r *DCPLoggingReceiver) GetMetaData(vbucketId uint16) (
+	value []byte, lastSeq uint64, err error) {
+	LogTo("DCP", "GetMetaData:%d", vbucketId)
+	return r.rec.GetMetaData(vbucketId)
+}
+
+func (r *DCPLoggingReceiver) SnapshotStart(vbucketId uint16,
+	snapStart, snapEnd uint64, snapType uint32) error {
+	LogTo("DCP", "SnapshotStart:%d, %d, %d, %d", vbucketId, snapStart, snapEnd, snapType)
+	return r.rec.SnapshotStart(vbucketId, snapStart, snapEnd, snapType)
+}
+
+func (r *DCPLoggingReceiver) SeedSeqnos(uuids map[uint16]uint64, seqs map[uint16]uint64) {
+	LogTo("DCP", "SeedSeqnos:%v, %v", uuids, seqs)
+	r.rec.SeedSeqnos(uuids, seqs)
+}
+
+func (r *DCPLoggingReceiver) updateSeq(vbucketId uint16, seq uint64) {
+	r.rec.updateSeq(vbucketId, seq)
+}
+
+func (r *DCPLoggingReceiver) SetEventFeed(c chan walrus.TapEvent) {
+	r.rec.SetEventFeed(c)
+}
+
+func (r *DCPLoggingReceiver) GetEventFeed() <-chan walrus.TapEvent {
+	return r.rec.GetEventFeed()
+}
+
+func (r *DCPLoggingReceiver) GetOutput() chan walrus.TapEvent {
+	return r.rec.GetOutput()
 }


### PR DESCRIPTION
Also includes support for a DCPLoggingReceiver to help diagnose DCP issues.  DCPLoggingReceiver is enabled when `DCP` is included in the config log keys.

Fixes #628.
