### PR TITLE
Workaround for #1371

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/sgw_pindex.go
+++ b/src/github.com/couchbase/sync_gateway/base/sgw_pindex.go
@@ -89,7 +89,7 @@ func (s *SyncGatewayPIndex) SeedSeqnos() error {
 	// GetStatsVbSeqno retrieves high sequence number for each vbucket, to enable starting
 	// DCP stream from that position.  Also being used as a check on whether the server supports
 	// DCP.
-	statsUuids, _, err := s.bucket.GetStatsVbSeqno(maxVbno)
+	statsUuids, highSeqnosFromBucket, err := s.bucket.GetStatsVbSeqno(maxVbno, true)
 	if err != nil {
 		return errors.New("Error retrieving stats-vbseqno - DCP not supported")
 	}
@@ -110,9 +110,18 @@ func (s *SyncGatewayPIndex) SeedSeqnos() error {
 	// The implementation has been reviewed with the cbdatasource owners and they agree this is a
 	// reasonable approach, as the structure of VBucketMetaData is expected to rarely change.
 	for vbucketId, vbuuid := range vbuuids {
+
 		failOver := make([][]uint64, 1)
 		failOverEntry := []uint64{vbuuid, 0}
 		failOver[0] = failOverEntry
+
+		highSeqnoFromStableClock := s.seqs[vbucketId]
+		highSeqnoFromBucket := highSeqnosFromBucket[vbucketId]
+
+		if highSeqnoFromStableClock > highSeqnoFromBucket {
+			Warn("issue_1259 highSeqnoFromStableClock (%d) > highSeqnoFromBucket (%d) for vb %d", highSeqnoFromStableClock, highSeqnoFromBucket, vbucketId)
+		}
+
 		metadata := &cbdatasource.VBucketMetaData{
 			SeqStart:    s.seqs[vbucketId],
 			SeqEnd:      uint64(0xFFFFFFFFFFFFFFFF),
@@ -268,7 +277,7 @@ func (s *SyncGatewayPIndex) updateMeta(partition string, seq uint64) error {
 
 	// GetStatsVbSeqno retrieves high sequence number for each vbucket, to enable starting
 	// DCP stream from that position.
-	vbuuids, _, err := s.bucket.GetStatsVbSeqno(maxVbno)
+	vbuuids, _, err := s.bucket.GetStatsVbSeqno(maxVbno, true)
 	if err != nil {
 		return errors.New("Error retrieving stats-vbseqno - DCP not supported")
 	}


### PR DESCRIPTION
For reasons not understood, this change seems to minimize the chances of https://github.com/couchbase/sync_gateway/issues/1371 being an issue.

As mentioned in https://github.com/couchbase/sync_gateway/issues/1412#issuecomment-169477903, this commit is causing the dcp reshard functional test to pass.

If https://github.com/couchbase/sync_gateway/issues/1371 is fixed at a deeper level, this workaround should be removed.
