### PR TITLE
Expiry support for SG documents

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -27,7 +27,10 @@ import (
 	"time"
 )
 
-const kMaxDeltaTtl = 60 * 60 * 24 * 30
+const (
+	kMaxDeltaTtl         = 60 * 60 * 24 * 30
+	kMaxDeltaTtlDuration = 60 * 60 * 24 * 30 * time.Second
+)
 
 func GenerateRandomSecret() string {
 	randomBytes := make([]byte, 20)
@@ -264,7 +267,7 @@ func (v *IntMax) SetIfMax(value int64) {
 //This function takes a ttl as a Duration and returns an int
 //formatted as required by CBS expiry processing
 func DurationToCbsExpiry(ttl time.Duration) int {
-	if ttl <= time.Duration(kMaxDeltaTtl)*time.Second {
+	if ttl <= kMaxDeltaTtlDuration {
 		return int(ttl.Seconds())
 	} else {
 		return int(time.Now().Add(ttl).Unix())

--- a/base/util.go
+++ b/base/util.go
@@ -16,6 +16,7 @@ import (
 	"expvar"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -26,7 +27,7 @@ import (
 	"time"
 )
 
-const kMaxDeltaTtl = 60 * 60 * 24 * 30 * time.Second
+const kMaxDeltaTtl = 60 * 60 * 24 * 30
 
 func GenerateRandomSecret() string {
 	randomBytes := make([]byte, 20)
@@ -263,10 +264,20 @@ func (v *IntMax) SetIfMax(value int64) {
 //This function takes a ttl as a Duration and returns an int
 //formatted as required by CBS expiry processing
 func DurationToCbsExpiry(ttl time.Duration) int {
-	if ttl <= kMaxDeltaTtl {
+	if ttl <= time.Duration(kMaxDeltaTtl)*time.Second {
 		return int(ttl.Seconds())
 	} else {
 		return int(time.Now().Add(ttl).Unix())
+	}
+}
+
+//This function takes a CBS expiry and returns as a time
+func CbsExpiryToTime(expiry uint32) time.Time {
+	if expiry <= kMaxDeltaTtl {
+		return time.Now().Add(time.Duration(expiry) * time.Second)
+	} else {
+		log.Printf("expiry for %v becomes %v", expiry, time.Unix(int64(expiry), 0))
+		return time.Unix(int64(expiry), 0)
 	}
 }
 

--- a/db/assimilator.go
+++ b/db/assimilator.go
@@ -34,7 +34,7 @@ func (c *DatabaseContext) watchDocChanges() {
 func (c *DatabaseContext) assimilate(docid string) {
 	base.LogTo("CRUD", "Importing new doc %q", docid)
 	db := Database{DatabaseContext: c, user: nil}
-	_, err := db.updateDoc(docid, true, func(doc *document) (Body, error) {
+	_, err := db.updateDoc(docid, true, 0, func(doc *document) (Body, error) {
 		if doc.HasValidSyncData(c.writeSequences()) {
 			return nil, couchbase.UpdateCancel // someone beat me to it
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -77,7 +77,7 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 
 // Returns the body of the current revision of a document
 func (db *Database) Get(docid string) (Body, error) {
-	return db.GetRevWithHistory(docid, "", 0, nil, nil)
+	return db.GetRevWithHistory(docid, "", 0, nil, nil, false)
 }
 
 // Shortcut for GetRevWithHistory
@@ -86,7 +86,7 @@ func (db *Database) GetRev(docid, revid string, history bool, attachmentsSince [
 	if history {
 		maxHistory = math.MaxInt32
 	}
-	return db.GetRevWithHistory(docid, revid, maxHistory, nil, attachmentsSince)
+	return db.GetRevWithHistory(docid, revid, maxHistory, nil, attachmentsSince, false)
 }
 
 // Returns the body of a revision of a document. Uses the revision cache.
@@ -97,7 +97,7 @@ func (db *Database) GetRev(docid, revid string, history bool, attachmentsSince [
 // * attachmentsSince is nil to return no attachment bodies, otherwise a (possibly empty) list of
 //   revisions for which the client already has attachments and doesn't need bodies. Any attachment
 //   that hasn't changed since one of those revisions will be returned as a stub.
-func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, historyFrom []string, attachmentsSince []string) (Body, error) {
+func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, historyFrom []string, attachmentsSince []string, showExp bool) (Body, error) {
 	var doc *document
 	var body Body
 	var revisions Body
@@ -171,6 +171,18 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 	// Add revision metadata:
 	if revisions != nil {
 		body["_revisions"] = revisions
+	}
+
+	if showExp {
+		// If doc is nil (we got the rev from the rev cache), look up the doc to find the exp on the doc
+		if doc == nil {
+			if doc, err = db.GetDoc(docid); doc == nil {
+				return nil, err
+			}
+		}
+		if doc.Expiry != nil && !doc.Expiry.IsZero() {
+			body["_exp"] = doc.Expiry.Format(base.ISO8601Format)
+		}
 	}
 
 	// Add attachment bodies:
@@ -411,7 +423,9 @@ func (db *Database) Put(docid string, body Body) (string, error) {
 	generation++
 	deleted, _ := body["_deleted"].(bool)
 
-	return db.updateDoc(docid, false, body.extractExpiry(), func(doc *document) (Body, error) {
+	expiry := body.extractExpiry()
+
+	return db.updateDoc(docid, false, expiry, func(doc *document) (Body, error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		// First, make sure matchRev matches an existing leaf revision:
 		if matchRev == "" {
@@ -703,6 +717,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, cal
 		}
 
 		doc.TimeSaved = time.Now()
+		doc.UpdateExpiry(expiry)
 
 		// Return the new raw document value for the bucket to store.
 		raw, err = json.Marshal(doc)

--- a/db/document.go
+++ b/db/document.go
@@ -32,6 +32,7 @@ type syncData struct {
 	Channels        channels.ChannelMap `json:"channels,omitempty"`
 	Access          UserAccessMap       `json:"access,omitempty"`
 	RoleAccess      UserAccessMap       `json:"role_access,omitempty"`
+	Expiry          *time.Time          `json:"exp,omitempty"` // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
 
 	// Fields used by bucket-shadowing:
 	UpstreamCAS *uint64 `json:"upstream_cas,omitempty"` // CAS value of remote doc
@@ -154,6 +155,17 @@ func (doc *document) setRevision(revid string, body Body) {
 			asJson, _ = json.Marshal(stripSpecialProperties(body))
 		}
 		doc.History.setRevisionBody(revid, asJson)
+	}
+}
+
+// Updates the expiry for a document
+func (doc *document) UpdateExpiry(expiry uint32) {
+
+	if expiry == 0 {
+		doc.Expiry = nil
+	} else {
+		expireTime := base.CbsExpiryToTime(expiry)
+		doc.Expiry = &expireTime
 	}
 }
 

--- a/db/revision.go
+++ b/db/revision.go
@@ -53,6 +53,21 @@ func (body Body) ImmutableAttachmentsCopy() Body {
 	return copied
 }
 
+func (body Body) extractExpiry() uint32 {
+	// TODO: enhance to handle other expiry formats
+	expiry, ok := body["_exp"].(uint32)
+	if ok {
+		delete(body, "_exp")
+	}
+	return expiry
+}
+
+func (body Body) getExpiry() uint32 {
+	// TODO: enhance to handle other expiry formats
+	expiry, _ := body["_exp"].(uint32)
+	return expiry
+}
+
 // Looks up the raw JSON data of a revision that's been archived to a separate doc.
 // If the revision isn't found (e.g. has been deleted by compaction) returns 404 error.
 func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byte, error) {

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -103,7 +103,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 	}
 
 	db, _ := CreateDatabase(s.context)
-	_, err := db.updateDoc(key, false, func(doc *document) (Body, error) {
+	_, err := db.updateDoc(key, false, body.extractExpiry(), func(doc *document) (Body, error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		if doc.UpstreamCAS != nil && *doc.UpstreamCAS == cas {
 			return nil, couchbase.UpdateCancel // we already have this doc revision

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -38,7 +38,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 		return "", base.HTTPErrorf(400, "Invalid doc ID")
 	}
 	var revid string
-	err := db.Bucket.Update(key, 0, func(value []byte) ([]byte, error) {
+	err := db.Bucket.Update(key, int(body.getExpiry()), func(value []byte) ([]byte, error) {
 		if len(value) == 0 {
 			if matchRev != "" || body == nil {
 				return nil, base.HTTPErrorf(http.StatusNotFound, "No previous revision to replace")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -411,7 +411,7 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	}
 
 	// attach to existing document with correct rev (should fail)
-	response = rt.sendUserRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders,"user1", "letmein")
+	response = rt.sendUserRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders, "user1", "letmein")
 	assertStatus(t, response, 404)
 }
 
@@ -2381,6 +2381,84 @@ func TestEventConfigValidationFailure(t *testing.T) {
 	assert.True(t, fmt.Sprintf("%v", err) == "Unsupported event property 'document_scribbled_on' defined for db invalid")
 
 	sc.Close()
+}
+
+// TestDocExpiry validates the value of the expiry as set in the document.  It doesn't validate actual expiration (not supported
+// in walrus).
+func TestDocExpiry(t *testing.T) {
+	var rt restTester
+	var body db.Body
+	response := rt.sendRequest("PUT", "/db/expNumericTTL", `{"_exp":100}`)
+	assertStatus(t, response, 201)
+
+	// Validate that exp isn't returned on the standard GET, bulk get
+	response = rt.sendRequest("GET", "/db/expNumericTTL", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	_, ok := body["_exp"]
+	assert.Equals(t, ok, false)
+
+	bulkGetDocs := `{"docs": [{"id": "expNumericTTL", "rev": "1-ca9ad22802b66f662ff171f226211d5c"}]}`
+	response = rt.sendRequest("POST", "/db/_bulk_get", bulkGetDocs)
+	assertStatus(t, response, 200)
+
+	response = rt.sendRequest("POST", "/db/_bulk_get?show_exp=true", bulkGetDocs)
+	assertStatus(t, response, 200)
+
+	body = nil
+	response = rt.sendRequest("GET", "/db/expNumericTTL?show_exp=true", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	_, ok = body["_exp"]
+	assert.Equals(t, ok, true)
+
+	// Validate other exp formats
+	body = nil
+	response = rt.sendRequest("PUT", "/db/expNumericUnix", `{"val":1, "_exp":4260211200}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/expNumericUnix?show_exp=true", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	log.Printf("numeric unix response: %s", response.Body.Bytes())
+	_, ok = body["_exp"]
+	assert.Equals(t, ok, true)
+
+	body = nil
+	response = rt.sendRequest("PUT", "/db/expNumericString", `{"val":1, "_exp":"100"}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/expNumericString?show_exp=true", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	_, ok = body["_exp"]
+	assert.Equals(t, ok, true)
+
+	body = nil
+	response = rt.sendRequest("PUT", "/db/expBadString", `{"_exp":"abc"}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/expBadString?show_exp=true", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	_, ok = body["_exp"]
+	assert.Equals(t, ok, false)
+
+	body = nil
+	response = rt.sendRequest("PUT", "/db/expDateString", `{"_exp":"2105-01-01T00:00:00.000+00:00"}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/expDateString?show_exp=true", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	_, ok = body["_exp"]
+	assert.Equals(t, ok, true)
+
+	body = nil
+	response = rt.sendRequest("PUT", "/db/expBadDateString", `{"_exp":"2105-0321-01T00:00:00.000+00:00"}`)
+	assertStatus(t, response, 201)
+	response = rt.sendRequest("GET", "/db/expBadDateString?show_exp=true", "")
+	assertStatus(t, response, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	_, ok = body["_exp"]
+	assert.Equals(t, ok, false)
+
 }
 
 // Reproduces https://github.com/couchbase/sync_gateway/issues/916.  The test-only RestartListener operation used to simulate a

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2401,9 +2402,13 @@ func TestDocExpiry(t *testing.T) {
 	bulkGetDocs := `{"docs": [{"id": "expNumericTTL", "rev": "1-ca9ad22802b66f662ff171f226211d5c"}]}`
 	response = rt.sendRequest("POST", "/db/_bulk_get", bulkGetDocs)
 	assertStatus(t, response, 200)
+	responseString := string(response.Body.Bytes())
+	assertTrue(t, !strings.Contains(responseString, "_exp"), "Bulk get response contains _exp property when show_exp not set.")
 
 	response = rt.sendRequest("POST", "/db/_bulk_get?show_exp=true", bulkGetDocs)
 	assertStatus(t, response, 200)
+	responseString = string(response.Body.Bytes())
+	assertTrue(t, strings.Contains(responseString, "_exp"), "Bulk get response doesn't contain _exp property when show_exp was set.")
 
 	body = nil
 	response = rt.sendRequest("GET", "/db/expNumericTTL?show_exp=true", "")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -286,6 +286,7 @@ func (h *handler) handleDumpChannel() error {
 // }
 func (h *handler) handleBulkGet() error {
 	includeAttachments := h.getBoolQuery("attachments")
+	showExp := h.getBoolQuery("show_exp")
 	revsLimit := 0
 	if h.getBoolQuery("revs") {
 		revsLimit = int(h.getIntQuery("revs_limit", math.MaxInt32))
@@ -347,7 +348,7 @@ func (h *handler) handleBulkGet() error {
 			}
 
 			if err == nil {
-				body, err = h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attsSince)
+				body, err = h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attsSince, showExp)
 			}
 
 			if err != nil {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -26,6 +26,7 @@ func (h *handler) handleGetDoc() error {
 	docid := h.PathVar("docid")
 	revid := h.getQuery("rev")
 	openRevs := h.getQuery("open_revs")
+	showExp := h.getBoolQuery("show_exp")
 
 	// Check whether the caller wants a revision history, or attachment bodies, or both:
 	var revsLimit = 0
@@ -60,7 +61,7 @@ func (h *handler) handleGetDoc() error {
 
 	if openRevs == "" {
 		// Single-revision GET:
-		value, err := h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince)
+		value, err := h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 		if err != nil {
 			return err
 		}
@@ -104,7 +105,7 @@ func (h *handler) handleGetDoc() error {
 		if h.requestAccepts("multipart/") {
 			err := h.writeMultipart("mixed", func(writer *multipart.Writer) error {
 				for _, revid := range revids {
-					revBody, err := h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince)
+					revBody, err := h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 					if err != nil {
 						revBody = db.Body{"missing": revid} //TODO: More specific error
 					}
@@ -119,7 +120,7 @@ func (h *handler) handleGetDoc() error {
 			h.response.Write([]byte(`[` + "\n"))
 			separator := []byte(``)
 			for _, revid := range revids {
-				revBody, err := h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince)
+				revBody, err := h.db.GetRevWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
 				if err != nil {
 					revBody = db.Body{"missing": revid} //TODO: More specific error
 				} else {


### PR DESCRIPTION
When writing a document to Sync Gateway (via PUT doc or bulk_docs), users can set the '_exp' property in the body of the document.  When Sync Gateway writes the document, it will:
- Set a Couchbase Server expiry on the document, based on the exp value (see below for format)
- Strip the _exp property from the document body (to avoid compatibility issues around the leading underscore when that document is replicated elsewhere)
- Set an expiry property - `exp` - in the document's sync metadata, to provide some visibility on the expiry value

When Sync Gateway reads a document (via document GET, bulk_get), it will recreate the _exp property in the body as an ISO-8601 only if the query string includes show_exp=true .

Supported formats for the incoming _exp value:
- JSON number.  Will be treated as a Couchbase Server expiry value (ttl in second when less than 30 days, unix time when greater)
- JSON string (numeric format) - same as JSON number
- JSON string (as ISO-8601 date).  Converted to Couchbase server expiry value.
- JSON null.  Sets expiry to zero (no expiry)

Note that subsequent updates to the document will use the expiry value on the update.  If no expiry value is set on a new revision of a document that was previously set to expire, the new version of the document will have no expiry set.

Fixes #1823

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1881)

<!-- Reviewable:end -->
