### PR TITLE
REST API for N1QL queries, using channel based access control.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "src/github.com/couchbase/sg-bucket"]
 	path = src/github.com/couchbase/sg-bucket
 	url = https://github.com/couchbase/sg-bucket.git
+[submodule "src/github.com/couchbase/gocb"]
+	path = src/github.com/couchbase/gocb
+	url = http://github.com/couchbase/gocb

--- a/examples/n1ql-bucket.json
+++ b/examples/n1ql-bucket.json
@@ -15,8 +15,18 @@
         `,
       "n1ql_queries" : {
         "type" : "SELECT DISTINCT(type) from \u0060travel-sample\u0060",
+        "type-positional" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $1",
+        "type-named" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $type",
         "airline" : "SELECT name from \u0060travel-sample\u0060 WHERE type = \"airline\"",
-        "name-filter" : "SELECT _sync.channels as _channels, name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL and name IS NOT NULL"
+        "name-filter" : "SELECT _sync.channels as _channels, name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL",
+        "name-filter-advanced" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND (ANY _userChannel IN $_userChannels SATISFIES _userChannel = \"*\" END OR ANY _channel IN OBJECT_PAIRS(_sync.channels) SATISFIES _channel.\u0060value\u0060 is null AND _channel.name IN $_userChannels END)"
+      },
+      "event_handlers" : {
+        "document_changed": [{
+          "handler": "webhook",
+          "url": "http://127.0.0.1:4984/default/",
+          "filter": "SELECT type, callsign, country WHERE type = \"airline\""
+        }]
       },
       "users": { 
         "GUEST": { 
@@ -43,13 +53,14 @@
           channel("beer")
         if (doc.good)
           channel("good")
+        if (doc.type) channel(doc.type)
       }
       `,
       "bucket": "default",
       "users": { 
         "GUEST": { 
           "disabled": false, 
-          "admin_channels": ["good"] 
+          "admin_channels": ["*"] 
         } 
       }
     }

--- a/examples/n1ql-bucket.json
+++ b/examples/n1ql-bucket.json
@@ -18,9 +18,9 @@
         "type-positional" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $1",
         "type-named" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $type",
         "airline" : "SELECT name from \u0060travel-sample\u0060 WHERE type = \"airline\"",
