### PR TITLE
Reuse client/transport for webhook posts to the same URL

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/event_manager_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/event_manager_test.go
@@ -275,7 +275,7 @@ func InitWebhookTest() (*int, *float64, *[][]byte) {
 	return &counter, &sum, &payloads
 }
 
-func TestWebhook(t *testing.T) {
+func TestWebhookBasic(t *testing.T) {
 
 	if !testLiveHTTP {
 		return


### PR DESCRIPTION
Previously we were instantiating a new http.Client for each request.  We should get better performance (and reuse of connections) by sharing the same http.Client for multiple calls.
