### PR TITLE
Avoid allocating unused sequence number when principal doesn't change

### DIFF
--- a/src/github.com/couchbase/sync_gateway/channels/timed_set.go
+++ b/src/github.com/couchbase/sync_gateway/channels/timed_set.go
@@ -93,6 +93,22 @@ func (set TimedSet) UpdateAtSequence(other base.Set, sequence uint64) bool {
 	return changed
 }
 
+// Check for matching entry names, ignoring sequence
+func (set TimedSet) Equals(other base.Set) bool {
+
+	for name, _ := range set {
+		if !other.Contains(name) {
+			return false
+		}
+	}
+	for name, _ := range other {
+		if !set.Contains(name) {
+			return false
+		}
+	}
+	return true
+}
+
 func (set TimedSet) AddChannel(channelName string, atSequence uint64) bool {
 	if atSequence > 0 {
 		if oldSequence := set[channelName]; oldSequence == 0 || atSequence < oldSequence {

--- a/src/github.com/couchbase/sync_gateway/channels/timed_set_test.go
+++ b/src/github.com/couchbase/sync_gateway/channels/timed_set_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbaselabs/go.assert"
 )
 
@@ -81,4 +82,20 @@ func TestEncodeSequenceID(t *testing.T) {
 	assert.DeepEquals(t, TimedSetFromString(",ABC:17"), TimedSet(nil))
 	assert.DeepEquals(t, TimedSetFromString("ABC:17,,NBC:12"), TimedSet(nil))
 	assert.DeepEquals(t, TimedSetFromString("ABC:17,ABC:12"), TimedSet(nil))
+}
+
+func TestEqualsWithEqualSet(t *testing.T) {
+	set1 := TimedSet{"ABC": 17, "CBS": 23, "BBC": 1}
+	set2 := base.SetFromArray([]string{"ABC", "CBS", "BBC"})
+	assert.True(t, set1.Equals(set2))
+
+}
+
+func TestEqualsWithUnequalSet(t *testing.T) {
+	set1 := TimedSet{"ABC": 17, "CBS": 23, "BBC": 1}
+	set2 := base.SetFromArray([]string{"ABC", "BBC"})
+	assert.True(t, !set1.Equals(set2))
+	set3 := base.SetFromArray([]string{"ABC", "BBC", "CBS", "FOO"})
+	assert.True(t, !set1.Equals(set3))
+
 }


### PR DESCRIPTION
In UpdatePrincipals, a new sequence was being allocated while identifying whether the principal had changed, and then the sequence was unused if no change was made.

Updated to only allocate the sequence when the principal is going to be updated.

Fix for #673
