### PR TITLE
Disable the star channel via config

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/change_listener.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_listener.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
 )
 
 // A wrapper around a Bucket's TapFeed that allows any number of client goroutines to wait for
@@ -185,4 +186,18 @@ func (waiter *changeWaiter) CurrentUserCount() uint64 {
 		return 0
 	}
 	return waiter.listener.CurrentCount(waiter.userKeys)
+}
+
+// Updates the set of channel keys in the ChangeWaiter (maintains the existing set of user keys)
+func (waiter *changeWaiter) UpdateChannels(chans channels.TimedSet) {
+	initialCapacity := len(chans) + len(waiter.userKeys)
+	updatedKeys := make([]string, 0, initialCapacity)
+	for channel, _ := range chans {
+		updatedKeys = append(updatedKeys, channel)
+	}
+	if len(waiter.userKeys) > 0 {
+		updatedKeys = append(updatedKeys, waiter.userKeys...)
+	}
+	waiter.keys = updatedKeys
+
 }

--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -209,6 +209,11 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 			} else {
 				channelsSince = channels.AtSequence(chans, 0)
 			}
+
+			// Updates the changeWaiter to the current set of available channels
+			if changeWaiter != nil {
+				changeWaiter.UpdateChannels(channelsSince)
+			}
 			base.LogTo("Changes+", "MultiChangesFeed: channels expand to %#v ... %s", channelsSince, to)
 
 			// lowSequence is used to send composite keys to clients, so that they can obtain any currently

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -135,6 +135,7 @@ type CacheConfig struct {
 	CachePendingSeqMaxWait *uint32 `json:"max_wait_pending,omitempty"` // Max wait for pending sequence before skipping
 	CachePendingSeqMaxNum  *int    `json:"max_num_pending,omitempty"`  // Max number of pending sequences before skipping
 	CacheSkippedSeqMaxWait *uint32 `json:"max_wait_skipped,omitempty"` // Max wait for skipped sequence before abandoning
+	EnableStarChannel      *bool   `json:"enable_star_channel"`        // Enable star channel
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -198,10 +198,6 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 	if config.Username != "" {
 		spec.Auth = config
 	}
-	bucket, err := db.ConnectToBucket(spec)
-	if err != nil {
-		return nil, err
-	}
 
 	// Set cache properties, if present
 	cacheOptions := db.CacheOptions{}
@@ -215,6 +211,15 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 		if config.CacheConfig.CacheSkippedSeqMaxWait != nil && *config.CacheConfig.CacheSkippedSeqMaxWait > 0 {
 			cacheOptions.CacheSkippedSeqMaxWait = time.Duration(*config.CacheConfig.CacheSkippedSeqMaxWait) * time.Millisecond
 		}
+		// set EnableStarChannelLog directly here (instead of via NewDatabaseContext), so that it's set when we create the channels view in ConnectToBucket
+		if config.CacheConfig.EnableStarChannel != nil {
+			db.EnableStarChannelLog = *config.CacheConfig.EnableStarChannel
+		}
+	}
+
+	bucket, err := db.ConnectToBucket(spec)
+	if err != nil {
+		return nil, err
 	}
 
 	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, cacheOptions)


### PR DESCRIPTION
Adds the `enable_star_channel` property to the cache settings in the sync gateway config file, which allows users to disable the star channel as a performance optimization.  Setting `enable_star_channel=false` prevents the channels view from emitting rows for the `*` channel, and the `*` channel cache isn't maintained.

Includes a fix for changeWaiter processing in during changes processing.  The Wait/Notify process uses the set of channels defined in the _changes request to manage notification - the _changes goroutine was notified whenever one of those channels changed.  This wasn't working as intended when clients passed `*` as the set of channels.  Instead of treating this as "all channels the user can see", it was being treated as "the star channel".  This resulted in some unnecessary _changes iterations in the standard configuration (enable_star_channel=true), and no _changes iterations at all when the star channel was disabled. 

Incremental performance improvement in p95/p99 numbers was seen after making these changes, when running in either configuration:

Master (control): 6.51/7.935 (run 804)
Issue 718, with star channel enabled: 4.95/5.895  (run 816)
Issue 718, with star channel disabled: 4.57/5.74   (run 817) - also shows significantly reduced memory usage
