### PR TITLE
Fixes #2590 panic: runtime error: slice bounds out of range

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -57,7 +57,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fd0e39b0de442b9629e43a06df8e5d3bccebad40"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="b8f5b7e5e256b586d30ddf92f484ad91dc1e8c60"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="98e48116286caa5c3ba06d9bb197f94498c97e89"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="d5a64dd7982b3c07cb0675e995e249fa58cd92ff"/>
 
@@ -67,7 +67,7 @@
 
   <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="f8b076f89aa2033c375ff86c3b52cdce72da5572"/>
+  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="1f30cbc110d3f6a525188ae7d87b84fa5b3751a5"/>
 
   <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="24212ec24bbdf7938c138ed328c2885a8a1e6adf"/>
 


### PR DESCRIPTION

Fixes #2590

Bump to later go-couchbase and go-membase versions to uptake fix