### PR TITLE
Treat transient gocb server errors as recoverable

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket.go
@@ -147,7 +147,7 @@ func (bucket CouchbaseBucket) View(ddoc, name string, params map[string]interfac
 	err, result := RetryLoop(description, worker, sleeper)
 
 	vres := result.(sgbucket.ViewResult)
-	return vres, err;
+	return vres, err
 }
 
 func (bucket CouchbaseBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_writer.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_writer.go
@@ -180,7 +180,7 @@ func (k *kvChangeIndexWriter) indexPending() error {
 	channelStorage := NewChannelStorage(k.indexWriteBucket, "", indexPartitions)
 
 	indexRetryCount := 0
-	maxRetries := 10
+	maxRetries := 15
 
 	// Continual processing of arriving entries from the feed.
 	var sleeper base.RetrySleeper
@@ -189,7 +189,7 @@ func (k *kvChangeIndexWriter) indexPending() error {
 		err := k.indexEntries(entries, indexPartitions.VbMap, channelStorage)
 		if err != nil {
 			if indexRetryCount == 0 {
-				sleeper = base.CreateDoublingSleeperFunc(10, 5)
+				sleeper = base.CreateDoublingSleeperFunc(maxRetries, 5)
 			}
 			indexRetryCount++
 			shouldContinue, sleepMs := sleeper(indexRetryCount)
@@ -359,7 +359,7 @@ func (k *kvChangeIndexWriter) indexEntries(entries []*LogEntry, indexPartitions 
 func (k *kvChangeIndexWriter) addSetToChannelIndex(channelName string, entries []*LogEntry) error {
 	writer, err := k.getOrCreateWriter(channelName)
 	if err != nil {
-		base.LogFatal("Unable to obtain channel writer - partition map not defined?")
+		base.Warn("Unable to obtain channel writer - partition map not defined?")
 		return err
 	}
 	err = writer.AddSet(entries)


### PR DESCRIPTION
Treat 'Server is busy' and 'Temporary failure occurred' Couchbase Server errors as recoverable gocb errors, so that they pick up the existing retry handling.

As a workaround until gocb exposes public error codes (still pending), defined a set of common gocb errors for ease of use by Sync Gateway.

Also includes processing of a few error return values that were previously ignored (or only issuing a warning).

Fixes #1405.
