### PR TITLE
DB Offline WebHook event is now fired if there is no error taking the DB offline

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api.go
@@ -106,14 +106,13 @@ func (h *handler) handleDbOnline() error {
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
-	if err = h.db.TakeDbOffline(); err != nil {
+	if err = h.db.TakeDbOffline(); err == nil {
 		if h.db.DatabaseContext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
 			h.db.DatabaseContext.EventMgr.RaiseDBStateChangeEvent(h.db.DatabaseContext.Name, "offline", "ADMIN Request", *h.server.config.AdminInterface)
 		}
 	}
 
 	return err
-
 }
 
 // Get admin database info


### PR DESCRIPTION
Previously the event would fire only if there was an error taking the db offline.

fixes #1389 
