### PR TITLE
Import of SDK-written documents

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -914,18 +914,33 @@ func (bucket CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, rv int
 
 		switch err {
 		case nil:
-			// Successfully retrieved doc and xattr.  Copy the contents into rv, xv and return.
+			// Successfully retrieved doc and (optionally) xattr.  Copy the contents into rv, xv and return.
 			err = res.Content("", rv)
 			if err != nil {
-				LogTo("gocb", "Unable to retrieve xattr content for key=%s, xattrKey=%s: %v", k, xattrKey, err)
+				LogTo("gocb", "Unable to retrieve document content for key=%s, xattrKey=%s: %v", k, xattrKey, err)
 				return false, err, nil
 			}
-			err = res.Content(xattrKey, xv)
-			if err != nil {
-				LogTo("gocb", "Unable to retrieve xattr content for key=%s, xattrKey=%s: %v", k, xattrKey, err)
-				return false, err, nil
+			if err != gocbcore.ErrSubDocBadMulti {
+				err = res.Content(xattrKey, xv)
+				if err != nil {
+					LogTo("gocb", "Unable to retrieve xattr content for key=%s, xattrKey=%s: %v", k, xattrKey, err)
+					return false, err, nil
+				}
 			}
 			cas = uint64(res.Cas())
+			return false, nil, cas
+
+		case gocbcore.ErrSubDocBadMulti:
+			// TODO: LookupIn should handle all cases with a single op:
+			//     - doc and xattr
+			//     - no doc, no xattr
+			//     - doc, no xattr
+			//     - no doc, xattr
+			cas, docOnlyErr := bucket.Get(k, rv)
+			if docOnlyErr != nil {
+				shouldRetry = isRecoverableGoCBError(docOnlyErr)
+				return shouldRetry, docOnlyErr, 0
+			}
 			return false, nil, cas
 
 		case gocb.ErrKeyNotFound:
@@ -1166,7 +1181,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 		}
 
 		// Invoke callback to get updated value
-		updatedValue, updatedXattrValue, err := callback(value, xattrValue)
+		updatedValue, updatedXattrValue, err := callback(value, xattrValue, cas)
 		if err != nil {
 			LogTo("gocb", "Callback in WriteUpdateWithXattr returned error for key=%s, xattrKey=%s: %v", k, xattrKey, err)
 			return err

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -38,8 +38,8 @@ func (t TestAuthenticator) GetCredentials() (username, password, bucketname stri
 
 func GetBucketOrPanic() Bucket {
 
-	username := "bucket-1"
-	bucketname := "bucket-1"
+	username := "default"
+	bucketname := "default"
 	password := "password"
 
 	testAuth := TestAuthenticator{
@@ -587,7 +587,7 @@ func CouchbaseTestWriteCasXattrSimple(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := "TestWriteCasXATTRA"
+	key := "TestWriteCasXATTRSimple"
 	xattrName := "_sync"
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -933,7 +933,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 	}
 
 	// Dummy write update function that increments 'counter' in the doc and 'seq' in the xattr
-	writeUpdateFunc := func(doc []byte, xattr []byte) (updatedDoc []byte, updatedXattr []byte, err error) {
+	writeUpdateFunc := func(doc []byte, xattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, err error) {
 
 		var docMap map[string]interface{}
 		var xattrMap map[string]interface{}

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -151,6 +151,7 @@ func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16, opcode sgbucket.
 		Value:    rq.Body,
 		Sequence: rq.Cas,
 		DataType: rq.DataType,
+		Cas:      rq.Cas,
 	}
 	return event
 }

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 )
@@ -41,7 +42,7 @@ type ChangeIndex interface {
 	GetCachedChanges(channelName string, options ChangesOptions) (validFrom uint64, entries []*LogEntry)
 
 	// Called to add a document to the index
-	DocChanged(docID string, docJSON []byte, seq uint64, vbucket uint16, dataType uint8)
+	DocChanged(event sgbucket.TapEvent)
 
 	// Retrieves stable sequence for index
 	GetStableSequence(docID string) SequenceID

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -26,7 +26,7 @@ type changeListener struct {
 	OnDocChanged          DocChangedFunc         // Called when change arrives on feed
 }
 
-type DocChangedFunc func(docID string, jsonData []byte, seq uint64, vbNo uint16, dataType uint8)
+type DocChangedFunc func(event sgbucket.TapEvent)
 
 func (listener *changeListener) Init(name string) {
 	listener.bucketName = name
@@ -68,16 +68,16 @@ func (listener *changeListener) Start(bucket base.Bucket, trackDocs bool, bucket
 				if strings.HasPrefix(key, auth.UserKeyPrefix) ||
 					strings.HasPrefix(key, auth.RoleKeyPrefix) {
 					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo, event.DataType)
+						listener.OnDocChanged(event)
 					}
 					listener.Notify(base.SetOf(key))
 				} else if strings.HasPrefix(key, UnusedSequenceKeyPrefix) {
 					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo, event.DataType)
+						listener.OnDocChanged(event)
 					}
 				} else if !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, base.KIndexPrefix) {
 					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(key, event.Value, event.Sequence, event.VbNo, event.DataType)
+						listener.OnDocChanged(event)
 					}
 					if trackDocs {
 						listener.DocChannel <- event

--- a/db/database.go
+++ b/db/database.go
@@ -943,11 +943,11 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		}
 		var err error
 		if db.UseXattrs() {
-			err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, func(currentValue []byte, currentXattr []byte) (raw []byte, rawXattr []byte, err error) {
+			err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, err error) {
 				if currentValue == nil || len(currentValue) == 0 {
 					return nil, nil, errors.New("Cancel update")
 				}
-				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr)
+				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -13,12 +13,12 @@ func TestParseXattr(t *testing.T) {
 	xattrKey := "_sync"
 	xattrValue := `{"seq":1}`
 	xattrPairLength := 4 + len(xattrKey) + len(xattrValue) + 2
-	xattrLength := xattrPairLength + 4
+	xattrTotalLength := xattrPairLength
 	body := `{"value":"ABC"}`
 
 	// Build up the dcp Body
 	dcpBody := make([]byte, 8)
-	binary.BigEndian.PutUint32(dcpBody[0:4], uint32(xattrLength))
+	binary.BigEndian.PutUint32(dcpBody[0:4], uint32(xattrTotalLength))
 	binary.BigEndian.PutUint32(dcpBody[4:8], uint32(xattrPairLength))
 	dcpBody = append(dcpBody, xattrKey...)
 	dcpBody = append(dcpBody, zeroByte)
@@ -36,4 +36,13 @@ func TestParseXattr(t *testing.T) {
 	assertNoError(t, err, "Unexpected error parsing dcp body")
 	assert.Equals(t, string(resultBody), string(body))
 	assert.Equals(t, string(resultXattr), "")
+}
+
+func TestParseDocumentCas(t *testing.T) {
+	syncData := &syncData{}
+	syncData.Cas = "0x00002ade734fb714"
+
+	casInt := syncData.GetSyncCas()
+
+	assert.Equals(t, casInt, uint64(1492749160563736576))
 }

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 )
 
@@ -174,9 +175,9 @@ func (k *kvChangeIndex) setIndexPartitionMap(partitionMap base.IndexPartitionMap
 	}
 }
 
-func (k *kvChangeIndex) DocChanged(docID string, docJSON []byte, seq uint64, vbNo uint16, dataType uint8) {
+func (k *kvChangeIndex) DocChanged(event sgbucket.TapEvent) {
 	// no-op for reader
-	base.Warn("DocChanged called in index reader for doc %s, will be ignored.", docID)
+	base.Warn("DocChanged called in index reader for doc %s, will be ignored.", event.Key)
 }
 
 // No-ops - pending refactoring of change_cache.go to remove usage (or deprecation of

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="19e1a1d5fea2e65a51c2a3025102937fd9de2c1e"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="01f7c43b4c592cc6779f9cbe36a07854c50b278d"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="51feaacbc82c08c2f091dc94b57e12912ab7fb40"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -491,7 +491,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, err
 	}
 
-	if importDocs {
+	// Support for legacy importDocs handling - if xattrs aren't enabled, support a backfill-style import on startup
+	if importDocs && !config.UseXattrs() {
 		db, _ := db.GetDatabase(dbcontext, nil)
 		if _, err := db.UpdateAllDocChannels(false, true); err != nil {
 			return nil, err


### PR DESCRIPTION
When auto-import is enabled in the config, triggers import processing for non-SG writes seen on the mutation feed.  Identifies non-SG writes by comparing the document cas w/ the cas stamped on the xattr.

Required passing the feed cas down through DocChanged - refactored to just pass the entire TapEvent, as the signature was getting a bit bloated.

Depends on https://github.com/couchbase/sg-bucket/pull/21.