### PR TITLE
Workaround for https://issues.couchbase.com/browse/MB-24037

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -8,8 +8,35 @@ const (
 
 	//kTestURL = "http://localhost:8091"
 	kTestURL = "walrus:"
+
+	kTestUseAuthHandler = false
+	kTestUsername       = "sync_gateway_tests"
+	kTestPassword       = "password"
+	kTestBucketname     = "sync_gateway_tests"
 )
 
 func UnitTestUrl() string {
 	return kTestURL
+}
+
+func UnitTestAuthHandler() AuthHandler {
+	if !kTestUseAuthHandler {
+		return nil
+	} else {
+		return &UnitTestAuth{
+			username:   kTestUsername,
+			password:   kTestPassword,
+			bucketname: kTestBucketname,
+		}
+	}
+}
+
+type UnitTestAuth struct {
+	username   string
+	password   string
+	bucketname string
+}
+
+func (u *UnitTestAuth) GetCredentials() (string, string, string) {
+	return TransformBucketCredentials(u.username, u.password, u.bucketname)
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -896,18 +896,22 @@ func TestChannelView(t *testing.T) {
 	assert.Equals(t, rev1id, body["_rev"])
 	assert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
 
+	var entries LogEntries
 	// Query view (retry loop to wait for indexing)
 	for i := 0; i < 10; i++ {
-		entries, err := db.getChangesInChannelFromView("*", 0, ChangesOptions{})
+		var err error
+		entries, err = db.getChangesInChannelFromView("*", 0, ChangesOptions{})
 
 		assertNoError(t, err, "Couldn't create document")
 		if len(entries) >= 1 {
-			log.Printf("got entry from view: %+v", entries[0])
+			log.Printf("View query returned entry: %+v", entries[0])
 			break
 		}
 		log.Printf("No entries found - retrying (%d/10)", i+1)
 		time.Sleep(500 * time.Millisecond)
 	}
+
+	assert.True(t, len(entries) == 1)
 
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -34,7 +34,9 @@ func testBucket() base.Bucket {
 	bucket, err := ConnectToBucket(base.BucketSpec{
 		Server:          base.UnitTestUrl(),
 		CouchbaseDriver: base.DefaultDriverForBucketType[base.DataBucket],
-		BucketName:      "sync_gateway_tests"}, nil)
+		BucketName:      "sync_gateway_tests",
+		Auth:            base.UnitTestAuthHandler(),
+		UseXattrs:       DefaultUseXattrs}, nil)
 	if err != nil {
 		log.Fatalf("Couldn't connect to bucket: %v", err)
 	}
@@ -879,6 +881,33 @@ func TestRecentSequenceHistory(t *testing.T) {
 	assert.True(t, err == nil)
 	log.Printf("Recent sequences: %v (shouldn't exceed %v)", len(doc.RecentSequences), kMaxRecentSequences)
 	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
+
+}
+
+func TestChannelView(t *testing.T) {
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+
+	// Create doc
+	log.Printf("Create doc 1...")
+	body := Body{"key1": "value1", "key2": 1234}
+	rev1id, err := db.Put("doc1", body)
+	assertNoError(t, err, "Couldn't create document")
+	assert.Equals(t, rev1id, body["_rev"])
+	assert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
+
+	// Query view (retry loop to wait for indexing)
+	for i := 0; i < 10; i++ {
+		entries, err := db.getChangesInChannelFromView("*", 0, ChangesOptions{})
+
+		assertNoError(t, err, "Couldn't create document")
+		if len(entries) >= 1 {
+			log.Printf("got entry from view: %+v", entries[0])
+			break
+		}
+		log.Printf("No entries found - retrying (%d/10)", i+1)
+		time.Sleep(500 * time.Millisecond)
+	}
 
 }
 


### PR DESCRIPTION
Due to MB-24037, views that only reference xattrs (and not anything in the document body) are failing to return results.  Underlying cause is that when view engine requests a DCP feed that doesn't include document bodies, the xattrs are also being excluded.  

As a workaround until this is fixed, add a reference to the document body to the xattr version of the views, to force the view engine to request a DCP feed that includes doc bodies.