### PR TITLE
Ensure changes feed doesn't run ahead of stable sequence

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/change_cache.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_cache.go
@@ -582,7 +582,7 @@ func (c *changeCache) GetStableSequence(docID string) SequenceID {
 	return SequenceID{Seq: c.nextSequence - 1}
 }
 
-func (c *changeCache) GetStableClock() (clock base.SequenceClock, err error) {
+func (c *changeCache) GetStableClock(stale bool) (clock base.SequenceClock, err error) {
 	return nil, errors.New("Change cache doesn't use vector clocks")
 }
 

--- a/src/github.com/couchbase/sync_gateway/db/change_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_index.go
@@ -45,7 +45,7 @@ type ChangeIndex interface {
 
 	// Retrieves stable sequence for index
 	GetStableSequence(docID string) SequenceID
-	GetStableClock() (clock base.SequenceClock, err error)
+	GetStableClock(stale bool) (clock base.SequenceClock, err error)
 
 	// Utility functions for unit testing
 	waitForSequenceID(sequence SequenceID)

--- a/src/github.com/couchbase/sync_gateway/db/change_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_index.go
@@ -45,6 +45,9 @@ type ChangeIndex interface {
 
 	// Retrieves stable sequence for index
 	GetStableSequence(docID string) SequenceID
+
+	// Retrieves stable sequence for index.  Stale=false forces a reload of the clock from the bucket,
+	// stable=true returns cached value (if available)
 	GetStableClock(stale bool) (clock base.SequenceClock, err error)
 
 	// Utility functions for unit testing

--- a/src/github.com/couchbase/sync_gateway/db/changes_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes_test.go
@@ -171,7 +171,6 @@ func TestIndexChangesAdminBackfill(t *testing.T) {
 
 	lastSeq := getLastSeq(changes)
 	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
-	log.Println("Get Chnages")
 	changes, err = db.GetChanges(base.SetOf("*"), ChangesOptions{Since: lastSeq})
 	assertNoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
@@ -132,7 +132,7 @@ func TestChangeIndexAddEntry(t *testing.T) {
 	assert.Equals(t, len(allEntries), 1)
 
 	// Verify stable sequence
-	stableClock, err := changeIndex.GetStableClock()
+	stableClock, err := changeIndex.GetStableClock(false)
 	assertNoError(t, err, "Get stable clock")
 	assert.Equals(t, stableClock.GetSequence(1), uint64(1))
 	assert.Equals(t, stableClock.GetSequence(2), uint64(0))

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_writer.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_writer.go
@@ -293,6 +293,7 @@ func (k *kvChangeIndexWriter) indexEntries(entries []*LogEntry, indexPartitions 
 				defer entryWg.Done()
 				err := channelStorage.WriteLogEntry(logEntry)
 				if err != nil {
+					base.Warn("Error writing entry:%v", err)
 					atomic.AddUint32(&errorCount, 1)
 				}
 			}(logEntry, entryErrorCount)
@@ -327,6 +328,7 @@ func (k *kvChangeIndexWriter) indexEntries(entries []*LogEntry, indexPartitions 
 		// Track vbucket sequences for clock update
 		updatedSequences.SetSequence(logEntry.VbNo, logEntry.Sequence)
 	}
+	entryWg.Wait()
 
 	// Wait group tracks when the current buffer has been completely processed
 	var channelWg sync.WaitGroup
@@ -340,12 +342,12 @@ func (k *kvChangeIndexWriter) indexEntries(entries []*LogEntry, indexPartitions 
 			err := k.addSetToChannelIndex(channelName, entrySet)
 			if err != nil {
 				atomic.AddUint32(&errorCount, 1)
+				base.Warn("Error writing channel set:%v", err)
 			}
 		}(channelName, entrySet, channelErrorCount)
 	}
 
 	// Wait for entry and channel processing to complete
-	entryWg.Wait()
 	channelWg.Wait()
 	if atomic.LoadUint32(&entryErrorCount) > 0 || atomic.LoadUint32(&channelErrorCount) > 0 {
 		return errors.New("Unrecoverable error indexing entry or channel")

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
@@ -76,7 +76,8 @@ func (k *kvChannelIndex) AddSet(entries []*LogEntry) error {
 
 	clockUpdates, err := k.channelStorage.AddEntrySet(entries)
 	if err != nil {
-		base.Warn("Error adding entry set:%v", err)
+		// Returns error, will be retried by the main indexing process.
+		base.Warn("Error adding entry set to channel %s: %v", k.channelName, err)
 		return err
 	}
 

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index.go
@@ -76,6 +76,7 @@ func (k *kvChannelIndex) AddSet(entries []*LogEntry) error {
 
 	clockUpdates, err := k.channelStorage.AddEntrySet(entries)
 	if err != nil {
+		base.Warn("Error adding entry set:%v", err)
 		return err
 	}
 


### PR DESCRIPTION
Fixes a race condition when running a changes feed for multiple channels.  Previously index_changes was returning everything up to the channel clock.  Since index writers commit the channel clocks before the stable sequence, this had the possibility for a race condition where one channel's clock had been updated, but another's hadn't.  In this scenario, the cumulative clock/since value for the changes feed could move ahead and miss entries in the slower channel.

Returning only entries earlier than the stable sequence for the index avoids this problem, since the stable clock is only updated after all clocks are updated (for a given batch).

Fixes #1440.
