### PR TITLE
Feature/issue accel 61

### DIFF
--- a/base/sequence_clock.go
+++ b/base/sequence_clock.go
@@ -245,8 +245,7 @@ func (c *SequenceClockImpl) Copy() SequenceClock {
 	return result
 }
 
-// Compares another sequence clock with this one.  Returns true if ANY vb values in the clock
-// are greater than the corresponding values in other
+// Sets a sequence clock equal to the specified clock
 func (c *SequenceClockImpl) SetTo(other SequenceClock) {
 	for vbNo := uint16(0); vbNo < KMaxVbNo; vbNo++ {
 		c.value[vbNo] = other.GetSequence(vbNo)
@@ -329,6 +328,12 @@ func NewSyncSequenceClock() *SyncSequenceClock {
 	// Initialize empty clock
 	syncClock := SyncSequenceClock{}
 	syncClock.Clock = NewSequenceClockImpl()
+	return &syncClock
+}
+
+func ConvertToSyncSequenceClock(clock *SequenceClockImpl) *SyncSequenceClock {
+	syncClock := SyncSequenceClock{}
+	syncClock.Clock = clock
 	return &syncClock
 }
 
@@ -418,8 +423,8 @@ func (c *SyncSequenceClock) IsEmptyClock() bool {
 
 // Copies a channel clock
 func (c *SyncSequenceClock) SetTo(other SequenceClock) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.Clock.SetTo(other)
 }
 

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -384,13 +384,15 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, opti
 		if isNewChannel || (backfillRequired && !backfillInProgress) {
 			// Case 2.  No backfill in progress, backfill required
 			chanOpts.Since = SequenceID{
-				Seq:              0,
-				vbNo:             0,
-				Clock:            base.NewSequenceClockImpl(),
-				TriggeredBy:      seqAddedAt,
-				TriggeredByVbNo:  vbAddedAt,
-				TriggeredByClock: getChangesClock(options.Since).Copy(),
+				Seq:             0,
+				vbNo:            0,
+				Clock:           base.NewSequenceClockImpl(),
+				TriggeredBy:     seqAddedAt,
+				TriggeredByVbNo: vbAddedAt,
 			}
+			chanOpts.Since.TriggeredByClock = base.NewSyncSequenceClock()
+			chanOpts.Since.TriggeredByClock.SetTo(getChangesClock(options.Since))
+
 			base.LogTo("Changes+", "Starting backfill for channel... %s, %+v", name, chanOpts.Since.Print())
 		} else if backfillInProgress {
 			// Case 3.  Backfill in progress.

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -216,7 +216,7 @@ func (s *sequenceHasher) GetHash(clock base.SequenceClock) (string, error) {
 	return seqHash.String(), nil
 }
 
-func (s *sequenceHasher) GetClock(sequence string) (base.SequenceClock, error) {
+func (s *sequenceHasher) GetClock(sequence string) (*base.SequenceClockImpl, error) {
 
 	clock := base.NewSequenceClockImpl()
 	var err error

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -185,9 +185,12 @@ func parseClockSequenceID(str string, sequenceHasher *sequenceHasher) (s Sequenc
 		}
 	} else if len(components) == 2 {
 		// TriggeredBy Clock Hash, and sequence
-		if s.TriggeredByClock, err = sequenceHasher.GetClock(components[0]); err != nil {
-			return SequenceID{}, err
+		triggeredByClock, hashErr := sequenceHasher.GetClock(components[0])
+		if hashErr != nil {
+			return SequenceID{}, hashErr
 		}
+		s.TriggeredByClock = base.ConvertToSyncSequenceClock(triggeredByClock)
+
 		// When triggered by hash is present, sequence is in the format TriggeredByVb.Vb.Sequence.  Split by delimiter "." and assign
 		// to the appropriate sequence properties.
 		sequenceComponents := strings.Split(components[1], ".")

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -338,7 +338,18 @@ func (s SequenceID) intEquals(s2 SequenceID) bool {
 }
 
 func (s SequenceID) vectorEquals(s2 SequenceID) bool {
-	return s.Seq == s2.Seq && s.vbNo == s2.vbNo && s.TriggeredBy == s2.TriggeredBy && s.TriggeredByVbNo == s2.TriggeredByVbNo
+
+	// Compare sequences
+	if s.Seq != s2.Seq || s.vbNo != s2.vbNo {
+		return false
+	}
+
+	// If triggered by is set, compare based on triggered by vb, seq
+	if s.TriggeredByClock != nil && s2.TriggeredByClock != nil {
+		return s.TriggeredBy == s2.TriggeredBy && s.TriggeredByVbNo == s2.TriggeredByVbNo
+	}
+
+	return true
 }
 
 // The most significant value is TriggeredBy, unless it's zero, in which case use Seq.


### PR DESCRIPTION
Fixes https://github.com/couchbaselabs/sync-gateway-accel/issues/61

Adds handling for the case where the backfill trigger vb.seq is lower than all documents to be backfilled.  In this scenario, the trigger vb.seq wasn't being added to the changes feed's cumulative clock (which normally happens on the first backfill sequence).

Also fixes unit test race detected when updating triggered by clock (by switching to synchronized clock).