### PR TITLE
Xattr support in internal and custom views

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -81,8 +81,9 @@ type BucketSpec struct {
 	Server, PoolName, BucketName, FeedType string
 	Auth                                   AuthHandler
 	CouchbaseDriver                        CouchbaseDriver
-	MaxNumRetries                          int // max number of retries before giving up
-	InitialRetrySleepTimeMS                int // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
+	MaxNumRetries                          int  // max number of retries before giving up
+	InitialRetrySleepTimeMS                int  // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
+	UseXattrs                              bool // Whether to use xattrs to store _sync metadata.  Used during view initialization
 }
 
 // Implementation of sgbucket.Bucket that talks to a Couchbase server

--- a/db/database.go
+++ b/db/database.go
@@ -46,11 +46,13 @@ var RunStateString = []string{
 	DBResyncing: "Resyncing",
 }
 
-const DefaultRevsLimit = 1000
-const DefaultUseXattrs = false        // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
-const KSyncKeyPrefix = "_sync:"       // All special/internal documents the gateway creates have this prefix in their keys.
-const kSyncDataKey = "_sync:syncdata" // Key used to store sync function
-const KSyncXattr = "_sync"            // Name of XATTR used to store sync metadata
+const (
+	DefaultRevsLimit = 1000
+	DefaultUseXattrs = false            // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	KSyncKeyPrefix   = "_sync:"         // All special/internal documents the gateway creates have this prefix in their keys.
+	kSyncDataKey     = "_sync:syncdata" // Key used to store sync function
+	KSyncXattr       = "_sync"          // Name of XATTR used to store sync metadata
+)
 
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.

--- a/db/document.go
+++ b/db/document.go
@@ -82,11 +82,10 @@ func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte) (*d
 		return unmarshalDocument(docid, data)
 	}
 	doc := newDocument(docid)
-	if len(data) > 0 {
-		if err := doc.UnmarshalWithXattr(data, xattrData); err != nil {
-			return nil, err
-		}
+	if err := doc.UnmarshalWithXattr(data, xattrData); err != nil {
+		return nil, err
 	}
+
 	return doc, nil
 }
 
@@ -306,6 +305,15 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte) error {
 		return err
 	}
 	// Unmarshal document body
+	if len(data) > 0 {
+		return doc.unmarshalBody(data)
+	} else {
+		// If there's an xattr but no body, set body as {"_deleted":true} to align with non-xattr handling
+		doc.body = Body{}
+		doc.body["_deleted"] = true
+		return nil
+	}
+
 	return doc.unmarshalBody(data)
 }
 

--- a/db/document.go
+++ b/db/document.go
@@ -304,17 +304,17 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte) error {
 	if err := json.Unmarshal(xdata, &doc.syncData); err != nil {
 		return err
 	}
-	// Unmarshal document body
+	// Unmarshal document body, if present
 	if len(data) > 0 {
 		return doc.unmarshalBody(data)
-	} else {
-		// If there's an xattr but no body, set body as {"_deleted":true} to align with non-xattr handling
-		doc.body = Body{}
-		doc.body["_deleted"] = true
-		return nil
 	}
 
-	return doc.unmarshalBody(data)
+	// If there's no body, but there is an xattr, set body as {"_deleted":true} to align with non-xattr handling
+	if len(xdata) > 0 {
+		doc.body = Body{}
+		doc.body["_deleted"] = true
+	}
+	return nil
 }
 
 func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -361,6 +361,13 @@ func (dbConfig *DbConfig) GetCredentials() (string, string, string) {
 	return base.TransformBucketCredentials(dbConfig.Username, dbConfig.Password, *dbConfig.Bucket)
 }
 
+func (dbConfig *DbConfig) UseXattrs() bool {
+	if dbConfig.Unsupported.EnableXattr != nil {
+		return *dbConfig.Unsupported.EnableXattr
+	}
+	return db.DefaultUseXattrs
+}
+
 // Implementation of AuthHandler interface for ShadowConfig
 func (shadowConfig *ShadowConfig) GetCredentials() (string, string, string) {
 	return base.TransformBucketCredentials(shadowConfig.Username, shadowConfig.Password, *shadowConfig.Bucket)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -316,6 +316,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		FeedType:        feedType,
 		Auth:            config,
 		CouchbaseDriver: base.DefaultDriverForBucketType[base.DataBucket],
+		UseXattrs:       config.UseXattrs(),
 	}
 
 	// Set cache properties, if present


### PR DESCRIPTION
Modifies views to retrieve _sync metadata from xattrs when running with xattrs enabled.  Since bucket and views are initialized before database context, required adding an xattrsEnabled flag to the bucket spec to trigger the xattr handling.  Applies to both SG's internal views, and the map function wrapper that's applied to user views.

Fixes #2393, #2394.

