### PR TITLE
Read-side distributed index performance fixes

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket_gocb.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket_gocb.go
@@ -281,6 +281,9 @@ func (bucket CouchbaseBucketGoCB) Incr(k string, amt, def uint64, exp int) (uint
 		// If successful, return.  Otherwise fall through to Counter attempt (handles non-existent counter)
 		if err == nil {
 			return result, nil
+		} else {
+			Warn("Error during Get during Incr for key %s:%v", k, err)
+			return 0, nil
 		}
 	}
 

--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
@@ -152,7 +152,9 @@ func (s *ShardedClock) Load() (isChanged bool, err error) {
 
 	newCounter, err := s.bucket.Incr(s.countKey, 0, 0, 0)
 	if err != nil {
+		Warn("Error getting count for %s:%v", s.countKey, err)
 		LogTo("DIndex+", "Error getting count:%v", err)
+		return false, err
 	}
 	if newCounter == s.counter {
 		return false, nil

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_reader.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_reader.go
@@ -155,9 +155,9 @@ func (k *kvChangeIndexReader) GetStableClock() (clock base.SequenceClock, err er
 	_, err = k.indexPartitionsCallback()
 	if err != nil {
 		// Unable to load partitions.  Check whether the index has data (stable counter is non-zero)
-		_, err := base.LoadClockCounter(base.KStableSequenceKey, k.indexReadBucket)
+		count, err := base.LoadClockCounter(base.KStableSequenceKey, k.indexReadBucket)
 		// Index has data, but we can't get partition map.  Return error
-		if err == nil {
+		if err == nil && count > 0 {
 			return nil, errors.New("Error: Unable to retrieve index partition map, but index counter exists")
 		} else {
 			// Index doesn't have data.  Return zero clock as stable clock

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_reader.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_reader.go
@@ -56,19 +56,29 @@ func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIn
 	// Start background task to poll for changes
 	k.terminator = make(chan struct{})
 	go func(k *kvChangeIndexReader) {
+
+		pollStart := time.Now()
 		for {
+			timeSinceLastPoll := time.Since(pollStart)
+			waitTime := (kPollFrequency * time.Millisecond) - timeSinceLastPoll
+			if waitTime < 0 {
+				waitTime = 0 * time.Millisecond
+			}
 			select {
-			case <-time.After(kPollFrequency * time.Millisecond):
+			case <-time.After(waitTime):
 				// TODO: Doesn't trigger the reader removal processing (in pollReaders) during long
 				//       periods without changes to stableSequence.  In that scenario we'll continue
 				//       stable sequence polling each poll interval, even if we *actually* don't have any
 				//       active readers.
 				if k.hasActiveReaders() && k.stableSequenceChanged() {
 					k.pollReaders()
+					indexTimingExpvars.Add("indexRead_polls_withChanges", 1)
 				}
 			case <-k.terminator:
 				return
 			}
+
+			indexTimingExpvars.Add("indexRead_polls_all", 1)
 		}
 	}(k)
 
@@ -246,7 +256,7 @@ func (k *kvChangeIndexReader) newChannelReader(channelName string) (*kvChannelIn
 	}
 	k.channelIndexReaders[channelName] = NewKvChannelIndex(channelName, k.indexReadBucket, indexPartitions.VbMap, k.onChange)
 	k.channelIndexReaders[channelName].setType("reader")
-	indexExpvars.Add("polling_readers_added", 1)
+	indexExpvars.Add("pollingChannels_active", 1)
 	return k.channelIndexReaders[channelName], nil
 }
 
@@ -266,6 +276,7 @@ func (k *kvChangeIndexReader) pollReaders() bool {
 		return true
 	}
 
+	channelClockStart := time.Now()
 	// Build the set of clock keys to retrieve.  Stable sequence, plus one per channel reader
 	keySet := make([]string, len(k.channelIndexReaders))
 	index := 0
@@ -280,9 +291,13 @@ func (k *kvChangeIndexReader) pollReaders() bool {
 	}
 	indexExpvars.Add("bulkGet_channelClocks", 1)
 	indexExpvars.Add("bulkGet_channelClocks_keyCount", int64(len(keySet)))
-
+	writeHistogram(indexTimingExpvars, channelClockStart, "indexRead_timing_getBulkRaw_clocks")
 	changedChannels := make(chan string, len(k.channelIndexReaders))
 	cancelledChannels := make(chan string, len(k.channelIndexReaders))
+
+	indexTimingExpvars.Add("pollTotal_channelClocks", time.Since(channelClockStart).Nanoseconds())
+
+	pollReadersStart := time.Now()
 	var wg sync.WaitGroup
 	for _, reader := range k.channelIndexReaders {
 		// For each channel, unmarshal new channel clock, then check with reader whether this represents changes
@@ -291,7 +306,7 @@ func (k *kvChangeIndexReader) pollReaders() bool {
 			defer func() {
 				wg.Done()
 			}()
-
+			channelStart := time.Now()
 			// Unmarshal channel clock.  If not present in the bulk get results, use empty clock to support
 			// channels that don't have any indexed data yet.  If clock was previously found successfully (i.e. empty clock is
 			// due to temporary error from server), empty clock treated safely as a non-update by pollForChanges.
@@ -308,6 +323,8 @@ func (k *kvChangeIndexReader) pollReaders() bool {
 					return
 				}
 			}
+
+			indexTimingExpvars.Add("pollTotal_perChannel_unmarshalClock", time.Since(channelStart).Nanoseconds())
 			// Poll for changes
 			hasChanges, cancelPolling := reader.pollForChanges(k.readerStableSequence.AsClock(), newChannelClock)
 			if hasChanges {
@@ -317,12 +334,17 @@ func (k *kvChangeIndexReader) pollReaders() bool {
 				cancelledChannels <- reader.channelName
 			}
 
+			indexTimingExpvars.Add("pollTotal_perChannel_total", time.Since(channelStart).Nanoseconds())
+
 		}(reader, &wg)
 	}
 
 	wg.Wait()
 	close(changedChannels)
 	close(cancelledChannels)
+
+	writeHistogram(indexTimingExpvars, channelClockStart, "indexRead_timing_readClocksAndPollReaders")
+	indexTimingExpvars.Add("pollTotal_pollReaders", time.Since(pollReadersStart).Nanoseconds())
 
 	// Build channel set from the changed channels
 	var channels []string
@@ -336,7 +358,7 @@ func (k *kvChangeIndexReader) pollReaders() bool {
 
 	// Remove cancelled channels from channel readers
 	for channelName := range cancelledChannels {
-		indexExpvars.Add("polling_readers_removed", 1)
+		indexExpvars.Add("pollingChannels_active", -1)
 		delete(k.channelIndexReaders, channelName)
 	}
 

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
@@ -189,11 +189,6 @@ func (k *kvChannelIndex) updateLastPolled(stableSequence base.SequenceClock, new
 		return errors.New("Expected changes based on clock, none found")
 	}
 
-	base.LogTo("IndexPoll", "updateLastPolled for %s: # changes:    %d", k.channelName, len(recentChanges))
-	base.LogTo("IndexPoll", "updateLastPolled for %s: since:        %v", k.channelName, base.PrintClock(k.lastPolledSince))
-	base.LogTo("IndexPoll", "updateLastPolled for %s: channelClock: %v", k.channelName, base.PrintClock(k.lastPolledChannelClock))
-	base.LogTo("IndexPoll", "updateLastPolled for %s: validTo:      %v", k.channelName, base.PrintClock(k.lastPolledValidTo))
-
 	return nil
 }
 
@@ -263,7 +258,6 @@ func (k *kvChannelIndex) getChanges(since base.SequenceClock) ([]*LogEntry, erro
 		}
 	}
 
-	base.LogTo("DIndex+", "[channelIndex.GetChanges] Channel clock for channel %s: %s", k.channelName, base.PrintClock(chanClock))
 	// If requested clock is later than the channel clock, return empty
 	if since.AllAfter(chanClock) {
 		base.LogTo("DIndex+", "requested clock is later than channel clock - no new changes to report")
@@ -368,7 +362,6 @@ func (k *kvChannelIndex) loadClock() {
 	}
 	k.clock.Unmarshal(data)
 	k.clock.SetCas(cas)
-	base.LogTo("DCache+", "Loaded channel clock: %s", base.PrintClock(k.clock))
 }
 
 func (k *kvChannelIndex) writeClockCas(updateClock base.SequenceClock) error {


### PR DESCRIPTION
Removes PrintClock diagnostics that were causing significant CPU usage.  Modifies the timing loop for polling to wait (at least) 500ms between polling start times, instead of 500ms between poll end time and the next start time.

Also includes additional read-side diagnostics, and provides better handling for gocb incr when the get operation fails on a zero-delta operation.
