### PR TITLE
add failing test, /db/_role/ returns hipster when it should return an empty array

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go
@@ -295,6 +295,27 @@ func TestRoleAPI(t *testing.T) {
 	assertStatus(t, rt.sendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
 }
 
+func TestRoleDeleteRole(t *testing.T) {
+	var rt restTester
+	// PUT a role
+	assertStatus(t, rt.sendAdminRequest("GET", "/db/_role/hipster", ""), 404)
+	response := rt.sendAdminRequest("PUT", "/db/_role/hipster", `{"admin_channels":["fedoras", "fixies"]}`)
+	assertStatus(t, response, 201)
+
+	response = rt.sendAdminRequest("GET", "/db/_role/", "")
+	assertStatus(t, response, 200)
+	assert.Equals(t, string(response.Body.Bytes()), `["hipster"]`)
+
+	// DELETE the role
+	assertStatus(t, rt.sendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
+	assertStatus(t, rt.sendAdminRequest("GET", "/db/_role/hipster", ""), 404)
+
+	// GET all the roles
+	response = rt.sendAdminRequest("GET", "/db/_role/", "")
+	assertStatus(t, response, 200)
+	assert.Equals(t, string(response.Body.Bytes()), `[]`)
+}
+
 func TestGuestUser(t *testing.T) {
 
 	guestUserEndpoint := fmt.Sprintf("/db/_user/%s", base.GuestUsername)


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/979)

<!-- Reviewable:end -->
