### PR TITLE
reported product name is now set by build

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -28,7 +28,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
-const ServerName = "Couchbase Sync Gateway"          // DO NOT CHANGE; clients check this
+const ServerName = "@PRODUCT_NAME@"                   // DO NOT CHANGE; clients check this
 const VersionNumber float64 = 1.4                    // API/feature level
 const VersionBuildNumberString = "@PRODUCT_VERSION@" // Real string substituted by Gerrit
 const VersionCommitSHA = "@COMMIT_SHA@"              // Real string substituted by Gerrit
@@ -41,6 +41,9 @@ var VersionString string
 
 // This includes build number; appears in the response of "GET /" and the initial log message
 var LongVersionString string
+
+// Either comes from Gerrit (jenkins builds) or Git (dev builds)
+var ProductName string
 
 func init() {
 	if VersionBuildNumberString[0] != '@' {
@@ -55,9 +58,11 @@ func init() {
 			ServerName, BuildVersionString, BuildNumberString, VersionCommitSHA)
 
 		VersionString = fmt.Sprintf("%s/%s", ServerName, BuildVersionString)
+		ProductName = ServerName
 	} else {
-		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s)", ServerName, GitBranch, GitCommit, GitDirty)
-		VersionString = fmt.Sprintf("%s/%g branch/%s commit/%.7s%s", ServerName, VersionNumber, GitBranch, GitCommit, GitDirty)
+		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s)", GitProductName, GitBranch, GitCommit, GitDirty)
+		VersionString = fmt.Sprintf("%s/%g branch/%s commit/%.7s%s", GitProductName, VersionNumber, GitBranch, GitCommit, GitDirty)
+		ProductName = GitProductName
 	}
 }
 
@@ -66,7 +71,7 @@ func (h *handler) handleRoot() error {
 	response := map[string]interface{}{
 		"couchdb": "Welcome",
 		"version": LongVersionString,
-		"vendor":  db.Body{"name": ServerName, "version": VersionNumber},
+		"vendor":  db.Body{"name": ProductName, "version": VersionNumber},
 	}
 	if h.privs == adminPrivs {
 		response["ADMIN"] = true

--- a/rest/git_info.go
+++ b/rest/git_info.go
@@ -1,7 +1,7 @@
 package rest
 
 // The git commit that was compiled. This will be filled in by the compiler.
-const GitProjectName = ""
+const GitProductName = ""
 const GitCommit = ""
 const GitBranch = ""
 const GitDirty = ""

--- a/rest/git_info.go
+++ b/rest/git_info.go
@@ -1,6 +1,7 @@
 package rest
 
 // The git commit that was compiled. This will be filled in by the compiler.
+const GitProjectName = ""
 const GitCommit = ""
 const GitBranch = ""
 const GitDirty = ""

--- a/set-version-stamp.sh
+++ b/set-version-stamp.sh
@@ -11,7 +11,7 @@ git update-index --assume-unchanged ${BUILD_INFO}
 
 # Escape forward slash's so sed command does not get confused
 # We use thses in feature branches e.g. feature/issue_nnn
-PRODUCT_NAME=`echo "Couchbase Sync Gateway"`
+PRODUCT_NAME="Couchbase Sync Gateway"
 GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\.\.\..*$//' | sed 's/\\//\\\\\//g' | sed 's/[[:space:]]//g'`
 GIT_COMMIT=`git rev-parse HEAD`
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)

--- a/set-version-stamp.sh
+++ b/set-version-stamp.sh
@@ -11,10 +11,12 @@ git update-index --assume-unchanged ${BUILD_INFO}
 
 # Escape forward slash's so sed command does not get confused
 # We use thses in feature branches e.g. feature/issue_nnn
+PRODUCT_NAME=`echo "Couchbase Sync Gateway"`
 GIT_BRANCH=`git status -b -s | sed q | sed 's/## //' | sed 's/\.\.\..*$//' | sed 's/\\//\\\\\//g' | sed 's/[[:space:]]//g'`
 GIT_COMMIT=`git rev-parse HEAD`
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 
+sed -i.bak -e 's/GitProductName.*=.*/GitProductName = "'"$PRODUCT_NAME"'"/' $BUILD_INFO
 sed -i.bak -e 's/GitCommit.*=.*/GitCommit = "'$GIT_COMMIT'"/' $BUILD_INFO
 sed -i.bak -e 's/GitBranch.*=.*/GitBranch = "'$GIT_BRANCH'"/' $BUILD_INFO
 sed -i.bak -e 's/GitDirty.*=.*/GitDirty = "'$GIT_DIRTY'"/' $BUILD_INFO


### PR DESCRIPTION
reported product name is now set by build to accommodate both Sync Gateway and SG Accel

fixes #1462

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/couchbase/sync_gateway/2092)

<!-- Reviewable:end -->
