### PR TITLE
re-instate the _sync property after executing a user defined view

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/design_doc.go
+++ b/src/github.com/couchbase/sync_gateway/db/design_doc.go
@@ -90,6 +90,7 @@ func wrapViews(ddoc *DesignDoc) {
 		                    };
 							(` + view.Map + `) (doc, meta);
 						}());
+						doc._sync = sync;
 					}`
 		ddoc.Views[name] = view // view is not a pointer, so have to copy it back
 	}

--- a/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
@@ -78,6 +78,40 @@ func TestViewQuery(t *testing.T) {
 	assert.DeepEquals(t, *result.Rows[0].Doc, map[string]interface{}{"key": 7.0, "value": "seven"})
 }
 
+//Tests #1109, where design doc contains multiple views
+func failingTestViewQueryMultipleViews(t *testing.T) {
+	var rt restTester
+	//Define three views
+	response := rt.sendAdminRequest("PUT", "/db/_design/foo", `{"views": {"by_fname": {"map": "function (doc, meta) { emit(doc.fname, null); }"},"by_lname": {"map": "function (doc, meta) { emit(doc.lname, null); }"},"by_age": {"map": "function (doc, meta) { emit(doc.age, doc); }"}}}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("PUT", "/db/doc1", `{"fname": "Alice", "lname":"Ten", "age":10}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("PUT", "/db/doc2", `{"fname": "Bob", "lname":"Seven", "age":7}`)
+	assertStatus(t, response, 201)
+
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/by_age", ``)
+	assertStatus(t, response, 200)
+	var result sgbucket.ViewResult
+	json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Equals(t, len(result.Rows), 2)
+	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface {}(nil)})
+	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface {}(nil)})
+
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/by_fname", ``)
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Equals(t, len(result.Rows), 2)
+	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice" , Value: interface {}(nil)})
+	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob" , Value: interface {}(nil)})
+
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/by_lname", ``)
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Equals(t, len(result.Rows), 2)
+	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven" , Value: interface {}(nil)})
+	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten" , Value: interface {}(nil)})
+}
+
 func TestUserViewQuery(t *testing.T) {
 	rt := restTester{syncFn: `function(doc) {channel(doc.channel)}`}
 	a := rt.ServerContext().Database("db").Authenticator()

--- a/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
@@ -79,6 +79,7 @@ func TestViewQuery(t *testing.T) {
 }
 
 //Tests #1109, where design doc contains multiple views
+//Currently fails against walrus bucket as '_sync' property will exist in doc if it is emmitted in the map function
 func failingTestViewQueryMultipleViews(t *testing.T) {
 	var rt restTester
 	//Define three views

--- a/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/view_api_test.go
@@ -79,7 +79,41 @@ func TestViewQuery(t *testing.T) {
 }
 
 //Tests #1109, where design doc contains multiple views
-//Currently fails against walrus bucket as '_sync' property will exist in doc if it is emmitted in the map function
+func TestViewQueryMultipleViews(t *testing.T) {
+	var rt restTester
+	//Define three views
+	response := rt.sendAdminRequest("PUT", "/db/_design/foo", `{"views": {"by_fname": {"map": "function (doc, meta) { emit(doc.fname, null); }"},"by_lname": {"map": "function (doc, meta) { emit(doc.lname, null); }"},"by_age": {"map": "function (doc, meta) { emit(doc.age, null); }"}}}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("PUT", "/db/doc1", `{"fname": "Alice", "lname":"Ten", "age":10}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("PUT", "/db/doc2", `{"fname": "Bob", "lname":"Seven", "age":7}`)
+	assertStatus(t, response, 201)
+
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/by_age", ``)
+	assertStatus(t, response, 200)
+	var result sgbucket.ViewResult
+	json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Equals(t, len(result.Rows), 2)
+	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface {}(nil)})
+	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface {}(nil)})
+
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/by_fname", ``)
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Equals(t, len(result.Rows), 2)
+	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice" , Value: interface {}(nil)})
+	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob" , Value: interface {}(nil)})
+
+	response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/by_lname", ``)
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Equals(t, len(result.Rows), 2)
+	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven" , Value: interface {}(nil)})
+	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten" , Value: interface {}(nil)})
+}
+
+//Waiting for a fix for couchbaselabs/Walrus #13
+//Currently fails against walrus bucket as '_sync' property will exist in doc object if it is emmitted in the map function
 func failingTestViewQueryMultipleViews(t *testing.T) {
 	var rt restTester
 	//Define three views


### PR DESCRIPTION
After executing a user defined couchbase server view map function, re-instate the _sync property. As the same doc instance is passed to all the views in a design document if the _sync property is not reinstated other views in the design doc will fail to behave as expected.

fixes #1109 

Raising this PR before writing unit tests as fix is not elegant, a more elegant option might be to make a deep copy of the input doc and work on the copy, but this is a potentially expensive operation on large documents e.g those with large rev trees in the _sync property.
