### PR TITLE
Enable HTTP/2 support

### DIFF
--- a/base/http_listener.go
+++ b/base/http_listener.go
@@ -25,7 +25,7 @@ func ListenAndServeHTTP(addr string, connLimit int, certFile *string, keyFile *s
 	if certFile != nil {
 		config = &tls.Config{}
 		config.MinVersion = tls.VersionTLS10 // Disable SSLv3 due to POODLE vulnerability
-		config.NextProtos = []string{"http/1.1"}
+		config.NextProtos = []string{"h2", "http/1.1"}
 		config.Certificates = make([]tls.Certificate, 1)
 		var err error
 		config.Certificates[0], err = tls.LoadX509KeyPair(*certFile, *keyFile)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -210,7 +210,11 @@ func (h *handler) logRequestLine() {
 	} else if h.user != nil && h.user.Name() != "" {
 		as = fmt.Sprintf("  (as %s)", h.user.Name())
 	}
-	base.LogTo("HTTP", " #%03d: %s %s%s", h.serialNumber, h.rq.Method, h.rq.URL, as)
+	proto := ""
+	if h.rq.ProtoMajor >= 2 {
+		proto = " HTTP/2"
+	}
+	base.LogTo("HTTP", " #%03d: %s %s%s%s", h.serialNumber, h.rq.Method, h.rq.URL, proto, as)
 }
 
 func (h *handler) logDuration(realTime bool) {


### PR DESCRIPTION
Also added "HTTP/2" suffix to HTTP logs, to identify which client
requests are coming over HTTP/2 connections.

(Requires Go 1.6, of course.)

Fixes #1626
