### PR TITLE
_all_docs keys can be encoded as a GET query string

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/rest/bulk_api.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/bulk_api.go
@@ -47,6 +47,18 @@ func (h *handler) handleAllDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad/missing keys")
 			}
 		}
+	} else if h.rq.Method == "GET" {
+		keys := h.getQuery("keys")
+		if len(keys) > 0 {
+			var queryKeys []string
+			err := json.Unmarshal([]byte(keys), &queryKeys)
+			if err != nil {
+				err = base.HTTPErrorf(http.StatusBadRequest, "Bad keys")
+			}
+			if len(queryKeys) > 0 {
+				explicitDocIDs = queryKeys
+			}
+		}
 	}
 
 	// Get the set of channels the user has access to; nil if user is admin or has access to user "*"


### PR DESCRIPTION
This helps compatibility with PouchDB and other clients that might expect to be able to use keys as part of an `all_docs` query.
