### PR TITLE
Remove new feature dependencies not available in lower rpm version to maintain backward compatibility

### DIFF
--- a/build/package-rpm.rb
+++ b/build/package-rpm.rb
@@ -59,7 +59,7 @@ Dir.chdir("#{START_DIR}") do
     sh %{tar --directory #{File.dirname(PREFIXD)} -czf "#{STAGE_DIR}/rpmbuild/SOURCES/#{PRODUCT}_#{RELEASE}.tar.gz" #{File.basename(PREFIXD)}}
 end
 Dir.chdir("#{STAGE_DIR}") do
-    sh %{rpmbuild -bb rpm.spec}
+    sh %{rpmbuild -bb --define "_binary_filedigest_algorithm  1"  --define "_binary_payload 1" rpm.spec}
 end
 
 FileUtils.cp "#{STAGE_DIR}/rpmbuild/RPMS/#{ARCH}/#{PRODUCT}-#{RELEASE}-#{BLDNUM}.#{ARCH}.rpm", "#{PREFIXD}/#{PRODUCT}_#{PRODUCT_VERSION}_#{ARCH}.rpm"


### PR DESCRIPTION
This will allow us to build on Centos 7 and newer going forward.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1944)

<!-- Reviewable:end -->
