### PR TITLE
If POST _session ttl value greater than max, use max value and log to "Auth" channel

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/session_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/session_api.go
@@ -20,6 +20,7 @@ import (
 )
 
 const kDefaultSessionTTL = 24 * time.Hour
+const kMaxSessionTTLValue = 2592000
 
 // Respond with a JSON struct containing info about the current login session
 func (h *handler) respondWithSessionInfo() error {
@@ -191,6 +192,11 @@ func (h *handler) createUserSession() error {
 			err = base.HTTPErrorf(http.StatusNotFound, "No such user %q", params.Name)
 		}
 		return err
+	}
+
+	if params.TTL > kMaxSessionTTLValue {
+		base.LogTo("Auth", "ttl [%d] exceeds max supported ttl [%d] (30 days), using max ttl to create session",params.TTL,kMaxSessionTTLValue)
+		params.TTL = kMaxSessionTTLValue
 	}
 	ttl := time.Duration(params.TTL) * time.Second
 	if ttl < 1.0 {


### PR DESCRIPTION
fixes #1049 
