### PR TITLE
Changes default feed type from DCP to TAP

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -107,7 +107,7 @@ type ShadowConfig struct {
 	Username     string  `json:"username,omitempty"`     // Username for authenticating to server
 	Password     string  `json:"password,omitempty"`     // Password for authenticating to server
 	Doc_id_regex *string `json:"doc_id_regex,omitempty"` // Optional regex that doc IDs must match
-	FeedType     string  `json:"feed_type,omitempty"`    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	FeedType     string  `json:"feed_type,omitempty"`    // Feed type - "DCP" or "TAP"; defaults to TAP
 }
 
 type EventHandlerConfig struct {


### PR DESCRIPTION
Fix for #657 - use TAP as default feed type.
