### PR TITLE
Avoid race between SG nodes when writing index partition map

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/bucket_gocb_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/bucket_gocb_test.go
@@ -64,6 +64,43 @@ func CouchbaseTestSetGetRaw(t *testing.T) {
 
 }
 
+func CouchbaseTestAddRaw(t *testing.T) {
+
+	bucket := GetBucketOrPanic()
+
+	key := "TestAddRaw"
+	val := []byte("bar")
+
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		t.Errorf("Key should not exist yet, expected error but got nil")
+	}
+
+	added, err := bucket.AddRaw(key, 0, val)
+	if err != nil {
+		t.Errorf("Error calling AddRaw(): %v", err)
+	}
+	assertTrue(t, added, "AddRaw returned added=false, expected true")
+
+	rv, _, err := bucket.GetRaw(key)
+	if string(rv) != string(val) {
+		t.Errorf("%v != %v", string(rv), string(val))
+	}
+
+	// Calling AddRaw for existing value should return added=false, no error
+	added, err = bucket.AddRaw(key, 0, val)
+	if err != nil {
+		t.Errorf("Error calling AddRaw(): %v", err)
+	}
+	assertTrue(t, added == false, "AddRaw returned added=true for duplicate, expected false")
+
+	err = bucket.Delete(key)
+	if err != nil {
+		t.Errorf("Error removing key from bucket")
+	}
+
+}
+
 func CouchbaseTestBulkGetRaw(t *testing.T) {
 
 	bucket := GetBucketOrPanic()

--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock_test.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock_test.go
@@ -19,7 +19,7 @@ var maxVbNo = uint16(1024)
 
 func GenerateTestIndexPartitions(maxVbNo uint16, numPartitions uint16) *IndexPartitions {
 
-	partitionDefs := make([]PartitionStorage, numPartitions)
+	partitionDefs := make(PartitionStorageSet, numPartitions)
 	vbPerPartition := maxVbNo / numPartitions
 	for partition := uint16(0); partition < numPartitions; partition++ {
 		storage := PartitionStorage{

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"expvar"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -146,58 +147,36 @@ func (k *kvChangeIndex) initIndexPartitions() (*base.IndexPartitions, error) {
 		return k.indexPartitions, nil
 	}
 
-	var partitionDef []base.PartitionStorage
 	// First attempt to load from the bucket
-	value, _, err := k.reader.indexReadBucket.GetRaw(base.KIndexPartitionKey)
-	indexExpvars.Add("get_indexPartitionMap", 1)
-	if err == nil {
-		if err = json.Unmarshal(value, &partitionDef); err != nil {
-			return nil, err
-		}
+	partitionDef, err := k.loadIndexPartitionsFromBucket()
+	if err != nil {
+		return nil, err
 	}
 
+	indexExpvars.Add("get_indexPartitionMap", 1)
 	// If unable to load from index bucket - attempt to initialize based on cbgt partitions
 	if partitionDef == nil {
-		var manager *cbgt.Manager
-		if k.context != nil {
-			manager = k.context.BucketSpec.CbgtContext.Manager
-		} else {
-			return nil, errors.New("Unable to determine partition map for index - not found in index, and no database context")
-		}
-
-		if manager == nil {
-			return nil, errors.New("Unable to determine partition map for index - not found in index, and no CBGT manager")
-		}
-
-		_, planPIndexesByName, _ := manager.GetPlanPIndexes(true)
-		indexName := k.context.GetCBGTIndexNameForBucket(k.context.Bucket)
-		pindexes := planPIndexesByName[indexName]
-
-		for index, pIndex := range pindexes {
-			vbStrings := strings.Split(pIndex.SourcePartitions, ",")
-			// convert string vbNos to uint16
-			vbNos := make([]uint16, len(vbStrings))
-			for i := 0; i < len(vbStrings); i++ {
-				vbNumber, err := strconv.ParseUint(vbStrings[i], 10, 16)
-				if err != nil {
-					base.LogFatal("Error creating index partition definition - unable to parse vbucket number %s as integer:%v", vbStrings[i], err)
-				}
-				vbNos[i] = uint16(vbNumber)
-			}
-			entry := base.PartitionStorage{
-				Index: uint16(index),
-				Uuid:  pIndex.UUID,
-				VbNos: vbNos,
-			}
-			partitionDef = append(partitionDef, entry)
-		}
-
-		// Persist to bucket
-		value, err = json.Marshal(partitionDef)
+		partitionDef, err = k.retrieveCBGTPartitions()
 		if err != nil {
 			return nil, err
 		}
-		k.reader.indexReadBucket.SetRaw(base.KIndexPartitionKey, 0, value)
+		// Add to the bucket
+		value, err := json.Marshal(partitionDef)
+		if err != nil {
+			return nil, err
+		}
+		added, err := k.reader.indexReadBucket.AddRaw(base.KIndexPartitionKey, 0, value)
+		if err != nil {
+			return nil, err
+		}
+		// If add fails, it may have been written by another node since the last read attempt.  Make
+		// another attempt to use the version from the bucket, to ensure consistency.
+		if added == false {
+			partitionDef, err = k.loadIndexPartitionsFromBucket()
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Create k.indexPartitions based on partitionDef
@@ -205,6 +184,62 @@ func (k *kvChangeIndex) initIndexPartitions() (*base.IndexPartitions, error) {
 	return k.indexPartitions, nil
 }
 
+func (k *kvChangeIndex) loadIndexPartitionsFromBucket() (base.PartitionStorageSet, error) {
+	var partitionDef base.PartitionStorageSet
+	value, _, err := k.reader.indexReadBucket.GetRaw(base.KIndexPartitionKey)
+	if err == nil {
+		if err = json.Unmarshal(value, &partitionDef); err != nil {
+			return nil, err
+		}
+	}
+	return partitionDef, nil
+}
+
+func (k *kvChangeIndex) retrieveCBGTPartitions() (partitionDef base.PartitionStorageSet, err error) {
+
+	var manager *cbgt.Manager
+	if k.context != nil {
+		manager = k.context.BucketSpec.CbgtContext.Manager
+	} else {
+		return nil, errors.New("Unable to determine partition map for index - not found in index, and no database context")
+	}
+
+	if manager == nil {
+		return nil, errors.New("Unable to determine partition map for index - not found in index, and no CBGT manager")
+	}
+
+	_, planPIndexesByName, _ := manager.GetPlanPIndexes(true)
+	indexName := k.context.GetCBGTIndexNameForBucket(k.context.Bucket)
+	pindexes := planPIndexesByName[indexName]
+
+	for _, pIndex := range pindexes {
+		vbStrings := strings.Split(pIndex.SourcePartitions, ",")
+		// convert string vbNos to uint16
+		vbNos := make([]uint16, len(vbStrings))
+		for i := 0; i < len(vbStrings); i++ {
+			vbNumber, err := strconv.ParseUint(vbStrings[i], 10, 16)
+			if err != nil {
+				base.LogFatal("Error creating index partition definition - unable to parse vbucket number %s as integer:%v", vbStrings[i], err)
+			}
+			vbNos[i] = uint16(vbNumber)
+		}
+		entry := base.PartitionStorage{
+			Index: uint16(0), // see below for index assignment
+			Uuid:  pIndex.UUID,
+			VbNos: vbNos,
+		}
+		partitionDef = append(partitionDef, entry)
+	}
+
+	// NOTE: the ordering of pindexes returned by manager.GetPlanPIndexes isn't fixed (it's doing a map iteration somewhere).
+	//    The mapping from UUID to VbNos will always be consistent.  Sorting by UUID to maintain a consistent index ordering,
+	// then assigning index values.
+	partitionDef.Sort()
+	for i := 0; i < len(partitionDef); i++ {
+		partitionDef[i].Index = uint16(i)
+	}
+	return partitionDef, nil
+}
 func (k *kvChangeIndex) getIndexPartitionMap() (base.IndexPartitionMap, error) {
 
 	partitions, err := k.getIndexPartitions()
@@ -312,6 +347,21 @@ func uint64ToByte(input uint64) []byte {
 type AllChannelStats struct {
 	Channels []ChannelStats `json:"channels"`
 }
+
+type IndexStats struct {
+	PartitionStats PartitionStats `json:"partitions"`
+}
+
+type PartitionStats struct {
+	PartitionMap    PartitionMapStats `json:"index_partitions"`
+	CBGTMap         PartitionMapStats `json:"cbgt_partitions"`
+	PartitionsMatch bool              `json:"matches"`
+}
+
+type PartitionMapStats struct {
+	Storage base.PartitionStorageSet `json:"partitions"`
+}
+
 type ChannelStats struct {
 	Name         string              `json:"channel_name"`
 	IndexStats   ChannelIndexStats   `json:"index,omitempty"`
@@ -325,6 +375,19 @@ type ChannelIndexStats struct {
 type ChannelPollingStats struct {
 	Clock     string `json:"poll_clock,omitempty"`
 	ClockHash uint64 `json:"poll_clock_hash,omitempty"`
+}
+
+func (db *DatabaseContext) IndexStats() (indexStats *IndexStats, err error) {
+
+	kvIndex, ok := db.changeCache.(*kvChangeIndex)
+	if !ok {
+		return nil, errors.New("No channel index in use")
+	}
+
+	indexStats = &IndexStats{}
+
+	indexStats.PartitionStats, err = kvIndex.generatePartitionStats()
+	return indexStats, err
 }
 
 func (db *DatabaseContext) IndexChannelStats(channelName string) (*ChannelStats, error) {
@@ -392,6 +455,36 @@ func (db *DatabaseContext) singleChannelStats(kvIndex *kvChangeIndex, channelNam
 		}
 	}
 	return channelStats, nil
+}
+
+func (k *kvChangeIndex) generatePartitionStats() (PartitionStats, error) {
+
+	partitionStats := PartitionStats{}
+	partitions, err := k.getIndexPartitions()
+	if err != nil {
+		return partitionStats, err
+	}
+
+	if partitions != nil {
+		partitions.PartitionDefs.Sort()
+		partitionStats.PartitionMap = PartitionMapStats{
+			Storage: partitions.PartitionDefs,
+		}
+	}
+
+	cbgtPartitions, err := k.retrieveCBGTPartitions()
+	if err != nil {
+		return partitionStats, err
+	}
+	if cbgtPartitions != nil {
+		cbgtPartitions.Sort()
+		partitionStats.CBGTMap = PartitionMapStats{
+			Storage: cbgtPartitions,
+		}
+	}
+
+	partitionStats.PartitionsMatch = reflect.DeepEqual(partitionStats.PartitionMap, partitionStats.CBGTMap)
+	return partitionStats, nil
 }
 
 func IsNotFoundError(err error) bool {

--- a/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_change_index_test.go
@@ -570,7 +570,7 @@ func TestChangeIndexAddSet(t *testing.T) {
 func SeedPartitionMap(bucket base.Bucket, numPartitions uint16) error {
 	maxVbNo := uint16(1024)
 	//maxVbNo := uint16(64)
-	partitionDefs := make([]base.PartitionStorage, numPartitions)
+	partitionDefs := make(base.PartitionStorageSet, numPartitions)
 	vbPerPartition := maxVbNo / numPartitions
 	for partition := uint16(0); partition < numPartitions; partition++ {
 		storage := base.PartitionStorage{

--- a/src/github.com/couchbase/sync_gateway/db/kv_channel_index_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/kv_channel_index_test.go
@@ -11,7 +11,7 @@ import (
 
 func testPartitionMap() *base.IndexPartitions {
 
-	partitions := make([]base.PartitionStorage, 64)
+	partitions := make(base.PartitionStorageSet, 64)
 
 	numPartitions := uint16(64)
 	vbPerPartition := 1024 / numPartitions

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api.go
@@ -11,15 +11,15 @@ package rest
 
 import (
 	"encoding/json"
-	"net/http"
 	"fmt"
 	"github.com/gorilla/mux"
+	"net/http"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"time"
 	"sync/atomic"
+	"time"
 )
 
 const kDefaultDBOnlineDelay = 0
@@ -48,12 +48,12 @@ func (h *handler) handleDbOnline() error {
 	h.assertAdminOnly()
 	dbState := atomic.LoadUint32(&h.db.State)
 	//If the DB is already trasitioning to: online or is online silently return
-	if (dbState == db.DBOnline || dbState == db.DBStarting) {
+	if dbState == db.DBOnline || dbState == db.DBStarting {
 		return nil
 	}
 
 	//If the DB is currently re-syncing return an error asking the user to retry later
-	if (dbState == db.DBResyncing) {
+	if dbState == db.DBResyncing {
 		return base.HTTPErrorf(http.StatusServiceUnavailable, "Database _resync is in progress, this may take some time, try again later")
 	}
 
@@ -63,12 +63,12 @@ func (h *handler) handleDbOnline() error {
 	}
 
 	var input struct {
-		Delay int           `json:"delay"`
+		Delay int `json:"delay"`
 	}
 
-	input.Delay = kDefaultDBOnlineDelay;
+	input.Delay = kDefaultDBOnlineDelay
 
-	json.Unmarshal(body, &input);
+	json.Unmarshal(body, &input)
 
 	base.LogTo("CRUD", "Taking Database : %v, online in %v seconds", h.db.Name, input.Delay)
 
@@ -104,7 +104,7 @@ func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
 	if err = h.db.TakeDbOffline("ADMIN Request"); err != nil {
-		base.LogTo("CRUD", "Unable to take Database : %v, offline",h.db.Name)
+		base.LogTo("CRUD", "Unable to take Database : %v, offline", h.db.Name)
 	}
 
 	return err
@@ -345,6 +345,20 @@ func (h *handler) getRoles() error {
 }
 
 // HTTP handler for /index/channel
+func (h *handler) handleIndex() error {
+	base.LogTo("HTTP", "Index")
+
+	indexStats, err := h.db.IndexStats()
+
+	if err != nil {
+		return err
+	}
+	bytes, err := json.Marshal(indexStats)
+	h.response.Write(bytes)
+	return err
+}
+
+// HTTP handler for /index/channel
 func (h *handler) handleIndexChannel() error {
 	channelName := h.PathVar("channel")
 	base.LogTo("HTTP", "Index channel %q", channelName)
@@ -373,7 +387,6 @@ func (h *handler) handleIndexAllChannels() error {
 	return err
 }
 
-
 func (h *handler) handlePurge() error {
 	h.assertAdminOnly()
 
@@ -393,18 +406,18 @@ func (h *handler) handlePurge() error {
 
 	for key, value := range input {
 		//For each one validate that the revision list is set to ["*"], otherwise skip doc and log warning
-		base.LogTo("CRUD","purging document = %v",key)
+		base.LogTo("CRUD", "purging document = %v", key)
 
 		if revisionList, ok := value.([]interface{}); ok {
 
 			//There should only be a single revision entry of "*"
 			if len(revisionList) != 1 {
-				base.LogTo("CRUD","Revision list for doc ID %v, should contain exactly one entry",key)
+				base.LogTo("CRUD", "Revision list for doc ID %v, should contain exactly one entry", key)
 				continue //skip this entry its not valid
 			}
 
 			if revisionList[0] != "*" {
-				base.LogTo("CRUD","Revision entry for doc ID %v, should be the '*' revison", key)
+				base.LogTo("CRUD", "Revision entry for doc ID %v, should be the '*' revison", key)
 				continue //skip this entry its not valid
 			}
 
@@ -427,7 +440,7 @@ func (h *handler) handlePurge() error {
 			}
 
 		} else {
-			base.LogTo("CRUD","Revision list for doc ID %v, is not an array, ", key)
+			base.LogTo("CRUD", "Revision list for doc ID %v, is not an array, ", key)
 			continue //skip this entry its not valid
 		}
 	}

--- a/src/github.com/couchbase/sync_gateway/rest/admin_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/admin_api.go
@@ -344,7 +344,7 @@ func (h *handler) getRoles() error {
 	return err
 }
 
-// HTTP handler for /index/channel
+// HTTP handler for /index
 func (h *handler) handleIndex() error {
 	base.LogTo("HTTP", "Index")
 

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api_test.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api_test.go
@@ -769,7 +769,7 @@ func assertTrue(t *testing.T, success bool, message string) {
 // Index partitions for testing
 func SeedPartitionMap(bucket base.Bucket, numPartitions uint16) error {
 	maxVbNo := uint16(1024)
-	partitionDefs := make([]base.PartitionStorage, numPartitions)
+	partitionDefs := make(base.PartitionStorageSet, numPartitions)
 	vbPerPartition := maxVbNo / numPartitions
 	for partition := uint16(0); partition < numPartitions; partition++ {
 		storage := base.PartitionStorage{

--- a/src/github.com/couchbase/sync_gateway/rest/routing.go
+++ b/src/github.com/couchbase/sync_gateway/rest/routing.go
@@ -213,6 +213,8 @@ func CreateAdminHandler(sc *ServerContext) http.Handler {
 		makeHandler(sc, adminPrivs, (*handler).handleView)).Methods("GET")
 	dbr.Handle("/_dumpchannel/{channel}",
 		makeHandler(sc, adminPrivs, (*handler).handleDumpChannel)).Methods("GET")
+	dbr.Handle("/_index",
+		makeHandler(sc, adminPrivs, (*handler).handleIndex)).Methods("GET")
 	dbr.Handle("/_index/channel/{channel}",
 		makeHandler(sc, adminPrivs, (*handler).handleIndexChannel)).Methods("GET")
 	dbr.Handle("/_index/channels",


### PR DESCRIPTION
When a new channel index is initialized, Sync Gateway writers will initialize the partition map based on information from CBGT when it's not found in the index bucket, and then persist the CBGT information to the index bucket.  There were two problems happening:
1. Sync Gateway nodes were doing a Set when they persisted the partition map, instead of an Add.  This was the race - two sync gateways could look for the partition map in the DB, not find it, then write new partition maps to the based on what they got from CBGT.
2. The ordering of partitions in the slice returned by CBGT isn't constant - there's an underlying map range happening.  As a result, Sync Gateways hitting this race condition would end up using two different partition maps (and clobbering each others partition map writes to the bucket)

The fix covers both aspects:
1. The partitions in the slice returned by CBGT are sorted by UUID before any processing by Sync Gateway.
2. Sync Gateway does an add instead of set when writing the partition map to the bucket, and when the key already exists, reloads and uses the version from the bucket.

Strictly speaking only one of these fixes are necessary for this issue, but adding both is better future-proofing for changes for either.
