### PR TITLE
Wrap gocb logging in standard Sync Gateway logging

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket_gocb.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket_gocb.go
@@ -23,10 +23,25 @@ type CouchbaseBucketGoCB struct {
 	spec         BucketSpec // keep a copy of the BucketSpec for DCP usage
 }
 
+type GoCBLogger struct{}
+
+func (l GoCBLogger) Output(s string) error {
+	LogTo("gocb", s)
+	return nil
+}
+
+func EnableGoCBLogging() {
+	gocbcore.SetLogger(GoCBLogger{})
+}
+
 // Creates a Bucket that talks to a real live Couchbase server.
 func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket Bucket, err error) {
 
-	gocbcore.SetLogger(gocbcore.DefaultStdOutLogger())
+	// Only wrap the gocb logging when the log key is set, to avoid the overhead of a log keys
+	// map lookup for every gocb log call
+	if LogEnabled("gocb") {
+		EnableGoCBLogging()
+	}
 
 	cluster, err := gocb.Connect(spec.Server)
 	if err != nil {

--- a/sync_gateway.sublime-project
+++ b/sync_gateway.sublime-project
@@ -45,6 +45,13 @@
 			],
 			"follow_symlinks": true,
 			"path": "src/github.com/couchbaselabs/cbgt"
+		},{
+			"file_exclude_patterns":
+			[
+				".*"
+			],
+			"follow_symlinks": true,
+			"path": "src/github.com/couchbase/gocb"
 		},
 		{
 			"follow_symlinks": true,


### PR DESCRIPTION
A few go fmt changes got triggered when I edited logging.go - they can be ignored.  The main change there is to ensure gocb logging gets enabled if someone uses the admin API to add the gocb log key. 
