### PR TITLE
Feature/issue 708

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/constants.go
+++ b/src/github.com/couchbase/sync_gateway/base/constants.go
@@ -1,0 +1,7 @@
+package base
+
+const (
+
+	// The username of the special "GUEST" user
+	GuestUsername = "GUEST"
+)

--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -40,6 +41,7 @@ type ChangeEntry struct {
 	Removed  base.Set    `json:"removed,omitempty"`
 	Doc      Body        `json:"doc,omitempty"`
 	Changes  []ChangeRev `json:"changes"`
+	Err      error       `json:"err,omitempty"` // Used to notify feed consumer of errors
 	branched bool
 }
 
@@ -141,6 +143,14 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) C
 	}
 	if logEntry.Flags&channels.Removed != 0 {
 		change.Removed = channels.SetOf(channelName)
+	}
+	return change
+}
+
+func makeErrorEntry(message string) ChangeEntry {
+
+	change := ChangeEntry{
+		Err: errors.New(message),
 	}
 	return change
 }
@@ -396,10 +406,16 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 			// Before checking again, update the User object in case its channel access has
 			// changed while waiting:
 			if newCount := changeWaiter.CurrentUserCount(); newCount > userChangeCount {
-				base.LogTo("Changes+", "MultiChangesFeed reloading user %q", db.user.Name())
+				base.LogTo("Changes+", "MultiChangesFeed reloading user %+v", db.user)
 				userChangeCount = newCount
+				isAdmin := db.user == nil
 				if err := db.ReloadUser(); err != nil {
 					base.Warn("Error reloading user %q: %v", db.user.Name(), err)
+					if !isAdmin {
+						change := makeErrorEntry("User not found during reload - terminating changes feed")
+						base.LogTo("Changes+", "User not found during reload - terminating changes feed with entry %+v", change)
+						output <- &change
+					}
 					return
 				}
 			}

--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -41,7 +41,7 @@ type ChangeEntry struct {
 	Removed  base.Set    `json:"removed,omitempty"`
 	Doc      Body        `json:"doc,omitempty"`
 	Changes  []ChangeRev `json:"changes"`
-	Err      error       `json:"err,omitempty"` // Used to notify feed consumer of errors
+	Err      error       // Used to notify feed consumer of errors
 	branched bool
 }
 

