### PR TITLE
Post install of SG automatically start as a service

### DIFF
--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -36,6 +36,12 @@ EOF
 
     chmod 755 @@PREFIX@@/service/sync_gateway_service_install.sh
 
+    if [ -z `id -u $RUNAS_TEMPLATE_VAR 2>/dev/null` ]; then
+      useradd -m sync_gateway
+    fi
+
+    @@PREFIX@@/service/sync_gateway_service_install.sh
+
     export UPGRADE_MARKER=/tmp/@@PRODUCT_BASE@@-`date +%Y%m%d`-upgrade-from
 
     cat <<EOF

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -78,6 +78,12 @@ fi
 
 # ln -f -s $RPM_INSTALL_PREFIX0 @@PREFIX@@
 
+if [ -z `id -u $RUNAS_TEMPLATE_VAR 2>/dev/null` ]; then
+  useradd -m sync_gateway
+fi
+
+@@PREFIX@@/service/sync_gateway_service_install.sh
+
 if ! grep `uname -m` $RPM_INSTALL_PREFIX0/manifest.txt >/dev/null
 then
   cat <<EOF


### PR DESCRIPTION
Post install of SG make sure the default sync_gateway user account has been created and install the SG service and start it automatically.

fixes #1022 
