### PR TITLE
Only initialize CBGT if there are any Index Writers

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -48,6 +48,7 @@ type DatabaseContext struct {
 	AllowEmptyPassword bool                    // Allow empty passwords?  Defaults to false
 	SequenceHasher     *sequenceHasher         // Used to generate and resolve hash values for vector clock sequences
 	SequenceType       SequenceType            // Type of sequences used for this DB (integer or vector clock)
+	Options            DatabaseContextOptions
 }
 
 type DatabaseContextOptions struct {
@@ -105,6 +106,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		StartTime:  time.Now(),
 		RevsLimit:  DefaultRevsLimit,
 		autoImport: autoImport,
+		Options:    options,
 	}
 	context.revisionCache = NewRevisionCache(RevisionCacheCapacity, context.revCacheLoader)
 

--- a/src/github.com/couchbase/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbase/sync_gateway/rest/routing.go
@@ -15,9 +15,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/cbgt"
 	"github.com/couchbase/cbgt/rest"
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbaselabs/sync_gateway_admin_ui"
 	"github.com/gorilla/mux"
 )
@@ -234,6 +234,11 @@ func addCbgtRoutes(router *mux.Router, sc *ServerContext) error {
 
 	// only do this if CBGT is enabled
 	if !sc.config.ClusterConfig.CBGTEnabled() {
+		return nil
+	}
+
+	// likewise, if there are no index writers and CBGT is not initialized, skip this
+	if !sc.HasIndexWriters() {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/1317.  This should get us past the current failures where the SG crashes on startup with some index writers and non-writers configured, which is blocking QE.

For the other scenario, I have filed a ticket to reproduce via a functional test: https://github.com/couchbaselabs/sync-gateway-testcluster/issues/70d  so that we can verify that the test detects the issue.  
