### PR TITLE
_changes since value can now be a JSON marshalled string fragment 

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/sequence_id.go
+++ b/src/github.com/couchbase/sync_gateway/db/sequence_id.go
@@ -101,18 +101,15 @@ func (s SequenceID) MarshalJSON() ([]byte, error) {
 }
 
 func (s *SequenceID) UnmarshalJSON(data []byte) error {
-	if len(data) > 0 && data[0] == '"' {
-		var raw string
-		err := json.Unmarshal(data, &raw)
-		if err == nil {
-			*s, err = ParseSequenceID(string(raw))
-		}
-		return err
+	var js string
+	err := json.Unmarshal(data, &js); if err != nil {
+		*s, err = ParseSequenceID(string(data))
 	} else {
-		s.TriggeredBy = 0
-		return json.Unmarshal(data, &s.Seq)
+		*s, err = ParseSequenceID(js)
 	}
+	return err
 }
+
 
 func (s SequenceID) SafeSequence() uint64 {
 	if s.LowSeq > 0 {

--- a/src/github.com/couchbase/sync_gateway/db/sequence_id_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/sequence_id_test.go
@@ -55,6 +55,33 @@ func TestMarshalSequenceID(t *testing.T) {
 	assert.Equals(t, s2, s)
 }
 
+func TestSequenceIDUnmarshalJSON(t *testing.T) {
+
+	str := "123"
+	s := SequenceID{}
+	err := s.UnmarshalJSON([]byte(str))
+	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.Equals(t, s, SequenceID{Seq: 123})
+
+	str = "456:123"
+	s = SequenceID{}
+	err = s.UnmarshalJSON([]byte(str))
+	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.Equals(t, s, SequenceID{TriggeredBy: 456, Seq: 123})
+
+	str = "\"234\""
+	s = SequenceID{}
+	err = s.UnmarshalJSON([]byte(str))
+	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.Equals(t, s, SequenceID{Seq: 234})
+
+	str = "\"567:234\""
+	s = SequenceID{}
+	err = s.UnmarshalJSON([]byte(str))
+	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.Equals(t, s, SequenceID{TriggeredBy: 567, Seq: 234})
+}
+
 func TestMarshalTriggeredSequenceID(t *testing.T) {
 	s := SequenceID{TriggeredBy: 5678, Seq: 1234}
 	assert.Equals(t, s.String(), "5678:1234")

--- a/src/github.com/couchbase/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api_test.go
@@ -1143,7 +1143,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Changes feed with since=gamma:8 would ordinarily be empty, but zegpold got access to channel
 	// alpha after sequence 8, so the pre-existing docs in that channel are included:
-	response = rt.send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s", since),
+	response = rt.send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=\"%s\"", since),
 		"", "zegpold"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
@@ -1222,7 +1222,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equals(t, since, db.SequenceID{Seq: 50})
 
 	//// Check the _changes feed with  since and limit, to get second half of feed
-	response = rt.send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "", "user1"))
+	response = rt.send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "", "user1"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
 	assert.Equals(t, err, nil)
@@ -1258,7 +1258,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	assert.Equals(t, since, db.SequenceID{TriggeredBy: 103, Seq: 51})
 
 	//// Get remainder of changes i.e. no limit parameter
-	response = rt.send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s", since), "", "user3"))
+	response = rt.send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=\"%s\"", since), "", "user3"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
 	assert.Equals(t, err, nil)

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -80,7 +80,7 @@ func (h *handler) handleChanges() error {
 		// GET request has parameters in URL:
 		feed = h.getQuery("feed")
 		var err error
-		if options.Since, err = db.ParseSequenceID(h.getQuery("since")); err != nil {
+		if options.Since, err = db.ParseSequenceID(unmarshalJSONString(h.getQuery("since"))); err != nil {
 			return err
 		}
 		options.Limit = int(h.getIntQuery("limit", 0))
@@ -478,3 +478,14 @@ func sequenceFromString(str string) uint64 {
 	}
 	return seq
 }
+
+
+func unmarshalJSONString(s string) string {
+	var js string
+	err := json.Unmarshal([]byte(s), &js); if err != nil {
+		return s
+	} else {
+		return js
+	}
+}
+

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -80,7 +80,7 @@ func (h *handler) handleChanges() error {
 		// GET request has parameters in URL:
 		feed = h.getQuery("feed")
 		var err error
-		if options.Since, err = db.ParseSequenceID(unmarshalJSONString(h.getQuery("since"))); err != nil {
+		if err = options.Since.UnmarshalJSON([]byte(h.getQuery("since"))); err != nil {
 			return err
 		}
 		options.Limit = int(h.getIntQuery("limit", 0))
@@ -478,14 +478,3 @@ func sequenceFromString(str string) uint64 {
 	}
 	return seq
 }
-
-
-func unmarshalJSONString(s string) string {
-	var js string
-	err := json.Unmarshal([]byte(s), &js); if err != nil {
-		return s
-	} else {
-		return js
-	}
-}
-


### PR DESCRIPTION
_changes since value can now be a JSON marshalled string fragment or a normal string. Updated a number of tests to use marshalled JSON string for since property in some requests

fixes #895 
