### PR TITLE
Refactor to make it easy to split views among design docs

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/changes_view.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes_view.go
@@ -33,7 +33,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	optMap := changesViewOptions(channelName, endSeq, options)
 	base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, options.Since.SafeSequence()+1, endSeq, options.Limit)
 	vres := channelsViewResult{}
-	err := dbc.Bucket.ViewCustom("sync_gateway", "channels", optMap, &vres)
+	err := dbc.Bucket.ViewCustom(DesignDocSyncGateway, ViewChannels, optMap, &vres)
 	if err != nil {
 		base.Logf("Error from 'channels' view: %v", err)
 		return nil, err

--- a/src/github.com/couchbase/sync_gateway/db/crud.go
+++ b/src/github.com/couchbase/sync_gateway/db/crud.go
@@ -11,10 +11,11 @@ package db
 
 import (
 	"encoding/json"
-	"github.com/couchbaselabs/walrus"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/couchbaselabs/walrus"
 
 	"github.com/couchbaselabs/go-couchbase"
 
@@ -812,7 +813,7 @@ func (context *DatabaseContext) ComputeChannelsForPrincipal(princ auth.Principal
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": key}
-	if verr := context.Bucket.ViewCustom("sync_gateway", "access", opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	channelSet := channels.TimedSet{}
@@ -832,7 +833,7 @@ func (context *DatabaseContext) ComputeRolesForUser(user auth.User) (channels.Ti
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom("sync_gateway", "role_access", opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewRoleAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	// Merge the TimedSets from the view result:

--- a/src/github.com/couchbase/sync_gateway/db/design_doc.go
+++ b/src/github.com/couchbase/sync_gateway/db/design_doc.go
@@ -12,6 +12,20 @@ import (
 
 type DesignDoc walrus.DesignDoc
 
+const (
+	DesignDocSyncGateway      = "sync_gateway"
+	DesignDocSyncHousekeeping = "sync_housekeeping"
+	ViewPrincipals            = "principals"
+	ViewChannels              = "channels"
+	ViewAccess                = "access"
+	ViewRoleAccess            = "role_access"
+	ViewAllBits               = "all_bits"
+	ViewAllDocs               = "all_docs"
+	ViewImport                = "import"
+	ViewOldRevs               = "old_revs"
+	ViewSessions              = "sessions"
+)
+
 func isInternalDDoc(ddocName string) bool {
 	return strings.HasPrefix(ddocName, "sync_")
 }

--- a/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
@@ -230,7 +230,7 @@ func (h *handler) handleDump() error {
 	viewName := h.PathVar("view")
 	base.LogTo("HTTP", "Dump view %q", viewName)
 	opts := db.Body{"stale": false, "reduce": false}
-	result, err := h.db.Bucket.View("sync_gateway", viewName, opts)
+	result, err := h.db.Bucket.View(db.DesignDocSyncGateway, viewName, opts)
 	if err != nil {
 		return err
 	}

--- a/src/github.com/couchbase/sync_gateway/rest/view_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/view_api.go
@@ -16,7 +16,7 @@ func (h *handler) handleGetDesignDoc() error {
 	ddocID := h.PathVar("ddoc")
 	base.TEMP("GetDesignDoc %q", ddocID)
 	var result interface{}
-	if ddocID == "sync_gateway" {
+	if ddocID == DesignDocSyncGateway {
 		// we serve this content here so that CouchDB 1.2 has something to
 		// hash into the replication-id, to correspond to our filter.
 		filter := "ok"
@@ -62,7 +62,7 @@ func (h *handler) handleView() error {
 	// http://docs.couchbase.com/admin/admin/REST/rest-views-get.html
 	ddocName := h.PathVar("ddoc")
 	if ddocName == "" {
-		ddocName = "sync_gateway"
+		ddocName = DesignDocSyncGateway
 	}
 	viewName := h.PathVar("view")
 	opts := db.Body{}


### PR DESCRIPTION
I did some minor changes to make it easier to split views among design docs.  I think this change should go onto the master branch, regardless of what we decide after doing some experiments.

In terms of behavior change, it should be a no-op.

Build passed: http://factory.couchbase.com/view/build/view/mobile_dev/view/sync_gateway/view/master/job/build_sync_gateway_dev_cents-x64/134/console

https://github.com/couchbase/sync_gateway/issues/752
