### PR TITLE
Open revs all

### DIFF
--- a/src/github.com/couchbaselabs/sync_gateway/db/revtree.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revtree.go
@@ -142,7 +142,7 @@ func (tree RevTree) getHistory(revid string) []string {
 }
 
 // Returns the leaf revision IDs (those that have no children.)
-func (tree RevTree) getLeaves() []string {
+func (tree RevTree) GetLeaves() []string {
 	isParent := map[string]bool{}
 	for _, info := range tree {
 		isParent[info.Parent] = true
@@ -288,7 +288,7 @@ func (tree RevTree) computeDepths() (maxDepth uint32) {
 	}
 	// Walk from each leaf to its root, assigning ancestors consecutive depths,
 	// but stopping if we'd increase an already-visited ancestor's depth:
-	for _, revid := range tree.getLeaves() {
+	for _, revid := range tree.GetLeaves() {
 		var depth uint32 = 1
 		for node := tree[revid]; node != nil; node = tree[node.Parent] {
 			if node.depth <= depth {

--- a/src/github.com/couchbaselabs/sync_gateway/db/revtree_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/db/revtree_test.go
@@ -69,9 +69,9 @@ func TestRevTreeGetHistory(t *testing.T) {
 }
 
 func TestRevTreeGetLeaves(t *testing.T) {
-	leaves := testmap.getLeaves()
+	leaves := testmap.GetLeaves()
 	assert.DeepEquals(t, leaves, []string{"3-three"})
-	leaves = branchymap.getLeaves()
+	leaves = branchymap.GetLeaves()
 	sort.Strings(leaves)
 	assert.DeepEquals(t, leaves, []string{"3-drei", "3-three"})
 }

--- a/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbaselabs/sync_gateway/rest/api_test.go
@@ -531,7 +531,7 @@ func TestOpenRevs(t *testing.T) {
 	response = rt.sendRequestWithHeaders("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "", reqHeaders)
 	assertStatus(t, response, 200)
 	assert.Equals(t, response.Body.String(), `[
-{"_id":"or1","_rev":"12-abc","_revisions":{"ids":["abc","eleven","ten","nine"],"start":12},"n":1}
+{"ok":{"_id":"or1","_rev":"12-abc","_revisions":{"ids":["abc","eleven","ten","nine"],"start":12},"n":1}}
 ,{"missing":"10-ten"}
 ]`)
 }


### PR DESCRIPTION
Serves `open_revs=all` queries to either JSON or Multipart readers. For PouchDB test suite assertion support.
