### PR TITLE
Channel cache performance tuning

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/change_cache_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_cache_test.go
@@ -23,9 +23,10 @@ import (
 
 func e(seq uint64, docid string, revid string) *LogEntry {
 	return &LogEntry{
-		Sequence: seq,
-		DocID:    docid,
-		RevID:    revid,
+		Sequence:     seq,
+		DocID:        docid,
+		RevID:        revid,
+		TimeReceived: time.Now(),
 	}
 }
 

--- a/src/github.com/couchbase/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/database_test.go
@@ -224,9 +224,9 @@ func TestAllDocs(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	// Lower the log expiration time to zero so no more than 50 items will be kept.
-	oldChannelCacheAge := ChannelCacheAge
-	ChannelCacheAge = 0
-	defer func() { ChannelCacheAge = oldChannelCacheAge }()
+	oldChannelCacheAge := DefaultChannelCacheAge
+	DefaultChannelCacheAge = 0
+	defer func() { DefaultChannelCacheAge = oldChannelCacheAge }()
 
 	/*
 		base.LogKeys["Changes"] = true


### PR DESCRIPTION
Enforce hard cap on channel cache sizes.  Use DocID map to avoid full cache scans for duplicate IDs when ID isn't present.
