### PR TITLE
Avoid redundant channel clock retrieval by index readers

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index.go
@@ -455,6 +455,7 @@ func (k *kvChangeIndex) newChannelReader(channelName string) (*kvChannelIndex, e
 		return nil, err
 	}
 	k.channelIndexReaders[channelName] = NewKvChannelIndex(channelName, k.indexBucket, indexPartitions, k.getStableClock, k.onChange)
+	k.channelIndexReaders[channelName].setType("reader")
 	return k.channelIndexReaders[channelName], nil
 }
 
@@ -471,6 +472,7 @@ func (k *kvChangeIndex) newChannelWriter(channelName string) (*kvChannelIndex, e
 		return nil, err
 	}
 	k.channelIndexWriters[channelName] = NewKvChannelIndex(channelName, k.indexBucket, indexPartitions, k.getStableClock, nil)
+	k.channelIndexWriters[channelName].setType("writer")
 	return k.channelIndexWriters[channelName], nil
 }
 

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
@@ -305,7 +305,8 @@ func TestPollingChangesFeed(t *testing.T) {
 		WriteDirectWithKey(db, fmt.Sprintf("multiDoc_%d", i), []string{"PBS", "HBO", "CBS"}, 1)
 		// Midway through, read from HBO
 		if i == 9 {
-			time.Sleep(20 * time.Millisecond)
+			// wait for polling cycle
+			time.Sleep(600 * time.Millisecond)
 			hboChanges, err := db.GetChanges(base.SetOf("HBO"), ChangesOptions{Since: simpleClockSequence(0), Wait: true})
 			assertTrue(t, err == nil, "Error getting changes")
 			assert.Equals(t, len(hboChanges), 10)


### PR DESCRIPTION
Also improves logging/diagnostics to differentiate between readers and writers.
