### PR TITLE
Add support for sharded clock management

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket_gocb_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket_gocb_test.go
@@ -200,3 +200,44 @@ func CouchbaseTestUpdate(t *testing.T) {
 	}
 
 }
+
+func TestIncrCounter(t *testing.T) {
+
+	bucket := GetBucketOrPanic()
+	key := "TestIncr"
+
+	defer func() {
+		err := bucket.Delete(key)
+		if err != nil {
+			t.Errorf("Error removing counter from bucket")
+		}
+	}()
+
+	// New Counter - incr 1, default 1
+	value, err := bucket.Incr(key, 1, 1, 0)
+	if err != nil {
+		t.Errorf("Error incrementing non-existent counter")
+	}
+	assert.Equals(t, value, uint64(1))
+
+	// Retrieve an existing counter using delta=0
+	retrieval, err := bucket.Incr(key, 0, 0, 0)
+	if err != nil {
+		t.Errorf("Error retrieving value for existing counter")
+	}
+	assert.Equals(t, retrieval, uint64(1))
+
+	// Increment existing counter
+	retrieval, err = bucket.Incr(key, 1, 1, 0)
+	if err != nil {
+		t.Errorf("Error incrementing value for existing counter")
+	}
+	assert.Equals(t, retrieval, uint64(2))
+
+	// Attempt retrieval of a non-existent counter using delta=0
+	retrieval, err = bucket.Incr("badkey", 0, 0, 0)
+	if err == nil {
+		t.Errorf("Attempt to retrieve non-existent counter should return error")
+	}
+
+}

