### PR TITLE
Refactor backfill processing to handle edge cases

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -46,12 +46,21 @@ type ChangeEntry struct {
 	Err        error       `json:"err,omitempty"` // Used to notify feed consumer of errors
 	allRemoved bool        // Flag to track whether an entry is a removal in all channels visible to the user.
 	branched   bool
+	backfill   backfillFlag // Flag used to identify non-client entries used for backfill synchronization (di only)
 }
 
 const (
 	WaiterClosed uint32 = iota
 	WaiterHasChanges
 	WaiterCheckTerminated
+)
+
+type backfillFlag int8
+
+const (
+	BackfillFlag_None backfillFlag = iota
+	BackfillFlag_Pending
+	BackfillFlag_Complete
 )
 
 type ChangeRev map[string]string // Key is always "rev", value is rev ID

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -203,7 +203,7 @@ func (k *KvChannelIndex) GetChanges(sinceClock base.SequenceClock, toClock base.
 
 	// Don't request values later than channel clock
 	if toClock != nil {
-		toClock.LimitTo(chanClock)
+		toClock = toClock.LimitTo(chanClock)
 	} else {
 		toClock = chanClock
 	}


### PR DESCRIPTION
Fix for https://github.com/couchbaselabs/sync-gateway-accel/issues/76.

The previous backfill processing had gaps when the changes feed was interrupted by limit.  Refactored to better follow the model used for non-vector sequences - once a channel is in backfill, we send everything pre-since for that channel, without interference from other non-backfill channels.

The key change is to defer calculation of the backfill results until the changes feed reaches the backfill trigger (instead of calculating at the start of the changes loop iteration).  This allows the backfill to be based on the since value at trigger time, and ignore anything later than the since value.