### PR TITLE
For Amazon Linux, will set OS to RedHat and will default versions to 5.0

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -43,6 +43,9 @@ ostype() {
     elif [ -f /etc/redhat-release ]; then
         OS=RedHat
         VER=`cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
+    elif [ -f /etc/system-release ]; then
+        OS=RedHat
+        VER=5.0
     else
         OS=$(uname -s)
         VER=$(uname -r)


### PR DESCRIPTION
For Amazon Linux, will set OS to RedHat and will default versions to 5.0

The Amazon Linux distro removes the /etc/redhat-release file and there is no direct way to determine the REDHAT/CentOS release the bistro is based on. Amazon say that it is binary compatible with at least RedHat 5, later releases are binary compatible with RedHat 6. Defaulting to RedHat 5 as the sysv_init scripts should be compatible with both.

fixes #1153 
