### PR TITLE
Poll principals performance optimization

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -47,11 +47,11 @@ type Principal interface {
 
 	// If the Principal has access to the given channel, returns the vb and sequence number at which
 	// access was granted; else returns zero.
-	CanSeeChannelSinceVbSeq(channel string, numVbuckets int) (base.VbSeq, bool)
+	CanSeeChannelSinceVbSeq(channel string, hashFunction VBHashFunction) (base.VbSeq, bool)
 
 	// Validate that the specified vbSeq has a non-zero sequence, and populate the vbucket for
 	// admin grants.
-	ValidateGrant(vbseq *ch.VbSequence, numVbuckets int) bool
+	ValidateGrant(vbseq *ch.VbSequence, hashFunction VBHashFunction) bool
 
 	// Returns an error if the Principal does not have access to all the channels in the set.
 	AuthorizeAllChannels(channels base.Set) error
@@ -67,7 +67,7 @@ type Principal interface {
 	accessViewKey() string
 	validate() error
 	setChannels(ch.TimedSet)
-	getVbNo(numVbuckets int) uint16
+	getVbNo(hashFunction VBHashFunction) uint16
 }
 
 // Role is basically the same as Principal, just concrete. Users can inherit channels from Roles.

--- a/auth/role.go
+++ b/auth/role.go
@@ -173,7 +173,7 @@ func (role *roleImpl) CanSeeChannelSince(channel string) uint64 {
 
 // Returns the sequence number since which the Role has been able to access the channel, else zero.  Sets the vb
 // for an admin channel grant, if needed.
-func (role *roleImpl) CanSeeChannelSinceVbSeq(channel string, numVbuckets int) (base.VbSeq, bool) {
+func (role *roleImpl) CanSeeChannelSinceVbSeq(channel string, hashFunction VBHashFunction) (base.VbSeq, bool) {
 	seq, ok := role.Channels_[channel]
 	if !ok {
 		seq, ok = role.Channels_[ch.UserStarChannel]
@@ -182,7 +182,7 @@ func (role *roleImpl) CanSeeChannelSinceVbSeq(channel string, numVbuckets int) (
 		}
 	}
 	if seq.VbNo == nil {
-		roleDocVbNo := role.getVbNo(numVbuckets)
+		roleDocVbNo := role.getVbNo(hashFunction)
 		seq.VbNo = &roleDocVbNo
 	}
 	return base.VbSeq{*seq.VbNo, seq.Sequence}, true
@@ -196,7 +196,7 @@ func (role *roleImpl) AuthorizeAnyChannel(channels base.Set) error {
 	return authorizeAnyChannel(role, channels)
 }
 
-func (role *roleImpl) ValidateGrant(vbSeq *ch.VbSequence, numVbuckets int) bool {
+func (role *roleImpl) ValidateGrant(vbSeq *ch.VbSequence, hashFunction VBHashFunction) bool {
 
 	// If the sequence is zero, this is an admin grant that hasn't been updated by accel - ignore
 	if vbSeq.Sequence == 0 {
@@ -205,15 +205,15 @@ func (role *roleImpl) ValidateGrant(vbSeq *ch.VbSequence, numVbuckets int) bool 
 
 	// If vbSeq is nil, this is an admin grant.  Set the vb to the vb of the user doc
 	if vbSeq.VbNo == nil {
-		calculatedVbNo := role.getVbNo(numVbuckets)
+		calculatedVbNo := role.getVbNo(hashFunction)
 		vbSeq.VbNo = &calculatedVbNo
 	}
 	return true
 }
 
-func (role *roleImpl) getVbNo(numVbuckets int) uint16 {
+func (role *roleImpl) getVbNo(hashFunction VBHashFunction) uint16 {
 	if role.vbNo == nil {
-		calculatedVbNo := uint16(base.VBHash(role.DocID(), numVbuckets))
+		calculatedVbNo := uint16(hashFunction(role.DocID()))
 		role.vbNo = &calculatedVbNo
 	}
 	return *role.vbNo

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -490,7 +490,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 		// If backfill required and the triggering seq is after the stable sequence, skip this channel in this iteration
 		stableSeq := stableClock.GetSequence(vbAddedAt)
 		if backfillRequired && seqAddedAt > stableSeq {
-			base.LogTo("Changes+", "Trigger for channel [%s] is post-stable sequence - skipped for this iteration")
+			base.LogTo("Changes+", "Trigger for channel [%s] is post-stable sequence - skipped for this iteration.  userVbNo:[%d] vbAddedAt:[%d] Seq:[%d] Stable seq:[%d]", name, userVbNo, vbAddedAt, seqAddedAt, stableSeq)
 			hasPostChangesTriggers = true
 			continue
 		}

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -23,10 +23,10 @@ import (
 var indexReaderOneShotCount expvar.Int
 var indexReaderPersistentCount expvar.Int
 var indexReaderPollReadersCount expvar.Int
-var indexReaderPollReadersTime base.DebugIntMeanVar
+var indexReaderPollReadersTime = base.NewIntRollingMeanVar(100)
 var indexReaderPollPrincipalsCount expvar.Int
-var indexReaderPollPrincipalsTime base.DebugIntMeanVar
-var indexReaderGetChangesTime base.DebugIntMeanVar
+var indexReaderPollPrincipalsTime = base.NewIntRollingMeanVar(100)
+var indexReaderGetChangesTime = base.NewIntRollingMeanVar(100)
 var indexReaderGetChangesCount expvar.Int
 var indexReaderGetChangesUseCached expvar.Int
 var indexReaderGetChangesUseIndexed expvar.Int

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -480,7 +480,10 @@ func (k *kvChangeIndexReader) pollPrincipals() {
 	}
 	k.overallPrincipalCount = overallCount
 
+	// There's been a change - check if our active principals have changed
 	var changedWaitKeys []string
+
+	// When using a gocb bucket, use a single bulk operation to retrieve counters.
 	if gocbIndexBucket, ok := k.indexReadBucket.(base.CouchbaseBucketGoCB); ok {
 		principalKeySet := make([]string, len(k.activePrincipalCounts))
 		i := 0


### PR DESCRIPTION
Add support for bulk counter retrieval via gocb, and uses that to retrieve principal counters during polling.

Includes a fix for vbucket counts and principal doc hashing which shows up when running against a 64-vbucket CBS instance (OS X).

Also converts the expvar used to track polling times to a rolling average, to better report the current state in Grafana.

