### PR TITLE
Issue #775 - handle sequences deduplicated by server feed

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/change_cache.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_cache.go
@@ -307,7 +307,8 @@ func (c *changeCache) DocChanged(docID string, docJSON []byte) {
 		}
 
 		// If the recent sequence history includes any sequences earlier than the current sequence, and
-		// not already seen by the gateway (more recent than c.nextSequence), add them as empty entries.
+		// not already seen by the gateway (more recent than c.nextSequence), add them as empty entries
+		// so that they are included in sequence buffering.
 		currentSequence := doc.Sequence
 		if len(doc.UnusedSequences) > 0 {
 			currentSequence = doc.UnusedSequences[0]

--- a/src/github.com/couchbase/sync_gateway/db/crud.go
+++ b/src/github.com/couchbase/sync_gateway/db/crud.go
@@ -548,30 +548,33 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 		// The server TAP/DCP feed will deduplicate multiple revisions for the same doc if they occur in
 		// the same mutation queue processing window. This results in missing sequences on the change listener.
 		// To account for this, we track the recent sequence numbers for the document.
-		if doc.RecentSequences != nil {
-			// Prune existing recent sequences that are earlier than the nextSequence.  The dedup window
-			// on the feed is small - typically sub-second, so we usually shouldn't care about more than
-			// 5 recent sequences.
-			if len(doc.RecentSequences) > 5 {
-				count := 0
-				for _, seq := range doc.RecentSequences {
-					// Only remove sequences if they are higher than a sequence that's been seen on the
-					// feed. This is valid across SG nodes (which could each have a different nextSequence),
-					// as the deduplication is consistent across feeds, so those feeds will eventually get
-					// the same events this node has already seen.
-					if seq < db.changeCache.nextSequence {
-						count++
-					} else {
-						break
-					}
-				}
-				if count > 0 {
-					doc.RecentSequences = doc.RecentSequences[count:]
-				}
-			}
-		} else {
+		if doc.RecentSequences == nil {
 			doc.RecentSequences = make([]uint64, 0, 1+len(unusedSequences))
 		}
+
+		if len(doc.RecentSequences) > 20 {
+			// Prune recent sequences that are earlier than the nextSequence.  The dedup window
+			// on the feed is small - sub-second, so we usually shouldn't care about more than
+			// a few recent sequences.  However, the pruning has some overhead (read lock on nextSequence),
+			// so we're allowing more 'recent sequences' on the doc (20) before attempting pruning
+			stableSequence := db.changeCache.getNextSequence() - 1
+			count := 0
+			for _, seq := range doc.RecentSequences {
+				// Only remove sequences if they are higher than a sequence that's been seen on the
+				// feed. This is valid across SG nodes (which could each have a different nextSequence),
+				// as the mutations that this node used to rev nextSequence will at some point be delivered
+				// to each node.
+				if seq < stableSequence {
+					count++
+				} else {
+					break
+				}
+			}
+			if count > 0 {
+				doc.RecentSequences = doc.RecentSequences[count:]
+			}
+		}
+
 		// Append current sequence and unused sequences to recent sequence history
 		doc.RecentSequences = append(doc.RecentSequences, unusedSequences...)
 		doc.RecentSequences = append(doc.RecentSequences, docSequence)

--- a/src/github.com/couchbase/sync_gateway/db/crud.go
+++ b/src/github.com/couchbase/sync_gateway/db/crud.go
@@ -24,6 +24,10 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 )
 
+const (
+	kMaxRecentSequences = 20 // Maximum number of sequences stored in RecentSequences before pruning is triggered
+)
+
 //////// READING DOCUMENTS:
 
 func realDocID(docid string) string {

--- a/src/github.com/couchbase/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/database_test.go
@@ -754,6 +754,61 @@ func TestIncrRetry(t *testing.T) {
 	seqAllocator, _ := newSequenceAllocator(leakyBucket)
 	err := seqAllocator.reserveSequences(1)
 	assert.True(t, err == nil)
+
+}
+
+func TestRecentSequenceHistory(t *testing.T) {
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+
+	// Validate recent sequence is written
+	body := Body{"val": "one"}
+	revid, err := db.Put("doc1", body)
+
+	assert.True(t, revid != "")
+	doc, err := db.GetDoc("doc1")
+	assert.True(t, err == nil)
+	assert.DeepEquals(t, doc.RecentSequences, []uint64{1})
+
+	// Add a few revisions - validate they are retained when less than max (5)
+	for i := 0; i < 3; i++ {
+		revid, err = db.Put("doc1", body)
+	}
+
+	doc, err = db.GetDoc("doc1")
+	assert.True(t, err == nil)
+	assert.DeepEquals(t, doc.RecentSequences, []uint64{1, 2, 3, 4})
+
+	// Add many sequences to validate pruning when past max (20)
+	for i := 0; i < 20; i++ {
+		revid, err = db.Put("doc1", body)
+		// Sleep needed to ensure consistent results when running single-threaded vs. multi-threaded test:
+		// without it we can't predict the relative update times of nextSequence and RecentSequences
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	db.changeCache.waitForSequence(24)
+	time.Sleep(50 * time.Millisecond)
+	revid, err = db.Put("doc1", body)
+	doc, err = db.GetDoc("doc1")
+	assert.True(t, err == nil)
+	assert.DeepEquals(t, doc.RecentSequences, []uint64{21, 22, 23, 24, 25})
+
+	// Ensure pruning works when sequences aren't sequential
+	doc2Body := Body{"val": "two"}
+	for i := 0; i < 20; i++ {
+		revid, err = db.Put("doc1", body)
+		revid, err = db.Put("doc2", doc2Body)
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	db.changeCache.waitForSequence(14)
+	time.Sleep(50 * time.Millisecond)
+	revid, err = db.Put("doc1", body)
+	doc, err = db.GetDoc("doc1")
+	assert.True(t, err == nil)
+	assert.DeepEquals(t, doc.RecentSequences, []uint64{58, 60, 62, 64, 66})
+
 }
 
 //////// BENCHMARKS

--- a/src/github.com/couchbase/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/database_test.go
@@ -780,7 +780,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 	assert.DeepEquals(t, doc.RecentSequences, []uint64{1, 2, 3, 4})
 
 	// Add many sequences to validate pruning when past max (20)
-	for i := 0; i < 20; i++ {
+	for i := 0; i < kMaxRecentSequences; i++ {
 		revid, err = db.Put("doc1", body)
 		// Sleep needed to ensure consistent results when running single-threaded vs. multi-threaded test:
 		// without it we can't predict the relative update times of nextSequence and RecentSequences
@@ -796,7 +796,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 
 	// Ensure pruning works when sequences aren't sequential
 	doc2Body := Body{"val": "two"}
-	for i := 0; i < 20; i++ {
+	for i := 0; i < kMaxRecentSequences; i++ {
 		revid, err = db.Put("doc1", body)
 		revid, err = db.Put("doc2", doc2Body)
 		time.Sleep(1 * time.Millisecond)

--- a/src/github.com/couchbase/sync_gateway/db/document.go
+++ b/src/github.com/couchbase/sync_gateway/db/document.go
@@ -27,6 +27,7 @@ type syncData struct {
 	Flags           uint8               `json:"flags,omitempty"`
 	Sequence        uint64              `json:"sequence"`
 	UnusedSequences []uint64            `json:"unused_sequences,omitempty"`
+	RecentSequences []uint64            `json:"recent_sequences,omitempty"`
 	History         RevTree             `json:"history"`
 	Channels        channels.ChannelMap `json:"channels,omitempty"`
 	Access          UserAccessMap       `json:"access,omitempty"`

--- a/src/github.com/couchbase/sync_gateway/db/document.go
+++ b/src/github.com/couchbase/sync_gateway/db/document.go
@@ -26,8 +26,8 @@ type syncData struct {
 	NewestRev       string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
 	Flags           uint8               `json:"flags,omitempty"`
 	Sequence        uint64              `json:"sequence"`
-	UnusedSequences []uint64            `json:"unused_sequences,omitempty"`
-	RecentSequences []uint64            `json:"recent_sequences,omitempty"`
+	UnusedSequences []uint64            `json:"unused_sequences,omitempty"` // unused due to update conflicts
+	RecentSequences []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
 	History         RevTree             `json:"history"`
 	Channels        channels.ChannelMap `json:"channels,omitempty"`
 	Access          UserAccessMap       `json:"access,omitempty"`


### PR DESCRIPTION
Write recent sequences to _sync metadata, to handle the case where the TAP or DCP feed deduplicates rapid multiple updates to the same doc.
