### PR TITLE
For service restart on SysV prefix stop/start calls with 'service' command.

### DIFF
--- a/service/script_templates/sysv_sync_gateway.tpl
+++ b/service/script_templates/sysv_sync_gateway.tpl
@@ -78,12 +78,12 @@ case \"\$1\" in
         fi
         ;;
     restart)
-        \$name stop
+        service \$name stop
         if is_running; then
             echo "Unable to stop, will not attempt to start"
             exit 1
         fi
-        \$name start
+        service \$name start
         ;;
     status)
         if is_running; then


### PR DESCRIPTION
For service restart on SysV prefix stop/start calls with 'service' command.

fixes #1719

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1749)

<!-- Reviewable:end -->
