### PR TITLE
if sg_binary_path does not point to a file, generate a new path

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -149,6 +149,10 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
         "raw",
     ]
 
+    #if sg_binary_path does not point to a file, generate a new path by starting with the location of sgcollect_info script
+    if not os.path.isfile(sg_binary_path):
+        sg_binary_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", os.path.basename(sg_binary_path))
+
     sg_pprof_url = "{}/_debug/pprof".format(sg_url)
 
     # make sure raw profile gz files end up in results dir

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -151,7 +151,13 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
 
     #if sg_binary_path does not point to a file, generate a new path by starting with the location of sgcollect_info script
     if not os.path.isfile(sg_binary_path):
-        sg_binary_path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", os.path.basename(sg_binary_path))
+        # the filename of the sg_binary without any path information, eg, "sync_gateway"
+        sg_binary_filename = os.path.basename(sg_binary_path)
+
+        # generate path to sync_gateway root folder relative to the location of this sgcollect_info binary (__file__)
+        root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+        sg_binary_path = os.path.join(root_path, "bin", sg_binary_filename)
 
     sg_pprof_url = "{}/_debug/pprof".format(sg_url)
 


### PR DESCRIPTION
if sg_binary_path does not point to a file, generate a new path by starting with the location of sgcollect_info script

fixes #1998

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2007)

<!-- Reviewable:end -->
