### PR TITLE
Prevent backfill for triggers later than stable sequence

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -86,6 +86,7 @@ func TestSkippedSequenceQueue(t *testing.T) {
 func TestLateSequenceHandling(t *testing.T) {
 
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Test1", 0)
 	assert.True(t, cache != nil)
 
@@ -149,6 +150,7 @@ func TestLateSequenceHandling(t *testing.T) {
 func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Test1", 0)
 	assert.True(t, cache != nil)
 

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -23,6 +23,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	base.EnableLogKey("Cache")
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Test1", 0)
 
 	// Add some entries to cache
@@ -66,6 +67,7 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	base.EnableLogKey("Cache")
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Test1", 0)
 
 	// Add some entries to cache
@@ -95,6 +97,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	base.EnableLogKey("Cache")
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Test1", 0)
 
 	// Add some entries to cache
@@ -124,6 +127,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	base.EnableLogKey("Cache")
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Test1", 0)
 
 	// Add some entries to cache
@@ -233,6 +237,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	base.SetLogLevel(2) // disables logging
 	//base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate doc IDs
 	docIDs := make([]string, b.N)
@@ -249,6 +254,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate doc IDs
 
@@ -264,6 +270,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	//base.LogKeys["Cache+"] = true
 	base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate doc IDs
 
@@ -278,6 +285,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate doc IDs
 
@@ -292,6 +300,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate doc IDs
 
@@ -307,6 +316,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	base.EnableLogKey("CacheTest")
 	//base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate doc IDs
 
@@ -321,6 +331,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
+	defer context.Close()
 	cache := newChannelCache(context, "Benchmark", 0)
 	// generate docs
 	docs := make([]*LogEntry, b.N)

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -60,7 +60,6 @@ func init() {
 	base.StatsExpvars.Set("indexReader.getChanges.UseIndexed", &indexReaderGetChangesUseIndexed)
 }
 
-
 func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIndexOptions, onChange func(base.Set), indexPartitionsCallback IndexPartitionsFunc, context *DatabaseContext) (err error) {
 
 	k.channelIndexReaders = make(map[string]*KvChannelIndex)
@@ -88,11 +87,10 @@ func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIn
 
 	// Make sure that the index bucket and data bucket have correct sequence parity
 	if err := k.verifyBucketSequenceParity(context); err != nil {
-		base.Warn("Unable to verify bucket sequence index parity [%v]. " +
-			"May indicate that Couchbase Server experienced a rollback," +
+		base.Warn("Unable to verify bucket sequence index parity [%v]. "+
+			"May indicate that Couchbase Server experienced a rollback,"+
 			" which Sync Gateway will attempt to handle gracefully.", err)
 	}
-
 
 	// Start background task to poll for changes
 	k.terminator = make(chan struct{})
@@ -115,7 +113,7 @@ func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIn
 				//       stable sequence polling each poll interval, even if we *actually* don't have any
 				//       active readers.
 				pollStart = time.Now()
-				if k.hasActiveReaders() && k.stableSequenceChanged() {
+				if k.stableSequenceChanged() {
 					var wg sync.WaitGroup
 					wg.Add(2)
 					go func() {
@@ -150,7 +148,6 @@ func (k *kvChangeIndexReader) verifyBucketSequenceParity(context *DatabaseContex
 	return base.VerifyBucketSequenceParity(indexBucketStableClock, context.Bucket)
 
 }
-
 
 func (k *kvChangeIndexReader) Clear() {
 	k.channelIndexReaders = make(map[string]*KvChannelIndex)

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -95,6 +95,13 @@ func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIn
 	// Start background task to poll for changes
 	k.terminator = make(chan struct{})
 	k.pollingActive = make(chan struct{})
+
+	// Skip polling initialization if writer
+	if indexOptions != nil && indexOptions.Writer {
+		close(k.pollingActive)
+		return nil
+	}
+
 	go func(k *kvChangeIndexReader) {
 		defer close(k.pollingActive)
 		pollStart := time.Now()

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -78,7 +78,6 @@ func initIndexTester(useBucketIndex bool, syncFn string) indexTester {
 				Server: &serverName,
 				Bucket: &indexBucketName,
 			},
-			IndexWriter: true,
 		}
 		dbConfig.ChannelIndex = channelIndexConfig
 	}


### PR DESCRIPTION
Channel backfill is skipped when the triggering sequence is later than the stable sequence, to ensure that the triggering sequence is included with the backfill (avoids duplicate backfill).

Also updates polling to remove activeReaders check - since one-shot changes are using the cached results, need to refresh the stable sequence even when no continuous changes are in progress.