### PR TITLE
Support XATTR storage of _sync metadata 

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -18,11 +18,11 @@ import (
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
+	"github.com/couchbase/gocb"
 	"github.com/couchbase/gomemcached"
 	memcached "github.com/couchbase/gomemcached/client"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
-	"gopkg.in/couchbase/gocbcore.v2"
 )
 
 const (
@@ -138,6 +138,21 @@ func (bucket CouchbaseBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err err
 	panic("SetBulk not implemented")
 }
 
+func (bucket CouchbaseBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+	Warn("WriteCasWithXattr not implemented by CouchbaseBucket")
+	return 0, errors.New("WriteCasWithXattr not implemented by CouchbaseBucket")
+}
+
+func (bucket CouchbaseBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	Warn("GetWithXattr not implemented by CouchbaseBucket")
+	return 0, errors.New("GetWithXattr not implemented by CouchbaseBucket")
+}
+
+func (bucket CouchbaseBucket) DeleteWithXattr(k string, xattr string) error {
+	Warn("DeleteWithXattr not implemented by CouchbaseBucket")
+	return errors.New("DeleteWithXattr not implemented by CouchbaseBucket")
+}
+
 func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpdateFunc) error {
 	cbCallback := func(current []byte) (updated []byte, opt couchbase.WriteOptions, err error) {
 		updated, walrusOpt, err := callback(current)
@@ -145,6 +160,11 @@ func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.W
 		return
 	}
 	return bucket.Bucket.WriteUpdate(k, exp, cbCallback)
+}
+
+func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) error {
+	Warn("WriteUpdateWithXattr not implemented by CouchbaseBucket")
+	return errors.New("WriteUpdateWithXattr not implemented by CouchbaseBucket")
 }
 
 func (bucket CouchbaseBucket) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
@@ -558,7 +578,7 @@ func IsKeyNotFoundError(bucket Bucket, err error) bool {
 		return false
 	}
 
