### PR TITLE
Ensure that SG views aren't created in bucket being shadowed

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -352,8 +352,10 @@ func (sc *ServerContext) startShadowing(dbcontext *db.DatabaseContext, shadow *S
 		spec.Auth = shadow
 	}
 
-	bucket, err := db.ConnectToBucket(spec)
+	bucket, err := base.GetBucket(spec)
 	if err != nil {
+		err = base.HTTPErrorf(http.StatusBadGateway,
+			"Unable to connect to shadow bucket: %s", err)
 		return err
 	}
 	shadower, err := db.NewShadower(dbcontext, bucket, pattern)


### PR DESCRIPTION
Sync gateway shouldn't be creating the Sync Gateway views in the shadowed (non-SG) bucket. 
