### PR TITLE
Ensure all seq values returned by changes feed can be used as since value

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/change_index.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_index.go
@@ -72,18 +72,20 @@ const (
 )
 
 type ChangeIndexOptions struct {
-	Type      IndexType       // Index type
-	Spec      base.BucketSpec // Indexing bucket spec
-	Bucket    base.Bucket     // Indexing bucket
-	Writer    bool            // Cache Writer
-	Options   CacheOptions    // Caching options
-	NumShards uint16          // The number of CBGT shards to use
+	Type          IndexType       // Index type
+	Spec          base.BucketSpec // Indexing bucket spec
+	Bucket        base.Bucket     // Indexing bucket
+	Writer        bool            // Cache Writer
+	Options       CacheOptions    // Caching options
+	NumShards     uint16          // The number of CBGT shards to use]
+	HashFrequency uint16          // Hash frequency for changes feeds
 }
 
 type SequenceHashOptions struct {
-	Bucket base.Bucket // Hash lookup bucket
-	Size   uint8       // Hash keyset size log 2
-	Expiry *uint32     // Expiry for untouched hash bucket docs
+	Bucket        base.Bucket // Hash lookup bucket
+	Size          uint8       // Hash keyset size log 2
+	Expiry        *uint32     // Expiry for untouched hash bucket docs
+	HashFrequency *int        // Hash frequency for changes feed
 }
 
 // ChannelIndex defines the API used by the ChangeIndex to interact with the underlying index storage

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -66,11 +66,10 @@ type DatabaseContext struct {
 	AllowEmptyPassword bool                    // Allow empty passwords?  Defaults to false
 	SequenceHasher     *sequenceHasher         // Used to generate and resolve hash values for vector clock sequences
 	SequenceType       SequenceType            // Type of sequences used for this DB (integer or vector clock)
-	Options            DatabaseContextOptions
+	Options            DatabaseContextOptions  // Database Context Options
 	AccessLock         sync.RWMutex            // Allows DB offline to block until synchronous calls have completed
-	State              uint32                  //The runtime state of the DB from a service perspective
-	ExitChanges        chan struct{}           //active _changes feeds on the DB will close when this channel is closed
-
+	State              uint32                  // The runtime state of the DB from a service perspective
+	ExitChanges        chan struct{}           // Active _changes feeds on the DB will close when this channel is closed
 }
 
 type DatabaseContextOptions struct {

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -174,8 +174,15 @@ type CacheConfig struct {
 
 type ChannelIndexConfig struct {
 	BucketConfig
-	IndexWriter bool   `json:"writer,omitempty"` // TODO: Partition information
-	NumShards   uint16 `json:"num_shards,omitempty"`
+	IndexWriter        bool                `json:"writer,omitempty"`      // Whether SG node is a channel index writer
+	NumShards          uint16              `json:"num_shards,omitempty"`  // Number of partitions in the channel index
+	SequenceHashConfig *SequenceHashConfig `json:"seq_hashing,omitempty"` // Sequence hash configuration
+}
+
+type SequenceHashConfig struct {
+	BucketConfig         // Bucket used for Sequence hashing
+	Expiry       *uint32 `json:"expiry,omitempty"`         // Expiry set for hash values on latest use
+	Frequency    *int    `json:"hash_frequency,omitempty"` // Frequency of sequence hashing in changes feeds
 }
 
 func (dbConfig *DbConfig) setup(name string) error {


### PR DESCRIPTION
When using vector clock sequences (distributed index), the changes feed returns a hashed sequence clock, instead of an integer sequence.  Previously longpoll and one-off changes requests were only hashing the last_seq value, to avoid the performance overhead of hashing a sequence clock for each changes entry - other entries were sent as simple vb.seq format.  However, this breaks clients (including CBL) that attempt to make a subsequent _changes request based on a change entry's sequence value, instead of last_seq.

To handle this, longpoll and one-off changes now use the same approach as previously used for continuous changes feeds - the cumulative sequence clock for a changes response is hashed periodically, and the most recent hash is sent as a `low` value for each changes entry (e.g. in the format `low::vb.seq`, where low is a clock hash.

To ensure that the last sequence sent in one-off and longpoll replication gets a new hash value (to avoid looping of longpoll requests), the changes loop processing was refactored in index_changes to identify the last sequence before it is sent on the output channel.

Included in this PR is the ability to define the frequency of the periodic sequence hashing in the Sync Gateway config, as an optional part of the channel_index configuration.  This also exposes the other sequence hash options that weren't previously exposed, including the ability to define a separate bucket for sequence hashes, and to customize the expiry for persisted hash values.  For 1.2 this seq_hashing config will be released as an undocumented feature, with the plan for full QE testing and documentation in 1.3.

Fixes #1475.
