### PR TITLE
Fixes #2574 CouchbaseBucketGoCB.GetAndTouchRaw() passes incorrect ret…

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -659,7 +659,7 @@ func (bucket CouchbaseBucketGoCB) GetAndTouchRaw(k string, exp int) (rv []byte, 
 		gocbExpvars.Add("SingleOps", -1)
 	}()
 
-	var returnVal interface{}
+	var returnVal []byte
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 
 		gocbExpvars.Add("GetAndTouchRaw", 1)
@@ -689,7 +689,7 @@ func (bucket CouchbaseBucketGoCB) GetAndTouchRaw(k string, exp int) (rv []byte, 
 		return nil, cas, err
 	}
 
-	return returnVal.([]byte), cas, err
+	return returnVal, cas, err
 
 }
 


### PR DESCRIPTION
…urn param to gocb.GetAndTouch()

Fixes #2574 by passing in a `[]byte` return param instead of an empty interface return param, which affects the transcoder behavior.