### PR TITLE
Remove \r from sync function strings as parsing will fail otherwise

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/util.go
+++ b/src/github.com/couchbase/sync_gateway/base/util.go
@@ -81,7 +81,8 @@ func ConvertBackQuotedStrings(data []byte) []byte {
 	// Find backquote-delimited strings and replace them:
 	return kBackquoteStringRegexp.ReplaceAllFunc(data, func(bytes []byte) []byte {
 		str := string(bytes)
-		// Escape newlines and double-quotes:
+		// Remove \r  and Escape newlines and double-quotes:
+		str = strings.Replace(str, "\r", "", -1)
 		str = strings.Replace(str, "\n", `\n`, -1)
 		str = strings.Replace(str, "\t", `\t`, -1)
 		str = strings.Replace(str, `"`, `\"`, -1)

--- a/src/github.com/couchbase/sync_gateway/base/util_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/util_test.go
@@ -48,4 +48,8 @@ func TestBackQuotedStrings(t *testing.T) {
 	input = "{\"foo\": `bar\n`, \"baz\": `howdy`}"
 	output = ConvertBackQuotedStrings([]byte(input))
 	assert.Equals(t, string(output), `{"foo": "bar\n", "baz": "howdy"}`)
+
+	input = "{\"foo\": `bar\r\n`, \"baz\": `\r\nhowdy`}"
+	output = ConvertBackQuotedStrings([]byte(input))
+	assert.Equals(t, string(output), `{"foo": "bar\n", "baz": "\nhowdy"}`)
 }


### PR DESCRIPTION
This is an issue for users writing SG config files on MS Windows, see #783 for an example.

Not sure how to unit test this, maybe this needs an integration test?
