### PR TITLE
Support Log keys, BLIP+ and BLIP++ log channels in logging config

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -551,6 +551,7 @@ func NewLoggerWriter(logKey string, serialNumber uint64, req *http.Request) *Log
 func CreateRollingLogger(logConfig *LogAppenderConfig) {
 	if logConfig != nil {
 		SetLogLevel(logConfig.LogLevel.sgLevel())
+		ParseLogFlags(logConfig.LogKeys)
 
 		if logConfig.LogFilePath == nil {
 			return

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -68,8 +68,8 @@ func (h *handler) handleBLIPSync() error {
 	ctx.blipContext.Logger = func(fmt string, params ...interface{}) {
 		base.LogTo("BLIP", fmt, params...)
 	}
-	ctx.blipContext.LogMessages = base.LogKeys["BLIP+"]
-	ctx.blipContext.LogFrames = base.LogKeys["BLIP++"]
+	ctx.blipContext.LogMessages = base.LogEnabledExcludingLogStar("BLIP+")
+	ctx.blipContext.LogFrames = base.LogEnabledExcludingLogStar("BLIP++")
 
 	// Start a WebSocket client and connect it to the BLIP handler:
 	wsHandler := func(conn *websocket.Conn) {


### PR DESCRIPTION
fixes #2458 

Parse log flags from logging config object, remove direct access to logKeys map for  BLIP+ and BLIP++ log key test