### PR TITLE
when running 'go tool pprof' quote the path to the SG binary

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -168,7 +168,7 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
         for format_type in format_types:
             out_filename = "{0}.{1}".format(profile_type, format_type)
             dest_path = os.path.join(os.environ["PPROF_TMPDIR"], out_filename)
-            cmd = "go tool pprof -{0} -seconds=5 {1} {2}/{3}".format(
+            cmd = 'go tool pprof -{0} -seconds=5 "{1}" {2}/{3}'.format(
                 format_type,
                 sg_binary_path,
                 sg_pprof_url,


### PR DESCRIPTION
when running 'go tool pprof' quote the path to the SG binary so that spaces in the path don't break the tool.

fixes #2011

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2012)

<!-- Reviewable:end -->
