### PR TITLE
Added Heartbeat logging to enable debugging of hanging sessions

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -198,7 +198,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			case <-heartbeat:
 				_, err = h.response.Write([]byte("\n"))
 				h.flush()
-				base.LogTo("Changes", "sent heartbeat")
+				base.LogTo("Heartbeat", "sent _changes heartbeat to user [%s]",h.user.Name())
 			case <-timeout:
 				message = "OK (timeout)"
 				break loop
@@ -319,6 +319,7 @@ loop:
 			}
 		case <-heartbeat:
 			err = send(nil)
+			base.LogTo("Heartbeat", "sent _changes heartbeat to user [%s]",h.user.Name())
 		case <-timeout:
 			break loop
 		}

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -198,6 +198,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			case <-heartbeat:
 				_, err = h.response.Write([]byte("\n"))
 				h.flush()
+				base.LogTo("Changes", "sent heartbeat")
 			case <-timeout:
 				message = "OK (timeout)"
 				break loop


### PR DESCRIPTION
Fixes #898 

Added log entries when writing _changes heartbeats, uses custom "Heartbeat" channel to avoid flooding logs when "Changes" and "Changes+" channels are enabled
