### PR TITLE
Enabling Log Rotation

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -64,6 +64,9 @@ func (l Level) String() string {
 	}
 }
 
+// Implementaion of the go encoding.TextMarshaller interface for the Level type
+// This method will also be called by the JSON Marshaller
+//
 // MarshalText marshals the Level to text. Note that the text representation
 // drops the -Level suffix (see example).
 func (l *Level) MarshalText() ([]byte, error) {
@@ -73,6 +76,10 @@ func (l *Level) MarshalText() ([]byte, error) {
 	return []byte(l.String()), nil
 }
 
+// Implementaion of the go encoding.TextUnmarshaller interface for the Level type
+// This method will also be called by the JSON Unmarshaller e.g. when loading
+// from logging configuration.
+//
 // UnmarshalText unmarshals text to a level. Like MarshalText, UnmarshalText
 // expects the text representation of a Level to drop the -Level suffix (see
 // example).
@@ -194,7 +201,7 @@ func (config *LogAppenderConfig) ValidateLogAppender() error {
 	//Fail validation if an appender contains a "rotation" sub document
 	// and no "logFilePath" appender property is defined
 	if config.Rotation != nil && config.LogFilePath == nil {
-		return fmt.Errorf("The appender must define a \"logFilePath\" when \"rotation\" is defined")
+		return fmt.Errorf("The default logger must define a \"logFilePath\" when \"rotation\" is defined")
 	}
 	return nil
 }

--- a/examples/logging-with-rotation.json
+++ b/examples/logging-with-rotation.json
@@ -1,0 +1,22 @@
+{
+  "logging": {
+    "default": {
+      "logFilePath": "/var/tmp/sglogfile.log",
+      "logKeys": ["*"],
+      "logLevel": "debug",
+      "rotation": {
+        "maxsize": 1,
+        "maxage": 30,
+        "maxbackups": 2,
+        "localtime": true
+      }
+    }
+  },
+  "databases": {
+    "db": {
+      "server": "walrus:data",
+      "bucket": "default",
+      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ func main() {
 
 	go func() {
 		for range signalchannel {
-			base.Logf("SIGHUP: Reloading Config....\n")
-			rest.ReloadConf()
+			base.Logf("Handling SIGHUP signal.\n")
+			rest.HandleSighup()
 		}
 	}()
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -71,6 +71,8 @@
 
   <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
+  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e"/>
+
   <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
 
   <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>

--- a/rest/config.go
+++ b/rest/config.go
@@ -592,6 +592,10 @@ func ParseCommandLine() {
 	}
 
 	base.ParseLogFlag(*logKeys)
+
+	// Logging config will now have been loaded from command line
+	// or from a sync_gateway config file so we can validate the
+	// configuration and setup logging now
 	if err := config.setupAndValidateLogging(*verbose); err != nil {
 		base.LogFatal("Error setting up logging %v", err)
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -69,7 +69,7 @@ type ServerConfig struct {
 	CORS                           *CORSConfig              `json:",omitempty"`            // Configuration for allowing CORS
 	DeprecatedLog                  []string                 `json:"log,omitempty"`         // Log keywords to enable
 	DeprecatedLogFilePath          *string                  `json:"logFilePath,omitempty"` // Path to log file, if missing write to stderr
-	Logging                        *base.LoggingConfigMap   `json:",omitempty"`            // Pre-configured databases, mapped by name
+	Logging                        *base.LoggingConfigMap   `json:",omitempty"`            // Configuration for logging with optional log file rotation
 	Pretty                         bool                     `json:",omitempty"`            // Pretty-print JSON responses?
 	DeploymentID                   *string                  `json:",omitempty"`            // Optional customer/deployment ID for stats reporting
 	StatsReportInterval            *float64                 `json:",omitempty"`            // Optional stats report interval (0 to disable)
@@ -132,11 +132,6 @@ type DbConfig struct {
 type DbConfigMap map[string]*DbConfig
 
 type ReplConfigMap map[string]*ReplicationConfig
-
-type PersonaConfig struct {
-	Origin   string // Canonical server URL for Persona authentication
-	Register bool   // If true, server will register new user accounts
-}
 
 type FacebookConfig struct {
 	Register bool // If true, server will register new user accounts


### PR DESCRIPTION
fixes #2160 

The current support for the external logrotate command is not usable on Windows.

To provide a cross platform implementation of log rotation we should build log rotation features into Sync Gateway.

The [lunberjack](https://github.com/natefinch/lumberjack) golang package provides simple logrotation capabilities: 

This can be used with any logging framework that can be initialised with an io.Writer. This compatible with SG current logger.

The sync_gateway config will be updated to support a new top level "logging" property that will have an Object containing the logging properties including log rotation. 

Below is the new logging config format:

```
{
  "log":["*"],
  "logFilePath":"<PATH_TO_LOG_FILE">,
  "logging" : {
    "default" : {
      "logFilePath":"<PATH_TO_LOG_FILE>",
      "logKeys":["*"],
      "logLevel":<"debug"|"info"|"warn"|"error"|"panic"|"fatal">,
      "rotation":{
        "maxsize":100, // The maximum size in MB of the log file before it gets rotated. default - 100Mb
        "maxage":30, // The maximum number of days to retain old log files
        "maxbackups":5, // The maximum number of old log files to retain. default - all log files
        "localtime":true // If 'true' use computer's local time to format backup timestamp. default - UTC
      }
    }
  }
}
```

The "logging" sub document must contain a single named logging appender called "default".

The "default" appender can write to "stdout", write to a single log file or the log file may be rotated by defining a "rotation" sub document.

 # Behaviour

In the absence of a "logging" sub document:
If neither top level property "log" or "logFilePath" are defined, log entries with the "HTTP" log key will be written to standard out.

If only the top level "log" property is defined, log entries with the log keys defined in the "log" property will be written to standard out.

If both "log" and "logFilePath" are defined, log entries with the log keys defined in the "log" property will be written to the file defined in the "logFilePath" property.

If a "logging" subdocument is defined the "log" and "logFilePath" properties will be ignored.

The "logging" subdocument must contain a single valid appender config with the name "default", config validation should fail if this is not the case.

The "default" appender may be defined without a "logFilePath" property, in this case the appender will write to the processes "stdout".

If the "default" appender has a "logFilePath" property, the appender will write to the log file at the path specified.

Log entries that match the appender "logKeys" and "logLevel" properties will be written by the appender.

If an appender contains a "rotation" sub document and no "logFilePath" appender property is defined config validation should fail.

If an appender contains a "rotation" sub document and the "logFilePath" appender property is defined the log file will be rotated using the provided configuration.

On non-windows platforms if the Sync Gateway receives a SIGHUP signal:

If there is no "logging" subdocument and the top level "logFilePath" property is not defined no action is taken.

If there is no "logging" subdocument and the top level "logFilePath" property is defined the log file handle will be cycled as it is currently.

If the "logging" subdocument is defined, and the "default" appender has no "logFilePath" property defined no action is taken.

If the "logging" subdocument is defined, and the "default" appender has no "rotation" subdocument defined the log file handle will be cycled as it is currently.

If the "logging" subdocument is defined, and the "default" appender has a "rotation" subdocument defined call Logger.Rotate() to force a log file rotation.

After rotating, this initiates a cleanup of old log files according to the rotation properties defined for that appender.

# Deprecation of old logging config

The current proposal is to remove the top level "log" and "logFilePath" properties in Sync Gateway 2.0.

For users that want to migrate to the new logging config to write to a log file but do not need log rotation they should use a default logger similar to the following:

```
"logging": {
  "default": {
    "logFilePath": "/var/tmp/sglogfile.log",
    "logKeys": ["*"],
    "logLevel": "debug"
  }
},
```

 # Example Configs
A basic logging-with-rotation.json SG config has been added to the examples folder

```
{
  "logging": {
    "default": {
      "logFilePath": "/var/tmp/sglogfile.log",
      "logKeys": ["*"],
      "logLevel": "debug",
      "rotation": {
        "maxsize": 1,
        "maxage": 30,
        "maxbackups": 2,
        "localtime": true
      }
    }
  },
  "databases": {
    "db": {
      "server": "walrus:data",
      "bucket": "default",
      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
    }
  }
}
```
For testing here are some additional SG config files

This should write log entries to a log file but will not rotate the file.
```
{
"logging": {
  "default": {
    "logFilePath": "/var/tmp/sglogfile.log",
    "logKeys": ["*"],
    "logLevel": "debug"
  }
},
"databases": {
    "db": {
      "server": "walrus:data",
      "bucket": "default",
      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
    }
  }
}
```

This should fail as the logging object has no entry.
```
{
  "logging": {},
  "databases": {
    "db": {
      "server": "walrus:data",
      "bucket": "default",
      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
    }
  }
}
```

This should fail as the logging object should have a single entry called "default".
```
{
  "logging" : {
    "notdefault" : {
      "logFilePath":"/var/tmp/sglogfile.log",
      "logKeys":["*"],
      "logLevel":"debug",
      "rotation":{
        "maxsize":100,
        "maxage":30,
        "maxbackups":5,
        "localtime":true
      }
    }
  },
  "databases": {
    "db": {
      "server": "walrus:data",
      "bucket": "default",
      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
    }
  }
}
```

This should fail as the logging object should have a single entry called "default".
```
{
  "logging" : {
    "default" : {
      "logFilePath":"/var/tmp/sglogfile.log",
      "logKeys":["*"],
      "logLevel":"debug",
      "rotation":{
        "maxsize":100,
        "maxage":30,
        "maxbackups":5,
        "localtime":true
      }
    },
    "another" : {
      "logFilePath":"/var/tmp/anothersglogfile.log",
      "logKeys":["*"],
      "logLevel":"debug",
      "rotation":{
        "maxsize":100,
        "maxage":30,
        "maxbackups":5,
        "localtime":true
      }
    }
  },
  "databases": {
    "db": {
      "server": "walrus:data",
      "bucket": "default",
      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
    }
  }
}
```

This should fail because the logging object has a rotation object defined but no logFilePath property
```
{
  "logging" : {
    "default" : {
      "logKeys":["*"],
      "logLevel":"debug",
      "rotation":{
        "maxsize":100,
        "maxage":30,
        "maxbackups":5,
        "localtime":true
      }
    }
  },
  "databases": {
    "db": {
      "server": "walrus:data",
      "bucket": "default",
      "users": {"GUEST": {"disabled": false,"admin_channels": ["*"]}}
    }
  }
}
```