### PR TITLE
Adds support for _doc_ids filter in one shot _changes feed

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/util.go
+++ b/src/github.com/couchbase/sync_gateway/base/util.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"sort"
 )
 
 const kMaxDeltaTtl = 60 * 60 * 24 * 30 * time.Second
@@ -337,4 +338,16 @@ func CreateDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs int) RetrySl
 	}
 	return sleeper
 
+}
+
+// Uint64Slice attaches the methods of sort.Interface to []uint64, sorting in increasing order.
+type Uint64Slice []uint64
+
+func (s Uint64Slice) Len() int           { return len(s) }
+func (s Uint64Slice) Less(i, j int) bool { return s[i] < s[j] }
+func (s Uint64Slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// Sort is a convenience method.
+func (s Uint64Slice) Sort() {
+	sort.Sort(s)
 }

--- a/src/github.com/couchbase/sync_gateway/db/crud.go
+++ b/src/github.com/couchbase/sync_gateway/db/crud.go
@@ -173,7 +173,7 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 
 // Returns the body of a revision of a document, as well as the document's current channels
 // and the user/roles it grants channel access to.
-func (db *Database) GetRevAndChannels(docid, revid string, listRevisions bool) (body Body, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, err error) {
+func (db *Database) GetRevAndChannels(docid, revid string, listRevisions bool) (body Body, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, sequence uint64, err error) {
 	doc, err := db.GetDoc(docid)
 	if doc == nil {
 		return
@@ -185,6 +185,7 @@ func (db *Database) GetRevAndChannels(docid, revid string, listRevisions bool) (
 	channels = doc.Channels
 	access = doc.Access
 	roleAccess = doc.RoleAccess
+	sequence = doc.Sequence
 	return
 }
 

--- a/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
@@ -136,7 +136,7 @@ func (h *handler) handleAllDocs() error {
 
 		if explicitDocIDs != nil || includeDocs || includeAccess {
 			// Fetch the document body and other metadata that lives with it:
-			body, channelSet, access, roleAccess, err := h.db.GetRevAndChannels(doc.DocID, doc.RevID, includeRevs)
+			body, channelSet, access, roleAccess, _, err := h.db.GetRevAndChannels(doc.DocID, doc.RevID, includeRevs)
 			if err != nil {
 				row.Status, _ = base.ErrorAsHTTPStatus(err)
 				return row


### PR DESCRIPTION
fixes #545 

To improve performance when using the _doc_ids filter, individual documents are retrieved for the supplied list of doc_ids rather than using the change cache.
