### PR TITLE
Index reader performance enhancements

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	exportDebugExpvars   = true
-	TimingExpvarsEnabled = false
+	exportDebugExpvars = true
 )
+
+var TimingExpvarsEnabled = false
 
 // SequenceTimingExpvarMap attempts to track timing information for targeted sequences as they move through the system.
 // Creates a map that looks like the following, where Indexed, Polled, Changes are the incoming stages, the values are

--- a/base/expvar.go
+++ b/base/expvar.go
@@ -10,14 +10,237 @@
 package base
 
 import (
+	"expvar"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
 )
 
 const (
-	exportDebugExpvars = true
+	exportDebugExpvars   = true
+	TimingExpvarsEnabled = true
 )
+
+// SequenceTimingExpvarMap attempts to track timing information for targeted sequences as they move through the system.
+// Creates a map that looks like the following, where Indexed, Polled, Changes are the incoming stages, the values are
+// nanosecond timestamps, and the sequences are the target sequences, based on the specified vb and frequency (in the example
+// frequency=1000).  Since we won't necessarily see every vb sequence, we track the first sequence we see higher than the
+// target frequency.  (e.g. if our last sequence was 1000 and frequency is 1000, it will track the first sequence seen higher than
+// 2000).
+// Note: Frequency needs to be high enough that a sequence can move through the system before the next sequence is seen, otherwise
+// earlier stages could be updating current before the later stages have processed it.
+/*
+{
+	"timingMap": {
+		"seq1000.Indexed" :  4738432432,
+		"seq1000.Polled" : 5743785947,
+		"seq1000.Changes" :
+		"seq2002.Indexed" :  4738432432,
+		"seq2002.Polled" : 5743785947,
+		"seq2002.Changes" :
+	}
+}
+*/
+type SequenceTimingExpvar struct {
+	frequency        uint64
+	currentTargetSeq uint64
+	currentActualSeq uint64
+	nextTargetSeq    uint64
+	vbNo             uint16
+	lock             sync.RWMutex
+	timingMap        *expvar.Map
+}
+
+func NewSequenceTimingExpvar(frequency uint64, targetVbNo uint16, name string) SequenceTimingExpvar {
+
+	storageMap := expvar.Map{}
+	storageMap.Init()
+
+	return SequenceTimingExpvar{
+		currentTargetSeq: 0,
+		nextTargetSeq:    0,
+		frequency:        frequency,
+		vbNo:             targetVbNo,
+		timingMap:        &storageMap,
+	}
+}
+
+type TimingStatus int
+
+const (
+	TimingStatusCurrent TimingStatus = iota
+	TimingStatusNext
+	TimingStatusNone
+	TimingStatusInit
+)
+
+func (s SequenceTimingExpvar) String() string {
+	return s.timingMap.String()
+}
+
+func (s *SequenceTimingExpvar) UpdateBySequence(stage string, vbNo uint16, seq uint64) {
+
+	if !TimingExpvarsEnabled {
+		return
+	}
+	timingStatus := s.isCurrentOrNext(vbNo, seq)
+	switch timingStatus {
+	case TimingStatusNone:
+		return
+	case TimingStatusInit:
+		s.initTiming(seq)
+	case TimingStatusCurrent:
+		s.setActual(seq)
+		s.writeCurrentSeq(stage, time.Now())
+	case TimingStatusNext:
+		s.updateNext(stage, seq, time.Now())
+	}
+	return
+}
+
+func (s *SequenceTimingExpvar) UpdateBySequenceAt(stage string, vbNo uint16, seq uint64, time time.Time) {
+
+	if !TimingExpvarsEnabled {
+		return
+	}
+	timingStatus := s.isCurrentOrNext(vbNo, seq)
+	switch timingStatus {
+	case TimingStatusNone:
+		return
+	case TimingStatusInit:
+		s.initTiming(seq)
+	case TimingStatusCurrent:
+		s.setActual(seq)
+		s.writeCurrentSeq(stage, time)
+	case TimingStatusNext:
+		s.updateNext(stage, seq, time)
+	}
+	return
+}
+
+// Update by sequence range is used for events (like clock polling) that don't see
+// every sequence.  Writes when current target sequence is in range.  Assumes callers
+// don't report overlapping ranges
+func (s *SequenceTimingExpvar) UpdateBySequenceRange(stage string, vbNo uint16, startSeq uint64, endSeq uint64) {
+
+	if !TimingExpvarsEnabled {
+		return
+	}
+	timingStatus := s.isCurrentOrNextRange(vbNo, startSeq, endSeq)
+	switch timingStatus {
+	case TimingStatusNone:
+		return
+	case TimingStatusInit:
+		s.initTiming(endSeq)
+	case TimingStatusCurrent:
+		s.writeCurrentRange(stage)
+	case TimingStatusNext:
+		s.updateNextRange(stage, startSeq, endSeq)
+	}
+}
+
+// Initializes based on the first sequence seen
+func (s *SequenceTimingExpvar) initTiming(startSeq uint64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.nextTargetSeq == 0 {
+		s.nextTargetSeq = ((startSeq / s.frequency) + 1) * s.frequency
+	}
+}
+
+func (s *SequenceTimingExpvar) setActual(seq uint64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.currentActualSeq == 0 || s.currentActualSeq < s.currentTargetSeq {
+		s.currentActualSeq = seq
+	}
+}
+
+func (s *SequenceTimingExpvar) writeCurrentSeq(stage string, time time.Time) {
+
+	key := fmt.Sprintf("seq%d:%s", s.currentTargetSeq, stage)
+	value := expvar.Int{}
+	value.Set(time.UnixNano())
+	s.timingMap.Set(key, &value)
+}
+
+func (s *SequenceTimingExpvar) writeCurrentRange(stage string) {
+
+	key := fmt.Sprintf("seq%d:%s", s.currentTargetSeq, stage)
+	value := expvar.Int{}
+	value.Set(time.Now().UnixNano())
+	s.timingMap.Set(key, &value)
+}
+
+func (s *SequenceTimingExpvar) updateNext(stage string, seq uint64, time time.Time) {
+
+	s.currentTargetSeq = s.nextTargetSeq
+	s.currentActualSeq = seq
+	s.nextTargetSeq = s.currentTargetSeq + s.frequency
+	s.writeCurrentSeq(stage, time)
+}
+
+// UpdateNextRange updates the target values, but not actual
+func (s *SequenceTimingExpvar) updateNextRange(stage string, fromSeq, toSeq uint64) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.currentTargetSeq = s.nextTargetSeq
+	s.nextTargetSeq = s.currentTargetSeq + s.frequency
+
+	s.writeCurrentRange(stage)
+}
+
+func (s *SequenceTimingExpvar) isCurrentOrNextRange(vbNo uint16, startSeq uint64, endSeq uint64) TimingStatus {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if vbNo != s.vbNo {
+		return TimingStatusNone
+	}
+
+	if s.nextTargetSeq == 0 {
+		return TimingStatusInit
+	}
+
+	if startSeq <= s.nextTargetSeq && endSeq >= s.nextTargetSeq {
+		return TimingStatusNext
+	}
+
+	if s.currentTargetSeq > 0 && startSeq <= s.currentTargetSeq && endSeq >= s.currentTargetSeq {
+		return TimingStatusCurrent
+	}
+
+	return TimingStatusNone
+}
+
+func (s *SequenceTimingExpvar) isCurrentOrNext(vbNo uint16, seq uint64) TimingStatus {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if vbNo != s.vbNo {
+		return TimingStatusNone
+	}
+
+	if s.nextTargetSeq == 0 {
+		return TimingStatusInit
+	}
+
+	if seq > 0 {
+		if seq > s.nextTargetSeq {
+			return TimingStatusNext
+		}
+		// If matches actual
+		if seq == s.currentActualSeq {
+			return TimingStatusCurrent
+		}
+		// If actual hasn't been set yet
+		if s.currentActualSeq < s.currentTargetSeq && seq >= s.currentTargetSeq {
+			return TimingStatusCurrent
+		}
+	}
+
+	return TimingStatusNone
+}
 
 // IntMax is an expvar.Value that tracks the maximum value it's given.
 type IntMax struct {
@@ -85,5 +308,59 @@ func (d *DebugIntMeanVar) AddValue(value int64) {
 func (d *DebugIntMeanVar) AddSince(start time.Time) {
 	if exportDebugExpvars {
 		d.v.AddSince(start)
+	}
+}
+
+// IntRollingMean is an expvar.Value that returns the mean of the [size] latest
+// values sent via AddValue.  Uses a slice to track values, so setting a large
+// size has memory implications
+type IntRollingMeanVar struct {
+	mean     float64 // average value
+	mu       sync.RWMutex
+	entries  []int64
+	capacity int
+	position int
+}
+
+func NewIntRollingMeanVar(capacity int) IntRollingMeanVar {
+	return IntRollingMeanVar{
+		capacity: capacity,
+		entries:  make([]int64, 0, capacity),
+	}
+}
+func (v *IntRollingMeanVar) String() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return strconv.FormatInt(int64(v.mean), 10)
+}
+
+// Adds value
+func (v *IntRollingMeanVar) AddValue(value int64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(v.entries) < v.capacity {
+		v.addValue(value)
+	} else {
+		v.replaceValue(value)
+	}
+}
+func (v *IntRollingMeanVar) AddSince(start time.Time) {
+	v.AddValue(time.Since(start).Nanoseconds())
+}
+
+// If we have fewer entries than capacity, regular mean calculation
+func (v *IntRollingMeanVar) addValue(value int64) {
+	v.entries = append(v.entries, value)
+	v.mean = v.mean + (float64(value)-v.mean)/float64(len(v.entries))
+}
+
+// If we have filled the ring buffer, replace value at position and recalculate mean
+func (v *IntRollingMeanVar) replaceValue(value int64) {
+	oldValue := v.entries[v.position]
+	v.entries[v.position] = value
+	v.mean = v.mean + float64(value-oldValue)/float64(v.capacity)
+	v.position++
+	if v.position > v.capacity-1 {
+		v.position = 0
 	}
 }

--- a/base/expvar.go
+++ b/base/expvar.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	exportDebugExpvars   = true
-	TimingExpvarsEnabled = true
+	TimingExpvarsEnabled = false
 )
 
 // SequenceTimingExpvarMap attempts to track timing information for targeted sequences as they move through the system.

