### PR TITLE
Updated post-install stdout text

### DIFF
--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -152,18 +152,19 @@ cat <<EOF
 
 You have successfully installed @@PRODUCT_BASE_CAP@@ Sync Gateway.
 
-You can start Couchbase Sync Gateway by using the following command:
+You can control the Couchbase Sync Gateway service by using the following command:
 
-@@PREFIX@@/bin/sync_gateway
+@@SERVICE_EXEC@@ @@SERVICE_NAME@@ @@SERVICE_EXEC_PARAMS@@
 
-That's it! This command starts Sync Gateway on port 4984, connects to a limited in-memory database
- that lives on Sync Gateway called "walrus", and starts the admin server on port 4985. 
+That's it! Sync Gateway is now running on port 4984. We've setup a simple in-memory database
+ which works great for exploring Sync Gateway's capabilities. A limited console is available
+ by opening your browser to http://localhost:4985/_admin/.
 
 The command-line options are:
 
   -adminInterface=":4985": Address to bind admin interface to
   -bucket="sync_gateway": Name of bucket
-  -dbname="": Name of CouchDB database (defaults to name of bucket)
+  -dbname="": Name to assign to this database (defaults to name of bucket)
   -interface=":4984": Address to bind to
   -log="": Log keywords, comma separated
   -personaOrigin="": Base URL that clients use to connect to the server

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -154,7 +154,7 @@ You have successfully installed @@PRODUCT_BASE_CAP@@ Sync Gateway.
 
 You can control the Couchbase Sync Gateway service by using the following command:
 
-@@SERVICE_EXEC@@ @@SERVICE_NAME@@ @@SERVICE_EXEC_PARAMS@@
+  @@SERVICE_CMD_EXAMPLE@@
 
 That's it! Sync Gateway is now running on port 4984. We've setup a simple in-memory database
  which works great for exploring Sync Gateway's capabilities. A limited console is available


### PR DESCRIPTION
...to reflect that the RPM already ran the service installer.

This change assumes two new vars are defined: `@@SERVICE_EXEC@@` and `@@SERVICE_EXEC_PARAMS@@`. The first should map to `service`, `initctl`, `systemctl`, or `launchctl`, and the second maps to whatever additional command-line params are required beyond `@@SERVICE_NAME@@`
