### PR TITLE
JWT validation and authentication, session support for OIDC auth

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -21,13 +21,14 @@ import (
 // Options for OpenID Connect
 type OIDCOptions struct {
 	JWTOptions
-	Issuer        *string `json:"issuer,omitempty"`         // OIDC Issuer
-	AuthorizeURL  *string `json:"authorize_url,omitempty"`  // OIDC OP authorize endpoint.
-	TokenURL      *string `json:"token_url,omitempty"`      // OIDC OP token endpoint.
-	Register      bool    `json:"register"`                 // If true, server will register new user accounts
-	ClientID      *string `json:"client_id",omitempty"`     // Client ID
-	ValidationKey *string `json:"validation_key,omitempty"` // Client secret
-	CallbackURL   *string `json:"callback_url,omitempty"`   // Sync Gateway redirect URL.  Needs to be specified to handle load balancer endpoints?  Or can we lazy load on first client use, based on request
+	Issuer         *string `json:"issuer,omitempty"`          // OIDC Issuer
+	AuthorizeURL   *string `json:"authorize_url,omitempty"`   // OIDC OP authorize endpoint.
+	TokenURL       *string `json:"token_url,omitempty"`       // OIDC OP token endpoint.
+	Register       bool    `json:"register"`                  // If true, server will register new user accounts
+	ClientID       *string `json:"client_id,omitempty"`       // Client ID
+	ValidationKey  *string `json:"validation_key,omitempty"`  // Client secret
+	CallbackURL    *string `json:"callback_url,omitempty"`    // Sync Gateway redirect URL.  Needs to be specified to handle load balancer endpoints?  Or can we lazy load on first client use, based on request
+	DisableSession bool    `json:"disable_session,omitempty"` // Disable Sync Gateway session creation on successful OIDC authentication
 }
 
 func CreateOIDCClient(options *OIDCOptions) (*oidc.Client, error) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -251,6 +251,18 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 		return nil
 	}
 
+	var err error
+	// If oidc client available, check for bearer ID token
+	if context.OIDCClient != nil {
+		if token := h.getBearerToken(); token != "" {
+			h.user, _, err = context.Authenticator().AuthenticateJWT(token, context.OIDCClient, context.Options.OIDCOptions.Register)
+			if h.user == nil || err != nil {
+				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
+			}
+			return nil
+		}
+	}
+
 	// Check basic auth first
 	if userName, password := h.getBasicAuth(); userName != "" {
 		h.user = context.Authenticator().AuthenticateUser(userName, password)
@@ -263,7 +275,6 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 	}
 
 	// Check cookie
-	var err error
 	h.user, err = context.Authenticator().AuthenticateCookie(h.rq, h.response)
 	if err != nil {
 		return err
@@ -411,6 +422,15 @@ func (h *handler) getBasicAuth() (username string, password string) {
 		}
 	}
 	return
+}
+
+func (h *handler) getBearerToken() string {
+	auth := h.rq.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		token := auth[7:]
+		return token
+	}
+	return ""
 }
 
 func (h *handler) currentEffectiveUserName() string {

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -84,19 +84,29 @@ func (h *handler) handleSessionDELETE() error {
 }
 
 func (h *handler) makeSession(user auth.User) error {
+
+	err := h.makeSessionWithTTL(user, kDefaultSessionTTL)
+	if err != nil {
+		return err
+	}
+	return h.respondWithSessionInfo()
+}
+
+// Creates a session with TTL and adds to the response.  Does NOT return the session info response.
+func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration) error {
 	if user == nil {
 		return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 	}
 	h.user = user
 	auth := h.db.Authenticator()
-	session, err := auth.CreateSession(user.Name(), kDefaultSessionTTL)
+	session, err := auth.CreateSession(user.Name(), expiry)
 	if err != nil {
 		return err
 	}
 	cookie := auth.MakeSessionCookie(session)
 	base.AddDbPathToCookie(h.rq, cookie)
 	http.SetCookie(h.response, cookie)
-	return h.respondWithSessionInfo()
+	return nil
 }
 
 func (h *handler) makeSessionFromEmail(email string, createUserIfNeeded bool) error {


### PR DESCRIPTION
When OIDC is enabled in the database config, SG supports authentication using a bearer ID token.

Also adds support for SG session creation by the `_oidc_callback` endpoint.  When the ID token obtained during callback processing is successfully validated, it will create a Sync Gateway session and set the cookie on the response.  Session creation can be disabled using the disable_session property in the OIDC config.

When register=true in the OIDC config, SG users will be autocreated based on the subject and (optional) email in the ID token claims.
