### PR TITLE
Do not use EncodedResponseWriter for WebSockets

### DIFF
--- a/rest/encoded_response_writer.go
+++ b/rest/encoded_response_writer.go
@@ -21,7 +21,10 @@ type EncodedResponseWriter struct {
 
 // Creates a new EncodedResponseWriter, or returns nil if the request doesn't allow encoded responses.
 func NewEncodedResponseWriter(response http.ResponseWriter, rq *http.Request) *EncodedResponseWriter {
-	if !strings.Contains(rq.Header.Get("Accept-Encoding"), "gzip") ||
+	isWebSocketRequest := strings.ToLower(rq.Header.Get("Upgrade")) == "websocket" &&
+		strings.Contains(strings.ToLower(rq.Header.Get("Connection")), "upgrade")
+
+	if isWebSocketRequest || !strings.Contains(rq.Header.Get("Accept-Encoding"), "gzip") ||
 		rq.Method == "HEAD" || rq.Method == "PUT" || rq.Method == "DELETE" {
 		return nil
 	}


### PR DESCRIPTION
Do not use EncodedResponseWriter if the current HTTP request is asking for a WebSocket upgrade, WebSockets us per message compression not whole response compression.

fixes #973

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/1945)

<!-- Reviewable:end -->
