### PR TITLE
Parse sync function (and wrapper) only once

### DIFF
--- a/src/github.com/couchbase/sync_gateway/channels/sync_runner_test.go
+++ b/src/github.com/couchbase/sync_gateway/channels/sync_runner_test.go
@@ -1,0 +1,61 @@
+package channels
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+func TestRequireUser(t *testing.T) {
+	const funcSource = `function(doc, oldDoc) { requireUser(oldDoc._names) }`
+	runner, err := NewSyncRunner(funcSource)
+	assert.Equals(t, err, nil)
+	var result interface{}
+	result,_ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), parse(`{"name": "alpha"}`))
+	assertNotRejected(t, result)
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["beta", "gamma"]}`), parse(`{"name": "beta"}`))
+	assertNotRejected(t, result)
+	result,_ = runner.Call(parse(`{}`), parse(`{"_names": ["delta"]}`), parse(`{"name": "beta"}`))
+	assertRejected(t, result, base.HTTPErrorf(403, "wrong user"))
+}
+
+func TestRequireRole(t *testing.T) {
+	const funcSource = `function(doc, oldDoc) { requireRole(oldDoc._roles) }`
+	runner, err := NewSyncRunner(funcSource)
+	assert.Equals(t, err, nil)
+	var result interface{}
+	result,_ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), parse(`{"name": "", "roles": {"alpha":""}}`))
+	assertNotRejected(t, result)
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["beta", "gamma"]}`), parse(`{"name": "", "roles": {"beta": ""}}`))
+	assertNotRejected(t, result)
+	result,_ = runner.Call(parse(`{}`), parse(`{"_roles": ["delta"]}`), parse(`{"name": "", "roles": {"beta":""}}`))
+	assertRejected(t, result, base.HTTPErrorf(403, "missing role"))
+}
+
+func TestRequireAccess(t *testing.T) {
+	const funcSource = `function(doc, oldDoc) { requireAccess(oldDoc._access) }`
+	runner, err := NewSyncRunner(funcSource)
+	assert.Equals(t, err, nil)
+	var result interface{}
+	result,_ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), parse(`{"name": "", "channels": ["alpha"]}`))
+	assertNotRejected(t, result)
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["beta", "gamma"]}`), parse(`{"name": "", "channels": ["beta"]}`))
+	assertNotRejected(t, result)
+	result,_ = runner.Call(parse(`{}`), parse(`{"_access": ["delta"]}`), parse(`{"name": "", "channels": ["beta"]}`))
+	assertRejected(t, result, base.HTTPErrorf(403, "missing channel access"))
+}
+
+// Helpers
+func assertRejected(t *testing.T, result interface{}, err *base.HTTPError) {
+	r, ok := result.(*ChannelMapperOutput)
+	assert.True(t, ok)
+	assert.DeepEquals(t, r.Rejection, err)
+}
+
+func assertNotRejected(t *testing.T, result interface{}) {
+	r, ok := result.(*ChannelMapperOutput)
+	if !ok || r.Rejection != nil {
+		t.Fatalf("%v", r.Rejection)
+	}
+}


### PR DESCRIPTION
The function returned by evaluating `funcSource` is called for every document update. The old function included the declarations of all helper function (`makeArray`, `requireUser` etc.) and the sync function. Thus, on every document update, all such functions are parsed all over again.

Steps to reproduce:

(Note [sync_runner.go#L26](https://github.com/couchbase/sync_gateway/blob/443be965f30e092307cbcfb9ae866e1fe0f82558/src/github.com/couchbase/sync_gateway/channels/sync_runner.go#L26) first)
1. Use the following as sync function in config:

```
"sync": `1; var a = v; v = function(d,o) {console.log("document:", d, "a:", a++);}`
```
1. Create/make two updates to any document.

Expected output:

```
document: [object Object] a: 1
document: [object Object] a: 2
```

Actual output:

```
document: [object Object] a: 1
document: [object Object] a: 1
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1579)

<!-- Reviewable:end -->