### PR TITLE
Removed duplicate ShallowCopy from Put, fixes #965

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/revision_cache.go
+++ b/src/github.com/couchbase/sync_gateway/db/revision_cache.go
@@ -56,7 +56,6 @@ func (rc *RevisionCache) Get(docid, revid string) (Body, Body, base.Set, error) 
 
 // Adds a revision to the cache.
 func (rc *RevisionCache) Put(body Body, history Body, channels base.Set) {
-	body = body.ShallowCopy()
 	if history == nil {
 		panic("Missing history for RevisionCache.Put")
 	}


### PR DESCRIPTION
Removed duplicate ShallowCopy from Put, retained ShallowCopy in store where body is placed in the revCache

fixes #965 
