### PR TITLE
Unit test fixes

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
@@ -487,9 +487,9 @@ func TestPollResultLongRunningContinuous(t *testing.T) {
 	// Start a continuous changes on channel (ABC).  Waitgroup keeps test open until continuous is terminated
 	var wg sync.WaitGroup
 	continuousTerminator := make(chan bool)
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		wg.Add(1)
 		since, err := db.ParseSequenceID("2-0")
 		abcChanges, err := db.GetChanges(base.SetOf("ABC"), ChangesOptions{Since: since, Wait: true, Continuous: true, Terminator: continuousTerminator})
 		assertTrue(t, err == nil, "Error getting changes")
@@ -511,6 +511,7 @@ func TestPollResultLongRunningContinuous(t *testing.T) {
 	WriteDirectWithKey(db, "terminatorCheck", []string{"ABC"}, 1)
 
 	wg.Wait()
+
 }
 
 func TestChangeIndexAddSet(t *testing.T) {

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_storage.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_storage.go
@@ -318,7 +318,6 @@ func (b *BitFlagStorage) GetChanges(fromSeq base.SequenceClock, toSeq base.Seque
 	// Bulk retrieval of individual entries.  Performs deduplication, and reordering into ascending vb and sequence order
 	results := b.bulkLoadEntries(entryKeys, entries)
 
-	base.LogTo("DIndex+", "[channelStorage.GetChanges] Returning %d entries...", len(results))
 	return results, nil
 
 }
@@ -532,7 +531,6 @@ func generateBitFlagBlockIndexes(channelName string, minSequence uint64, maxSequ
 	for index := firstIndex; index <= lastIndex; index++ {
 		indexes = append(indexes, index)
 	}
-	base.LogTo("DIndex+", "generatedBitFlagBlockIndexes for (%d, %d): %+v", minSequence, maxSequence, indexes)
 	return indexes
 }
 
@@ -787,7 +785,6 @@ func (b *BitFlagBufferBlock) AddEntry(entry *LogEntry) error {
 	if err != nil {
 		return err
 	}
-	base.LogTo("DIndex+", "Adding entry (%d, %d) at index: %d", entry.VbNo, entry.Sequence, index)
 	if entry.isRemoved() {
 		b.value[index] = byte(2)
 	} else {


### PR DESCRIPTION
Reduces debug-style DIndex logging to reduce test output.

Also fixes potential race condition in TestPollResultLongRunningContinuous.