-	if err.Error() == gocbcore.ErrKeyNotFound.Error() {
+	if err == gocb.ErrKeyNotFound {
 		return true
 	}
 
@@ -583,7 +603,7 @@ func IsCasMismatch(bucket Bucket, err error) bool {
 	}
 
 	// GoCB handling
-	if err.Error() == gocbcore.ErrKeyExists.Error() {
+	if err == gocb.ErrKeyExists {
 		return true
 	}
 
@@ -594,5 +614,3 @@ func IsCasMismatch(bucket Bucket, err error) bool {
 
 	return false
 }
-
-

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -62,6 +62,25 @@ func GetBucketOrPanic() Bucket {
 	return bucket
 }
 
+func TestTranscoder(t *testing.T) {
+	transcoder := SGTranscoder{}
+
+	jsonBody := `{"a":1}`
+	jsonBytes := []byte(jsonBody)
+	binaryFlags := gocbcore.EncodeCommonFlags(gocbcore.BinaryType, gocbcore.NoCompression)
+	jsonFlags := gocbcore.EncodeCommonFlags(gocbcore.JsonType, gocbcore.NoCompression)
+
+	resultBytes, flags, err := transcoder.Encode([]byte(jsonBody))
+	assert.Equals(t, bytes.Compare(resultBytes, jsonBytes), 0)
+	assert.Equals(t, flags, jsonFlags)
+	assert.Equals(t, err, nil)
+
+	resultBytes, flags, err = transcoder.Encode(BinaryDocument(jsonBody))
+	assert.Equals(t, bytes.Compare(resultBytes, jsonBytes), 0)
+	assert.Equals(t, flags, binaryFlags)
+	assert.Equals(t, err, nil)
+}
+
 func CouchbaseTestSetGetRaw(t *testing.T) {
 
 	bucket := GetBucketOrPanic()

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -11,12 +11,14 @@ package base
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/go.assert"
+	"gopkg.in/couchbase/gocbcore.v5"
 )
 
 // NOTE: most of these tests are disabled by default and have been renamed to Couchbase*
@@ -24,15 +26,38 @@ import (
 // them to remove the Couchbase* prefix, and then rename them back before checking into
 // Git.
 
+type TestAuthenticator struct {
+	Username   string
+	Password   string
+	BucketName string
+}
+
+func (t TestAuthenticator) GetCredentials() (username, password, bucketname string) {
+	return t.Username, t.Password, t.BucketName
+}
+
 func GetBucketOrPanic() Bucket {
+
+	username := "bucket-1"
+	bucketname := "bucket-1"
+	password := "password"
+
+	testAuth := TestAuthenticator{
+		Username:   username,
+		Password:   password,
+		BucketName: bucketname,
+	}
+
 	spec := BucketSpec{
-		Server:     UnitTestUrl(),
-		BucketName: "bucket-1",
+		Server:          UnitTestUrl(),
+		BucketName:      bucketname,
 		CouchbaseDriver: DefaultDriverForBucketType[DataBucket],
+		Auth:            testAuth,
 	}
 	bucket, err := GetCouchbaseBucketGoCB(spec)
+	bucket.SetTranscoder(SGTranscoder{})
 	if err != nil {
-		panic("Could not open bucket")
+		panic(fmt.Sprintf("Could not open bucket: %v", err))
 	}
 	return bucket
 }
@@ -41,7 +66,7 @@ func CouchbaseTestSetGetRaw(t *testing.T) {
 
 	bucket := GetBucketOrPanic()
 
-	key := "TestSetGetRaw"
+	key := "TestSetGetRaw2"
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -62,7 +87,6 @@ func CouchbaseTestSetGetRaw(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error removing key from bucket")
 	}
-
 }
 
 func CouchbaseTestAddRaw(t *testing.T) {
@@ -531,4 +555,384 @@ func TestCreateBatchesKeys(t *testing.T) {
 	assert.Equals(t, batches[2][0], "five")
 	assert.Equals(t, batches[2][1], "six")
 	assert.Equals(t, batches[3][0], "seven")
+}
+
+// TestWriteCasXATTR.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
+func CouchbaseTestWriteCasXATTR(t *testing.T) {
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+	bucket.SetTranscoder(SGTranscoder{})
+
+	key := "TestWriteCasXATTR"
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = float64(123)
+	xattrVal["rev"] = "1-1234"
+
+	var existsVal map[string]interface{}
+	_, err := bucket.Get(key, existsVal)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		err = bucket.DeleteWithXattr(key, xattrName)
+	}
+
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+	log.Printf("Post-write, cas is %d", cas)
+
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	// TODO: Cas check fails, pending xattr code to make it to gocb master
+	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+	assert.Equals(t, getCas, cas)
+	assert.Equals(t, retrievedVal["body_field"], val["body_field"])
+	assert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+	assert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+}
+
+// TestWriteCasXATTR.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
+func TestWriteCasXattrDeleted(t *testing.T) {
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+	bucket.SetTranscoder(SGTranscoder{})
+
+	key := "TestWriteCasXATTR"
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = float64(123)
+	xattrVal["rev"] = "1-1234"
+
+	var existsVal map[string]interface{}
+	_, err := bucket.Get(key, existsVal)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		err = bucket.DeleteWithXattr(key, xattrName)
+	}
+
+	// Write document with xattr
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+	log.Printf("Post-write, cas is %d", cas)
+
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	// TODO: Cas check fails, pending xattr code to make it to gocb master
+	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+	assert.Equals(t, getCas, cas)
+	assert.Equals(t, retrievedVal["body_field"], val["body_field"])
+	assert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+	assert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+
+	err = bucket.Delete(key)
+	if err != nil {
+		t.Errorf("Error doing Delete: %+v", err)
+	}
+
+	// Update the xattr
+	xattrVal = make(map[string]interface{})
+	xattrVal["seq"] = float64(456)
+	xattrVal["rev"] = "2-2345"
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, nil, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// Verify retrieval
+	getCas, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	// TODO: Cas check fails, pending xattr code to make it to gocb master
+	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+	assert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+	assert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+
+}
+
+// TestWriteCasXATTRRaw.  Validates basic write of document and xattr as raw bytes.
+func CouchbaseTestWriteCasXattrRaw(t *testing.T) {
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+	bucket.SetTranscoder(SGTranscoder{})
+
+	key := "TestWriteCasXattrRaw"
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+	valRaw, _ := json.Marshal(val)
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = float64(123)
+	xattrVal["rev"] = "1-1234"
+	xattrValRaw, _ := json.Marshal(xattrVal)
+
+	var existsVal map[string]interface{}
+	_, err := bucket.Get(key, existsVal)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		err = bucket.DeleteWithXattr(key, xattrName)
+	}
+
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, valRaw, xattrValRaw)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	// TODO: Fails until https://issues.couchbase.com/browse/GOCBC-183 is available
+	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+	assert.Equals(t, getCas, cas)
+	assert.Equals(t, retrievedVal["body_field"], val["body_field"])
+	assert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+	assert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+}
+
+// TestWriteUpdateXATTR.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
+func CouchbaseTestWriteUpdateXATTR(t *testing.T) {
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+	bucket.SetTranscoder(SGTranscoder{})
+
+	key := "TestWriteUpdateXATTR38"
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["counter"] = float64(1)
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = float64(1)
+	xattrVal["rev"] = "1-1234"
+
+	var existsVal map[string]interface{}
+	var existsXattr map[string]interface{}
+	_, err := bucket.GetWithXattr(key, xattrName, &existsVal, &existsXattr)
+	if err == nil {
+		log.Printf("Key should not exist yet, but get succeeded.  Doing cleanup, assuming couchbase bucket testing")
+		err := bucket.DeleteWithXattr(key, xattrName)
+		if err != nil {
+			log.Printf("Got error trying to do pre-test cleanup:%v", err)
+		}
+	}
+
+	// Dummy write update function that increments 'counter' in the doc and 'seq' in the xattr
+	writeUpdateFunc := func(doc []byte, xattr []byte) (updatedDoc []byte, updatedXattr []byte, err error) {
+
+		var docMap map[string]interface{}
+		var xattrMap map[string]interface{}
+		// Marshal the doc
+		if len(doc) > 0 {
+			err = json.Unmarshal(doc, &docMap)
+			if err != nil {
+				return nil, nil, fmt.Errorf("Unable to unmarshal incoming doc: %v", err)
+			}
+		} else {
+			// No incoming doc, treat as insert.
+			docMap = make(map[string]interface{})
+		}
+
+		// Marshal the xattr
+		if len(xattr) > 0 {
+			err = json.Unmarshal(xattr, &xattrMap)
+			if err != nil {
+				return nil, nil, fmt.Errorf("Unable to unmarshal incoming xattr: %v", err)
+			}
+		} else {
+			// No incoming xattr, treat as insert.
+			xattrMap = make(map[string]interface{})
+		}
+
+		// Update the doc
+		existingCounter, ok := docMap["counter"].(float64)
+		if ok {
+			docMap["counter"] = existingCounter + float64(1)
+		} else {
+			docMap["counter"] = float64(1)
+		}
+
+		// Update the xattr
+		existingSeq, ok := xattrMap["seq"].(float64)
+		if ok {
+			xattrMap["seq"] = existingSeq + float64(1)
+		} else {
+			xattrMap["seq"] = float64(1)
+		}
+
+		updatedDoc, _ = json.Marshal(docMap)
+		updatedXattr, _ = json.Marshal(xattrMap)
+		return updatedDoc, updatedXattr, nil
+	}
+
+	// Insert
+	err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
+	if err != nil {
+		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
+	}
+
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	log.Printf("Retrieval after WriteUpdate insert: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	assert.Equals(t, retrievedVal["counter"], float64(1))
+	assert.Equals(t, retrievedXattr["seq"], float64(1))
+
+	// Update
+	err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
+	if err != nil {
+		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
+	}
+	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	log.Printf("Retrieval after WriteUpdate update: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
+
+	assert.Equals(t, retrievedVal["counter"], float64(2))
+	assert.Equals(t, retrievedXattr["seq"], float64(2))
+
+}
+
+// TestDeleteDocumentHavingXATTR.  Delete document that has a system xattr.  System XATTR should be retained and retrievable.
+func CouchbaseTestDeleteDocumentHavingXATTR(t *testing.T) {
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// Create document with XATTR
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	key := "TestDeleteDocumentHavingXATTR"
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		bucket.Delete(key)
+	}
+
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// Delete the document.
+	err = bucket.Delete(key)
+	if err != nil {
+		t.Errorf("Error doing Delete: %+v", err)
+	}
+
+	// Verify delete of body was successful, retrieve XATTR
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	assert.Equals(t, len(retrievedVal), 0)
+	assert.Equals(t, retrievedXattr["seq"], float64(123))
+
+}
+
+// TestDeleteDocumentAndXATTR.  Delete document and XATTR, ensure it's not available
+func CouchbaseTestDeleteDocumentAndXATTR(t *testing.T) {
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// Create document with XATTR
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	key := "TestDeleteDocumentAndXATTR"
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		bucket.Delete(key)
+	}
+
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// Delete the document and XATTR.
+	err = bucket.DeleteWithXattr(key, xattrName)
+	if err != nil {
+		t.Errorf("Error doing DeleteWithXATTR: %+v", err)
+	}
+
+	// Verify delete of body and XATTR
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	assert.Equals(t, err, gocbcore.ErrKeyNotFound)
+
 }

