### PR TITLE
Added support for partial GETs of attachments (Range: header)

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/doc_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/doc_api.go
@@ -140,16 +140,25 @@ func (h *handler) handleGetAttachment() error {
 		return err
 	}
 
+	status, start, end := h.handleRange(uint64(len(data)))
+	if status > 299 {
+		return base.HTTPErrorf(status, "")
+	} else if status == http.StatusPartialContent {
+		data = data[start:end]
+	}
+	h.setHeader("Content-Length", strconv.FormatUint(uint64(len(data)), 10))
+
 	h.setHeader("Etag", strconv.Quote(digest))
 	if contentType, ok := meta["content_type"].(string); ok {
 		h.setHeader("Content-Type", contentType)
 	}
 	if encoding, ok := meta["encoding"].(string); ok {
-		h.setHeader("Content-Encoding", encoding)
+			h.setHeader("Content-Encoding", encoding)
 	}
 	if h.privs == adminPrivs { // #720
 		h.setHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", attachmentName))
 	}
+	h.response.WriteHeader(status)
 	h.response.Write(data)
 	return nil
 }

--- a/src/github.com/couchbase/sync_gateway/rest/handler_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/handler_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -96,4 +97,67 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		false,
 	)
 	assert.Equals(t, restricted, minValue)
+}
+
+func TestParseHTTPRangeHeader(t *testing.T) {
+	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+	type testcase struct {
+		header        string
+		contentLength uint64
+		status        int
+		start         uint64
+		end           uint64
+	}
+	testcases := []testcase{
+		// No Range: header at all:
+		{"", 100, http.StatusOK, 0, 0},
+
+		// Syntactically invalid Range headers are ignored:
+		{"lolwut", 100, http.StatusOK, 0, 0},
+		{"inches=-", 100, http.StatusOK, 0, 0},
+		{"bytes=-", 100, http.StatusOK, 0, 0},
+		{"bytes=50-bar", 100, http.StatusOK, 0, 0},
+		{"bytes=50-49", 100, http.StatusOK, 0, 0},                  // invalid, not unsatisfiable
+		{"bytes=99999999999999999999-1", 100, http.StatusOK, 0, 0}, // again, invalid
+
+		// These requests return the entire document:
+		{"bytes=0-", 100, http.StatusOK, 0, 0},
+		{"bytes=0-99", 100, http.StatusOK, 0, 0},
+		{"bytes=-100", 100, http.StatusOK, 0, 0},
+		{"bytes=-99999999999999999999", 100, http.StatusOK, 0, 0},
+
+		// Not satisfiable:
+		{"bytes=100-", 100, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+		{"bytes=100-200", 100, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+		{"bytes=100-99999999999999999999", 100, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+		{"bytes=-0", 100, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+
+		{"bytes=10-", 100, http.StatusPartialContent, 10, 99},
+		{"bytes=-10", 100, http.StatusPartialContent, 90, 99},
+		{"bytes=0-0", 100, http.StatusPartialContent, 0, 0},
+		{"bytes=50-60", 100, http.StatusPartialContent, 50, 60},
+		{"bytes=99-", 100, http.StatusPartialContent, 99, 99},
+		{"bytes=99-200", 100, http.StatusPartialContent, 99, 99},
+		{"bytes=90-200", 100, http.StatusPartialContent, 90, 99},
+		{"bytes=90-99999999999999999999", 100, http.StatusPartialContent, 90, 99},
+		{"bytes=2-98", 100, http.StatusPartialContent, 2, 98},
+
+		// Test with empty content:
+		{"bytes=-1", 0, http.StatusOK, 0, 0},
+		{"bytes=-10", 0, http.StatusOK, 0, 0},
+		{"bytes=0-0", 0, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+		{"bytes=0-49", 0, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+		{"bytes=1-1", 0, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+		{"bytes=-0", 0, http.StatusRequestedRangeNotSatisfiable, 0, 0},
+	}
+
+	for _, expected := range testcases {
+		status, start, end := parseHTTPRangeHeader(expected.header, expected.contentLength)
+		t.Logf("*** Range: %s  --> %d %d-%d", expected.header, status, start, end)
+		assert.Equals(t, status, expected.status)
+		if status == http.StatusPartialContent {
+			assert.Equals(t, start, expected.start)
+			assert.Equals(t, end, expected.end)
+		}
+	}
 }


### PR DESCRIPTION
The HTTP handler for attachments (/db/doc/attachmentname) now supports
GETs of byte ranges using the standard "Range:" header. This will allow
clients to resume interrupted attachment downloads, or do random-access
streaming of attachments.
Fixes #1046
