### PR TITLE
Resolve channels prior to changeWaiter init

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -117,6 +117,14 @@ type User interface {
 	// to, annotated with the sequence number at which access was granted.
 	FilterToAvailableChannels(channels base.Set) ch.TimedSet
 
+	// Every channel the user has access to, including those inherited from Roles.
+	InheritedChannelsForClock(since base.SequenceClock) (channels ch.TimedSet, secondaryTriggers ch.TimedSet)
+
+	// If the input set contains the wildcard "*" channel, returns the user's InheritedChannels, restricted
+	// by the since value;
+	// else returns the input channel list unaltered.
+	ExpandWildCardChannelSince(channels base.Set, since base.SequenceClock) base.Set
+
 	// Returns a TimedSet containing only the channels from the input set that the user has access
 	// to, annotated with the sequence number at which access was granted.  When there are multiple grants
 	// to the same channel, priority is given to values prior to the specified since.

--- a/auth/user.go
+++ b/auth/user.go
@@ -347,6 +347,15 @@ func (user *userImpl) GetAddedChannels(channels ch.TimedSet) base.Set {
 
 /////////// Support for vb.seq based comparison of channel, role, and role channel grants
 
+// If a channel list contains the all-channel wildcard, replace it with all the user's accessible channels.
+func (user *userImpl) ExpandWildCardChannelSince(channels base.Set, since base.SequenceClock) base.Set {
+	if channels.Contains(ch.AllChannelWildcard) {
+		channelSet, _ := user.InheritedChannelsForClock(since)
+		channels = channelSet.AsSet()
+	}
+	return channels
+}
+
 // FilterToAvailableChannelsForSince is used for clock-based changes, and gives priority to vb.seq values
 // earlier than the provided since clock when returning results (because that means the channel doesn't require
 // backfill).


### PR DESCRIPTION
Filter to available channels w/ since prior to change waiter and user polling initialization.  Apply the same filtering when checking for user updates post-wait.

Fixes https://github.com/couchbaselabs/sync-gateway-accel/issues/111