### PR TITLE
Adds XATTR operations to bucket

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -138,6 +138,21 @@ func (bucket CouchbaseBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err err
 	panic("SetBulk not implemented")
 }
 
+func (bucket CouchbaseBucket) WriteCasWithXattr(k string, xattr string, flags int, exp int, cas uint64, v interface{}, xv interface{}, opt sgbucket.WriteOptions) (casOut uint64, err error) {
+	Warn("WriteCasWithXattr not implemented by CouchbaseBucket")
+	return 0, errors.New("WriteCasWithXattr not implemented by CouchbaseBucket")
+}
+
+func (bucket CouchbaseBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	Warn("GetWithXattr not implemented by CouchbaseBucket")
+	return 0, errors.New("GetWithXattr not implemented by CouchbaseBucket")
+}
+
+func (bucket CouchbaseBucket) DeleteWithXattr(k string, xattr string) error {
+	Warn("DeleteWithXattr not implemented by CouchbaseBucket")
+	return errors.New("DeleteWithXattr not implemented by CouchbaseBucket")
+}
+
 func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpdateFunc) error {
 	cbCallback := func(current []byte) (updated []byte, opt couchbase.WriteOptions, err error) {
 		updated, walrusOpt, err := callback(current)

--- a/base/constants.go
+++ b/base/constants.go
@@ -6,9 +6,8 @@ const (
 	GuestUsername = "GUEST"
 	ISO8601Format = "2006-01-02T15:04:05.000Z07:00"
 
-	// kTestURL = "http://localhost:8091"
+	//kTestURL = "http://localhost:8091"
 	kTestURL = "walrus:"
-
 )
 
 func UnitTestUrl() string {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -117,6 +117,18 @@ func (b *LeakyBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
+func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, flags int, exp int, cas uint64, v interface{}, xv interface{}, opt sgbucket.WriteOptions) (casOut uint64, err error) {
+	return b.bucket.WriteCasWithXattr(k, xattr, flags, exp, cas, v, xv, opt)
+}
+
+func (b *LeakyBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	return b.bucket.GetWithXattr(k, xattr, rv, xv)
+}
+
+func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {
+	return b.bucket.DeleteWithXattr(k, xattr)
+}
+
 func (b *LeakyBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {
 
 	if b.config.TapFeedDeDuplication {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -92,6 +92,21 @@ func (b *LoggingBucket) Incr(k string, amt, def uint64, exp int) (uint64, error)
 	defer func() { LogTo("Bucket", "Incr(%q, %d, %d, %d) [%v]", k, amt, def, exp, time.Since(start)) }()
 	return b.bucket.Incr(k, amt, def, exp)
 }
+func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, flags int, exp int, cas uint64, v interface{}, xv interface{}, opt sgbucket.WriteOptions) (casOut uint64, err error) {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "WriteCasWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
+	return b.bucket.WriteCasWithXattr(k, xattr, flags, exp, cas, v, xv, opt)
+}
+func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "GetWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
+	return b.bucket.GetWithXattr(k, xattr, rv, xv)
+}
+func (b *LoggingBucket) DeleteWithXattr(k string, xattr string) error {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "DeleteWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
+	return b.bucket.DeleteWithXattr(k, xattr)
+}
 func (b *LoggingBucket) GetDDoc(docname string, value interface{}) error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "GetDDoc(%q, ...) [%v]", docname, time.Since(start)) }()
@@ -125,11 +140,10 @@ func (b *LoggingBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
 	return b.bucket.SetBulk(entries)
 }
 
-
-func (b *LoggingBucket)  Refresh() error {
+func (b *LoggingBucket) Refresh() error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Refresh() [%v]", time.Since(start)) }()
-	return b.bucket.Refresh();
+	return b.bucket.Refresh()
 }
 
 func (b *LoggingBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -170,6 +170,28 @@ func (b *StatsBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpda
 func (b *StatsBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {
 	return b.bucket.Incr(k, amt, def, exp)
 }
+func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, flags int, exp int, cas uint64, v interface{}, xv interface{}, opt sgbucket.WriteOptions) (casOut uint64, err error) {
+	if vBytes, ok := v.([]byte); ok {
+		defer b.docWrite(1, len(vBytes))
+	} else {
+		defer b.docWrite(1, -1)
+	}
+	return b.bucket.WriteCasWithXattr(k, xattr, flags, exp, cas, v, xv, opt)
+}
+func (b *StatsBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	cas, err = b.bucket.GetWithXattr(k, xattr, rv, xv)
+	if vBytes, ok := rv.([]byte); ok {
+		defer b.docRead(1, len(vBytes))
+	} else if marshalledJSON, marshalErr := json.Marshal(rv); marshalErr == nil {
+		defer b.docRead(1, len(marshalledJSON))
+	} else {
+		defer b.docRead(1, -1)
+	}
+	return cas, err
+}
+func (b *StatsBucket) DeleteWithXattr(k string, xattr string) error {
+	return b.bucket.DeleteWithXattr(k, xattr)
+}
 func (b *StatsBucket) GetDDoc(docname string, value interface{}) error {
 	return b.bucket.GetDDoc(docname, value)
 }


### PR DESCRIPTION
Unit tests have been run against a Couchbase Server that supports XATTRs, but are disabled until XATTR support is added to walrus (https://github.com/couchbase/sync_gateway/issues/2390)

Write and Get operations are implemented as two-part operations, pending https://issues.couchbase.com/browse/MB-23522

Delete unit tests fail, pending the ability for SG to write system XATTRs (https://issues.couchbase.com/browse/MB-23207)

Fixes #2389.

Associated with
https://github.com/couchbase/sg-bucket/pull/19
https://github.com/couchbaselabs/walrus/pull/26