### PR TITLE
Disable watchDocChanges listening unless needed

### DIFF
--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -66,11 +66,14 @@ func (listener *changeListener) Start(bucket base.Bucket, trackDocs bool, notify
 						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
 					}
 					listener.Notify(base.SetOf(key))
-				} else if trackDocs && !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, kIndexPrefix) {
+				} else if !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, kIndexPrefix) {
 					if listener.OnDocChanged != nil {
 						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
 					}
-					listener.DocChannel <- event
+					if trackDocs {
+						listener.DocChannel <- event
+					}
+
 				}
 			}
 		}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -54,6 +54,17 @@ func setupTestDB(t *testing.T) *Database {
 	return setupTestDBWithCacheOptions(t, CacheOptions{})
 }
 
+func setupTestDBForShadowing(t *testing.T) *Database {
+	dbcOptions := DatabaseContextOptions{
+		TrackDocs: true,
+	}
+	context, err := NewDatabaseContext("db", testBucket(), false, dbcOptions)
+	assertNoError(t, err, "Couldn't create context for database 'db'")
+	db, err := CreateDatabase(context)
+	assertNoError(t, err, "Couldn't create database 'db'")
+	return db
+}
+
 func setupTestDBWithCacheOptions(t *testing.T, options CacheOptions) *Database {
 
 	dbcOptions := DatabaseContextOptions{

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/couchbaselabs/go.assert"
 
+	"encoding/json"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"encoding/json"
 )
 
 func makeExternalBucket() base.Bucket {
@@ -44,7 +44,7 @@ func TestShadowerPull(t *testing.T) {
 	bucket.Set("key2", 0, Body{"bar": -1})
 	bucket.SetRaw("key3", 0, []byte("qwertyuiop")) //will be ignored
 
-	db := setupTestDB(t)
+	db := setupTestDBForShadowing(t)
 	defer tearDownTestDB(t, db)
 
 	shadower, err := NewShadower(db.DatabaseContext, bucket, nil)
@@ -87,7 +87,7 @@ func TestShadowerPush(t *testing.T) {
 	bucket := makeExternalBucket()
 	defer bucket.Close()
 
-	db := setupTestDB(t)
+	db := setupTestDBForShadowing(t)
 	defer tearDownTestDB(t, db)
 
 	var err error
@@ -133,7 +133,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 	bucket := makeExternalBucket()
 	defer bucket.Close()
 
-	db := setupTestDB(t)
+	db := setupTestDBForShadowing(t)
 	defer tearDownTestDB(t, db)
 
 	var err error
@@ -166,7 +166,7 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 	bucket := makeExternalBucket()
 	defer bucket.Close()
 
-	db := setupTestDB(t)
+	db := setupTestDBForShadowing(t)
 	defer tearDownTestDB(t, db)
 
 	var err error
@@ -221,7 +221,7 @@ func TestShadowerPattern(t *testing.T) {
 	bucket.Set("ignorekey", 0, Body{"bar": -1})
 	bucket.Set("key2", 0, Body{"bar": -1})
 
-	db := setupTestDB(t)
+	db := setupTestDBForShadowing(t)
 	defer tearDownTestDB(t, db)
 
 	pattern, _ := regexp.Compile(`key\d+`)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -412,6 +412,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
+	// Enable doc tracking if needed for autoImport or shadowing
+	trackDocs := autoImport || config.Shadow != nil
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:          &cacheOptions,
 		IndexOptions:          channelIndexOptions,
@@ -419,6 +422,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		RevisionCacheCapacity: revCacheSize,
 		AdminInterface:        sc.config.AdminInterface,
 		UnsupportedOptions:    unsupportedOptions,
+		TrackDocs:             trackDocs,
 	}
 
 	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, contextOptions)


### PR DESCRIPTION
watchDocChanges listens to an echoed channel that gets populated with non-system docs that are seen on the server mutation feed, and is used to drive autoImport or bucket shadowing.   It's now disabled unless the database is actually configured for autoImport or bucket shadowing.

The channel used for watchDocChanges is initialized in NewDatabaseContext, which is called before the shadower is initialized (when present), so we can't just check for shadower != nil at that point.  To pass this information into NewDatabaseContext, added a new TrackDocs property to the DatabaseContextOptions to pass the value in.

Fixes #1631
