### PR TITLE
Pre-processes Config Server response to convert embedded back quoted strings

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -486,7 +486,7 @@ func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error)
 	}
 
 	var config DbConfig
-	j := json.NewDecoder(res.Body)
+	j := json.NewDecoder(base.ConvertBackQuotedStrings(res.Body))
 	if err = j.Decode(&config); err != nil {
 		return nil, base.HTTPErrorf(http.StatusBadGateway,
 			"Bad response from config server: %v", err)

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"io/ioutil"
 )
 
 // The URL that stats will be reported to if deployment_id is set in the config
@@ -486,7 +487,13 @@ func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error)
 	}
 
 	var config DbConfig
-	j := json.NewDecoder(base.ConvertBackQuotedStrings(res.Body))
+
+	var bodyBytes []byte
+	if bodyBytes, err = ioutil.ReadAll(res.Body); err != nil {
+		return nil, err
+	}
+
+	j := json.NewDecoder(bytes.NewReader(base.ConvertBackQuotedStrings(bodyBytes)))
 	if err = j.Decode(&config); err != nil {
 		return nil, base.HTTPErrorf(http.StatusBadGateway,
 			"Bad response from config server: %v", err)

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -489,6 +489,7 @@ func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error)
 	var config DbConfig
 
 	var bodyBytes []byte
+	defer res.Body.Close()
 	if bodyBytes, err = ioutil.ReadAll(res.Body); err != nil {
 		return nil, err
 	}

--- a/src/github.com/couchbase/sync_gateway/rest/server_context_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context_test.go
@@ -81,7 +81,7 @@ func TestConfigServerWithSyncFunction(t *testing.T) {
       }
     `
 	//Create config with embedded sync function in back quotes
-	responseBody := fmt(fakeConfig,"`",fakeSyncFunction,"`")
+	responseBody := fmt.Sprintf(fakeConfig,"`",fakeSyncFunction,"`")
 
 	mockClient := NewMockClient()
 	mockClient.RespondToGET(fakeConfigURL+"/db2", MakeResponse(200, nil, responseBody))

--- a/src/github.com/couchbase/sync_gateway/rest/server_context_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context_test.go
@@ -51,6 +51,58 @@ func TestConfigServer(t *testing.T) {
 	rt.bucket() // no-op that just keeps rt from being GC'd/finalized (bug CBL-9)
 }
 
+// Tests the ConfigServer feature.
+func TestConfigServerWithSyncFunction(t *testing.T) {
+	fakeConfigURL := "http://example.com/config"
+	fakeConfig := `{
+			"bucket": "fivez",
+			"server": "walrus:/fake",
+			"users": {
+				"GUEST": {"disabled": false, "admin_channels": ["*"] }
+			},
+			"sync":%s%s%s
+		}`
+
+	fakeSyncFunction := `
+      function(doc, oldDoc) {
+        if (doc.type == "reject_me") {
+	      throw({forbidden : "Rejected document"})
+        } else if (doc.type == "bar") {
+	  // add "bar" docs to the "important" channel
+            channel("important");
+	} else if (doc.type == "secret") {
+          if (!doc.owner) {
+            throw({forbidden : "Secret documents must have an owner field"})
+          }
+	} else {
+	    // all other documents just go into all channels listed in the doc["channels"] field
+	    channel(doc.channels)
+	}
+      }
+    `
+	//Create config with embedded sync function in back quotes
+	responseBody := fmt(fakeConfig,"`",fakeSyncFunction,"`")
+
+	mockClient := NewMockClient()
+	mockClient.RespondToGET(fakeConfigURL+"/db2", MakeResponse(200, nil, responseBody))
+
+	var rt restTester
+	sc := rt.ServerContext()
+	sc.HTTPClient = mockClient.Client
+	sc.config.ConfigServer = &fakeConfigURL
+
+	dbc, err := sc.GetDatabase("db")
+	assert.Equals(t, err, nil)
+	assert.Equals(t, dbc.Name, "db")
+
+	dbc, err = sc.GetDatabase("db2")
+	assert.Equals(t, err, nil)
+	assert.Equals(t, dbc.Name, "db2")
+	assert.Equals(t, dbc.Bucket.GetName(), "fivez")
+
+	rt.bucket() // no-op that just keeps rt from being GC'd/finalized (bug CBL-9)
+}
+
 //////// MOCK HTTP CLIENT: (TODO: Move this into a separate package)
 
 // Creates a filled-in http.Response from minimal details


### PR DESCRIPTION
Pre-processes Config Server response to convert embedded back quoted strings e.g. sync function

fixes #1281 
