### PR TITLE
Write attachments after document validation

### DIFF
--- a/db/assimilator.go
+++ b/db/assimilator.go
@@ -34,14 +34,14 @@ func (c *DatabaseContext) watchDocChanges() {
 func (c *DatabaseContext) assimilate(docid string) {
 	base.LogTo("CRUD", "Importing new doc %q", docid)
 	db := Database{DatabaseContext: c, user: nil}
-	_, err := db.updateDoc(docid, true, 0, func(doc *document) (Body, error) {
+	_, err := db.updateDoc(docid, true, 0, func(doc *document) (Body, AttachmentData, error) {
 		if doc.HasValidSyncData(c.writeSequences()) {
-			return nil, couchbase.UpdateCancel // someone beat me to it
+			return nil, nil, couchbase.UpdateCancel // someone beat me to it
 		}
 		if err := db.initializeSyncData(doc); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return doc.body, nil
+		return doc.body, nil, nil
 	})
 	if err != nil && err != couchbase.UpdateCancel {
 		base.Warn("Failed to import new doc %q: %v", docid, err)


### PR DESCRIPTION
Previously attachments that were sent inline would be persisted to the DB even if the owning document failed sync function validation.

Inline attachment data in the document needs to be removed and replaced with digest references before the revision ID is calculated (since it's a change to the document body), so it's not possible to just move the entire storeAttachments processing after Sync Function execution.  The fix is to split the functionality - the updateDoc callback now updates the attachments to digest in the doc body, then returns any attachment bodies for later storage.  After the document passes Sync Function validation, the attachments are stored in the DB.

This doesn't change the handling for multiple invocations of updateDoc (for concurrent writes).  The previous implementation already had the potential to try to store a document multiple times: if the attachment already existed, it proceeds without error.  The new implementation does the same - the only difference is that the attempted attachment writes happen after Sync Function validation.

There's still a corner case where:
(a) Document passes Sync Function validation on first attempt
(b) Attachments are written
(c) Document write fails and retries (someone else has updated the doc)
(d) Document fails Sync Function validation on second attempt (because oldDoc has changed)

For this corner case the risk/overhead associated with the attachments written in (b) is minor.  In particular, it's not possible to repeatedly trigger this scenario in the same way as the previous issue.

Fixes #1728.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1898)

<!-- Reviewable:end -->
