### PR TITLE
Lazy loading of OIDC client

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -252,10 +252,10 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 	}
 
 	var err error
-	// If oidc client available, check for bearer ID token
-	if context.OIDCClient != nil {
+	// If oidc enabled, check for bearer ID token
+	if context.Options.OIDCOptions != nil {
 		if token := h.getBearerToken(); token != "" {
-			h.user, _, err = context.Authenticator().AuthenticateJWT(token, context.OIDCClient, context.Options.OIDCOptions.Register)
+			h.user, _, err = context.Authenticator().AuthenticateJWT(token, context.GetOIDCClient(), context.Options.OIDCOptions.Register)
 			if h.user == nil || err != nil {
 				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 			}

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -98,7 +98,7 @@ func (h *handler) handleOIDCCallback() error {
 
 	// Create a Sync Gateway session
 	if !h.db.Options.OIDCOptions.DisableSession {
-		user, jwt, err := h.db.Authenticator().AuthenticateJWT(tokenResponse.IDToken, h.db.OIDCClient, h.db.Options.OIDCOptions.Register)
+		user, jwt, err := h.db.Authenticator().AuthenticateJWT(tokenResponse.IDToken, client, h.db.Options.OIDCOptions.Register)
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func (h *handler) handleOIDCRefresh() error {
 }
 
 func (h *handler) getOIDCClient() (*oidc.Client, error) {
-	client := h.db.OIDCClient
+	client := h.db.GetOIDCClient()
 	if client == nil {
 		return nil, base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("OpenID Connect not configured for database %v", h.db.Name))
 	}


### PR DESCRIPTION
Allows use of local provider when REST API isn't initialized at database context init time.
