### PR TITLE
Add sgcollect_info to sync_gateway package.

### DIFF
--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -197,6 +197,7 @@ exit 0
 %dir %attr (0755, @@PRODUCT_BASE@@, @@PRODUCT_BASE@@) @@PREFIX@@
 
 %dir %attr (0755, bin, bin) @@PREFIX@@/bin
+%dir %attr (0755, bin, bin) @@PREFIX@@/tools
 %dir %attr (0644, bin, bin) @@PREFIX@@/examples
 %dir %attr (0755, bin, bin) @@PREFIX@@/service
 
@@ -204,6 +205,7 @@ exit 0
 #
 
 %attr (0755, bin, bin) @@PREFIX@@/bin/*
+%attr (0755, bin, bin) @@PREFIX@@/tools/*
 %attr (0644, bin, bin) @@PREFIX@@/examples/*
 %attr (0755, bin, bin) @@PREFIX@@/service/*
 %attr (0644, bin, bin) @@PREFIX@@/LICENSE.txt


### PR DESCRIPTION
Just Centos needs couple changes to the rpm spec to pickup the new tools directory.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1863)

<!-- Reviewable:end -->
