### PR TITLE
Added retry loop when connecting to bucket and when inserting design docs

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -122,8 +122,8 @@ func ConnectToBucket(spec base.BucketSpec, callback func(bucket string, err erro
 	}
 
 	sleeper := base.CreateDoublingSleeperFunc(
-		20, //MaxNumRetries
-		5,  //InitialRetrySleepTimeMS
+		7, //MaxNumRetries approx 10 minutes total retry duration
+		5, //InitialRetrySleepTimeMS
 	)
 
 	description := fmt.Sprintf("Attempt to connect to bucket : %v", spec.BucketName)
@@ -570,8 +570,8 @@ func installViews(bucket base.Bucket) error {
 		}
 
 		sleeper := base.CreateDoublingSleeperFunc(
-			20, //MaxNumRetries
-			5,  //InitialRetrySleepTimeMS
+			6, //MaxNumRetries approx 5 minutes total retry duration
+			5, //InitialRetrySleepTimeMS
 		)
 
 		description := fmt.Sprintf("Attempt to install Couchbase design doc bucket : %v", designDocName)

--- a/db/database.go
+++ b/db/database.go
@@ -115,11 +115,25 @@ func ValidateDatabaseName(dbName string) error {
 
 // Helper function to open a Couchbase connection and return a specific bucket.
 func ConnectToBucket(spec base.BucketSpec, callback func(bucket string, err error)) (bucket base.Bucket, err error) {
-	bucket, err = base.GetBucket(spec, callback)
+	//start a retry loop to connect to the bucket backing off double the delay each time
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		bucket, err = base.GetBucket(spec, callback)
+		return err != nil, err, bucket
+	}
+
+	sleeper := base.CreateDoublingSleeperFunc(
+		20, //MaxNumRetries
+		5,  //InitialRetrySleepTimeMS
+	)
+
+	description := fmt.Sprintf("Attempt to connect to bucket : %v", spec.BucketName)
+	err, ibucket := base.RetryLoop(description, worker, sleeper)
+
 	if err != nil {
 		err = base.HTTPErrorf(http.StatusBadGateway,
 			" Unable to connect to Couchbase Server (connection refused). Please ensure it is running and reachable at the configured host and port.  Detailed error: %s", err)
 	} else {
+		bucket, _ := ibucket.(base.Bucket)
 		err = installViews(bucket)
 	}
 	return
@@ -545,10 +559,25 @@ func installViews(bucket base.Bucket) error {
 
 	// add all design docs from map into bucket
 	for designDocName, designDoc := range designDocMap {
-		if err := bucket.PutDDoc(designDocName, designDoc); err != nil {
-			base.Warn("Error installing Couchbase design doc: %v", err)
-			return err
+
+		//start a retry loop to put design document backing off double the delay each time
+		worker := func() (shouldRetry bool, err error, value interface{}) {
+			err = bucket.PutDDoc(designDocName, designDoc)
+			if err != nil {
+				base.Warn("Error installing Couchbase design doc: %v", err)
+			}
+			return err != nil, err, nil
 		}
+
+		sleeper := base.CreateDoublingSleeperFunc(
+			20, //MaxNumRetries
+			5,  //InitialRetrySleepTimeMS
+		)
+
+		description := fmt.Sprintf("Attempt to install Couchbase design doc bucket : %v", designDocName)
+		err, _ := base.RetryLoop(description, worker, sleeper)
+
+		return err
 	}
 
 	return nil

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -357,7 +357,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 				//start a retry loop to pick up tap feed again backing off double the delay each time
 				worker := func() (shouldRetry bool, err error, value interface{}) {
-					err = dc.Bucket.Refresh()
+
+					//If DB is going online via an admin request Bucket will be nil
+					if dc.Bucket != nil {
+						err = dc.Bucket.Refresh()
+					} else {
+						err = base.HTTPErrorf(http.StatusPreconditionFailed, "Database %q is going _online", dbName)
+					}
+
 					return err != nil, err, nil
 				}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -362,7 +362,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 					if dc.Bucket != nil {
 						err = dc.Bucket.Refresh()
 					} else {
-						err = base.HTTPErrorf(http.StatusPreconditionFailed, "Database %q is going _online", dbName)
+						err = base.HTTPErrorf(http.StatusPreconditionFailed, "Database %q, bucket is no available", dbName)
 						return false, err, nil
 					}
 
@@ -370,8 +370,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 				}
 
 				sleeper := base.CreateDoublingSleeperFunc(
-					20, //MaxNumRetries
-					5,   //InitialRetrySleepTimeMS
+					7,  //MaxNumRetries approx 10 minutes total retry duration
+					5,  //InitialRetrySleepTimeMS
 				)
 
 				description := fmt.Sprintf("Attempt reconnect to lost TAP Feed for : %v", dc.Name)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -363,6 +363,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 						err = dc.Bucket.Refresh()
 					} else {
 						err = base.HTTPErrorf(http.StatusPreconditionFailed, "Database %q is going _online", dbName)
+						return false, err, nil
 					}
 
 					return err != nil, err, nil


### PR DESCRIPTION
Added retry loop when connecting to bucket and when inserting design docs. After the cluster config becomes available there is a further delay before buckets can be written to.

This can cause design docs to fail to be written to the bucket.

fixes #1745

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2020)

<!-- Reviewable:end -->
