### PR TITLE
Fix for channel notification when user/role doc unblocks buffered docs

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -428,7 +428,10 @@ func (c *changeCache) processPrincipalDoc(docID string, docJSON []byte, isUser b
 
 	base.LogTo("Cache", "Received #%d (%q)", change.Sequence, change.DocID)
 
-	c.processEntry(change)
+	changedChannels := c.processEntry(change)
+	if c.onChange != nil && len(changedChannels) > 0 {
+		c.onChange(changedChannels)
+	}
 }
 
 // Handles a newly-arrived LogEntry.


### PR DESCRIPTION
When documents that had been buffered for sequence ordered caching were released by a user or role doc, changes notifications weren't being raised for the channels on those documents.

Fixes #1780
