### PR TITLE
Prevent GET /db/ from returning an error if the underlying bucket is unavailable

### DIFF
--- a/src/github.com/couchbase/sync_gateway/rest/api.go
+++ b/src/github.com/couchbase/sync_gateway/rest/api.go
@@ -146,10 +146,7 @@ func (h *handler) handleGetDB() error {
 	if h.rq.Method == "HEAD" {
 		return nil
 	}
-	lastSeq, err := h.db.LastSequence()
-	if err != nil {
-		return err
-	}
+	lastSeq, _ := h.db.LastSequence()
 
 	response := db.Body{
 		"db_name":              h.db.Name,


### PR DESCRIPTION
Prevent GET /db/ from returning an error if the underlying bucket is unavailable, this was a regression introduced when errors were correctly returned from sequence_allocator.incrWithRetry

fixes #1655
