### PR TITLE
Send minimal lists of revisions from doc GET, _bulk_get, _revs_diff

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -76,12 +77,27 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 
 // Returns the body of the current revision of a document
 func (db *Database) Get(docid string) (Body, error) {
-	return db.GetRev(docid, "", false, nil)
+	return db.GetRevWithHistory(docid, "", 0, nil, nil)
+}
+
+// Shortcut for GetRevWithHistory
+func (db *Database) GetRev(docid, revid string, history bool, attachmentsSince []string) (Body, error) {
+	maxHistory := 0
+	if history {
+		maxHistory = math.MaxInt32
+	}
+	return db.GetRevWithHistory(docid, revid, maxHistory, nil, attachmentsSince)
 }
 
 // Returns the body of a revision of a document. Uses the revision cache.
-// revid may be "", meaning the current revision.
-func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsSince []string) (Body, error) {
+// * revid may be "", meaning the current revision.
+// * maxHistory is >0 if the caller wants a revision history; it's the max length of the history.
+// * historyFrom is an optional list of revIDs the client already has. If any of these are found
+//   in the revision's history, it will be trimmed after that revID.
+// * attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
+//   revisions for which the client already has attachments and doesn't need bodies. Any attachment
+//   that hasn't changed since one of those revisions will be returned as a stub.
+func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, historyFrom []string, attachmentsSince []string) (Body, error) {
 	var doc *document
 	var body Body
 	var revisions Body
@@ -98,6 +114,9 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 			}
 			return nil, err
 		}
+		if maxHistory == 0 {
+			revisions = nil
+		}
 	} else {
 		// No rev ID given, so load doc and get its current revision:
 		if doc, err = db.GetDoc(docid); doc == nil {
@@ -110,8 +129,14 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 		if doc.hasFlag(channels.Deleted) {
 			body["_deleted"] = true
 		}
-		revisions = encodeRevisions(doc.History.getHistory(revid))
+		if maxHistory != 0 {
+			revisions = encodeRevisions(doc.History.getHistory(revid))
+		}
 		inChannels = doc.History[revid].Channels
+	}
+
+	if revisions != nil {
+		trimEncodedRevisionsToAncestor(revisions, historyFrom, maxHistory)
 	}
 
 	// Authorize the access:
@@ -130,7 +155,7 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 			} else {
 				redactedBody["_removed"] = true
 			}
