### PR TITLE
Fix error handling for Incr retry failure

### DIFF
--- a/src/github.com/couchbase/sync_gateway/db/database_test.go
+++ b/src/github.com/couchbase/sync_gateway/db/database_test.go
@@ -796,15 +796,28 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 
 }
 
-func TestIncrRetry(t *testing.T) {
+func TestIncrRetrySuccess(t *testing.T) {
 	leakyBucketConfig := base.LeakyBucketConfig{
-		IncrTemporaryFail: true,
+		IncrTemporaryFailCount: 2,
 	}
 	leakyBucket := testLeakyBucket(leakyBucketConfig)
 	defer leakyBucket.Close()
 	seqAllocator, _ := newSequenceAllocator(leakyBucket)
 	err := seqAllocator.reserveSequences(1)
 	assert.True(t, err == nil)
+
+}
+
+func TestIncrRetryFail(t *testing.T) {
+	leakyBucketConfig := base.LeakyBucketConfig{
+		IncrTemporaryFailCount: 10,
+	}
+	leakyBucket := testLeakyBucket(leakyBucketConfig)
+	defer leakyBucket.Close()
+	seqAllocator, _ := newSequenceAllocator(leakyBucket)
+	err := seqAllocator.reserveSequences(1)
+	log.Printf("Got error: %v", err)
+	assert.True(t, err != nil)
 
 }
 

--- a/src/github.com/couchbase/sync_gateway/db/sequence_allocator.go
+++ b/src/github.com/couchbase/sync_gateway/db/sequence_allocator.go
@@ -78,9 +78,10 @@ func (s *sequenceAllocator) reserveSequences(numToReserve uint64) error {
 func (s *sequenceAllocator) incrWithRetry(key string, numToReserve uint64) (uint64, error) {
 
 	var err error
+	var max uint64
 	retries := 0
 	for retries < kMaxIncrRetries {
-		max, err := s.bucket.Incr(key, numToReserve, numToReserve, 0)
+		max, err = s.bucket.Incr(key, numToReserve, numToReserve, 0)
 		if err != nil {
 			retries++
 			base.Warn("Error from Incr in sequence allocator (%d) - attempt (%d/%d): %v", numToReserve, retries, kMaxIncrRetries, err)


### PR DESCRIPTION
When Incr retry was hitting the max failure count, it wasn't returning the error properly.  This was resulting in subsequent sequence operations proceeding with seq=0.

Includes an enhancement to the leaky bucket support for failing incr to enable a test case for this scenario.

Fixes #1581.
