### PR TITLE
Fixes #1454 ValidateConfigOrPanic doesn't seem to be respecting "skiprunmode_validation": true in the config.

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -494,7 +494,7 @@ func ParseCommandLine() {
 			config.LogFilePath = logFilePath
 		}
 
-		if skipRunModeValidation != nil {
+		if *skipRunModeValidation == true {
 			config.SkipRunmodeValidation = *skipRunModeValidation
 		}
 


### PR DESCRIPTION
https://github.com/couchbase/sync_gateway/issues/1454
