### PR TITLE
Feature/issue 53

### DIFF
--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"expvar"
 	"fmt"
-	"log"
 	"math"
 	"sort"
 	"sync"
@@ -267,7 +266,6 @@ func (s *ShardedClock) UpdateAndWrite(updates map[uint16]uint64) (err error) {
 	partitionSequences := make(map[uint16][]VbSequence)
 
 	for vb, sequence := range updates {
-		log.Printf("Setting stable sequence: [%d:%d]", vb, sequence)
 		partitionNo := s.partitionMap.VbMap[uint16(vb)]
 		_, ok := partitionSequences[partitionNo]
 		if !ok {

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -28,6 +28,8 @@ var indexReaderPollPrincipalsCount expvar.Int
 var indexReaderPollPrincipalsTime base.DebugIntMeanVar
 var indexReaderGetChangesTime base.DebugIntMeanVar
 var indexReaderGetChangesCount expvar.Int
+var indexReaderGetChangesUseCached expvar.Int
+var indexReaderGetChangesUseIndexed expvar.Int
 
 type kvChangeIndexReader struct {
 	indexReadBucket           base.Bucket                // Index bucket
@@ -55,6 +57,8 @@ func init() {
 	base.StatsExpvars.Set("indexReader.pollPrincipals.Count", &indexReaderPollPrincipalsCount)
 	base.StatsExpvars.Set("indexReader.getChanges.Time", &indexReaderGetChangesTime)
 	base.StatsExpvars.Set("indexReader.getChanges.Count", &indexReaderGetChangesCount)
+	base.StatsExpvars.Set("indexReader.getChanges.UseCached", &indexReaderGetChangesUseCached)
+	base.StatsExpvars.Set("indexReader.getChanges.UseIndexed", &indexReaderGetChangesUseIndexed)
 }
 
 func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIndexOptions, onChange func(base.Set), indexPartitionsCallback IndexPartitionsFunc) (err error) {

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -18,9 +18,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 )
 
-const (
-	MaxBlockSize = 10000 // Maximum size of index block, in bytes
-)
+var MaxBlockSize = 10000 // Maximum size of index block, in bytes
 
 // DenseBlock stores a collection of LogEntries for a channel.  Entries which are added to a DenseBlock are
 // appended to existing entries.  A DenseBlock is considered 'full' when the size of the block exceeds
@@ -81,7 +79,7 @@ func (d *DenseBlock) getClock() base.PartitionClock {
 // the starting clock for this block, plus any changes made in this block
 func (d *DenseBlock) getCumulativeClock() base.PartitionClock {
 	cumulativeClock := d.startClock.Copy()
-	cumulativeClock.Add(d.clock)
+	cumulativeClock.Set(d.clock)
 	return cumulativeClock
 }
 

--- a/db/kv_dense_channel_storage_reader.go
+++ b/db/kv_dense_channel_storage_reader.go
@@ -285,15 +285,16 @@ func (l *DenseBlockList) LoadBlock(listEntry DenseBlockListEntry) *DenseBlock {
 }
 
 type DensePartitionStorageReader struct {
-	channelName       string                 // Channel name
-	partitionNo       uint16                 // Partition number
-	indexBucket       base.Bucket            // Index bucket
-	blockList         *DenseBlockList        // Cached block list
-	blockCache        map[string]*DenseBlock // Cached blocks
-	lock              sync.RWMutex           // Storage reader lock
-	validFrom         base.PartitionClock    // Reader cache is valid from this clock
-	pendingReload     map[string]bool        // Set of blocks to be reloaded in next poll
-	pendingReloadLock sync.Mutex             // Allow holders of lock.RLock to update pendingReload
+	channelName          string                 // Channel name
+	partitionNo          uint16                 // Partition number
+	indexBucket          base.Bucket            // Index bucket
+	blockList            *DenseBlockList        // Cached block list
+	blockCache           map[string]*DenseBlock // Cached blocks
+	activeCachedBlockKey string                 // Latest block cached
+	lock                 sync.RWMutex           // Storage reader lock
+	validFrom            base.PartitionClock    // Reader cache is valid from this clock
+	pendingReload        map[string]bool        // Set of blocks to be reloaded in next poll
+	pendingReloadLock    sync.Mutex             // Allow holders of lock.RLock to update pendingReload
 }
 
 func NewDensePartitionStorageReader(channelName string, partitionNo uint16, indexBucket base.Bucket) *DensePartitionStorageReader {
@@ -316,10 +317,12 @@ func (pr *DensePartitionStorageReader) GetChanges(partitionRange base.PartitionR
 		return nil, err
 	}
 	if cacheOk {
+		base.LogTo("Cache+", "Returning cached changes for channel:[%s], partition:[%d]", pr.channelName, pr.partitionNo)
 		return changes, nil
 	}
 
 	// Cache didn't cover the partition range - retrieve from the index
+	base.LogTo("Cache+", "Returning indexed changes for channel:[%s], partition:[%d]", pr.channelName, pr.partitionNo)
 	return pr.getIndexedChanges(partitionRange)
 
 }
@@ -333,6 +336,11 @@ func (pr *DensePartitionStorageReader) UpdateCache(numBlocks int) error {
 		pr.blockList = NewDenseBlockListReader(pr.channelName, pr.partitionNo, pr.indexBucket)
 		if pr.blockList == nil {
 			return errors.New("Unable to initialize block list")
+		}
+	} else {
+		pr.blockList.loadDenseBlockList()
+		for _, block := range pr.blockList.blocks {
+			base.LogTo("Cache+", "block valid from: %v", block.StartClock)
 		}
 	}
 
@@ -355,35 +363,38 @@ func (pr *DensePartitionStorageReader) UpdateCache(numBlocks int) error {
 	// cacheKeySet tracks the blocks that should be in the cache - used for cache expiry, below
 	cacheKeySet := make(map[string]bool)
 
-	// Reload the active block
-	activeBlockEntry := pr.blockList.blocks[blockCount-1]
-	_, err := pr._loadAndCacheBlock(activeBlockEntry)
-	cacheKeySet[activeBlockEntry.Key(pr.blockList)] = true
+	// Reload the active block first
+	blockListEntry := pr.blockList.ActiveListEntry()
+	base.LogTo("Cache+", "Reloading active block: %s", blockListEntry.Key(pr.blockList))
+	activeBlockKey := blockListEntry.Key(pr.blockList)
+	_, err := pr._loadAndCacheBlock(blockListEntry)
+	cacheKeySet[blockListEntry.Key(pr.blockList)] = true
 	if err != nil {
 		return err
 	}
-	pr.validFrom = activeBlockEntry.StartClock
+	pr.validFrom = blockListEntry.StartClock
 
 	// Update cache with older blocks, up to numBlocks, when present.
 	blocksCached := 1
 	for blocksCached < numBlocks {
-		blockIndex := blockCount - blocksCached
-		if blockIndex < 0 {
+		blockListEntry, err = pr.blockList.PreviousBlock(blockListEntry.BlockIndex)
+		if blockListEntry == nil {
 			// We've hit the end of the block list before reaching num blocks - we're done.
 			break
 		}
-		blockListEntry := pr.blockList.blocks[blockIndex]
 		blockKey := blockListEntry.Key(pr.blockList)
 
 		_, ok := pr.blockCache[blockKey]
 		if ok {
-			// If it's already in the cache, only reload if it's been flagged for reload
-			if pr.pendingReload[blockKey] {
+			// If it's already in the cache, reload if it was the previous active block, or it's been flagged for reload
+			if blockKey == pr.activeCachedBlockKey || pr.pendingReload[blockKey] {
+				base.LogTo("Cache+", "Reloading older block: %s", blockListEntry.Key(pr.blockList))
 				pr._loadAndCacheBlock(blockListEntry)
 				delete(pr.pendingReload, blockKey)
 			}
 		} else {
 			// Not in the cache - add it
+			base.LogTo("Cache+", "Adding older block to the cache: %s", blockListEntry.Key(pr.blockList))
 			pr._loadAndCacheBlock(blockListEntry)
 		}
 		cacheKeySet[blockKey] = true
@@ -397,6 +408,9 @@ func (pr *DensePartitionStorageReader) UpdateCache(numBlocks int) error {
 			delete(pr.blockCache, key)
 		}
 	}
+
+	// Update the active block key
+	pr.activeCachedBlockKey = activeBlockKey
 	return nil
 }
 
@@ -544,7 +558,7 @@ func (pr *DensePartitionStorageReader) getIndexedChanges(partitionRange base.Par
 }
 
 // Loads a block and adds to cache.  Callers must hold pr.lock.Lock()
-func (pr *DensePartitionStorageReader) _loadAndCacheBlock(listEntry DenseBlockListEntry) (*DenseBlock, error) {
+func (pr *DensePartitionStorageReader) _loadAndCacheBlock(listEntry *DenseBlockListEntry) (*DenseBlock, error) {
 	blockKey := listEntry.Key(pr.blockList)
 	block, err := pr.loadBlock(blockKey, listEntry.StartClock)
 	if err != nil {

--- a/db/kv_dense_channel_storage_reader.go
+++ b/db/kv_dense_channel_storage_reader.go
@@ -319,11 +319,13 @@ func (pr *DensePartitionStorageReader) GetChanges(partitionRange base.PartitionR
 	}
 	if cacheOk {
 		base.LogTo("Cache+", "Returning cached changes for channel:[%s], partition:[%d]", pr.channelName, pr.partitionNo)
+		indexReaderGetChangesUseCached.Add(1)
 		return changes, nil
 	}
 
 	// Cache didn't cover the partition range - retrieve from the index
 	base.LogTo("Cache+", "Returning indexed changes for channel:[%s], partition:[%d]", pr.channelName, pr.partitionNo)
+	indexReaderGetChangesUseIndexed.Add(1)
 	return pr.getIndexedChanges(partitionRange)
 
 }

--- a/db/kv_dense_channel_storage_reader.go
+++ b/db/kv_dense_channel_storage_reader.go
@@ -299,10 +299,11 @@ type DensePartitionStorageReader struct {
 
 func NewDensePartitionStorageReader(channelName string, partitionNo uint16, indexBucket base.Bucket) *DensePartitionStorageReader {
 	storage := &DensePartitionStorageReader{
-		channelName: channelName,
-		partitionNo: partitionNo,
-		indexBucket: indexBucket,
-		blockCache:  make(map[string]*DenseBlock),
+		channelName:   channelName,
+		partitionNo:   partitionNo,
+		indexBucket:   indexBucket,
+		blockCache:    make(map[string]*DenseBlock),
+		pendingReload: make(map[string]bool),
 	}
 	return storage
 }
@@ -450,7 +451,7 @@ func (pr *DensePartitionStorageReader) getCachedChanges(partitionRange base.Part
 		if !ok {
 			base.Warn("Unexpected missing block from partition cache. blockKey:[%s] block startClock:[%s] cache validFrom:[%s]",
 				blockKey, blockListEntry.StartClock.String(), pr.validFrom.String())
-			return nil, true, nil
+			return nil, false, nil
 		}
 		blockIter := NewDenseBlockIterator(currBlock)
 		blockChanges := NewPartitionChanges()


### PR DESCRIPTION
Corrects block cache processing issues:
- Fix for incorrect block list clock values (add instead of set)
- Always reload block list on UpdateCache
- Always reload the previous active block during UpdateCache (to ensure cache validity over block rollover)
- use PreviousBlock to iterate over block list, to ensure multi-doc block lists are loaded
