### PR TITLE
Check if file exists before deleting

### DIFF
--- a/snap-manifest.sh
+++ b/snap-manifest.sh
@@ -75,7 +75,8 @@ def prepare_repo_dir():
     """
     initial_directory = os.getcwd()
     os.chdir(".repo")
-    os.remove("manifest.xml")
+    if os.path.exists("manifest.xml"):
+        os.remove("manifest.xml")
     os.chdir("manifests")
     subprocess.call(['git', 'reset', '--hard'])
     os.chdir(initial_directory)


### PR DESCRIPTION
Fixes error:

tleyden_macbook:sync_gateway tleyden$ ./snap-manifest.sh --sg-commit 69ddd244902a2fbb4e5de78b6dfd5921ae2d24a0
Traceback (most recent call last):
  File "./snap-manifest.sh", line 101, in <module>
    prepare_repo_dir()
  File "./snap-manifest.sh", line 78, in prepare_repo_dir
    os.remove("manifest.xml")
OSError: [Errno 2] No such file or directory: 'manifest.xml'