### PR TITLE
Avoid early termination of changes feed when using channel wildcard

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -196,7 +196,12 @@ func (db *Database) MultiChangesFeed(chans base.Set, options ChangesOptions) (<-
 
 		if options.Wait {
 			options.Wait = false
-			changeWaiter = db.tapListener.NewWaiterWithChannels(chans, db.user)
+			waitChans := chans
+			if db.user != nil {
+				waitChans = db.user.ExpandWildCardChannel(chans)
+			}
+			changeWaiter = db.tapListener.NewWaiterWithChannels(waitChans, db.user)
+
 			userChangeCount = changeWaiter.CurrentUserCount()
 			// If a longpoll request has a low sequence that matches the current lowSequence,
 			// ignore the low sequence.  This avoids infinite looping of the records between

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -134,6 +134,17 @@ func (context *DatabaseContext) IsClosed() bool {
 	return context.Bucket == nil
 }
 
+// For testing only!
+func (context *DatabaseContext) RestartListener() error {
+	context.tapListener.Stop()
+	// Delay needed to properly stop
+	time.Sleep(2 * time.Second)
+	if err := context.tapListener.Start(context.Bucket, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 	// Authenticators are lightweight & stateless, so it's OK to return a new one every time
 	return auth.NewAuthenticator(context.Bucket, context)


### PR DESCRIPTION
Resolve wildcard channel token during changes feed processing before initializing changeWaiter. 

Fixes #916.
