### PR TITLE
Adds _oidc_challenge endpoint

### DIFF
--- a/rest/routing.go
+++ b/rest/routing.go
@@ -91,6 +91,7 @@ func createHandler(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mux.Rou
 	dbr.Handle("/_oidc", makeHandler(sc, publicPrivs, (*handler).handleOIDC)).Methods("GET")
 	dbr.Handle("/_oidc_callback", makeHandler(sc, publicPrivs, (*handler).handleOIDCCallback)).Methods("GET")
 	dbr.Handle("/_oidc_refresh", makeHandler(sc, publicPrivs, (*handler).handleOIDCRefresh)).Methods("GET")
+	dbr.Handle("/_oidc_challenge", makeHandler(sc, publicPrivs, (*handler).handleOIDCChallenge)).Methods("GET")
 
 	oidcr := dbr.PathPrefix("/_oidc_testing").Subrouter()
 


### PR DESCRIPTION
_oidc_challenge has the same functionality as _oidc, but returns a 401 instead of 302.  Returns the auth redirect URL in the WWW-Authenticate header in the form `WWW-Authenticate: OIDC login="[url]"

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1807)

<!-- Reviewable:end -->
