### PR TITLE
Avoid errors when user is deleted during changes processing

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -40,6 +41,7 @@ type ChangeEntry struct {
 	Removed  base.Set    `json:"removed,omitempty"`
 	Doc      Body        `json:"doc,omitempty"`
 	Changes  []ChangeRev `json:"changes"`
+	Err      error       `json:"err,omitempty"` // Used to notify feed consumer of errors
 	branched bool
 }
 
@@ -141,6 +143,14 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) C
 	}
 	if logEntry.Flags&channels.Removed != 0 {
 		change.Removed = channels.SetOf(channelName)
+	}
+	return change
+}
+
+func makeErrorEntry(message string) ChangeEntry {
+
+	change := ChangeEntry{
+		Err: errors.New(message),
 	}
 	return change
 }
@@ -396,10 +406,16 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 			// Before checking again, update the User object in case its channel access has
 			// changed while waiting:
 			if newCount := changeWaiter.CurrentUserCount(); newCount > userChangeCount {
-				base.LogTo("Changes+", "MultiChangesFeed reloading user %q", db.user.Name())
+				base.LogTo("Changes+", "MultiChangesFeed reloading user %+v", db.user)
 				userChangeCount = newCount
+				isAdmin := db.user == nil
 				if err := db.ReloadUser(); err != nil {
 					base.Warn("Error reloading user %q: %v", db.user.Name(), err)
+					if !isAdmin {
+						change := makeErrorEntry("User not found during reload - terminating changes feed")
+						base.LogTo("Changes+", "User not found during reload - terminating changes feed with entry %+v", change)
+						output <- &change
+					}
 					return
 				}
 			}

--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -41,7 +41,7 @@ type ChangeEntry struct {
 	Removed  base.Set    `json:"removed,omitempty"`
 	Doc      Body        `json:"doc,omitempty"`
 	Changes  []ChangeRev `json:"changes"`
-	Err      error       `json:"err,omitempty"` // Used to notify feed consumer of errors
+	Err      error       // Used to notify feed consumer of errors
 	branched bool
 }
 

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"expvar"
 	"fmt"
 	"net/http"
@@ -157,10 +158,15 @@ func (db *Database) ReloadUser() error {
 		return nil
 	}
 	user, err := db.Authenticator().GetUser(db.user.Name())
-	if err == nil {
-		db.user = user
+	if err != nil {
+		return err
 	}
-	return err
+	if user == nil {
+		return errors.New("User not found during reload")
+	} else {
+		db.user = user
+		return nil
+	}
 }
 
 //////// ALL DOCUMENTS:

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
@@ -103,7 +103,7 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 
 	rt := restTester{syncFn: `function(doc) {channel(doc.channel); if(doc.type == "setaccess") { access(doc.owner, doc.channel);}}`}
 
-	response := rt.sendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Changes":true, "HTTP":true}`)
+	response := rt.sendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Changes":true, "Cache":true, "HTTP":true}`)
 
 	response = rt.sendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["foo"]}`)
 	assertStatus(t, response, 201)

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
@@ -130,6 +130,8 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 		}
 	}()
 
+	// TODO: sleep required to ensure the changes feed iteration starts before the delete gets processed.
+	time.Sleep(100 * time.Millisecond)
 	rt.sendAdminRequest("PUT", "/db/bernard_doc1", `{"type":"setaccess", "owner":"bernard","channel":"foo"}`)
 	rt.sendAdminRequest("DELETE", "/db/_user/bernard", "")
 	rt.sendAdminRequest("PUT", "/db/manny_doc1", `{"type":"setaccess", "owner":"manny","channel":"bar"}`)

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -183,6 +183,9 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 					break loop // end of feed
 				}
 				if nil != entry {
+					if entry.Err != nil {
+						break loop // error returned by feed - end changes
+					}
 					if first {
 						first = false
 					} else {
@@ -269,6 +272,8 @@ loop:
 				feed = nil
 			} else if entry == nil {
 				err = send(nil)
+			} else if entry.Err != nil {
+				break loop // error returned by feed - end changes
 			} else {
 				entries := []*db.ChangeEntry{entry}
 				waiting := false
@@ -283,6 +288,8 @@ loop:
 						} else if entry == nil {
 							waiting = true
 							break collect
+						} else if entry.Err != nil {
+							break loop // error returned by feed - end changes
 						}
 						entries = append(entries, entry)
 					default:


### PR DESCRIPTION
When a user with an active continuous or longpoll _changes feed is deleted through the admin API, the changes feed will now be closed.  This was previously causing a panic when the user record was reloaded during changes processing.  Closing of feed is communicated back to the handler by a new error property on the ChangesEntry.

Fixes #809.
