### PR TITLE
Removed handler scoped log line

### DIFF
--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -659,8 +659,7 @@ loop:
 			return nil, forceClose // error is probably because the client closed the connection
 		}
 	}
-
-	h.logStatus(http.StatusOK, "OK (continuous feed closed)")
+	
 	return nil, forceClose
 }
 


### PR DESCRIPTION
Removed handler scoped log line, panics if handler is null, and the log entry is now duplicated in the calling function