### PR TITLE
Do not require signature for trusted ID tokens

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -85,9 +85,14 @@ type DatabaseContextOptions struct {
 	OIDCOptions           *auth.OIDCOptions
 }
 
+type OidcTestProviderOptions struct {
+	Enabled         bool `json:"enabled,omitempty"`           // Whether the oidc_test_provider endpoints should be exposed on the public API
+	UnsignedIDToken bool `json:"unsigned_id_token,omitempty"` // Whether the internal test provider returns a signed ID token on a refresh request.  Used to simulate Azure behaviour
+}
+
 type UnsupportedOptions struct {
-	EnableUserViews        bool
-	EnableOidcTestProvider bool
+	EnableUserViews  bool
+	OidcTestProvider OidcTestProviderOptions
 }
 
 const DefaultRevsLimit = 1000

--- a/rest/config.go
+++ b/rest/config.go
@@ -198,16 +198,12 @@ type SequenceHashConfig struct {
 }
 
 type UnsupportedConfig struct {
-	UserViews        *UserViewsConfig        `json:"user_views,omitempty"`         // Config settings for user views
-	OidcTestProvider *OidcTestProviderConfig `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
+	UserViews        *UserViewsConfig            `json:"user_views,omitempty"`         // Config settings for user views
+	OidcTestProvider *db.OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
 }
 
 type UnsupportedServerConfig struct {
 	Http2Config *Http2Config `json:"http2,omitempty"` // Config settings for HTTP2
-}
-
-type OidcTestProviderConfig struct {
-	Enabled *bool `json:"enabled,omitempty"` // Whether the oidc_test_provider endpoints should be exposed on the public API
 }
 
 type UserViewsConfig struct {

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -131,7 +131,7 @@ func (h *handler) handleOIDCCallback() error {
 	}
 
 	// Create a Sync Gateway session
-	username, sessionID, err := h.createSessionForIdToken(tokenResponse.IDToken, provider)
+	username, sessionID, err := h.createSessionForTrustedIdToken(tokenResponse.IDToken, provider)
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (h *handler) handleOIDCRefresh() error {
 		return err
 	}
 
-	username, sessionID, err := h.createSessionForIdToken(tokenResponse.IDToken, provider)
+	username, sessionID, err := h.createSessionForTrustedIdToken(tokenResponse.IDToken, provider)
 	if err != nil {
 		return err
 	}
@@ -200,9 +200,9 @@ func (h *handler) handleOIDCRefresh() error {
 	return nil
 }
 
-func (h *handler) createSessionForIdToken(idToken string, provider *auth.OIDCProvider) (username string, sessionID string, err error) {
+func (h *handler) createSessionForTrustedIdToken(idToken string, provider *auth.OIDCProvider) (username string, sessionID string, err error) {
 
-	user, jwt, err := h.db.Authenticator().AuthenticateJWTForProvider(idToken, provider, h.getOIDCCallbackURL)
+	user, jwt, err := h.db.Authenticator().AuthenticateTrustedJWT(idToken, provider, h.getOIDCCallbackURL)
 	if err != nil {
 		return "", "", err
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -363,7 +363,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 				sleeper := base.CreateDoublingSleeperFunc(
 					20, //MaxNumRetries
-					5,   //InitialRetrySleepTimeMS
+					5,  //InitialRetrySleepTimeMS
 				)
 
 				description := fmt.Sprintf("Attempt reconnect to lost TAP Feed for : %v", dc.Name)
@@ -464,11 +464,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 				unsupportedOptions.EnableUserViews = *config.Unsupported.UserViews.Enabled
 			}
 		}
-		if config.Unsupported.OidcTestProvider != nil {
-			if config.Unsupported.OidcTestProvider.Enabled != nil {
-				unsupportedOptions.EnableOidcTestProvider = *config.Unsupported.OidcTestProvider.Enabled
-			}
-		}
+		unsupportedOptions.OidcTestProvider = *config.Unsupported.OidcTestProvider
 	}
 
 	// Enable doc tracking if needed for autoImport or shadowing


### PR DESCRIPTION
OPs may return unsigned tokens in response to a token request made by Sync Gateway (auth code or refresh flows).  These tokens will be invalid for client authentication (via bearer token), but when received from the token endpoint can be treated as valid identity confirmation.  In this scenario, create and return a valid session to the client.  The unsigned token is also returned to the client, as it may still be useful to client applications (extracting claim information).

The test provider is enhanced to simulate this scenario, by setting the unsigned_id_token property in the SG config:

```
        "unsupported": {
          "oidc_test_provider": {
            "enabled":true,
            "unsigned_id_token":true
          }
        }
```

Fixes #2013

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2043)

<!-- Reviewable:end -->
