### PR TITLE
Add LRU cache to sequence hasher

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/sequence_hasher.go
+++ b/src/github.com/couchbase/sync_gateway/db/sequence_hasher.go
@@ -11,12 +11,13 @@ package db
 
 import (
 	"bytes"
+	"container/list"
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -24,18 +25,31 @@ import (
 const kHashPrefix = "_sequence:"
 const kDefaultHashExpiry = uint32(2592000)
 const kDefaultSize = uint8(32)
+const kDefaultHasherCacheCapacity = 500
 
 type sequenceHasher struct {
-	bucket     base.Bucket // Bucket to store hashed instances
-	exp        uint8       // Range of hash values is from 0 to 2^exp
-	mod        uint64      // 2^exp.  Stored during init to reduce computation during hash.
-	modMinus1  uint64      // 2^exp - 1.  Stored during init to reduce computation during hash.
-	hashExpiry uint32
+	bucket        base.Bucket              // Bucket to store hashed instances
+	exp           uint8                    // Range of hash values is from 0 to 2^exp
+	mod           uint64                   // 2^exp.  Stored during init to reduce computation during hash.
+	modMinus1     uint64                   // 2^exp - 1.  Stored during init to reduce computation during hash.
+	hashExpiry    uint32                   // expiry in bucket
+	cache         map[uint64]*list.Element // Fast lookup of clocks by hash
+	lruList       *list.List               // List ordered by most recent access (Front is newest)
+	cacheCapacity int                      // Max number of hashes to cache
+	cacheLock     sync.Mutex               // mutex for cache
 }
 
 type sequenceHash struct {
 	hashValue      uint64
 	collisionIndex uint16
+}
+
+type SeqHashCacheLoaderFunc func(hashValue uint64) (clocks *storedClocks, err error)
+type hashCacheValue struct {
+	key    uint64        // hashValue
+	clocks *storedClocks // stored clocks for this hash value (array of clocks, indexed by collision index)
+	lock   sync.Mutex    // synchronization for disk load
+	err    error         // load error
 }
 
 func (s *sequenceHash) String() string {
@@ -44,6 +58,7 @@ func (s *sequenceHash) String() string {
 
 // Creates a new sequenceHasher using 2^exp as mod.
 func NewSequenceHasher(options *SequenceHashOptions) (*sequenceHasher, error) {
+
 	if options == nil {
 		return nil, errors.New("Options must be specified for new sequence hasher")
 	}
@@ -60,15 +75,17 @@ func NewSequenceHasher(options *SequenceHashOptions) (*sequenceHasher, error) {
 	expireTime := kDefaultHashExpiry
 	if options.Expiry != nil {
 		expireTime = *options.Expiry
-		log.Println("Creating with expiry:", expireTime)
 	}
 
 	return &sequenceHasher{
-		bucket:     options.Bucket,
-		exp:        size,
-		mod:        uint64(1 << size),   // 2^exp
-		modMinus1:  uint64(1<<size - 1), // 2^exp - 1
-		hashExpiry: expireTime,
+		bucket:        options.Bucket,
+		exp:           size,
+		mod:           uint64(1 << size),   // 2^exp
+		modMinus1:     uint64(1<<size - 1), // 2^exp - 1
+		hashExpiry:    expireTime,
+		cache:         map[uint64]*list.Element{},
+		lruList:       list.New(),
+		cacheCapacity: kDefaultHasherCacheCapacity,
 	}, nil
 
 }
@@ -95,53 +112,88 @@ func (s *sequenceHasher) GetHash(clock base.SequenceClock) (string, error) {
 	if clock == nil {
 		return "", errors.New("Can't calculate hash for nil clock")
 	}
+
 	hashValue := s.calculateHash(clock)
 
-	// Load stored clocks for this hash, to see if it's already been defined
-	storedClocks, err := s.loadClocks(hashValue)
+	// Load stored clocks for this hash, to see if it's already been defined.
+	// Note: getCacheValue and load are handled as separate operations to optimize locking.
+	//   1. getCacheValue locks the cache, and retrieves the current cache entry (or creates a new empty entry if not found)
+	//   2. cachedValue.load locks the entry, and loads from the DB if no previous entry is found
+	cachedValue := s.getCacheValue(hashValue)
+	cachedClocks, err := cachedValue.load(s.loadClocks)
 	if err != nil {
 		return "", err
 	}
-	exists, index := storedClocks.Contains(clock)
+
+	// Check whether the cached clocks for the hash value match our clock
+	exists, index := cachedClocks.Contains(clock.Value())
 	if exists {
 		seqHash := sequenceHash{
 			hashValue:      hashValue,
 			collisionIndex: uint16(index),
 		}
-		indexExpvars.Add("hash_getHash_hits", 1)
+		indexExpvars.Add("seqHash_getHash_hits", 1)
 		return seqHash.String(), nil
 	}
-	indexExpvars.Add("hash_getHash_misses", 1)
 
-	// Didn't find a match
-	storedClocks.Sequences = append(storedClocks.Sequences, clock.Value())
-	//storedIndex := len(storedClocks.Sequences) - 1
-	key := kHashPrefix + strconv.FormatUint(hashValue, 10)
-	initialValue, err := storedClocks.Marshal()
-	index = len(storedClocks.Sequences) - 1
-	if err != nil {
-		return "", err
-	}
-	_, err = writeCasRaw(s.bucket, key, initialValue, storedClocks.cas, int(s.hashExpiry), func(value []byte) (updatedValue []byte, err error) {
-		// Note: The following is invoked upon cas failure - may be called multiple times
-		base.LogTo("DIndex+", "CAS fail - reapplying changes for hash storage for key: %s", key)
-		err = storedClocks.Unmarshal(value)
-		if err != nil {
-			base.Warn("Error unmarshalling hash storage during update", err)
-			return nil, err
-		}
-		exists, index = storedClocks.Contains(clock)
-		if exists {
-			// return empty byte array to cancel the update
-			return []byte{}, nil
-		}
-		// Not found - add
-		storedClocks.Sequences = append(storedClocks.Sequences, clock.Value())
+	// Didn't find a match in cache - update the index and the cache.  Get a write lock on the index value
+	// first, to ensure only one goroutine on this SG attempts to write.  writeCas handling below handles
+	// the case where other SGs are updating the value concurrently
+	indexExpvars.Add("seqHash_getHash_misses", 1)
 
-		base.LogTo("DIndex+", "Reattempting stored hash write for key %s:", key)
+	// First copy the clock value, to ensure we store a non-mutable version in the cache
+	clockValue := make([]uint64, len(clock.Value()))
+	copy(clockValue, clock.Value())
+
+	updateErr := func() error {
+		cachedValue.lock.Lock()
+		defer cachedValue.lock.Unlock()
+
+		// If the number of cached clocks has changed, check whether someone else has added this clock
+		// while we waited for the lock
+		if len(cachedValue.clocks.Sequences) > len(cachedClocks.Sequences) {
+			exists, index = cachedValue.clocks.Contains(clockValue)
+			if exists {
+				return nil
+			}
+		}
+
+		// Add our clock to the cached clocks for this hash
+		storedClocks := cachedValue.clocks
+		storedClocks.Sequences = append(storedClocks.Sequences, clockValue)
+
+		// Update the hash entry in the bucket
+		key := kHashPrefix + strconv.FormatUint(hashValue, 10)
+		initialValue, err := storedClocks.Marshal()
 		index = len(storedClocks.Sequences) - 1
-		return storedClocks.Marshal()
-	})
+		if err != nil {
+			return err
+		}
+		_, err = writeCasRaw(s.bucket, key, initialValue, storedClocks.cas, int(s.hashExpiry), func(value []byte) (updatedValue []byte, err error) {
+			// Note: The following is invoked upon cas failure - may be called multiple times
+			base.LogTo("DIndex+", "CAS fail - reapplying changes for hash storage for key: %s", key)
+			err = storedClocks.Unmarshal(value)
+			if err != nil {
+				base.Warn("Error unmarshalling hash storage during update", err)
+				return nil, err
+			}
+			exists, index = storedClocks.Contains(clockValue)
+			if exists {
+				// return empty byte array to cancel the update
+				return []byte{}, nil
+			}
+			// Not found - add
+			storedClocks.Sequences = append(storedClocks.Sequences, clockValue)
+			base.LogTo("DIndex+", "Reattempting stored hash write for key %s:", key)
+			index = len(storedClocks.Sequences) - 1
+			return storedClocks.Marshal()
+		})
+		return nil
+	}()
+
+	if updateErr != nil {
+		return "", updateErr
+	}
 
 	indexExpvars.Add("writeCasRaw_hash", 1)
 
@@ -153,7 +205,6 @@ func (s *sequenceHasher) GetHash(clock base.SequenceClock) (string, error) {
 		hashValue:      hashValue,
 		collisionIndex: uint16(index),
 	}
-
 	return seqHash.String(), nil
 }
 
@@ -162,6 +213,7 @@ func (s *sequenceHasher) GetClock(sequence string) (base.SequenceClock, error) {
 	clock := base.NewSequenceClockImpl()
 	var err error
 	var seqHash sequenceHash
+
 	components := strings.Split(sequence, "-")
 	if len(components) == 1 {
 		seqHash.hashValue, err = strconv.ParseUint(sequence, 10, 64)
@@ -180,21 +232,73 @@ func (s *sequenceHasher) GetClock(sequence string) (base.SequenceClock, error) {
 		}
 	}
 
-	stored, loadErr := s.loadClocks(seqHash.hashValue)
+	cachedValue := s.getCacheValue(seqHash.hashValue)
+	storedClocks, loadErr := cachedValue.load(s.loadClocks)
 	if loadErr != nil {
 		return clock, loadErr
 	}
 
-	if uint16(len(stored.Sequences)) <= seqHash.collisionIndex {
+	if uint16(len(storedClocks.Sequences)) <= seqHash.collisionIndex {
 		return clock, errors.New(fmt.Sprintf("Stored hash not found for sequence [%s], returning zero clock", sequence))
 	}
 	clock = base.NewSequenceClockImpl()
-	clock.Init(stored.Sequences[seqHash.collisionIndex], seqHash.String())
+	clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())
 	return clock, nil
 
 }
 
-func (s *sequenceHasher) loadClocks(hashValue uint64) (storedClocks, error) {
+// s.cache[hashValue] contains the storedClocks for this hash value.  If present, getCacheValue
+// returns the storedClocks.  If not present, getValue initializes an empty entry, which will trigger
+// index bucket retrieval on subsequent load
+func (s *sequenceHasher) getCacheValue(hashValue uint64) (value *hashCacheValue) {
+
+	s.cacheLock.Lock()
+	defer s.cacheLock.Unlock()
+	if elem := s.cache[hashValue]; elem != nil {
+		s.lruList.MoveToFront(elem)
+		value = elem.Value.(*hashCacheValue)
+	} else {
+		value = &hashCacheValue{key: hashValue}
+		s.cache[hashValue] = s.lruList.PushFront(value)
+		for len(s.cache) > s.cacheCapacity {
+			// purge oldest from cache
+			value := s.lruList.Remove(s.lruList.Back()).(*hashCacheValue)
+			delete(s.cache, value.key)
+		}
+	}
+	return
+}
+
+// Adds a revision to the cache.
+func (s *sequenceHasher) putCacheValue(hashValue uint64, clocks *storedClocks) {
+	value := s.getCacheValue(hashValue)
+	value.store(clocks)
+}
+
+// Gets the stored clocks out of a hashCacheValue.  If nil, will attempt to load from the index bucket
+func (value *hashCacheValue) load(loaderFunc SeqHashCacheLoaderFunc) (*storedClocks, error) {
+	value.lock.Lock()
+	defer value.lock.Unlock()
+	if value.clocks == nil {
+		indexExpvars.Add("seqHashCache_misses", 1)
+		value.clocks, value.err = loaderFunc(value.key)
+	} else {
+		indexExpvars.Add("seqHashCacheCache_hits", 1)
+	}
+
+	// return a copy to ensure cache values don't get mutated outside of a hashCacheValue.store
+	return value.clocks.Copy(), value.err
+}
+
+// Stores a body etc. into a revCacheValue if there isn't one already.
+func (value *hashCacheValue) store(clocks *storedClocks) {
+	value.lock.Lock()
+	defer value.lock.Unlock()
+	value.clocks = clocks.Copy()
+	indexExpvars.Add("seqHashCache_adds", 1)
+}
+
+func (s *sequenceHasher) loadClocks(hashValue uint64) (*storedClocks, error) {
 
 	stored := storedClocks{}
 	key := kHashPrefix + strconv.FormatUint(hashValue, 10)
@@ -204,15 +308,31 @@ func (s *sequenceHasher) loadClocks(hashValue uint64) (storedClocks, error) {
 
 	if err != nil {
 		// Assume no clocks stored for this string
-		return stored, nil
+		return &stored, nil
 	}
 	if err = stored.Unmarshal(bytes); err != nil {
 		base.Warn("Error unmarshalling stored clocks for key [%s], returning zero sequence", key)
-		return stored, errors.New("Error unmarshalling stored clocks for key")
+		return &stored, errors.New("Error unmarshalling stored clocks for key")
 	}
 	stored.cas = cas
-	return stored, nil
+	return &stored, nil
 }
+
+/*
+func (s *sequenceHasher) logCache(id int) {
+
+	s.cacheLock.Lock()
+	defer s.cacheLock.Unlock()
+	log.Printf("[%d]---print cache---", id)
+	for key, elem := range s.cache {
+		cacheValue := elem.Value.(*hashCacheValue)
+		cacheValue.lock.Lock()
+		log.Printf("key: %d, value: %s", key, cacheValue.clocks.String())
+		cacheValue.lock.Unlock()
+	}
+	log.Printf("[%d]---end print cache---", id)
+}
+*/
 
 type storedClocks struct {
 	cas       uint64
@@ -241,13 +361,37 @@ func (s *storedClocks) Unmarshal(value []byte) error {
 	return nil
 }
 
-func (s *storedClocks) Contains(clock base.SequenceClock) (bool, int) {
+func (s *storedClocks) Contains(clockValue []uint64) (bool, int) {
 	for index, storedClock := range s.Sequences {
-		if ClockMatches(storedClock, clock.Value()) {
+		if ClockMatches(storedClock, clockValue) {
 			return true, index
 		}
 	}
 	return false, 0
+}
+
+func (s *storedClocks) String() string {
+	results := ""
+	for index, storedClock := range s.Sequences {
+		results = fmt.Sprintf("%s[%d--", results, index)
+		for vb, sequence := range storedClock {
+			if sequence != 0 {
+				results = fmt.Sprintf("%s(%d,%d),", results, vb, sequence)
+			}
+		}
+		results = fmt.Sprintf("%s],", results)
+	}
+	return results
+}
+
+func (s *storedClocks) Copy() *storedClocks {
+	copyClock := storedClocks{}
+	copyClock.cas = s.cas
+
+	for _, storedClock := range s.Sequences {
+		copyClock.Sequences = append(copyClock.Sequences, storedClock)
+	}
+	return &copyClock
 }
 
 func ClockMatches(a, b []uint64) bool {


### PR DESCRIPTION
Stores up to 500 recently used hash values in an LRU cache.  Implementation is based on revision cache, with modifications to support changes to the set of clocks for a hash within the cache (hash collisions).  Reduces the number of bucket ops required when multiple connected users have the same set of channels.  On cache hit, uses the cache value.  On cache miss, writes to the hash bucket then updates the cache.  Existing CAS write processing handles the case where another Sync Gateway node has already written that value to the bucket - cached value will be updated with the current state of the hash bucket value.

Two-level locking, similar to revision cache.  The entire cache only gets locked during read/write of the cache entry.  A lock on the individual entry is used when doing bucket operations, to avoid blocking for other cache readers.
