### PR TITLE
Feature/distributed index byte buffer clocks

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
@@ -22,6 +22,14 @@ const (
 	kClockPartitionKeyFormat = "_idx_c:%s:clock-%d" // key, partition index
 )
 
+const (
+	_ = iota
+	seq_size_uint16
+	seq_size_uint32
+	seq_size_uint48
+	seq_size_uint64
+)
+
 type PartitionStorage struct {
 	Uuid  string   `json:"uuid"`
 	Index uint16   `json:"index"`
@@ -232,7 +240,7 @@ type ShardedClockPartition struct {
 
 func NewShardedClockPartition(baseKey string, index uint16, vbuckets []uint16) *ShardedClockPartition {
 
-	initialSeqSize := 1
+	initialSeqSize := seq_size_uint16
 
 	p := &ShardedClockPartition{
 		Key:   fmt.Sprintf(kClockPartitionKeyFormat, baseKey, index),
@@ -287,13 +295,13 @@ func (p *ShardedClockPartition) SetSequence(vb uint16, seq uint64) {
 func (p *ShardedClockPartition) setSequenceForOffset(offset uint16, size uint8, seq uint64) {
 
 	switch size {
-	case 1:
+	case seq_size_uint16:
 		p.setSequenceUint16(offset, seq)
-	case 2:
+	case seq_size_uint32:
 		p.setSequenceUint32(offset, seq)
-	case 3:
+	case seq_size_uint48:
 		p.setSequenceUint48(offset, seq)
-	case 4:
+	case seq_size_uint64:
 		p.setSequenceUint64(offset, seq)
 	}
 
@@ -344,13 +352,13 @@ func (p *ShardedClockPartition) GetSequence(vb uint16) (seq uint64) {
 func (p *ShardedClockPartition) getSequenceForOffset(offset uint16, size uint8) (seq uint64) {
 
 	switch size {
-	case 1:
+	case seq_size_uint16:
 		return p.getSequenceUint16(offset)
-	case 2:
+	case seq_size_uint32:
 		return p.getSequenceUint32(offset)
-	case 3:
+	case seq_size_uint48:
 		return p.getSequenceUint48(offset)
-	case 4:
+	case seq_size_uint64:
 		return p.getSequenceUint64(offset)
 	default:
 		return p.getSequenceUint64(offset)
@@ -438,8 +446,8 @@ func (p *ShardedClockPartition) SetSeqSize(size uint8) {
 func (p *ShardedClockPartition) resize(seq uint64) {
 
 	// Figure out what the new size should be
-	newSize := uint8(4)
-	for i := 2; i <= 4; i++ {
+	newSize := uint8(seq_size_uint64)
+	for i := seq_size_uint32; i <= seq_size_uint64; i++ {
 		if seq < kClockMaxSequences[i] {
 			newSize = uint8(i)
 			break

--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock_test.go
@@ -1,0 +1,226 @@
+package base
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"log"
+	"math/rand"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+var numShards = uint16(64)
+var maxVbNo = uint16(1024)
+
+func GenerateTestIndexPartitions(maxVbNo uint16, numPartitions uint16) *IndexPartitions {
+
+	partitionDefs := make([]PartitionStorage, numPartitions)
+	vbPerPartition := maxVbNo / numPartitions
+	for partition := uint16(0); partition < numPartitions; partition++ {
+		storage := PartitionStorage{
+			Index: partition,
+			VbNos: make([]uint16, vbPerPartition),
+		}
+		for index := uint16(0); index < vbPerPartition; index++ {
+			vb := partition*vbPerPartition + index
+			storage.VbNos[index] = vb
+		}
+		partitionDefs[partition] = storage
+	}
+
+	return NewIndexPartitions(partitionDefs)
+}
+
+func TestShardedClockSizes(t *testing.T) {
+
+	scp := InitShardedClockPartition()
+	scpBytes, _ := scp.Marshal()
+	clock := NewSequenceClockImpl()
+	scp.AddToClock(clock)
+	log.Printf("SCP bytes:%d", len(scpBytes))
+
+	p := InitShardedClockPartition()
+	pclock := NewSequenceClockImpl()
+	p.AddToClock(pclock)
+	pBytes, _ := p.Marshal()
+	log.Printf("Packed SCP bytes:%d", len(pBytes))
+
+}
+
+func InitGobShardedClockPartition() *GobShardedClockPartition {
+	scp := NewGobShardedClockPartition("testKey", 0)
+	r := rand.New(rand.NewSource(42))
+	numVbs := 1024 / numShards
+	for i := uint16(0); i < numVbs; i++ {
+		seq := r.Int63()
+		scp.SetSequence(uint16(i), uint64(seq))
+	}
+	return scp
+}
+
+func InitShardedClockPartition() *ShardedClockPartition {
+	return InitShardedClockPartitionWithVbNos(GenerateTestIndexPartitions(maxVbNo, numShards).PartitionDefs[0].VbNos)
+}
+
+func InitShardedClockPartitionWithVbNos(vbnos []uint16) *ShardedClockPartition {
+
+	p := NewShardedClockPartition("testKey", 0, vbnos)
+	r := rand.New(rand.NewSource(42))
+	numVbs := 1024 / numShards
+	for i := uint16(0); i < numVbs; i++ {
+		seq := r.Int63()
+		p.SetSequence(uint16(i), uint64(seq))
+	}
+	return p
+}
+
+func TestShardedClockPartition(t *testing.T) {
+
+	vbNos := GenerateTestIndexPartitions(maxVbNo, numShards).PartitionDefs[5].VbNos
+	p := NewShardedClockPartition("testKey", 5, vbNos)
+	assert.Equals(t, p.GetIndex(), uint16(5))
+
+	p.SetSequence(vbNos[0], 50)
+
+	assert.Equals(t, p.GetSequence(vbNos[0]), uint64(50))
+}
+
+func BenchmarkShardedClockPartitionInit(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		InitShardedClockPartition()
+	}
+}
+
+func BenchmarkShardedClockPartitionMarshal(b *testing.B) {
+	scp := InitShardedClockPartition()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = scp.Marshal()
+	}
+}
+
+func BenchmarkShardedClockPartitionUnmarshal(b *testing.B) {
+	scp := InitShardedClockPartition()
+	bytes, _ := scp.Marshal()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = scp.Unmarshal(bytes)
+	}
+}
+
+func BenchmarkShardedClockPartitionSetSequence(b *testing.B) {
+	scp := InitShardedClockPartition()
+	vbNo := uint16(12)
+	seq := uint64(453678593)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scp.SetSequence(vbNo, seq)
+	}
+}
+
+func BenchmarkShardedClockPartitionAddToClock(b *testing.B) {
+	scp := InitShardedClockPartition()
+	clock := NewSequenceClockImpl()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = scp.AddToClock(clock)
+	}
+}
+
+func BenchmarkGobShardedClockPartitionInit(b *testing.B) {
+	vbNos := GenerateTestIndexPartitions(maxVbNo, numShards).PartitionDefs[0].VbNos
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		InitShardedClockPartitionWithVbNos(vbNos)
+	}
+}
+
+func BenchmarkGobShardedClockPartitionMarshal(b *testing.B) {
+	p := InitGobShardedClockPartition()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = p.Marshal()
+	}
+}
+
+func BenchmarkGobShardedClockPartitionUnmarshal(b *testing.B) {
+	p := InitGobShardedClockPartition()
+	bytes, _ := p.Marshal()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.Unmarshal(bytes)
+	}
+}
+
+func BenchmarkGobShardedClockPartitionSetSequence(b *testing.B) {
+	p := InitGobShardedClockPartition()
+	vbNo := uint16(12)
+	seq := uint64(453678593)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.SetSequence(vbNo, seq)
+	}
+}
+
+func BenchmarkGobShardedClockPartitionAddToClock(b *testing.B) {
+	p := InitGobShardedClockPartition()
+	clock := NewSequenceClockImpl()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.AddToClock(clock)
+	}
+}
+
+// ShardedClockPartition manages storage for one clock partition, where a clock partition is a set of
+// {vb, seq} values for a subset of vbuckets.
+type GobShardedClockPartition struct {
+	Index  uint16            // Partition Index
+	Key    string            // Clock partition document key
+	values map[uint16]uint64 // Clock partition values, indexed by vb
+	cas    uint64            // cas value of partition doc
+	dirty  bool              // Whether values have been updated since last save/load
+}
+
+func NewGobShardedClockPartition(baseKey string, index uint16) *GobShardedClockPartition {
+	return &GobShardedClockPartition{
+		Index:  index,
+		Key:    fmt.Sprintf(kClockPartitionKeyFormat, baseKey, index),
+		values: make(map[uint16]uint64),
+	}
+}
+
+// TODO: replace with something more intelligent than gob encode, to take advantage of known
+//       clock structure?
+func (scp *GobShardedClockPartition) Marshal() ([]byte, error) {
+	var output bytes.Buffer
+	enc := gob.NewEncoder(&output)
+	err := enc.Encode(scp)
+	if err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func (scp *GobShardedClockPartition) Unmarshal(value []byte) error {
+	input := bytes.NewBuffer(value)
+	dec := gob.NewDecoder(input)
+	err := dec.Decode(&scp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (scp *GobShardedClockPartition) SetSequence(vb uint16, seq uint64) {
+	scp.values[vb] = seq
+	scp.dirty = true
+}
+
+func (scp *GobShardedClockPartition) AddToClock(clock SequenceClock) error {
+	for vb, seq := range scp.values {
+		clock.SetSequence(vb, seq)
+	}
+	return nil
+}

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
@@ -122,7 +122,6 @@ func (k *kvChannelIndex) setType(channelIndexType string) {
 func (k *kvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChannelClock base.SequenceClock) (hasChanges bool, cancelPolling bool) {
 
 	changeCacheExpvars.Add(fmt.Sprintf("pollCount-%s", k.channelName), 1)
-
 	// Increment the overall poll count since a changes request (regardless of whether there have been polled changes)
 	totalPollCount := atomic.AddUint32(&k.pollCount, 1)
 	unreadPollCount := atomic.LoadUint32(&k.unreadPollCount)
@@ -139,7 +138,6 @@ func (k *kvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 
 	k.lastPolledLock.Lock()
 	defer k.lastPolledLock.Unlock()
-	base.LogTo("IndexPoll", "Poll for changes for channel %s", k.channelName)
 
 	// First poll handling
 	if k.lastPolledChannelClock == nil {


### PR DESCRIPTION
Switch to using []byte directly for clock partition interactions, instead of doing gob encoding/decoding.

Avoids marshal/unmarshal overhead when reading/writing clock partitions.

Based on benchmarks (included in unit test), the previous marshal/unmarshal was taking 50+ milliseconds.  This drops down to several nanoseconds using the new approach:

```
BenchmarkShardedClockPartitionInit    100000         20471 ns/op
BenchmarkShardedClockPartitionMarshal   1000000000           2.35 ns/op
BenchmarkShardedClockPartitionUnmarshal 200000000            5.80 ns/op
BenchmarkShardedClockPartitionSetSequence   30000000            43.0 ns/op
BenchmarkShardedClockPartitionGetSequence   30000000            43.2 ns/op
BenchmarkShardedClockPartitionAddToClock     1000000          1179 ns/op

BenchmarkGobShardedClockPartitionInit     100000         19074 ns/op
BenchmarkGobShardedClockPartitionMarshal      200000          6504 ns/op
BenchmarkGobShardedClockPartitionUnmarshal     30000         50572 ns/op
BenchmarkGobShardedClockPartitionSetSequence    50000000            44.0 ns/op
BenchmarkGobShardedClockPartitionGetSequence    50000000            28.5 ns/op
BenchmarkGobShardedClockPartitionAddToClock  3000000           462 ns/op
```

Based on perf tests, this change reduces P95 TimeToSubscriber latency by about 1s at low load (1K/1K, 30 minute run).  
