### PR TITLE
Admin role handling fix for distributed index

### DIFF
--- a/src/github.com/couchbase/sync_gateway/auth/auth.go
+++ b/src/github.com/couchbase/sync_gateway/auth/auth.go
@@ -344,6 +344,7 @@ func (auth *Authenticator) updateVbucketSequences(docID string, factory func() P
 				seq := vbSeq.Sequence
 				if seq == 0 {
 					userPrinc.ExplicitRoles_[role] = sequence
+					rolesChanged = true
 				}
 			}
 			// Invalidate calculated roles if changed.


### PR DESCRIPTION
Principal wasn't being updated when admin roles changed but admin channels did not.

Fixes #1403 
