### PR TITLE
Lock build repo to SHA for 1.3.0 release

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -19,7 +19,7 @@
   <default remote="couchbase" revision="master"/>
 
   <!-- Build Scripts (required on CI servers) -->
-  <project name="build" path="cbbuild" remote="couchbase">
+  <project name="build" path="cbbuild" remote="couchbase" revision="99819ed7a41654b838e2422da8de55153b40432c">
     <annotation name="VERSION" value="1.3.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
This is will prevent build triggered due to build repo changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1918)

<!-- Reviewable:end -->
