### PR TITLE
Uptake BucketUpdater support in go-couchbase

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket.go
@@ -336,6 +336,10 @@ func GetCouchbaseBucket(spec BucketSpec) (bucket Bucket, err error) {
 	}
 	cbbucket, err := pool.GetBucket(spec.BucketName)
 	if err == nil {
+		// Start bucket updater - see SG issue 1011
+		cbbucket.RunBucketUpdater(func(bucket string, err error) {
+			Warn("Bucket Updater for bucket %s returned error: %v", bucket, err)
+		})
 		bucket = CouchbaseBucket{cbbucket, spec}
 	}
 


### PR DESCRIPTION
On create of a couchbase bucket, enable the BucketUpdater for that bucket, which will monitor Couchbase Server for cluster changes and update the bucket definition appropriately.
