### PR TITLE
Support for max heartbeat parameter in SG config

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api.go
@@ -78,7 +78,7 @@ func (h *handler) handleSetLogging() error {
 		return nil
 	}
 	if h.getQuery("level") != "" {
-		base.SetLogLevel(int(getRestrictedIntQuery(h.rq.URL.Query(), "level", uint64(base.LogLevel()), 1, 3)))
+		base.SetLogLevel(int(getRestrictedIntQuery(h.rq.URL.Query(), "level", uint64(base.LogLevel()), 1, 3, false)))
 		if len(body) == 0 {
 			return nil // empty body is OK if request is just setting the log level
 		}

--- a/src/github.com/couchbase/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api_test.go
@@ -815,9 +815,14 @@ func TestLogin(t *testing.T) {
 }
 
 func TestReadChangesOptionsFromJSON(t *testing.T) {
+
+	h := &handler{}
+	h.server = NewServerContext(&ServerConfig{})
+
+	// Basic case, no heartbeat, no timeout
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",
 				"include_docs": true, "filter": "Melitta", "channels": "ABC,BBC"}`
-	feed, options, filter, channelsArray, err := readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, err := h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, feed, "longpoll")
 
@@ -825,9 +830,45 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	assert.Equals(t, options.Limit, 123)
 	assert.Equals(t, options.Conflicts, true)
 	assert.Equals(t, options.IncludeDocs, true)
+	assert.Equals(t, options.HeartbeatMs, uint64(kDefaultHeartbeatMS))
+	assert.Equals(t, options.TimeoutMs, uint64(kDefaultTimeoutMS))
 
 	assert.Equals(t, filter, "Melitta")
 	assert.DeepEquals(t, channelsArray, []string{"ABC", "BBC"})
+
+	// Attempt to set heartbeat, timeout to valid values
+	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":30000, "timeout":60000}`
+	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	assert.Equals(t, err, nil)
+	assert.Equals(t, options.HeartbeatMs, uint64(30000))
+	assert.Equals(t, options.TimeoutMs, uint64(60000))
+
+	// Attempt to set valid timeout, no heartbeat
+	optStr = `{"feed":"longpoll", "since": "1", "timeout":2000}`
+	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	assert.Equals(t, err, nil)
+	assert.Equals(t, options.TimeoutMs, uint64(2000))
+
+	// Disable heartbeat, timeout by explicitly setting to zero
+	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":0, "timeout":0}`
+	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	assert.Equals(t, err, nil)
+	assert.Equals(t, options.HeartbeatMs, uint64(0))
+	assert.Equals(t, options.TimeoutMs, uint64(0))
+
+	// Attempt to set heartbeat less than minimum heartbeat, timeout greater than max timeout
+	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":1000, "timeout":1000000}`
+	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	assert.Equals(t, err, nil)
+	assert.Equals(t, options.HeartbeatMs, uint64(kMinHeartbeatMS))
+	assert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
+
+	// Set max heartbeat in server context, attempt to set heartbeat greater than max
+	h.server.config.MaxHeartbeat = 60
+	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
+	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	assert.Equals(t, err, nil)
+	assert.Equals(t, options.HeartbeatMs, uint64(60000))
 }
 
 func TestAccessControl(t *testing.T) {

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -72,6 +72,7 @@ type ServerConfig struct {
 	MaxFileDescriptors             *uint64         // Max # of open file descriptors (RLIMIT_NOFILE)
 	CompressResponses              *bool           // If false, disables compression of HTTP responses
 	Databases                      DbConfigMap     // Pre-configured databases, mapped by name
+	MaxHeartbeat                   uint64          // Max heartbeat value for _changes request (seconds)
 }
 
 // JSON object that defines a database configuration within the ServerConfig.

--- a/src/github.com/couchbase/sync_gateway/rest/handler.go
+++ b/src/github.com/couchbase/sync_gateway/rest/handler.go
@@ -278,7 +278,7 @@ func (h *handler) getOptBoolQuery(query string, defaultValue bool) bool {
 
 // Returns the integer value of a URL query, defaulting to 0 if unparseable
 func (h *handler) getIntQuery(query string, defaultValue uint64) (value uint64) {
-	return getRestrictedIntQuery(h.rq.URL.Query(), query, defaultValue, 0, 0)
+	return getRestrictedIntQuery(h.rq.URL.Query(), query, defaultValue, 0, 0, false)
 }
 
 func (h *handler) getJSONQuery(query string) (value interface{}, err error) {
@@ -501,45 +501,55 @@ func (h *handler) writeStatus(status int, message string) {
 
 // Returns the integer value of a URL query, restricted to a min and max value,
 // but returning 0 if missing or unparseable
-func getRestrictedIntQuery(values url.Values, query string, defaultValue, minValue, maxValue uint64) uint64 {
+func getRestrictedIntQuery(values url.Values, query string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
 	return getRestrictedIntFromString(
 		values.Get(query),
 		defaultValue,
 		minValue,
 		maxValue,
+		allowZero,
 	)
 }
 
-func getRestrictedIntFromString(rawValue string, defaultValue, minValue, maxValue uint64) uint64 {
-	value := defaultValue
+func getRestrictedIntFromString(rawValue string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
+	var value *uint64
 	if rawValue != "" {
-		var err error
-		value, err = strconv.ParseUint(rawValue, 10, 64)
+		intValue, err := strconv.ParseUint(rawValue, 10, 64)
 		if err != nil {
-			value = 0
+			value = nil
+		} else {
+			value = &intValue
 		}
-
-		return getRestrictedInt(
-			value,
-			defaultValue,
-			minValue,
-			maxValue,
-		)
-
 	}
-	return value
+
+	return getRestrictedInt(
+		value,
+		defaultValue,
+		minValue,
+		maxValue,
+		allowZero,
+	)
 }
 
-func getRestrictedInt(rawValue, defaultValue, minValue, maxValue uint64) uint64 {
+func getRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
 
-	value := defaultValue
+	var value uint64
 
-	if rawValue < minValue {
-		value = minValue
-	} else if rawValue > maxValue && maxValue > 0 {
-		value = maxValue
+	// Only use the defaultValue if rawValue isn't specified.
+	if rawValue == nil {
+		value = defaultValue
 	} else {
-		value = rawValue
+		value = *rawValue
+	}
+
+	// If value is zero and allowZero=true, we don't want to set to the minimum value
+	validZero := (value == 0 && allowZero)
+	if value < minValue && !validZero {
+		value = minValue
+	}
+
+	if value > maxValue && maxValue > 0 {
+		value = maxValue
 	}
 
 	return value

--- a/src/github.com/couchbase/sync_gateway/rest/handler.go
+++ b/src/github.com/couchbase/sync_gateway/rest/handler.go
@@ -500,7 +500,8 @@ func (h *handler) writeStatus(status int, message string) {
 }
 
 // Returns the integer value of a URL query, restricted to a min and max value,
-// but returning 0 if missing or unparseable
+// but returning 0 if missing or unparseable.  If allowZero is true, values coming in
+// as zero will stay zero, instead of being set to the minValue.
 func getRestrictedIntQuery(values url.Values, query string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
 	return getRestrictedIntFromString(
 		values.Get(query),
@@ -542,7 +543,7 @@ func getRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64,
 		value = *rawValue
 	}
 
-	// If value is zero and allowZero=true, we don't want to set to the minimum value
+	// If value is zero and allowZero=true, leave value at zero rather than forcing it to the minimum value
 	validZero := (value == 0 && allowZero)
 	if value < minValue && !validZero {
 		value = minValue

--- a/src/github.com/couchbase/sync_gateway/rest/handler_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/handler_test.go
@@ -21,6 +21,19 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		defaultValue,
 		minValue,
 		maxValue,
+		false,
+	)
+	assert.Equals(t, restricted, defaultValue)
+
+	// make sure it returns default value when passed Values that doesn't contain key
+	values.Set("bar", "99")
+	restricted = getRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
 	)
 	assert.Equals(t, restricted, defaultValue)
 
@@ -32,6 +45,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		defaultValue,
 		minValue,
 		maxValue,
+		false,
 	)
 	assert.Equals(t, restricted, uint64(99))
 
@@ -43,6 +57,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		defaultValue,
 		minValue,
 		maxValue,
+		false,
 	)
 	assert.Equals(t, restricted, maxValue)
 
@@ -54,7 +69,31 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		defaultValue,
 		minValue,
 		maxValue,
+		false,
 	)
 	assert.Equals(t, restricted, minValue)
 
+	// Return zero when allowZero=true
+	values.Set("foo", "0")
+	restricted = getRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		true,
+	)
+	assert.Equals(t, restricted, uint64(0))
+
+	// Return minValue when allowZero=false
+	values.Set("foo", "0")
+	restricted = getRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equals(t, restricted, minValue)
 }


### PR DESCRIPTION
Allows users to define a maximum heartbeat value for continuous changes feeds for a Sync Gateway node.  Primary use case is when Sync Gateway is deployed behind a proxy/load balancer with a known timeout - it's more efficient to define the max heartbeat on Sync Gateway, instead of depending on clients to scale back their heartbeat in response to closed connections.

Required refactoring of the existing getRestrictedInt... handling to address a couple of issues:
1. Allow use of '0' to mean 'disabled'.  e.g. clients explicitly sending heartbeat=0 will result in no heartbeats being sent.  Previously incoming requests were converting 0 to minValue.
2. Continue to support 'omitted' as 'default'.  e.g. clients not sending a heartbeat value will use the default heartbeat value.
3. Make readChangesOptionsFromJSON a handler method, to enable access to the new heartbeat value from config.

Unit tests have good coverage of JSON handling (via TestReadChangesOptionsFromJSON), but there isn't a good way to exercise the GET _changes flow via the current unit tests - there's no easy way to get visibility into the heartbeat/timeout values after making an httptest invocation of _changes.  Tested this flow in standalone SG to ensure it works as expected.
