### PR TITLE
Add support to package additional binary.

### DIFF
--- a/build/package-deb.rb
+++ b/build/package-deb.rb
@@ -8,7 +8,6 @@ require 'rake'
 
 PRODUCT         = "couchbase-sync-gateway"
 PRODUCT_BASE    = "couchbase"
-PRODUCT_KIND    = "sync-gateway"
 DEBEMAIL        = "build@couchbase.com"
 
 PREFIX          = ARGV[0] || "/opt/#{PRODUCT}"
@@ -17,7 +16,9 @@ PRODUCT_VERSION = ARGV[2] || "1.0-1234"
 REPO_SHA        = ARGV[3] || "master"
 PLATFORM        = ARGV[4] || `uname -s`.chomp + "-" +  `uname -m`.chomp
 ARCH            = ARGV[5] ||                           `uname -m`.chomp
+PRODUCT_KIND    = ARGV[6] || "sync-gateway"
 
+PRODUCT         = "#{PRODUCT_BASE}-#{PRODUCT_KIND}"
 RELEASE         = PRODUCT_VERSION.split('-')[0]    # e.g., 1.0
 BLDNUM          = PRODUCT_VERSION.split('-')[1]    # e.g., 1234
 

--- a/build/package-mac.rb
+++ b/build/package-mac.rb
@@ -16,7 +16,6 @@ require 'rake'
 
 PRODUCT         = "couchbase-sync-gateway"
 PRODUCT_BASE    = "couchbase"
-PRODUCT_KIND    = "sync-gateway"
 
 PREFIX          = ARGV[0] || "/opt/#{PRODUCT}"
 PREFIXD         = ARGV[1] || "./opt/#{PRODUCT}"
@@ -24,9 +23,11 @@ PRODUCT_VERSION = ARGV[2] || "1.0-1234"
 REPO_SHA        = ARGV[3] || "master"
 PLATFORM        = ARGV[4] || `uname -s`.chomp + "-" +  `uname -m`.chomp
 ARCH            = ARGV[5] ||                           `uname -m`.chomp
+PRODUCT_KIND    = ARGV[6] || "sync-gateway"
 
 platform = PLATFORM.gsub("Darwin", "macosx")
 
+PRODUCT         = "#{PRODUCT_BASE}-#{PRODUCT_KIND}"
 RELEASE         = PRODUCT_VERSION.split('-')[0]    # e.g., 1.0
 BLDNUM          = PRODUCT_VERSION.split('-')[1]    # e.g., 1234
 

--- a/build/package-rpm.rb
+++ b/build/package-rpm.rb
@@ -8,7 +8,6 @@ require 'rake'
 
 PRODUCT         = "couchbase-sync-gateway"
 PRODUCT_BASE    = "couchbase"
-PRODUCT_KIND    = "sync-gateway"
 
 PREFIX          = ARGV[0] || "/opt/#{PRODUCT}"
 PREFIXD         = ARGV[1] || "./opt/#{PRODUCT}"
@@ -16,7 +15,9 @@ PRODUCT_VERSION = ARGV[2] || "1.0-1234"
 REPO_SHA        = ARGV[3] || "master"
 PLATFORM        = ARGV[4] || `uname -s`.chomp + "-" +  `uname -m`.chomp
 ARCH            = ARGV[5] ||                           `uname -m`.chomp
+PRODUCT_KIND    = ARGV[6] || "sync-gateway"
 
+PRODUCT         = "#{PRODUCT_BASE}-#{PRODUCT_KIND}"
 RELEASE         = PRODUCT_VERSION.split('-')[0]    # e.g., 1.0
 BLDNUM          = PRODUCT_VERSION.split('-')[1]    # e.g., 1234
 

--- a/build/package-win.rb
+++ b/build/package-win.rb
@@ -16,7 +16,6 @@ require 'rake'
 
 PRODUCT         = "couchbase-sync-gateway"
 PRODUCT_BASE    = "couchbase"
-PRODUCT_KIND    = "sync-gateway"
 
 PREFIX          = ARGV[0] || "/opt/#{PRODUCT}"
 PREFIXD         = ARGV[1] || "./opt/#{PRODUCT}"
@@ -24,7 +23,9 @@ PRODUCT_VERSION = ARGV[2] || "0.0.0-1234"
 REPO_SHA        = ARGV[3] || "master"
 PLATFORM        = ARGV[4] || 'windows-x64'
 ARCH            = ARGV[5] || 'x64'
+PRODUCT_KIND    = ARGV[6] || "sync-gateway"
 
+PRODUCT         = "#{PRODUCT_BASE}-#{PRODUCT_KIND}"
 RELEASE         = PRODUCT_VERSION.split('-')[0]    # e.g., 1.0.0
 BLDNUM          = PRODUCT_VERSION.split('-')[1]    # e.g., 1234
 


### PR DESCRIPTION
Required for 1.2 release.  It is backward compatible so will not break packaging on existing builds.
