### PR TITLE
Avoid nested read locks in logging.go

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/logging.go
+++ b/src/github.com/couchbase/sync_gateway/base/logging.go
@@ -243,7 +243,7 @@ func logWithCaller(color string, prefix string, format string, args ...interface
 		dim, " -- ", GetCallersName(2), reset)
 }
 
-// Simple wrapper that converts Print to Printf
+// Simple wrapper that converts Print to Printf.  Assumes caller is holding logLock read lock.
 func print(args ...interface{}) {
 	ok := logLevel <= 1
 
@@ -252,10 +252,8 @@ func print(args ...interface{}) {
 	}
 }
 
-// Logs a formatted message to the underlying logger
+// Logs a formatted message to the underlying logger.  Assumes caller is holding logLock read lock.
 func printf(format string, args ...interface{}) {
-	logLock.RLock()
-	defer logLock.RUnlock()
 	ok := logLevel <= 1
 
 	if ok {


### PR DESCRIPTION
There were several locations (including LogTo) where the logLock read lock was getting acquired twice - once on the initial call to LogTo, and then again in printf.  If another process requests the write lock between these read locks, it will deadlock.

Since the write lock is rarely requested (outside of unit tests), this is a relatively low risk issue.  It's intermittently deadlocking/failing unit tests and builds, however.

Fixes #1491
