### PR TITLE
Delete _sync in map function never recreated

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/design_doc.go
+++ b/src/github.com/couchbase/sync_gateway/db/design_doc.go
@@ -107,7 +107,9 @@ func wrapViews(ddoc *DesignDoc, enableUserViews bool) {
 	                      return;
 	                    delete doc._sync;
 	                    meta.rev = sync.rev;
-						(` + view.Map + `) (doc, meta); }`
+						(` + view.Map + `) (doc, meta);
+						doc._sync = sync;
+						}`
 			ddoc.Views[name] = view // view is not a pointer, so have to copy it back
 		}
 	}


### PR DESCRIPTION
If user views are disabled recreate the _sync so multiple views by design can work.
