### PR TITLE
Updated sg-replicate git commit in repo manifest

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -71,7 +71,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="c67b30ae54eb7435045483665f986bdbaee243ea"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="e90e6d70808923d0d46de82fd283a211420ce372"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="eebc98233c3e032eb6b9036575d51324ab5932e6"/>
 


### PR DESCRIPTION
Updated sg-replicate git commit to pick up changes that print 'replication-id' in log entires

fixes #1734
