### PR TITLE
GZip compression for WebSocket-based changes feeds (#1179)

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api_test.go
@@ -891,7 +891,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	// Basic case, no heartbeat, no timeout
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",
 				"include_docs": true, "filter": "Melitta", "channels": "ABC,BBC"}`
-	feed, options, filter, channelsArray, err := h.readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, _, err := h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, feed, "longpoll")
 
@@ -907,27 +907,27 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 
 	// Attempt to set heartbeat, timeout to valid values
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":30000, "timeout":60000}`
-	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, options.HeartbeatMs, uint64(30000))
 	assert.Equals(t, options.TimeoutMs, uint64(60000))
 
 	// Attempt to set valid timeout, no heartbeat
 	optStr = `{"feed":"longpoll", "since": "1", "timeout":2000}`
-	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, options.TimeoutMs, uint64(2000))
 
 	// Disable heartbeat, timeout by explicitly setting to zero
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":0, "timeout":0}`
-	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, options.HeartbeatMs, uint64(0))
 	assert.Equals(t, options.TimeoutMs, uint64(0))
 
 	// Attempt to set heartbeat less than minimum heartbeat, timeout greater than max timeout
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":1000, "timeout":1000000}`
-	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, options.HeartbeatMs, uint64(kMinHeartbeatMS))
 	assert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
@@ -935,7 +935,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	// Set max heartbeat in server context, attempt to set heartbeat greater than max
 	h.server.config.MaxHeartbeat = 60
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
-	feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON([]byte(optStr))
+	feed, options, filter, channelsArray, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.Equals(t, err, nil)
 	assert.Equals(t, options.HeartbeatMs, uint64(60000))
 }

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -10,6 +10,8 @@
 package rest
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -100,7 +102,7 @@ func (h *handler) handleChanges() error {
 		if err != nil {
 			return err
 		}
-		feed, options, filter, channelsArray, err = h.readChangesOptionsFromJSON(body)
+		feed, options, filter, channelsArray, _, err = h.readChangesOptionsFromJSON(body)
 		if err != nil {
 			return err
 		}
@@ -372,12 +374,13 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 		}()
 
 		// Read changes-feed options from an initial incoming WebSocket message in JSON format:
+		var compress bool
 		if msg, err := readWebSocketMessage(conn); err != nil {
 			return
 		} else {
 			var channelNames []string
 			var err error
-			if _, options, _, channelNames, err = h.readChangesOptionsFromJSON(msg); err != nil {
+			if _, options, _, channelNames, compress, err = h.readChangesOptionsFromJSON(msg); err != nil {
 				return
 			}
 			if channelNames != nil {
@@ -387,6 +390,14 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 
 		options.Terminator = make(chan bool)
 		defer close(options.Terminator)
+
+		// Set up GZip compression
+		var writer *bytes.Buffer
+		var zipWriter *gzip.Writer
+		if compress {
+			writer = bytes.NewBuffer(nil)
+			zipWriter = GetGZipWriter(writer)
+		}
 
 		caughtUp := false
 		h.generateContinuousChanges(inChannels, options, func(changes []*db.ChangeEntry) error {
@@ -399,9 +410,23 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 			} else {
 				data = []byte{}
 			}
+			if compress && len(data) > 8 {
+				// Compress JSON, using same GZip context, and send as binary msg:
+				zipWriter.Write(data)
+				zipWriter.Flush()
+				data = writer.Bytes()
+				writer.Reset()
+				conn.PayloadType = websocket.BinaryFrame
+			} else {
+				conn.PayloadType = websocket.TextFrame
+			}
 			_, err := conn.Write(data)
 			return err
 		})
+
+		if zipWriter != nil {
+			ReturnGZipWriter(zipWriter)
+		}
 	}
 	server := websocket.Server{
 		Handshake: func(*websocket.Config, *http.Request) error { return nil },
@@ -411,17 +436,18 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 	return nil
 }
 
-func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, options db.ChangesOptions, filter string, channelsArray []string, err error) {
+func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, options db.ChangesOptions, filter string, channelsArray []string, compress bool, err error) {
 	var input struct {
-		Feed        string        `json:"feed"`
-		Since       db.SequenceID `json:"since"`
-		Limit       int           `json:"limit"`
-		Style       string        `json:"style"`
-		IncludeDocs bool          `json:"include_docs"`
-		Filter      string        `json:"filter"`
-		Channels    string        `json:"channels"` // a filter query param, so it has to be a string
-		HeartbeatMs *uint64       `json:"heartbeat"`
-		TimeoutMs   *uint64       `json:"timeout"`
+		Feed           string        `json:"feed"`
+		Since          db.SequenceID `json:"since"`
+		Limit          int           `json:"limit"`
+		Style          string        `json:"style"`
+		IncludeDocs    bool          `json:"include_docs"`
+		Filter         string        `json:"filter"`
+		Channels       string        `json:"channels"` // a filter query param, so it has to be a string
+		HeartbeatMs    *uint64       `json:"heartbeat"`
+		TimeoutMs      *uint64       `json:"timeout"`
+		AcceptEncoding string        `json:"accept_encoding"`
 	}
 	if err = json.Unmarshal(jsonData, &input); err != nil {
 		return
@@ -452,6 +478,8 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 		kMaxTimeoutMS,
 		true,
 	)
+
+	compress = (input.AcceptEncoding == "gzip")
 
 	return
 }


### PR DESCRIPTION
If the client request JSON message contains "Accept-Encoding":"gzip",
the WebSocket change messages sent by the server may be GZip-compressed.
Compressed messages are WebSocket binary messages, instead of the text
messages that contain JSON. There is one GZip context for the duration
of the WebSocket, and each message is compressed using that context.
For more info see couchbase/couchbase-lite-ios#927

I'm seeing messages compressed down to about 30-40% original size.

Fixes #1179
