### PR TITLE
Improve attachment revpos handling for pruned ancestors

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -392,7 +392,7 @@ func (db *Database) Put(docid string, body Body) (string, error) {
 
 		// Process the attachments, replacing bodies with digests. This alters 'body' so it has to
 		// be done before calling createRevID (the ID is based on the digest of the body.)
-		if err := db.storeAttachments(doc, body, generation, matchRev); err != nil {
+		if err := db.storeAttachments(doc, body, generation, matchRev, nil); err != nil {
 			return nil, err
 		}
 
@@ -441,7 +441,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 
 		// Process the attachments, replacing bodies with digests.
 		parentRevID := doc.History[newRev].Parent
-		if err := db.storeAttachments(doc, body, generation, parentRevID); err != nil {
+		if err := db.storeAttachments(doc, body, generation, parentRevID, docHistory); err != nil {
 			return nil, err
 		}
 		body["_rev"] = newRev


### PR DESCRIPTION
Document updates including previously existing attachments were failing when an ancestor revision body is no longer available, as SG isn't able to match the incoming revpos with an attachment on non-compacted ancestor body.  The most common scenario is the addition of a conflicting revision under a revision that is no longer in the rev cache, and the temporary revision copy has expired out of the DB.

This commit adds an additional check in this scenario: if the incoming revision has a common ancestor with the active revision, we can use this to look up any attachments with revpos earlier (or matching) the common ancestor.

Fixes #1706.
