### PR TITLE
Do not require callback_url, validation_key for OIDC authentication

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -284,7 +284,7 @@ func (auth *Authenticator) AuthenticateUser(username string, password string) Us
 // issuer in the token with a provider.
 // If the token is validated but the user for the username defined in the subject claim doesn't exist,
 // creates the user when autoRegister=true.
-func (auth *Authenticator) AuthenticateJWT(token string, providers OIDCProviderMap) (User, jose.JWT, error) {
+func (auth *Authenticator) AuthenticateJWT(token string, providers OIDCProviderMap, callbackURLFunc OIDCCallbackURLFunc) (User, jose.JWT, error) {
 
 	// Parse JWT (needed to determine issuer/provider)
 	jwt, err := jose.ParseJWT(token)
@@ -303,13 +303,13 @@ func (auth *Authenticator) AuthenticateJWT(token string, providers OIDCProviderM
 		return nil, jose.JWT{}, fmt.Errorf("No provider found for issuer %v", issuer)
 	}
 
-	return auth.authenticateJWT(jwt, provider)
+	return auth.authenticateJWT(jwt, provider, callbackURLFunc)
 }
 
 // Authenticates a user based on a JWT token string and a provider.
 // If the token is validated but the user for the username defined in the subject claim doesn't exist,
 // creates the user when autoRegister=true.
-func (auth *Authenticator) AuthenticateJWTForProvider(token string, provider *OIDCProvider) (User, jose.JWT, error) {
+func (auth *Authenticator) AuthenticateJWTForProvider(token string, provider *OIDCProvider, callbackURLFunc OIDCCallbackURLFunc) (User, jose.JWT, error) {
 
 	// Parse JWT
 	jwt, err := jose.ParseJWT(token)
@@ -317,12 +317,12 @@ func (auth *Authenticator) AuthenticateJWTForProvider(token string, provider *OI
 		return nil, jose.JWT{}, err
 	}
 
-	return auth.authenticateJWT(jwt, provider)
+	return auth.authenticateJWT(jwt, provider, callbackURLFunc)
 }
 
-func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider) (User, jose.JWT, error) {
+func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider, callbackURLFunc OIDCCallbackURLFunc) (User, jose.JWT, error) {
 	// Verify JWT
-	client := provider.GetClient()
+	client := provider.GetClient(callbackURLFunc)
 	err := client.VerifyJWT(jwt)
 	if err != nil {
 		return nil, jwt, err

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -255,7 +255,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 	// If oidc enabled, check for bearer ID token
 	if context.Options.OIDCOptions != nil {
 		if token := h.getBearerToken(); token != "" {
-			h.user, _, err = context.Authenticator().AuthenticateJWT(token, context.OIDCProviders)
+			h.user, _, err = context.Authenticator().AuthenticateJWT(token, context.OIDCProviders, h.getOIDCCallbackURL)
 			if h.user == nil || err != nil {
 				return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 			}

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -74,7 +74,7 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 		return redirectURLString, err
 	}
 
-	client := provider.GetClient()
+	client := provider.GetClient(h.getOIDCCallbackURL)
 	if client == nil {
 		return redirectURLString, base.HTTPErrorf(http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider:%s", providerName))
 	}
@@ -120,7 +120,7 @@ func (h *handler) handleOIDCCallback() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to identify provider for callback request")
 	}
 
-	oac, err := provider.GetClient().OAuthClient()
+	oac, err := provider.GetClient(h.getOIDCCallbackURL).OAuthClient()
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (h *handler) handleOIDCRefresh() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to identify provider for callback request")
 	}
 
-	oac, err := provider.GetClient().OAuthClient()
+	oac, err := provider.GetClient(h.getOIDCCallbackURL).OAuthClient()
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (h *handler) handleOIDCRefresh() error {
 
 func (h *handler) createSessionForIdToken(idToken string, provider *auth.OIDCProvider) (username string, sessionID string, err error) {
 
-	user, jwt, err := h.db.Authenticator().AuthenticateJWTForProvider(idToken, provider)
+	user, jwt, err := h.db.Authenticator().AuthenticateJWTForProvider(idToken, provider, h.getOIDCCallbackURL)
 	if err != nil {
 		return "", "", err
 	}
@@ -224,12 +224,19 @@ func (h *handler) getOIDCProvider(providerName string) (*auth.OIDCProvider, erro
 	if provider == nil || err != nil {
 		return nil, base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("OpenID Connect not configured for database %v", h.db.Name))
 	}
-
-	// If the redirect URL is not defined for the provider generate it from the
-	// handler request and set it on the provider
-	if provider.CallbackURL == nil || *provider.CallbackURL == "" {
-		callbackURL := callbackUrlForDB(h, h.db.Name)
-		provider.CallbackURL = &callbackURL
-	}
 	return provider, nil
+}
+
+// Builds the OIDC callback based on the current request and database. Used during OIDC Client lazy initialization.  Needs to pass
+// in dbName, as it's not necessarily initialized on the request yet.
+func (h *handler) getOIDCCallbackURL() string {
+	scheme := "http"
+	if h.rq.TLS != nil {
+		scheme = "https"
+	}
+	if h.PathVar("db") == "" {
+		base.Warn("Can't calculate OIDC callback URL without DB in path.")
+		return ""
+	}
+	return fmt.Sprintf("%s://%s/%s/%s", scheme, h.rq.Host, h.PathVar("db"), "_oidc_callback")
 }

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -234,9 +234,10 @@ func (h *handler) getOIDCCallbackURL() string {
 	if h.rq.TLS != nil {
 		scheme = "https"
 	}
-	if h.PathVar("db") == "" {
+	if dbName := h.PathVar("db"); dbName == "" {
 		base.Warn("Can't calculate OIDC callback URL without DB in path.")
 		return ""
+	} else {
+		return fmt.Sprintf("%s://%s/%s/%s", scheme, h.rq.Host, dbName, "_oidc_callback")
 	}
-	return fmt.Sprintf("%s://%s/%s/%s", scheme, h.rq.Host, h.PathVar("db"), "_oidc_callback")
 }

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -379,15 +379,6 @@ func issuerUrlForDB(h *handler, dbname string) string {
 	return fmt.Sprintf("%s://%s/%s/%s", scheme, h.rq.Host, dbname, "_oidc_testing")
 }
 
-func callbackUrlForDB(h *handler, dbname string) string {
-	scheme := "http"
-
-	if h.rq.TLS != nil {
-		scheme = "https"
-	}
-	return fmt.Sprintf("%s://%s/%s/%s", scheme, h.rq.Host, dbname, "_oidc_callback")
-}
-
 //Return the internal test RSA private key, this is decoded from a base64 encoded string
 //stored as a constant above
 func privateKey() (key *rsa.PrivateKey, err error) {


### PR DESCRIPTION
If callback_url isn't present, SG builds the callback based on the request scope.  This wasn't working for ID token-based auth.  While fixing, realized that the existing callback URL initialization code wasn't synchronized, and also wouldn't work if the client was initialized before the callback url was set on the provider.  Modified to use a callback function to calculate the callback URL, and enforced that this function be passed as a parameter provider.GetClient(), and only called once during client initialization.  To support cases where the db isn't set on the request (ID token auth flow), switched to use PathVar("db") directly instead of getting it from h.rq.db.  It requires some passing around of the callback function (from the handler, to auth, eventually to GetClient(), but this was the cleanest approach without completely rebuilding the lazy initialization of the client.  Fixes #1883

Also removed requirement for Validation Key - clients using the implicit flow don't need to define a validation key.  Added a warning on startup if the validation key isn't defined to make it clear that the auth code flow won't work if the validation key isn't present.  Fixes #1877

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1889)

<!-- Reviewable:end -->
