### PR TITLE
Don’t return an error if stored hash is not found for a sequence

### DIFF
--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -258,13 +258,14 @@ func (s *sequenceHasher) GetClock(sequence string) (*base.SequenceClockImpl, err
 		return clock, loadErr
 	}
 
+	clock = base.NewSequenceClockImpl()
 	if uint16(len(storedClocks.Sequences)) <= seqHash.collisionIndex {
 		base.LogTo("Changes+", "Stored hash not found for sequence [%s] collision index [%d], #storedClocks:%d, returning zero clock", sequence, seqHash.collisionIndex, len(storedClocks.Sequences))
+	} else {
+		clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())
 	}
-	clock = base.NewSequenceClockImpl()
-	clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())
-	return clock, nil
 
+	return clock, nil
 }
 
 // s.cache[hashValue] contains the storedClocks for this hash value.  If present, getCacheValue

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -260,7 +260,7 @@ func (s *sequenceHasher) GetClock(sequence string) (*base.SequenceClockImpl, err
 
 	clock = base.NewSequenceClockImpl()
 	if uint16(len(storedClocks.Sequences)) <= seqHash.collisionIndex {
-		base.LogTo("Changes+", "Stored hash not found for sequence [%s] collision index [%d], #storedClocks:%d, returning zero clock", sequence, seqHash.collisionIndex, len(storedClocks.Sequences))
+		base.Warn("Stored hash not found for sequence [%s] collision index [%d], #storedClocks:%d, returning zero clock", sequence, seqHash.collisionIndex, len(storedClocks.Sequences))
 	} else {
 		clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())
 	}

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -259,8 +259,7 @@ func (s *sequenceHasher) GetClock(sequence string) (*base.SequenceClockImpl, err
 	}
 
 	if uint16(len(storedClocks.Sequences)) <= seqHash.collisionIndex {
-		base.LogTo("Changes+", "Stored hash not found for sequence [%s] collision index [%d], #storedClocks:%d", sequence, seqHash.collisionIndex, len(storedClocks.Sequences))
-		return clock, errors.New(fmt.Sprintf("Stored hash not found for sequence [%s], returning zero clock", sequence))
+		base.LogTo("Changes+", "Stored hash not found for sequence [%s] collision index [%d], #storedClocks:%d, returning zero clock", sequence, seqHash.collisionIndex, len(storedClocks.Sequences))
 	}
 	clock = base.NewSequenceClockImpl()
 	clock.Init(storedClocks.Sequences[seqHash.collisionIndex], seqHash.String())

--- a/db/sequence_hasher_test.go
+++ b/db/sequence_hasher_test.go
@@ -133,7 +133,7 @@ func TestHashStorage(t *testing.T) {
 
 	// Retrieve non-existent hash
 	missingClock, err := seqHasher.GetClock("1234")
-	assertTrue(t, err != nil, "Should return error for non-existent hash")
+	assertTrue(t, err == nil, "Should NOT return error for non-existent hash")
 	assert.Equals(t, missingClock.GetSequence(50), uint64(0))
 	assert.Equals(t, missingClock.GetSequence(80), uint64(0))
 	assert.Equals(t, missingClock.GetSequence(150), uint64(0))


### PR DESCRIPTION
fixes couchbaselabs/sync-gateway-accel/issues/127