### PR TITLE
Fixes for backfill handling when using vector clock

### DIFF
--- a/base/sharded_sequence_clock_test.go
+++ b/base/sharded_sequence_clock_test.go
@@ -404,18 +404,18 @@ func (scp *GobShardedClockPartition) AddToClock(clock SequenceClock) error {
 func TestCompareVbAndSequence(t *testing.T) {
 
 	// Vb and Seq equal
-	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 100), 0)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 100), CompareEquals)
 
 	// Vb equal
-	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 101), -1)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 99), 1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 101), CompareLessThan)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 99), CompareGreaterThan)
 
 	// Vb different
-	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 100), -1)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 99), -1)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 101), -1)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 100), 1)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 99), 1)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 101), 1)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 100), CompareLessThan)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 99), CompareLessThan)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 101), CompareLessThan)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 100), CompareGreaterThan)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 99), CompareGreaterThan)
+	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 101), CompareGreaterThan)
 
 }

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -261,6 +261,9 @@ func (s *SequenceID) UnmarshalJSON(data []byte) error {
 
 func (s *SequenceID) unmarshalIntSequence(data []byte) error {
 	var raw string
+	if s.SeqType == Undefined {
+		s.SeqType = IntSequenceType
+	}
 	err := json.Unmarshal(data, &raw)
 	if err != nil {
 		*s, err = parseIntegerSequenceID(string(data))
@@ -274,6 +277,9 @@ func (s *SequenceID) unmarshalIntSequence(data []byte) error {
 // Unmarshals clock sequence.  If s.SequenceHasher is nil, UnmarshalClockSequence only populates the s.ClockHash value.
 func (s *SequenceID) unmarshalClockSequence(data []byte) error {
 	var hashValue string
+	if s.SeqType == Undefined {
+		s.SeqType = ClockSequenceType
+	}
 	err := json.Unmarshal(data, &hashValue)
 	if err != nil {
 		hashValue = string(data)


### PR DESCRIPTION
Corrects sequence ordering when doing backfill, to ensure that:
 - interrupted backfill processing (via changes with limit) doesn't requery the full dataset
 - concurrent backfill of multiple channels is ordered correctly
 - cumulative clock (used to built the changes last_seq) is updated to include backfill sequences higher than the since value, but earlier than the backfill trigger