### PR TITLE
Delete support when using xattrs

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -140,6 +140,11 @@ func (bucket CouchbaseBucket) Update(k string, exp int, callback sgbucket.Update
 	return bucket.Bucket.Update(k, exp, couchbase.UpdateFunc(callback))
 }
 
+func (bucket CouchbaseBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
+	Warn("CouchbaseBucket doesn't support cas-safe removal - handling as simple delete")
+	return 0, bucket.Bucket.Delete(k)
+
+}
 func (bucket CouchbaseBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
 	panic("SetBulk not implemented")
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1215,21 +1215,22 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 			if writeErr == nil {
 				return nil
 			}
-		}
+		} else {
 
-		// Not a delete - update the body and xattr
-		_, writeErr = bucket.WriteCasWithXattr(k, xattrKey, exp, cas, updatedValue, xattrMap)
+			// Not a delete - update the body and xattr
+			_, writeErr = bucket.WriteCasWithXattr(k, xattrKey, exp, cas, updatedValue, xattrMap)
 
-		// ErrKeyExists is CAS failure, which we want to retry.  Other non-recoverable errors should cancel the
-		// WriteUpdate.
-		if writeErr != nil && writeErr != gocb.ErrKeyExists && !isRecoverableGoCBError(writeErr) {
-			LogTo("CRUD", "Update of new value during WriteUpdateWithXattr failed for key %s: %v", k, writeErr)
-			return writeErr
-		}
+			// ErrKeyExists is CAS failure, which we want to retry.  Other non-recoverable errors should cancel the
+			// WriteUpdate.
+			if writeErr != nil && writeErr != gocb.ErrKeyExists && !isRecoverableGoCBError(writeErr) {
+				LogTo("CRUD", "Update of new value during WriteUpdateWithXattr failed for key %s: %v", k, writeErr)
+				return writeErr
+			}
 
-		// If there was no error, we're done
-		if writeErr == nil {
-			return nil
+			// If there was no error, we're done
+			if writeErr == nil {
+				return nil
+			}
 		}
 	}
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1126,6 +1126,8 @@ func CouchbaseTestDeleteDocumentUpdateXattr(t *testing.T) {
 	var postDeleteXattr map[string]interface{}
 	getCas2, err := bucket.GetWithXattr(key, xattrName, &postDeleteVal, &postDeleteXattr)
 	assertNoError(t, err, "Error getting document post-delete")
+	assert.Equals(t, postDeleteXattr["seq"], float64(2))
+	assert.Equals(t, len(postDeleteVal), 0)
 	log.Printf("Post-delete xattr (2): %s", postDeleteXattr)
 	log.Printf("Post-delete cas (2): %x", getCas2)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1178,7 +1178,7 @@ func CouchbaseTestDeleteDocumentAndXATTR(t *testing.T) {
 
 }
 
-// TestDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Used during SG delete
+// TestDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Pending https://issues.couchbase.com/browse/MB-24098
 func CouchbaseTestDeleteDocumentAndUpdateXATTR(t *testing.T) {
 	b := GetBucketOrPanic()
 	bucket, ok := b.(*CouchbaseBucketGoCB)
@@ -1221,23 +1221,14 @@ func CouchbaseTestDeleteDocumentAndUpdateXATTR(t *testing.T) {
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
 	mutateCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	assert.Equals(t, len(retrievedVal), 0)
+	assert.Equals(t, retrievedXattr["seq"], float64(123))
 	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
 	log.Printf("MutateInEx cas: %v", mutateCas)
-	// Post-delete
 
-	/*
-		bucket.Bucket.Remove(key, gocb.Cas(mutateCas))
-
-		var delRetrievedVal map[string]interface{}
-		var delRetrievedXattr map[string]interface{}
-		deleteCas, err := bucket.GetWithXattr(key, xattrName, &delRetrievedVal, &delRetrievedXattr)
-		log.Printf("del value: %v, del xattr: %v", delRetrievedVal, delRetrievedXattr)
-
-		log.Printf("Post-delete cas: %v", deleteCas)
-	*/
 }
 
-// TestDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Used during SG delete
+// CouchbaseTestRetrieveDocumentAndXattr.  Pending https://issues.couchbase.com/browse/MB-24152
 func CouchbaseTestRetrieveDocumentAndXattr(t *testing.T) {
 	b := GetBucketOrPanic()
 	bucket, ok := b.(*CouchbaseBucketGoCB)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -15,7 +15,9 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
+	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/go.assert"
 	"gopkg.in/couchbase/gocbcore.v7"
@@ -933,7 +935,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 	}
 
 	// Dummy write update function that increments 'counter' in the doc and 'seq' in the xattr
-	writeUpdateFunc := func(doc []byte, xattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, err error) {
+	writeUpdateFunc := func(doc []byte, xattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, isDelete bool, err error) {
 
 		var docMap map[string]interface{}
 		var xattrMap map[string]interface{}
@@ -941,7 +943,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 		if len(doc) > 0 {
 			err = json.Unmarshal(doc, &docMap)
 			if err != nil {
-				return nil, nil, fmt.Errorf("Unable to unmarshal incoming doc: %v", err)
+				return nil, nil, false, fmt.Errorf("Unable to unmarshal incoming doc: %v", err)
 			}
 		} else {
 			// No incoming doc, treat as insert.
@@ -952,7 +954,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 		if len(xattr) > 0 {
 			err = json.Unmarshal(xattr, &xattrMap)
 			if err != nil {
-				return nil, nil, fmt.Errorf("Unable to unmarshal incoming xattr: %v", err)
+				return nil, nil, false, fmt.Errorf("Unable to unmarshal incoming xattr: %v", err)
 			}
 		} else {
 			// No incoming xattr, treat as insert.
@@ -977,7 +979,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 
 		updatedDoc, _ = json.Marshal(docMap)
 		updatedXattr, _ = json.Marshal(xattrMap)
-		return updatedDoc, updatedXattr, nil
+		return updatedDoc, updatedXattr, false, nil
 	}
 
 	// Insert
@@ -1013,7 +1015,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 }
 
 // TestDeleteDocumentHavingXATTR.  Delete document that has a system xattr.  System XATTR should be retained and retrievable.
-func CouchbaseTestDeleteDocumentHavingXATTR(t *testing.T) {
+func CouchbaseTestDeleteDocumentHavingXattr(t *testing.T) {
 	b := GetBucketOrPanic()
 	bucket, ok := b.(*CouchbaseBucketGoCB)
 	if !ok {
@@ -1037,7 +1039,7 @@ func CouchbaseTestDeleteDocumentHavingXATTR(t *testing.T) {
 		bucket.Delete(key)
 	}
 
-	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
 	cas := uint64(0)
 	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
 	if err != nil {
@@ -1059,6 +1061,73 @@ func CouchbaseTestDeleteDocumentHavingXATTR(t *testing.T) {
 	}
 	assert.Equals(t, len(retrievedVal), 0)
 	assert.Equals(t, retrievedXattr["seq"], float64(123))
+
+}
+
+// TestDeleteDocumentUpdateXATTR.  Delete document that has a system xattr along with an xattr update.
+func CouchbaseTestDeleteDocumentUpdateXattr(t *testing.T) {
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// Create document with XATTR
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 1
+	xattrVal["rev"] = "1-1234"
+
+	key := "TestDeleteDocumentHavingXATTR"
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		bucket.Delete(key)
+	}
+
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// Delete the document.
+	err = bucket.Delete(key)
+	if err != nil {
+		t.Errorf("Error doing Delete: %+v", err)
+	}
+
+	// Verify delete of body was successful, retrieve XATTR
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != nil {
+		t.Errorf("Error doing GetWithXattr: %+v", err)
+	}
+	assert.Equals(t, len(retrievedVal), 0)
+	assert.Equals(t, retrievedXattr["seq"], float64(1))
+	log.Printf("Post-delete xattr (1): %s", retrievedXattr)
+	log.Printf("Post-delete cas (1): %x", getCas)
+
+	// Update the xattr only
+	xattrVal["seq"] = 2
+	xattrVal["rev"] = "1-1234"
+	casOut, writeErr := bucket.WriteCasWithXattr(key, xattrName, 0, getCas, nil, xattrVal)
+	assertNoError(t, writeErr, "Error updating xattr post-delete")
+	log.Printf("WriteCasWithXattr cas: %d", casOut)
+
+	// Retrieve the document, validate cas values
+	var postDeleteVal map[string]interface{}
+	var postDeleteXattr map[string]interface{}
+	getCas2, err := bucket.GetWithXattr(key, xattrName, &postDeleteVal, &postDeleteXattr)
+	assertNoError(t, err, "Error getting document post-delete")
+	log.Printf("Post-delete xattr (2): %s", postDeleteXattr)
+	log.Printf("Post-delete cas (2): %x", getCas2)
 
 }
 
@@ -1106,5 +1175,153 @@ func CouchbaseTestDeleteDocumentAndXATTR(t *testing.T) {
 	var retrievedXattr map[string]interface{}
 	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
 	assert.Equals(t, err, gocbcore.ErrKeyNotFound)
+
+}
+
+// TestDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Used during SG delete
+func CouchbaseTestDeleteDocumentAndUpdateXATTR(t *testing.T) {
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// Create document with XATTR
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	key := "TestDeleteDocumentAndUpdateXATTR_2"
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+		bucket.DeleteWithXattr(key, xattrName)
+	}
+
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	_, mutateErr := bucket.Bucket.MutateInEx(key, gocb.SubdocDocFlagReplaceDoc&gocb.SubdocDocFlagAccessDeleted, gocb.Cas(cas), uint32(0)).
+		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                     // Update the xattr
+		UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+		RemoveEx("", gocb.SubdocFlagNone).                                                       // Delete the document body
+		Execute()
+
+	log.Printf("MutateInEx error: %v", mutateErr)
+	// Verify delete of body and XATTR
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	mutateCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
+	log.Printf("MutateInEx cas: %v", mutateCas)
+	// Post-delete
+
+	/*
+		bucket.Bucket.Remove(key, gocb.Cas(mutateCas))
+
+		var delRetrievedVal map[string]interface{}
+		var delRetrievedXattr map[string]interface{}
+		deleteCas, err := bucket.GetWithXattr(key, xattrName, &delRetrievedVal, &delRetrievedXattr)
+		log.Printf("del value: %v, del xattr: %v", delRetrievedVal, delRetrievedXattr)
+
+		log.Printf("Post-delete cas: %v", deleteCas)
+	*/
+}
+
+// TestDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Used during SG delete
+func CouchbaseTestRetrieveDocumentAndXattr(t *testing.T) {
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// 1. Create document with XATTR
+	val := make(map[string]interface{})
+	val["type"] = "docExistsXattrExists"
+
+	xattrName := "_sync"
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	key1 := "DocExistsXattrExists"
+	key2 := "DocExistsNoXattr"
+	key3 := "XattrExistsNoDoc"
+	key4 := "NoDocNoXattr"
+	var err error
+
+	// Create w/ XATTR
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// 2. Create document with no XATTR
+	val = make(map[string]interface{})
+	val["type"] = "DocExistsNoXattr"
+	_, err = bucket.Add(key2, 0, val)
+
+	// 3. Xattr, no document
+	val = make(map[string]interface{})
+	val["type"] = "xattrExistsNoDoc"
+
+	xattrVal = make(map[string]interface{})
+	xattrVal["seq"] = 456
+	xattrVal["rev"] = "1-1234"
+
+	// Create w/ XATTR
+	cas = uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+	// Delete the doc
+	bucket.Delete(key3)
+
+	// 4. No xattr, no document
+
+	// Attempt to retrieve all 4 docs
+	res1, key1err := bucket.Bucket.LookupInEx(key1, gocb.SubdocDocFlagAccessDeleted).
+		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
+		GetEx("", gocb.SubdocFlagNone).         // Get the document body
+		Execute()
+	log.Printf("key1err: %v", key1err)
+	log.Printf("key1res: %+v", res1)
+
+	time.Sleep(100 * time.Millisecond)
+	res2, key2err := bucket.Bucket.LookupInEx(key2, gocb.SubdocDocFlagAccessDeleted).
+		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
+		GetEx("", gocb.SubdocFlagNone).         // Get the document body
+		Execute()
+	log.Printf("key2err: %v", key2err)
+	log.Printf("key2res: %+v", res2)
+
+	time.Sleep(100 * time.Millisecond)
+	res3, key3err := bucket.Bucket.LookupInEx(key3, gocb.SubdocDocFlagAccessDeleted).
+		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
+		GetEx("", gocb.SubdocFlagNone).         // Get the document body
+		Execute()
+	log.Printf("key3err: %v", key3err)
+	log.Printf("key3res: %+v", res3)
+
+	time.Sleep(100 * time.Millisecond)
+	res4, key4err := bucket.Bucket.LookupInEx(key4, gocb.SubdocDocFlagAccessDeleted).
+		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
+		GetEx("", gocb.SubdocFlagNone).         // Get the document body
+		Execute()
+	log.Printf("key4err: %v", key4err)
+	log.Printf("key4res: %+v", res4)
 
 }

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -68,6 +68,9 @@ func (b *LeakyBucket) SetRaw(k string, exp int, v []byte) error {
 func (b *LeakyBucket) Delete(k string) error {
 	return b.bucket.Delete(k)
 }
+func (b *LeakyBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
+	return b.bucket.Remove(k, cas)
+}
 func (b *LeakyBucket) Write(k string, flags int, exp int, v interface{}, opt sgbucket.WriteOptions) error {
 	return b.bucket.Write(k, flags, exp, v, opt)
 }
@@ -296,7 +299,7 @@ func (b *LeakyBucket) CouchbaseServerVersion() (major uint64, minor uint64, micr
 }
 
 func (b *LeakyBucket) UUID() (string, error) {
-		return b.bucket.UUID()
+	return b.bucket.UUID()
 }
 
 func (b *LeakyBucket) CloseAndDelete() error {
@@ -305,6 +308,7 @@ func (b *LeakyBucket) CloseAndDelete() error {
 	}
 	return nil
 }
+
 // An implementation of a sgbucket tap feed that wraps
 // tap events on the upstream tap feed to better emulate real world
 // TAP/DCP behavior.
@@ -369,4 +373,3 @@ func dedupeTapEvents(tapEvents []sgbucket.TapEvent) []sgbucket.TapEvent {
 func VBHash(key string, numVb int) uint32 {
 	return sgbucket.VBHash(key, uint16(numVb))
 }
-

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -84,7 +84,7 @@ func (b *LeakyBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpda
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
 func (b *LeakyBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
-	panic("SetBulk not implemented")
+	return b.bucket.SetBulk(entries)
 }
 
 func (b *LeakyBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -65,6 +65,11 @@ func (b *LoggingBucket) Delete(k string) error {
 	defer func() { LogTo("Bucket", "Delete(%q) [%v]", k, time.Since(start)) }()
 	return b.bucket.Delete(k)
 }
+func (b *LoggingBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "Remove(%q) [%v]", k, time.Since(start)) }()
+	return b.bucket.Remove(k, cas)
+}
 func (b *LoggingBucket) Write(k string, flags int, exp int, v interface{}, opt sgbucket.WriteOptions) error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Write(%q, 0x%x, %d, ..., 0x%x) [%v]", k, flags, exp, opt, time.Since(start)) }()

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -143,6 +143,9 @@ func (b *StatsBucket) SetRaw(k string, exp int, v []byte) error {
 func (b *StatsBucket) Delete(k string) error {
 	return b.bucket.Delete(k)
 }
+func (b *StatsBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
+	return b.bucket.Remove(k, cas)
+}
 func (b *StatsBucket) Write(k string, flags int, exp int, v interface{}, opt sgbucket.WriteOptions) error {
 	if vBytes, ok := v.([]byte); ok {
 		defer b.docWrite(1, len(vBytes))

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -339,13 +339,12 @@ func (c *changeCache) DocChanged(event sgbucket.TapEvent) {
 		if c.context.autoImport && c.context.UseXattrs() {
 			// If syncData is nil, or if this was not an SG write, attempt to import
 			if doc == nil || !doc.IsSGWrite(event.Cas) {
-				// import
-				if event.Opcode == sgbucket.TapDeletion {
+				isDelete := event.Opcode == sgbucket.TapDeletion
+				if isDelete {
 					rawBody = nil
 				}
-				base.LogTo("Import", "Importing %s", docID)
 				db := Database{DatabaseContext: c.context, user: nil}
-				db.ImportDoc(docID, rawBody, false)
+				db.ImportDoc(docID, rawBody, isDelete)
 				return
 			}
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -258,6 +258,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	}
 
+	// watchDocChanges is used for bucket shadowing and legacy import - not required when running w/ xattrs.
 	if !context.UseXattrs() {
 		go context.watchDocChanges()
 	}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b0f96cf430707aff15d3f63d8a76fcd0a7d43c94"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="111db2a5062e0d027e7f0a3845ce165789f19024"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="e324a422a750407f19950152cf6a7dd06460d48b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="19e1a1d5fea2e65a51c2a3025102937fd9de2c1e"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="51feaacbc82c08c2f091dc94b57e12912ab7fb40"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="dfabea1281f55d02e67d3a470b2e0951df723aab"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="d5cac425555ca5cf00694df246e04f05e6a55150"/>
 


### PR DESCRIPTION
Documents deleted through Sync Gateway delete the document, and update the xattr on the deleted document.  Currently being done in two steps (pending server enhancement for single op).  Requires cas-safe delete, which wasn't previously in the bucket API.  Added to walrus, sg-bucket and gocb bucket.  The go-couchbase Remove downgrades to a cas-unsafe delete and logs a warning (isn't used in current processing).

To differentiate between deletes and updates, the WriteUpdateWithXattrFunc now includes a deletedDoc flag in the response.  This was preferable to making assumptions about delete based on the returned updatedDoc []byte, because:
 - updatedDoc=nil is already used to skip the update of the doc body
 - updatedDoc = []byte{} is technically a valid update, even if it's not something Sync Gateway needs to do today

Documents deleted through the SDK now trigger import processing to update the sync metadata appropriately.

Requires https://github.com/couchbase/sg-bucket/pull/22