### PR TITLE
Backfill fix for admin role grant

### DIFF
--- a/auth/user.go
+++ b/auth/user.go
@@ -381,7 +381,7 @@ func (user *userImpl) InheritedChannelsForClock(sinceClock base.SequenceClock) (
 	// For each role, evaluate role grant vbseq and role channel grant vbseq.
 	for _, role := range user.GetRoles() {
 		roleSince := user.RolesSince_[role.Name()]
-		roleGrantValid := role.ValidateGrant(&roleSince, numVbuckets)
+		roleGrantValid := user.ValidateGrant(&roleSince, numVbuckets)
 		if !roleGrantValid {
 			continue
 		}

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -89,7 +89,7 @@ func (v VbSequence) IsLTEClock(clock base.SequenceClock) bool {
 	if v.VbNo == nil {
 		return false
 	}
-	return v.Sequence < clock.GetSequence(*v.VbNo)
+	return v.Sequence <= clock.GetSequence(*v.VbNo)
 }
 
 // A mutable mapping from channel names to sequence numbers (interpreted as the sequence when

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -490,6 +490,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 		// If backfill required and the triggering seq is after the stable sequence, skip this channel in this iteration
 		stableSeq := stableClock.GetSequence(vbAddedAt)
 		if backfillRequired && seqAddedAt > stableSeq {
+			base.LogTo("Changes+", "Trigger for channel [%s] is post-stable sequence - skipped for this iteration")
 			hasPostChangesTriggers = true
 			continue
 		}


### PR DESCRIPTION
The trigger for admin role grants was being calculated using the role doc vbno, instead of the user doc vbno.

The unit test for this fix also caught a bug in the LTE processing.