### PR TITLE
Prevent panic when null body sent to handlePutDoc

### DIFF
--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -252,6 +252,9 @@ func (h *handler) handlePutDoc() error {
 	if err != nil {
 		return err
 	}
+	if body == nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "Document Body is nil")
+	}
 	var newRev string
 
 	if h.getQuery("new_edits") != "false" {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -253,7 +253,7 @@ func (h *handler) handlePutDoc() error {
 		return err
 	}
 	if body == nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "Document Body is nil")
+		return base.HTTPErrorf(http.StatusBadRequest, "Document Body is empty")
 	}
 	var newRev string
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -253,7 +253,7 @@ func (h *handler) handlePutDoc() error {
 		return err
 	}
 	if body == nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "Document Body is empty")
+		return base.HTTPErrorf(http.StatusBadRequest, "Document body is empty")
 	}
 	var newRev string
 


### PR DESCRIPTION
Prevent panic when null body sent to handlePutDoc, now returns an error status 400

fixes #2102 
