### PR TITLE
Add tap de-duplication functionality to leaky bucket, make configurable

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/leaky_bucket.go
+++ b/src/github.com/couchbase/sync_gateway/base/leaky_bucket.go
@@ -3,6 +3,8 @@ package base
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/couchbaselabs/walrus"
 )
 
@@ -10,14 +12,30 @@ const (
 	maxIncrFailures = 2
 )
 
-// A wrapper around a Bucket to support forced errors.  For testing use only
+// A wrapper around a Bucket to support forced errors.  For testing use only.
 type LeakyBucket struct {
 	bucket    Bucket
 	incrCount uint16
+	config    LeakyBucketConfig
 }
 
-func NewLeakyBucket(bucket Bucket) Bucket {
-	return &LeakyBucket{bucket: bucket}
+// The config object that controls the LeakyBucket behavior
+type LeakyBucketConfig struct {
+
+	// Incr() fails 3 times before finally succeeding
+	IncrTemporaryFail bool
+
+	// Emulate TAP/DCP feed de-dupliation behavior, such that within a
+	// window of # of mutations or a timeout, mutations for a given document
+	// will be filtered such that only the _latest_ mutation will make it through.
+	TapFeedDeDupliation bool
+}
+
+func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
+	return &LeakyBucket{
+		bucket: bucket,
+		config: config,
+	}
 }
 func (b *LeakyBucket) GetName() string {
 	return b.bucket.GetName()
@@ -57,11 +75,14 @@ func (b *LeakyBucket) WriteUpdate(k string, exp int, callback walrus.WriteUpdate
 }
 func (b *LeakyBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {
 
-	if b.incrCount < maxIncrFailures {
-		b.incrCount++
-		return 0, errors.New(fmt.Sprintf("Incr forced fail (%d/%d), try again maybe?", b.incrCount, maxIncrFailures))
+	if b.config.IncrTemporaryFail {
+		if b.incrCount < maxIncrFailures {
+			b.incrCount++
+			return 0, errors.New(fmt.Sprintf("Incr forced fail (%d/%d), try again maybe?", b.incrCount, maxIncrFailures))
+		}
+		b.incrCount = 0
+
 	}
-	b.incrCount = 0
 	return b.bucket.Incr(k, amt, def, exp)
 }
 
@@ -80,9 +101,81 @@ func (b *LeakyBucket) View(ddoc, name string, params map[string]interface{}) (wa
 func (b *LeakyBucket) ViewCustom(ddoc, name string, params map[string]interface{}, vres interface{}) error {
 	return b.bucket.ViewCustom(ddoc, name, params, vres)
 }
+
 func (b *LeakyBucket) StartTapFeed(args walrus.TapArguments) (walrus.TapFeed, error) {
-	return b.bucket.StartTapFeed(args)
+
+	if !b.config.TapFeedDeDupliation {
+		return b.bucket.StartTapFeed(args)
+	}
+
+	// create an output channel
+	// start a goroutine which reads off the walrus tap feed
+	//   - de-duplicate certain events
+	//   - puts them to output channel
+
+	// the number of changes that it will buffer up before de-duplicating
+	deDuplicationWindowSize := 5
+
+	// the timeout window in milliseconds after which it will flush to output, even if
+	// the dedupe buffer has not filled up yet.
+	deDuplicationTimeoutMs := time.Millisecond * 1000
+
+	// kick off the wrapped walrus tap feed
+	walrusTapFeed, err := b.bucket.StartTapFeed(args)
+	if err != nil {
+		return walrusTapFeed, err
+	}
+
+	// create an output channel for de-duplicated events
+	channel := make(chan walrus.TapEvent, 10)
+
+	// this is the walrus.TapFeed impl we'll return to callers, which
+	// will reead from the de-duplicated events channel
+	dupeTapFeed := &deDuplicatorTapFeedImpl{
+		channel:        channel,
+		wrappedTapFeed: walrusTapFeed,
+	}
+
+	go func() {
+
+		// the buffer to hold tap events that are candidates for de-duplication
+		deDupeBuffer := []walrus.TapEvent{}
+
+		for {
+			select {
+			case tapEvent, ok := <-walrusTapFeed.Events():
+				if !ok {
+					// channel closed, goroutine is done
+					// dedupe and send what we currently have
+					dedupeAndForward(deDupeBuffer, channel)
+					deDupeBuffer = []walrus.TapEvent{}
+					return
+				}
+				deDupeBuffer = append(deDupeBuffer, tapEvent)
+
+				// if we've collected enough, dedeupe and send what we have,
+				// and reset buffer.
+				if len(deDupeBuffer) >= deDuplicationWindowSize {
+					dedupeAndForward(deDupeBuffer, channel)
+					deDupeBuffer = []walrus.TapEvent{}
+				}
+
+			case <-time.After(deDuplicationTimeoutMs):
+
+				// give up on waiting for the buffer to fill up,
+				// de-dupe and send what we currently have
+				dedupeAndForward(deDupeBuffer, channel)
+				deDupeBuffer = []walrus.TapEvent{}
+
+			}
+		}
+
+	}()
+
+	return dupeTapFeed, nil
+
 }
+
 func (b *LeakyBucket) Close() {
 	b.bucket.Close()
 }
@@ -91,4 +184,60 @@ func (b *LeakyBucket) Dump() {
 }
 func (b *LeakyBucket) VBHash(docID string) uint32 {
 	return b.bucket.VBHash(docID)
+}
+
+// An implementation of a walrus tap feed that wraps and de-duplicates
+// tap events on the upstream tap feed to better emulate real world
+// TAP/DCP behavior.
+type deDuplicatorTapFeedImpl struct {
+	channel        chan walrus.TapEvent
+	wrappedTapFeed walrus.TapFeed
+}
+
+func (feed *deDuplicatorTapFeedImpl) Close() error {
+	return feed.wrappedTapFeed.Close()
+}
+
+func (feed *deDuplicatorTapFeedImpl) Events() <-chan walrus.TapEvent {
+	return feed.channel
+}
+
+func dedupeAndForward(tapEvents []walrus.TapEvent, destChannel chan<- walrus.TapEvent) {
+
+	deduped := dedupeTapEvents(tapEvents)
+
+	for _, tapEvent := range deduped {
+		destChannel <- tapEvent
+	}
+
+}
+
+func dedupeTapEvents(tapEvents []walrus.TapEvent) []walrus.TapEvent {
+
+	// For each document key, keep track of the latest seen tapEvent
+	// doc1 -> tapEvent with Seq=1
+	// doc2 -> tapEvent with Seq=5
+	// (if tapEvent with Seq=7 comes in for doc1, it will clobber existing)
+	latestTapEventPerKey := map[string]walrus.TapEvent{}
+
+	for _, tapEvent := range tapEvents {
+		key := string(tapEvent.Key)
+		latestTapEventPerKey[key] = tapEvent
+	}
+
+	// Iterate over the original tapEvents, and only keep what
+	// is in latestTapEventPerKey, and discard all previous mutations
+	// of that doc.  This will preserve the original
+	// sequence order as read off the feed.
+	deduped := []walrus.TapEvent{}
+	for _, tapEvent := range tapEvents {
+		key := string(tapEvent.Key)
+		latestTapEventForKey := latestTapEventPerKey[key]
+		if tapEvent.Sequence == latestTapEventForKey.Sequence {
+			deduped = append(deduped, tapEvent)
+		}
+	}
+
+	return deduped
+
 }

--- a/src/github.com/couchbase/sync_gateway/base/leaky_bucket_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/leaky_bucket_test.go
@@ -1,0 +1,60 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+	"github.com/couchbaselabs/walrus"
+)
+
+func TestDedupeTapEventsLaterSeqSameDoc(t *testing.T) {
+
+	tapEvents := []walrus.TapEvent{
+		walrus.TapEvent{
+			Opcode:   walrus.TapMutation,
+			Key:      []byte("doc1"),
+			Value:    []byte(`".."`),
+			Sequence: 1,
+		},
+		walrus.TapEvent{
+			Opcode:   walrus.TapMutation,
+			Key:      []byte("doc1"),
+			Value:    []byte(`".."`),
+			Sequence: 2,
+		},
+	}
+
+	deduped := dedupeTapEvents(tapEvents)
+
+	// make sure that one was deduped
+	assert.Equals(t, len(deduped), 1)
+
+	// make sure the earlier event was deduped
+	dedupedEvent := deduped[0]
+	assert.True(t, dedupedEvent.Sequence == 2)
+
+}
+
+func TestDedupeNoDedupeDifferentDocs(t *testing.T) {
+
+	tapEvents := []walrus.TapEvent{
+		walrus.TapEvent{
+			Opcode:   walrus.TapMutation,
+			Key:      []byte("doc1"),
+			Value:    []byte(`".."`),
+			Sequence: 1,
+		},
+		walrus.TapEvent{
+			Opcode:   walrus.TapMutation,
+			Key:      []byte("doc2"),
+			Value:    []byte(`".."`),
+			Sequence: 2,
+		},
+	}
+
+	deduped := dedupeTapEvents(tapEvents)
+
+	// make sure that nothing was deduped
+	assert.True(t, len(deduped) == 2)
+
+}

--- a/src/github.com/couchbase/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/database_test.go
@@ -43,9 +43,9 @@ func testBucket() base.Bucket {
 	return bucket
 }
 
-func testLeakyBucket() base.Bucket {
+func testLeakyBucket(config base.LeakyBucketConfig) base.Bucket {
 	testBucket := testBucket()
-	leakyBucket := base.NewLeakyBucket(testBucket)
+	leakyBucket := base.NewLeakyBucket(testBucket, config)
 	return leakyBucket
 }
 
@@ -749,7 +749,10 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 }
 
 func TestIncrRetry(t *testing.T) {
-	leakyBucket := testLeakyBucket()
+	leakyBucketConfig := base.LeakyBucketConfig{
+		IncrTemporaryFail: true,
+	}
+	leakyBucket := testLeakyBucket(leakyBucketConfig)
 	defer leakyBucket.Close()
 	seqAllocator, _ := newSequenceAllocator(leakyBucket)
 	err := seqAllocator.reserveSequences(1)


### PR DESCRIPTION
The tap de-dupe will be useful for creating an enhanced unit test for Issue #775.  See https://github.com/couchbase/sync_gateway/pull/798

@adamcfraser I'm assigning to you, but wait a day or two in case I push more commits (I just wanted to send a PR now so we don't completely forget about these changes)
