### PR TITLE
No longer return an error if the replication params contain replication_id and source and target

### DIFF
--- a/base/replicator.go
+++ b/base/replicator.go
@@ -52,7 +52,16 @@ func (r *Replicator) Replicate(params sgreplicate.ReplicationParameters, isCance
 		return nil, r.stopReplication(replicationId)
 
 	} else {
-		// Check whether specified replication is already active
+		replicationId := params.ReplicationId
+		// If replicationId is defined, check that a replication with the same ID is not already running
+		if replicationId != "" {
+			sgreplication := r.getReplication(replicationId)
+			if  sgreplication != nil {
+				return nil, HTTPErrorf(http.StatusConflict, "Replication already active for specified replication_id [%v]",replicationId)
+			}
+		}
+
+		// Check whether specified replication is already active for the given params
 		_, found := r.getReplicationForParams(params)
 		if found {
 			return nil, HTTPErrorf(http.StatusConflict, "Replication already active for specified parameters")

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -223,11 +223,18 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 	params.ReplicationId = requestParams.ReplicationId
 
 	//cancel parameter is only supported via the REST API
-	if !paramsFromConfig {
-		if requestParams.Cancel {
-			return params, requestParams.Cancel, false, nil
+	if requestParams.Cancel {
+		if paramsFromConfig {
+			err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate cancel is invalid in Sync Gateway configuration", requestParams.Source)
+			return
+		} else {
+			cancel = true
+			if params.ReplicationId != "" {
+				return params, cancel, localdb, nil
+			}
 		}
 	}
+
 
 	sourceUrl, err := url.Parse(requestParams.Source)
 	if err != nil || requestParams.Source == "" {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -220,16 +220,11 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 		return
 	}
 
+	params.ReplicationId = requestParams.ReplicationId
+
 	//cancel parameter is only supported via the REST API
 	if !paramsFromConfig {
-		//A replication_id with cancel set to false is a NOOP just return
-		if requestParams.ReplicationId != "" && !requestParams.Cancel {
-			return
-		}
-
-		//A replication_id with cancel set to true, add properties and return
-		if requestParams.ReplicationId != "" && requestParams.Cancel {
-			params.ReplicationId = requestParams.ReplicationId
+		if requestParams.Cancel {
 			return params, requestParams.Cancel, false, nil
 		}
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -220,11 +220,6 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 		return
 	}
 
-	if requestParams.ReplicationId != "" && (requestParams.Source != "" || requestParams.Target != "") {
-		err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate replication_id can not be used with source or target values.")
-		return
-	}
-
 	//cancel parameter is only supported via the REST API
 	if !paramsFromConfig {
 		//A replication_id with cancel set to false is a NOOP just return

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1051,8 +1051,6 @@ func TestReplicateErrorConditions(t *testing.T) {
 	//Send JSON Object containing no source and target as local DB
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"target":"mylocaltargetdb"}`), 400)
 
-	//Send JSON Object containing source and target as absolute URL and a replication_id
-	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"http://myhost:4985/mytargetdb", "replication_id":"myreplicationid"}`), 400)
 }
 
 //These tests validate request parameters not actual replication
@@ -1085,6 +1083,9 @@ func TestReplicate(t *testing.T) {
 
 	//Initiate continuous replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names and custom changes_feed_limit
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db4", "target":"http://localhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10, "continuous":true}`), 200)
+
+	//Send JSON Object containing source and target as absolute URL and a replication_id
+	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"http://myhost:4985/mytargetdb", "replication_id":"myreplicationid"}`), 500)
 
 	//Cancel a replication
 	assertStatus(t, rt.sendAdminRequest("POST", "/_replicate", `{"replication_id":"ABC", "cancel":true}`), 404)

--- a/rest/config.go
+++ b/rest/config.go
@@ -54,36 +54,36 @@ const (
 
 // JSON object that defines the server configuration.
 type ServerConfig struct {
-	Interface                      *string         `json:",omitempty"`                        // Interface to bind REST API to, default ":4984"
-	SSLCert                        *string         `json:",omitempty"`                        // Path to SSL cert file, or nil
-	SSLKey                         *string         `json:",omitempty"`                        // Path to SSL private key file, or nil
-	ServerReadTimeout              *int            `json:",omitempty"`                        // maximum duration.Second before timing out read of the HTTP(S) request
-	ServerWriteTimeout             *int            `json:",omitempty"`                        // maximum duration.Second before timing out write of the HTTP(S) response
-	AdminInterface                 *string         `json:",omitempty"`                        // Interface to bind admin API to, default ":4985"
-	AdminUI                        *string         `json:",omitempty"`                        // Path to Admin HTML page, if omitted uses bundled HTML
-	ProfileInterface               *string         `json:",omitempty"`                        // Interface to bind Go profile API to (no default)
-	ConfigServer                   *string         `json:",omitempty"`                        // URL of config server (for dynamic db discovery)
-	Persona                        *PersonaConfig  `json:",omitempty"`                        // Configuration for Mozilla Persona validation
-	Facebook                       *FacebookConfig `json:",omitempty"`                        // Configuration for Facebook validation
-	Google                         *GoogleConfig   `json:",omitempty"`                        // Configuration for Google validation
-	CORS                           *CORSConfig     `json:",omitempty"`                        // Configuration for allowing CORS
-	Log                            []string        `json:",omitempty"`                        // Log keywords to enable
-	LogFilePath                    *string         `json:",omitempty"`                        // Path to log file, if missing write to stderr
-	Pretty                         bool            `json:",omitempty"`                        // Pretty-print JSON responses?
-	DeploymentID                   *string         `json:",omitempty"`                        // Optional customer/deployment ID for stats reporting
-	StatsReportInterval            *float64        `json:",omitempty"`                        // Optional stats report interval (0 to disable)
-	MaxCouchbaseConnections        *int            `json:",omitempty"`                        // Max # of sockets to open to a Couchbase Server node
-	MaxCouchbaseOverflow           *int            `json:",omitempty"`                        // Max # of overflow sockets to open
-	CouchbaseKeepaliveInterval     *int            `json:",omitempty"`                        // TCP keep-alive interval between SG and Couchbase server
-	SlowServerCallWarningThreshold *int            `json:",omitempty"`                        // Log warnings if database calls take this many ms
-	MaxIncomingConnections         *int            `json:",omitempty"`                        // Max # of incoming HTTP connections to accept
-	MaxFileDescriptors             *uint64         `json:",omitempty"`                        // Max # of open file descriptors (RLIMIT_NOFILE)
-	CompressResponses              *bool           `json:",omitempty"`                        // If false, disables compression of HTTP responses
-	Databases                      DbConfigMap     `json:",omitempty"`                        // Pre-configured databases, mapped by name
-	Replications                   *ReplConfigMap  `json:",omitempty"`                        // Configuration for replications to run on startup
-	MaxHeartbeat                   uint64          `json:",omitempty"`                        // Max heartbeat value for _changes request (seconds)
-	ClusterConfig                  *ClusterConfig  `json:"cluster_config,omitempty"`          // Bucket and other config related to CBGT
-	SkipRunmodeValidation          bool            `json:"skip_runmode_validation,omitempty"` // If this is true, skips any config validation regarding accel vs normal mode
+	Interface                      *string              `json:",omitempty"` // Interface to bind REST API to, default ":4984"
+	SSLCert                        *string              `json:",omitempty"` // Path to SSL cert file, or nil
+	SSLKey                         *string              `json:",omitempty"` // Path to SSL private key file, or nil
+	ServerReadTimeout              *int                 `json:",omitempty"` // maximum duration.Second before timing out read of the HTTP(S) request
+	ServerWriteTimeout             *int                 `json:",omitempty"` // maximum duration.Second before timing out write of the HTTP(S) response
+	AdminInterface                 *string              `json:",omitempty"` // Interface to bind admin API to, default ":4985"
+	AdminUI                        *string              `json:",omitempty"` // Path to Admin HTML page, if omitted uses bundled HTML
+	ProfileInterface               *string              `json:",omitempty"` // Interface to bind Go profile API to (no default)
+	ConfigServer                   *string              `json:",omitempty"` // URL of config server (for dynamic db discovery)
+	Persona                        *PersonaConfig       `json:",omitempty"` // Configuration for Mozilla Persona validation
+	Facebook                       *FacebookConfig      `json:",omitempty"` // Configuration for Facebook validation
+	Google                         *GoogleConfig        `json:",omitempty"` // Configuration for Google validation
+	CORS                           *CORSConfig          `json:",omitempty"` // Configuration for allowing CORS
+	Log                            []string             `json:",omitempty"` // Log keywords to enable
+	LogFilePath                    *string              `json:",omitempty"` // Path to log file, if missing write to stderr
+	Pretty                         bool                 `json:",omitempty"` // Pretty-print JSON responses?
+	DeploymentID                   *string              `json:",omitempty"` // Optional customer/deployment ID for stats reporting
+	StatsReportInterval            *float64             `json:",omitempty"` // Optional stats report interval (0 to disable)
+	MaxCouchbaseConnections        *int                 `json:",omitempty"` // Max # of sockets to open to a Couchbase Server node
+	MaxCouchbaseOverflow           *int                 `json:",omitempty"` // Max # of overflow sockets to open
+	CouchbaseKeepaliveInterval     *int                 `json:",omitempty"` // TCP keep-alive interval between SG and Couchbase server
+	SlowServerCallWarningThreshold *int                 `json:",omitempty"` // Log warnings if database calls take this many ms
+	MaxIncomingConnections         *int                 `json:",omitempty"` // Max # of incoming HTTP connections to accept
+	MaxFileDescriptors             *uint64              `json:",omitempty"` // Max # of open file descriptors (RLIMIT_NOFILE)
+	CompressResponses              *bool                `json:",omitempty"` // If false, disables compression of HTTP responses
+	Databases                      DbConfigMap          `json:",omitempty"` // Pre-configured databases, mapped by name
+	Replications                   []*ReplicationConfig `json:",omitempty"`
+	MaxHeartbeat                   uint64               `json:",omitempty"`                        // Max heartbeat value for _changes request (seconds)
+	ClusterConfig                  *ClusterConfig       `json:"cluster_config,omitempty"`          // Bucket and other config related to CBGT
+	SkipRunmodeValidation          bool                 `json:"skip_runmode_validation,omitempty"` // If this is true, skips any config validation regarding accel vs normal mode
 }
 
 // Bucket configuration elements - used by db, shadow, index

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -86,7 +86,7 @@ func NewServerContext(config *ServerConfig) *ServerContext {
 
 	if config.Replications != nil {
 
-		for _, replicationConfig := range *config.Replications {
+		for _,replicationConfig := range config.Replications {
 
 			params, _, localdb, err := validateReplicationParameters(*replicationConfig, true, *config.AdminInterface)
 


### PR DESCRIPTION
No longer return an error if the replication params contain replication_id and source and target

fixes #1707
