### PR TITLE
Fixes for CAS failure handling during Dense Block List management

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -478,3 +478,51 @@ func WriteCasRaw(bucket Bucket, key string, value []byte, cas uint64, exp int, c
 		}
 	}
 }
+
+func IsKeyNotFoundError(bucket Bucket, err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	switch bucket.(type) {
+	case CouchbaseBucket:
+		if strings.Contains(err.Error(), "Not found") {
+			return true
+		}
+	case CouchbaseBucketGoCB:
+		if GoCBErrorType(err) == GoCBErr_MemdStatusKeyNotFound {
+			return true
+		}
+	default:
+		if _, ok := err.(sgbucket.MissingError); ok {
+			return true
+		}
+	}
+
+	return false
+
+}
+
+func IsCasMismatch(bucket Bucket, err error) bool {
+	if err == nil {
+		return false
+	}
+
+	switch bucket.(type) {
+	case CouchbaseBucket:
+		if strings.Contains(err.Error(), "CAS mismatch") {
+			return true
+		}
+	case CouchbaseBucketGoCB:
+		if GoCBErrorType(err) == GoCBErr_MemdStatusKeyExists {
+			return true
+		}
+	default:
+		if strings.Contains(err.Error(), "CAS mismatch") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/db/kv_dense_channel_storage.go
+++ b/db/kv_dense_channel_storage.go
@@ -191,6 +191,22 @@ func NewDenseBlockList(channelName string, partition uint16, indexBucket base.Bu
 	return list
 }
 
+func NewDenseBlockListReader(channelName string, partition uint16, indexBucket base.Bucket) *DenseBlockList {
+
+	list := &DenseBlockList{
+		channelName: channelName,
+		partition:   partition,
+		indexBucket: indexBucket,
+	}
+	list.activeKey = list.generateActiveListKey()
+	found, err := list.loadDenseBlockList()
+	if !found || err != nil {
+		base.Warn("Error initializing dense block list:  found:[%v] err:[%v]", found, err)
+		return nil
+	}
+	return list
+}
+
 func (l *DenseBlockList) ActiveListEntry() *DenseBlockListEntry {
 	if len(l.blocks) == 0 {
 		return nil
@@ -267,11 +283,17 @@ func (l *DenseBlockList) AddBlock() (*DenseBlock, error) {
 	if err != nil {
 		// CAS error.  If there's a concurrent writer for this partition, assume they have created the new block.
 		//  Re-initialize the current block list, and get the active block key from there.
-		l.initDenseBlockList()
+		err = l.initDenseBlockList()
+		if err != nil {
+			return nil, err
+		}
+
 		if len(l.blocks) == 0 {
 			return nil, fmt.Errorf("Unable to determine active block after DenseBlockList cas write failure")
 		}
 		latestEntry := l.blocks[len(l.blocks)-1]
+
+		base.LogTo("ChannelStorage+", "Handled AddBlock cas failure.  casOut:[%d] activeCas:[%d], err:[%v], activeBlock:[%v]", casOut, l.activeCas, err, latestEntry.BlockIndex)
 		return NewDenseBlock(l.generateBlockKey(latestEntry.BlockIndex), latestEntry.StartClock), nil
 	}
 	l.activeCas = casOut
@@ -300,9 +322,11 @@ func (l *DenseBlockList) rotate() error {
 		return err
 	}
 	_, err = l.indexBucket.WriteCas(rotatedKey, 0, 0, 0, rotatedValue, sgbucket.Raw)
-	if err != nil {
-		// TODO: confirm cas error and not retry error
-		// CAS error - someone else has already rotated out for this count.  Continue to initialize empty
+
+	// For CAS error - someone else has already rotated out for this count.  Continue to initialize empty.  For all other errors,
+	// return error
+	if err != nil && !base.IsCasMismatch(l.indexBucket, err) {
+		return err
 	}
 
 	// Empty the active list
@@ -312,38 +336,68 @@ func (l *DenseBlockList) rotate() error {
 	if err != nil {
 		return err
 	}
-	l.activeCas, err = l.indexBucket.WriteCas(l.activeKey, 0, 0, l.activeCas, activeValue, sgbucket.Raw)
+	var casOut uint64
+	casOut, err = l.indexBucket.WriteCas(l.activeKey, 0, 0, l.activeCas, activeValue, sgbucket.Raw)
 	if err != nil {
-		// CAS error.  Assume concurrent writer has already updated the active block list.
-		//  Re-initialize the current block list.
-		l.initDenseBlockList()
+		if base.IsCasMismatch(l.indexBucket, err) {
+			// CAS error.  Assume concurrent writer has already updated the active block list.
+			//  Re-initialize the current block list and return
+			err = l.initDenseBlockList()
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	} else {
+		l.activeCas = casOut
 	}
 
 	return nil
 }
 
+// Loads the dense block list.  Initializes an empty block list if not found.
+func (l *DenseBlockList) initDenseBlockList() error {
+	// Load the existing block list
+	found, err := l.loadDenseBlockList()
+	if err != nil {
+		return err
+	}
+	// If block list doesn't exist, add a block (which will initialize)
+	if !found {
+		l.activeCas = 0
+		base.LogTo("ChannelStorage+", "Creating new block list. channel:[%s] partition:[%d] cas:[%d]", l.channelName, l.partition, l.activeCas)
+		l.blocks = make([]DenseBlockListEntry, 0)
+		_, err = l.AddBlock()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Only loads the active block list doc during init.  Older entries are lazy loaded when a search
 // requests a clock earlier than the first entry's clock
-func (l *DenseBlockList) initDenseBlockList() error {
+func (l *DenseBlockList) loadDenseBlockList() (found bool, err error) {
 	var activeBlockList DenseBlockListStorage
-	var err error
-	l.activeCas, err = l.indexBucket.Get(l.activeKey, &activeBlockList)
-	if err != nil {
-		// TODO: figure out how to make this work with walrus
-		//if base.GoCBErrorType(err) == base.GoCBErr_MemdStatusKeyNotFound {
+	var casOut uint64
+	casOut, err = l.indexBucket.Get(l.activeKey, &activeBlockList)
 
-		// New block list - add first empty block
-		base.LogTo("ChannelStorage+", "Creating new block list. channel:[%s] partition:[%d]", l.channelName, l.partition)
-		l.blocks = make([]DenseBlockListEntry, 0)
-		l.AddBlock()
-	} else {
-		l.blocks = activeBlockList.Blocks
-		l.activeCounter = activeBlockList.Counter
-		l.activeBlock = l.loadActiveBlock()
+	if err != nil {
+		if base.IsKeyNotFoundError(l.indexBucket, err) {
+			return false, nil
+		} else {
+			base.LogTo("ChannelStorage+", "Unexpected error attempting to retrieve active block list.  key:[%s] err:[%v]", l.activeKey, err)
+			return false, err
+		}
 	}
+	l.activeCas = casOut
+	l.blocks = activeBlockList.Blocks
+	l.activeCounter = activeBlockList.Counter
+	l.activeBlock = l.loadActiveBlock()
 	l.activeStartIndex = 0
 	l.validFromCounter = l.activeCounter
-	return nil
+	return true, nil
 }
 
 func (l *DenseBlockList) GetActiveBlock() *DenseBlock {


### PR DESCRIPTION
Readers no longer attempt to create the list when not found.  For writers, active cas value is properly updated after cas write failure and reload.

Also validates error type, instead of assuming failure type in a few scenarios.

Fixes #2204.