### PR TITLE
Added support for _active_task stats and query_params takes JSON Object or Array

### DIFF
--- a/base/replicator.go
+++ b/base/replicator.go
@@ -19,11 +19,16 @@ type Replicator struct {
 }
 
 type ActiveTask struct {
-	TaskType      string `json:"type"`
-	ReplicationID string `json:"replication_id"`
-	Continuous    bool   `json:"continuous"`
-	Source        string `json:"source"`
-	Target        string `json:"target"`
+	TaskType         string      `json:"type"`
+	ReplicationID    string      `json:"replication_id"`
+	Continuous       bool        `json:"continuous"`
+	Source           string      `json:"source"`
+	Target           string      `json:"target"`
+	DocsRead         uint32      `json:"docs_read"`
+	DocsWritten      uint32      `json:"docs_written"`
+	DocWriteFailures uint32      `json:"doc_write_failures"`
+	StartLastSeq     uint32      `json:"start_last_seq"`
+	EndLastSeq       interface{} `json:"end_last_seq"`
 }
 
 func NewReplicator() *Replicator {
@@ -65,13 +70,19 @@ func (r *Replicator) ActiveTasks() (tasks []ActiveTask) {
 	tasks = make([]ActiveTask, 0)
 	for _, replication := range r.replications {
 		params := replication.GetParameters()
+		stats := replication.GetStats()
 
 		task := ActiveTask{
-			TaskType:      "replication",
-			ReplicationID: params.ReplicationId,
-			Source:        params.GetSourceDbUrl(),
-			Target:        params.GetTargetDbUrl(),
-			Continuous:    params.Lifecycle == sgreplicate.CONTINUOUS,
+			TaskType:         "replication",
+			ReplicationID:    params.ReplicationId,
+			Source:           params.GetSourceDbUrl(),
+			Target:           params.GetTargetDbUrl(),
+			Continuous:       params.Lifecycle == sgreplicate.CONTINUOUS,
+			DocsRead:         stats.DocsRead,
+			DocsWritten:      stats.DocsWritten,
+			DocWriteFailures: stats.DocWriteFailures,
+			StartLastSeq:     stats.StartLastSeq,
+			EndLastSeq:       stats.EndLastSeq,
 		}
 		tasks = append(tasks, task)
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -271,7 +271,7 @@ func readReplicationParametersFromJSON(jsonData []byte) (params sgreplicate.Repl
 					return
 				}
 			} else if chanarray, ok = in.QueryParams.([]interface{}); ok {
-
+				// query params is an array and chanarray has been set, now drop out of if-then-else for processing
 			} else {
 				err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate sync_gateway/bychannel filter; Bad channels array")
 				return

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1026,8 +1026,11 @@ func TestReplicateErrorConditions(t *testing.T) {
 	//Send JSON Object containing filter property other than 'sync_gateway/bychannel'
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"filter":"somefilter"}`), 400)
 
-	//Send JSON Object containing filter 'sync_gateway/bychannel' with non string array query_params property
+	//Send JSON Object containing filter 'sync_gateway/bychannel' with non array query_params property
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"filter":"sync_gateway/bychannel", "query_params":{"someproperty":"somevalue"}}`), 400)
+
+	//Send JSON Object containing filter 'sync_gateway/bychannel' with non string array query_params property
+	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"filter":"sync_gateway/bychannel", "query_params":["someproperty",false]}`), 400)
 
 	//Send JSON Object containing proxy property
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"proxy":"http://myproxy/}`), 400)


### PR DESCRIPTION
Added support for _active_task stats and also change query_params to take a JSON Object or Array (CouchDB strictly only accepts JSON Object)

fixes #1672
