### PR TITLE
Notify when sequences are allocated and not used

### DIFF
--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -71,6 +71,10 @@ func (listener *changeListener) Start(bucket base.Bucket, trackDocs bool, notify
 						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
 					}
 					listener.Notify(base.SetOf(key))
+				} else if strings.HasPrefix(key, UnusedSequenceKeyPrefix) {
+					if listener.OnDocChanged != nil {
+						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
+					}
 				} else if !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, base.KIndexPrefix) {
 					if listener.OnDocChanged != nil {
 						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -598,6 +599,157 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
 	assert.Equals(t, len(changes.Results), 1)
+
+}
+
+func TestConcurrentDelete(t *testing.T) {
+	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+"})
+
+	rt := restTester{syncFn: `function(doc,oldDoc) {
+			 channel(doc.channel)
+		 }`}
+
+	// Create doc
+	response := rt.sendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId := body["rev"].(string)
+
+	// Issue concurrent deletes
+	var wg sync.WaitGroup
+	for i := 1; i <= 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			deleteResponse := rt.sendAdminRequest("DELETE", fmt.Sprintf("/db/doc1?rev=%s", revId), "")
+			log.Printf("Delete #%d got response code: %d", i, deleteResponse.Code)
+		}(i)
+	}
+	wg.Wait()
+
+	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+
+	response = rt.sendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+
+	// Wait for writes to be processed and indexed
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+
+}
+
+func TestConcurrentPutAsDelete(t *testing.T) {
+	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+"})
+
+	rt := restTester{syncFn: `function(doc,oldDoc) {
+			 channel(doc.channel)
+		 }`}
+
+	// Create doc
+	response := rt.sendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId := body["rev"].(string)
+
+	// Issue concurrent deletes
+	var wg sync.WaitGroup
+	for i := 1; i <= 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			deleteResponse := rt.sendAdminRequest("PUT", fmt.Sprintf("/db/doc1?rev=%s", revId), `{"_deleted":true}`)
+			log.Printf("Delete #%d got response code: %d", i, deleteResponse.Code)
+		}(i)
+	}
+	wg.Wait()
+
+	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+
+	// Write another doc, to validate sequences restart
+	response = rt.sendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+}
+
+func TestConcurrentUpdate(t *testing.T) {
+	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+"})
+
+	rt := restTester{syncFn: `function(doc,oldDoc) {
+			 channel(doc.channel)
+		 }`}
+
+	// Create doc
+	response := rt.sendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId := body["rev"].(string)
+
+	// Issue concurrent updates
+	var wg sync.WaitGroup
+	for i := 1; i <= 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			updateResponse := rt.sendAdminRequest("PUT", fmt.Sprintf("/db/doc1?rev=%s", revId), `{"value":10}`)
+			log.Printf("Update #%d got response code: %d", i, updateResponse.Code)
+		}(i)
+	}
+	wg.Wait()
+
+	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+
+	// Write another doc, to validate sequences restart
+	response = rt.sendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+}
+
+func TestConcurrentNewEditsFalseDelete(t *testing.T) {
+	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+", "HTTP", "HTTP+"})
+
+	rt := restTester{syncFn: `function(doc,oldDoc) {
+			 channel(doc.channel)
+		 }`}
+
+	// Create doc
+	response := rt.sendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId := body["rev"].(string)
+	revIdHash := strings.TrimPrefix(revId, "1-")
+
+	deleteRequestBody := fmt.Sprintf(`{"_rev": "2-foo", "_revisions": {"start": 2, "ids": ["foo", "%s"]}, "_deleted":true}`, revIdHash)
+	// Issue concurrent deletes
+	var wg sync.WaitGroup
+	for i := 1; i <= 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			deleteResponse := rt.sendAdminRequest("PUT", "/db/doc1?rev=2-foo&new_edits=false", deleteRequestBody)
+			log.Printf("Delete #%d got response code: %d", i, deleteResponse.Code)
+		}(i)
+	}
+	wg.Wait()
+
+	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+
+	// Write another doc, to see where sequences are at
+	response = rt.sendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
+	assertStatus(t, response, 201)
+	rt.ServerContext().Database("db").WaitForPendingChanges()
 
 }
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -602,7 +602,16 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 }
 
-func TestConcurrentDelete(t *testing.T) {
+func TestUnusedSequences(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		_testConcurrentDelete(t)
+		_testConcurrentPutAsDelete(t)
+		_testConcurrentUpdate(t)
+		_testConcurrentNewEditsFalseDelete(t)
+	}
+}
+
+func _testConcurrentDelete(t *testing.T) {
 	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+"})
 
 	rt := restTester{syncFn: `function(doc,oldDoc) {
@@ -640,7 +649,7 @@ func TestConcurrentDelete(t *testing.T) {
 
 }
 
-func TestConcurrentPutAsDelete(t *testing.T) {
+func _testConcurrentPutAsDelete(t *testing.T) {
 	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+"})
 
 	rt := restTester{syncFn: `function(doc,oldDoc) {
@@ -677,7 +686,7 @@ func TestConcurrentPutAsDelete(t *testing.T) {
 	rt.ServerContext().Database("db").WaitForPendingChanges()
 }
 
-func TestConcurrentUpdate(t *testing.T) {
+func _testConcurrentUpdate(t *testing.T) {
 	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+"})
 
 	rt := restTester{syncFn: `function(doc,oldDoc) {
@@ -714,7 +723,7 @@ func TestConcurrentUpdate(t *testing.T) {
 	rt.ServerContext().Database("db").WaitForPendingChanges()
 }
 
-func TestConcurrentNewEditsFalseDelete(t *testing.T) {
+func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 	base.ParseLogFlags([]string{"Cache", "Cache+", "Changes+", "CRUD", "CRUD+", "HTTP", "HTTP+"})
 
 	rt := restTester{syncFn: `function(doc,oldDoc) {


### PR DESCRIPTION
When Sync Gateway fails to update a document after an unsuccessful WriteUpdate (CAS write loop), it ends up with an unused allocated sequence.  This causes Sync Gateway nodes that are reading the TAP/DCP feed and trying to generate a set of ordered sequences to block waiting for that sequence (eventually triggering the skipped sequence handling).

Successful WriteUpdate retries were already handling this case using the unusedSequences property on the successfully updated doc.

On failed WriteUpdate with unused sequences, we now persist a transient document named _sync:unusedSeq:[seqnumber].  When Sync Gateway nodes working the TAP/DCP feed see a document of this type, the sequence gets buffered as an unused sequence.

Fixes #2365