### PR TITLE
OIDC compatibility enhancements

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -347,7 +347,7 @@ func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider,
 		return nil, jwt, identityErr
 	}
 
-	username := auth.getOIDCUsername(provider, identity.ID)
+	username := GetOIDCUsername(provider, identity.ID)
 	base.LogTo("OIDC+", "OIDCUsername: %v", username)
 
 	user, userErr := auth.GetUser(username)
@@ -381,10 +381,6 @@ func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider,
 	}
 
 	return user, jwt, nil
-}
-
-func (auth *Authenticator) getOIDCUsername(provider *OIDCProvider, subject string) string {
-	return fmt.Sprintf("%s_%s", provider.UserPrefix, subject)
 }
 
 // Registers a new user account based on the given verified email address.

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -139,12 +139,13 @@ func (op *OIDCProvider) InitOIDCClient() error {
 			providerLoaded = true
 			break
 		}
-		base.LogTo("OIDC", "Unable to fetch provider config from discovery endpoint for %s (attempt %v/%v): %v",
+		base.LogTo("OIDC+", "Unable to fetch provider config from discovery endpoint for %s (attempt %v/%v): %v",
 			op.Issuer, i, retryCount, err)
-		time.Sleep(1 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	if !providerLoaded {
+		base.Warn("Unable to retrieve and validate config from discovery endpoint based on issuer %s", op.Issuer)
 		return fmt.Errorf("Unable to fetch provider - OIDC unavailable")
 	}
 

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -10,7 +10,7 @@
 package auth
 
 import (
-	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,9 +18,14 @@ import (
 	"sync"
 	"time"
 
+	phttp "github.com/coreos/go-oidc/http"
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
+)
+
+const (
+	discoveryConfigPath = "/.well-known/openid-configuration"
 )
 
 // Options for OpenID Connect
@@ -31,19 +36,21 @@ type OIDCOptions struct {
 
 type OIDCProvider struct {
 	JWTOptions
-	Issuer             string   `json:"issuer"`                    // OIDC Issuer
-	Register           bool     `json:"register"`                  // If true, server will register new user accounts
-	ClientID           *string  `json:"client_id,omitempty"`       // Client ID
-	ValidationKey      *string  `json:"validation_key,omitempty"`  // Client secret
-	CallbackURL        *string  `json:"callback_url,omitempty"`    // Sync Gateway redirect URL.  Needs to be specified to handle load balancer endpoints?  Or can we lazy load on first client use, based on request
-	DisableSession     bool     `json:"disable_session,omitempty"` // Disable Sync Gateway session creation on successful OIDC authentication
-	Scope              []string `json:"scope,omitempty"`           // Scope sent for openid request
-	IncludeAccessToken bool     `json:"include_access,omitempty"`  // Whether the _oidc_callback response should include OP access token and associated fields (token_type, expires_in)
-	UserPrefix         string   `json:"user_prefix,omitempty"`     // Username prefix for users created for this provider
-	OIDCClient         *oidc.Client
-	OIDCClientOnce     sync.Once
-	IsDefault          bool
-	Name               string
+	Issuer                  string   `json:"issuer"`                           // OIDC Issuer
+	Register                bool     `json:"register"`                         // If true, server will register new user accounts
+	ClientID                *string  `json:"client_id,omitempty"`              // Client ID
+	ValidationKey           *string  `json:"validation_key,omitempty"`         // Client secret
+	CallbackURL             *string  `json:"callback_url,omitempty"`           // Sync Gateway redirect URL.  Needs to be specified to handle load balancer endpoints?  Or can we lazy load on first client use, based on request
+	DisableSession          bool     `json:"disable_session,omitempty"`        // Disable Sync Gateway session creation on successful OIDC authentication
+	Scope                   []string `json:"scope,omitempty"`                  // Scope sent for openid request
+	IncludeAccessToken      bool     `json:"include_access,omitempty"`         // Whether the _oidc_callback response should include OP access token and associated fields (token_type, expires_in)
+	UserPrefix              string   `json:"user_prefix,omitempty"`            // Username prefix for users created for this provider
+	DiscoveryURI            string   `json:"discovery_url,omitempty"`          // Non-standard discovery endpoints
+	DisableConfigValidation bool     `json:"disable_cfg_validation,omitempty"` // Bypasses config validation based on the OIDC spec.  Required for some OPs that don't strictly adhere to spec (eg. Yahoo)
+	OIDCClient              *oidc.Client
+	OIDCClientOnce          sync.Once
+	IsDefault               bool
+	Name                    string
 }
 
 type OIDCProviderMap map[string]*OIDCProvider
@@ -115,38 +122,24 @@ func (op *OIDCProvider) InitUserPrefix() error {
 	op.UserPrefix = issuerURL.Host + issuerURL.Path
 
 	// If the prefix contains forward slash or underscore, it's not valid as-is for a username: forward slash
-	// breaks the REST API, underscore breaks uniqueness of "[prefix]_[sub]".  MD5 hash the prefix in this
-	// scenario.
-	if strings.ContainsAny(op.UserPrefix, "/_") {
-		op.UserPrefix = fmt.Sprintf("%x", md5.Sum([]byte(op.UserPrefix)))
-	}
+	// breaks the REST API, underscore breaks uniqueness of "[prefix]_[sub]".  URL encode the prefix to cover
+	// this scenario
+
+	op.UserPrefix = url.QueryEscape(op.UserPrefix)
+
 	return nil
 }
 
 func (op *OIDCProvider) InitOIDCClient() error {
 
-	var config oidc.ProviderConfig
-	var err error
 	if op.Issuer == "" {
 		return fmt.Errorf("Issuer not defined for OpenID Connect provider %+v", op)
 	}
-	base.LogTo("OIDC", "Attempting to fetch provider config from discovery endpoint for issuer %s...", op.Issuer)
-	retryCount := 5
-	var providerLoaded bool
-	for i := 1; i <= 5; i++ {
-		config, err = oidc.FetchProviderConfig(http.DefaultClient, op.Issuer)
-		if err == nil {
-			providerLoaded = true
-			break
-		}
-		base.LogTo("OIDC+", "Unable to fetch provider config from discovery endpoint for %s (attempt %v/%v): %v",
-			op.Issuer, i, retryCount, err)
-		time.Sleep(500 * time.Millisecond)
-	}
 
-	if !providerLoaded {
-		base.Warn("Unable to retrieve and validate config from discovery endpoint based on issuer %s", op.Issuer)
-		return fmt.Errorf("Unable to fetch provider - OIDC unavailable")
+	config, shouldSyncConfig, err := op.DiscoverConfig()
+	if err != nil || config == nil {
+		base.Warn("Error during OIDC discovery - unable to initialize client: %v", err)
+		return err
 	}
 
 	clientCredentials := oidc.ClientCredentials{
@@ -157,7 +150,7 @@ func (op *OIDCProvider) InitOIDCClient() error {
 	}
 
 	clientConfig := oidc.ClientConfig{
-		ProviderConfig: config,
+		ProviderConfig: *config,
 		Credentials:    clientCredentials,
 		RedirectURL:    *op.CallbackURL,
 	}
@@ -174,7 +167,10 @@ func (op *OIDCProvider) InitOIDCClient() error {
 	}
 
 	// Start process for ongoing sync of the provider config
-	op.OIDCClient.SyncProviderConfig(op.Issuer)
+	if shouldSyncConfig {
+		base.LogTo("OIDC", "Not synchronizing provider config for issuer %s...", op.Issuer)
+		op.OIDCClient.SyncProviderConfig(op.Issuer)
+	}
 
 	// Initialize the prefix for users created for this provider
 	if err = op.InitUserPrefix(); err != nil {
@@ -182,6 +178,85 @@ func (op *OIDCProvider) InitOIDCClient() error {
 	}
 
 	return nil
+}
+
+func (op *OIDCProvider) DiscoverConfig() (config *oidc.ProviderConfig, shouldSync bool, err error) {
+
+	// If discovery URI is explicitly defined, use it instead of the standard issuer-based discovery.
+
+	if op.DiscoveryURI != "" || op.DisableConfigValidation {
+		config, err = op.FetchCustomProviderConfig(op.DiscoveryURI)
+		shouldSync = false
+	} else {
+
+		var standardConfig oidc.ProviderConfig
+		maxRetryAttempts := 5
+		for i := 1; i <= maxRetryAttempts; i++ {
+			standardConfig, err = oidc.FetchProviderConfig(http.DefaultClient, op.Issuer)
+			if err == nil {
+				config = &standardConfig
+				shouldSync = true
+				break
+			}
+			base.LogTo("OIDC+", "Unable to fetch provider config from discovery endpoint for %s (attempt %v/%v): %v",
+				op.Issuer, i, maxRetryAttempts, err)
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+
+	return config, shouldSync, err
+}
+
+func (op *OIDCProvider) FetchCustomProviderConfig(discoveryURL string) (*oidc.ProviderConfig, error) {
+
+	var customConfig OidcProviderConfiguration
+
+	// If discovery URL is empty, use the standard discovery URL
+	if discoveryURL == "" {
+		discoveryURL = strings.TrimSuffix(op.Issuer, "/") + discoveryConfigPath
+	}
+
+	base.LogTo("OIDC+", "Fetching custom provider config from %s", discoveryURL)
+	req, err := http.NewRequest("GET", discoveryURL, nil)
+	if err != nil {
+		base.LogTo("OIDC+", "Error building new request for URL %s: %v", discoveryURL, err)
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		base.LogTo("OIDC+", "Error invoking calling discovery URL %s: %v", discoveryURL, err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&customConfig); err != nil {
+		base.LogTo("OIDC+", "Error parsing body %s: %v", discoveryURL, err)
+		return nil, err
+	}
+
+	var oidcConfig oidc.ProviderConfig
+	oidcConfig, err = customConfig.AsProviderConfig()
+	if err != nil {
+		base.LogTo("OIDC+", "Error invoking calling discovery URL %s: %v", discoveryURL, err)
+		return nil, err
+	}
+
+	// Set expiry on config, if defined in response header
+	var ttl time.Duration
+	var ok bool
+	ttl, ok, err = phttp.Cacheable(resp.Header)
+	if err != nil {
+		return nil, err
+	} else if ok {
+		oidcConfig.ExpiresAt = time.Now().UTC().Add(ttl)
+	}
+
+	base.LogTo("OIDC+", "Returning config: %v", oidcConfig)
+	return &oidcConfig, nil
+
+}
+
+func GetOIDCUsername(provider *OIDCProvider, subject string) string {
+	return fmt.Sprintf("%s_%s", provider.UserPrefix, url.QueryEscape(subject))
 }
 
 // Converts an OpenID Connect / OAuth2 error to an HTTP error

--- a/auth/oidc_provider.go
+++ b/auth/oidc_provider.go
@@ -1,0 +1,142 @@
+//  Copyright (c) 2016 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/coreos/go-oidc/oidc"
+)
+
+type OidcProviderConfiguration struct {
+	Issuer                 string   `json:"issuer"`
+	AuthEndpoint           string   `json:"authorization_endpoint"`
+	TokenEndpoint          string   `json:"token_endpoint"`
+	JwksUri                string   `json:"jwks_uri"`
+	UserInfoEndpoint       string   `json:"userinfo_endpoint,omitempty"`
+	RegistrationEndpoint   string   `json:"registration_endpoint,omitempty"`
+	ResponseTypesSupported []string `json:"response_types_supported,omitempty"`
+	SubjectTypesSupported  []string `json:"subject_types_supported,omitempty"`
+	ItsaValuesSupported    []string `json:"id_token_signing_alg_values_supported,omitempty"`
+	ScopesSupported        []string `json:"scopes_supported,omitempty"`
+	AuthMethodsSupported   []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	ClaimsSupported        []string `json:"claims_supported,omitempty"`
+
+	ResponseModesSupported []string `json:"response_modes_supported,omitempty"`
+	GrantTypesSupported    []string `json:"grant_types_supported,omitempty"`
+	ACRValuesSupported     []string `json:"acr_values_supported,omitempty"`
+
+	IDTokenSigningAlgValues     []string `json:"id_token_signing_alg_values_supported,omitempty"`
+	IDTokenEncryptionAlgValues  []string `json:"id_token_encryption_alg_values_supported,omitempty"`
+	IDTokenEncryptionEncValues  []string `json:"id_token_encryption_enc_values_supported,omitempty"`
+	UserInfoSigningAlgValues    []string `json:"userinfo_signing_alg_values_supported,omitempty"`
+	UserInfoEncryptionAlgValues []string `json:"userinfo_encryption_alg_values_supported,omitempty"`
+	UserInfoEncryptionEncValues []string `json:"userinfo_encryption_enc_values_supported,omitempty"`
+	ReqObjSigningAlgValues      []string `json:"request_object_signing_alg_values_supported,omitempty"`
+	ReqObjEncryptionAlgValues   []string `json:"request_object_encryption_alg_values_supported,omitempty"`
+	ReqObjEncryptionEncValues   []string `json:"request_object_encryption_enc_values_supported,omitempty"`
+
+	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported,omitempty"`
+
+	DisplayValuesSupported        []string `json:"display_values_supported,omitempty"`
+	ClaimTypesSupported           []string `json:"claim_types_supported,omitempty"`
+	ServiceDocs                   string   `json:"service_documentation,omitempty"`
+	ClaimsLocalsSupported         []string `json:"claims_locales_supported,omitempty"`
+	UILocalsSupported             []string `json:"ui_locales_supported,omitempty"`
+	ClaimsParameterSupported      bool     `json:"claims_parameter_supported,omitempty"`
+	RequestParameterSupported     bool     `json:"request_parameter_supported,omitempty"`
+	RequestURIParamaterSupported  bool     `json:"request_uri_parameter_supported,omitempty"`
+	RequireRequestURIRegistration bool     `json:"require_request_uri_registration,omitempty"`
+
+	Policy         string `json:"op_policy_uri,omitempty"`
+	TermsOfService string `json:"op_tos_uri,omitempty"`
+}
+
+// Converts a provider config (based on the OpenID Connect spec) to the type used by coreos/go-oidc.  Used to handle scenarios
+// where the provider doesn't adhere to spec.
+func (pc OidcProviderConfiguration) AsProviderConfig() (oidc.ProviderConfig, error) {
+	conf := oidc.ProviderConfig{
+		ScopesSupported:                            pc.ScopesSupported,
+		ResponseTypesSupported:                     pc.ResponseTypesSupported,
+		ResponseModesSupported:                     pc.ResponseModesSupported,
+		GrantTypesSupported:                        pc.GrantTypesSupported,
+		ACRValuesSupported:                         pc.ACRValuesSupported,
+		SubjectTypesSupported:                      pc.SubjectTypesSupported,
+		IDTokenSigningAlgValues:                    pc.IDTokenSigningAlgValues,
+		IDTokenEncryptionAlgValues:                 pc.IDTokenEncryptionAlgValues,
+		IDTokenEncryptionEncValues:                 pc.IDTokenEncryptionEncValues,
+		UserInfoSigningAlgValues:                   pc.UserInfoSigningAlgValues,
+		UserInfoEncryptionAlgValues:                pc.UserInfoEncryptionAlgValues,
+		UserInfoEncryptionEncValues:                pc.UserInfoEncryptionEncValues,
+		ReqObjSigningAlgValues:                     pc.ReqObjSigningAlgValues,
+		ReqObjEncryptionAlgValues:                  pc.ReqObjEncryptionAlgValues,
+		ReqObjEncryptionEncValues:                  pc.ReqObjEncryptionEncValues,
+		TokenEndpointAuthMethodsSupported:          pc.TokenEndpointAuthMethodsSupported,
+		TokenEndpointAuthSigningAlgValuesSupported: pc.TokenEndpointAuthSigningAlgValuesSupported,
+		DisplayValuesSupported:                     pc.DisplayValuesSupported,
+		ClaimTypesSupported:                        pc.ClaimTypesSupported,
+		ClaimsSupported:                            pc.ClaimsSupported,
+		ClaimsLocalsSupported:                      pc.ClaimsLocalsSupported,
+		UILocalsSupported:                          pc.UILocalsSupported,
+		ClaimsParameterSupported:                   pc.ClaimsParameterSupported,
+		RequestParameterSupported:                  pc.RequestParameterSupported,
+		RequestURIParamaterSupported:               pc.RequestURIParamaterSupported,
+		RequireRequestURIRegistration:              pc.RequireRequestURIRegistration,
+	}
+
+	var err error
+	if conf.Issuer, err = pc.parseURI(pc.Issuer); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.AuthEndpoint, err = pc.parseURI(pc.AuthEndpoint); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.TokenEndpoint, err = pc.parseURI(pc.TokenEndpoint); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.UserInfoEndpoint, err = pc.parseURI(pc.UserInfoEndpoint); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.KeysEndpoint, err = pc.parseURI(pc.JwksUri); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.RegistrationEndpoint, err = pc.parseURI(pc.RegistrationEndpoint); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.Policy, err = pc.parseURI(pc.Policy); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.Policy, err = pc.parseURI(pc.Policy); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.TermsOfService, err = pc.parseURI(pc.TermsOfService); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+	if conf.ServiceDocs, err = pc.parseURI(pc.ServiceDocs); err != nil {
+		return oidc.ProviderConfig{}, err
+	}
+
+	return conf, nil
+}
+
+func (pc *OidcProviderConfiguration) parseURI(s string) (*url.URL, error) {
+
+	u, err := url.Parse(s)
+	if err == nil {
+		if u.Host == "" {
+			return nil, fmt.Errorf("Host required in URI [%s]:", s)
+		} else if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("Invalid URI scheme [%s]:", s)
+		}
+	}
+	return u, nil
+}

--- a/auth/oidc_provider.go
+++ b/auth/oidc_provider.go
@@ -130,6 +130,9 @@ func (pc OidcProviderConfiguration) AsProviderConfig() (oidc.ProviderConfig, err
 
 func (pc *OidcProviderConfiguration) parseURI(s string) (*url.URL, error) {
 
+	if s == "" {
+		return nil, nil
+	}
 	u, err := url.Parse(s)
 	if err == nil {
 		if u.Host == "" {

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -1,0 +1,43 @@
+//  Copyright (c) 2016 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestOIDCUsername(t *testing.T) {
+
+	provider := OIDCProvider{
+		Issuer: "http://www.someprovider.com",
+	}
+
+	err := provider.InitUserPrefix()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, provider.UserPrefix, "www.someprovider.com")
+
+	oidcUsername := GetOIDCUsername(&provider, "bernard")
+	assert.Equals(t, oidcUsername, "www.someprovider.com_bernard")
+	assert.Equals(t, IsValidPrincipalName(oidcUsername), true)
+
+	oidcUsername = GetOIDCUsername(&provider, "{bernard}")
+	assert.Equals(t, oidcUsername, "www.someprovider.com_%7Bbernard%7D")
+	assert.Equals(t, IsValidPrincipalName(oidcUsername), true)
+
+	provider.UserPrefix = ""
+	provider.Issuer = "http://www.someprovider.com/extra"
+	err = provider.InitUserPrefix()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, provider.UserPrefix, "www.someprovider.com%2Fextra")
+	assert.Equals(t, IsValidPrincipalName(oidcUsername), true)
+
+}

--- a/auth/role.go
+++ b/auth/role.go
@@ -32,7 +32,7 @@ var kValidNameRegexp *regexp.Regexp
 
 func init() {
 	var err error
-	kValidNameRegexp, err = regexp.Compile(`^[-+.@\w]*$`)
+	kValidNameRegexp, err = regexp.Compile(`^[-+.@%\w]*$`)
 	if err != nil {
 		panic("Bad kValidNameRegexp")
 	}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -90,7 +90,7 @@
 
   <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="e6174c764e906bd60c76fdfc33faf5e0bdc875d6"/>
+  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
 
   <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/key"
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -80,19 +81,6 @@ type Page struct {
 	Query string
 }
 
-type OidcProviderConfiguration struct {
-	Issuer                 string   `json:"issuer"`
-	AuthEndpoint           string   `json:"authorization_endpoint"`
-	TokenEndpoint          string   `json:"token_endpoint"`
-	JwksUri                string   `json:"jwks_uri"`
-	ResponseTypesSupported []string `json:"response_types_supported"`
-	SubjectTypesSupported  []string `json:"subject_types_supported"`
-	ItsaValuesSupported    []string `json:"id_token_signing_alg_values_supported"`
-	ScopesSupported        []string `json:"scopes_supported"`
-	AuthMethodsSupported   []string `json:"token_endpoint_auth_methods_supported"`
-	ClaimsSupported        []string `json:"claims_supported"`
-}
-
 type AuthState struct {
 	CallbackURL string
 	TokenTTL    time.Duration
@@ -112,7 +100,7 @@ func (h *handler) handleOidcProviderConfiguration() error {
 	issuerUrl := issuerUrl(h)
 	base.LogTo("OIDC+", "handleOidcProviderConfiguration issuerURL = %s", issuerUrl)
 
-	config := &OidcProviderConfiguration{
+	config := &auth.OidcProviderConfiguration{
 		Issuer:                 issuerUrl,
 		AuthEndpoint:           fmt.Sprintf("%s/%s", issuerUrl, "authorize"),
 		TokenEndpoint:          fmt.Sprintf("%s/%s", issuerUrl, "token"),

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -25,11 +25,13 @@ import (
 const dbRegex = "[^_/][^/]*"
 const docRegex = "[^_/][^/]*"
 
-// Regex that matches a URI containing a regular doc ID with an escaped "/" character
+// Regex that matches a URI containing either:
+//  - A regular doc ID with an escaped "/" character
+//  - A user name with an escaped "/" character
 var docWithSlashPathRegex *regexp.Regexp
 
 func init() {
-	docWithSlashPathRegex, _ = regexp.Compile("/" + dbRegex + "/[^_].*%2[fF]")
+	docWithSlashPathRegex, _ = regexp.Compile("/" + dbRegex + "/([^_]|_user/).*%2[fF]")
 }
 
 // Creates a GorillaMux router containing the basic HTTP handlers for a server.


### PR DESCRIPTION
Adds handling for providers that don't strictly adhere to the OIDC spec, by allowing users to disable OIDC config validation (in the SG config).  Setting the `discovery` property in the SG config allows users to define an OIDC discovery endpoint at a location other than `[issuer]/.well-known/openid-configuration`, and disables strict config validation.  Fixes #1921.  
Setting the 'disable_cfg_validation` property allows users to bypass strict validation in other scenarios.  Fixes #1922.

Adds handling for the case where the OIDC subject or issuer contains characters not usually supported in username - URL encodes the username string in this scenario.   Includes addition of `%` to the set of valid username characters, and handling for escaped slashes in requests to the /db/_user endpoint. Fixes #1926

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1937)

<!-- Reviewable:end -->