--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -290,7 +290,7 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 				if options.Since.Before(userSeq) {
 					name := db.user.Name()
 					if name == "" {
-						name = "GUEST"
+						name = base.GuestUsername
 					}
 					entry := ChangeEntry{
 						Seq:     userSeq,

--- a/src/github.com/couchbase/sync_gateway/db/crud.go
+++ b/src/github.com/couchbase/sync_gateway/db/crud.go
@@ -639,7 +639,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, callback func(*doc
 		}
 
 		// Prune old revision history to limit the number of revisions:
-		if pruned := doc.History.pruneRevisions(db.RevsLimit); pruned > 0 {
+		if pruned := doc.History.pruneRevisions(db.RevsLimit, doc.CurrentRev); pruned > 0 {
 			base.LogTo("CRUD+", "updateDoc(%q): Pruned %d old revisions", docid, pruned)
 		}
 

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"expvar"
 	"fmt"
 	"net/http"
@@ -157,10 +158,15 @@ func (db *Database) ReloadUser() error {
 		return nil
 	}
 	user, err := db.Authenticator().GetUser(db.user.Name())
-	if err == nil {
-		db.user = user
+	if err != nil {
+		return err
 	}
-	return err
+	if user == nil {
+		return errors.New("User not found during reload")
+	} else {
+		db.user = user
+		return nil
+	}
 }
 
 //////// ALL DOCUMENTS:

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api.go
@@ -94,7 +94,7 @@ func (h *handler) handleSetLogging() error {
 //////// USERS & ROLES:
 
 func internalUserName(name string) string {
-	if name == "GUEST" {
+	if name == base.GuestUsername {
 		return ""
 	}
 	return name
@@ -102,7 +102,7 @@ func internalUserName(name string) string {
 
 func externalUserName(name string) string {
 	if name == "" {
-		return "GUEST"
+		return base.GuestUsername
 	}
 	return name
 }

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
@@ -103,7 +103,7 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 
 	rt := restTester{syncFn: `function(doc) {channel(doc.channel); if(doc.type == "setaccess") { access(doc.owner, doc.channel);}}`}
 
-	response := rt.sendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Changes":true, "HTTP":true}`)
+	response := rt.sendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Changes":true, "Cache":true, "HTTP":true}`)
 
 	response = rt.sendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["foo"]}`)
 	assertStatus(t, response, 201)

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
@@ -130,6 +130,8 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 		}
 	}()
 
+	// TODO: sleep required to ensure the changes feed iteration starts before the delete gets processed.
+	time.Sleep(100 * time.Millisecond)
 	rt.sendAdminRequest("PUT", "/db/bernard_doc1", `{"type":"setaccess", "owner":"bernard","channel":"foo"}`)
 	rt.sendAdminRequest("DELETE", "/db/_user/bernard", "")
 	rt.sendAdminRequest("PUT", "/db/manny_doc1", `{"type":"setaccess", "owner":"manny","channel":"bar"}`)

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/auth"
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
@@ -211,22 +212,25 @@ func TestRoleAPI(t *testing.T) {
 }
 
 func TestGuestUser(t *testing.T) {
+
+	guestUserEndpoint := fmt.Sprintf("/db/_user/%s", base.GuestUsername)
+
 	rt := restTester{noAdminParty: true}
-	response := rt.sendAdminRequest("GET", "/db/_user/GUEST", "")
+	response := rt.sendAdminRequest("GET", guestUserEndpoint, "")
 	assertStatus(t, response, 200)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "GUEST")
+	assert.Equals(t, body["name"], base.GuestUsername)
 	// This ain't no admin-party, this ain't no nightclub, this ain't no fooling around:
 	assert.DeepEquals(t, body["admin_channels"], nil)
 
-	response = rt.sendAdminRequest("PUT", "/db/_user/GUEST", `{"disabled":true}`)
+	response = rt.sendAdminRequest("PUT", guestUserEndpoint, `{"disabled":true}`)
 	assertStatus(t, response, 200)
 
-	response = rt.sendAdminRequest("GET", "/db/_user/GUEST", "")
+	response = rt.sendAdminRequest("GET", guestUserEndpoint, "")
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "GUEST")
+	assert.Equals(t, body["name"], base.GuestUsername)
 	assert.DeepEquals(t, body["disabled"], true)
 
 	// Check that the actual User object is correct:

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -183,6 +183,9 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 					break loop // end of feed
 				}
 				if nil != entry {
+					if entry.Err != nil {
+						break loop // error returned by feed - end changes
+					}
 					if first {
 						first = false
 					} else {
@@ -269,6 +272,8 @@ loop:
 				feed = nil
 			} else if entry == nil {
 				err = send(nil)
+			} else if entry.Err != nil {
+				break loop // error returned by feed - end changes
 			} else {
 				entries := []*db.ChangeEntry{entry}
 				waiting := false
@@ -283,6 +288,8 @@ loop:
 						} else if entry == nil {
 							waiting = true
 							break collect
+						} else if entry.Err != nil {
+							break loop // error returned by feed - end changes
 						}
 						entries = append(entries, entry)
 					default:

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -27,21 +27,23 @@ import (
 // Register profiling handlers (see Go docs)
 import _ "net/http/pprof"
 
-var DefaultInterface = ":4984"
+var DefaultInterface = "127.0.0.1:4984"      // Only accessible on localhost!
 var DefaultAdminInterface = "127.0.0.1:4985" // Only accessible on localhost!
 var DefaultServer = "walrus:"
 var DefaultPool = "default"
 
 var config *ServerConfig
 
-const DefaultMaxCouchbaseConnections = 16
-const DefaultMaxCouchbaseOverflowConnections = 0
+const (
+	DefaultMaxCouchbaseConnections         = 16
+	DefaultMaxCouchbaseOverflowConnections = 0
 
-// Default value of ServerConfig.MaxIncomingConnections
-const DefaultMaxIncomingConnections = 0
+	// Default value of ServerConfig.MaxIncomingConnections
+	DefaultMaxIncomingConnections = 0
 
-// Default value of ServerConfig.MaxFileDescriptors
-const DefaultMaxFileDescriptors uint64 = 5000
+	// Default value of ServerConfig.MaxFileDescriptors
+	DefaultMaxFileDescriptors uint64 = 5000
+)
 
 // JSON object that defines the server configuration.
 type ServerConfig struct {
@@ -388,6 +390,12 @@ func ParseCommandLine() {
 					Server: couchbaseURL,
 					Bucket: bucketName,
 					Pool:   poolName,
+					Users: map[string]*db.PrincipalConfig{
+						base.GuestUsername: &db.PrincipalConfig{
+							Disabled:         false,
+							ExplicitChannels: base.SetFromArray([]string{"*"}),
+						},
+					},
 				},
 			},
 		}

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -389,7 +389,7 @@ func (sc *ServerContext) RemoveDatabase(dbName string) bool {
 
 func (sc *ServerContext) installPrincipals(context *db.DatabaseContext, spec map[string]*db.PrincipalConfig, what string) error {
 	for name, princ := range spec {
-		isGuest := name == "GUEST"
+		isGuest := name == base.GuestUsername
 		if isGuest {
 			internalName := ""
 			princ.Name = &internalName

--- a/src/github.com/couchbase/sync_gateway/rest/session_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/session_api.go
@@ -181,7 +181,7 @@ func (h *handler) createUserSession() error {
 	err := h.readJSONInto(&params)
 	if err != nil {
 		return err
-	} else if params.Name == "" || params.Name == "GUEST" || !auth.IsValidPrincipalName(params.Name) {
+	} else if params.Name == "" || params.Name == base.GuestUsername || !auth.IsValidPrincipalName(params.Name) {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid or missing user name")
 	} else if user, err := h.db.Authenticator().GetUser(params.Name); user == nil {
 		if err == nil {


### PR DESCRIPTION
Fix for #708.

Verified manually via:

Start SG

```
$ ./build.sh && ./run.sh &
```

Create a doc as guest user

```
$ curl -X POST -H "Content-Type: application/json" -d '{"foo":"bar"}' localhost:4984/sync_gateway/
{"id":"509993e708c616d42406a87456cb9678","ok":true,"rev":"1-cd809becc169215072fd567eebd8b8de"}
```

View changes feed as guest user

```
$ curl localhost:4985/sync_gateway/_changes
{"results":[
{"seq":1,"id":"_user/","changes":[{"rev":""}],}
,{"seq":2,"id":"509993e708c616d42406a87456cb9678","changes":[{"rev":"1-cd809becc169215072fd567eebd8b8de"}]}
],
"last_seq":"2"}
```
