### PR TITLE
_changes with _doc_ids filter handle deleted doc with no channels metadata

### DIFF
--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -339,7 +339,9 @@ func (h *handler) sendChangesForDocIds(userChannels base.Set, explicitDocIds []s
 
 		userCanSeeDocChannel := false
 
-		if len(populatedDoc.Channels) > 0 {
+		if h.user.Channels().Contains(ch.UserStarChannel) {
+			userCanSeeDocChannel = true
+		} else if len(populatedDoc.Channels) > 0 {
 			//Do special _removed/_deleted processing
 			for channel, removal := range populatedDoc.Channels {
 				//Doc is tagged with channel or was removed at a sequence later that since sequence
@@ -357,22 +359,7 @@ func (h *handler) sendChangesForDocIds(userChannels base.Set, explicitDocIds []s
 					}
 				}
 			}
-		} else if h.user.Channels().Contains(ch.UserStarChannel) {
-			userCanSeeDocChannel = true
 		}
-
-		/*
-		if len(channels) > 0 {
-		for channel := range channels {
-			if princ.CanSeeChannel(channel) {
-				return nil
-			}
-		}
-	} else if princ.Channels().Contains(ch.UserStarChannel) {
-		return nil
-	}
-	return princ.UnauthError("You are not allowed to see this")
-		 */
 
 		if !userCanSeeDocChannel {
 			return nil

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -332,17 +332,24 @@ func (h *handler) sendChangesForDocIds(userChannels base.Set, explicitDocIds []s
 		row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 
 		var removedChannels []string
-		//Do special _removed/_deleted processing
-		for channel, removal := range populatedDoc.Channels {
-			//Doc is tagged with channel or was removed at a sequence later that since sequence
-			if removal == nil || removal.Seq > options.Since.Seq {
-				//if the current user has access to this channel
-				if h.user.CanSeeChannel(channel) {
-					//If the doc has been removed
-					if removal != nil {
-						removedChannels = append(removedChannels,channel)
-						if removal.Deleted {
-							row.Deleted = true
+
+		if len(populatedDoc.Channels) == 0 {
+			if deleted, _ := body["_deleted"].(bool); deleted {
+				row.Deleted = true
+			}
+		} else {
+			//Do special _removed/_deleted processing
+			for channel, removal := range populatedDoc.Channels {
+				//Doc is tagged with channel or was removed at a sequence later that since sequence
+				if removal == nil || removal.Seq > options.Since.Seq {
+					//if the current user has access to this channel
+					if h.user.CanSeeChannel(channel) {
+						//If the doc has been removed
+						if removal != nil {
+							removedChannels = append(removedChannels, channel)
+							if removal.Deleted {
+								row.Deleted = true
+							}
 						}
 					}
 				}


### PR DESCRIPTION
For _changes with _doc_ids filter if doc has no channels metadata check _deleted property on revision body.

fixes #1857

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1861)

<!-- Reviewable:end -->
