### PR TITLE
For the 1.1 release, pass through view queries are not supported on port 4984.

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/design_doc.go
+++ b/src/github.com/couchbase/sync_gateway/db/design_doc.go
@@ -4,9 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
-	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbaselabs/walrus"
 )
 
@@ -54,27 +52,9 @@ func (db *Database) PutDesignDoc(ddocName string, ddoc DesignDoc) (err error) {
 	                      return;
 	                    if ((sync.flags & 1) || sync.deleted)
 	                      return;
-	                    var channels = [];
-	                    var channelMap = sync.channels;
-						if (channelMap) {
-							for (var name in channelMap) {
-								removed = channelMap[name];
-								if (!removed)
-									channels.push(name);
-							}
-						}
 	                    delete doc.sync;
 	                    meta.rev = sync.rev;
-	                    meta.channels = channels;
-
-	                    var _emit = emit;
-	                    (function(){
-		                    var emit = function(key,value) {
-		                    	_emit(key,[channels, value]);
-		                    };
-							(` + view.Map + `) (doc, meta);
-						}());
-					}`
+						(` + view.Map + `) (doc, meta); }`
 		ddoc.Views[name] = view // view is not a pointer, so have to copy it back
 	}
 
@@ -91,69 +71,25 @@ func (db *Database) DeleteDesignDoc(ddocName string) (err error) {
 	return
 }
 
-func (db *Database) QueryDesignDoc(ddocName string, viewName string, options map[string]interface{}) (*walrus.ViewResult, error) {
+func (db *Database) QueryDesignDoc(ddocName string, viewName string, options map[string]interface{}) (result walrus.ViewResult, err error) {
 	// Query has slightly different access control than checkDDocAccess():
 	// * Admins can query any design doc including the internal ones
 	// * Regular users can query non-internal design docs
-	if db.user != nil && isInternalDDoc(ddocName) {
-		return nil, base.HTTPErrorf(http.StatusForbidden, "forbidden")
+	//NOTE: Restricting query access to admins until we implement proper result-set filtering.
+	if db.user != nil /*&& isInternalDDoc(ddocName)*/ {
+		err = base.HTTPErrorf(http.StatusForbidden, "forbidden")
+		return
 	}
-
-	result, err := db.Bucket.View(ddocName, viewName, options)
-	if err != nil {
-		return nil, err
-	}
-	if isInternalDDoc(ddocName) {
-		if options["include_docs"] == true {
+	result, err = db.Bucket.View(ddocName, viewName, options)
+	if err == nil {
+		if includeDocs := options["include_docs"]; includeDocs == true {
+			// Stripg "_sync" properties from doc bodies:
 			for _, row := range result.Rows {
-				stripSyncProperty(row)
+				if doc := row.Doc; doc != nil {
+					delete((*doc).(map[string]interface{}), "_sync")
+				}
 			}
-		}
-	} else {
-		result = filterViewResult(result, db.user)
-	}
-	return &result, nil
-}
-
-// Cleans up the Value property, and removes rows that aren't visible to the current user
-func filterViewResult(input walrus.ViewResult, user auth.User) (result walrus.ViewResult) {
-	checkChannels := false
-	var visibleChannels ch.TimedSet
-	if user != nil {
-		visibleChannels = user.InheritedChannels()
-		checkChannels = !visibleChannels.Contains("*")
-	}
-	result.TotalRows = input.TotalRows
-	result.Rows = make([]*walrus.ViewRow, 0, len(input.Rows)/2)
-	for _, row := range input.Rows {
-		value := row.Value.([]interface{})
-		// value[0] is the array of channels; value[1] is the actual value
-		if !checkChannels || channelsIntersect(visibleChannels, value[0].([]interface{})) {
-			// Add this row:
-			stripSyncProperty(row)
-			result.Rows = append(result.Rows, &walrus.ViewRow{
-				Key:   row.Key,
-				Value: value[1],
-				ID:    row.ID,
-				Doc:   row.Doc,
-			})
 		}
 	}
 	return
-}
-
-// Is any item of channels found in visibleChannels?
-func channelsIntersect(visibleChannels ch.TimedSet, channels []interface{}) bool {
-	for _, channel := range channels {
-		if visibleChannels.Contains(channel.(string)) || channel == "*" {
-			return true
-		}
-	}
-	return false
-}
-
-func stripSyncProperty(row *walrus.ViewRow) {
-	if doc := row.Doc; doc != nil {
-		delete((*doc).(map[string]interface{}), "_sync")
-	}
 }


### PR DESCRIPTION
https://github.com/couchbase/sync_gateway/issues/862
