### PR TITLE
Prevent panic when receiving session POST with with Origin header and no CORS config

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api_test.go
@@ -407,6 +407,28 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 	assertStatus(t, response, 401)
 }
 
+// #issue 991
+func TestCORSLoginOriginOnSessionPostNoCORSConfig(t *testing.T) {
+	var rt restTester
+	reqHeaders := map[string]string{
+		"Origin": "http://example.com",
+	}
+
+	req := request("POST", "/db/_session", "{\"name\":\"jchris\",\"password\":\"secret\"}")
+	for k, v := range reqHeaders {
+		req.Header.Set(k, v)
+	}
+
+	response := &testResponse{httptest.NewRecorder(), req}
+	response.Code = 200
+
+	sc := rt.ServerContext()
+	sc.config.CORS = nil
+	CreatePublicHandler(sc).ServeHTTP(response, req)
+
+	assertStatus(t, response, 400)
+}
+
 func TestNoCORSOriginOnSessionPost(t *testing.T) {
 	var rt restTester
 	reqHeaders := map[string]string{

--- a/src/github.com/couchbase/sync_gateway/rest/session_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/session_api.go
@@ -40,7 +40,10 @@ func (h *handler) handleSessionPOST() error {
 	// CORS not allowed for login #115 #762
 	originHeader := h.rq.Header["Origin"]
 	if len(originHeader) > 0 {
-		matched := matchedOrigin(h.server.config.CORS.LoginOrigin, originHeader)
+		matched := ""
+		if h.server.config.CORS != nil {
+			matched = matchedOrigin(h.server.config.CORS.LoginOrigin, originHeader)
+		}
 		if matched == "" {
 			return base.HTTPErrorf(http.StatusBadRequest, "No CORS")
 		}


### PR DESCRIPTION
Prevent Sync Gateway  panicking when receiving session POST with Origin header and no CORS config

fixes #991 
