### PR TITLE
Fixes #2352 by changing /RUNBASE_TEMPLATE_VAR from /Home/sync_gateway…

### DIFF
--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -1,19 +1,31 @@
 #!/bin/sh
 
+# Detect OSX to set home dir
+OS="`uname`"
+case $OS in
+  'Darwin') 
+    HOME='Users'
+    ;;
+  *) OS='Home';;
+esac
+
 # Set default values
-OS=""
+HOME=""
 VER=""
 SERVICE_NAME="sync_gateway"
 SRCCFGDIR=../examples
 SRCCFG=serviceconfig.json
 RUNAS_TEMPLATE_VAR=sync_gateway
-RUNBASE_TEMPLATE_VAR=/home/sync_gateway
+RUNBASE_TEMPLATE_VAR=/${OS}/sync_gateway
 PIDFILE_TEMPLATE_VAR=/var/run/sync-gateway.pid
 GATEWAYROOT_TEMPLATE_VAR=/opt/couchbase-sync-gateway
 GATEWAY_TEMPLATE_VAR=/opt/couchbase-sync-gateway/bin/sync_gateway
 CONFIG_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/sync_gateway.json
 LOGS_TEMPLATE_VAR=${RUNBASE_TEMPLATE_VAR}/logs
 SERVICE_CMD_ONLY=false
+
+# Create the directory
+mkdir -p -- "/${OS}/sync_gateway"
 
 
 usage()


### PR DESCRIPTION
Fixes #2352 by adding check to determine if OSX or not. If OS X, it will switch RUNBASE_TEMPLATE_VAR location to **/Users** instead of **/Home** which is for Linux.