### PR TITLE
Fix error handling in index_changes

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -343,9 +343,9 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			// included in the initial changes loop iteration, and (b) won't wake up the changeWaiter.
 			if db.user != nil {
 				if err := db.ReloadUser(); err != nil {
+					base.Warn("Error reloading user during changes initialization %q: %v", db.user.Name(), err)
 					change := makeErrorEntry("User not found during reload - terminating changes feed")
 					output <- &change
-					base.Warn("Error reloading user during changes initialization %q: %v", db.user.Name(), err)
 					return
 				}
 			}
@@ -438,6 +438,8 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				feed, err := db.changesFeed(name, chanOpts)
 				if err != nil {
 					base.Warn("MultiChangesFeed got error reading changes feed %q: %v", name, err)
+					change := makeErrorEntry("Error reading changes feed - terminating changes feed")
+					output <- &change
 					return
 				}
 				feeds = append(feeds, feed)

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -15,7 +15,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -253,8 +252,6 @@ func (s *sequenceHasher) GetClock(sequence string) (*base.SequenceClockImpl, err
 	}
 	clock = base.NewSequenceClockImpl()
 	clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())
-
-	log.Printf("Hash %s converts to clock: %s", sequence, base.PrintClock(clock))
 	return clock, nil
 
 }


### PR DESCRIPTION
Ensures that index_changes breaks out of the changes_api loop on error.

Fixes https://github.com/couchbaselabs/sync-gateway-accel/issues/72

Also cleans up logging in sequence hasher, unnecessary clock copy during backfill.