### PR TITLE
Fix for panic during attempted view retrieval of skipped sequence

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/database_test.go
@@ -61,6 +61,14 @@ func setupTestDBWithCacheOptions(t *testing.T, options CacheOptions) *Database {
 	return db
 }
 
+func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyOptions base.LeakyBucketConfig) *Database {
+	context, err := NewDatabaseContext("db", testLeakyBucket(leakyOptions), false, options, RevisionCacheCapacity)
+	assertNoError(t, err, "Couldn't create context for database 'db'")
+	db, err := CreateDatabase(context)
+	assertNoError(t, err, "Couldn't create database 'db'")
+	return db
+}
+
 func tearDownTestDB(t *testing.T, db *Database) {
 	db.Close()
 }


### PR DESCRIPTION
Attempted view retrieval of long-skipped sequences had two problems - view range was being defined incorrectly, and error check was reversed.  New unit test validates the correct behaviour via logging when run, but isn't able to replicate the long-skipped sequence that exists in the DB (we don't have a way to simulate something making it to the DB but not showing up on the TAP feed yet).

Fixes #1050
