### PR TITLE
Change ssh url to include git username

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -14,7 +14,7 @@
   <remote fetch="https://github.com/kardianos/" name="kardianos"/>
   <remote fetch="https://github.com/coreos/" name="coreos"/>
   <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
-  <remote fetch="ssh://github.com/couchbaselabs/" name="couchbaselabs_private" />
+  <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
   <default remote="couchbase" revision="master"/>
 


### PR DESCRIPTION
Fixes error:

Permission denied (publickey).
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
