### PR TITLE
Refactor functionality to sg_accel

### DIFF
--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -576,7 +576,7 @@ func LoadClockCounter(baseKey string, bucket Bucket) (uint64, error) {
 }
 
 // Index partitions for unit tests
-func SeedTestPartitionMap(bucket Bucket, numPartitions uint16) error {
+func SeedTestPartitionMap(bucket Bucket, numPartitions uint16) (PartitionStorageSet, error) {
 	maxVbNo := uint16(1024)
 	partitionDefs := make(PartitionStorageSet, numPartitions)
 	vbPerPartition := maxVbNo / numPartitions
@@ -595,8 +595,8 @@ func SeedTestPartitionMap(bucket Bucket, numPartitions uint16) error {
 	// Persist to bucket
 	value, err := json.Marshal(partitionDefs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	bucket.SetRaw(KIndexPartitionKey, 0, value)
-	return nil
+	return partitionDefs, nil
 }

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -98,11 +98,11 @@ type ChannelIndex interface {
 	Compact()
 }
 
-func (entry *LogEntry) isRemoved() bool {
+func (entry *LogEntry) IsRemoved() bool {
 	return entry.Flags&channels.Removed != 0
 }
 
-func (entry *LogEntry) setRemoved() {
+func (entry *LogEntry) SetRemoved() {
 	entry.Flags |= channels.Removed
 }
 

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -235,7 +235,7 @@ func (k *kvChangeIndexReader) GetChanges(channelName string, options ChangesOpti
 		base.Warn("Error obtaining channel reader (need partition index?) for channel %s", channelName)
 		return nil, err
 	}
-	changes, err := reader.getChanges(sinceClock)
+	changes, err := reader.GetChanges(sinceClock)
 	if err != nil {
 		base.LogTo("DIndex+", "No clock found for channel %s, assuming no entries in index", channelName)
 		return nil, nil

--- a/db/kv_channel_index_test.go
+++ b/db/kv_channel_index_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"log"
 	"testing"
 
@@ -45,12 +46,21 @@ func testOnChange(keys base.Set) {
 }
 
 func makeEntry(vbNo int, sequence int, removal bool) *LogEntry {
+	docId := fmt.Sprintf("doc_%d_%d", vbNo, sequence)
+	revId := "1-abcdef01234567890123456789"
+	return makeEntryForDoc(docId, revId, vbNo, sequence, removal)
+
+}
+
+func makeEntryForDoc(docId string, revId string, vbNo int, sequence int, removal bool) *LogEntry {
 	entry := LogEntry{
+		DocID:    docId,
+		RevID:    revId,
 		VbNo:     uint16(vbNo),
 		Sequence: uint64(sequence),
 	}
 	if removal {
-		entry.setRemoved()
+		entry.SetRemoved()
 	}
 	return &entry
 }
@@ -99,47 +109,6 @@ func TestIndexBlockStorage(t *testing.T) {
 	loadedEntries := newBlock.GetAllEntries()
 	assert.Equals(t, 5, len(loadedEntries))
 	log.Printf("Unmarshalled: %+v", loadedEntries)
-
-}
-
-func TestChannelIndexWrite(t *testing.T) {
-
-	context, channelIndex := testContextAndChannelIndex("ABC")
-	defer context.Close()
-	channelStorage, ok := channelIndex.channelStorage.(*BitFlagStorage)
-	assert.True(t, ok)
-
-	// Init block for sequence 100, partition 1
-	entry_5_100 := makeEntry(5, 100, false)
-
-	// Add entries
-	assertNoError(t, channelIndex.Add(entry_5_100), "Add entry 5_100")
-
-	log.Println("ADD COMPLETE")
-
-	// Reset the channel index to verify loading the block from the DB and validate contents
-	channelIndex = NewKvChannelIndex("ABC", context.Bucket, testPartitionMap(), testOnChange)
-	block := channelStorage.getIndexBlockForEntry(entry_5_100)
-	assert.Equals(t, len(block.GetAllEntries()), 1)
-
-	// Test CAS handling.  AnotherChannelIndex is another writer updating the same block in the DB.
-	anotherChannelIndex := NewKvChannelIndex("ABC", context.Bucket, testPartitionMap(), testOnChange)
-	anotherChannelStorage, ok := channelIndex.channelStorage.(*BitFlagStorage)
-
-	// Init block for sequence 100, partition 1
-	entry_5_101 := makeEntry(5, 101, false)
-	assertNoError(t, anotherChannelIndex.Add(entry_5_101), "Add entry 5_100")
-	log.Println("ADD 101 COMPLETE")
-
-	// Now send another update to the original index (which now has a stale cas/cache).  Ensure all three entries
-	// end up in the block.
-	entry_5_102 := makeEntry(5, 102, false)
-	channelIndex.Add(entry_5_102)
-
-	log.Println("ADD 102 COMPLETE")
-
-	block = anotherChannelStorage.getIndexBlockForEntry(entry_5_102)
-	assert.Equals(t, len(block.GetAllEntries()), 3)
 
 }
 
@@ -201,92 +170,6 @@ func TestAddPartitionSetMultiBlock(t *testing.T) {
 
 }
 */
-
-func TestAddSet(t *testing.T) {
-
-	context, channelIndex := testContextAndChannelIndex("ABC")
-	defer context.Close()
-	channelStorage, ok := channelIndex.channelStorage.(*BitFlagStorage)
-	assert.True(t, ok)
-
-	// Init entries across multiple partitions
-	entrySet := []*LogEntry{
-		makeEntry(5, 100, false),
-		makeEntry(5, 105, false),
-		makeEntry(7, 100, false),
-		makeEntry(50, 100, false),
-		makeEntry(75, 1001, false),
-	}
-	// Add entries
-	assertNoError(t, channelIndex.AddSet(entrySet), "Add entry set")
-
-	block := channelStorage.getIndexBlockForEntry(makeEntry(5, 100, false))
-	assert.Equals(t, len(block.GetAllEntries()), 3)
-	block = channelStorage.getIndexBlockForEntry(makeEntry(50, 100, false))
-	assert.Equals(t, len(block.GetAllEntries()), 1)
-	block = channelStorage.getIndexBlockForEntry(makeEntry(75, 1001, false))
-	assert.Equals(t, len(block.GetAllEntries()), 1)
-
-	// check non-existent entry
-	block = channelStorage.getIndexBlockForEntry(makeEntry(100, 1, false))
-	assert.Equals(t, len(block.GetAllEntries()), 0)
-
-}
-
-func TestAddSetMultiBlock(t *testing.T) {
-
-	context, channelIndex := testContextAndChannelIndex("ABC")
-	defer context.Close()
-	channelStorage, ok := channelIndex.channelStorage.(*BitFlagStorage)
-	assert.True(t, ok)
-
-	// Init entries across multiple partitions
-	entrySet := []*LogEntry{
-		makeEntry(5, 100, false),
-		makeEntry(5, 15000, false),
-		makeEntry(7, 100, false),
-		makeEntry(9, 100, false),
-		makeEntry(9, 25000, false),
-	}
-	// Add entries
-	assertNoError(t, channelIndex.AddSet(entrySet), "Add set")
-
-	block := channelStorage.getIndexBlockForEntry(makeEntry(5, 100, false))
-	assert.Equals(t, len(block.GetAllEntries()), 3) // 5_100, 7_100, 9_100
-	block = channelStorage.getIndexBlockForEntry(makeEntry(5, 15000, false))
-	assert.Equals(t, len(block.GetAllEntries()), 1) // 5_15000
-	block = channelStorage.getIndexBlockForEntry(makeEntry(9, 25000, false))
-	assert.Equals(t, len(block.GetAllEntries()), 1) // 9_25000
-
-}
-
-func TestSequenceClockWrite(t *testing.T) {
-
-	context, channelIndex := testContextAndChannelIndex("ABC")
-	defer context.Close()
-
-	// Init entries across multiple partitions
-	entrySet := []*LogEntry{
-		makeEntry(5, 100, false),
-		makeEntry(5, 15000, false),
-		makeEntry(7, 100, false),
-		makeEntry(9, 100, false),
-		makeEntry(9, 25000, false),
-	}
-	// Add entries
-	assertNoError(t, channelIndex.AddSet(entrySet), "Add set")
-
-	assert.Equals(t, channelIndex.clock.Value()[9], uint64(25000))
-	assert.Equals(t, channelIndex.clock.Value()[5], uint64(15000))
-	assert.Equals(t, channelIndex.clock.Value()[7], uint64(100))
-
-	// Load clock from db and reverify
-	channelIndex.loadClock()
-	assert.Equals(t, channelIndex.clock.Value()[9], uint64(25000))
-	assert.Equals(t, channelIndex.clock.Value()[5], uint64(15000))
-	assert.Equals(t, channelIndex.clock.Value()[7], uint64(100))
-
-}
 
 // vbCache tests
 /*

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -86,7 +86,7 @@ func initIndexTester(useBucketIndex bool, syncFn string) indexTester {
 	dbContext, err := it._sc.AddDatabaseFromConfig(dbConfig)
 
 	if useBucketIndex {
-		err := base.SeedTestPartitionMap(dbContext.GetIndexBucket(), 64)
+		_, err := base.SeedTestPartitionMap(dbContext.GetIndexBucket(), 64)
 		if err != nil {
 			panic(fmt.Sprintf("Error from seed partition map: %v", err))
 		}

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,6 @@ echo "Running Sync Gateway unit tests"
 go test -v "$@" github.com/couchbase/sync_gateway/...
 
 if [ -d godeps/src/github.com/couchbaselabs/sync-gateway-accel ]; then
-    # when I tried this, it was hanging for a long time for me
-    echo "NOT Running Sync Gateway Accel unit tests -- are these working?"
-    #go test -v "$@" github.com/couchbaselabs/sync-gateway-accel/...
+    echo "Running Sync Gateway Accel unit tests"
+    go test -v "$@" github.com/couchbaselabs/sync-gateway-accel/...
 fi


### PR DESCRIPTION
Moves index write functionality from kv_channel_index to sg_accel.  

Some additional minor refactoring - mainly making methods public - to support the move and running tests from sg_accel. 