### PR TITLE
Make sure Wait sync.Cond is called for all cases of forceClose == true

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -242,7 +242,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 		}
 
 		encoder := json.NewEncoder(h.response)
-		forceClose := false
+		forceClose = false
 	loop:
 		for {
 			select {

--- a/src/github.com/couchbase/sync_gateway/rest/changes_api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/changes_api.go
@@ -242,7 +242,6 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 		}
 
 		encoder := json.NewEncoder(h.response)
-		forceClose = false
 	loop:
 		for {
 			select {


### PR DESCRIPTION
Includes fix to prevent forceClose from being rescoped to inner block, preventing some values being returned
