### PR TITLE
Support session TTL values greater than maximum offset TTL of 2592000 seconds (30 days)

### DIFF
--- a/src/github.com/couchbase/sync_gateway/auth/session.go
+++ b/src/github.com/couchbase/sync_gateway/auth/session.go
@@ -77,14 +77,13 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 		return nil, base.HTTPErrorf(400, "Invalid session time-to-live")
 	}
 
-	expirationTime := time.Now().Add(ttl)
 	session := &LoginSession{
 		ID:         base.GenerateRandomSecret(),
 		Username:   username,
-		Expiration: expirationTime,
+		Expiration: time.Now().Add(ttl),
 		Ttl:        ttl,
 	}
-	if err := auth.bucket.Set(docIDForSession(session.ID), int(expirationTime.Unix()), session); err != nil {
+	if err := auth.bucket.Set(docIDForSession(session.ID), base.DurationToCbsExpiry(ttl), session); err != nil {
 		return nil, err
 	}
 	return session, nil

--- a/src/github.com/couchbase/sync_gateway/auth/session.go
+++ b/src/github.com/couchbase/sync_gateway/auth/session.go
@@ -76,13 +76,15 @@ func (auth *Authenticator) CreateSession(username string, ttl time.Duration) (*L
 	if ttlSec <= 0 {
 		return nil, base.HTTPErrorf(400, "Invalid session time-to-live")
 	}
+
+	expirationTime := time.Now().Add(ttl)
 	session := &LoginSession{
 		ID:         base.GenerateRandomSecret(),
 		Username:   username,
-		Expiration: time.Now().Add(ttl),
+		Expiration: expirationTime,
 		Ttl:        ttl,
 	}
-	if err := auth.bucket.Set(docIDForSession(session.ID), ttlSec, session); err != nil {
+	if err := auth.bucket.Set(docIDForSession(session.ID), int(expirationTime.Unix()), session); err != nil {
 		return nil, err
 	}
 	return session, nil

--- a/src/github.com/couchbase/sync_gateway/base/util.go
+++ b/src/github.com/couchbase/sync_gateway/base/util.go
@@ -18,7 +18,10 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 )
+
+const kMaxDeltaTtl = 60 * 60 * 24 * 30 * time.Second
 
 func GenerateRandomSecret() string {
 	randomBytes := make([]byte, 20)
@@ -142,5 +145,25 @@ func (v *IntMax) SetIfMax(value int64) {
 	defer v.mu.Unlock()
 	if value > v.i {
 		v.i = value
+	}
+}
+
+// This is how Couchbase Server handles document expiration times
+//
+//The actual value sent may either be
+//Unix time (number of seconds since January 1, 1970, as a 32-bit
+//value), or a number of seconds starting from current time. In the
+//latter case, this number of seconds may not exceed 60*60*24*30 (number
+//of seconds in 30 days); if the number sent by a client is larger than
+//that, the server will consider it to be real Unix time value rather
+//than an offset from current time.
+//
+//This function takes a ttl as a Duration and returns an int
+//formatted as required by CBS expiry processing
+func DurationToCbsExpiry (ttl time.Duration) int {
+	if (ttl <= kMaxDeltaTtl) {
+		return int(ttl.Seconds())
+	} else {
+		return int(time.Now().Add(ttl).Unix())
 	}
 }

--- a/src/github.com/couchbase/sync_gateway/rest/session_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/session_api.go
@@ -20,7 +20,6 @@ import (
 )
 
 const kDefaultSessionTTL = 24 * time.Hour
-const kMaxSessionTTLValue = 2592000
 
 // Respond with a JSON struct containing info about the current login session
 func (h *handler) respondWithSessionInfo() error {
@@ -194,10 +193,6 @@ func (h *handler) createUserSession() error {
 		return err
 	}
 
-	if params.TTL > kMaxSessionTTLValue {
-		base.LogTo("Auth", "ttl [%d] exceeds max supported ttl [%d] (30 days), using max ttl to create session",params.TTL,kMaxSessionTTLValue)
-		params.TTL = kMaxSessionTTLValue
-	}
 	ttl := time.Duration(params.TTL) * time.Second
 	if ttl < 1.0 {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid or missing ttl")


### PR DESCRIPTION
fixes #974 

ttl was being passed to bucket as an offset, which limited values to 2592000, values slightly greater than this e.g. 2592001 were being treated as UNIX epoch time, this example converts to:

Sat, 31 Jan 1970 00:00:01 GMT

So session would be deleted immediately as it's expiry time had already passed.

Found detailed description of expiry value handling in [memcached docs line 79](https://github.com/memcached/memcached/blob/master/doc/protocol.txt)

Now all ttl's are converted to UNIX epoch time when passed to bucket.
