### PR TITLE
Fixes #1259 cbheartbeat start delay causes DCP stream to not be re-sharded when SG node killed quickly

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/sgw_pindex.go
+++ b/src/github.com/couchbase/sync_gateway/base/sgw_pindex.go
@@ -326,7 +326,7 @@ func (s *SyncGatewayPIndex) Rollback(partition string, rollbackSeq uint64) error
 	// As of the time of this writing, I believe this is also broken in the master branch
 	// of Sync Gateway.
 
-	Warn("DCP Rollback request - rolling back DCP feed for: vbucketId: %s, rollbackSeq: %x", partition, rollbackSeq)
+	Warn("DCP Rollback request SyncGatewayPIndex - rolling back DCP feed for: vbucketId: %s, rollbackSeq: %x", partition, rollbackSeq)
 
 	s.rollbackSeq(partition, rollbackSeq)
 
@@ -362,8 +362,11 @@ type HeartbeatStoppedHandler struct {
 
 func (h HeartbeatStoppedHandler) StaleHeartBeatDetected(nodeUuid string) {
 
+	LogTo("DIndex+", "StaleHeartBeatDetected for node: %v", nodeUuid)
+
 	kinds := []string{cbgt.NODE_DEFS_KNOWN, cbgt.NODE_DEFS_WANTED}
 	for _, kind := range kinds {
+		LogTo("DIndex+", "Telling CBGT to remove node: %v (kind: %v, cbgt version: %v)", nodeUuid, kind, h.CbgtVersion)
 		if err := cbgt.CfgRemoveNodeDef(
 			h.Cfg,
 			kind,

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -375,6 +375,8 @@ func (sc *ServerContext) validateCBGTPartitionMap() error {
 
 func (sc *ServerContext) InitCBGTManager() (base.CbgtContext, error) {
 
+	base.LogTo("DIndex+", "Initializing CBGT")
+
 	couchbaseUrl, err := base.CouchbaseUrlWithAuth(
 		*sc.config.ClusterConfig.Server,
 		sc.config.ClusterConfig.Username,
@@ -467,6 +469,7 @@ func (sc *ServerContext) InitCBGTManager() (base.CbgtContext, error) {
 
 func (sc *ServerContext) enableCBGTAutofailover(version string, mgr *cbgt.Manager, cfg cbgt.Cfg, uuid, couchbaseUrl, keyPrefix string) error {
 
+	base.LogTo("DIndex+", "Enabling CBGT auto-failover")
 	cbHeartbeater, err := cbheartbeat.NewCouchbaseHeartbeater(
 		couchbaseUrl,
 		*sc.config.ClusterConfig.Bucket,
@@ -483,6 +486,7 @@ func (sc *ServerContext) enableCBGTAutofailover(version string, mgr *cbgt.Manage
 		intervalMs = int(*sc.config.ClusterConfig.HeartbeatIntervalSeconds) * 1000
 	}
 
+	base.LogTo("DIndex+", "Sending CBGT node heartbeats at interval: %v ms", intervalMs)
 	cbHeartbeater.StartSendingHeartbeats(intervalMs)
 
 	deadNodeHandler := base.HeartbeatStoppedHandler{
@@ -495,6 +499,7 @@ func (sc *ServerContext) enableCBGTAutofailover(version string, mgr *cbgt.Manage
 	if err := cbHeartbeater.StartCheckingHeartbeats(staleThresholdMs, deadNodeHandler); err != nil {
 		return err
 	}
+	base.LogTo("DIndex+", "Checking CBGT node heartbeats with stale threshold: %v ms", staleThresholdMs)
 
 	return nil
 


### PR DESCRIPTION
https://github.com/couchbase/sync_gateway/issues/1259