-        "name-filter" : "SELECT _sync.channels as _channels, name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL",
-        "name-filter-advanced" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND (ANY _userChannel IN $_userChannels SATISFIES _userChannel = \"*\" END OR ANY _channel IN OBJECT_PAIRS(_sync.channels) SATISFIES _channel.\u0060value\u0060 is null AND _channel.name IN $_userChannels END)",
-        "name-filter-expansion" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND CHANNEL_FILTER()"
+        "type-filter" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $type AND CHANNEL_FILTER()",
+        "airline-filter" : "SELECT name from \u0060travel-sample\u0060 WHERE type = \"airline\"",
+        "basic-filter" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND CHANNEL_FILTER()"
       },
       "event_handlers" : {
         "document_changed": [{

--- a/examples/n1ql-bucket.json
+++ b/examples/n1ql-bucket.json
@@ -13,13 +13,14 @@
             channel(doc.country.replace(" ","."))
         }
         `,
-      "n1ql_queries" : {
+      "queries" : {
         "type" : "SELECT DISTINCT(type) from \u0060travel-sample\u0060",
         "type-positional" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $1",
         "type-named" : "SELECT name from \u0060travel-sample\u0060 WHERE type = $type",
         "airline" : "SELECT name from \u0060travel-sample\u0060 WHERE type = \"airline\"",
         "name-filter" : "SELECT _sync.channels as _channels, name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL",
-        "name-filter-advanced" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND (ANY _userChannel IN $_userChannels SATISFIES _userChannel = \"*\" END OR ANY _channel IN OBJECT_PAIRS(_sync.channels) SATISFIES _channel.\u0060value\u0060 is null AND _channel.name IN $_userChannels END)"
+        "name-filter-advanced" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND (ANY _userChannel IN $_userChannels SATISFIES _userChannel = \"*\" END OR ANY _channel IN OBJECT_PAIRS(_sync.channels) SATISFIES _channel.\u0060value\u0060 is null AND _channel.name IN $_userChannels END)",
+        "name-filter-expansion" : "SELECT name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL AND name IS NOT NULL AND CHANNEL_FILTER()"
       },
       "event_handlers" : {
         "document_changed": [{
@@ -31,7 +32,7 @@
       "users": { 
         "GUEST": { 
           "disabled": false, 
-          "admin_channels": ["United.Kingdom"] 
+          "admin_channels": ["France"] 
         }
       }
     },

--- a/examples/n1ql-bucket.json
+++ b/examples/n1ql-bucket.json
@@ -1,0 +1,57 @@
+{
+  "log": ["CRUD"],
+  "databases": {
+    "travel-sample": {
+      "server": "http://127.0.0.1:8091",
+      "import_docs" : true,
+      "sync" : 
+        `
+        function(doc)  {
+          if (doc.type)
+            channel(doc.type)
+          if (doc.country)
+            channel(doc.country.replace(" ","."))
+        }
+        `,
+      "n1ql_queries" : {
+        "type" : "SELECT DISTINCT(type) from \u0060travel-sample\u0060",
+        "airline" : "SELECT name from \u0060travel-sample\u0060 WHERE type = \"airline\"",
+        "name-filter" : "SELECT _sync.channels as _channels, name, country, type from \u0060travel-sample\u0060 WHERE country IS NOT NULL and name IS NOT NULL"
+      },
+      "users": { 
+        "GUEST": { 
+          "disabled": false, 
+          "admin_channels": ["United.Kingdom"] 
+        }
+      }
+    },
+    "default": {
+      "server": "http://localhost:8091",
+      "n1ql_queries" : {
+        "all" : "SELECT _sync.channels as _channels, * from default",
+        "beer" : "SELECT _sync.channels as _channels, beer, META(default).id from default WHERE beer IS NOT NULL",
+        "good" : "SELECT _sync.channels as _channels, beer, good, META(default).id from default WHERE good IS NOT NULL",
+        "nofilter" : "SELECT good, beer as bier, META(default).id from default WHERE beer IS NOT NULL",
+        "beer-positional" : "SELECT _sync.channels as _channels, beer, META(default).id from default WHERE beer = $1",
+        "beer-named" : "SELECT _sync.channels as _channels, beer, META(default).id from default WHERE beer = $beer",
+        "from-param" : "SELECT true as filter WHERE $1.beer = \"cider\" and $1.good = true"
+      },
+      "sync" : 
+`
+      function(doc)  {
+        if (doc.beer)
+          channel("beer")
+        if (doc.good)
+          channel("good")
+      }
+      `,
+      "bucket": "default",
+      "users": { 
+        "GUEST": { 
+          "disabled": false, 
+          "admin_channels": ["good"] 
+        } 
+      }
+    }
+  }
+}

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -19,7 +19,10 @@ import (
 	"strings"
 	"time"
 
+	// "database/sql"
+	// _ "github.com/couchbaselabs/go_n1ql"
 	"github.com/couchbase/go-couchbase"
+	"github.com/couchbase/gocb"
 
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
@@ -30,20 +33,23 @@ import (
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.
 type DatabaseContext struct {
-	Name               string                  // Database name
-	Bucket             base.Bucket             // Storage
-	tapListener        changeListener          // Listens on server Tap feed
-	sequences          *sequenceAllocator      // Source of new sequence numbers
-	ChannelMapper      *channels.ChannelMapper // Runs JS 'sync' function
-	StartTime          time.Time               // Timestamp when context was instantiated
-	ChangesClientStats Statistics              // Tracks stats of # of changes connections
-	RevsLimit          uint32                  // Max depth a document's revision tree can grow to
-	autoImport         bool                    // Add sync data to new untracked docs?
-	Shadower           *Shadower               // Tracks an external Couchbase bucket
-	revisionCache      *RevisionCache          // Cache of recently-accessed doc revisions
-	changeCache        changeCache             //
-	EventMgr           *EventManager           // Manages notification events
-	AllowEmptyPassword bool                    // Allow empty passwords?  Defaults to false
+	Name               string                     // Database name
+	Bucket             base.Bucket                // Storage
+	tapListener        changeListener             // Listens on server Tap feed
+	sequences          *sequenceAllocator         // Source of new sequence numbers
+	ChannelMapper      *channels.ChannelMapper    // Runs JS 'sync' function
+	StartTime          time.Time                  // Timestamp when context was instantiated
+	ChangesClientStats Statistics                 // Tracks stats of # of changes connections
+	RevsLimit          uint32                     // Max depth a document's revision tree can grow to
+	autoImport         bool                       // Add sync data to new untracked docs?
+	Shadower           *Shadower                  // Tracks an external Couchbase bucket
+	revisionCache      *RevisionCache             // Cache of recently-accessed doc revisions
+	changeCache        changeCache                //
+	EventMgr           *EventManager              // Manages notification events
+	AllowEmptyPassword bool                       // Allow empty passwords?  Defaults to false
+	N1QLConnection     *gocb.Bucket               // connection object, instantiated lazily on first query
+	N1QLQueries        map[string]string          // named queries
+	N1QLStatements     map[string]*gocb.N1qlQuery // prepared statment
 }
 
 const DefaultRevsLimit = 1000

--- a/src/github.com/couchbase/sync_gateway/db/design_doc.go
+++ b/src/github.com/couchbase/sync_gateway/db/design_doc.go
@@ -3,11 +3,13 @@ package db
 import (
 	"net/http"
 	"strings"
+	// "encoding/json"
 
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	// "github.com/couchbase/gocb"
 )
 
 type DesignDoc sgbucket.DesignDoc
@@ -127,6 +129,69 @@ func (db *Database) QueryDesignDoc(ddocName string, viewName string, options map
 	return &result, nil
 }
 
+// Result of a n1ql query.
+type N1QLResult struct {
+	Rows []interface{} `json:"results"`
+}
+
+func (db *Database) N1QLQuery(queryName string, params map[string]interface{}, args []interface{}) (*N1QLResult, error) {
+	vres := N1QLResult{}
+
+	if queryString := db.N1QLQueries[queryName]; queryString != "" {
+		// queries that don't start with SELECT _channels are restricted to users with * access
+		hasMeta := strings.HasPrefix(queryString, "SELECT _sync.channels as _channels,")
+		query := db.N1QLStatements[queryName]
+
+		checkChannels := false
+		var visibleChannels ch.TimedSet
+		if db.user != nil {
+			visibleChannels = db.user.InheritedChannels()
+			checkChannels = !visibleChannels.Contains("*")
+		}
+		if checkChannels && !hasMeta {
+			return nil, base.HTTPErrorf(http.StatusForbidden, "Only users with acccess to `*` channel can query without `SELECT _sync.channels as _channels,` prefix.")
+		}
+
+		var queryParams interface{};
+		if len(args) > 0 {
+			queryParams = args
+		} else {
+			queryParams = params
+		}
+		rows, err := db.N1QLConnection.ExecuteN1qlQuery(query, queryParams)
+		if err != nil {
+			return nil, err
+		}
+		for {
+			var row map[string]interface{}
+			hasRow := rows.Next(&row)
+			if !hasRow {
+				break
+			}
+			// fmt.Printf("Row: %+v\n", row)
+			if checkChannels {
+				if docCh0 := row["_channels"]; docCh0 != nil {
+					docChannels := docCh0.(map[string]interface{})
+					docChannelsList := make([]interface{}, 0, len(docChannels))
+					for k := range docChannels {
+						channelStatus := docChannels[k]
+						if channelStatus == nil {
+							docChannelsList = append(docChannelsList, k)
+						}
+					}
+					if channelsIntersect(visibleChannels, docChannelsList) {
+						vres.Rows = append(vres.Rows, row)
+					}
+				}
+			} else {
+				vres.Rows = append(vres.Rows, row)
+			}
+		}
+		rows.Close()
+	}
+	return &vres, nil
+}
+
 // Cleans up the Value property, and removes rows that aren't visible to the current user
 func filterViewResult(input sgbucket.ViewResult, user auth.User, reduce bool) (result sgbucket.ViewResult) {
 	checkChannels := false
@@ -134,14 +199,14 @@ func filterViewResult(input sgbucket.ViewResult, user auth.User, reduce bool) (r
 	if user != nil {
 		visibleChannels = user.InheritedChannels()
 		checkChannels = !visibleChannels.Contains("*")
-		if (reduce) {
-			return; // this is an error
+		if reduce {
+			return // this is an error
 		}
 	}
 	result.TotalRows = input.TotalRows
 	result.Rows = make([]*sgbucket.ViewRow, 0, len(input.Rows)/2)
 	for _, row := range input.Rows {
-		if (reduce){
+		if reduce {
 			// Add the raw row:
 			result.Rows = append(result.Rows, &sgbucket.ViewRow{
 				Key:   row.Key,

--- a/src/github.com/couchbase/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api_test.go
@@ -45,8 +45,9 @@ var gBucketCounter = 0
 type restTester struct {
 	_bucket      base.Bucket
 	_sc          *ServerContext
-	noAdminParty bool   // Unless this is true, Admin Party is in full effect
-	syncFn       string // put the sync() function source in here (optional)
+	noAdminParty bool              // Unless this is true, Admin Party is in full effect
+	syncFn       string            // put the sync() function source in here (optional)
+	Queries      map[string]string // for N1QL tests
 }
 
 func (rt *restTester) bucket() base.Bucket {

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -35,7 +35,7 @@ var DefaultPool = "default"
 var config *ServerConfig
 
 const (
-	DefaultMaxCouchbaseConnections = 16
+	DefaultMaxCouchbaseConnections         = 16
 	DefaultMaxCouchbaseOverflowConnections = 0
 
 	// Default value of ServerConfig.MaxIncomingConnections
@@ -86,6 +86,7 @@ type DbConfig struct {
 	Sync               *string                        `json:"sync"`                           // Sync function defines which users can see which data
 	Users              map[string]*db.PrincipalConfig `json:"users,omitempty"`                // Initial user accounts
 	Roles              map[string]*db.PrincipalConfig `json:"roles,omitempty"`                // Initial roles
+	N1QLQueries        map[string]string              `json:"n1ql_queries,omitempty"`         // Initial user accounts
 	RevsLimit          *uint32                        `json:"revs_limit,omitempty"`           // Max depth a document's revision tree can grow to
 	ImportDocs         interface{}                    `json:"import_docs,omitempty"`          // false, true, or "continuous"
 	Shadow             *ShadowConfig                  `json:"shadow,omitempty"`               // External bucket to shadow

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -86,7 +86,7 @@ type DbConfig struct {
 	Sync               *string                        `json:"sync"`                           // Sync function defines which users can see which data
 	Users              map[string]*db.PrincipalConfig `json:"users,omitempty"`                // Initial user accounts
 	Roles              map[string]*db.PrincipalConfig `json:"roles,omitempty"`                // Initial roles
-	N1QLQueries        map[string]string              `json:"n1ql_queries,omitempty"`         // Initial user accounts
+	N1QLQueries        map[string]string              `json:"queries,omitempty"`         // Initial user accounts
 	RevsLimit          *uint32                        `json:"revs_limit,omitempty"`           // Max depth a document's revision tree can grow to
 	ImportDocs         interface{}                    `json:"import_docs,omitempty"`          // false, true, or "continuous"
 	Shadow             *ShadowConfig                  `json:"shadow,omitempty"`               // External bucket to shadow

--- a/src/github.com/couchbase/sync_gateway/rest/n1ql_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/n1ql_api.go
@@ -1,0 +1,43 @@
+package rest
+
+import (
+	// "crypto/sha1"
+	"encoding/json"
+	// "fmt"
+	// "io"
+	// "net/http"
+
+	// "database/sql"
+	// _ "github.com/couchbaselabs/go_n1ql"
+
+	"github.com/couchbase/sync_gateway/base"
+	// "github.com/couchbase/sync_gateway/db"
+)
+
+// HTTP handler for GET _query/$query
+func (h *handler) handleN1QLQuery() error {
+	queryName := h.PathVar("query")
+
+	var args []interface{}
+	if rawVal := h.getQuery("args"); "" != rawVal {
+		if err := json.Unmarshal([]byte(rawVal), &args); err != nil {
+			return err
+		}
+	}
+
+	var params map[string]interface{}
+	if rawVal := h.getQuery("params"); "" != rawVal {
+		if err := json.Unmarshal([]byte(rawVal), &params); err != nil {
+			return err
+		}
+	}
+
+	base.LogTo("HTTP", "N1QL query %q - params %v args %v", queryName, params, args)
+	result, err := h.db.N1QLQuery(queryName, params, args)
+	if err != nil {
+		return err
+	}
+	h.setHeader("Content-Type", `application/json; charset="UTF-8"`)
+	h.writeJSON(result)
+	return nil
+}

--- a/src/github.com/couchbase/sync_gateway/rest/n1ql_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/n1ql_api_test.go
@@ -1,0 +1,49 @@
+//  Copyright (c) 2012 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package rest
+
+import (
+	// "encoding/json"
+	"fmt"
+	// "net/http"
+	"testing"
+
+	// "github.com/couchbase/sg-bucket"
+	// "github.com/couchbase/sync_gateway/channels"
+
+	// "github.com/couchbaselabs/go.assert"
+)
+
+func TestSelectStarQuery(t *testing.T) {
+
+	rt := restTester{
+		syncFn: `function(doc) {channel(doc.channel)}`,
+		Queries: map[string]string{
+			"all": "SELECT field FROM db",
+		}}
+
+	response := rt.sendAdminRequest("GET", "/db/_query/all", ``)
+	assertStatus(t, response, 200)
+	// why does this 200 when underlying engine doesn't support n1ql?
+	fmt.Println(response.Body)
+
+	// var result sgbucket.ViewResult
+
+	// // Admin view query:
+	// response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/bar?reduce=true", ``)
+	// assertStatus(t, response, 200)
+	// json.Unmarshal(response.Body.Bytes(), &result)
+
+	// // we should get 1 row with the reduce result
+	// assert.Equals(t, len(result.Rows), 1)
+	// row := result.Rows[0]
+	// value := row.Value.(float64)
+	// assert.Equals(t, value, 108.0)
+}

--- a/src/github.com/couchbase/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbase/sync_gateway/rest/routing.go
@@ -55,6 +55,7 @@ func createHandler(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mux.Rou
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, (*handler).handlePutDesignDoc)).Methods("PUT")
 	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
 	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, (*handler).handleView)).Methods("GET")
+	dbr.Handle("/_query/{query}", makeHandler(sc, privs, (*handler).handleN1QLQuery)).Methods("GET")
 	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, (*handler).handleEFC)).Methods("POST")
 	dbr.Handle("/_revs_diff", makeHandler(sc, privs, (*handler).handleRevsDiff)).Methods("POST")
 

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/couchbase/go-couchbase"
+	"github.com/couchbase/gocb"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -239,6 +240,21 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, cacheOptions, revCacheSize)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.N1QLQueries != nil {
+		dbcontext.N1QLQueries = config.N1QLQueries
+		dbcontext.N1QLStatements = make(map[string]*gocb.N1qlQuery)
+		cluster, _ := gocb.Connect(*config.Server)
+		bucket, err := cluster.OpenBucket(bucketName, "")
+		if err != nil {
+			return nil, err
+		}
+		dbcontext.N1QLConnection = bucket
+		for name := range dbcontext.N1QLQueries {
+			dbcontext.N1QLStatements[name] = gocb.NewN1qlQuery(dbcontext.N1QLQueries[name])
+			dbcontext.N1QLStatements[name].AdHoc(false)
+		}
 	}
 
 	syncFn := ""

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -252,7 +252,10 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 		}
 		dbcontext.N1QLConnection = bucket
 		for name := range dbcontext.N1QLQueries {
-			dbcontext.N1QLStatements[name] = gocb.NewN1qlQuery(dbcontext.N1QLQueries[name])
+			// todo make it work with positional params
+			// test for use of positionals, and replace $_userChannels
+			queryWithFilter := strings.Replace(dbcontext.N1QLQueries[name], "CHANNEL_FILTER()", "(ANY _userChannel IN $_userChannels SATISFIES _userChannel = \"*\" END OR ANY _channel IN OBJECT_PAIRS(_sync.channels) SATISFIES _channel.`value` is null AND _channel.name IN $_userChannels END)", -1)
+			dbcontext.N1QLStatements[name] = gocb.NewN1qlQuery(queryWithFilter)
 			dbcontext.N1QLStatements[name].AdHoc(false)
 		}
 	}


### PR DESCRIPTION
Because this uses gocb as a dependency, we have a couple of choices:
- patch gocb to have a n1ql only mode, that doesn't establish it's own connection to CBS
- steal the REST API N1QL [query and prepared statement code](https://github.com/couchbase/gocb/blob/master/bucket_http.go#L245) (maybe move it to go-couchbase?)
- Move everything else to gocb (probably not for this PR)
