### PR TITLE
Trim both leading and trailing '/' characters from replication source/target DB names.

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -228,8 +228,8 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 	if syncSource != "" {
 		params.Source, _ = url.Parse(syncSource)
 	}
-	// Strip leading / from path to get db name
-	params.SourceDb = strings.TrimLeft(sourceUrl.Path, "/")
+	// Strip leading and trailing / from path to get db name
+	params.SourceDb = strings.Trim(sourceUrl.Path, "/")
 
 	targetUrl, err := url.Parse(requestParams.Target)
 	if err != nil || requestParams.Target == "" {
@@ -240,7 +240,7 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 	if syncTarget != "" {
 		params.Target, _ = url.Parse(syncTarget)
 	}
-	params.TargetDb = strings.TrimLeft(targetUrl.Path, "/")
+	params.TargetDb = strings.Trim(targetUrl.Path, "/")
 
 	if requestParams.Continuous {
 		params.Lifecycle = sgreplicate.CONTINUOUS


### PR DESCRIPTION
fixes #1907

Covers both SG config.json and REST API replicate configurations

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1912)

<!-- Reviewable:end -->
