### PR TITLE
Fixes #2266 loading persisted walrus buckets CBL ios test failure

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -53,7 +53,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="37776129003ea73e3aad3306f7e4945edfa76fcc"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4a98979fe7e3cd5e6bb8d06be3e73bc00172d6f2"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
 


### PR DESCRIPTION
If the Walrus PR is merged via "rebase and merge", then this PR should already be pointing to the exact commit that will land on the walrus master branch.  Otherwise if "squash" or "normal merge" is used, we'll have to rework this PR to point to the correct commit in the walrus repo.