### PR TITLE
Use Go's sync.Pool to maintain cache of gzip.Writers

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -3,8 +3,8 @@
 # This script runs the given Go subcommand with GOPATH set up correctly for sync_gateway.
 
 GO_MAJOR_MINOR_VERSION=`go version | sed -E 's/.*go([0-9]\.[0-9]+).*/\1/'`
-if [[ $(echo "$GO_MAJOR_MINOR_VERSION >= 1.2" | bc) -eq 0 ]]; then
-  echo "*** Go 1.2 or higher is required to build Sync Gateway; you have" `go version`
+if [[ $(echo "$GO_MAJOR_MINOR_VERSION >= 1.3" | bc) -eq 0 ]]; then
+  echo "*** Go 1.3 or higher is required to build Sync Gateway; you have" `go version`
   echo "Please visit http://golang.org/doc/install or use your package manager to upgrade."
   exit 1
 fi


### PR DESCRIPTION
This is conceptually similar to the existing approach that uses a
channel as a cache; but the sync.Pool class is tied into the Go runtime
and GC, so it should be able to make better decisions about memory
management.

I made the gzip.Writer cache available via functions so that other code
in SG that uses gzip can take advantage of it. (Right now that code is
down in db/attachment.go, but in my delta branch it's moving into the
rest package.)

Also updated version requirement in go.sh, because sync.Pool is a Go 1.3
feature.
