### PR TITLE
Only log value of new logging logFilePath if it has been set.

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -550,14 +550,16 @@ func NewLoggerWriter(logKey string, serialNumber uint64, req *http.Request) *Log
 
 func CreateRollingLogger(logConfig *LogAppenderConfig) {
 	if logConfig != nil {
+		SetLogLevel(logConfig.LogLevel.sgLevel())
+
 		lj := lumberjack.Logger{}
 
-		if logConfig.LogFilePath != nil {
+		if logConfig.LogFilePath == nil {
+			return
+		} else {
 			lj.Filename = *logConfig.LogFilePath
 			log.Printf("Log entries will be written to the file %v", *logConfig.LogFilePath)
 		}
-
-		SetLogLevel(logConfig.LogLevel.sgLevel())
 
 		if rotation := logConfig.Rotation; rotation != nil {
 			if rotation.MaxSize > 0 {
@@ -571,7 +573,7 @@ func CreateRollingLogger(logConfig *LogAppenderConfig) {
 			}
 			lj.LocalTime = rotation.LocalTime
 		}
-		
+
 		//Update default GoLang logger to use new rolling logger
 		logger.SetOutput(&lj)
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -552,14 +552,14 @@ func CreateRollingLogger(logConfig *LogAppenderConfig) {
 	if logConfig != nil {
 		SetLogLevel(logConfig.LogLevel.sgLevel())
 
-		lj := lumberjack.Logger{}
-
 		if logConfig.LogFilePath == nil {
 			return
-		} else {
-			lj.Filename = *logConfig.LogFilePath
-			log.Printf("Log entries will be written to the file %v", *logConfig.LogFilePath)
 		}
+
+		lj := lumberjack.Logger{}
+
+		lj.Filename = *logConfig.LogFilePath
+		log.Printf("Log entries will be written to the file %v", *logConfig.LogFilePath)
 
 		if rotation := logConfig.Rotation; rotation != nil {
 			if rotation.MaxSize > 0 {

--- a/base/logging.go
+++ b/base/logging.go
@@ -554,6 +554,7 @@ func CreateRollingLogger(logConfig *LogAppenderConfig) {
 
 		if logConfig.LogFilePath != nil {
 			lj.Filename = *logConfig.LogFilePath
+			log.Printf("Log entries will be written to the file %v", *logConfig.LogFilePath)
 		}
 
 		SetLogLevel(logConfig.LogLevel.sgLevel())
@@ -570,8 +571,7 @@ func CreateRollingLogger(logConfig *LogAppenderConfig) {
 			}
 			lj.LocalTime = rotation.LocalTime
 		}
-
-		log.Printf("Log entries will be written to the file %v", *logConfig.LogFilePath)
+		
 		//Update default GoLang logger to use new rolling logger
 		logger.SetOutput(&lj)
 


### PR DESCRIPTION
Fixes #2367 

This is a fix for the panic in SG when the logging section config does not contain a logFIlePath

In this case SG should log to stderr