### PR TITLE
Fix potential race scenarios in changes processing

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -617,7 +617,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	// Go-routine to work the feed channel and write to an array for use by assertions
 	var changes = make([]*ChangeEntry, 0, 50)
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Validate the initial sequences arrive as expected
 	err = appendFromFeed(&changes, feed, 3)
@@ -637,7 +637,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	db.changeCache.waitForSequence(9)
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	err = appendFromFeed(&changes, feed, 4)
 	assert.True(t, err == nil)
 	assert.Equals(t, len(changes), 7)

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -189,6 +189,7 @@ type changeWaiter struct {
 	userKeys                  []string
 	lastCounter               uint64
 	lastTerminateCheckCounter uint64
+	lastUserCount             uint64
 }
 
 // Creates a new changeWaiter that will wait for changes for the given document keys.
@@ -216,6 +217,9 @@ func (listener *changeListener) NewWaiterWithChannels(chans base.Set, user auth.
 	}
 	waiter := listener.NewWaiter(waitKeys)
 	waiter.userKeys = userKeys
+	if userKeys != nil {
+		waiter.lastUserCount = listener.CurrentCount(userKeys)
+	}
 	return waiter
 }
 
@@ -225,6 +229,9 @@ func (waiter *changeWaiter) Wait() uint32 {
 	lastTerminateCheckCounter := waiter.lastTerminateCheckCounter
 	lastCounter := waiter.lastCounter
 	waiter.lastCounter, waiter.lastTerminateCheckCounter = waiter.listener.Wait(waiter.keys, waiter.lastCounter, waiter.lastTerminateCheckCounter)
+	if waiter.userKeys != nil {
+		waiter.lastUserCount = waiter.listener.CurrentCount(waiter.userKeys)
+	}
 	countChanged := waiter.lastCounter > lastCounter
 
 	//Uses != to compare as value can cycle back through 0
@@ -242,10 +249,7 @@ func (waiter *changeWaiter) Wait() uint32 {
 // Returns the current counter value for the waiter's user (and roles).
 // If this value changes, it means the user or roles have been updated.
 func (waiter *changeWaiter) CurrentUserCount() uint64 {
-	if waiter.userKeys == nil {
-		return 0
-	}
-	return waiter.listener.CurrentCount(waiter.userKeys)
+	return waiter.lastUserCount
 }
 
 // Updates the set of channel keys in the ChangeWaiter (maintains the existing set of user keys)


### PR DESCRIPTION
Addresses two potential race conditions in changes processing:

1. User Count and changeWaiter initialization
Previously calls to waiter.CurrentUserCount() were going straight through to the listener (i.e. using the global user count), instead of using the last known user count for the waiter instance. This has the potential for missed user notifications in changes.go, when user changes happen between changes waking up, and changes calling CurrentUserCount().

2. Channel and user feeds running ahead of the stable sequence
Adds an explicit check to terminate a changes iteration if it sees sequences higher than the stable sequence.  This avoids a race where entries are cached between channel retrievals for multi-channel changes requests, as well as preventing user doc updates being sent out of sequence.

Fixes #1865 
