### PR TITLE
Fixes #1472 bulk_get compression regression: compressing parts without X-Accept-Part-Encoding: gzip header

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/bulk_api.go
@@ -308,7 +308,7 @@ func (h *handler) handleBulkGet() error {
 	// DO want to compress the parts since the full response will not be gzipped, since those clients can't handle it.
 	// See https://github.com/couchbase/sync_gateway/issues/1419 and encoded_response_writer.go
 	userAgentVersion := NewUserAgentVersion(h.rq.Header.Get("User-Agent"))
-	if userAgentVersion.IsBefore(1, 2) {
+	if userAgentVersion.IsBefore(1, 2) && acceptGzipPartEncoding {
 		canCompressParts = true
 	}
 


### PR DESCRIPTION
https://github.com/couchbase/sync_gateway/issues/1472
