### PR TITLE
sgcollectinfo: convert response and lookup key to lowercase so that case differences are ignored

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -199,7 +199,10 @@ def extract_element_from_config(element, config):
     sync_regex = r'"Sync":(`.*`)'
     config = re.sub(sync_regex, '"Sync":""', config)
     try:
-        return json.loads(config)[element]
+        # convert dictionary keys to lower case
+        lower_case_keys_dict = {k.lower():v for k,v in json.loads(config).items()}
+        #lookup key after converting element name to lower case
+        return lower_case_keys_dict[element.lower()]
     except (ValueError, KeyError):
         # If we can't deserialise the json or find the key then return nothing
         return
@@ -211,7 +214,7 @@ def extract_element_from_default_logging_config(element, config):
             if logging_config:
                 default_logging_config = extract_element_from_config('default', json.dumps(logging_config))
                 if default_logging_config:
-                    guessed_log_path = extract_element_from_config('LogFilePath', json.dumps(default_logging_config))
+                    guessed_log_path = extract_element_from_config(element, json.dumps(default_logging_config))
                     if guessed_log_path:
                         return guessed_log_path
             return

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -189,6 +189,9 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
 
     return pprof_tasks
 
+def to_lower_case_keys_dict(original_dict):
+    return {k.lower():v for k,v in original_dict.items()}
+
 def extract_element_from_config(element, config):
     """ The config returned from /_config may not be fully formed json
         due to the fact that the sync function is inside backticks (`)
@@ -200,7 +203,9 @@ def extract_element_from_config(element, config):
     config = re.sub(sync_regex, '"Sync":""', config)
     try:
         # convert dictionary keys to lower case
-        lower_case_keys_dict = {k.lower():v for k,v in json.loads(config).items()}
+        original_dict = json.loads(config)
+        lower_case_keys_dict = to_lower_case_keys_dict(original_dict)
+        
         #lookup key after converting element name to lower case
         return lower_case_keys_dict[element.lower()]
     except (ValueError, KeyError):


### PR DESCRIPTION
fixes #2400

When looking up keys in the SG(A) /_config response convert response keys and lookup key to lowercase so that case differences are ignored.