### PR TITLE
Windows service startup blocks when starting SG allowing errors to be returned

### DIFF
--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -19,11 +19,15 @@ type program struct {
 }
 
 func (p *program) Start(s service.Service) error {
-	go p.run()
+	err := p.startup()
+	if err != nil {
+		return err
+	}
+	go p.wait()
 	return nil
 }
 
-func (p *program) run() {
+func (p *program) startup() error {
 	logger.Infof("Starting Sync Gateway service using command: `%s %s`", p.ExePath, p.ConfigPath)
 
 	if p.ConfigPath != "" {
@@ -36,7 +40,7 @@ func (p *program) run() {
 	f, err := os.OpenFile(stderrPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
 	if err != nil {
 		logger.Warningf("Failed to open std err %q: %v", stderrPath, err)
-		return
+		return err
 	}
 	defer f.Close()
 	p.SyncGateway.Stderr = f
@@ -44,9 +48,13 @@ func (p *program) run() {
 	err = p.SyncGateway.Start()
 	if err != nil {
 		logger.Errorf("Failed to start Sync Gateway due to error %v", err)
-		return
+		return err
 	}
-	err = p.SyncGateway.Wait()
+	return nil
+}
+
+func (p *program) wait() {
+	err := p.SyncGateway.Wait()
 	if err != nil {
 		logger.Errorf("Sync Gateway exiting with %v", err)
 		panic("Failed to start Sync Gateway service.")

--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -57,8 +57,8 @@ func (p *program) wait() {
 	err := p.SyncGateway.Wait()
 	if err != nil {
 		logger.Errorf("Sync Gateway exiting with %v", err)
-		panic("Failed to start Sync Gateway service.")
 	}
+	panic("Sync Gateway service exited.")
 }
 
 func (p *program) Stop(s service.Service) error {


### PR DESCRIPTION
fixes #2270 

Changed service startup sequence so that Sync Gateway execution is now a blocking call to give a chance for startup errors to be returned to the Windows service.

It’s not clear that this will resolve all race conditions as the golang docs contain the following comment for program.Run()

`Start starts the specified command but does not wait for it to complete.

The Wait method will return the exit code and release associated resources once the command exits.`

It’s not clear how quickly Run() returns after starting Sync Gateway and whether a config validation error would sucessfully return an error from the Start() function.