### PR TITLE
Throttle concurrent gocb calls

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket_gocb.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket_gocb.go
@@ -20,14 +20,22 @@ import (
 
 var gocbExpvars *expvar.Map
 
+const (
+	MaxConcurrentSingleOps = 1000 // Max 1000 concurrent single bucket ops
+	MaxConcurrentBulkOps   = 35   // Max 35 concurrent bulk ops
+	MaxBulkBatchSize       = 100  // Maximum number of ops per bulk call
+)
+
 func init() {
 	gocbExpvars = expvar.NewMap("syncGateway_gocb")
 }
 
 // Implementation of sgbucket.Bucket that talks to a Couchbase server and uses gocb
 type CouchbaseBucketGoCB struct {
-	*gocb.Bucket            // the underlying gocb bucket
-	spec         BucketSpec // keep a copy of the BucketSpec for DCP usage
+	*gocb.Bucket               // the underlying gocb bucket
+	spec         BucketSpec    // keep a copy of the BucketSpec for DCP usage
+	singleOps    chan struct{} // Manages max concurrent single ops
+	bulkOps      chan struct{} // Manages max concurrent bulk ops
 }
 
 type GoCBLogger struct{}
@@ -68,9 +76,13 @@ func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket Bucket, err error) {
 		return nil, err
 	}
 
+	// Define channels to limit the number of concurrent single and bulk operations,
+	// to avoid gocb queue overflow issues
 	bucket = CouchbaseBucketGoCB{
 		goCBBucket,
 		spec,
+		make(chan struct{}, MaxConcurrentSingleOps),
+		make(chan struct{}, MaxConcurrentBulkOps),
 	}
 
 	return bucket, err
