### PR TITLE
#1866: Escape literal backslashes in backquoted strings

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -81,7 +81,7 @@ func FixJSONNumbers(value interface{}) interface{} {
 var kBackquoteStringRegexp *regexp.Regexp
 
 // Preprocesses a string containing `...`-delimited strings. Converts the backquotes into double-quotes,
-// and escapes any newlines or double-quotes within them with backslashes.
+// and escapes any literal backslashes, newlines or double-quotes within them with backslashes.
 func ConvertBackQuotedStrings(data []byte) []byte {
 	if kBackquoteStringRegexp == nil {
 		kBackquoteStringRegexp = regexp.MustCompile("`((?s).*?)[^\\\\]`")
@@ -89,7 +89,8 @@ func ConvertBackQuotedStrings(data []byte) []byte {
 	// Find backquote-delimited strings and replace them:
 	return kBackquoteStringRegexp.ReplaceAllFunc(data, func(bytes []byte) []byte {
 		str := string(bytes)
-		// Remove \r  and Escape newlines and double-quotes:
+		// Remove \r  and Escape literal backslashes, newlines and double-quotes:
+		str = strings.Replace(str, `\`, `\\`, -1)
 		str = strings.Replace(str, "\r", "", -1)
 		str = strings.Replace(str, "\n", `\n`, -1)
 		str = strings.Replace(str, "\t", `\t`, -1)

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -56,6 +56,10 @@ func TestBackQuotedStrings(t *testing.T) {
 	input = "{\"foo\": `bar\r\n`, \"baz\": `\r\nhowdy`}"
 	output = ConvertBackQuotedStrings([]byte(input))
 	assert.Equals(t, string(output), `{"foo": "bar\n", "baz": "\nhowdy"}`)
+
+	input = "{\"foo\": `bar\\baz`, \"something\": `else\\is\\here`}"
+	output = ConvertBackQuotedStrings([]byte(input))
+	assert.Equals(t, string(output), `{"foo": "bar\\baz", "something": "else\\is\\here"}`)
 }
 
 func TestCouchbaseUrlWithAuth(t *testing.T) {


### PR DESCRIPTION
Fixes #1866 by escaping literal backslash characters in `ConvertBackQuotedStrings` before escaping newlines, tabs and double quotes. This will allow the use of, for example, predefined character classes like `\d`, `\s`, `\w`, etc. in regular expressions in sync functions and webhook event handlers that are defined within backquoted strings.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1867)

<!-- Reviewable:end -->
