### PR TITLE
Added event.String() into error message when webhook fails to send

### DIFF
--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -128,7 +128,7 @@ func (wh *Webhook) HandleEvent(event Event) {
 		}()
 
 		if err != nil {
-			base.Warn("Error attempting to post to url %s: %s -- %+v", wh.SanitizedUrl(), err)
+			base.Warn("Error attempting to post %s to url %s: %s -- %+v", event.String(), wh.SanitizedUrl(), err)
 			return
 		}
 


### PR DESCRIPTION
Added event.String() into error message when webhook fails to send, to give context to the error message

fixes #2060

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2082)

<!-- Reviewable:end -->
