### PR TITLE
Handling for role grant and role-channel grant triggered backfill (accel)

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -45,6 +45,14 @@ type Principal interface {
 	// access was granted; else returns zero.
 	CanSeeChannelSince(channel string) uint64
 
+	// If the Principal has access to the given channel, returns the vb and sequence number at which
+	// access was granted; else returns zero.
+	CanSeeChannelSinceVbSeq(channel string, numVbuckets int) (base.VbSeq, bool)
+
+	// Validate that the specified vbSeq has a non-zero sequence, and populate the vbucket for
+	// admin grants.
+	ValidateGrant(vbseq *ch.VbSequence, numVbuckets int) bool
+
 	// Returns an error if the Principal does not have access to all the channels in the set.
 	AuthorizeAllChannels(channels base.Set) error
 
@@ -59,6 +67,7 @@ type Principal interface {
 	accessViewKey() string
 	validate() error
 	setChannels(ch.TimedSet)
+	getVbNo(numVbuckets int) uint16
 }
 
 // Role is basically the same as Principal, just concrete. Users can inherit channels from Roles.
@@ -107,6 +116,11 @@ type User interface {
 	// Returns a TimedSet containing only the channels from the input set that the user has access
 	// to, annotated with the sequence number at which access was granted.
 	FilterToAvailableChannels(channels base.Set) ch.TimedSet
+
+	// Returns a TimedSet containing only the channels from the input set that the user has access
+	// to, annotated with the sequence number at which access was granted.  When there are multiple grants
+	// to the same channel, priority is given to values prior to the specified since.
+	FilterToAvailableChannelsForSince(channels base.Set, since base.SequenceClock) (ch.TimedSet, ch.TimedSet)
 
 	// Returns a Set containing channels that the user has access to, that aren't present in the
 	// input set

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -332,6 +332,6 @@ func dedupeTapEvents(tapEvents []sgbucket.TapEvent) []sgbucket.TapEvent {
 }
 
 // VBHash finds the vbucket for the given key.
-func VBHash(key string, numVb uint16) uint32 {
-	return sgbucket.VBHash(key, numVb)
+func VBHash(key string, numVb int) uint32 {
+	return sgbucket.VBHash(key, uint16(numVb))
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -185,6 +185,30 @@ func (ce *ChangeEntry) SetBranched(isBranched bool) {
 	ce.branched = isBranched
 }
 
+func (ce *ChangeEntry) String() string {
+
+	var deletedString, removedString, errString, allRemovedString, branchedString, backfillString string
+	if ce.Deleted {
+		deletedString = ", Deleted:true"
+	}
+	if len(ce.Removed) > 0 {
+		removedString = fmt.Sprintf(", Removed:%v", ce.Removed)
+	}
+	if ce.Err != nil {
+		errString = fmt.Sprintf(", Err:%v", ce.Err)
+	}
+	if ce.allRemoved {
+		allRemovedString = ", allRemoved:true"
+	}
+	if ce.branched {
+		branchedString = ", branched:true"
+	}
+	if ce.backfill != BackfillFlag_None {
+		backfillString = fmt.Sprintf(", backfill:%d", ce.backfill)
+	}
+	return fmt.Sprintf("{Seq:%s, ID:%s, Changes:%s%s%s%s%s%s%s}", ce.Seq, ce.ID, ce.Changes, deletedString, removedString, errString, allRemovedString, branchedString, backfillString)
+}
+
 func makeErrorEntry(message string) ChangeEntry {
 
 	change := ChangeEntry{

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -20,6 +20,7 @@ const (
 	ViewAccess                = "access"
 	ViewAccessVbSeq           = "access_vbseq"
 	ViewRoleAccess            = "role_access"
+	ViewRoleAccessVbSeq       = "role_access_vbseq"
 	ViewAllBits               = "all_bits"
 	ViewAllDocs               = "all_docs"
 	ViewImport                = "import"

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -15,6 +15,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -252,6 +253,8 @@ func (s *sequenceHasher) GetClock(sequence string) (*base.SequenceClockImpl, err
 	}
 	clock = base.NewSequenceClockImpl()
 	clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())
+
+	log.Printf("Hash %s converts to clock: %s", sequence, base.PrintClock(clock))
 	return clock, nil
 
 }


### PR DESCRIPTION
Added view (RoleAccessVbSeq) to provide vb, seq information for role grants.  Same approach as the one used by the existing AccessVbSeq view (for principal channel grants), along with uptake to include this information in the user roles collection when running in vector clock mode

Added handling for backfill triggers for user access to a channel via a role.  Two main changes:

 - When using vector clock sequences, we can't do a sequence-based comparison between user and role grants to identify the earliest sequence at which a user gained access to a channel (because grants may occur in multiple vbuckets).  Instead, when trying to determine whether a user needs backfill for a channel, we need to compare the set of grants for the channel with the current since value, and only trigger backfill when there are no grants earlier than the since value.  When evaluating role-based channel access, only one of the role grant or the role channel grant need to be post-since to require a backfill
 - When both the role grant and the role channel grant are post-since, they can result in multiple backfill triggers.  To avoid this, we're tracking secondary triggers for channel backfill.  When backfill starts for a channel, the secondary trigger is also added to the user's cumulative clock.