### PR TITLE
Added support for "sync_gateway/bychannel" filter

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1023,11 +1023,11 @@ func TestReplicateErrorConditions(t *testing.T) {
 	//Send JSON Object containing doc_ids property
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"doc_ids":["foo","bar","moo","car"]}`), 400)
 
-	//Send JSON Object containing filter property
+	//Send JSON Object containing filter property other than 'sync_gateway/bychannel'
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"filter":"somefilter"}`), 400)
 
-	//Send JSON Object containing query_params property
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"query_params":{"someproperty":"somevalue"}}`), 400)
+	//Send JSON Object containing filter 'sync_gateway/bychannel' with non string array query_params property
+	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"filter":"sync_gateway/bychannel", "query_params":{"someproperty":"somevalue"}}`), 400)
 
 	//Send JSON Object containing proxy property
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"proxy":"http://myproxy/}`), 400)
@@ -1046,27 +1046,4 @@ func TestReplicateErrorConditions(t *testing.T) {
 
 	//Send JSON Object containing source and target as absolute URL and a replication_id
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"http://myhost:4985/mytargetdb", "replication_id":"myreplicationid"}`), 400)
-}
-
-func TestReplicate(t *testing.T) {
-	var rt restTester
-
-	//Send JSON Object containing source and target as absolute URL
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"http://myhost:4985/mytargetdb"}`), 200)
-
-	//Send JSON Object containing source as absolute URL and target as local DB
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"mylocaltargetdb"}`), 200)
-
-	//Send JSON Object containing source as local DB and target as absolute URL
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"mylocalsourcedb", "target":"http://myhost:4985/mytargetdb"}`), 200)
-
-	//Send JSON Object containing source as local DB and target as local DB
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"mylocalsourcedb", "target":"mylocaltargetdb"}`), 200)
-
-	//Send JSON Object containing replication_id but no cancel property
-	//Will be treated as NOOP
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"replication_id":"myreplicationid"}`), 200)
-
-	//Send JSON Object containing replication_id and a cancel true
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"replication_id":"myreplicationid", "cancel":true}`), 200)
 }


### PR DESCRIPTION
Added support for "sync_gateway/bychannel" filter that takes an array of channel names to in the query_params property

fixes #1671
