### PR TITLE
Take a copy when retaining GetRaw results

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -135,12 +135,12 @@ func (bucket CouchbaseBucketGoCB) GetName() string {
 
 func (bucket CouchbaseBucketGoCB) GetRaw(k string) (rv []byte, cas uint64, err error) {
 
-	var returnVal interface{}
+	var returnVal []byte
 	cas, err = bucket.Get(k, &returnVal)
 	if returnVal == nil {
 		return nil, cas, err
 	}
-	return returnVal.([]byte), cas, err
+	return returnVal, cas, err
 
 }
 

--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -455,7 +455,8 @@ func (p *ShardedClockPartition) Marshal() ([]byte, error) {
 }
 
 func (p *ShardedClockPartition) Unmarshal(value []byte) error {
-	p.value = value
+	p.value = make([]byte, len(value))
+	copy(p.value, value)
 	return nil
 }
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -736,7 +736,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, cal
 
 		// Return the new raw document value for the bucket to store.
 		raw, err = json.Marshal(doc)
-		base.LogTo("Cache", "SAVING #%d", doc.Sequence) //TEMP?
+		base.LogTo("CRUD+", "SAVING #%d", doc.Sequence) //TEMP?
 		return
 	})
 


### PR DESCRIPTION
When retaining with the results of a GetRaw operation as raw bytes, make a copy of the results to ensure the underlying slice doesn't get overwritten.

Fixes https://github.com/couchbaselabs/sync-gateway-accel/issues/95