### PR TITLE
Fix for backfill sequence handling

### DIFF
--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -105,6 +105,29 @@ type VbSequence struct {
 	seq  uint64
 }
 
+// Compares based on vbno, then sequence.  Returns 0 if identical, 1 if s1 > s2, -1 if s1 < s2
+func CompareVbSequence(s1, s2 VbSequence) int {
+	return CompareVbAndSequence(s1.vbNo, s1.seq, s2.vbNo, s2.seq)
+}
+
+// Compares based on vbno, then sequence.  Returns 0 if identical, 1 if s1 > s2, -1 if s1 < s2
+func CompareVbAndSequence(vb1 uint16, s1 uint64, vb2 uint16, s2 uint64) int {
+	if vb1 < vb2 {
+		return -1
+	}
+	if vb1 > vb2 {
+		return 1
+	}
+	// Vbno equal, compare sequences
+	if s1 < s2 {
+		return -1
+	}
+	if s1 > s2 {
+		return 1
+	}
+	return 0
+}
+
 // ShardedClock maintains the collection of clock shards (ShardedClockPartitions), and also manages
 // the counter for the clock.
 type ShardedClock struct {

--- a/base/sharded_sequence_clock_test.go
+++ b/base/sharded_sequence_clock_test.go
@@ -400,3 +400,22 @@ func (scp *GobShardedClockPartition) AddToClock(clock SequenceClock) error {
 	}
 	return nil
 }
