### PR TITLE
Parse revisions in _rev property

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/revtree.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revtree.go
@@ -334,12 +334,22 @@ func (tree RevTree) pruneRevisions(maxDepth uint32) (pruned int) {
 
 //////// HELPERS:
 
-// Parses a CouchDB _revisions property into a list of revision IDs
+// Parses a CouchDB _rev or _revisions property into a list of revision IDs
 func ParseRevisions(body Body) []string {
 	// http://wiki.apache.org/couchdb/HTTP_Document_API#GET
 	revisions, ok := body["_revisions"].(map[string]interface{})
 	if !ok {
-		return nil
+		revid, ok := body["_rev"].(string)
+		if !ok {
+			return nil
+		}
+		gen, _ := parseRevID(revid)
+		if gen < 1 {
+			return nil
+		}
+		oneRev := make([]string, 0, 1)
+		oneRev = append(oneRev, revid)
+		return oneRev
 	}
 	var start int
 	if startf, ok := revisions["start"].(float64); ok {

--- a/src/github.com/couchbaselabs/sync_gateway/db/revtree_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revtree_test.go
@@ -176,12 +176,16 @@ func TestParseRevisions(t *testing.T) {
 			[]string{"5-huey", "4-dewey", "3-louie"}},
 		{`{"_revisions": {"start": 3, "ids": ["huey"]}}`,
 			[]string{"3-huey"}},
+		{`{"_rev": "3-huey"}`,
+			[]string{"3-huey"}},
 		{`{"_revisions": {"start": 2, "ids": ["huey", "dewey", "louie"]}}`, nil},
 		{`{"_revisions": {"ids": ["huey", "dewey", "louie"]}}`, nil},
 		{`{"_revisions": {"ids": "bogus"}}`, nil},
 		{`{"_revisions": {"start": 2}}`, nil},
 		{`{"_revisions": {"start": "", "ids": ["huey", "dewey", "louie"]}}`, nil},
 		{`{"_revisions": 3.14159}`, nil},
+		{`{"_rev": 3.14159}`, nil},
+		{`{"_rev": "x-14159"}`, nil},
 		{`{"_Xrevisions": {"start": "", "ids": ["huey", "dewey", "louie"]}}`, nil},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
This makes the PouchDB tests pass better. I think it's because of _bulk_docs writes but could use some review as I'm coming at it from a narrow perspective right now.