--- a/base/constants.go
+++ b/base/constants.go
@@ -6,8 +6,8 @@ const (
 	GuestUsername = "GUEST"
 	ISO8601Format = "2006-01-02T15:04:05.000Z07:00"
 
-	kTestURL = "http://localhost:8091"
-	//kTestURL = "walrus:"
+	//kTestURL = "http://localhost:8091"
+	kTestURL = "walrus:"
 )
 
 func UnitTestUrl() string {

--- a/base/constants.go
+++ b/base/constants.go
@@ -6,9 +6,8 @@ const (
 	GuestUsername = "GUEST"
 	ISO8601Format = "2006-01-02T15:04:05.000Z07:00"
 
-	// kTestURL = "http://localhost:8091"
-	kTestURL = "walrus:"
-
+	kTestURL = "http://localhost:8091"
+	//kTestURL = "walrus:"
 )
 
 func UnitTestUrl() string {

--- a/base/error.go
+++ b/base/error.go
@@ -14,9 +14,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/couchbase/gocb"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
-	"gopkg.in/couchbase/gocbcore.v2"
 )
 
 // Simple error implementation wrapping an HTTP response status.
@@ -40,19 +40,19 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		return 200, "OK"
 	}
 
-	switch err.Error() {
-	case gocbcore.ErrKeyNotFound.Error():
+	switch err {
+	case gocb.ErrKeyNotFound:
 		return http.StatusNotFound, "missing"
-	case gocbcore.ErrKeyExists.Error():
+	case gocb.ErrKeyExists:
 		return http.StatusConflict, "Conflict"
-	case gocbcore.ErrTimeout.Error():
-		return http.StatusServiceUnavailable, "Database timeout error (gocbcore.ErrTimeout.Error)"
-	case gocbcore.ErrOverload.Error():
-		return http.StatusServiceUnavailable, "Database server is over capacity (gocbcore.ErrOverload.Error)"
-	case gocbcore.ErrBusy.Error():
-		return http.StatusServiceUnavailable, "Database server is over capacity (gocbcore.ErrBusy.Error)"
-	case gocbcore.ErrTmpFail.Error():
-		return http.StatusServiceUnavailable, "Database server is over capacity (gocbcore.ErrTmpFail.Error)"
+	case gocb.ErrTimeout:
+		return http.StatusServiceUnavailable, "Database timeout error (gocb.ErrTimeout)"
+	case gocb.ErrOverload:
+		return http.StatusServiceUnavailable, "Database server is over capacity (gocb.ErrOverload)"
+	case gocb.ErrBusy:
+		return http.StatusServiceUnavailable, "Database server is over capacity (gocb.ErrBusy)"
+	case gocb.ErrTmpFail:
+		return http.StatusServiceUnavailable, "Database server is over capacity (gocb.ErrTmpFail)"
 	}
 
 	switch err := err.(type) {
@@ -108,7 +108,7 @@ func CouchHTTPErrorName(status int) string {
 // Returns true if an error is a doc-not-found error
 func IsDocNotFoundError(err error) bool {
 
-	if err != nil && err.Error() == gocbcore.ErrKeyNotFound.Error() {
+	if err != nil && err == gocb.ErrKeyNotFound {
 		return true
 	}
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -121,6 +121,22 @@ func (b *LeakyBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
+func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
+}
+
+func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (err error) {
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
+}
+
+func (b *LeakyBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	return b.bucket.GetWithXattr(k, xattr, rv, xv)
+}
+
+func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {
+	return b.bucket.DeleteWithXattr(k, xattr)
+}
+
 func (b *LeakyBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {
 
 	if b.config.TapFeedDeDuplication {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -87,10 +87,33 @@ func (b *LoggingBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUp
 	defer func() { LogTo("Bucket", "WriteUpdate(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start)) }()
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
+
 func (b *LoggingBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Incr(%q, %d, %d, %d) [%v]", k, amt, def, exp, time.Since(start)) }()
 	return b.bucket.Incr(k, amt, def, exp)
+}
+func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "WriteCasWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
+	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
+}
+func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (err error) {
+	start := time.Now()
+	defer func() {
+		LogTo("Bucket", "WriteUpdateWithXattr(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start))
+	}()
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
+}
+func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "GetWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
+	return b.bucket.GetWithXattr(k, xattr, rv, xv)
+}
+func (b *LoggingBucket) DeleteWithXattr(k string, xattr string) error {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "DeleteWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
+	return b.bucket.DeleteWithXattr(k, xattr)
 }
 func (b *LoggingBucket) GetDDoc(docname string, value interface{}) error {
 	start := time.Now()
@@ -125,11 +148,10 @@ func (b *LoggingBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
 	return b.bucket.SetBulk(entries)
 }
 
-
-func (b *LoggingBucket)  Refresh() error {
+func (b *LoggingBucket) Refresh() error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Refresh() [%v]", time.Since(start)) }()
-	return b.bucket.Refresh();
+	return b.bucket.Refresh()
 }
 
 func (b *LoggingBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {

--- a/base/sg_transcoding.go
+++ b/base/sg_transcoding.go
@@ -27,10 +27,10 @@ func (t SGTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
 	var err error
 
 	flags := gocbcore.EncodeCommonFlags(gocbcore.JsonType, gocbcore.NoCompression)
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case BinaryDocument:
 		flags = gocbcore.EncodeCommonFlags(gocbcore.BinaryType, gocbcore.NoCompression)
-		bytes = value.([]byte)
+		bytes = []byte(typedValue)
 	case []byte:
 		bytes = value.([]byte)
 	case *[]byte:

--- a/base/sg_transcoding.go
+++ b/base/sg_transcoding.go
@@ -1,23 +1,27 @@
 package base
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"gopkg.in/couchbase/gocbcore.v5"
+)
 
 type SGTranscoder struct {
 }
 
-// This is needed because the default transcoding.go code in gocb is relying heavily on the
-// document flags (Binary/JSON,etc), however the Sync Gateway codebase is currently not "flags-aware",
-// and would require a decent amount of overhaul in order to use the default gocb transcoding.
-// It currently has parity with the existing go-couchbase library, namely to use the legacy json flag.
+// The default transcoding.go code in gocb makes assumptions about the document
+// type (binary, json) based on the incoming value (e.g. []byte as binary, interface{} as json).
+// Sync Gateway needs the ability to write json as raw bytes, so defines separate transcoders for storing
+// json and binary documents.
 
 // Encode applies the default Couchbase transcoding behaviour to encode a Go type.
-// Figures out how to convert the given struct into bytes and then figures out what to use for flags (uses 0 value, legacy JSON flag)
+// Figures out how to convert the given struct into bytes and then sets the json flag.
 func (t SGTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
 
 	var bytes []byte
-	var flags uint32 // 0 value, which corresponds to gocb.lfJson
 	var err error
 
+	flags := gocbcore.EncodeCommonFlags(gocbcore.JsonType, gocbcore.NoCompression)
 	switch value.(type) {
 	case []byte:
 		bytes = value.([]byte)
@@ -56,6 +60,66 @@ func (t SGTranscoder) Decode(bytes []byte, flags uint32, out interface{}) error 
 		}
 		return nil
 
+	}
+
+}
+
+type SGBinaryTranscoder struct {
+}
+
+// Encode applies the default Couchbase transcoding behaviour to encode a Go type, and sets the storage flag as binary.
+func (t SGBinaryTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
+
+	var bytes []byte
+	var flags uint32
+	var err error
+
+	flags = gocbcore.EncodeCommonFlags(gocbcore.BinaryType, gocbcore.NoCompression)
+	switch value.(type) {
+	case []byte:
+		bytes = value.([]byte)
+	case *[]byte:
+		bytes = *value.(*[]byte)
+	case string:
+		bytes = []byte(value.(string))
+	case *string:
+		bytes = []byte(*value.(*string))
+	case *interface{}:
+		// calls back into this
+		return t.Encode(*value.(*interface{}))
+	default:
+		bytes, err = json.Marshal(value)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	// No compression supported currently
+
+	return bytes, flags, nil
+}
+
+// Decode applies the default Couchbase transcoding behaviour to decode into a Go type.
+func (t SGBinaryTranscoder) Decode(bytes []byte, flags uint32, out interface{}) error {
+
+	valueType, _ := gocbcore.DecodeCommonFlags(flags)
+	if valueType != gocbcore.BinaryType {
+		Warn("Binary Transcoder used to process non-binary document")
+	}
+
+	switch typedOut := out.(type) {
+	case *[]byte:
+		*typedOut = bytes
+		return nil
+	case *interface{}:
+		*typedOut = bytes
+		return nil
+	default:
+		err := json.Unmarshal(bytes, &out)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -711,7 +711,6 @@ func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, cal
 					// might not incorporate the effects of this change.
 					writeOpts |= sgbucket.Indexable
 				}
-
 			}
 
 		} else {

--- a/db/database.go
+++ b/db/database.go
@@ -91,6 +91,7 @@ type OidcTestProviderOptions struct {
 }
 
 type UnsupportedOptions struct {
+	EnableXATTR      bool `json:"enable_extended_attributes"`
 	EnableUserViews  bool
 	OidcTestProvider OidcTestProviderOptions
 }
@@ -999,6 +1000,13 @@ func (context *DatabaseContext) GetIndexBucket() base.Bucket {
 func (context *DatabaseContext) GetUserViewsEnabled() bool {
 	if context.Options.UnsupportedOptions != nil {
 		return context.Options.UnsupportedOptions.EnableUserViews
+	}
+	return false
+}
+
+func (context *DatabaseContext) UseXATTRs() bool {
+	if context.Options.UnsupportedOptions != nil {
+		return context.Options.UnsupportedOptions.EnableXATTR
 	}
 	return false
 }

--- a/db/document.go
+++ b/db/document.go
@@ -76,9 +76,14 @@ func unmarshalDocument(docid string, data []byte) (*document, error) {
 }
 
 func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte) (*document, error) {
+
+	// If no xattr data, unmarshal as standard doc
+	if xattrData == nil || len(xattrData) == 0 {
+		return unmarshalDocument(docid, data)
+	}
 	doc := newDocument(docid)
 	if len(data) > 0 {
-		if err := doc.UnmarshalWithXATTR(data, xattrData); err != nil {
+		if err := doc.UnmarshalWithXattr(data, xattrData); err != nil {
 			return nil, err
 		}
 	}
@@ -289,7 +294,7 @@ func (doc *document) MarshalJSON() ([]byte, error) {
 	return data, err
 }
 
-func (doc *document) UnmarshalWithXATTR(data []byte, xdata []byte) error {
+func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte) error {
 	if doc.ID == "" {
 		base.Warn("Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
@@ -304,7 +309,7 @@ func (doc *document) UnmarshalWithXATTR(data []byte, xdata []byte) error {
 	return doc.unmarshalBody(data)
 }
 
-func (doc *document) MarshalWithXATTR() (data []byte, xdata []byte, err error) {
+func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	body := doc.body
 	if body == nil {
 		body = Body{}

--- a/examples/config-xattr.json
+++ b/examples/config-xattr.json
@@ -1,0 +1,11 @@
+{
+  "databases": {
+    "db": {
+      "server": "http://localhost:8091",
+      "bucket": "default",
+      "unsupportedOptions": {
+         "enable_extended_attributes":true,
+      }
+    }
+  }
+}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -59,9 +59,9 @@
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="67fb8fa4c62451372108f31c93034c07d9d9f4ab"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="0b7d1f6bcc66d996bde8b53c9b39ea746317ffba"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v2" remote="couchbase" revision="22d72f05785ba26be033aa8b6726435b5e50a7a0"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v5" remote="couchbase" revision="914e11b4b638118d36ad6715ed37d7dba1e77644"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -55,19 +55,21 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="6cc7d15a05a3157527478c8c370b4738b755177f"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2e274eeaf8a3e46c8428ee4d1e649778b335a178"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="0b7d1f6bcc66d996bde8b53c9b39ea746317ffba"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="92706fe26b36a706406fb2391d7c3c90ddddf81b"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v5" remote="couchbase" revision="914e11b4b638118d36ad6715ed37d7dba1e77644"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v6" remote="couchbase" revision="e6b35c26561b2ab6d50a5577996aa68af9ae740c"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
+  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="dc85f3f16107a7340e5a06193d310d343368e523"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="34c0ce4bed3f990af90d59d56e00d24531bf55fe"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="9fa3a628abefb6abd1582aad8e01455e956d76f1"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b0f96cf430707aff15d3f63d8a76fcd0a7d43c94"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
 
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="a8c331792d12b82705f34df4adaa26f9f086ea2f"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e3c4b39715123596b338aebf430b09e8ce9567cb"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2e274eeaf8a3e46c8428ee4d1e649778b335a178"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="9fa3a628abefb6abd1582aad8e01455e956d76f1"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
 
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="34c0ce4bed3f990af90d59d56e00d24531bf55fe"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="a8c331792d12b82705f34df4adaa26f9f086ea2f"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -51,7 +51,7 @@ var kHandlersByProfile = map[string]func(*blipHandler, *blip.Message) error{
 
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
 func (h *handler) handleBLIPSync() error {
-	if u := h.server.GetDatabaseConfig(h.db.Name).Unsupported; u == nil || !u.Replicator2 {
+	if !h.server.GetDatabaseConfig(h.db.Name).Unsupported.Replicator2 {
 		return base.HTTPErrorf(http.StatusNotFound, "feature not enabled")
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -126,7 +126,7 @@ type DbConfig struct {
 	ChannelIndex       *ChannelIndexConfig            `json:"channel_index,omitempty"`        // Channel index settings
 	RevCacheSize       *uint32                        `json:"rev_cache_size,omitempty"`       // Maximum number of revisions to store in the revision cache
 	StartOffline       bool                           `json:"offline,omitempty"`              // start the DB in the offline state, defaults to false
-	Unsupported        *UnsupportedConfig             `json:"unsupported,omitempty"`          // Config for unsupported features
+	Unsupported        db.UnsupportedOptions          `json:"unsupported,omitempty"`          // Config for unsupported features
 	OIDCConfig         *auth.OIDCOptions              `json:"oidc,omitempty"`                 // Config properties for OpenID Connect authentication
 }
 
@@ -193,18 +193,8 @@ type SequenceHashConfig struct {
 	Frequency    *int    `json:"hash_frequency,omitempty"` // Frequency of sequence hashing in changes feeds
 }
 
-type UnsupportedConfig struct {
-	UserViews        *UserViewsConfig            `json:"user_views,omitempty"`         // Config settings for user views
-	Replicator2      bool                        `json:"replicator_2,omitempty"`       // Enable new replicator (_blipsync)
-	OidcTestProvider *db.OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
-}
-
 type UnsupportedServerConfig struct {
 	Http2Config *Http2Config `json:"http2,omitempty"` // Config settings for HTTP2
-}
-
-type UserViewsConfig struct {
-	Enabled *bool `json:"enabled,omitempty"` // Whether pass-through view query is supported through public API
 }
 
 type Http2Config struct {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -311,14 +311,12 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 		* and the username and password match those in the oidc default provider config
 		* then authorize this request
 		 */
-		if unsupportedOptions := context.Options.UnsupportedOptions; unsupportedOptions != nil {
-			if unsupportedOptions.OidcTestProvider.Enabled && strings.HasSuffix(h.rq.URL.Path, "/_oidc_testing/token") {
-				if username, password := h.getBasicAuth(); username != "" && password != "" {
-					provider := context.Options.OIDCOptions.Providers.GetProviderForIssuer(issuerUrlForDB(h, context.Name), testProviderAudiences)
-					if provider != nil && provider.ClientID != nil && provider.ValidationKey != nil {
-						if *provider.ClientID == username && *provider.ValidationKey == password {
-							return nil
-						}
+		if context.Options.UnsupportedOptions.OidcTestProvider.Enabled && strings.HasSuffix(h.rq.URL.Path, "/_oidc_testing/token") {
+			if username, password := h.getBasicAuth(); username != "" && password != "" {
+				provider := context.Options.OIDCOptions.Providers.GetProviderForIssuer(issuerUrlForDB(h, context.Name), testProviderAudiences)
+				if provider != nil && provider.ClientID != nil && provider.ValidationKey != nil {
+					if *provider.ClientID == username && *provider.ValidationKey == password {
+						return nil
 					}
 				}
 			}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -462,18 +462,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		revCacheSize = db.KDefaultRevisionCacheCapacity
 	}
 
-	unsupportedOptions := &db.UnsupportedOptions{}
-	if config.Unsupported != nil {
-		if config.Unsupported.UserViews != nil {
-			if config.Unsupported.UserViews.Enabled != nil {
-				unsupportedOptions.EnableUserViews = *config.Unsupported.UserViews.Enabled
-			}
-		}
-		if config.Unsupported.OidcTestProvider != nil {
-			unsupportedOptions.OidcTestProvider = *config.Unsupported.OidcTestProvider
-		}
-	}
-
 	// Enable doc tracking if needed for autoImport or shadowing
 	trackDocs := autoImport || config.Shadow != nil
 
@@ -483,7 +471,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		SequenceHashOptions:   sequenceHashOptions,
 		RevisionCacheCapacity: revCacheSize,
 		AdminInterface:        sc.config.AdminInterface,
-		UnsupportedOptions:    unsupportedOptions,
+		UnsupportedOptions:    config.Unsupported,
 		TrackDocs:             trackDocs,
 		OIDCOptions:           config.OIDCConfig,
 	}


### PR DESCRIPTION
Supports storing _sync metadata in extended attribute instead of document body.

 - Adds XATTR operations to bucket interface for Get, Delete, WriteCas and WriteUpdate
 - Config flag (unsupported.enable_extended_attributes) to enable
 - Updates document struct to support marshal/unmarshal from either doc or doc + xattr
 - Refactor WriteUpdate and Update callback handling to support either doc or doc + xattr

Fixes #2392.

Associated PRs:
https://github.com/couchbaselabs/walrus/pull/26
https://github.com/couchbase/sg-bucket/pull/19

Pending https://issues.couchbase.com/browse/GOCBC-180