### PR TITLE
Fixed if-guard for active_only

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -82,7 +82,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 				if !leaf.Deleted {
 					entry.Deleted = false
 				}
-				if !options.ActiveOnly {
+				if ! (options.ActiveOnly && leaf.Deleted) {
 					entry.Changes = append(entry.Changes, ChangeRev{"rev": leaf.ID})
 				}
 			}


### PR DESCRIPTION
This is a fix for the active_only flag from issue  #1503 and pull request #1511 

I only tested this locally with a data set of mixed resolved conflicts (all but one leaf node deleted) and unresolved conflicts (multiple leaf nodes deleted).  I didn't see any unit tests and was unsure how to add them, but the behavior is closer to the desired behavior than the current master.

Change in English: 
If ActiveOnly is false, then we always want to add the changes (as before), but if it is true, then we add the change iff leaf is not deleted. Thus, only supress it if ActiveOnly and Deleted are both true.
