### PR TITLE
Fix '_sync' property deletion from doc in design views

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/design_doc.go
+++ b/src/github.com/couchbase/sync_gateway/db/design_doc.go
@@ -63,7 +63,7 @@ func (db *Database) PutDesignDoc(ddocName string, ddoc DesignDoc) (err error) {
 									channels.push(name);
 							}
 						}
-	                    delete doc.sync;
+	                    delete doc._sync;
 	                    meta.rev = sync.rev;
 	                    meta.channels = channels;
 


### PR DESCRIPTION
Hi:

Without this change, the documents returned by the view include the _sync property.

Regards,
