### PR TITLE
Trigger import handling on attempted retrieval of non-SG write

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1184,7 +1184,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 		// Invoke callback to get updated value
 		updatedValue, updatedXattrValue, deleteDoc, err := callback(value, xattrValue, cas)
 		if err != nil {
-			LogTo("CRUD", "Callback in WriteUpdateWithXattr returned error for key=%s, xattrKey=%s: %v", k, xattrKey, err)
+			LogTo("CRUD+", "Callback in WriteUpdateWithXattr returned error for key=%s, xattrKey=%s: %v", k, xattrKey, err)
 			return err
 		}
 

--- a/base/error.go
+++ b/base/error.go
@@ -19,6 +19,29 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
+type sgErrorCode uint16
+
+const (
+	alreadyImported = sgErrorCode(0x00)
+)
+
+type SGError struct {
+	code sgErrorCode
+}
+
+var (
+	ErrAlreadyImported = &SGError{alreadyImported}
+)
+
+func (e SGError) Error() string {
+	switch e.code {
+	case alreadyImported:
+		return "Document already imported"
+	default:
+		return "Unknown error"
+	}
+}
+
 // Simple error implementation wrapping an HTTP response status.
 type HTTPError struct {
 	Status  int

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -344,7 +344,10 @@ func (c *changeCache) DocChanged(event sgbucket.TapEvent) {
 					rawBody = nil
 				}
 				db := Database{DatabaseContext: c.context, user: nil}
-				db.ImportDoc(docID, rawBody, isDelete)
+				err := db.ImportDoc(docID, rawBody, isDelete)
+				if err != nil {
+					base.Warn("Error importing doc %q: %v", docID, err)
+				}
 				return
 			}
 		}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -346,7 +346,7 @@ func (c *changeCache) DocChanged(event sgbucket.TapEvent) {
 				db := Database{DatabaseContext: c.context, user: nil}
 				err := db.ImportDoc(docID, rawBody, isDelete)
 				if err != nil {
-					base.Warn("Error importing doc %q: %v", docID, err)
+					base.Warn("Unable to import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", docID, err)
 				}
 				return
 			}

