### PR TITLE
Avoid notification problems due to user channel visibility

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -637,7 +637,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, cal
 				doc.RecentSequences = make([]uint64, 0, 1+len(unusedSequences))
 			}
 
-			if len(doc.RecentSequences) > 20 {
+			if len(doc.RecentSequences) > kMaxRecentSequences {
 				// Prune recent sequences that are earlier than the nextSequence.  The dedup window
 				// on the feed is small - sub-second, so we usually shouldn't care about more than
 				// a few recent sequences.  However, the pruning has some overhead (read lock on nextSequence),

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -863,12 +863,11 @@ func TestRecentSequenceHistory(t *testing.T) {
 	}
 
 	db.changeCache.waitForSequence(24)
-	time.Sleep(50 * time.Millisecond)
 	revid, err = db.Put("doc1", body)
 	doc, err = db.GetDoc("doc1")
 	assert.True(t, err == nil)
 	log.Printf("recent:%d, max:%d", len(doc.RecentSequences), kMaxRecentSequences)
-	assert.True(t, len(doc.RecentSequences) < kMaxRecentSequences)
+	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
 
 	// Ensure pruning works when sequences aren't sequential
 	doc2Body := Body{"val": "two"}
@@ -878,11 +877,11 @@ func TestRecentSequenceHistory(t *testing.T) {
 	}
 
 	db.changeCache.waitForSequence(64)
-	time.Sleep(50 * time.Millisecond)
 	revid, err = db.Put("doc1", body)
 	doc, err = db.GetDoc("doc1")
 	assert.True(t, err == nil)
-	assert.True(t, len(doc.RecentSequences) < kMaxRecentSequences)
+	log.Printf("Recent sequences: %v (shouldn't exceed %v)", len(doc.RecentSequences), kMaxRecentSequences)
+	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
 
 }
 

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -1,0 +1,152 @@
+//  Copyright (c) 2016 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+// This file contains tests which depend on the race detector being disabled.  Contains changes tests
+// that have unpredictable timing when running w/ race detector due to longpoll/continuous changes request
+// processing.
+// +build !race
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestChangesAccessNotifyInteger(t *testing.T) {
+
+	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`)
+	defer it.Close()
+
+	response := it.sendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "DIndex+":true}`)
+	assert.True(t, response != nil)
+
+	// Create user:
+	a := it.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("ABC"))
+	assert.True(t, err == nil)
+	a.Save(bernard)
+
+	// Put several documents in channel PBS
+	response = it.sendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.sendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.sendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	// Start longpoll changes request
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var changes struct {
+			Results  []db.ChangeEntry
+			Last_Seq db.SequenceID
+		}
+		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
+		changesResponse := it.send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		assert.Equals(t, len(changes.Results), 3)
+	}()
+
+	// Wait for changes to start.
+	time.Sleep(1 * time.Second)
+
+	// Put document that triggers access grant for user, PBS
+	response = it.sendAdminRequest("PUT", "/db/access1", `{"accessUser":"bernard", "accessChannel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	wg.Wait()
+}
+
+// Test for SG issue #1999.  Verify that the notify handling works as expected when the user specifies a channel filter that includes channels
+// the user doesn't have access to, where those channels have been updated more recently than the user and/or the valid channels.  Non-granted
+// channels in the filter were being included in the waiter initialization, but not in the subsequent wait.  Resulting difference in count was resulting
+// in longpoll terminating without any changes.
+func TestChangesNotifyChannelFilter(t *testing.T) {
+
+	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
+	defer it.Close()
+
+	response := it.sendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "Wait":true}`)
+	assert.True(t, response != nil)
+
+	// Create user:
+	userResponse := it.sendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["ABC"]}`)
+	assertStatus(t, userResponse, 201)
+
+	// Get user, to trigger all_channels calculation and bump the user change count BEFORE we write the PBS docs - otherwise the user key count
+	// will still be higher than the latest change count.
+	userResponse = it.sendAdminRequest("GET", "/db/_user/bernard", "")
+	assertStatus(t, userResponse, 200)
+
+	/*
+		a := it.ServerContext().Database("db").Authenticator()
+		bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("ABC"))
+		assert.True(t, err == nil)
+		a.Save(bernard)
+	*/
+
+	// Put several documents in channel PBS
+	response = it.sendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.sendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.sendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	// Run an initial changes request to get the user doc, and update since based on last_seq:
+	var initialChanges struct {
+		Results  []db.ChangeEntry
+		Last_Seq db.SequenceID
+	}
+	changesJSON := `{"style":"all_docs", 
+					 "heartbeat":300000, 
+					 "feed":"longpoll", 
+					 "limit":50, 
+					 "since":"%s",
+					 "filter":"sync_gateway/bychannel",
+					 "channels":"ABC,PBS"}`
+	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
+	changesResponse := it.send(requestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
+	err := json.Unmarshal(changesResponse.Body.Bytes(), &initialChanges)
+	lastSeq := initialChanges.Last_Seq.String()
+	assert.Equals(t, lastSeq, "1")
+
+	// Start longpoll changes request, requesting (unavailable) channel PBS.  Should block.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var changes struct {
+			Results  []db.ChangeEntry
+			Last_Seq db.SequenceID
+		}
+		sinceLastJSON := fmt.Sprintf(changesJSON, lastSeq)
+		changesResponse := it.send(requestByUser("POST", "/db/_changes", sinceLastJSON, "bernard"))
+		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		assert.Equals(t, len(changes.Results), 1)
+	}()
+
+	// Wait to see if the longpoll will terminate before a document shows up on the channel
+	time.Sleep(1 * time.Second)
+
+	// Put public document that triggers termination of the longpoll
+	response = it.sendAdminRequest("PUT", "/db/abc1", `{"value":3, "channel":["ABC"]}`)
+	assertStatus(t, response, 201)
+	wg.Wait()
+}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"sync"
 	"testing"
 	"time"
 
@@ -849,58 +848,6 @@ func changesActiveOnly(t *testing.T, it indexTester) {
 		}
 	}
 
-}
-
-func DisableTestChangesAccessNotifyInteger(t *testing.T) {
-
-	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`)
-	defer it.Close()
-	postChangesAccessNotify(t, it)
-}
-
-func postChangesAccessNotify(t *testing.T, it indexTester) {
-
-	response := it.sendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "DIndex+":true}`)
-	assert.True(t, response != nil)
-
-	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("ABC"))
-	assert.True(t, err == nil)
-	a.Save(bernard)
-
-	// Put several documents in channel PBS
-	response = it.sendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
-	assertStatus(t, response, 201)
-	response = it.sendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
-	assertStatus(t, response, 201)
-	response = it.sendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
-	assertStatus(t, response, 201)
-
-	// Start longpoll changes request
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		var changes struct {
-			Results  []db.ChangeEntry
-			Last_Seq db.SequenceID
-		}
-		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := it.send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.Equals(t, len(changes.Results), 3)
-	}()
-
-	// Wait for changes to start.  Unreliable as we don't know how long it will take the above goroutine to
-	// initialize the longpoll request when running under race - needs a better approach long-term
-	time.Sleep(1 * time.Second)
-
-	// Put document that triggers access grant for user, PBS
-	response = it.sendAdminRequest("PUT", "/db/access1", `{"accessUser":"bernard", "accessChannel":["PBS"]}`)
-	assertStatus(t, response, 201)
-
-	wg.Wait()
 }
 
 //////// HELPERS:


### PR DESCRIPTION
Apply the user visibility filter to the set of incoming channels before initializing the changeWaiter.  Avoids the scenario where specifically requested changes channels (e.g. using sync_gateway/bychannel filter) aren't available to the user, but cause the wait loop to short circuit (no data is sent to the user, but breaks out of wait loop anyway).

Fixes #1999.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2033)

<!-- Reviewable:end -->
