### PR TITLE
Bucket authentication fix when starting DCP feed

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -158,8 +158,7 @@ func (bucket CouchbaseBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket
 	// Uses tap by default, unless DCP is explicitly specified
 	switch bucket.spec.FeedType {
 	case DcpFeedType:
-		Warn("DCP feed type disabled due to https://github.com/couchbase/sync_gateway/issues/1406.  Reverting to TAP mode")
-		return bucket.StartCouchbaseTapFeed(args)
+		return bucket.StartDCPFeed(args)
 
 	case DcpShardFeedType:
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -313,10 +313,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		PoolName:   pool,
 		BucketName: bucketName,
 		FeedType:   feedType,
-	}
-
-	if config.Username != "" {
-		spec.Auth = config
+		Auth:       config,
 	}
 
 	// Set cache properties, if present


### PR DESCRIPTION
Sync Gateway configs that didn't explicitly set a username weren't setting the Auth in the bucket spec, and so weren't using the default auth handling (TransformBucketCredentials, via config.GetCredentials).  In particular, this handling is required to set username=bucketname when the username isn't specified.

Fixes #1406.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2081)

<!-- Reviewable:end -->
