### PR TITLE
raw ddoc feature and passing tests for sum reduce

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
@@ -172,3 +172,34 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	// value = row.Value.(float64)
 	// assert.True(t, value == 1)
 }
+
+func TestAdminReduceSumQuery(t *testing.T) {
+
+	rt := restTester{syncFn: `function(doc) {channel(doc.channel)}`}
+
+	// Create a view with a reduce:
+	response := rt.sendAdminRequest("PUT", "/db/_design/foo", `{"options":{"raw":true},"views":{"bar": {"map": "function(doc) {if (doc.key && doc.value) emit(doc.key, doc.value);}", "reduce": "_sum"}}}`)
+	assertStatus(t, response, 201)
+
+	for i := 0; i < 9; i++ {
+		// Create docs:
+		response = rt.sendRequest("PUT", fmt.Sprintf("/db/doc%v", i), `{"key":"A", "value":1}`)
+		assertStatus(t, response, 201)
+
+	}
+	response = rt.sendRequest("PUT", fmt.Sprintf("/db/doc%v", 10), `{"key":"B", "value":99}`)
+	assertStatus(t, response, 201)
+
+	var result sgbucket.ViewResult
+
+	// Admin view query:
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/bar?reduce=true", ``)
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &result)
+
+	// we should get 1 row with the reduce result
+	assert.Equals(t, len(result.Rows), 1)
+	row := result.Rows[0]
+	value := row.Value.(float64)
+	assert.Equals(t, value, 108.0)
+}


### PR DESCRIPTION
This allows users to add a design doc option `"raw" : true` to skip the channels wrapper in our view engine. This is only useful for admin-only views where the intent is to run reduce on the results.

To enable, have a design doc like:

``` javascript
{
  "options" : {
    "raw" : true
  },
  "views: { 
    // ...
  }
}
```

There is another code path I didn't write that could allow reduce on the wrapped views but I don't think it's practical or necessary at this stage.

This requires the pull request at https://github.com/couchbase/sg-bucket/pull/4 to be merged
