### PR TITLE
Merge #880 to master (from 1.1.0)

### DIFF
--- a/src/github.com/couchbase/sync_gateway/auth/principal.go
+++ b/src/github.com/couchbase/sync_gateway/auth/principal.go
@@ -102,5 +102,9 @@ type User interface {
 	// to, annotated with the sequence number at which access was granted.
 	FilterToAvailableChannels(channels base.Set) ch.TimedSet
 
+	// Returns a Set containing channels that the user has access to, that aren't present in the
+	// input set
+	GetAddedChannels(channels ch.TimedSet) base.Set
+
 	setRolesSince(ch.TimedSet)
 }

--- a/src/github.com/couchbase/sync_gateway/auth/user.go
+++ b/src/github.com/couchbase/sync_gateway/auth/user.go
@@ -291,6 +291,17 @@ func (user *userImpl) FilterToAvailableChannels(channels base.Set) ch.TimedSet {
 	return output
 }
 
+func (user *userImpl) GetAddedChannels(channels ch.TimedSet) base.Set {
+	output := base.Set{}
+	for userChannel, _ := range user.InheritedChannels() {
+		_, found := channels[userChannel]
+		if !found {
+			output[userChannel] = struct{}{}
+		}
+	}
+	return output
+}
+
 //////// MARSHALING:
 
 // JSON encoding/decoding -- these functions are ugly hacks to work around the current


### PR DESCRIPTION
Already reviewed and merged on 1.1.0 - porting to master.

Under heavy access load, it's possible for the _changes feed to send the document that triggered an access grant before being notified that the user record has been updated and should be reloaded.  In this scenario backfill of the channel was being skipped.

This change forces a backfill of any new channels when the user gets reloaded - even if the seqAddedAt for that channel is earlier than the current since value.  This has the potential for duplicate entries being sent on the _changes feed if the client terminates mid-backfill, but these will get handled by revs diff.