-			if listRevisions {
+			if revisions != nil {
 				redactedBody["_revisions"] = revisions
 			}
 			return redactedBody, nil
@@ -144,7 +169,7 @@ func (db *Database) GetRev(docid, revid string, listRevisions bool, attachmentsS
 	}
 
 	// Add revision metadata:
-	if listRevisions {
+	if revisions != nil {
 		body["_revisions"] = revisions
 	}
 
@@ -964,7 +989,8 @@ func (context *DatabaseContext) ComputeRolesForUser(user auth.User) (channels.Ti
 
 //////// REVS_DIFF:
 
-// Given a document ID and a set of revision IDs, looks up which ones are not known.
+// Given a document ID and a set of revision IDs, looks up which ones are not known. Returns an
+// array of the unknown revisions, and an array of known revisions that might be recent ancestors.
 func (db *Database) RevDiff(docid string, revids []string) (missing, possible []string) {
 	if strings.HasPrefix(docid, "_design/") && db.user != nil {
 		return // Users can't upload design docs, so ignore them
@@ -978,35 +1004,34 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 		missing = revids
 		return
 	}
-	revmap := doc.History
-	found := make(map[string]bool)
-	maxMissingGen := 0
+	// Check each revid to see if it's in the doc's rev tree:
+	revtree := doc.History
+	revidsSet := base.SetFromArray(revids)
+	possibleSet := make(map[string]bool)
 	for _, revid := range revids {
-		if revmap.contains(revid) {
-			found[revid] = true
-		} else {
-			if missing == nil {
-				missing = make([]string, 0, 5)
-			}
-			gen, _ := parseRevID(revid)
-			if gen > 0 {
-				missing = append(missing, revid)
-				if gen > maxMissingGen {
-					maxMissingGen = gen
-				}
+		if !revtree.contains(revid) {
+			missing = append(missing, revid)
+			// Look at the doc's leaves for a known possible ancestor:
+			if gen, _ := parseRevID(revid); gen > 1 {
+				revtree.forEachLeaf(func(possible *RevInfo) {
+					if !revidsSet.Contains(possible.ID) {
+						possibleGen, _ := parseRevID(possible.ID)
+						if possibleGen < gen && possibleGen >= gen-100 {
+							possibleSet[possible.ID] = true
+						} else if possibleGen == gen && possible.Parent != "" {
+							possibleSet[possible.Parent] = true // since parent is < gen
+						}
+					}
+				})
 			}
 		}
 	}
-	if missing != nil {
-		possible = make([]string, 0, 5)
-		for revid := range revmap {
-			gen, _ := parseRevID(revid)
-			if !found[revid] && gen < maxMissingGen {
-				possible = append(possible, revid)
-			}
-		}
-		if len(possible) == 0 {
-			possible = nil
+
+	// Convert possibleSet to an array (possible)
+	if len(possibleSet) > 0 {
+		possible = make([]string, 0, len(possibleSet))
+		for revid, _ := range possibleSet {
+			possible = append(possible, revid)
 		}
 	}
 	return

--- a/db/revision.go
+++ b/db/revision.go
@@ -13,6 +13,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -166,4 +167,23 @@ func canonicalEncoding(body Body) []byte {
 		panic(fmt.Sprintf("Couldn't encode body %v", body))
 	}
 	return encoded
+}
+
+func GetStringArrayProperty(body Body, property string) ([]string, error) {
+	if raw, exists := body[property]; !exists {
+		return nil, nil
+	} else if strings, ok := raw.([]string); ok {
+		return strings, nil
+	} else if items, ok := raw.([]interface{}); ok {
+		strings := make([]string, len(items))
+		for i := 0; i < len(items); i++ {
+			strings[i], ok = items[i].(string)
+			if !ok {
+				return nil, base.HTTPErrorf(http.StatusBadRequest, property+" must be a string array")
+			}
+		}
+		return strings, nil
+	} else {
+		return nil, base.HTTPErrorf(http.StatusBadRequest, property+" must be a string array")
+	}
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -514,7 +514,6 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assert.True(t, response.Header().Get("Content-Disposition") == "")
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
-
 	// add attachment with two embedded '/' (%2F HEX)
 	response = rt.sendRequestWithHeaders("PUT", "/db/AC%2FDC/attachpath%2Fattachpath2%2Fattachment.txt?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
@@ -525,7 +524,6 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
 	assert.True(t, response.Header().Get("Content-Disposition") == "")
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
-
 
 	//Create Doc with embedded '+' (%2B HEX) in name
 	doc1revId = rt.createDoc(t, "AC%2BDC%2BGC2")
@@ -547,7 +545,6 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
 	assert.True(t, response.Header().Get("Content-Disposition") == "")
 	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
-
 
 	// add attachment with two embedded '/' (%2F HEX)
 	response = rt.sendRequestWithHeaders("PUT", "/db/AC%2BDC%2BGC2/attachpath%2Fattachpath2%2Fattachment.txt?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
@@ -947,8 +944,8 @@ func TestRevsDiff(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	// Now call _revs_diff:
-	input = `{"rd1": ["13-def", "12-abc", "11-eleven"],
-              "rd2": ["34-def", "31-one"],
+	input = `{"rd1": ["13-def", "12-xyz"],
+              "rd2": ["34-def"],
               "rd9": ["1-a", "2-b", "3-c"],
               "_design/ddoc": ["1-woo"]
              }`
@@ -958,8 +955,8 @@ func TestRevsDiff(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &diffResponse)
 	sort.Strings(diffResponse["rd1"]["possible_ancestors"])
 	assert.DeepEquals(t, diffResponse, RevsDiffResponse{
-		"rd1": RevDiffResponse{"missing": []string{"13-def"},
-			"possible_ancestors": []string{"10-ten", "9-nine"}},
+		"rd1": RevDiffResponse{"missing": []string{"13-def", "12-xyz"},
+			"possible_ancestors": []string{"11-eleven", "12-abc"}},
 		"rd9": RevDiffResponse{"missing": []string{"1-a", "2-b", "3-c"}}})
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -345,6 +345,17 @@ func (h *handler) getJSONQuery(query string) (value interface{}, err error) {
 	return
 }
 
+func (h *handler) getJSONStringArrayQuery(param string) ([]string, error) {
+	var strings []string
+	value := h.getQuery(param)
+	if value != "" {
+		if err := json.Unmarshal([]byte(value), &strings); err != nil {
+			return nil, base.HTTPErrorf(http.StatusBadRequest, "%s URL param is not a JSON string array", param)
+		}
+	}
+	return strings, nil
+}
+
 func (h *handler) userAgentIs(agent string) bool {
 	userAgent := h.rq.Header.Get("User-Agent")
 	return len(userAgent) > len(agent) && userAgent[len(agent)] == '/' && strings.HasPrefix(userAgent, agent)


### PR DESCRIPTION
The REST API currently includes the revision's entire history in the
_revisions property of a document and the possible_ancestors property of
a _revs_diff response. This is vastly more than the client needs.
Sending a minimal number of revisions will decrease the bandwidth used
by replication, and save CPU cycles on both server and client.

There are a few parameter additions to the REST API — see #1752 
for details.

Docs:
https://github.com/couchbase/sync_gateway/wiki/Sending-Minimal-Histories

Fixes #1752
