### PR TITLE
Add temporary drone CI support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,8 @@
+build:
+  image: golang
+  commands:
+    - curl https://storage.googleapis.com/git-repo-downloads/repo > repo
+    - chmod +x repo
+    - ./repo init -u "https://github.com/couchbase/sync_gateway.git" -m manifest/default.xml
+    - ./repo sync
+    - GOPATH=/drone/src/github.com/couchbase/sync_gateway/godeps go test github.com/couchbase/sync_gateway/...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](http://drone.couchbasemobile.com/api/badges/couchbase/sync_gateway/status.svg)](http://drone.couchbasemobile.com/couchbase/sync_gateway)
+
 # Couchbase Sync Gateway
 
 [![Join the chat at https://gitter.im/couchbase/sync_gateway](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/couchbase/sync_gateway?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
I don't know why but the status badge doesn't seem to be reflecting the build status.  But the good news is that it is showing the test running a part of the PR checks.

<img width="1015" alt="screen shot 2016-02-16 at 7 46 09 pm" src="https://cloud.githubusercontent.com/assets/296876/13099396/744849d4-d4e6-11e5-9481-13516253f243.png">
