### PR TITLE
Made revision pruning algorithm more effective

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/revision.go
+++ b/src/github.com/couchbase/sync_gateway/db/revision.go
@@ -96,6 +96,21 @@ func createRevID(generation int, parentRevID string, body Body) string {
 	return fmt.Sprintf("%d-%x", generation, digester.Sum(nil))
 }
 
+// Returns the generation number (numeric prefix) of a revision ID.
+func genOfRevID(revid string) int {
+	if revid == "" {
+		return 0
+	}
+	var generation int
+	n, _ := fmt.Sscanf(revid, "%d-", &generation)
+	if n < 1 || generation < 1 {
+		base.Warn("genOfRevID failed on %q", revid)
+		return -1
+	}
+	return generation
+}
+
+// Splits a revision ID into generation number and hex digest.
 func parseRevID(revid string) (int, string) {
 	if revid == "" {
 		return 0, ""


### PR DESCRIPTION
With the old algorithm, the rev-tree nodes of a merged conflict would
never get pruned, nor would the /maxRevTreeDepth/ ancestors below them.
This led to some huge revision trees.
The new algorithm simply finds the min generation # of all non-deleted
leaf nodes (i.e. current node + conflicts) and prunes all nodes whose
generation number is /maxRevTreeDepth/ less than that.
Fixes #501