--- a/db/crud.go
+++ b/db/crud.go
@@ -66,7 +66,7 @@ func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
 
 			// Limit the number of import attempts for a given GET request, to guard against unexpected infinite looping
 			if importAttempts > 20 {
-				base.Warn("Unable to import non-SG write of document %s after 20 attempts", docid)
+				base.Warn("Unable to complete request-triggered import of document %s after 20 attempts.  Will be re-attempted by background import processing.", docid)
 				return nil, base.HTTPErrorf(404, "Not imported")
 			}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -48,10 +48,36 @@ func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
 	dbExpvars.Add("document_gets", 1)
 	if db.UseXattrs() {
 		var rawDoc, rawXattr []byte
-		cas, err := db.Bucket.GetWithXattr(key, KSyncXattrName, &rawDoc, &rawXattr)
-		doc, err = unmarshalDocumentWithXattr(docid, rawDoc, rawXattr, cas)
-		if err != nil {
-			return nil, err
+		importAttempts := 0
+		for {
+			cas, getErr := db.Bucket.GetWithXattr(key, KSyncXattrName, &rawDoc, &rawXattr)
+			if getErr != nil {
+				return nil, getErr
+			}
+			var unmarshalErr error
+			doc, unmarshalErr = unmarshalDocumentWithXattr(docid, rawDoc, rawXattr, cas)
+			if unmarshalErr != nil {
+				return nil, unmarshalErr
+			}
+			// If this was an SG Write, return the doc.  Otherwise, attempt to import
+			if doc.IsSGWrite() {
+				break
+			}
+
+			// Limit the number of import attempts for a given GET request, to guard against unexpected infinite looping
+			if importAttempts > 20 {
+				base.Warn("Unable to import non-SG write of document %s after 20 attempts", docid)
+				return nil, base.HTTPErrorf(404, "Not imported")
+			}
+
+			// Attempt to import
+			isDelete := rawDoc == nil
+			db := Database{DatabaseContext: db, user: nil}
+			importErr := db.ImportDoc(docid, rawDoc, isDelete)
+			if importErr != nil {
+				return nil, importErr
+			}
+			importAttempts++
 		}
 	} else {
 		doc = newDocument(docid)
@@ -528,9 +554,8 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 // Imports a document that was written by someone other than sync gateway.
 func (db *Database) ImportDoc(docid string, value []byte, isDelete bool) error {
 
-	base.LogTo("Import", "Importing %s %s (delete=%v)", docid, value, isDelete)
 	var body Body
-
+	var newRev string
 	if isDelete {
 		body = Body{"_deleted": true}
 	} else {
@@ -545,15 +570,15 @@ func (db *Database) ImportDoc(docid string, value []byte, isDelete bool) error {
 		// If the current version of the doc is an SG write, document has been updated by SG subsequent to the update that triggered this import.
 		// Cancel update
 		if doc.IsSGWrite() {
-			base.LogTo("Import", "During import, existing doc (%s) identified as SG write.  Canceling import.", docid)
-			return nil, nil, couchbase.UpdateCancel
+			base.LogTo("Import+", "During import, existing doc (%s) identified as SG write.  Canceling import.", docid)
+			return nil, nil, base.ErrAlreadyImported
 		}
 
 		// The active rev is the parent for an import
 		parentRev := doc.CurrentRev
 		generation, _ := ParseRevID(parentRev)
 		generation++
-		newRev := createRevID(generation, parentRev, body)
+		newRev = createRevID(generation, parentRev, body)
 		base.LogTo("Import", "Created new rev ID %v", newRev)
 		body["_rev"] = newRev
 		doc.History.addRevision(RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete})
@@ -561,10 +586,15 @@ func (db *Database) ImportDoc(docid string, value []byte, isDelete bool) error {
 		// Note - no attachments processing is done during ImportDoc.  We don't (currently) support writing attachments through anything but SG.
 		return body, nil, nil
 	})
-	if err != nil {
+	if err != nil && err != base.ErrAlreadyImported {
 		base.LogTo("Import", "Error importing doc %q: %v", docid, err)
+		return err
 	}
-	return err
+	if err != base.ErrAlreadyImported {
+		base.LogTo("Import+", "Imported %s %s (delete=%v) as rev %s", docid, value, isDelete, newRev)
+	}
+
+	return nil
 }
 
 // Common subroutine of Put and PutExistingRev: a shell that loads the document, lets the caller
@@ -805,7 +835,7 @@ func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, cal
 			return raw, rawXattr, deleteDoc, err
 		})
 		if err != nil {
-			base.LogTo("CRUD+", "Error updating document %q w/ xattr: %v", key, err)
+			base.LogTo("CRUD+", "Failed to update document %q w/ xattr: %v", key, err)
 		}
 	} else {
 		err = db.Bucket.WriteUpdate(key, int(expiry), func(currentValue []byte) (raw []byte, writeOpts sgbucket.WriteOptions, err error) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -926,7 +926,7 @@ func CouchbaseTestConcurrentImport(t *testing.T) {
 	// Add doc to the underlying bucket:
 	db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
 
-	// Make sure they aren't visible thru the gateway:
+	// Attempt concurrent retrieval of the docs, and validate that they are only imported once (based on revid)
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)

--- a/db/document.go
+++ b/db/document.go
@@ -244,8 +244,11 @@ func (s *syncData) IsSGWrite(cas uint64) bool {
 }
 
 func (doc *document) IsSGWrite() bool {
-	base.LogTo("Import+", "Comparing cas to see if an update to doc %q was SG write:  cas: %x  syncCas: %s", doc.Cas, doc.syncData.Cas)
-	return doc.syncData.IsSGWrite(doc.Cas)
+	result := doc.syncData.IsSGWrite(doc.Cas)
+	if result == false {
+		base.LogTo("Import+", "Update to doc %s was not an SG write, based on cas. cas:%x syncCas:%q", doc.ID, doc.Cas, doc.syncData.Cas)
+	}
+	return result
 }
 
 func (doc *document) hasFlag(flag uint8) bool {


### PR DESCRIPTION
When running w/ xattrs enabled, we need to handle attempted retrieval of documents that are still pending import processing (they haven't appeared on the DCP feed on an import node).
On document retrieval, whether whether document was an SG write.  If not, trigger ImportDoc handling. 

Includes some improvements related to error handling during concurrent imports.

Adds SGError struct to simplify and centralize management of typed Sync Gateway errors.  Currently only used for concurrent import scenario.

Includes logging cleanup, to reduce the amount of noise in the Import and Import+ log channels.

Fixes #2503.