### PR TITLE
Trigger doc import on SG write

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -184,9 +184,9 @@ func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.W
 	return bucket.Bucket.WriteUpdate(k, exp, cbCallback)
 }
 
-func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) error {
+func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	Warn("WriteUpdateWithXattr not implemented by CouchbaseBucket")
-	return errors.New("WriteUpdateWithXattr not implemented by CouchbaseBucket")
+	return 0, errors.New("WriteUpdateWithXattr not implemented by CouchbaseBucket")
 }
 
 func (bucket CouchbaseBucket) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1183,7 +1183,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 			if !bucket.IsKeyNotFoundError(err) {
 				// Unexpected error, cancel writeupdate
 				LogTo("CRUD", "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", k, xattrKey, err)
-				return casOut, err
+				return emptyCas, err
 			}
 			// Key not found - initialize cas and values
 			cas = 0

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1167,13 +1167,14 @@ func (bucket CouchbaseBucketGoCB) WriteUpdate(k string, exp int, callback sgbuck
 	}
 }
 
-func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) error {
+func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 
 	for {
 		var value []byte
 		var xattrValue []byte
 		var err error
 		var cas uint64
+		emptyCas := uint64(0)
 
 		// Load the existing value.
 		gocbExpvars.Add("Update_GetWithXattr", 1)
@@ -1182,7 +1183,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 			if !bucket.IsKeyNotFoundError(err) {
 				// Unexpected error, cancel writeupdate
 				LogTo("CRUD", "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", k, xattrKey, err)
-				return err
+				return casOut, err
 			}
 			// Key not found - initialize cas and values
 			cas = 0
@@ -1193,14 +1194,14 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 		// Invoke callback to get updated value
 		updatedValue, updatedXattrValue, deleteDoc, err := callback(value, xattrValue, cas)
 		if err != nil {
-			return err
+			return emptyCas, err
 		}
 
 		// TODO: Avoid unmarshalling the raw xattr value here
 		var xattrMap map[string]interface{}
 		err = json.Unmarshal(updatedXattrValue, &xattrMap)
 		if err != nil {
-			return err
+			return emptyCas, err
 		}
 
 		var writeErr error
@@ -1218,35 +1219,35 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 				continue
 			} else {
 				// Non-recoverable error - return
-				return removeErr
+				return emptyCas, removeErr
 			}
 
 			// update xattr only
-			_, writeErr := bucket.WriteCasWithXattr(k, xattrKey, exp, cas, nil, xattrMap)
+			casOut, writeErr := bucket.WriteCasWithXattr(k, xattrKey, exp, cas, nil, xattrMap)
 			if writeErr != nil && writeErr != gocb.ErrKeyExists && !isRecoverableGoCBError(writeErr) {
 				LogTo("CRUD", "Update of new value during WriteUpdateWithXattr failed for key %s: %v", k, writeErr)
-				return writeErr
+				return emptyCas, writeErr
 			}
 
 			// If there was no error, we're done
 			if writeErr == nil {
-				return nil
+				return casOut, nil
 			}
 		} else {
 
 			// Not a delete - update the body and xattr
-			_, writeErr = bucket.WriteCasWithXattr(k, xattrKey, exp, cas, updatedValue, xattrMap)
+			casOut, writeErr = bucket.WriteCasWithXattr(k, xattrKey, exp, cas, updatedValue, xattrMap)
 
 			// ErrKeyExists is CAS failure, which we want to retry.  Other non-recoverable errors should cancel the
 			// WriteUpdate.
 			if writeErr != nil && writeErr != gocb.ErrKeyExists && !isRecoverableGoCBError(writeErr) {
 				LogTo("CRUD", "Update of new value during WriteUpdateWithXattr failed for key %s: %v", k, writeErr)
-				return writeErr
+				return emptyCas, writeErr
 			}
 
 			// If there was no error, we're done
 			if writeErr == nil {
-				return nil
+				return casOut, nil
 			}
 		}
 	}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -985,7 +985,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 	}
 
 	// Insert
