### PR TITLE
Issue #1925: Obscure HTTP basic auth credentials in webhook URLs

### DIFF
--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"time"
 )
 
@@ -31,6 +32,9 @@ type Webhook struct {
 
 // default HTTP post timeout
 const kDefaultWebhookTimeout = 60
+
+// used to match the HTTP basic auth component of a URL
+var kBasicAuthUrlRegexp = regexp.MustCompilePOSIX(`:\/\/[^:/]+:[^@/]+@`)
 
 // Creates a new webhook handler based on the url and filter function.
 func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, error) {
@@ -135,5 +139,8 @@ func (wh *Webhook) HandleEvent(event Event) {
 }
 
 func (wh *Webhook) String() string {
-	return fmt.Sprintf("Webhook handler [%s]", wh.url)
+	// Basic auth credentials may have been included in the URL, in which case obscure them
+	sanitizedUrl := kBasicAuthUrlRegexp.ReplaceAllLiteralString(wh.url, "://****:****@")
+
+	return fmt.Sprintf("Webhook handler [%s]", sanitizedUrl)
 }

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -128,19 +128,21 @@ func (wh *Webhook) HandleEvent(event Event) {
 		}()
 
 		if err != nil {
-			base.Warn("Error attempting to post to url %s: %s -- %+v", wh.url, err)
+			base.Warn("Error attempting to post to url %s: %s -- %+v", wh.SanitizedUrl(), err)
 			return
 		}
 
 		base.LogTo("Events+", "Webhook handler ran for event.  Payload %s posted to URL %s, got status %s",
-			payload, wh.url, resp.Status)
+			payload, wh.SanitizedUrl(), resp.Status)
 	}()
 
 }
 
 func (wh *Webhook) String() string {
-	// Basic auth credentials may have been included in the URL, in which case obscure them
-	sanitizedUrl := kBasicAuthUrlRegexp.ReplaceAllLiteralString(wh.url, "://****:****@")
+	return fmt.Sprintf("Webhook handler [%s]", wh.SanitizedUrl())
+}
 
-	return fmt.Sprintf("Webhook handler [%s]", sanitizedUrl)
+func (wh *Webhook) SanitizedUrl() string {
+	// Basic auth credentials may have been included in the URL, in which case obscure them
+	return kBasicAuthUrlRegexp.ReplaceAllLiteralString(wh.url, "://****:****@")
 }

--- a/db/event_handler_test.go
+++ b/db/event_handler_test.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"github.com/couchbaselabs/go.assert"
+	"testing"
+)
+
+func TestWebhookString(t *testing.T) {
+	var wh *Webhook
+
+	wh = &Webhook {
+		url: "http://username:password@example.com/foo",
+	}
+	assert.Equals(t, wh.String(), "Webhook handler [http://****:****@example.com/foo]")
+
+	wh = &Webhook {
+		url: `https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar`,
+	}
+	assert.Equals(t, wh.String(), "Webhook handler [https://****:****@example.com:8888/bar]")
+
+	wh = &Webhook {
+		url: "http://example.com:9000/baz",
+	}
+	assert.Equals(t, wh.String(), "Webhook handler [http://example.com:9000/baz]")
+
+	wh = &Webhook {
+		url: "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
+	}
+	assert.Equals(t, wh.String(), "Webhook handler [https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux]")
+}

--- a/db/event_handler_test.go
+++ b/db/event_handler_test.go
@@ -14,17 +14,21 @@ func TestWebhookString(t *testing.T) {
 	assert.Equals(t, wh.String(), "Webhook handler [http://****:****@example.com/foo]")
 
 	wh = &Webhook {
-		url: `https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar`,
-	}
-	assert.Equals(t, wh.String(), "Webhook handler [https://****:****@example.com:8888/bar]")
-
-	wh = &Webhook {
 		url: "http://example.com:9000/baz",
 	}
 	assert.Equals(t, wh.String(), "Webhook handler [http://example.com:9000/baz]")
+}
+
+func TestSanitizedUrl(t *testing.T) {
+	var wh *Webhook
+
+	wh = &Webhook {
+		url: "https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar",
+	}
+	assert.Equals(t, wh.SanitizedUrl(), "https://****:****@example.com:8888/bar")
 
 	wh = &Webhook {
 		url: "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
 	}
-	assert.Equals(t, wh.String(), "Webhook handler [https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux]")
+	assert.Equals(t, wh.SanitizedUrl(), "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux")
 }


### PR DESCRIPTION
A webhook event's URL may have HTTP basic auth credentials embedded directly into it (e.g. `http://username:password@example.com/events`), which was, but is no longer, exposed as plain text when the webhook is included in a log message (e.g. when the webhook is first registered or a webhook event is processed). Instead the username-and-password component of a webhook's URL is now obscured with asterisks (e.g. `http://****:****@example.com/events`) when it is converted to a string.

While it may have been simplest to remove the webhook URL from such log messages altogether, I thought it best to leave it in but in a sanitized format so that it's possible to distinguish between different event types when a bucket/database has more than one webhook enabled. Otherwise webhook events are effectively indistinguishable from each other without the URL.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1932)

<!-- Reviewable:end -->
