### PR TITLE
Store rev bodies in JSON-marshaled RevTree more efficiently

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/revtree_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/revtree_test.go
@@ -36,8 +36,6 @@ var branchymap = RevTree{"3-three": {ID: "3-three", Parent: "2-two"},
 // 1-one -- 2-two
 //               \ 3-drei
 
-const testJSON = `{"revs": ["3-three", "2-two", "1-one"], "parents": [1, 2, -1], "bodies": ["{}", "", ""], "channels": [null, ["ABC", "CBS"], ["ABC"]]}`
-
 func testUnmarshal(t *testing.T, jsonString string) RevTree {
 	gotmap := RevTree{}
 	assertNoError(t, json.Unmarshal([]byte(jsonString), &gotmap), "Couldn't parse RevTree from JSON")
@@ -45,7 +43,14 @@ func testUnmarshal(t *testing.T, jsonString string) RevTree {
 	return gotmap
 }
 
+func TestRevTreeUnmarshalOldFormat(t *testing.T) {
+	const testJSON = `{"revs": ["3-three", "2-two", "1-one"], "parents": [1, 2, -1], "bodies": ["{}", "", ""], "channels": [null, ["ABC", "CBS"], ["ABC"]]}`
+	gotmap := testUnmarshal(t, testJSON)
+	fmt.Printf("Unmarshaled to %v\n", gotmap)
+}
+
 func TestRevTreeUnmarshal(t *testing.T) {
+	const testJSON = `{"revs": ["3-three", "2-two", "1-one"], "parents": [1, 2, -1], "bodymap": {"0":"{}"}, "channels": [null, ["ABC", "CBS"], ["ABC"]]}`
 	gotmap := testUnmarshal(t, testJSON)
 	fmt.Printf("Unmarshaled to %v\n", gotmap)
 }


### PR DESCRIPTION
The JSON form of a RevTree (as stored in the bucket) stores revision
bodies inefficiently. It's an array of strings indexed parallel to the
"revs" array. Since almost all revs have no body stored (only conflicts
do) it ends up being a long array of empty strings.

This patch changes the format. There's no more "bodies" array. Instead
there's a "bodymap", a JSON dictionary whose keys are indexes into
"revs" and values are revision bodies. Typically this property will be
missing entirely or have only one item in it.