-	err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
+	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}
@@ -1001,7 +1001,7 @@ func CouchbaseTestWriteUpdateXattr(t *testing.T) {
 	assert.Equals(t, retrievedXattr["seq"], float64(1))
 
 	// Update
-	err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
+	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -128,7 +128,7 @@ func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
-func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (err error) {
+func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
 }
 

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -103,7 +103,7 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp int, cas u
 	defer func() { LogTo("Bucket", "WriteCasWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (err error) {
+func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() {
 		LogTo("Bucket", "WriteUpdateWithXattr(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start))

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -181,7 +181,7 @@ func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	}
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (err error) {
+func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	defer b.docWrite(1, -1)
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -896,7 +896,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 				return
 			}
 
-			docOut, _, shadowerEcho, err = documentUpdateFunc(doc, currentValue != nil)
+			docOut, _, _, err = documentUpdateFunc(doc, currentValue != nil)
 			if err != nil {
 				return
 			}

--- a/db/database.go
+++ b/db/database.go
@@ -1008,7 +1008,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		}
 		var err error
 		if db.UseXattrs() {
-			err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
+			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
 				// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing, so deleteDoc is always returned as false.
 				if currentValue == nil || len(currentValue) == 0 {
 					return nil, nil, deleteDoc, errors.New("Cancel update")

--- a/db/document.go
+++ b/db/document.go
@@ -246,7 +246,7 @@ func (s *syncData) IsSGWrite(cas uint64) bool {
 func (doc *document) IsSGWrite() bool {
 	result := doc.syncData.IsSGWrite(doc.Cas)
 	if result == false {
-		base.LogTo("Import+", "Update to doc %s was not an SG write, based on cas. cas:%x syncCas:%q", doc.ID, doc.Cas, doc.syncData.Cas)
+		base.LogTo("Import+", "Existing doc %s is not an SG write, based on cas. cas:%x syncCas:%q", doc.ID, doc.Cas, doc.syncData.Cas)
 	}
 	return result
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b3c390b82430c3486541eeac86107a9943c1ff3e"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="4b675cc3e1a3a246170719f0f604b7b23fb114b2"/>
 
   
   <!-- Dependencies specific to Sync Gateway Accel-->
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fd0e39b0de442b9629e43a06df8e5d3bccebad40"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f615a8ee94550d6f45300c30d92295fa38dd8c7b"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="98e48116286caa5c3ba06d9bb197f94498c97e89"/>
 
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="1f30cbc110d3f6a525188ae7d87b84fa5b3751a5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="24212ec24bbdf7938c138ed328c2885a8a1e6adf"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e5ac98828d9d08f50638f58637dbf785c3fca71b"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="4b675cc3e1a3a246170719f0f604b7b23fb114b2"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="f340ef747c4010ea76e579ca23f8a11cec54d613"/>
 
   
   <!-- Dependencies specific to Sync Gateway Accel-->
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f615a8ee94550d6f45300c30d92295fa38dd8c7b"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f9d52719c4f55dcb08b944a96cebe8a49d548085"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="98e48116286caa5c3ba06d9bb197f94498c97e89"/>
 
@@ -69,7 +69,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="1f30cbc110d3f6a525188ae7d87b84fa5b3751a5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e5ac98828d9d08f50638f58637dbf785c3fca71b"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="d6a1b73dec2cb5eaa09562bf8495d1829b7cbb04"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
If a document has been updated by a non-SG author but has not yet been imported, trigger import on an attempt to update the doc via Sync Gateway. Fixes #2554.

Refactored the import processing to return the imported doc, so that on-demand imports can proceed without having to requery the bucket for the document.  Normal cas check will handle the case where the document is updated by someone else after import but before subsequent processing.

This cleans up the on-demand import during a GET (no longer requires loop), and avoids an unnecessary kv operation when on-demand import is triggered by a PUT.

Also fixed handling in change_cache.go when node is running in xattr mode but not importing.  Previously non-SG writes would attempt to get cached, then be rejected based on the stale sequence value.  Instead, we shouldn't even try to cache in the first place.