### PR TITLE
Generate WebHook event for DBOffline state for all scenarios

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/shadower.go
+++ b/src/github.com/couchbase/sync_gateway/db/shadower.go
@@ -29,7 +29,7 @@ type Shadower struct {
 // Creates a new Shadower.
 func NewShadower(context *DatabaseContext, bucket base.Bucket, docIDPattern *regexp.Regexp) (*Shadower, error) {
 	tapFeed, err := bucket.StartTapFeed(sgbucket.TapArguments{Backfill: 0, Notify: func(bucket string, err error) {
-		context.TakeDbOffline()
+		context.TakeDbOffline("Lost shadower TAP Feed")
 	}})
 	if err != nil {
 		return nil, err

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api.go
@@ -103,10 +103,8 @@ func (h *handler) handleDbOnline() error {
 func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
-	if err = h.db.TakeDbOffline(); err == nil {
-		if h.db.DatabaseContext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			h.db.DatabaseContext.EventMgr.RaiseDBStateChangeEvent(h.db.DatabaseContext.Name, "offline", "ADMIN Request", *h.server.config.AdminInterface)
-		}
+	if err = h.db.TakeDbOffline("ADMIN Request"); err != nil {
+		base.LogTo("CRUD", "Unable to take Database : %v, offline",h.db.Name)
 	}
 
 	return err

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -642,7 +642,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		base.Warn("Lost TAP feed for bucket %s, with error: %v", bucket, err)
 
 		if dc := sc.databases_[dbName]; dc != nil {
-			dc.TakeDbOffline()
+			dc.TakeDbOffline("Lost TAP feed")
 		}
 	})
 
@@ -713,6 +713,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		IndexOptions:          channelIndexOptions,
 		SequenceHashOptions:   sequenceHashOptions,
 		RevisionCacheCapacity: revCacheSize,
+		AdminInterface:        sc.config.AdminInterface,
 	}
 
 	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, contextOptions)


### PR DESCRIPTION
fixes #1434 

WebHook was not triggered for all offline scenarios.

Tested loosing TAP feed by deleting the DB using following event handler config:

```
"event_handlers": {
                                "max_processes" : 500,
                                "wait_for_process" : "100",
                                "db_state_changed": [
                                        {
                                                "handler": "webhook",
                                                "url": "http://requestb.in/1g6ceh11",
                                                "timeout": 0
                                        }
                                ]
                        }
```
