### PR TITLE
Add purge support

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -23,6 +23,7 @@ type sgErrorCode uint16
 
 const (
 	alreadyImported = sgErrorCode(0x00)
+	importCancelled = sgErrorCode(0x01)
 )
 
 type SGError struct {
@@ -31,12 +32,15 @@ type SGError struct {
 
 var (
 	ErrAlreadyImported = &SGError{alreadyImported}
+	ErrImportCancelled = &SGError{importCancelled}
 )
 
 func (e SGError) Error() string {
 	switch e.code {
 	case alreadyImported:
 		return "Document already imported"
+	case importCancelled:
+		return "Import cancelled"
 	default:
 		return "Unknown error"
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -332,6 +332,11 @@ func (c *changeCache) DocChanged(event sgbucket.TapEvent) {
 			return
 		}
 
+		// If this is a delete and there are no xattrs (no existing SG revision), we can ignore
+		if event.Opcode == sgbucket.TapDeletion && len(docJSON) == 0 {
+			return
+		}
+
 		// First unmarshal the doc (just its metadata, to save time/memory):
 		doc, rawBody, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, false)
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -595,7 +595,7 @@ func (db *Database) ImportDoc(docid string, value []byte, isDelete bool) error {
 		// If this is a delete, and there is no xattr on the existing doc,
 		// we shouldn't import.  (SG purge arriving over DCP feed)
 		if isDelete && doc.CurrentRev == "" {
-			base.LogTo("Import+", "Import skipped for delete of doc with no existing SG xattr (SG purge): %s", docid)
+			base.LogTo("Import+", "Import not required for delete mutation with no existing SG xattr (SG purge): %s", docid)
 			return nil, nil, base.ErrImportCancelled
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -218,7 +218,6 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 		}
 	}
 
-
 	sourceUrl, err := url.Parse(requestParams.Source)
 	if err != nil || requestParams.Source == "" {
 		err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate source URL [%s] is invalid.", requestParams.Source)
@@ -288,7 +287,6 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 			return
 		}
 	}
-
 
 	//If source and/or target are local DB names add local AdminInterface URL
 	localDbUrl := "http://" + adminInterface
@@ -588,7 +586,7 @@ func (h *handler) handlePurge() error {
 			}
 
 			//Attempt to delete document, if successful add to response, otherwise log warning
-			err = h.db.Bucket.Delete(key)
+			err = h.db.Purge(key)
 			if err == nil {
 
 				if first {


### PR DESCRIPTION
Currently purge has to be done as a two-step operation (delete body, then delete xattr) until server delivers the capability to do both in one operation.  To ensure this doesn't break anything in the meantime, import is cancelled for delete mutations if we can't find an existing _sync xattr.

Adds check in change_cache.go to skip import processing when the echo of the purge comes over the DCP feed.

Includes a fix in GetWithXattr to properly return KeyNotFound when both xattr and doc don't exist. 

Fixes #2509