### PR TITLE
Improve skipped sequence cleanup

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -695,6 +695,8 @@ func (h *SkippedSequenceQueue) Remove(x uint64) error {
 
 	i := SearchSequenceQueue(*h, x)
 	if i < len(*h) && (*h)[i].seq == x {
+		// GC-friendly removal of skipped sequence entries from the queue.
+		// (https://github.com/golang/go/wiki/SliceTricks)
 		copy((*h)[i:], (*h)[i+1:])
 		(*h)[len(*h)-1] = nil
 		*h = (*h)[:len(*h)-1]

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -695,7 +695,10 @@ func (h *SkippedSequenceQueue) Remove(x uint64) error {
 
 	i := SearchSequenceQueue(*h, x)
 	if i < len(*h) && (*h)[i].seq == x {
-		*h = append((*h)[:i], (*h)[i+1:]...)
+
+		copy((*h)[i:], (*h)[i+1:])
+		(*h)[len(*h)-1] = nil
+		*h = (*h)[:len(*h)-1]
 		return nil
 	} else {
 		return errors.New("Value not found")

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -695,7 +695,6 @@ func (h *SkippedSequenceQueue) Remove(x uint64) error {
 
 	i := SearchSequenceQueue(*h, x)
 	if i < len(*h) && (*h)[i].seq == x {
-
 		copy((*h)[i:], (*h)[i+1:])
 		(*h)[len(*h)-1] = nil
 		*h = (*h)[:len(*h)-1]


### PR DESCRIPTION
Switches to GC-friendly removal of skipped sequence entries from the queue.  (https://github.com/golang/go/wiki/SliceTricks)