@@ -82,12 +94,26 @@ func (bucket CouchbaseBucketGoCB) GetName() string {
 }
 
 func (bucket CouchbaseBucketGoCB) Get(k string, rv interface{}) (cas uint64, err error) {
+	bucket.singleOps <- struct{}{}
+	gocbExpvars.Add("SingleOps", 1)
+	defer func() {
+		<-bucket.singleOps
+		gocbExpvars.Add("SingleOps", -1)
+	}()
 	gocbExpvars.Add("Get", 1)
 	casGoCB, err := bucket.Bucket.Get(k, rv)
 	return uint64(casGoCB), err
 }
 
 func (bucket CouchbaseBucketGoCB) GetRaw(k string) (rv []byte, cas uint64, err error) {
+
+	bucket.singleOps <- struct{}{}
+	gocbExpvars.Add("SingleOps", 1)
+	defer func() {
+		<-bucket.singleOps
+		gocbExpvars.Add("SingleOps", -1)
+	}()
+
 	var returnVal interface{}
 
 	gocbExpvars.Add("GetRaw", 1)
@@ -102,29 +128,50 @@ func (bucket CouchbaseBucketGoCB) GetBulkRaw(keys []string) (map[string][]byte, 
 
 	gocbExpvars.Add("GetBulkRaw", 1)
 	result := make(map[string][]byte)
-	var items []gocb.BulkOp
-	for _, key := range keys {
-		var value []byte
-		item := &gocb.GetOp{Key: key, Value: &value}
-		items = append(items, item)
-	}
-	err := bucket.Do(items)
-	if err != nil {
-		return nil, err
-	}
 
-	for _, item := range items {
-		getOp, ok := item.(*gocb.GetOp)
-		if !ok {
-			continue
+	bucket.bulkOps <- struct{}{}
+	gocbExpvars.Add("BulkOps", 1)
+	defer func() {
+		<-bucket.bulkOps
+		gocbExpvars.Add("BulkOps", -1)
+	}()
+
+	// Process in sets of MaxBulkBatchSize
+	for len(keys) > 0 {
+		var batchSize int
+		if len(keys) > MaxBulkBatchSize {
+			batchSize = MaxBulkBatchSize
+		} else {
+			batchSize = len(keys)
 		}
-		// Ignore any ops with errors.
-		// NOTE: some of the errors are misleading:
-		// https://issues.couchbase.com/browse/GOCBC-64
-		if getOp.Err == nil {
-			byteValue, ok := getOp.Value.(*[]byte)
-			if ok {
-				result[getOp.Key] = *byteValue
+		batchKeys := keys[0:batchSize]
+		keys = keys[batchSize:]
+
+		var items []gocb.BulkOp
+		for _, key := range batchKeys {
+			var value []byte
+			item := &gocb.GetOp{Key: key, Value: &value}
+			items = append(items, item)
+		}
+		err := bucket.Do(items)
+		if err != nil {
+			Warn("Bulk get error for batch size %d:%v", len(items), err)
+			return nil, err
+		}
+
+		for _, item := range items {
+			getOp, ok := item.(*gocb.GetOp)
+			if !ok {
+				continue
+			}
+			// Ignore any ops with errors.
+			// NOTE: some of the errors are misleading:
+			// https://issues.couchbase.com/browse/GOCBC-64
+			if getOp.Err == nil {
+				byteValue, ok := getOp.Value.(*[]byte)
+				if ok {
+					result[getOp.Key] = *byteValue
+				}
 			}
 		}
 	}
@@ -133,6 +180,13 @@ func (bucket CouchbaseBucketGoCB) GetBulkRaw(keys []string) (map[string][]byte, 
 }
 
 func (bucket CouchbaseBucketGoCB) GetAndTouchRaw(k string, exp int) (rv []byte, cas uint64, err error) {
+
+	bucket.singleOps <- struct{}{}
+	gocbExpvars.Add("SingleOps", 1)
+	defer func() {
+		<-bucket.singleOps
+		gocbExpvars.Add("SingleOps", -1)
+	}()
 	var returnVal interface{}
 	gocbExpvars.Add("GetAndTouchRaw", 1)
 	casGoCB, err := bucket.Bucket.GetAndTouch(k, uint32(exp), &returnVal)
@@ -159,18 +213,33 @@ func (bucket CouchbaseBucketGoCB) Append(k string, data []byte) error {
 
 func (bucket CouchbaseBucketGoCB) Set(k string, exp int, v interface{}) error {
 
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+
 	gocbExpvars.Add("Set", 1)
 	_, err := bucket.Bucket.Upsert(k, v, uint32(exp))
 	return err
 }
 
 func (bucket CouchbaseBucketGoCB) SetRaw(k string, exp int, v []byte) error {
+
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
 	gocbExpvars.Add("SetRaw", 1)
 	_, err := bucket.Bucket.Upsert(k, v, uint32(exp))
 	return err
 }
 
 func (bucket CouchbaseBucketGoCB) Delete(k string) error {
+
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
 	gocbExpvars.Add("Delete", 1)
 	_, err := bucket.Bucket.Remove(k, 0)
 	return err
@@ -182,6 +251,11 @@ func (bucket CouchbaseBucketGoCB) Write(k string, flags int, exp int, v interfac
 }
 
 func (bucket CouchbaseBucketGoCB) WriteCas(k string, flags int, exp int, cas uint64, v interface{}, opt sgbucket.WriteOptions) (casOut uint64, err error) {
+
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
 
 	// we only support the sgbucket.Raw WriteOption at this point
 	if opt != sgbucket.Raw {
@@ -209,6 +283,11 @@ func (bucket CouchbaseBucketGoCB) WriteCas(k string, flags int, exp int, cas uin
 }
 
 func (bucket CouchbaseBucketGoCB) Update(k string, exp int, callback sgbucket.UpdateFunc) error {
+
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
 
 	maxCasRetries := 100000 // prevent infinite loop
 	for i := 0; i < maxCasRetries; i++ {
@@ -272,6 +351,11 @@ func (bucket CouchbaseBucketGoCB) WriteUpdate(k string, exp int, callback sgbuck
 }
 
 func (bucket CouchbaseBucketGoCB) Incr(k string, amt, def uint64, exp int) (uint64, error) {
+
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
 
 	var result uint64
 	// GoCB's Counter returns an error if amt=0 and the counter exists.  If amt=0, instead first

--- a/src/github.com/couchbase/sync_gateway/base/bucket_gocb_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket_gocb_test.go
@@ -63,10 +63,10 @@ func CouchbaseTestBulkGetRaw(t *testing.T) {
 	bucket := GetBucketOrPanic()
 
 	keyPrefix := "TestBulkGetRaw"
-	keySet := make([]string, 10)
-	valueSet := make(map[string][]byte, 10)
+	keySet := make([]string, 1000)
+	valueSet := make(map[string][]byte, 1000)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1000; i++ {
 		key := fmt.Sprintf("%s%d", keyPrefix, i)
 		val := []byte(fmt.Sprintf("bar%d", i))
 		keySet[i] = key
@@ -84,10 +84,10 @@ func CouchbaseTestBulkGetRaw(t *testing.T) {
 
 	results, err := bucket.GetBulkRaw(keySet)
 	assertNoError(t, err, fmt.Sprintf("Error calling GetBulkRaw(): %v", err))
-	assert.True(t, len(results) == 10)
+	assert.True(t, len(results) == 1000)
 
 	// validate results, and prepare new keySet with non-existent keys
-	mixedKeySet := make([]string, 20)
+	mixedKeySet := make([]string, 2000)
 	for index, key := range keySet {
 		// Verify value
 		assert.True(t, bytes.Equal(results[key], valueSet[key]))
@@ -98,7 +98,7 @@ func CouchbaseTestBulkGetRaw(t *testing.T) {
 	// Validate bulkGet that include non-existent keys work as expected
 	mixedResults, err := bucket.GetBulkRaw(mixedKeySet)
 	assertNoError(t, err, fmt.Sprintf("Error calling GetBulkRaw(): %v", err))
-	assert.True(t, len(results) == 10)
+	assert.True(t, len(results) == 1000)
 
 	// Clean up
 	for _, key := range keySet {

--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
@@ -371,13 +371,7 @@ func (p *ShardedClockPartition) getSequenceForOffset(offset uint16, size uint8) 
 func (p *ShardedClockPartition) getSequenceUint16(offset uint16) (seq uint64) {
 
 	return uint64(p.value[offset+1]) |
-		uint64(p.value[offset])<<8 |
-		uint64(0)<<16 |
-		uint64(0)<<24 |
-		uint64(0)<<32 |
-		uint64(0)<<40 |
-		uint64(0)<<48 |
-		uint64(0)<<56
+		uint64(p.value[offset])<<8
 }
 
 func (p *ShardedClockPartition) getSequenceUint32(offset uint16) (seq uint64) {
@@ -385,11 +379,7 @@ func (p *ShardedClockPartition) getSequenceUint32(offset uint16) (seq uint64) {
 	return uint64(p.value[offset+3]) |
 		uint64(p.value[offset+2])<<8 |
 		uint64(p.value[offset+1])<<16 |
-		uint64(p.value[offset])<<24 |
-		uint64(0)<<32 |
-		uint64(0)<<40 |
-		uint64(0)<<48 |
-		uint64(0)<<56
+		uint64(p.value[offset])<<24
 }
 
 func (p *ShardedClockPartition) getSequenceUint48(offset uint16) (seq uint64) {
@@ -399,9 +389,7 @@ func (p *ShardedClockPartition) getSequenceUint48(offset uint16) (seq uint64) {
 		uint64(p.value[offset+3])<<16 |
 		uint64(p.value[offset+2])<<24 |
 		uint64(p.value[offset+1])<<32 |
-		uint64(p.value[offset])<<40 |
-		uint64(0)<<48 |
-		uint64(0)<<56
+		uint64(p.value[offset])<<40
 	return seq
 }
 

--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock_test.go
@@ -207,6 +207,9 @@ func BenchmarkShardedClockPartitionGetSequence(b *testing.B) {
 
 func BenchmarkShardedClockPartitionAddToClock(b *testing.B) {
 	scp := InitShardedClockPartition()
+	vbNo := uint16(12)
+	seq := uint64(453678593)
+	scp.SetSequence(vbNo, seq)
 	clock := NewSequenceClockImpl()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_storage.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_storage.go
@@ -296,7 +296,7 @@ func (b *BitFlagStorage) bulkLoadBlocks(loadedBlocks map[string]IndexBlock) {
 	if err != nil {
 		// TODO FIX: if there's an error on a single block retrieval, differentiate between that
 		//  and an empty/non-existent block.  Requires identification of expected blocks by the cache.
-		base.Warn("Error doing bulk get:", err)
+		base.Warn("Error doing bulk get:%v", err)
 	}
 
 	indexExpvars.Add("bulkGet_bulkLoadBlocks", 1)
@@ -326,7 +326,7 @@ func (b *BitFlagStorage) bulkLoadEntries(keySet []string, blockEntries []*LogEnt
 
 	entries, err := b.bucket.GetBulkRaw(keySet)
 	if err != nil {
-		base.Warn("Error doing bulk get:", err)
+		base.Warn("Error doing bulk get:%v", err)
 	}
 	indexExpvars.Add("bulkGet_bulkLoadEntries", 1)
 	indexExpvars.Add("bulkGet_bulkLoadEntriesCount", int64(len(keySet)))
@@ -619,11 +619,8 @@ func (b *BitFlagBlock) GetAllEntries() []*LogEntry {
 // Block entry retrieval - used by GetEntries and GetEntriesAndKeys.
 func (b *BitFlagBlock) GetEntries(vbNo uint16, fromSeq uint64, toSeq uint64, includeKeys bool) (entries []*LogEntry, keySet []string) {
 
-	// To avoid GC overhead when we append entries one-by-one into the results below, define the capacity as the
-	// max possible (toSeq - fromSeq).  This is going to be unnecessarily large in most cases - could consider writing
-	// a custom append
-	entries = make([]*LogEntry, 0, toSeq-fromSeq+1)
-	keySet = make([]string, 0, toSeq-fromSeq+1)
+	entries = make([]*LogEntry, 0)
+	keySet = make([]string, 0)
 	vbEntries, ok := b.value.Entries[vbNo]
 	if !ok { // nothing for this vbucket
 		base.LogTo("DIndex+", "No entries found for vbucket %d in block %s", vbNo, b.Key())


### PR DESCRIPTION
Updates gocb bucket to put a limit the number of concurrent gocb calls, to avoid queue overflow errors.  This includes batching of large bulk operations.

Also fixes CPU issue related to array allocation in sharded clocks - allocation of these arrays was showing up as a significant source of CPU usage on latest perf runs.  Existing value will be much too large for everything other than the \* channel.