+
+func TestCompareVbAndSequence(t *testing.T) {
+
+	// Vb and Seq equal
+	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 100), 0)
+
+	// Vb equal
+	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 101), -1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 99), 1)
+
+	// Vb different
+	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 100), -1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 99), -1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 101), -1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 100), 1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 99), 1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 101), 1)
+
+}

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -252,7 +252,7 @@ func getNextSequenceFromFeeds(current []*ChangeEntry, feeds []<-chan *ChangeEntr
 
 	// Clear the current entries for any duplicates of the sequence just sent:
 	for i, cur := range current {
-		if cur != nil && cur.Seq == minSeq {
+		if cur != nil && cur.Seq.Equals(minSeq) {
 			current[i] = nil
 			// Track whether this is a removal from all user's channels
 			if cur.Removed == nil && minEntry.allRemoved == true {

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -406,6 +406,9 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions) (<
 
 				// If vb.seq for the entry is earlier than the vb.seq that triggered this channel's backfill, send as backfill.
 				isBackfill := false
+				if base.CompareVbAndSequence(logEntry.VbNo, logEntry.Sequence, options.Since.TriggeredByVbNo, options.Since.TriggeredBy) == -1 {
+					isBackfill = true
+				}
 				if logEntry.VbNo < options.Since.TriggeredByVbNo || (logEntry.VbNo == options.Since.TriggeredByVbNo && logEntry.Sequence < options.Since.TriggeredBy) {
 					isBackfill = true
 				}

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -409,9 +409,6 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions) (<
 				if base.CompareVbAndSequence(logEntry.VbNo, logEntry.Sequence, options.Since.TriggeredByVbNo, options.Since.TriggeredBy) == -1 {
 					isBackfill = true
 				}
-				if logEntry.VbNo < options.Since.TriggeredByVbNo || (logEntry.VbNo == options.Since.TriggeredByVbNo && logEntry.Sequence < options.Since.TriggeredBy) {
-					isBackfill = true
-				}
 				// Only send backfill that's hasn't already been sent (i.e. after the sequence part of options.Since)
 				isPending := options.Since.VbucketSequenceBefore(logEntry.VbNo, logEntry.Sequence)
 

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -24,8 +24,8 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 		to = fmt.Sprintf("  (to %s)", db.user.Name())
 		userVbNo = uint16(db.Bucket.VBHash(db.user.DocID()))
 	}
-
 	base.LogTo("Changes+", "Vector MultiChangesFeed(%s, %+v) ... %s", chans, options, to)
+
 	output := make(chan *ChangeEntry, 50)
 
 	go func() {
@@ -313,7 +313,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 			vbAddedAt = *vbSeqAddedAt.VbNo
 		}
 
-		base.LogTo("Changes+", "Starting for channel... %s, %d", name, seqAddedAt)
+		base.LogTo("Changes+", "Starting for channel... %s, %d.%d", name, vbAddedAt, seqAddedAt)
 		chanOpts := options
 
 		// Check whether requires backfill based on addedChannels in this _changes feed
@@ -340,7 +340,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 
 		if isNewChannel || (backfillRequired && !backfillInProgress) {
 			// Case 2.  No backfill in progress, backfill required
-			base.LogTo("Changes+", "Starting backfill for channel... %s, %d", name, seqAddedAt)
+			base.LogTo("Changes+", "Starting backfill for channel... %s, [%d:%d]", name, vbAddedAt, seqAddedAt)
 			chanOpts.Since = SequenceID{
 				Seq:              0,
 				vbNo:             0,
@@ -362,6 +362,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 		} else {
 			// Case 1.  Leave chanOpts.Since set to options.Since.
 		}
+
 		feed, err := db.vectorChangesFeed(name, chanOpts)
 		if err != nil {
 			base.Warn("MultiChangesFeed got error reading changes feed %q: %v", name, err)
@@ -402,9 +403,12 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions) (<
 		if options.Since.TriggeredByClock != nil {
 			for i := 0; i < len(log); i++ {
 				logEntry := log[i]
-				// If sequence is less than the backfillTo clock sequence for its vbucket, send as backfill (i.e. with triggered by)
-				isBackfill := logEntry.Sequence <= options.Since.TriggeredByClock.GetSequence(logEntry.VbNo)
 
+				// If vb.seq for the entry is earlier than the vb.seq that triggered this channel's backfill, send as backfill.
+				isBackfill := false
+				if logEntry.VbNo < options.Since.TriggeredByVbNo || (logEntry.VbNo == options.Since.TriggeredByVbNo && logEntry.Sequence < options.Since.TriggeredBy) {
+					isBackfill = true
+				}
 				// Only send backfill that's hasn't already been sent (i.e. after the sequence part of options.Since)
 				isPending := options.Since.VbucketSequenceBefore(logEntry.VbNo, logEntry.Sequence)
 

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -60,6 +60,13 @@ func (s SequenceID) String() string {
 	}
 }
 
+// Diagnostic print of SequenceID
+func (s SequenceID) Print() string {
+	return fmt.Sprintf(
+		"SeqType:[%d] TriggeredBy:[%d] LowSeq:[%d] Seq:[%d] Clock:[%v] TriggeredByClock[%v] ClockHash:[%s] vbNo:[%d] TriggeredByVbno:[%d] LowHash:[%s]",
+		s.SeqType, s.TriggeredBy, s.LowSeq, s.Seq, s.Clock != nil, s.TriggeredByClock != nil, s.ClockHash, s.vbNo, s.TriggeredByVbNo, s.LowHash)
+}
+
 func (s SequenceID) intSeqToString() string {
 
 	if s.LowSeq > 0 && s.LowSeq < s.Seq {
@@ -294,6 +301,23 @@ func (s SequenceID) IsNonZero() bool {
 	} else {
 		return s.Seq > 0
 	}
+}
+
+// Equality of sequences, based on seq, triggered by and low hash
+func (s SequenceID) Equals(s2 SequenceID) bool {
+	if s.SeqType == ClockSequenceType {
+		return s.vectorEquals(s2)
+	} else {
+		return s.intEquals(s2)
+	}
+}
+
+func (s SequenceID) intEquals(s2 SequenceID) bool {
+	return s.SafeSequence() == s2.SafeSequence() && s.TriggeredBy == s2.TriggeredBy
+}
+
+func (s SequenceID) vectorEquals(s2 SequenceID) bool {
+	return s.Seq == s2.Seq && s.vbNo == s2.vbNo && s.TriggeredBy == s2.TriggeredBy && s.TriggeredByVbNo == s2.TriggeredByVbNo
 }
 
 // The most significant value is TriggeredBy, unless it's zero, in which case use Seq.


### PR DESCRIPTION
Use a vb.seq comparison when determining whether to write a changes entry as backfill.

Fixes #2186.