--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
@@ -1,0 +1,269 @@
+package base
+
+import (
+	"bytes"
+	"encoding/gob"
+	"expvar"
+	"fmt"
+	"sync"
+
+	"github.com/couchbase/sg-bucket"
+)
+
+var shardedClockExpvars *expvar.Map
+
+func init() {
+	shardedClockExpvars = expvar.NewMap("syncGateway_index_clocks")
+}
+
+const (
+	KIndexPartitionKey       = "_idxPartitionMap"
+	kIndexPrefix             = "_idx"
+	kCountKeyFormat          = "_idx_c:%s:count"    // key
+	kClockPartitionKeyFormat = "_idx_c:%s:clock-%d" // key, partition index
+)
+
+type PartitionStorage struct {
+	Uuid  string   `json:"uuid"`
+	Index uint16   `json:"index"`
+	VbNos []uint16 `json:"vbNos"`
+}
+
+type IndexPartitionMap map[uint16]uint16 // Maps vbuckets to index partition value
+
+type IndexPartitions struct {
+	VbMap         IndexPartitionMap
+	PartitionDefs []PartitionStorage
+}
+
+func NewIndexPartitions(partitions []PartitionStorage) *IndexPartitions {
+
+	indexPartitions := &IndexPartitions{
+		PartitionDefs: make([]PartitionStorage, len(partitions)),
+	}
+	copy(indexPartitions.PartitionDefs, partitions)
+
+	indexPartitions.VbMap = make(map[uint16]uint16)
+	for _, partition := range partitions {
+		for _, vbNo := range partition.VbNos {
+			indexPartitions.VbMap[vbNo] = partition.Index
+		}
+	}
+	return indexPartitions
+}
+
+// ShardedClock maintains the collection of clock shards (ShardedClockPartitions), and also manages
+// the counter for the clock.
+type ShardedClock struct {
+	baseKey       string                            // key prefix used to build keys for clock component docs
+	counter       uint64                            // count value for clock
+	countKey      string                            // key used to incr count value
+	partitionMap  *IndexPartitions                  // Index partition map
+	partitions    map[uint16]*ShardedClockPartition // Clock partitions - one doc written per partition
+	bucket        Bucket                            // Bucket used to store clocks
+	partitionKeys []string                          // Keys for all partitions.  Convenience to avoid rebuilding set from partitions
+}
+
+// ShardedClockPartition manages storage for one clock partition, where a clock partition is a set of
+// {vb, seq} values for a subset of vbuckets.
+type ShardedClockPartition struct {
+	Index  uint16            // Partition Index
+	Key    string            // Clock partition document key
+	Values map[uint16]uint64 // Clock partition values, indexed by vb
+	cas    uint64            // cas value of partition doc
+	dirty  bool              // Whether values have been updated since last save/load
+}
+
+func NewShardedClockPartition(baseKey string, index uint16) *ShardedClockPartition {
+	return &ShardedClockPartition{
+		Index:  index,
+		Key:    fmt.Sprintf(kClockPartitionKeyFormat, baseKey, index),
+		Values: make(map[uint16]uint64),
+	}
+}
+
+// TODO: replace with something more intelligent than gob encode, to take advantage of known
+//       clock structure?
+func (scp *ShardedClockPartition) Marshal() ([]byte, error) {
+	var output bytes.Buffer
+	enc := gob.NewEncoder(&output)
+	err := enc.Encode(scp)
+	if err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func (scp *ShardedClockPartition) Unmarshal(value []byte) error {
+	input := bytes.NewBuffer(value)
+	dec := gob.NewDecoder(input)
+	err := dec.Decode(&scp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (scp *ShardedClockPartition) SetSequence(vb uint16, seq uint64) {
+	scp.Values[vb] = seq
+	scp.dirty = true
+}
+
+func NewShardedClock(baseKey string, partitions *IndexPartitions, bucket Bucket) *ShardedClock {
+	clock := &ShardedClock{
+		baseKey:      baseKey,
+		partitionMap: partitions,
+		countKey:     fmt.Sprintf(kCountKeyFormat, baseKey),
+		bucket:       bucket,
+	}
+
+	// Initialize partitions
+	numPartitions := len(partitions.PartitionDefs)
+
+	clock.partitions = make(map[uint16]*ShardedClockPartition, numPartitions)
+	clock.partitionKeys = make([]string, numPartitions)
+
+	return clock
+
+}
+
+func NewShardedClockWithPartitions(baseKey string, partitions *IndexPartitions, bucket Bucket) *ShardedClock {
+	clock := &ShardedClock{
+		baseKey:      baseKey,
+		partitionMap: partitions,
+		countKey:     fmt.Sprintf(kCountKeyFormat, baseKey),
+		bucket:       bucket,
+	}
+
+	// Initialize partitions
+	numPartitions := len(partitions.PartitionDefs)
+
+	clock.partitions = make(map[uint16]*ShardedClockPartition, numPartitions)
+	clock.partitionKeys = make([]string, numPartitions)
+
+	// Initialize empty clock partitions
+	for _, partitionDef := range partitions.PartitionDefs {
+		partition := NewShardedClockPartition(baseKey, partitionDef.Index)
+		clock.partitions[partitionDef.Index] = partition
+		clock.partitionKeys[partitionDef.Index] = partition.Key
+	}
+
+	return clock
+
+}
+
+func (s *ShardedClock) Write() (err error) {
+	// write all modified partitions to bucket
+	shardedClockExpvars.Add("count_write", 1)
+	var wg sync.WaitGroup
+	for _, partition := range s.partitions {
+		if partition.dirty {
+			wg.Add(1)
+			// TODO: replace with SetBulk when available
+			go func(p *ShardedClockPartition) {
+				defer wg.Done()
+				value, err := p.Marshal()
+				casOut, err := s.bucket.WriteCas(p.Key, 0, 0, p.cas, value, sgbucket.Raw)
+
+				if err != nil {
+					Warn("Error writing sharded clock partition [%d]:%v", p.Key, err)
+					shardedClockExpvars.Add("partition_cas_failures", 1)
+					return
+				}
+
+				p.cas = casOut
+				p.dirty = false
+			}(partition)
+		}
+	}
+	wg.Wait()
+
+	// Increment the clock count
+	s.counter, err = s.bucket.Incr(s.countKey, 1, 1, 0)
+	return err
+}
+
+// Loads clock from bucket.  If counter isn't changed, returns false and leaves as-is.
+// For newly initialized ShardedClocks (counter=0), this will only happen if there are no
+// entries in the bucket for the clock.
+func (s *ShardedClock) Load() (isChanged bool, err error) {
+
+	newCounter, err := s.bucket.Incr(s.countKey, 0, 0, 0)
+	if err != nil {
+		LogTo("DIndex+", "Error getting count:%v", err)
+	}
+	if newCounter == s.counter {
+		return false, nil
+	}
+	s.counter = newCounter
+
+	resultsMap, err := s.bucket.GetBulkRaw(s.partitionKeys)
+	if err != nil {
+		Warn("Error retrieving partition keys")
+		return false, err
+	}
+	for _, partitionBytes := range resultsMap {
+		if len(partitionBytes) > 0 {
+			clockPartition := &ShardedClockPartition{}
+			err := clockPartition.Unmarshal(partitionBytes)
+			if err != nil {
+				Warn("Error unmarshalling partition bytes")
+				return false, err
+			}
+			s.partitions[clockPartition.Index] = clockPartition
+		}
+	}
+
+	return true, nil
+}
+
+func (s *ShardedClock) UpdateAndWrite(updateClock SequenceClock) error {
+	for vb, sequence := range updateClock.Value() {
+		if sequence > 0 {
+			partitionNo := s.partitionMap.VbMap[uint16(vb)]
+			if s.partitions[partitionNo] == nil {
+				shardedClockExpvars.Add("count_update_partition_not_found", 1)
+				err := s.initPartition(partitionNo)
+				if err != nil {
+					return err
+				}
+			}
+			s.partitions[partitionNo].SetSequence(uint16(vb), sequence)
+		}
+	}
+	return s.Write()
+}
+
+func (s *ShardedClock) initPartition(partitionNo uint16) error {
+
+	// initialize the partition
+	s.partitions[partitionNo] = NewShardedClockPartition(s.baseKey, partitionNo)
+	partitionKey := fmt.Sprintf(kClockPartitionKeyFormat, s.baseKey, partitionNo)
+
+	partitionBytes, casOut, err := s.bucket.GetRaw(partitionKey)
+	if err == nil {
+		unmarshalErr := s.partitions[partitionNo].Unmarshal(partitionBytes)
+		s.partitions[partitionNo].cas = casOut
+		if unmarshalErr != nil {
+			return unmarshalErr
+		}
+	}
+	s.partitionKeys[partitionNo] = partitionKey
+	return nil
+}
+
+func (s *ShardedClock) AsClock() *SequenceClockImpl {
+	clock := NewSequenceClockImpl()
+	for _, partition := range s.partitions {
+		for vb, seq := range partition.Values {
+			clock.SetSequence(vb, seq)
+		}
+	}
+	return clock
+}
+
+// Count retrieval - utility for use outside of the context of a sharded clock.
+func LoadClockCounter(baseKey string, bucket Bucket) (uint64, error) {
+	countKey := fmt.Sprintf(kCountKeyFormat, baseKey)
+	return bucket.Incr(countKey, 0, 0, 0)
+}

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -789,6 +789,15 @@ func (db *Database) invalUserOrRoleChannels(name string) {
 	}
 }
 
+// Helper method for API unit test retrieval of index bucket
+func (context *DatabaseContext) GetIndexBucket() base.Bucket {
+	if kvChangeIndex, ok := context.changeCache.(*kvChangeIndex); ok {
+		return kvChangeIndex.indexReadBucket
+	} else {
+		return nil
+	}
+}
+
 //////// SEQUENCE ALLOCATION:
 
 func (context *DatabaseContext) LastSequence() (uint64, error) {

--- a/src/github.com/couchbase/sync_gateway/db/index_changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/index_changes.go
@@ -23,13 +23,13 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 		to = fmt.Sprintf("  (to %s)", db.user.Name())
 	}
 
-	base.LogTo("DIndex+", "Vector MultiChangesFeed(%s, %+v) ... %s", chans, options, to)
-	base.LogTo("DIndex+", "Vector MultiChangesFeed since:%s", base.PrintClock(options.Since.Clock))
+	base.LogTo("Changes+", "Vector MultiChangesFeed(%s, %+v) ... %s", chans, options, to)
+	base.LogTo("Changes+", "Vector MultiChangesFeed since:%s", base.PrintClock(options.Since.Clock))
 	output := make(chan *ChangeEntry, 50)
 
 	go func() {
 		defer func() {
-			base.LogTo("DIndex+", "MultiChangesFeed done %s", to)
+			base.LogTo("Changes+", "MultiChangesFeed done %s", to)
 			close(output)
 		}()
 
@@ -71,10 +71,10 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 			// Populate the  array of feed channels:
 			feeds := make([]<-chan *ChangeEntry, 0, len(channelsSince))
 
-			base.LogTo("DIndex+", "GotChannelSince... %v", channelsSince)
+			base.LogTo("Changes+", "GotChannelSince... %v", channelsSince)
 			for name, seqAddedAt := range channelsSince {
 
-				base.LogTo("DIndex+", "Starting for channel... %s", name)
+				base.LogTo("Changes+", "Starting for channel... %s", name)
 				chanOpts := options
 
 				// Check whether requires backfill based on addedChannels in this _changes feed
@@ -174,7 +174,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 				minEntry.Seq.Clock = cumulativeClock
 				clockHash, err := db.SequenceHasher.GetHash(minEntry.Seq.Clock)
 				minEntry.Seq.Clock = &base.SequenceClockImpl{}
-				base.LogTo("DIndex+", "calculated hash...%v", clockHash)
+				base.LogTo("Changes+", "calculated hash...%v", clockHash)
 				if err != nil {
 					base.Warn("Error calculating hash for clock:%v", base.PrintClock(minEntry.Seq.Clock))
 				} else {

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/couchbaselabs/go.assert"
 )
 
-func testPartitionMap() IndexPartitionMap {
+func testPartitionMap() base.IndexPartitionMap {
 	// Simplified partition map of 64 sequential partitions, 16 vbuckets each
-	partitions := make(IndexPartitionMap, 64)
+	partitions := make(base.IndexPartitionMap, 64)
 
 	numPartitions := uint16(64)
 	vbPerPartition := 1024 / numPartitions
@@ -26,7 +26,7 @@ func testPartitionMap() IndexPartitionMap {
 func testContextAndChannelIndex(channelName string) (*DatabaseContext, *kvChannelIndex) {
 	context, _ := NewDatabaseContext("db", testBucket(), false, DatabaseContextOptions{})
 	// TODO: don't use the base bucket as the index bucket in tests
-	channelIndex := NewKvChannelIndex(channelName, context.Bucket, testPartitionMap(), testStableClock, testOnChange)
+	channelIndex := NewKvChannelIndex(channelName, context.Bucket, testPartitionMap(), testOnChange)
 	return context, channelIndex
 }
 
@@ -46,10 +46,6 @@ func testBitFlagStorage(channelName string) *BitFlagStorage {
 
 func testStableSequence() (uint64, error) {
 	return 0, nil
-}
-
-func testStableClock() base.SequenceClock {
-	return base.NewSequenceClockImpl()
 }
 
 func testOnChange(keys base.Set) {
@@ -132,12 +128,12 @@ func TestChannelIndexWrite(t *testing.T) {
 	log.Println("ADD COMPLETE")
 
 	// Reset the channel index to verify loading the block from the DB and validate contents
-	channelIndex = NewKvChannelIndex("ABC", context.Bucket, testPartitionMap(), testStableClock, testOnChange)
+	channelIndex = NewKvChannelIndex("ABC", context.Bucket, testPartitionMap(), testOnChange)
 	block := channelStorage.getIndexBlockForEntry(entry_5_100)
 	assert.Equals(t, len(block.GetAllEntries()), 1)
 
 	// Test CAS handling.  AnotherChannelIndex is another writer updating the same block in the DB.
-	anotherChannelIndex := NewKvChannelIndex("ABC", context.Bucket, testPartitionMap(), testStableClock, testOnChange)
+	anotherChannelIndex := NewKvChannelIndex("ABC", context.Bucket, testPartitionMap(), testOnChange)
 	anotherChannelStorage, ok := channelIndex.channelStorage.(*BitFlagStorage)
 
 	// Init block for sequence 100, partition 1

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api_test.go
@@ -71,7 +71,15 @@ func initIndexTester(useBucketIndex bool, syncFn string) indexTester {
 		dbConfig.ChannelIndex = channelIndexConfig
 	}
 
-	_, err := it._sc.AddDatabaseFromConfig(dbConfig)
+	dbContext, err := it._sc.AddDatabaseFromConfig(dbConfig)
+
+	if useBucketIndex {
+		err := SeedPartitionMap(dbContext.GetIndexBucket(), 64)
+		if err != nil {
+			panic(fmt.Sprintf("Error from seed partition map: %v", err))
+		}
+	}
+
 	if err != nil {
 		panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))
 	}
@@ -384,4 +392,30 @@ func assertTrue(t *testing.T, success bool, message string) {
 	if !success {
 		t.Fatalf("%s", message)
 	}
+}
+
+// Index partitions for testing
+func SeedPartitionMap(bucket base.Bucket, numPartitions uint16) error {
+	maxVbNo := uint16(1024)
+	partitionDefs := make([]base.PartitionStorage, numPartitions)
+	vbPerPartition := maxVbNo / numPartitions
+	for partition := uint16(0); partition < numPartitions; partition++ {
+		storage := base.PartitionStorage{
+			Index: partition,
+			VbNos: make([]uint16, vbPerPartition),
+		}
+		for index := uint16(0); index < vbPerPartition; index++ {
+			vb := partition*vbPerPartition + index
+			storage.VbNos = append(storage.VbNos, vb)
+		}
+		partitionDefs[partition] = storage
+	}
+
+	// Persist to bucket
+	value, err := json.Marshal(partitionDefs)
+	if err != nil {
+		return err
+	}
+	bucket.SetRaw(base.KIndexPartitionKey, 0, value)
+	return nil
 }


### PR DESCRIPTION
Includes basic framework for sharded clock management (sharded_sequence_clock.go).  Results in clearer distinction between reader and writer stable sequence in kv_change_index.

Uses sharded clock for stable sequence only.

Adds Incr capability to CouchbaseBucketGoCB.  Unlike go-couchbase's Incr, gocb's Counter operation doesn't allow setting the delta to 0 to do a basic retrieval of a counter.  Instead, need to use basic Get for non-update retrieval of counter docs.

Fixes #1243
