### PR TITLE
Fix for active_only handling of conflict revisions

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/changes.go
+++ b/src/github.com/couchbase/sync_gateway/db/changes.go
@@ -82,7 +82,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 				if !leaf.Deleted {
 					entry.Deleted = false
 				}
-				if !options.ActiveOnly {
+				if !(options.ActiveOnly && leaf.Deleted) {
 					entry.Changes = append(entry.Changes, ChangeRev{"rev": leaf.ID})
 				}
 			}


### PR DESCRIPTION
Corrects an error in the handling of deleted revisions in an all_docs request, and adds unit test coverage for that scenario.
