### PR TITLE
Added 'Restart=on-failure' option to re-execute sync_gateway

### DIFF
--- a/service/script_templates/systemd_sync_gateway.tpl
+++ b/service/script_templates/systemd_sync_gateway.tpl
@@ -18,6 +18,7 @@ ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${LOGS_TE
 ExecStartPre=/bin/mkdir -p ${RUNBASE_TEMPLATE_VAR}/data
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${RUNBASE_TEMPLATE_VAR}/data
 ExecStart=/usr/bin/bash -c '\${GATEWAY} \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
+Restart=on-failure
 
 # Give a reasonable amount of time for the server to start up/shut down
 TimeoutSec=60


### PR DESCRIPTION
Added 'Restart=on-failure' option to re-execute sync_gateway in the event of abnormal termination

fixes #1638
