### PR TITLE
Explicitly set bash as the shell and the call ‘set -e’

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+set -e
 
 ## Go Tests
 echo "Testing code with 'go test' ..."


### PR DESCRIPTION
fixes #2399 

Explicitly set bash as the shell and the call ‘set -e’ so that the script will exit if any single line in the script fails. Previously the test for sg_accel was masking the SG test error code.