### PR TITLE
Setting timeout=0 for webhook disables timeout

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -128,10 +128,10 @@ type EventHandlerConfig struct {
 }
 
 type EventConfig struct {
-	HandlerType string `json:"handler"`           // Handler type
-	Url         string `json:"url,omitempty"`     // Url (webhook)
-	Filter      string `json:"filter,omitempty"`  // Filter function (webhook)
-	Timeout     uint64 `json:"timeout,omitempty"` // Timeout (webhook)
+	HandlerType string  `json:"handler"`           // Handler type
+	Url         string  `json:"url,omitempty"`     // Url (webhook)
+	Filter      string  `json:"filter,omitempty"`  // Filter function (webhook)
+	Timeout     *uint64 `json:"timeout,omitempty"` // Timeout (webhook)
 }
 
 type CacheConfig struct {


### PR DESCRIPTION
Also includes a fix to close the HTTP response to ensure connections aren't left open.

Fixes #773.
