### PR TITLE
Don’t limit number of changes retrieved if ChannelOptions option.ActiveOnly is set

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -80,7 +80,7 @@ func changesViewOptions(channelName string, endSeq uint64, options ChangesOption
 		"startkey": []interface{}{channelName, options.Since.SafeSequence() + 1},
 		"endkey":   endKey,
 	}
-	if options.Limit > 0 {
+	if options.Limit > 0 && !options.ActiveOnly {
 		optMap["limit"] = options.Limit
 	}
 	return optMap

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -148,7 +148,7 @@ func (c *channelCache) _getCachedChanges(options ChangesOptions) (validFrom uint
 	}
 
 	n := len(log) - start
-	if options.Limit > 0 && n > options.Limit {
+	if options.Limit > 0 && n > options.Limit && !options.ActiveOnly {
 		n = options.Limit
 	}
 	result = make([]*LogEntry, n)


### PR DESCRIPTION
fixes #2238 

Don’t limit the number of changes retrieved if ChaneOptions option.ActiveOnly is set to true, as deleted entries will be skipped so requiring more entries from the feed than the limit value.

I have manually reproduced this scenario, the specific fix for this is [here](https://github.com/couchbase/sync_gateway/blob/master/db/channel_cache.go#L151)

When options.ActiveOnly is true then don't limit the number of entries retrieved from the cache.

There is an additional limit set when retrieving changes from the [ChangesView](https://github.com/couchbase/sync_gateway/blob/master/db/changes_view.go#L83), I have modified this but I'm not sure if this needs to be done.