### PR TITLE
Fixes #1632 Use a ring buffer for storage of goroutineTracker snapshots

### DIFF
--- a/rest/debug.go
+++ b/rest/debug.go
@@ -18,7 +18,10 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-const kDebugURLPathPrefix = "/_expvar"
+const (
+	kDebugURLPathPrefix    = "/_expvar"
+	kMaxGoroutineSnapshots = 100000
+)
 
 var (
 	poolhistos = map[string]metrics.Histogram{}
@@ -85,6 +88,12 @@ func (g *goroutineTracker) recordSnapshot() {
 
 	// append to history
 	g.Snapshots = append(g.Snapshots, numGoroutines)
+
+	// drop the oldest one if we've gone over the max
+	if len(g.Snapshots) > kMaxGoroutineSnapshots {
+		g.Snapshots = g.Snapshots[1:]
+	}
+
 }
 
 func connPoolHisto(name string) metrics.Histogram {

--- a/rest/debug_test.go
+++ b/rest/debug_test.go
@@ -1,0 +1,16 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestMaxSnapshotsRingBuffer(t *testing.T) {
+
+	for i := 0; i < kMaxGoroutineSnapshots*2; i++ {
+		grTracker.recordSnapshot()
+	}
+	assert.True(t, len(grTracker.Snapshots) <= kMaxGoroutineSnapshots)
+
+}


### PR DESCRIPTION
https://github.com/couchbase/sync_gateway/issues/1632
