### PR TITLE
Fixes #2323 Bump gorillamux to latest version

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -72,9 +72,9 @@
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
-  <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="708054d61e5a2918b9f4e9700000ee611dcf03f5"/>
+  <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
-  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="9b36453141c35697401168b07f2c09fcff7721ce"/>
+  <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="043ee6597c29786140136a5747b6a886364f5282"/>
 
   <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/2323

TODO: Move to same version as couchbasedeps version.

Functional tests in progress

* [cen7-sync-gateway-functional-tests-base-cc/385/](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-base-cc/385/) Passed
* [cen7-sync-gateway-functional-tests-base-di/309/](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-base-di/309/) Passed
* [cen7-sync-gateway-functional-tests-topology-specific-cc/253/](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-topology-specific-cc/253/) Passed
* [cen7-sync-gateway-functional-tests-topology-specific-di/239](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-topology-specific-di/268/) In progress

Performance regression tests

- [ ] TODO