### PR TITLE
Principal notification when using distributed index

### DIFF
--- a/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
+++ b/src/github.com/couchbase/sync_gateway/base/sharded_sequence_clock.go
@@ -20,6 +20,9 @@ const (
 	kIndexPrefix             = "_idx"
 	kCountKeyFormat          = "_idx_c:%s:count"    // key
 	kClockPartitionKeyFormat = "_idx_c:%s:clock-%d" // key, partition index
+	KPrincipalCountKeyFormat = "_idx_p_count:%s"    // key for principal count
+	KPrincipalCountKeyPrefix = "_idx_p_count:"      // key prefix for principal count
+	KTotalPrincipalCountKey  = "_idx_p_count_all"   // key for overall principal count
 )
 
 const (

--- a/src/github.com/couchbase/sync_gateway/db/change_listener.go
+++ b/src/github.com/couchbase/sync_gateway/db/change_listener.go
@@ -249,3 +249,13 @@ func (waiter *changeWaiter) UpdateChannels(chans channels.TimedSet) {
 	waiter.keys = updatedKeys
 
 }
+
+// Returns the set of user keys for this ChangeWaiter
+func (waiter *changeWaiter) GetUserKeys() (result []string) {
+	if len(waiter.userKeys) == 0 {
+		return result
+	}
+	result = make([]string, len(waiter.userKeys))
+	copy(result, waiter.userKeys)
+	return result
+}


### PR DESCRIPTION
Changes to principal docs (users, roles) weren't triggering notification when Sync Gateway was running as an index reader in distributed channel index mode, with the exception of single node reader-writers.

Updates index writers to increment principal counts as part of processPrincipalDoc, and updates index readers to poll for changes to principal counts in the same way that's done for channels.

In 1.3, targeted for review to move away from a polling approach, along with the channel handling, for the GA release of distributed index.

Fixes #1524.
