### PR TITLE
Feature/issue 2295 logtee

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -27,6 +27,12 @@ import (
 
 var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
 
+const (
+	// If true, all HTTP request/response bodies will be logged.
+	// Use this sparingly as it will probably dump sensitive information into the logs.
+	EnableLogHTTPBodies = false
+)
+
 type Level int32
 
 //By setting DebugLevel to -1, if LogLevel is not set in the logging config it
@@ -522,7 +528,7 @@ func UpdateLogger(logFilePath string) {
 
 // This provides an io.Writer interface around the base.Log API
 type LoggerWriter struct {
-	LogKey       string        // The log key to log to, eg, "HTTP++"
+	LogKey       string        // The log key to log to, eg, "HTTP+"
 	SerialNumber uint64        // The request ID
 	Request      *http.Request // The request
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -201,7 +201,7 @@ func (h *handler) invoke(method handlerMethod) error {
 		}
 	}
 
-	if base.LogEnabledExcludingLogStar("HTTP+") {
+	if base.LogEnabledExcludingLogStar("HTTP++") {
 		// Wrap the existing ResponseWriter with one that "Tees" the output
 		// to stdout as well as writing back to the socket
 		h.response = NewLoggerTeeResponseWriter(

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -189,7 +189,7 @@ func (h *handler) invoke(method handlerMethod) error {
 
 	h.logRequestLine()
 
-	if base.LogKeys["HTTP++"] {
+	if base.EnableLogHTTPBodies {
 		h.logRequestBody()
 	}
 
@@ -201,12 +201,12 @@ func (h *handler) invoke(method handlerMethod) error {
 		}
 	}
 
-	if base.LogEnabledExcludingLogStar("HTTP++") {
+	if base.EnableLogHTTPBodies {
 		// Wrap the existing ResponseWriter with one that "Tees" the output
 		// to stdout as well as writing back to the socket
 		h.response = NewLoggerTeeResponseWriter(
 			h.response,
-			"HTTP++",
+			"HTTP",
 			h.serialNumber,
 			h.rq,
 		)
@@ -235,16 +235,16 @@ func (h *handler) logRequestLine() {
 
 func (h *handler) logRequestBody() {
 
-	if !base.LogEnabled("HTTP++") {
+	if !base.EnableLogHTTPBodies {
 		return
 	}
 
 	// Replace the requestBody io.ReadCloser with a TeeReadCloser that
-	// tees the request body to the base.Log with the HTTP++ logging key
+	// tees the request body to the base.Log with the HTTPBody logging key
 	h.requestBody = NewTeeReadCloser(
 		h.requestBody,
 		base.NewLoggerWriter(
-			"HTTP++",
+			"HTTP",
 			h.serialNumber,
 			h.rq,
 		),
@@ -261,7 +261,7 @@ func (h *handler) logDuration(realTime bool) {
 	var duration time.Duration
 	if realTime {
 		duration = time.Since(h.startTime)
-		bin := int(duration / (100 * time.Millisecond)) * 100
+		bin := int(duration/(100*time.Millisecond)) * 100
 		restExpvars.Add(fmt.Sprintf("requests_%04dms", bin), 1)
 	}
 

--- a/rest/ioutil.go
+++ b/rest/ioutil.go
@@ -35,7 +35,7 @@ func (t *TeeReadCloser) Close() error {
 // the logging key
 type LoggingTeeResponseWriter struct {
 	http.ResponseWriter
-	LogKey       string        // The log key to use, eg "HTTP++"
+	LogKey       string        // The log key to use, eg "HTTP+"
 	SerialNumber uint64        // The request ID
 	Request      *http.Request // The request
 }


### PR DESCRIPTION
Fixes #2295 by checking the correct logging flag when deciding whether to try to log the response body or not.  (previously was checking the wrong flag)

As an added security measure, put this behind a compile time flag.

