### PR TITLE
Force user reload after longpoll wait

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -58,8 +58,8 @@ type BucketSpec struct {
 
 // Implementation of sgbucket.Bucket that talks to a Couchbase server
 type CouchbaseBucket struct {
-	*couchbase.Bucket // the underlying go-couchbase bucket
-	spec BucketSpec   // keep a copy of the BucketSpec for DCP usage
+	*couchbase.Bucket            // the underlying go-couchbase bucket
+	spec              BucketSpec // keep a copy of the BucketSpec for DCP usage
 }
 
 type couchbaseFeedImpl struct {
@@ -377,8 +377,6 @@ func (bucket CouchbaseBucket) CBSVersion() (major uint64, minor uint64, micro st
 	}
 
 	micro = arr[2]
-
-	LogTo("CRUD+", "major = %i, minor = %i, micro = %s", major, minor, micro)
 
 	return
 }

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -1,10 +1,9 @@
 package db
 
 import (
+	"math"
 	"strings"
 	"sync"
-
-	"math"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 	"testing"
 	"time"
 
@@ -218,6 +219,56 @@ func postChanges(t *testing.T, it indexTester) {
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
 	assertNoError(t, err, "Error unmarshalling changes response")
 	assert.Equals(t, len(changes.Results), 3)
+
+}
+
+// Tests race between waking up the changes feed, and detecting that the user doc has changed
+func TestPostChangesUserTiming(t *testing.T) {
+
+	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`)
+	defer it.Close()
+
+	response := it.sendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "DIndex+":true}`)
+	assert.True(t, response != nil)
+
+	// Create user:
+	a := it.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("bernard"))
+	assert.True(t, err == nil)
+	a.Save(bernard)
+
+	var wg sync.WaitGroup
+
+	// Put several documents to channel PBS
+	response = it.sendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.sendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.sendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var changes struct {
+			Results  []db.ChangeEntry
+			Last_Seq string
+		}
+		changesJSON := `{"style":"all_docs", "timeout":6000, "feed":"longpoll", "limit":50, "since":"0"}`
+		changesResponse := it.send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+		// Validate that the user receives backfill plus the new doc
+		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		assertNoError(t, err, "Error unmarshalling changes response")
+		assert.Equals(t, len(changes.Results), 4)
+	}()
+
+	// Wait for changes feed to get into wait mode, even when running under race
+	time.Sleep(2 * time.Second)
+
+	// Put a doc in channel bernard, that also grants bernard access to channel PBS
+	response = it.sendAdminRequest("PUT", "/db/grant1", `{"value":1, "channel":["bernard"], "accessUser":"bernard", "accessChannel":"PBS"}`)
+	assertStatus(t, response, 201)
+	wg.Wait()
 
 }
 


### PR DESCRIPTION
Avoids race between granting doc and associated user update when longpoll is awakened.  Workaround until complete fix for https://github.com/couchbase/sync_gateway/issues/2068 is available.