### PR TITLE
Unlock build repo in manifest (#1462)

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -19,7 +19,7 @@
   <default remote="couchbase" revision="master"/>
 
   <!-- Build Scripts (required on CI servers) -->
-  <project name="build" path="cbbuild" remote="couchbase" revision="388ec72a70fc0925823d726609a209201052567b">
+  <project name="build" path="cbbuild" remote="couchbase">
     <annotation name="VERSION" value="1.4"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
This should work this time as I've fixed a problem in the new build scripts. Tested locally on centos 70 at least.