### PR TITLE
Changed retriever URL to reference couchbase repo instead of couchbaselabs repo

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -22,7 +22,7 @@
   <!-- Dependencies -->
   <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="retriever" path="godeps/src/github.com/couchbaselabs/retriever" remote="couchbaselabs" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="e3419088e4d3b4fe3aad3b364fdbe9a154f85f17"/>
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -22,7 +22,7 @@
   <!-- Dependencies -->
   <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
 
-  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="e3419088e4d3b4fe3aad3b364fdbe9a154f85f17"/>
+  <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 


### PR DESCRIPTION
relates to #682 
