### PR TITLE
Remove sensitive data from HTTP logging

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -214,7 +214,31 @@ func (h *handler) logRequestLine() {
 	if h.rq.ProtoMajor >= 2 {
 		proto = " HTTP/2"
 	}
-	base.LogTo("HTTP", " #%03d: %s %s%s%s", h.serialNumber, h.rq.Method, h.rq.URL, proto, as)
+
+	base.LogTo("HTTP", " #%03d: %s %s%s%s", h.serialNumber, h.rq.Method, sanitizeRequestURL(h.rq.URL), proto, as)
+}
+
+// Replaces sensitive data from the URL query string with ******.
+// Have to use string replacement instead of writing directly to the Values URL object, as only the URL's raw query is mutable.
+func sanitizeRequestURL(requestURL *url.URL) string {
+	urlString := requestURL.String()
+	// Do a basic contains for the values we care about, to minimize performance impact on other requests.
+	if strings.Contains(urlString, "code=") || strings.Contains(urlString, "token=") {
+		// Iterate over the URL values looking for matches, and then do a string replacement of the found value
+		// into urlString.  Need to unescapte the urlString, as the values returned by URL.Query() get unescaped.
+		urlString, _ = url.QueryUnescape(urlString)
+		values := requestURL.Query()
+		for key, vals := range values {
+			if key == "code" || strings.Contains(key, "token") {
+				//In case there are multiple entries
+				for _, val := range vals {
+					urlString = strings.Replace(urlString, fmt.Sprintf("%s=%s", key, val), fmt.Sprintf("%s=******", key), -1)
+				}
+			}
+		}
+	}
+
+	return urlString
 }
 
 func (h *handler) logDuration(realTime bool) {

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -161,3 +161,39 @@ func TestParseHTTPRangeHeader(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeURL(t *testing.T) {
+
+	url, err := url.Parse("http://localhost:4985/default/_oidc_callback?code=4/1zaCA0RXtFqw93PmcP9fqOMMHfyBDhI0fS2AzeQw-5E")
+	assertNoError(t, err, "Unable to parse URL")
+	sanitizedURL := sanitizeRequestURL(url)
+	assert.Equals(t, sanitizedURL, "http://localhost:4985/default/_oidc_callback?code=******")
+
+	url, err = url.Parse("http://localhost:4985/default/_oidc_refresh?refresh_token==1/KPuhjLJrTZO9OExSypWtqiDioXf3nzAUJnewmyhK94s")
+	assertNoError(t, err, "Unable to parse URL")
+	sanitizedURL = sanitizeRequestURL(url)
+	assert.Equals(t, sanitizedURL, "http://localhost:4985/default/_oidc_refresh?refresh_token=******")
+
+	// Ensure non-matching parameters aren't getting sanitized
+
+	url, err = url.Parse("http://localhost:4985/default/_oidc_callback?code=4/1zaCA0RXtFqw93PmcP9fqOMMHfyBDhI0fS2AzeQw-5E&state=123456")
+	assertNoError(t, err, "Unable to parse URL")
+	sanitizedURL = sanitizeRequestURL(url)
+	assert.Equals(t, sanitizedURL, "http://localhost:4985/default/_oidc_callback?code=******&state=123456")
+
+	url, err = url.Parse("http://localhost:4985/default/_changes?since=5&feed=longpoll")
+	assertNoError(t, err, "Unable to parse URL")
+	sanitizedURL = sanitizeRequestURL(url)
+	assert.Equals(t, sanitizedURL, "http://localhost:4985/default/_changes?since=5&feed=longpoll")
+
+	// Ensure matching non-parameters aren't getting sanitized
+	url, err = url.Parse("http://localhost:4985/default/doctokencode")
+	assertNoError(t, err, "Unable to parse URL")
+	sanitizedURL = sanitizeRequestURL(url)
+	assert.Equals(t, sanitizedURL, "http://localhost:4985/default/doctokencode")
+
+	url, err = url.Parse("http://localhost:4985/default/doctoken=code=")
+	assertNoError(t, err, "Unable to parse URL")
+	sanitizedURL = sanitizeRequestURL(url)
+	assert.Equals(t, sanitizedURL, "http://localhost:4985/default/doctoken=code=")
+}


### PR DESCRIPTION
Changes query string parameters named 'code' or including 'token' to show values as ******.

Fixes #1880

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1915)

<!-- Reviewable:end -->