--- a/base/expvar_test.go
+++ b/base/expvar_test.go
@@ -45,7 +45,7 @@ func assertMapEntry(t *testing.T, e SequenceTimingExpvar, key string) {
 }
 
 func TestTimingExpvarSequenceOnly(t *testing.T) {
-
+	TimingExpvarsEnabled = true
 	// Sequence only
 	e := NewSequenceTimingExpvar(5, 0, "testSeqOnlyTiming")
 	e.UpdateBySequence("SequenceBased", 0, 1)
@@ -57,14 +57,15 @@ func TestTimingExpvarSequenceOnly(t *testing.T) {
 	e.UpdateBySequence("SequenceBased", 0, 13)
 	e.UpdateBySequence("SequenceBased", 0, 16)
 
+	log.Printf("sequence only: %s", e.String())
 	assertMapEntry(t, e, "seq5:SequenceBased")
 	assertMapEntry(t, e, "seq10:SequenceBased")
 	assertMapEntry(t, e, "seq15:SequenceBased")
-	log.Printf("sequence only: %s", e.String())
 
 }
 
 func TestTimingExpvarRangeOnly(t *testing.T) {
+	TimingExpvarsEnabled = true
 
 	// Range only
 	e := NewSequenceTimingExpvar(5, 0, "testRangeTiming")
@@ -82,6 +83,7 @@ func TestTimingExpvarRangeOnly(t *testing.T) {
 }
 
 func TestTimingExpvarMixed(t *testing.T) {
+	TimingExpvarsEnabled = true
 
 	e := NewSequenceTimingExpvar(5, 0, "testTimingMixed")
 	e.UpdateBySequenceRange("Polled", 0, 0, 3)

--- a/base/expvar_test.go
+++ b/base/expvar_test.go
@@ -1,0 +1,117 @@
+//  Copyright (c) 2012 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package base
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestRollingMeanExpvar(t *testing.T) {
+
+	rollingMean := NewIntRollingMeanVar(5)
+	// Add a few values below capacity, validate mean
+	rollingMean.AddValue(2)
+	rollingMean.AddValue(4)
+	rollingMean.AddValue(6)
+	rollingMean.AddValue(8)
+	assert.Equals(t, rollingMean.String(), "5")
+
+	// Add a few more to exceed capacity
+	rollingMean.AddValue(10)
+	rollingMean.AddValue(22)
+	assert.Equals(t, rollingMean.String(), "10")
+
+	// Go around the capacity loop a few times to make sure things don't break
+	for i := 0; i < 100; i++ {
+		rollingMean.AddValue(100)
+	}
+	assert.Equals(t, rollingMean.String(), "100")
+
+}
+
+func assertMapEntry(t *testing.T, e SequenceTimingExpvar, key string) {
+	assertTrue(t, e.timingMap.Get(key) != nil, fmt.Sprintf("Expected map key %s not found", key))
+}
+
+func TestTimingExpvarSequenceOnly(t *testing.T) {
+
+	// Sequence only
+	e := NewSequenceTimingExpvar(5, 0, "testSeqOnlyTiming")
+	e.UpdateBySequence("SequenceBased", 0, 1)
+	e.UpdateBySequence("SequenceBased", 0, 3)
+	e.UpdateBySequence("SequenceBased", 0, 4)
+	e.UpdateBySequence("SequenceBased", 0, 6)
+	e.UpdateBySequence("SequenceBased", 0, 7)
+	e.UpdateBySequence("SequenceBased", 0, 10)
+	e.UpdateBySequence("SequenceBased", 0, 13)
+	e.UpdateBySequence("SequenceBased", 0, 16)
+
+	assertMapEntry(t, e, "seq5:SequenceBased")
+	assertMapEntry(t, e, "seq10:SequenceBased")
+	assertMapEntry(t, e, "seq15:SequenceBased")
+	log.Printf("sequence only: %s", e.String())
+
+}
+
+func TestTimingExpvarRangeOnly(t *testing.T) {
+
+	// Range only
+	e := NewSequenceTimingExpvar(5, 0, "testRangeTiming")
+	e.UpdateBySequenceRange("SequenceBased", 0, 0, 3)
+	e.UpdateBySequenceRange("SequenceBased", 0, 4, 6)
+	e.UpdateBySequenceRange("SequenceBased", 0, 7, 9)
+	e.UpdateBySequenceRange("SequenceBased", 0, 10, 12)
+	e.UpdateBySequenceRange("SequenceBased", 0, 13, 15)
+
+	assertMapEntry(t, e, "seq5:SequenceBased")
+	assertMapEntry(t, e, "seq10:SequenceBased")
+	assertMapEntry(t, e, "seq15:SequenceBased")
+	log.Printf("range only: %s", e.String())
+
+}
+
+func TestTimingExpvarMixed(t *testing.T) {
+
+	e := NewSequenceTimingExpvar(5, 0, "testTimingMixed")
+	e.UpdateBySequenceRange("Polled", 0, 0, 3)
+	e.UpdateBySequenceRange("ChangesNotified", 0, 0, 3)
+	e.UpdateBySequence("ChangeEntrySent", 0, 2)
+	e.UpdateBySequence("ChangeEntrySent", 0, 3)
+
+	e.UpdateBySequenceRange("Polled", 0, 3, 7)
+	e.UpdateBySequenceRange("ChangesNotified", 0, 3, 7)
+	e.UpdateBySequence("ChangeEntrySent", 0, 6)
+	e.UpdateBySequence("ChangeEntrySent", 0, 7)
+
+	e.UpdateBySequenceRange("Polled", 0, 8, 10)
+	e.UpdateBySequenceRange("ChangesNotified", 0, 8, 10)
+	e.UpdateBySequence("ChangeEntrySent", 0, 10)
+
+	e.UpdateBySequenceRange("Polled", 0, 11, 18)
+	e.UpdateBySequenceRange("ChangesNotified", 0, 11, 18)
+	e.UpdateBySequence("ChangeEntrySent", 0, 12)
+	e.UpdateBySequence("ChangeEntrySent", 0, 13)
+	e.UpdateBySequence("ChangeEntrySent", 0, 16)
+	e.UpdateBySequence("ChangeEntrySent", 0, 17)
+	e.UpdateBySequence("ChangeEntrySent", 0, 18)
+
+	log.Printf("mixed only: %s", e.String())
+	assertMapEntry(t, e, "seq5:Polled")
+	assertMapEntry(t, e, "seq5:ChangesNotified")
+	assertMapEntry(t, e, "seq5:ChangeEntrySent")
+	assertMapEntry(t, e, "seq10:Polled")
+	assertMapEntry(t, e, "seq10:ChangesNotified")
+	assertMapEntry(t, e, "seq10:ChangeEntrySent")
+
+}

--- a/base/sequence_clock.go
+++ b/base/sequence_clock.go
@@ -35,7 +35,7 @@ type SequenceClock interface {
 	GetHashedValue() string                        // Returns previously hashed value, if present.  If not present, does NOT generate hash
 	SetHashedValue(value string)                   // Returns previously hashed value, if present.  If not present, does NOT generate hash
 	Equals(otherClock SequenceClock) bool          // Evaluates whether two clocks are identical
-	IsEmptyClock () bool			       // Evaluates if this an empty clock
+	IsEmptyClock() bool                            // Evaluates if this an empty clock
 	AllAfter(otherClock SequenceClock) bool        // True if all entries in clock are greater than or equal to the corresponding values in otherClock
 	AllBefore(otherClock SequenceClock) bool       // True if all entries in clock are less than or equal to the corresponding values in otherClock
 	AnyAfter(otherClock SequenceClock) bool        // True if any entries in clock are greater than the corresponding values in otherClock
@@ -327,9 +327,10 @@ func (c *SyncSequenceClock) SetMaxSequence(vbNo uint16, vbSequence uint64) {
 	defer c.lock.Unlock()
 	c.Clock.SetMaxSequence(vbNo, vbSequence)
 }
+
 func (c *SyncSequenceClock) GetSequence(vbNo uint16) (sequence uint64) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.Clock.GetSequence(vbNo)
 }
 

--- a/base/stats.go
+++ b/base/stats.go
@@ -3,6 +3,12 @@ package base
 import "expvar"
 
 var StatsExpvars *expvar.Map = expvar.NewMap("syncGateway_stats")
+var TimingExpvars SequenceTimingExpvar
+
+const (
+	KTimingExpvarVbNo      = 0
+	KTimingExpvarFrequency = 200
+)
 
 //initialise the expvar properties that are exposed via syncGateway_stats
 //this ensures the properties are published even if there are no metrics
@@ -16,4 +22,7 @@ func init() {
 	StatsExpvars.Add("requests_active", 0)
 	StatsExpvars.Add("revisionCache_hits", 0)
 	StatsExpvars.Add("revisionCache_misses", 0)
+	TimingExpvars = NewSequenceTimingExpvar(KTimingExpvarFrequency, KTimingExpvarVbNo, "st")
+	StatsExpvars.Set("sequenceTiming", TimingExpvars)
+
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -159,9 +159,9 @@ func TestValueToStringArray(t *testing.T) {
 	result := ValueToStringArray("foobar")
 	assert.DeepEquals(t, result, []string{"foobar"})
 
-	result = ValueToStringArray([]string{"foobar","moocar"})
-	assert.DeepEquals(t, result, []string{"foobar","moocar"})
+	result = ValueToStringArray([]string{"foobar", "moocar"})
+	assert.DeepEquals(t, result, []string{"foobar", "moocar"})
 
-	result = ValueToStringArray([]interface{}{"foobar",1,true})
+	result = ValueToStringArray([]interface{}{"foobar", 1, true})
 	assert.DeepEquals(t, result, []string{"foobar"})
 }

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -87,6 +88,11 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 			current := make([]*ChangeEntry, len(feeds))
 			var sentSomething bool
 			nextEntry := getNextSequenceFromFeeds(current, feeds)
+
+			// postStableSeqsFound tracks whether we hit any sequences later than the stable sequence.  In this scenario the user
+			// may not get another wait notification, so we bypass wait loop processing.
+			postStableSeqsFound := false
+
 			for {
 				minEntry := nextEntry
 
@@ -106,6 +112,8 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 
 				// Don't send any entries later than the stable sequence
 				if stableClock.GetSequence(minEntry.Seq.vbNo) < minEntry.Seq.Seq {
+					postStableSeqsFound = true
+					dbExpvars.Add("index_changes.postStableSeqs", 1)
 					continue
 				}
 
@@ -182,6 +190,12 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 
 		waitForChanges:
 			for {
+				if postStableSeqsFound {
+					// If we saw documents later than the stable sequence, use a temporary wait
+					// instead of the changeWaiter, as we won't get notified again about those documents
+					time.Sleep(kPollFrequency * time.Millisecond)
+					break waitForChanges
+				}
 				waitResponse := changeWaiter.Wait()
 				if waitResponse == WaiterClosed {
 					break outer
@@ -340,7 +354,6 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 
 		if isNewChannel || (backfillRequired && !backfillInProgress) {
 			// Case 2.  No backfill in progress, backfill required
-			base.LogTo("Changes+", "Starting backfill for channel... %s, [%d:%d]", name, vbAddedAt, seqAddedAt)
 			chanOpts.Since = SequenceID{
 				Seq:              0,
 				vbNo:             0,
@@ -349,6 +362,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 				TriggeredByVbNo:  vbAddedAt,
 				TriggeredByClock: getChangesClock(options.Since).Copy(),
 			}
+			base.LogTo("Changes+", "Starting backfill for channel... %s, %+v", name, chanOpts.Since.Print())
 		} else if backfillInProgress {
 			// Case 3.  Backfill in progress.
 			chanOpts.Since = SequenceID{
@@ -359,6 +373,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 				TriggeredByVbNo:  vbAddedAt,
 				TriggeredByClock: options.Since.TriggeredByClock,
 			}
+			base.LogTo("Changes+", "Backfill in progress for channel... %s, %+v", name, chanOpts.Since.Print())
 		} else {
 			// Case 1.  Leave chanOpts.Since set to options.Since.
 		}

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -199,7 +198,6 @@ func (k *kvChangeIndexReader) stableSequenceChanged() bool {
 	}
 
 	if base.TimingExpvarsEnabled && isChanged {
-		log.Printf("Timing stable sequence: from %d to %d", prevTimingSeq, k.readerStableSequence.GetSequence(base.KTimingExpvarVbNo))
 		base.TimingExpvars.UpdateBySequenceRange("StableSequence", base.KTimingExpvarVbNo, prevTimingSeq, k.readerStableSequence.GetSequence(base.KTimingExpvarVbNo))
 	}
 

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -92,6 +92,13 @@ func (k *KvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 		k.lastPolledValidTo = k.clock.Copy()
 	}
 
+	// Ensure we haven't read a channel clock that's later than the stable sequence (since writers persist channel clocks
+	// before the stable sequence).  If so, use the stable sequence as channel clock
+	// as the latest channel clock
+	if newChannelClock.AnyAfter(stableClock) {
+		newChannelClock = stableClock
+	}
+
 	if !newChannelClock.AnyAfter(k.lastPolledChannelClock) {
 		// No changes to channel clock - update validTo based on the new stable sequence
 		k.lastPolledValidTo.SetTo(stableClock)

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -44,6 +44,7 @@ type KvChannelIndex struct {
 	onChange               func(base.Set)          // Notification callback
 	clock                  *base.SequenceClockImpl // Channel clock
 	channelStorage         ChannelStorageReader    // Channel storage - manages interaction with the index format
+	partitions             *base.IndexPartitions   // Partition map
 }
 
 func NewKvChannelIndex(channelName string, bucket base.Bucket, partitions *base.IndexPartitions, onChangeCallback func(base.Set)) *KvChannelIndex {
@@ -53,6 +54,7 @@ func NewKvChannelIndex(channelName string, bucket base.Bucket, partitions *base.
 		indexBucket:    bucket,
 		onChange:       onChangeCallback,
 		channelStorage: NewDenseStorageReader(bucket, channelName, partitions),
+		partitions:     partitions,
 	}
 
 	// Initialize and load channel clock
@@ -92,13 +94,9 @@ func (k *KvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 		k.lastPolledValidTo = k.clock.Copy()
 	}
 
-	// Ensure we haven't read a channel clock that's later than the stable sequence (since writers persist channel clocks
-	// before the stable sequence).  If so, set the channel clock as the minimum of (channel clock, stable clock) per vbucket
-	if newChannelClock.AnyAfter(stableClock) {
-		newChannelClock = base.GetMinimumClock(newChannelClock, stableClock)
-	}
+	isChanged, changedPartitions := k.calculateChanges(k.lastPolledChannelClock, stableClock, newChannelClock)
 
-	if !newChannelClock.AnyAfter(k.lastPolledChannelClock) {
+	if !isChanged {
 		// No changes to channel clock - update validTo based on the new stable sequence
 		k.lastPolledValidTo.SetTo(stableClock)
 		// If we've exceeded empty poll count, return hasChanges=true to trigger the "is
@@ -111,7 +109,7 @@ func (k *KvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 	}
 
 	// The clock has changed - load the changes and store in last polled
-	if err := k.updateLastPolled(stableClock, newChannelClock); err != nil {
+	if err := k.updateLastPolled(stableClock, newChannelClock, changedPartitions); err != nil {
 		base.Warn("Error updating last polled for channel %s: %v", k.channelName, err)
 		return false, false
 	}
@@ -123,7 +121,41 @@ func (k *KvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 	return true, false
 }
 
-func (k *KvChannelIndex) updateLastPolled(stableSequence base.SequenceClock, newChannelClock base.SequenceClock) error {
+func (k *KvChannelIndex) calculateChanges(lastPolledClock base.SequenceClock, stableClock base.SequenceClock, newChannelClock base.SequenceClock) (isChanged bool, changedPartitions []*PartitionRange) {
+
+	// One iteration through the new channel clock, to:
+	//   1. Check whether it's later than the previous channel clock
+	//   2. If it's later than the stable clock, roll back to the stable clock
+	//   3. If it still represents a change, add to set of changed vbs and partition ranges
+	changedPartitions = make([]*PartitionRange, k.partitions.PartitionCount())
+	for vbNoInt, newChannelClockSeq := range newChannelClock.Value() {
+		vbNo := uint16(vbNoInt)
+		lastPolledClockSeq := lastPolledClock.GetSequence(vbNo)
+		if lastPolledClockSeq < newChannelClockSeq {
+			// Handle rollback to stable sequence if needed
+			stableSeq := stableClock.GetSequence(vbNo)
+			if stableSeq < newChannelClockSeq {
+				newChannelClock.SetSequence(vbNo, stableSeq)
+				// We've rolled back the new channel clock to the stable sequence.  Ensure that we still have a change for this vb.
+				if !(lastPolledClockSeq < stableSeq) {
+					continue
+				}
+				newChannelClockSeq = stableSeq
+			}
+			isChanged = true
+			partitionNo := k.partitions.PartitionForVb(vbNo)
+			if changedPartitions[partitionNo] == nil {
+				partitionRange := NewPartitionRange()
+				changedPartitions[partitionNo] = &partitionRange
+			}
+			changedPartitions[partitionNo].SetRange(vbNo, lastPolledClockSeq, newChannelClockSeq)
+		}
+	}
+	return isChanged, changedPartitions
+
+}
+
+func (k *KvChannelIndex) updateLastPolled(stableSequence base.SequenceClock, newChannelClock base.SequenceClock, changedPartitions []*PartitionRange) error {
 
 	timingFrom := uint64(0)
 	if base.TimingExpvarsEnabled {
@@ -131,7 +163,7 @@ func (k *KvChannelIndex) updateLastPolled(stableSequence base.SequenceClock, new
 	}
 
 	// Update the storage cache, if present
-	err := k.channelStorage.UpdateCache(k.lastPolledChannelClock, newChannelClock)
+	err := k.channelStorage.UpdateCache(k.lastPolledChannelClock, newChannelClock, changedPartitions)
 	if err != nil {
 		return err
 	}
@@ -141,12 +173,6 @@ func (k *KvChannelIndex) updateLastPolled(stableSequence base.SequenceClock, new
 	k.lastPolledChannelClock.SetTo(newChannelClock)
 	k.lastPolledValidTo.SetTo(stableSequence)
 
-	if base.TimingExpvarsEnabled {
-		base.TimingExpvars.UpdateBySequenceRange("UpdateLastPolled",
-			base.KTimingExpvarVbNo,
-			timingFrom,
-			newChannelClock.GetSequence(base.KTimingExpvarVbNo))
-	}
 	return nil
 }
 

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -157,11 +157,6 @@ func (k *KvChannelIndex) calculateChanges(lastPolledClock base.SequenceClock, st
 
 func (k *KvChannelIndex) updateLastPolled(stableSequence base.SequenceClock, newChannelClock base.SequenceClock, changedPartitions []*PartitionRange) error {
 
-	timingFrom := uint64(0)
-	if base.TimingExpvarsEnabled {
-		timingFrom = k.lastPolledChannelClock.GetSequence(base.KTimingExpvarVbNo)
-	}
-
 	// Update the storage cache, if present
 	err := k.channelStorage.UpdateCache(k.lastPolledChannelClock, newChannelClock, changedPartitions)
 	if err != nil {

--- a/db/kv_channel_storage.go
+++ b/db/kv_channel_storage.go
@@ -35,7 +35,7 @@ const (
 type ChannelStorageReader interface {
 	// GetAllEntries returns all entries for the channel in the specified range, for all vbuckets
 	GetChanges(fromSeq base.SequenceClock, channelClock base.SequenceClock, limit int) ([]*LogEntry, error)
-	UpdateCache(fromSeq base.SequenceClock, channelClock base.SequenceClock) error
+	UpdateCache(fromSeq base.SequenceClock, channelClock base.SequenceClock, changedPartitions []*PartitionRange) error
 }
 
 type ChannelStorageWriter interface {
@@ -323,7 +323,7 @@ func (b *BitFlagStorage) GetChanges(fromSeq base.SequenceClock, toSeq base.Seque
 
 }
 
-func (b *BitFlagStorage) UpdateCache(sinceClock base.SequenceClock, toClock base.SequenceClock) error {
+func (b *BitFlagStorage) UpdateCache(sinceClock base.SequenceClock, toClock base.SequenceClock, changedPartitions []*PartitionRange) error {
 	// no-op, not a caching reader
 	return nil
 }

--- a/db/kv_channel_storage.go
+++ b/db/kv_channel_storage.go
@@ -35,6 +35,7 @@ const (
 type ChannelStorageReader interface {
 	// GetAllEntries returns all entries for the channel in the specified range, for all vbuckets
 	GetChanges(fromSeq base.SequenceClock, channelClock base.SequenceClock, limit int) ([]*LogEntry, error)
+	UpdateCache(fromSeq base.SequenceClock, channelClock base.SequenceClock) error
 }
 
 type ChannelStorageWriter interface {
@@ -320,6 +321,11 @@ func (b *BitFlagStorage) GetChanges(fromSeq base.SequenceClock, toSeq base.Seque
 
 	return results, nil
 
+}
+
+func (b *BitFlagStorage) UpdateCache(sinceClock base.SequenceClock, toClock base.SequenceClock) error {
+	// no-op, not a caching reader
+	return nil
 }
 
 type vbBlockSet struct {

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MaxBlockSize = 1000 // Maximum size of index block, in bytes
+	MaxBlockSize = 50000 // Maximum size of index block, in bytes
 )
 
 // DenseBlock stores a collection of LogEntries for a channel.  Entries which are added to a DenseBlock are
@@ -86,6 +86,7 @@ func (d *DenseBlock) getCumulativeClock() PartitionClock {
 func (d *DenseBlock) loadBlock(bucket base.Bucket) (err error) {
 	d.value, d.cas, err = bucket.GetRaw(d.Key)
 	d.clock = nil
+	IndexExpvars.Add("indexReader.blocksLoaded", 1)
 	return err
 }
 

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MaxBlockSize = 50000 // Maximum size of index block, in bytes
+	MaxBlockSize = 10000 // Maximum size of index block, in bytes
 )
 
 // DenseBlock stores a collection of LogEntries for a channel.  Entries which are added to a DenseBlock are

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	MaxBlockSize = 10000 // Maximum size of index block, in bytes
+	MaxBlockSize = 1000 // Maximum size of index block, in bytes
 )
 
 // DenseBlock stores a collection of LogEntries for a channel.  Entries which are added to a DenseBlock are

--- a/db/kv_dense_channel_storage_reader.go
+++ b/db/kv_dense_channel_storage_reader.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -36,6 +37,44 @@ func NewDenseStorageReader(bucket base.Bucket, channelName string, partitions *b
 	return storage
 }
 
+// Number of blocks to store in channel cache, per partition
+const kCachedBlocksPerShard = 2
+
+func (ds *DenseStorageReader) UpdateCache(sinceClock base.SequenceClock, toClock base.SequenceClock) error {
+
+	// Identify what's changed:
+	//  changedVbuckets: ordered list of vbuckets that have changes, based on the clock comparison
+	//  partitionRanges: array indexed by partitionNo of PartitionRange for each partition that's changed
+	_, partitionRanges := ds.calculateChanged(sinceClock, toClock)
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(partitionRanges))
+	for partitionNo, partitionRange := range partitionRanges {
+		if partitionRange == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(partitionNo uint16, partitionRange *PartitionRange) {
+			defer wg.Done()
+			reader := ds.getPartitionStorageReader(partitionNo)
+			if reader == nil {
+				base.Warn("Expected to get reader for channel %s partition %d, based on changed range %v", ds.channelName, partitionNo, partitionRange)
+				return
+			}
+			err := reader.UpdateCache(kCachedBlocksPerShard)
+			if err != nil {
+				base.Warn("Unable to update cache for channel:[%s] partition:[%d] : %v", ds.channelName, partitionNo, err)
+				errCh <-err
+			}
+		}(uint16(partitionNo), partitionRange)
+	}
+	wg.Wait()
+	if len(errCh) > 0 {
+		return <-errCh
+	}
+	return nil
+
+}
+
 // Returns all changes for the channel with sequences greater than sinceClock, and less than or equal to
 // toClock.  Changes need to be ordered by vbNo in order to support interleaving of results from multiple channels by
 // caller.  Changes are retrieved in vbucket order, to allow a limit check after each vbucket (to avoid retrieval).  Since
@@ -47,10 +86,11 @@ func (ds *DenseStorageReader) GetChanges(sinceClock base.SequenceClock, toClock 
 
 	// Identify what's changed:
 	//  changedVbuckets: ordered list of vbuckets that have changes, based on the clock comparison
-	//  partitionRanges: map from partitionNo to PartitionRange for each partition that's changed
-	changedVbuckets, partitionRanges := ds.calculateChanged(sinceClock, toClock)
-	base.LogTo("ChannelStorage+", "DenseStorageReader.GetChanges.  #changed vbuckets:[%d]", len(changedVbuckets))
+	//  partitionRanges: array of PartitionRange, indexed by partitionNo 
 
+	changedVbuckets, partitionRanges := ds.calculateChanged(sinceClock, toClock)
+	
+	// changed partitions is a cache of changes for a partition, for reuse by multiple vbs
 	changedPartitions := make(map[uint16]*PartitionChanges, len(partitionRanges))
 
 	for _, vbNo := range changedVbuckets {
@@ -61,13 +101,14 @@ func (ds *DenseStorageReader) GetChanges(sinceClock base.SequenceClock, toClock 
 			if err != nil {
 				return changes, err
 			}
-		}
-		// Append the changes for this vbucket
+			changedPartitions[partitionNo] = partitionChanges
+		} 
 		changes = append(changes, partitionChanges.GetVbChanges(vbNo)...)
 		if limit > 0 && len(changes) > limit {
 			break
 		}
 	}
+
 	return changes, nil
 }
 
@@ -123,13 +164,6 @@ func (ds *DenseStorageReader) calculateChanged(sinceClock, toClock base.Sequence
 	return changedVbs, changedPartitions
 }
 
-// DensePartitionStorageReader is a non-caching reader - every read request retrieves the latest from the bucket.
-type DensePartitionStorageReader struct {
-	channelName string      // Channel name
-	partitionNo uint16      // Partition number
-	indexBucket base.Bucket // Index bucket
-}
-
 type PartitionChanges struct {
 	changes map[uint16][]*LogEntry
 }
@@ -163,8 +197,25 @@ func (p *PartitionChanges) Count() int {
 	return count
 }
 
-func NewDensePartitionStorageReader(channelName string, partitionNo uint16, indexBucket base.Bucket) *DensePartitionStorageReader {
-	storage := &DensePartitionStorageReader{
+func (p *PartitionChanges) PrependChanges(other *PartitionChanges) {
+	for vbNo, otherChanges := range other.changes {
+		_, ok := p.changes[vbNo]
+		if !ok {
+			p.changes[vbNo] = make([]*LogEntry, 0)
+		}
+		p.changes[vbNo] = append(otherChanges, p.changes[vbNo]...)
+	}
+}
+
+// DensePartitionStorageReaderNonCaching is a non-caching reader - every read request retrieves the latest from the bucket.
+type DensePartitionStorageReaderNonCaching struct {
+	channelName string      // Channel name
+	partitionNo uint16      // Partition number
+	indexBucket base.Bucket // Index bucket
+}
+
+func NewDensePartitionStorageReaderNonCaching(channelName string, partitionNo uint16, indexBucket base.Bucket) *DensePartitionStorageReaderNonCaching {
+	storage := &DensePartitionStorageReaderNonCaching{
 		channelName: channelName,
 		partitionNo: partitionNo,
 		indexBucket: indexBucket,
@@ -172,9 +223,10 @@ func NewDensePartitionStorageReader(channelName string, partitionNo uint16, inde
 	return storage
 }
 
-func (r *DensePartitionStorageReader) GetChanges(partitionRange PartitionRange) (*PartitionChanges, error) {
+func (r *DensePartitionStorageReaderNonCaching) GetChanges(partitionRange PartitionRange) (*PartitionChanges, error) {
 
 	changes := NewPartitionChanges()
+
 
 	// Initialize the block list to the starting range, then find the starting block for the partition range
 	blockList := r.GetBlockListForRange(partitionRange)
@@ -212,7 +264,7 @@ func (r *DensePartitionStorageReader) GetChanges(partitionRange PartitionRange) 
 	return changes, nil
 }
 
-func (r *DensePartitionStorageReader) GetBlockListForRange(partitionRange PartitionRange) *DenseBlockList {
+func (r *DensePartitionStorageReaderNonCaching) GetBlockListForRange(partitionRange PartitionRange) *DenseBlockList {
 
 	// Initialize the block list, by loading all block list docs until we get one with
 	// a starting clock earlier than the partitionRange start.
@@ -236,3 +288,297 @@ func (l *DenseBlockList) LoadBlock(listEntry DenseBlockListEntry) *DenseBlock {
 	block.loadBlock(l.indexBucket)
 	return block
 }
+
+type DensePartitionStorageReader struct {
+	channelName       string                 // Channel name
+	partitionNo       uint16                 // Partition number
+	indexBucket       base.Bucket            // Index bucket
+	blockList         *DenseBlockList        // Cached block list
+	blockCache        map[string]*DenseBlock // Cached blocks
+	lock              sync.RWMutex           // Storage reader lock
+	validFrom         PartitionClock         // Reader cache is valid from this clock
+	pendingReload     map[string]bool        // Set of blocks to be reloaded in next poll
+	pendingReloadLock sync.Mutex             // Allow holders of lock.RLock to update pendingReload
+}
+
+func NewDensePartitionStorageReader(channelName string, partitionNo uint16, indexBucket base.Bucket) *DensePartitionStorageReader {
+	storage := &DensePartitionStorageReader{
+		channelName: channelName,
+		partitionNo: partitionNo,
+		indexBucket: indexBucket,
+		blockCache:  make(map[string]*DenseBlock),
+	}
+	return storage
+}
+
+// GetChanges attempts to return results from the cached changes.  If the cache doesn't satisfy the specified range,
+// retrieves from the index.  Note: currently no writeback of indexed retrieval into the cache - cache is only updated
+// during UpdateCache()
+func (pr *DensePartitionStorageReader) GetChanges(partitionRange PartitionRange) (*PartitionChanges, error) {
+
+	changes, cacheOk, err := pr.getCachedChanges(partitionRange)
+	if err != nil {
+		return nil, err
+	}
+	if cacheOk {
+		return changes, nil
+	}
+
+	// Cache didn't cover the partition range - retrieve from the index
+	return pr.getIndexedChanges(partitionRange)
+
+}
+
+func (pr *DensePartitionStorageReader) UpdateCache(numBlocks int) error {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+
+	// Reload the block list if changed
+	if pr.blockList == nil {
+		pr.blockList = NewDenseBlockListReader(pr.channelName, pr.partitionNo, pr.indexBucket)
+		if pr.blockList == nil {
+			return errors.New("Unable to initialize block list")
+		}
+	}
+
+	// Block lists can span multiple documents.  If pr.blockList include numBlocks,
+	// of the requested partitionRange, attempt to load previous block list doc(s).
+	blockCount := len(pr.blockList.blocks)
+	for blockCount < numBlocks {
+		err := pr.blockList.LoadPrevious()
+		if err != nil {
+			// No previous blocks - we're done
+			break
+		}
+		blockCount = len(pr.blockList.blocks)
+	}
+
+	if blockCount == 0 {
+		base.Warn("Attempted to update reader cache for partition with no blocks. channel:[%s] partition:[%d]", pr.channelName, pr.partitionNo)
+		return errors.New("No blocks found when updating partition cache")
+	}
+	// cacheKeySet tracks the blocks that should be in the cache - used for cache expiry, below
+	cacheKeySet := make(map[string]bool)
+
+	// Reload the active block
+	activeBlockEntry := pr.blockList.blocks[blockCount-1]
+	_, err := pr._loadAndCacheBlock(activeBlockEntry)
+	cacheKeySet[activeBlockEntry.Key(pr.blockList)] = true
+	if err != nil {
+		return err
+	}
+	pr.validFrom = activeBlockEntry.StartClock
+
+	// Update cache with older blocks, up to numBlocks, when present.
+	blocksCached := 1
+	for blocksCached < numBlocks {
+		blockIndex := blockCount - blocksCached
+		if blockIndex < 0 {
+			// We've hit the end of the block list before reaching num blocks - we're done.
+			break
+		}
+		blockListEntry := pr.blockList.blocks[blockIndex]
+		blockKey := blockListEntry.Key(pr.blockList)
+
+		_, ok := pr.blockCache[blockKey]
+		if ok {
+			// If it's already in the cache, only reload if it's been flagged for reload
+			if pr.pendingReload[blockKey] {
+				pr._loadAndCacheBlock(blockListEntry)
+				delete(pr.pendingReload, blockKey)
+			}
+		} else {
+			// Not in the cache - add it
+			pr._loadAndCacheBlock(blockListEntry)
+		}
+		cacheKeySet[blockKey] = true
+		pr.validFrom = blockListEntry.StartClock
+		blocksCached++
+	}
+
+	// Remove expired blocks from the cache
+	for key := range pr.blockCache {
+		if _, ok := cacheKeySet[key]; !ok {
+			delete(pr.blockCache, key)
+		}
+	}
+	return nil
+}
+
+// GetCachedChanges attempts to retrieve changes for the specified range using cached data.  If cache isn't
+// sufficient for the range, returns isCached=false and callers should call getIndexChanges
+func (pr *DensePartitionStorageReader) getCachedChanges(partitionRange PartitionRange) (changes *PartitionChanges, isCached bool, err error) {
+	pr.lock.RLock()
+	defer pr.lock.RUnlock()
+
+	// If blocklist isn't loaded, no cache
+	if pr.blockList == nil {
+		return nil, false, nil
+	}
+
+	// If the since value is earlier than the cache's validFrom, can't use cache
+	// Note: We're not comparing partitionRange.To with pr.validTo, because it's valid for the partition reader to
+	// be behind the requested range.
+	if partitionRange.SinceBefore(pr.validFrom) {
+		return nil, false, nil
+	}
+
+	// Iterate over the blocks, collecting entries.  Iterating over the blocks in reverse to support simple
+	// duplicate detection.
+	// KeySet is used to identify duplicates across blocks. Writers guarantee no duplicates within a
+	// given block, but we may see duplicates when spanning multiple blocks, in this scenario:
+	//         1. Writer adds foo rev2 to block 2
+	//         2. We read block 2, see foo rev2
+	//         3. We read block 1, see foo rev1
+	//         4. Writer removes foo rev1 from block 1
+	changes = NewPartitionChanges()
+	keySet := make(map[string]bool, 0)
+	for i := len(pr.blockList.blocks) - 1; i >= 0; i-- {
+
+		blockListEntry := pr.blockList.blocks[i]
+		blockKey := blockListEntry.Key(pr.blockList)
+		currBlock, ok := pr._getCachedBlock(blockKey)
+		if !ok {
+			base.Warn("Unexpected missing block from partition cache. blockKey:[%s] block startClock:[%s] cache validFrom:[%s]",
+				blockKey, blockListEntry.StartClock.String(), pr.validFrom.String())
+			return nil, true, nil
+		}
+		blockIter := NewDenseBlockIterator(currBlock)
+		blockChanges := NewPartitionChanges()
+		for {
+			logEntry := blockIter.next()
+			if logEntry == nil {
+				// End of block, continue to next block
+				break
+			}
+			switch compare := partitionRange.Compare(logEntry.VbNo, logEntry.Sequence); compare {
+			case PartitionRangeAfter:
+				// Possible when processing the most recent block in the range, when block is ahead of stable seq
+				case PartitionRangeWithin:
+				// Deduplication check
+				if keySet[logEntry.DocID] {
+					pr.notifyDuplicateFound(currBlock.Key)
+				} else {
+					blockChanges.AddEntry(logEntry)
+					keySet[logEntry.DocID] = true
+				}
+			case PartitionRangeBefore:
+				// Expected when processing the oldest block in the range.  Don't include in set
+			}
+		}
+		// Prepend partition changes with the results for this block
+		changes.PrependChanges(blockChanges)
+
+		// If we've reached a block with a startclock earlier than our since value, we're done
+		if partitionRange.SinceAfter(blockListEntry.StartClock) {
+			break
+		}
+	}
+
+	return changes, true, err
+}
+
+// If a reader hits a duplicate during load from cache, it means that one of the older blocks in the cache is stale (i.e. has been
+// updated by an index writer to remove an older revision).  Flag it for reload during next cache update
+func (pr *DensePartitionStorageReader) notifyDuplicateFound(blockKey string) {
+
+	pr.pendingReloadLock.Lock()
+	defer pr.pendingReloadLock.Unlock()
+	pr.pendingReload[blockKey] = true
+
+}
+
+// GetIndexedChanges retrieves changes directly from the index.
+func (pr *DensePartitionStorageReader) getIndexedChanges(partitionRange PartitionRange) (changes *PartitionChanges, err error) {
+
+	// Initialize block list
+	blockList := NewDenseBlockListReader(pr.channelName, pr.partitionNo, pr.indexBucket)
+	if blockList == nil {
+		return nil, errors.New("Unable to initialize block list")
+	}
+	err = blockList.populateForRange(partitionRange)
+	if err != nil {
+		return nil, err
+	}
+	changes = NewPartitionChanges()
+	keySet := make(map[string]bool, 0)
+	for i := len(blockList.blocks) - 1; i >= 0; i-- {
+
+		blockListEntry := blockList.blocks[i]
+		blockKey := blockListEntry.Key(blockList)
+
+		currBlock, err := pr.loadBlock(blockKey, blockListEntry.StartClock)
+
+		if err != nil {
+			base.Warn("Unexpected missing block from index. blockKey:[%s] err:[%v]",
+				blockKey, err)
+			return nil, err
+		}
+		blockIter := NewDenseBlockIterator(currBlock)
+		blockChanges := NewPartitionChanges()
+		for {
+			logEntry := blockIter.next()
+			if logEntry == nil {
+				// End of block, continue to next block
+				break
+			}
+			switch compare := partitionRange.Compare(logEntry.VbNo, logEntry.Sequence); compare {
+			case PartitionRangeAfter:
+				// Possible when processing the most recent block in the range
+			case PartitionRangeWithin:
+				// Deduplication check
+				if keySet[logEntry.DocID] {
+					// Ignore duplicates.
+				} else {
+					blockChanges.AddEntry(logEntry)
+					keySet[logEntry.DocID] = true
+				}
+			case PartitionRangeBefore:
+				// Expected when processing the oldest block in the range.  Don't include in set
+			}
+		}
+		// Prepend partition changes with the results for this block
+		changes.PrependChanges(blockChanges)
+
+		// If we've reached a block with a startclock earlier than our since value, we're done
+		if partitionRange.SinceAfter(blockListEntry.StartClock) {
+			break
+		}
+	}
+	return changes, nil
+}
+
+// Loads a block and adds to cache.  Callers must hold pr.lock.Lock()
+func (pr *DensePartitionStorageReader) _loadAndCacheBlock(listEntry DenseBlockListEntry) (*DenseBlock, error) {
+	blockKey := listEntry.Key(pr.blockList)
+	block, err := pr.loadBlock(blockKey, listEntry.StartClock)
+	if err != nil {
+		return nil, err
+	}
+	pr.blockCache[blockKey] = block
+	IndexExpvars.Add("indexReader.blocksCached", 1)
+	return block, nil
+}
+
+// Check whether the block for the specified block list entry is in the cached block map.
+//  Callers must hold pr.lock.RLock()
+func (pr *DensePartitionStorageReader) _getCachedBlock(key string) (*DenseBlock, bool) {
+	block, ok := pr.blockCache[key]
+	if !ok {
+		return nil, false
+	}
+	return block, true
+}
+
+// Loads a block from the index bucket
+func (pr *DensePartitionStorageReader) loadBlock(key string, startClock PartitionClock) (*DenseBlock, error) {
+
+	block := NewDenseBlock(key, startClock)
+	err := block.loadBlock(pr.indexBucket)
+	if err != nil {
+		return nil, err
+	}
+	IndexExpvars.Add("indexReader.blocksLoaded", 1)
+	return block, nil
+}
+

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -573,12 +573,12 @@ func TestCalculateChangedPartitions(t *testing.T) {
 			assertTrue(t, partition == 0 || partition == 6 || partition == 12, "Unexpected changed partition")
 		}
 	}
-	assert.Equals(t, changedPartitions[0].Since.GetSequence(0), uint64(0))
-	assert.Equals(t, changedPartitions[6].Since.GetSequence(100), uint64(0))
-	assert.Equals(t, changedPartitions[12].Since.GetSequence(200), uint64(0))
-	assert.Equals(t, changedPartitions[0].To.GetSequence(0), uint64(5))
-	assert.Equals(t, changedPartitions[6].To.GetSequence(100), uint64(10))
-	assert.Equals(t, changedPartitions[12].To.GetSequence(200), uint64(15))
+	assert.Equals(t, changedPartitions[0].GetSequenceRange(0).since, uint64(0))
+	assert.Equals(t, changedPartitions[6].GetSequenceRange(100).since, uint64(0))
+	assert.Equals(t, changedPartitions[12].GetSequenceRange(200).since, uint64(0))
+	assert.Equals(t, changedPartitions[0].GetSequenceRange(0).to, uint64(5))
+	assert.Equals(t, changedPartitions[6].GetSequenceRange(100).to, uint64(10))
+	assert.Equals(t, changedPartitions[12].GetSequenceRange(200).to, uint64(15))
 	assert.Equals(t, changedPartitionCount, 3)
 
 }

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -388,7 +388,7 @@ func TestDenseBlockIterator(t *testing.T) {
 	i := 0
 	logEntry := reader.next()
 	for logEntry != nil {
-		assertLogEntry(t, logEntry, fmt.Sprintf("doc%d", i), "1-abc", 10*i+1, i+1)
+		assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc%d", i), "1-abc", 10*i+1, i+1)
 		i++
 		logEntry = reader.next()
 	}
@@ -399,7 +399,7 @@ func TestDenseBlockIterator(t *testing.T) {
 	i = 9
 	logEntry = reader.previous()
 	for logEntry != nil {
-		assertLogEntry(t, logEntry, fmt.Sprintf("doc%d", i), "1-abc", 10*i+1, i+1)
+		assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc%d", i), "1-abc", 10*i+1, i+1)
 		i--
 		logEntry = reader.previous()
 	}
@@ -407,18 +407,18 @@ func TestDenseBlockIterator(t *testing.T) {
 
 	bidiReader := NewDenseBlockIterator(block)
 	logEntry = bidiReader.next()
-	assertLogEntry(t, logEntry, fmt.Sprintf("doc0"), "1-abc", 1, 1)
+	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc0"), "1-abc", 1, 1)
 	logEntry = bidiReader.previous()
-	assertLogEntry(t, logEntry, fmt.Sprintf("doc0"), "1-abc", 1, 1)
+	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc0"), "1-abc", 1, 1)
 	logEntry = bidiReader.previous()
 	assert.Equals(t, logEntry == nil, true)
 	logEntry = bidiReader.next()
-	assertLogEntry(t, logEntry, fmt.Sprintf("doc0"), "1-abc", 1, 1)
+	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc0"), "1-abc", 1, 1)
 	bidiReader.end()
 	logEntry = bidiReader.next()
 	assert.Equals(t, logEntry == nil, true)
 	logEntry = bidiReader.previous()
-	assertLogEntry(t, logEntry, fmt.Sprintf("doc9"), "1-abc", 91, 10)
+	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc9"), "1-abc", 91, 10)
 
 }
 

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -238,7 +238,7 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 
 }
 
-func TestDenseBlockOverflow(t *testing.T) {
+func DisableTestDenseBlockOverflow(t *testing.T) {
 	base.EnableLogKey("ChannelStorage")
 	indexBucket := testIndexBucket()
 	defer indexBucket.Close()

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -63,8 +63,8 @@ func (s SequenceID) String() string {
 // Diagnostic print of SequenceID
 func (s SequenceID) Print() string {
 	return fmt.Sprintf(
-		"SeqType:[%d] TriggeredBy:[%d] LowSeq:[%d] Seq:[%d] Clock:[%v] TriggeredByClock[%v] ClockHash:[%s] vbNo:[%d] TriggeredByVbno:[%d] LowHash:[%s]",
-		s.SeqType, s.TriggeredBy, s.LowSeq, s.Seq, s.Clock != nil, s.TriggeredByClock != nil, s.ClockHash, s.vbNo, s.TriggeredByVbNo, s.LowHash)
+		"Since:[%d:%d], TriggeredBy:[%d:%d]",
+		s.vbNo, s.Seq, s.TriggeredByVbNo, s.TriggeredBy)
 }
 
 func (s SequenceID) intSeqToString() string {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="9ca9f8aaf101668372b224db175e5e65cbb9f6bd"/>
 
   
   <!-- Dependencies specific to Sync Gateway Accel-->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="9ca9f8aaf101668372b224db175e5e65cbb9f6bd"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private"/>
 
   
   <!-- Dependencies specific to Sync Gateway Accel-->

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1504,7 +1504,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	assertStatus(t, rt.send(request("PUT", "/db/epsilon", `{"owner":"waldo"}`)), 201)
 
 	// Wait for change caching to complete before running resync below
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Finally, throw a wrench in the works by changing the sync fn. Note that normally this wouldn't
 	// be changed while the database is in use (only when it's re-opened) but for testing purposes


### PR DESCRIPTION
Squashed to four main commits - commit notes have more details on the four changes:
1. Correct wait handling when changes requests see entries later than the stable sequence.
2. Refactor DenseStorageReader to decouple from index write handling, and optimize for normal Sync Gateway read processing.
3. Use native block storage when iterating over blocks - only convert to LogEntry when needed.
4. Fixes for several CPU hotspots.
