### PR TITLE
Supports HTTP compression on the entire _bulk_get response

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
@@ -297,7 +297,7 @@ func (h *handler) handleDumpChannel() error {
 func (h *handler) handleBulkGet() error {
 	includeRevs := h.getBoolQuery("revs")
 	includeAttachments := h.getBoolQuery("attachments")
-	canCompress := strings.Contains(h.rq.Header.Get("X-Accept-Part-Encoding"), "gzip")
+	canCompress := strings.Contains(h.rq.Header.Get("X-Accept-Part-Encoding"), "gzip") && !strings.Contains(h.rq.Header.Get("Accept-Encoding"), "gzip")
 	body, err := h.readJSON()
 	if err != nil {
 		return err

--- a/src/github.com/couchbase/sync_gateway/rest/encoded_response_writer.go
+++ b/src/github.com/couchbase/sync_gateway/rest/encoded_response_writer.go
@@ -64,7 +64,7 @@ func (w *EncodedResponseWriter) sniff(bytes []byte) {
 
 	// Can/should we compress the response?
 	if w.status >= 300 || w.Header().Get("Content-Encoding") != "" ||
-		(!strings.HasPrefix(respType, "application/json") && !strings.HasPrefix(respType, "text/")) {
+	(!strings.HasPrefix(respType, "application/json") && !strings.HasPrefix(respType, "text/") && !strings.HasPrefix(respType, "multipart/mixed")) {
 		return
 	}
 


### PR DESCRIPTION
fixes #1163

If a client passes the HTTP header "Accept-Encoding: gzip"  then the header "X-Accept-Part-Encoding: gzip" will be ignored if it is passed and the entire HTTP response will be gzip compressed.
