### PR TITLE
Require 'unsupported' config option for view query support on public API

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/util.go
+++ b/src/github.com/couchbase/sync_gateway/base/util.go
@@ -308,6 +308,9 @@ func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (er
 		}
 		shouldContinue, sleepMs := sleeper(numAttempts)
 		if !shouldContinue {
+			if err == nil {
+				err = fmt.Errorf("RetryLoop for %v giving up after %v attempts", description, numAttempts)
+			}
 			Warn("RetryLoop for %v giving up after %v attempts", description, numAttempts)
 			return err, value
 		}

--- a/src/github.com/couchbase/sync_gateway/base/util.go
+++ b/src/github.com/couchbase/sync_gateway/base/util.go
@@ -18,11 +18,11 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"sort"
 )
 
 const kMaxDeltaTtl = 60 * 60 * 24 * 30 * time.Second
@@ -306,13 +306,12 @@ func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (er
 			}
 			return nil, value
 		}
-
 		shouldContinue, sleepMs := sleeper(numAttempts)
 		if !shouldContinue {
-			err := fmt.Errorf("RetryLoop for %v giving up after %v attempts", description, numAttempts)
+			Warn("RetryLoop for %v giving up after %v attempts", description, numAttempts)
 			return err, value
 		}
-		Warn("RetryLoop retrying %v after %v ms.", description, sleepMs)
+		LogTo("Debug", "RetryLoop retrying %v after %v ms.", description, sleepMs)
 
 		<-time.After(time.Millisecond * time.Duration(sleepMs))
 

--- a/src/github.com/couchbase/sync_gateway/db/database.go
+++ b/src/github.com/couchbase/sync_gateway/db/database.go
@@ -78,6 +78,11 @@ type DatabaseContextOptions struct {
 	SequenceHashOptions   *SequenceHashOptions
 	RevisionCacheCapacity uint32
 	AdminInterface        *string
+	UnsupportedOptions    *UnsupportedOptions
+}
+
+type UnsupportedOptions struct {
+	EnableUserViews bool
 }
 
 const DefaultRevsLimit = 1000
@@ -899,6 +904,17 @@ func (context *DatabaseContext) GetIndexBucket() base.Bucket {
 	} else {
 		return nil
 	}
+}
+
+func (context *DatabaseContext) GetUserViewsEnabled() bool {
+	if context.Options.UnsupportedOptions != nil {
+		return context.Options.UnsupportedOptions.EnableUserViews
+	}
+	return false
+}
+
+func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
+	context.Options.UnsupportedOptions.EnableUserViews = value
 }
 
 //////// SEQUENCE ALLOCATION:

--- a/src/github.com/couchbase/sync_gateway/rest/config.go
+++ b/src/github.com/couchbase/sync_gateway/rest/config.go
@@ -122,6 +122,7 @@ type DbConfig struct {
 	ChannelIndex       *ChannelIndexConfig            `json:"channel_index,omitempty"`        // Channel index settings
 	RevCacheSize       *uint32                        `json:"rev_cache_size,omitempty"`       // Maximum number of revisions to store in the revision cache
 	StartOffline       bool                           `json:"offline,omitempty"`              // start the DB in the offline state, defaults to false
+	Unsupported        *UnsupportedConfig             `json:"unsupported,omitempty"`          // Config for unsupported features
 }
 
 type DbConfigMap map[string]*DbConfig
@@ -183,6 +184,14 @@ type SequenceHashConfig struct {
 	BucketConfig         // Bucket used for Sequence hashing
 	Expiry       *uint32 `json:"expiry,omitempty"`         // Expiry set for hash values on latest use
 	Frequency    *int    `json:"hash_frequency,omitempty"` // Frequency of sequence hashing in changes feeds
+}
+
+type UnsupportedConfig struct {
+	UserViews *UserViewsConfig `json:"user_views,omitempty"` // Config settings for user views
+}
+
+type UserViewsConfig struct {
+	Enabled *bool `json:"enabled,omitempty"` // Whether pass-through view query is supported through public API
 }
 
 func (dbConfig *DbConfig) setup(name string) error {

--- a/src/github.com/couchbase/sync_gateway/rest/server_context.go
+++ b/src/github.com/couchbase/sync_gateway/rest/server_context.go
@@ -724,12 +724,22 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		revCacheSize = db.KDefaultRevisionCacheCapacity
 	}
 
+	unsupportedOptions := &db.UnsupportedOptions{}
+	if config.Unsupported != nil {
+		if config.Unsupported.UserViews != nil {
+			if config.Unsupported.UserViews.Enabled != nil {
+				unsupportedOptions.EnableUserViews = *config.Unsupported.UserViews.Enabled
+			}
+		}
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:          &cacheOptions,
 		IndexOptions:          channelIndexOptions,
 		SequenceHashOptions:   sequenceHashOptions,
 		RevisionCacheCapacity: revCacheSize,
 		AdminInterface:        sc.config.AdminInterface,
+		UnsupportedOptions:    unsupportedOptions,
 	}
 
 	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, contextOptions)


### PR DESCRIPTION
Fixes #1493

Original issue was that view query support via the public API isn't backward-compatible with views created prior to 1.2.  After review, there were additional concerns raised about exposing view query support over the non-admin API, primarily around Couchbase view performance.  Until those concerns are addressed, non-admin view query support will be disabled by default, and treated as an unsupported feature.

This feature can still be enabled via a new config setting - adding the following to your database config will re-enable view query support over the public API:

```
        "unsupported": {
          "user_views": {
            "enabled":true
          }
        }
```
