### PR TITLE
Fixes #1361 Separate index writer binary stub

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,5 +20,7 @@ sed -i.bak -e 's/GitBranch.*=.*/GitBranch = "'$GIT_BRANCH'"/' $BUILD_INFO
 sed -i.bak -e 's/GitDirty.*=.*/GitDirty = "'$GIT_DIRTY'"/' $BUILD_INFO
 
 export GOBIN="`pwd`/bin"
+
 ./go.sh install "$@" -v github.com/couchbase/sync_gateway
-echo "Success! Output is bin/sync_gateway"
+./go.sh install "$@" -v github.com/couchbase/sync_gateway/index_writer
+echo "Success! Output is bin/sync_gateway and bin/index_writer"

--- a/src/github.com/couchbase/sync_gateway/index_writer/main.go
+++ b/src/github.com/couchbase/sync_gateway/index_writer/main.go
@@ -1,0 +1,38 @@
+//  Copyright (c) 2012 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/rest"
+)
+
+// Simple Sync Gateway launcher tool.
+func main() {
+
+	log.Printf("TODO: customize this to function as the index_writer")
+
+	signalchannel := make(chan os.Signal, 1)
+	signal.Notify(signalchannel, syscall.SIGHUP)
+
+	go func() {
+		for _ = range signalchannel {
+			base.Logf("SIGHUP: Reloading Config....\n")
+			rest.ReloadConf()
+		}
+	}()
+
+	rest.ServerMain()
+}


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/1361

@michaelkwok once this is merged, you can update https://github.com/couchbase/build/blob/master/scripts/jenkins/mobile/build_sync_gateway.sh#L242 to add a new line:

```
GOOS=${GOOS} GOARCH=${GOARCH} go build -v github.com/couchbase/sync_gateway/index_writer
```

which should cause the `bin/index_writer` executable to be created.
