### PR TITLE
Fix issue in sgcollect sgconfig json-isation

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -139,7 +139,7 @@ def extract_element_from_config(element, config):
     """
 
     sync_regex = r'"Sync":(`.*`)'
-    config = re.sub(sync_regex, '""', config)
+    config = re.sub(sync_regex, '"Sync":""', config)
     try:
         return json.loads(config)[element]
     except ValueError, KeyError:


### PR DESCRIPTION
- As part of 33834ad the ability to parse the non-json sgconfig as
  json was added to sgcollect by replacing the sync function
- The replacement was too restrictive though depending on where the
  sync function is located in the response
- This commit should now allow it to work in all circumstances

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1840)

<!-- Reviewable:end -->
