### PR TITLE
Terminate housekeeping goroutines when change cache is closed

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/change_cache.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_cache.go
@@ -109,15 +109,21 @@ func (c *changeCache) Init(context *DatabaseContext, lastSequence uint64, onChan
 
 	// Start a background task for periodic housekeeping:
 	go func() {
-		for c.CleanUp() {
+		for {
 			time.Sleep(c.options.CachePendingSeqMaxWait / 2)
+			if c.stopped || !c.CleanUp() {
+				break
+			}
 		}
 	}()
 
 	// Start a background task for SkippedSequenceQueue housekeeping:
 	go func() {
-		for c.CleanSkippedSequenceQueue() {
+		for {
 			time.Sleep(c.options.CacheSkippedSeqMaxWait / 2)
+			if c.stopped || !c.CleanSkippedSequenceQueue() {
+				break
+			}
 		}
 	}()
 }

--- a/src/github.com/couchbase/sync_gateway/db/change_cache.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_cache.go
@@ -109,21 +109,17 @@ func (c *changeCache) Init(context *DatabaseContext, lastSequence uint64, onChan
 
 	// Start a background task for periodic housekeeping:
 	go func() {
-		for {
+		time.Sleep(c.options.CachePendingSeqMaxWait / 2)
+		for !c.IsStopped() && c.CleanUp() {
 			time.Sleep(c.options.CachePendingSeqMaxWait / 2)
-			if c.stopped || !c.CleanUp() {
-				break
-			}
 		}
 	}()
 
 	// Start a background task for SkippedSequenceQueue housekeeping:
 	go func() {
-		for {
+		time.Sleep(c.options.CacheSkippedSeqMaxWait / 2)
+		for !c.IsStopped() && c.CleanSkippedSequenceQueue() {
 			time.Sleep(c.options.CacheSkippedSeqMaxWait / 2)
-			if c.stopped || !c.CleanSkippedSequenceQueue() {
-				break
-			}
 		}
 	}()
 }
@@ -134,6 +130,12 @@ func (c *changeCache) Stop() {
 	c.stopped = true
 	c.logsDisabled = true
 	c.lock.Unlock()
+}
+
+func (c *changeCache) IsStopped() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.stopped
 }
 
 // Forgets all cached changes for all channels.
@@ -560,7 +562,7 @@ func (c *changeCache) _getChannelCache(channelName string) *channelCache {
 //////// CHANGE ACCESS:
 
 func (c *changeCache) GetChangesInChannel(channelName string, options ChangesOptions) ([]*LogEntry, error) {
-	if c.stopped {
+	if c.IsStopped() {
 		return nil, base.HTTPErrorf(503, "Database closed")
 	}
 	return c.getChannelCache(channelName).GetChanges(options)

--- a/src/github.com/couchbase/sync_gateway/db/changes_view.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes_view.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"time"
 
 	"github.com/couchbase/go-couchbase"
@@ -28,6 +29,9 @@ type channelsViewRow struct {
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
 func (dbc *DatabaseContext) getChangesInChannelFromView(
 	channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
+	if dbc.Bucket == nil {
+		return nil, errors.New("No bucket available for channel view query")
+	}
 	start := time.Now()
 	// Query the view:
 	optMap := changesViewOptions(channelName, endSeq, options)


### PR DESCRIPTION
Housekeeping routines weren't being terminated.  Led to a potential SG panic if the CleanSkippedSequenceQueue processing fired after the bucket was closed.  Also added some additional defensive coding for nil bucket in the channel view call.

Fixes #1093
