### PR TITLE
Added two additional tests for Unmarshalling a three component SequenceID

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/sequence_id_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/sequence_id_test.go
@@ -69,6 +69,12 @@ func TestSequenceIDUnmarshalJSON(t *testing.T) {
 	assertNoError(t, err, "UnmarshalJSON failed")
 	assert.Equals(t, s, SequenceID{TriggeredBy: 456, Seq: 123})
 
+	str = "220::222"
+	s = SequenceID{}
+	err = s.UnmarshalJSON([]byte(str))
+	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.Equals(t, s, SequenceID{ LowSeq: 220, TriggeredBy: 0, Seq: 222})
+
 	str = "\"234\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
@@ -80,6 +86,12 @@ func TestSequenceIDUnmarshalJSON(t *testing.T) {
 	err = s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
 	assert.Equals(t, s, SequenceID{TriggeredBy: 567, Seq: 234})
+
+	str = "\"220::222\""
+	s = SequenceID{}
+	err = s.UnmarshalJSON([]byte(str))
+	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.Equals(t, s, SequenceID{ LowSeq: 220, TriggeredBy: 0, Seq: 222})
 }
 
 func TestMarshalTriggeredSequenceID(t *testing.T) {


### PR DESCRIPTION
Added two additional tests for Unmarshalling a three component SequenceID
with and without embedded quotation marks i.e. 220::222  and "220::222"

This provides coverage on master for the issue raised in #1168 
