### PR TITLE
Use LRU cache for index writer block cache

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/lru_cache.go
+++ b/src/github.com/couchbase/sync_gateway/base/lru_cache.go
@@ -1,0 +1,82 @@
+package base
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+)
+
+// An LRU cache of document revision bodies, together with their channel access.
+type LRUCache struct {
+	cache      map[string]*list.Element // Fast lookup of list element by key
+	lruList    *list.List               // List ordered by most recent access (Front is newest)
+	capacity   int                      // Max number of entries to cache
+	lruLock    sync.Mutex               // For thread-safety
+	loaderFunc LRUCacheLoaderFunc
+}
+
+type LRUCacheLoaderFunc func(key string) (value interface{}, err error)
+
+// The cache payload data. Stored as the Value of a list Element.
+type lruCacheValue struct {
+	key          string
+	value        interface{}
+	err          error      // Error from loaderFunc if it failed
+	lruValueLock sync.Mutex // Synchronizes access to this struct
+}
+
+// Creates an LRU cache with the given capacity and an optional loader function.
+func NewLRUCache(capacity int) (*LRUCache, error) {
+
+	if capacity <= 0 {
+		return nil, errors.New("LRU cache capacity must be non-zero")
+	}
+
+	return &LRUCache{
+		cache:    map[string]*list.Element{},
+		lruList:  list.New(),
+		capacity: capacity}, nil
+}
+
+// Looks up an entry from the cache.
+func (lc *LRUCache) Get(key string) (result interface{}, found bool) {
+	lc.lruLock.Lock()
+	defer lc.lruLock.Unlock()
+	if elem, ok := lc.cache[key]; ok {
+		lc.lruList.MoveToFront(elem)
+		return elem.Value.(*lruCacheValue).value, true
+	}
+	return result, false
+}
+
+// Adds an entry to the cache.
+func (lc *LRUCache) Put(key string, value interface{}) {
+
+	// If already present, move to front
+	if elem := lc.cache[key]; elem != nil {
+		lc.lruList.MoveToFront(elem)
+		value = elem.Value.(*lruCacheValue)
+		return
+	}
+
+	// Not found - add as new
+	cacheValue := &lruCacheValue{
+		key:   key,
+		value: value,
+	}
+	lc.cache[key] = lc.lruList.PushFront(cacheValue)
+
+	// Purge oldest if over capacity
+	for len(lc.cache) > lc.capacity {
+		lc.purgeOldest_()
+	}
+}
+
+func (lc *LRUCache) purgeOldest_() {
+	value := lc.lruList.Remove(lc.lruList.Back()).(*lruCacheValue)
+	delete(lc.cache, value.key)
+}
+
+func (lc *LRUCache) Count() int {
+	return len(lc.cache)
+}

--- a/src/github.com/couchbase/sync_gateway/base/lru_cache_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/lru_cache_test.go
@@ -1,0 +1,69 @@
+package base
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+type testStruct struct {
+	x int
+	y int
+}
+
+func keyForTest(i int) string {
+	return fmt.Sprintf("key-%d", i)
+}
+
+func valueForTest(i int) *testStruct {
+	return &testStruct{
+		x: i,
+		y: i * i,
+	}
+}
+
+func verifyValue(t *testing.T, value *testStruct, i int) {
+	assert.True(t, value != nil)
+	assert.Equals(t, value.x, i)
+	assert.Equals(t, value.y, i*i)
+}
+
+func TestLRUCache(t *testing.T) {
+	ids := make([]string, 20)
+	for i := 0; i < 20; i++ {
+		ids[i] = fmt.Sprintf("%d", i)
+	}
+
+	cache, err := NewLRUCache(10)
+	assert.True(t, err == nil)
+	for i := 0; i < 10; i++ {
+		key := keyForTest(i)
+		value := valueForTest(i)
+		cache.Put(key, value)
+	}
+
+	for i := 0; i < 10; i++ {
+		value, _ := cache.Get(keyForTest(i))
+		testValue, ok := value.(*testStruct)
+		assert.True(t, ok)
+		verifyValue(t, testValue, i)
+	}
+
+	for i := 10; i < 13; i++ {
+		key := keyForTest(i)
+		value := valueForTest(i)
+		cache.Put(key, value)
+	}
+
+	for i := 0; i < 3; i++ {
+		value, _ := cache.Get(keyForTest(i))
+		assert.True(t, value == nil)
+	}
+	for i := 3; i < 13; i++ {
+		value, _ := cache.Get(keyForTest(i))
+		testValue, ok := value.(*testStruct)
+		assert.True(t, ok)
+		verifyValue(t, testValue, i)
+	}
+}

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index_test.go
@@ -84,7 +84,7 @@ func TestIndexBlockCreation(t *testing.T) {
 	defer testStorage.bucket.Close()
 	entry := makeEntry(1, 1, false)
 	block := testStorage.getIndexBlockForEntry(entry)
-	assert.True(t, len(testStorage.indexBlockCache) == 1)
+	assert.Equals(t, testStorage.indexBlockCache.Count(), 1)
 	blockEntries := block.GetAllEntries()
 	assert.Equals(t, len(blockEntries), 0)
 


### PR DESCRIPTION
Adds a generic simple locking LRU cache, and switches index writers to use that cache for index block management, instead of an unbounded map.

Fixes #1391
