### PR TITLE
DCP support for sync metadata in xattr

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -305,6 +305,12 @@ func (bucket CouchbaseBucket) StartDCPFeed(args sgbucket.TapArguments) (sgbucket
 	}
 	dcpReceiver.SeedSeqnos(vbuuids, startSeqnos)
 
+	var dataSourceOptions *cbdatasource.BucketDataSourceOptions
+	if bucket.spec.UseXattrs {
+		dataSourceOptions = cbdatasource.DefaultBucketDataSourceOptions
+		dataSourceOptions.IncludeXAttrs = true
+	}
+
 	LogTo("Feed+", "Connecting to new bucket datasource.  URLs:%s, pool:%s, name:%s, auth:%s", urls, poolName, bucketName, bucket.spec.Auth)
 	bds, err := cbdatasource.NewBucketDataSource(
 		urls,
@@ -314,7 +320,7 @@ func (bucket CouchbaseBucket) StartDCPFeed(args sgbucket.TapArguments) (sgbucket
 		vbucketIdsArr,
 		bucket.spec.Auth,
 		dcpReceiver,
-		nil,
+		dataSourceOptions,
 	)
 	if err != nil {
 		return nil, err

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -19,6 +19,14 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
+// Memcached binary protocol datatype bit flags (https://github.com/couchbase/memcached/blob/master/docs/BinaryProtocol.md#data-types),
+// used in MCRequest.DataType
+const (
+	MemcachedDataTypeJSON = 1 << iota
+	MemcachedDataTypeSnappy
+	MemcachedDataTypeXattr
+)
+
 type couchbaseDCPFeedImpl struct {
 	bds    cbdatasource.BucketDataSource
 	events chan sgbucket.TapEvent
@@ -142,6 +150,7 @@ func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16, opcode sgbucket.
 		Key:      rq.Key,
 		Value:    rq.Body,
 		Sequence: rq.Cas,
+		DataType: rq.DataType,
 	}
 	return event
 }

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -309,7 +309,7 @@ func (c *changeCache) waitForSequenceWithMissing(sequence uint64) {
 
 // Given a newly changed document (received from the tap feed), adds change entries to channels.
 // The JSON must be the raw document from the bucket, with the metadata and all.
-func (c *changeCache) DocChanged(docID string, docJSON []byte, seq uint64, vbNo uint16) {
+func (c *changeCache) DocChanged(docID string, docJSON []byte, seq uint64, vbNo uint16, dataType uint8) {
 	entryTime := time.Now()
 	// ** This method does not directly access any state of c, so it doesn't lock.
 	go func() {
@@ -329,7 +329,7 @@ func (c *changeCache) DocChanged(docID string, docJSON []byte, seq uint64, vbNo 
 		}
 
 		// First unmarshal the doc (just its metadata, to save time/memory):
-		doc, err := UnmarshalDocumentSyncData(docJSON, false)
+		doc, err := UnmarshalDocumentSyncDataFromFeed(docJSON, dataType, false)
 		if err != nil || !doc.HasValidSyncData(c.context.writeSequences()) {
 			base.Warn("changeCache: Error unmarshaling doc %q: %v", docID, err)
 			return

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -41,7 +41,7 @@ type ChangeIndex interface {
 	GetCachedChanges(channelName string, options ChangesOptions) (validFrom uint64, entries []*LogEntry)
 
 	// Called to add a document to the index
-	DocChanged(docID string, docJSON []byte, seq uint64, vbucket uint16)
+	DocChanged(docID string, docJSON []byte, seq uint64, vbucket uint16, dataType uint8)
 
 	// Retrieves stable sequence for index
 	GetStableSequence(docID string) SequenceID

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -26,7 +26,7 @@ type changeListener struct {
 	OnDocChanged          DocChangedFunc         // Called when change arrives on feed
 }
 
-type DocChangedFunc func(docID string, jsonData []byte, seq uint64, vbNo uint16)
+type DocChangedFunc func(docID string, jsonData []byte, seq uint64, vbNo uint16, dataType uint8)
 
 func (listener *changeListener) Init(name string) {
 	listener.bucketName = name
@@ -68,16 +68,16 @@ func (listener *changeListener) Start(bucket base.Bucket, trackDocs bool, bucket
 				if strings.HasPrefix(key, auth.UserKeyPrefix) ||
 					strings.HasPrefix(key, auth.RoleKeyPrefix) {
 					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
+						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo, event.DataType)
 					}
 					listener.Notify(base.SetOf(key))
 				} else if strings.HasPrefix(key, UnusedSequenceKeyPrefix) {
 					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
+						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo, event.DataType)
 					}
 				} else if !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, base.KIndexPrefix) {
 					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo)
+						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo, event.DataType)
 					}
 					if trackDocs {
 						listener.DocChannel <- event

--- a/db/crud.go
+++ b/db/crud.go
@@ -48,7 +48,7 @@ func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
 	dbExpvars.Add("document_gets", 1)
 	if db.UseXattrs() {
 		var rawDoc, rawXattr []byte
-		_, err = db.Bucket.GetWithXattr(key, KSyncXattr, &rawDoc, &rawXattr)
+		_, err = db.Bucket.GetWithXattr(key, KSyncXattrName, &rawDoc, &rawXattr)
 		doc, err = unmarshalDocumentWithXattr(docid, rawDoc, rawXattr)
 		if err != nil {
 			return nil, err
@@ -744,7 +744,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, cal
 
 	// Update the document
 	if db.UseXattrs() {
-		err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattr, int(expiry), func(currentValue []byte, currentXattr []byte) (raw []byte, rawXattr []byte, err error) {
+		err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, int(expiry), func(currentValue []byte, currentXattr []byte) (raw []byte, rawXattr []byte, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocumentWithXattr(docid, currentValue, currentXattr); err != nil {
 				return

--- a/db/database.go
+++ b/db/database.go
@@ -51,7 +51,7 @@ const (
 	DefaultUseXattrs = false            // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	KSyncKeyPrefix   = "_sync:"         // All special/internal documents the gateway creates have this prefix in their keys.
 	kSyncDataKey     = "_sync:syncdata" // Key used to store sync function
-	KSyncXattr       = "_sync"          // Name of XATTR used to store sync metadata
+	KSyncXattrName   = "_sync"          // Name of XATTR used to store sync metadata
 )
 
 // Basic description of a database. Shared between all Database objects on the same database.
@@ -430,7 +430,7 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 	// in the document body when xattrs disabled, in the mobile xattr when xattrs enabled.
 	syncData := "doc._sync"
 	if useXattrs {
-		syncData = fmt.Sprintf("meta.xattrs.%s", KSyncXattr)
+		syncData = fmt.Sprintf("meta.xattrs.%s", KSyncXattrName)
 	}
 
 	// View for finding every Couchbase doc (used when deleting a database)
@@ -943,7 +943,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		}
 		var err error
 		if db.UseXattrs() {
-			err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattr, 0, func(currentValue []byte, currentXattr []byte) (raw []byte, rawXattr []byte, err error) {
+			err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, func(currentValue []byte, currentXattr []byte) (raw []byte, rawXattr []byte, err error) {
 				if currentValue == nil || len(currentValue) == 0 {
 					return nil, nil, errors.New("Cancel update")
 				}

--- a/db/document.go
+++ b/db/document.go
@@ -111,7 +111,6 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*syncData, error)
 
 // Unmarshals sync metadata for a document arriving via DCP.  Includes handling for xattr content
 // being included in data.  If not present in either xattr or document body, returns nil but no error.
-// We may need to
 func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory bool) (result *syncData, err error) {
 
 	var body []byte
@@ -148,42 +147,60 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory 
 }
 
 // parseXattrStreamData returns the raw bytes of the body and the requested xattr (when present) from the raw DCP data bytes.
-// Details on format: https://docs.google.com/document/d/18UVa5j8KyufnLLy29VObbWRtoBn9vs8pcxttuMt6rz8/edit#heading=h.caqiui1pmmmb
+// Details on format (taken from https://docs.google.com/document/d/18UVa5j8KyufnLLy29VObbWRtoBn9vs8pcxttuMt6rz8/edit#heading=h.caqiui1pmmmb.):
+/*
+	When the XATTR bit is set the first uint32_t in the body contains the size of the entire XATTR section.
+
+
+	      Byte/     0       |       1       |       2       |       3       |
+	         /              |               |               |               |
+	        |0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|
+	        +---------------+---------------+---------------+---------------+
+	       0| Total xattr length in network byte order                      |
+	        +---------------+---------------+---------------+---------------+
+
+	Following the length you'll find an iovector-style encoding of all of the XATTR key-value pairs with the following encoding:
+
+	uint32_t length of next xattr pair (network order)
+	xattr key in modified UTF-8
+	0x00
+	xattr value in modified UTF-8
+	0x00
+
+	The 0x00 byte after the key saves us from storing a key length, and the trailing 0x00 is just for convenience to allow us to use string functions to search in them.
+*/
+
 func parseXattrStreamData(xattrName string, data []byte) (body []byte, xattr []byte, err error) {
 
 	xattrsLen := binary.BigEndian.Uint32(data[0:4])
-
 	body = data[xattrsLen:]
 	if xattrsLen == 0 {
 		return body, nil, nil
 	}
 
-	// In the xattr key/value pairs, key and value are both terminated by 0x00 (byte(0)).
-	separator := []byte{byte(0)}
+	// In the xattr key/value pairs, key and value are both terminated by 0x00 (byte(0)).  Use this as a separator to split the byte slice
+	separator := []byte("\x00")
 
-	// Iterate over xattrs
+	// Iterate over xattr key/value pairs
 	pos := uint32(4)
 	for pos < xattrsLen {
 		pairLen := binary.BigEndian.Uint32(data[pos : pos+4])
-		pos += 4
-		if pairLen > 0 {
-			pairBytes := data[pos : pos+pairLen]
-			components := bytes.Split(pairBytes, separator)
-			// xattr pair has the format:
-			//	  xattr key in modified UTF-8
-			//    0x00
-			//    xattr value in modified UTF-8
-			//    0x00
-			if len(components) != 3 {
-				return nil, nil, fmt.Errorf("Unexpected number of components found in xattr pair: %s", pairBytes)
-			}
-			xattrPairName := string(components[0])
-			// If this is the xattr we're looking for , we're done
-			if xattrName == xattrPairName {
-				return body, components[1], nil
-			}
-			pos += pairLen
+		if pairLen == 0 || int(pos+pairLen) > len(data) {
+			return nil, nil, fmt.Errorf("Unexpected xattr pair length (%d) - unable to parse xattrs", pairLen)
 		}
+		pos += 4
+		pairBytes := data[pos : pos+pairLen]
+		components := bytes.Split(pairBytes, separator)
+		// xattr pair has the format [key]0x00[value]0x00, and so should split into three components
+		if len(components) != 3 {
+			return nil, nil, fmt.Errorf("Unexpected number of components found in xattr pair: %s", pairBytes)
+		}
+		xattrKey := string(components[0])
+		// If this is the xattr we're looking for , we're done
+		if xattrName == xattrKey {
+			return body, components[1], nil
+		}
+		pos += pairLen
 	}
 
 	return body, xattr, nil

--- a/db/document.go
+++ b/db/document.go
@@ -10,8 +10,11 @@
 package db
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -104,6 +107,86 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*syncData, error)
 		root.SyncData.Flags |= channels.Deleted // Backward compatibility with old Deleted property
 	}
 	return root.SyncData, nil
+}
+
+// Unmarshals sync metadata for a document arriving via DCP.  Includes handling for xattr content
+// being included in data.  If not present in either xattr or document body, returns nil but no error.
+// We may need to
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory bool) (result *syncData, err error) {
+
+	var body []byte
+
+	// If attr datatype flag is set, data includes both xattrs and document body.  Check for presence of sync xattr.
+	// Note that there could be a non-sync xattr present
+	if dataType&base.MemcachedDataTypeXattr != 0 {
+		var syncXattr []byte
+		body, syncXattr, err = parseXattrStreamData(KSyncXattrName, data)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the sync xattr is present, use that to build syncData
+		if syncXattr != nil && len(syncXattr) > 0 {
+			result = &syncData{}
+			if needHistory {
+				result.History = make(RevTree)
+			}
+			err = json.Unmarshal(syncXattr, result)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		}
+	} else {
+		// Xattr flag not set - data is just the document body
+		body = data
+	}
+
+	// Non-xattr data, or sync xattr not present.  Attempt to retrieve sync metadata from document body
+	return UnmarshalDocumentSyncData(body, needHistory)
+
+}
+
+// parseXattrStreamData returns the raw bytes of the body and the requested xattr (when present) from the raw DCP data bytes.
+// Details on format: https://docs.google.com/document/d/18UVa5j8KyufnLLy29VObbWRtoBn9vs8pcxttuMt6rz8/edit#heading=h.caqiui1pmmmb
+func parseXattrStreamData(xattrName string, data []byte) (body []byte, xattr []byte, err error) {
+
+	xattrsLen := binary.BigEndian.Uint32(data[0:4])
+
+	body = data[xattrsLen:]
+	if xattrsLen == 0 {
+		return body, nil, nil
+	}
+
+	// In the xattr key/value pairs, key and value are both terminated by 0x00 (byte(0)).
+	separator := []byte{byte(0)}
+
+	// Iterate over xattrs
+	pos := uint32(4)
+	for pos < xattrsLen {
+		pairLen := binary.BigEndian.Uint32(data[pos : pos+4])
+		pos += 4
+		if pairLen > 0 {
+			pairBytes := data[pos : pos+pairLen]
+			components := bytes.Split(pairBytes, separator)
+			// xattr pair has the format:
+			//	  xattr key in modified UTF-8
+			//    0x00
+			//    xattr value in modified UTF-8
+			//    0x00
+			if len(components) != 3 {
+				return nil, nil, fmt.Errorf("Unexpected number of components found in xattr pair: %s", pairBytes)
+			}
+			xattrPairName := string(components[0])
+			// If this is the xattr we're looking for , we're done
+			if xattrName == xattrPairName {
+				return body, components[1], nil
+			}
+			pos += pairLen
+		}
+	}
+
+	return body, xattr, nil
 }
 
 func (doc *syncData) HasValidSyncData(requireSequence bool) bool {

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestParseXattr(t *testing.T) {
+	zeroByte := byte(0)
+	// Build payload for single xattr pair and body
+	xattrKey := "_sync"
+	xattrValue := `{"seq":1}`
+	xattrPairLength := 4 + len(xattrKey) + len(xattrValue) + 2
+	xattrLength := xattrPairLength + 4
+	body := `{"value":"ABC"}`
+
+	// Build up the dcp Body
+	dcpBody := make([]byte, 8)
+	binary.BigEndian.PutUint32(dcpBody[0:4], uint32(xattrLength))
+	binary.BigEndian.PutUint32(dcpBody[4:8], uint32(xattrPairLength))
+	dcpBody = append(dcpBody, xattrKey...)
+	dcpBody = append(dcpBody, zeroByte)
+	dcpBody = append(dcpBody, xattrValue...)
+	dcpBody = append(dcpBody, zeroByte)
+	dcpBody = append(dcpBody, body...)
+
+	resultBody, resultXattr, err := parseXattrStreamData("_sync", dcpBody)
+	assertNoError(t, err, "Unexpected error parsing dcp body")
+	assert.Equals(t, string(resultBody), string(body))
+	assert.Equals(t, string(resultXattr), string(xattrValue))
+
+	// Attempt to retrieve non-existent xattr
+	resultBody, resultXattr, err = parseXattrStreamData("nonexistent", dcpBody)
+	assertNoError(t, err, "Unexpected error parsing dcp body")
+	assert.Equals(t, string(resultBody), string(body))
+	assert.Equals(t, string(resultXattr), "")
+}

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -174,7 +174,7 @@ func (k *kvChangeIndex) setIndexPartitionMap(partitionMap base.IndexPartitionMap
 	}
 }
 
-func (k *kvChangeIndex) DocChanged(docID string, docJSON []byte, seq uint64, vbNo uint16) {
+func (k *kvChangeIndex) DocChanged(docID string, docJSON []byte, seq uint64, vbNo uint16, dataType uint8) {
 	// no-op for reader
 	base.Warn("DocChanged called in index reader for doc %s, will be ignored.", docID)
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="19e1a1d5fea2e65a51c2a3025102937fd9de2c1e"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e3c4b39715123596b338aebf430b09e8ce9567cb"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="01f7c43b4c592cc6779f9cbe36a07854c50b278d"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -57,7 +57,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b0f96cf430707aff15d3f63d8a76fcd0a7d43c94"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6575cf14363c4a840f4fafc01532b42c473472f8"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="e324a422a750407f19950152cf6a7dd06460d48b"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="d7249420369bcf410668a0954f4ed386ca6434c0"/>
 
@@ -67,7 +67,7 @@
 
   <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="6172a8c61c821c420071fe9e20e74d8e24c8cbd5"/>
+  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="19e1a1d5fea2e65a51c2a3025102937fd9de2c1e"/>
 
   <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e3c4b39715123596b338aebf430b09e8ce9567cb"/>
 


### PR DESCRIPTION
When running in xattr mode, adds flag to request xattrs when DCP stream is opened.  When sync xattr is included in data associated with a DCP mutation or deletion, uses that instead of looking in document body for _sync.

Fixes #2395.