### PR TITLE
Fixes SG Accel issue #69 db online / offline with out of sync index bucket fails

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -483,11 +483,7 @@ func VerifyBucketSequenceParity(indexBucketStableClock SequenceClock, bucket Buc
 	// otherwise it could indicate that the data bucket has been _reset_ to empty or to
 	// a value, which would render the index bucket incorrect
 	if !indexBucketStableClock.AllBefore(dataBucketClock) {
-		return fmt.Errorf(
-			"IndexBucketStable clock [%v] is not AllBefore the data bucket clock [%v]",
-			indexBucketStableClock,
-			dataBucketClock,
-		)
+		return fmt.Errorf("IndexBucketStable clock is not AllBefore the data bucket clock")
 	}
 
 	return nil

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -88,7 +88,9 @@ func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIn
 
 	// Make sure that the index bucket and data bucket have correct sequence parity
 	if err := k.verifyBucketSequenceParity(context); err != nil {
-		base.LogFatal("Unable to verify bucket sequence index parity: %v", err)
+		base.Warn("Unable to verify bucket sequence index parity [%v]. " +
+			"Can indicate that Couchbase Server experienced a rollback," +
+			" which Sync Gateway will attempt to handle gracefully.", err)
 	}
 
 


### PR DESCRIPTION
Changes fatal error into warning.  Make less verbose and do not dump out stable clocks.

https://github.com/couchbaselabs/sync-gateway-accel/issues/69

I figure the warning is potentially useful as a signal to someone who is trying to debug/support Sync Gateway.  If an admin does delete/flush the data bucket without deleting/flushing the index bucket, and then files a support ticket about changes not making it to clients while SG is dealing with the rollback .. which could take a while depending on data set size .. then it would be useful for the person supporting to see this warning in the logs.