### PR TITLE
No longer display an error on windows when setting MaxFileDescriptors

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/rlimit.go
+++ b/src/github.com/couchbase/sync_gateway/base/rlimit.go
@@ -17,5 +17,12 @@ func SetMaxFileDescriptors(maxFDs uint64) (uint64, error) {
 	}
 	limits.Cur = maxFDs
 	limits.Max = maxFDs
-	return maxFDs, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limits)
+
+	err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limits)
+
+	if err == nil {
+		Logf("Configured process to allow %d open file descriptors", maxFDs)
+	}
+
+	return maxFDs, err
 }

--- a/src/github.com/couchbase/sync_gateway/base/rlimit_windows.go
+++ b/src/github.com/couchbase/sync_gateway/base/rlimit_windows.go
@@ -1,7 +1,5 @@
 package base
 
-import "fmt"
-
 func SetMaxFileDescriptors(maxFDs uint64) (uint64, error) {
-	return 0, fmt.Errorf("Unsupported on Windows")
+	return 0, nil
 }

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -437,11 +437,9 @@ func setMaxFileDescriptors(maxP *uint64) {
 	if maxP != nil {
 		maxFDs = *maxP
 	}
-	actualMax, err := base.SetMaxFileDescriptors(maxFDs)
+	_ , err := base.SetMaxFileDescriptors(maxFDs)
 	if err != nil {
 		base.Warn("Error setting MaxFileDescriptors to %d: %v", maxFDs, err)
-	} else if maxP != nil && actualMax > 0 { //Windows no support for setting max file descriptors, returns 0 actualMax
-		base.Logf("Configured process to allow %d open file descriptors", actualMax)
 	}
 }
 

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -440,7 +440,7 @@ func setMaxFileDescriptors(maxP *uint64) {
 	actualMax, err := base.SetMaxFileDescriptors(maxFDs)
 	if err != nil {
 		base.Warn("Error setting MaxFileDescriptors to %d: %v", maxFDs, err)
-	} else if maxP != nil {
+	} else if maxP != nil && actualMax > 0 { //Windows no support for setting max file descriptors, returns 0 actualMax
 		base.Logf("Configured process to allow %d open file descriptors", actualMax)
 	}
 }


### PR DESCRIPTION
Fixes #792  

Also does not display a confirmation of setting MaxFileDescriptors on Windows
