### PR TITLE
Add event type validation during config processing

### DIFF
--- a/examples/events_webhook.json
+++ b/examples/events_webhook.json
@@ -1,0 +1,30 @@
+{
+   "log":["CRUD+","Events+"],
+   "databases": {
+      "db": {
+        "server": "walrus:",
+        "event_handlers": {
+          "max_processes" : 500,
+          "wait_for_process" : "100",
+          "document_changed": [
+            {"handler": "webhook",
+             "url": "http://localhost:8081/my_webhook_target",
+             "timeout": 0,
+             "filter": `function(doc) {
+                  if (doc._id.indexOf('webhooktest') >= 0) {
+                    return true;
+                  }
+                  return false;
+                }`
+            }
+          ]
+        }
+      }
+    }
+}
+
+
+
+
+
+

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -87,7 +87,7 @@ type DbConfig struct {
 	RevsLimit          *uint32                        `json:"revs_limit,omitempty"`           // Max depth a document's revision tree can grow to
 	ImportDocs         interface{}                    `json:"import_docs,omitempty"`          // false, true, or "continuous"
 	Shadow             *ShadowConfig                  `json:"shadow,omitempty"`               // External bucket to shadow
-	EventHandlers      *EventHandlerConfig            `json:"event_handlers,omitempty"`       // Event handlers (webhook)
+	EventHandlers      interface{}                    `json:"event_handlers,omitempty"`       // Event handlers (webhook)
 	FeedType           string                         `json:"feed_type,omitempty"`            // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
 	AllowEmptyPassword bool                           `json:"allow_empty_password,omitempty"` // Allow empty passwords?  Defaults to false
 	CacheConfig        *CacheConfig                   `json:"cache,omitempty"`                // Cache settings


### PR DESCRIPTION
Sync Gateway throws an error if an unsupported event type is defined in the config.  Stop-gap until we get full JSON schema validation for the config.
