### PR TITLE
Use "less sticky" approach to setting $GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ $ ./repo sync
 **Build, Test and Install**
 
 ```
-$ export GOPATH=`pwd`/godeps
-$ cd $GOPATH/src/github.com/couchbase/sync_gateway
-$ go test ./... && go install ./...
+$ GOPATH=`pwd`/godeps go test github.com/couchbase/sync_gateway/...
+$ GOPATH=`pwd`/godeps go install github.com/couchbase/sync_gateway/...
 ```
 
 ## Building From source via `go get`


### PR DESCRIPTION
Use "less sticky" approach to setting $GOPATH, since I was running into unexpected behavior when I was expecting my system gopath to be used but I'd hijacked it earlier..

Also, no need to cd into the directory.
