### PR TITLE
Avoid looping on one-off changes requests with low sequence

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api_test.go
@@ -45,9 +45,10 @@ var gBucketCounter = 0
 type restTester struct {
 	_bucket          base.Bucket
 	_sc              *ServerContext
-	noAdminParty     bool   // Unless this is true, Admin Party is in full effect
-	distributedIndex bool   // Test with walrus-based index bucket
-	syncFn           string // put the sync() function source in here (optional)
+	noAdminParty     bool         // Unless this is true, Admin Party is in full effect
+	distributedIndex bool         // Test with walrus-based index bucket
+	syncFn           string       // put the sync() function source in here (optional)
+	cacheConfig      *CacheConfig // Cache options (optional)
 }
 
 func (rt *restTester) bucket() base.Bucket {
@@ -78,8 +79,9 @@ func (rt *restTester) bucket() base.Bucket {
 			BucketConfig: BucketConfig{
 				Server: &server,
 				Bucket: &bucketName},
-			Name: "db",
-			Sync: syncFnPtr,
+			Name:        "db",
+			Sync:        syncFnPtr,
+			CacheConfig: rt.cacheConfig,
 		})
 		if err != nil {
 			panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -111,7 +111,7 @@ type DbConfig struct {
 	FeedType           string                         `json:"feed_type,omitempty"`            // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
 	AllowEmptyPassword bool                           `json:"allow_empty_password,omitempty"` // Allow empty passwords?  Defaults to false
 	CacheConfig        *CacheConfig                   `json:"cache,omitempty"`                // Cache settings
-	ChannelIndex       *ChannelIndexConfig            `json:"channel_index,omitEmpty"`        // Channel index settings
+	ChannelIndex       *ChannelIndexConfig            `json:"channel_index,omitempty"`        // Channel index settings
 	RevCacheSize       *uint32                        `json:"rev_cache_size,omitempty"`       // Maximum number of revisions to store in the revision cache
 	StartOffline       bool                           `json:"offline,omitempty"`              // start the DB in the offline state, defaults to false
 }


### PR DESCRIPTION
When a one-off changes request comes in with a low sequence included (e.g. since="2::5"), we want to use the same handling we're already doing for longpoll - ignore the low sequence value if it matches the SG's current lowSequence.  This avoids infinite looping of the records between low::high.  It also means any additional skipped sequences between low::high won't be sent until low arrives or is abandoned.

Fixes #1309.
