### PR TITLE
Added the following header to simple, longpoll and continuous HTTP _changes response

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -156,6 +156,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	}
 
 	h.setHeader("Content-Type", "application/json")
+	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
 	h.response.Write([]byte("{\"results\":[\r\n"))
 	if options.Wait {
 		h.flush()
@@ -340,6 +341,7 @@ func (h *handler) sendContinuousChangesByHTTP(inChannels base.Set, options db.Ch
 	// a real content-type from the response text, which can delay or prevent the client app from
 	// receiving the response.
 	h.setHeader("Content-Type", "application/octet-stream")
+	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
 	h.logStatus(http.StatusOK, "sending continuous feed")
 	return h.generateContinuousChanges(inChannels, options, func(changes []*db.ChangeEntry) error {
 		var err error


### PR DESCRIPTION
Added the following header to simple, longpoll and continuous HTTP _changes response

This should prevent all _changes responses and heartbeats being cached by intermediate proxies.

Fixes #945 

h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")

Not sure which testing strategy should be used for this, currently this is only covered by scenario testing, should we flag this for integration testing also?
