### PR TITLE
Store old revisions as non-JSON binary

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -213,11 +213,7 @@ func (auth *Authenticator) Save(p Principal) error {
 		return err
 	}
 
-	data, err := json.Marshal(p)
-	if err != nil {
-		return err
-	}
-	if err := auth.bucket.SetRaw(p.DocID(), 0, data); err != nil {
+	if err := auth.bucket.Set(p.DocID(), 0, p); err != nil {
 		return err
 	}
 	if user, ok := p.(User); ok {
@@ -230,7 +226,7 @@ func (auth *Authenticator) Save(p Principal) error {
 			//FIX: Unregister old email address if any
 		}
 	}
-	base.LogTo("Auth", "Saved %s: %s", p.DocID(), data)
+	base.LogTo("Auth", "Saved %s: %s", p.DocID(), p)
 	return nil
 }
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -748,7 +748,6 @@ func (bucket CouchbaseBucketGoCB) SetRaw(k string, exp int, v []byte) error {
 		<-bucket.singleOps
 	}()
 	gocbExpvars.Add("SetRaw", 1)
-	LogTo("CRUD", "calling bucket Upsert with type %T", v)
 	_, err := bucket.Bucket.Upsert(k, BinaryDocument(v), uint32(exp))
 	return err
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -748,7 +748,8 @@ func (bucket CouchbaseBucketGoCB) SetRaw(k string, exp int, v []byte) error {
 		<-bucket.singleOps
 	}()
 	gocbExpvars.Add("SetRaw", 1)
-	_, err := bucket.Bucket.Upsert(k, v, uint32(exp))
+	LogTo("CRUD", "calling bucket Upsert with type %T", v)
+	_, err := bucket.Bucket.Upsert(k, BinaryDocument(v), uint32(exp))
 	return err
 }
 

--- a/db/revision.go
+++ b/db/revision.go
@@ -101,6 +101,8 @@ func (body Body) getExpiry() (uint32, error) {
 	return 0, nil
 }
 
+const nonJSONPrefix = byte(1)
+
 // Looks up the raw JSON data of a revision that's been archived to a separate doc.
 // If the revision isn't found (e.g. has been deleted by compaction) returns 404 error.
 func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byte, error) {
@@ -110,6 +112,10 @@ func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byt
 		err = base.HTTPErrorf(404, "missing")
 	}
 	if data != nil {
+		// Strip out the non-JSON prefix
+		if len(data) > 0 && data[0] == nonJSONPrefix {
+			data = data[1:]
+		}
 		base.LogTo("CRUD+", "Got old revision %q / %q --> %d bytes", docid, revid, len(data))
 	}
 	return data, err
@@ -120,7 +126,14 @@ func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte) 
 
 	// Set old revisions to expire after 5 minutes.  Future enhancement to make this a config
 	// setting might be appropriate.
-	return db.Bucket.SetRaw(oldRevisionKey(docid, revid), 300, body)
+
+	// Prepend the data with non-JSON prefix so that N1QL, views ignore as non-JSON.  Prepending
+	// using append/shift/set to reduce garbage.
+	body = append(body, byte(0))
+	copy(body[1:], body[0:])
+	body[0] = nonJSONPrefix
+
+	return db.Bucket.SetRaw(oldRevisionKey(docid, revid), 300, base.BinaryDocument(body))
 }
 
 //////// UTILITY FUNCTIONS:

--- a/db/revision.go
+++ b/db/revision.go
@@ -101,6 +101,7 @@ func (body Body) getExpiry() (uint32, error) {
 	return 0, nil
 }
 
+// nonJSONPrefix is used to ensure old revision bodies aren't hidden from N1QL/Views.
 const nonJSONPrefix = byte(1)
 
 // Looks up the raw JSON data of a revision that's been archived to a separate doc.
@@ -127,8 +128,9 @@ func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte) 
 	// Set old revisions to expire after 5 minutes.  Future enhancement to make this a config
 	// setting might be appropriate.
 
-	// Prepend the data with non-JSON prefix so that N1QL, views ignore as non-JSON.  Prepending
-	// using append/shift/set to reduce garbage.
+	// Setting the binary flag isn't sufficient to make N1QL ignore the doc - the binary flag is only used by the SDKs.
+	// To ensure it's not available via N1QL, need to prefix the raw bytes with non-JSON data.
+	// Prepending using append/shift/set to reduce garbage.
 	body = append(body, byte(0))
 	copy(body[1:], body[0:])
 	body[0] = nonJSONPrefix


### PR DESCRIPTION
To prevent temporary revision backups appearing in N1QL and view queries without requiring additional work in the query/map function, store the backups as non-JSON binary data.

Requires switching gocbBucket.SetRaw to store as Binary.  Only other non-binary usage was in auth.go - switched that to a simple Set.

Fixes #2558