### PR TITLE
Compact purged tombstones from view

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -30,7 +30,6 @@ import (
 // them to remove the Couchbase* prefix, and then rename them back before checking into
 // Git.
 
-
 func TestTranscoder(t *testing.T) {
 	transcoder := SGTranscoder{}
 
@@ -264,7 +263,6 @@ func TestWriteCasAdvanced(t *testing.T) {
 
 // When enabling this test, you should also uncomment the code in isRecoverableGoCBError()
 func TestSetBulk(t *testing.T) {
-
 
 	// Might be failing due to something related to this comment:
 	//    When enabling this test, you should also uncomment the code in isRecoverableGoCBError()
@@ -821,7 +819,6 @@ func TestWriteCasXattrTombstoneResurrect(t *testing.T) {
 func TestWriteCasXattrTombstoneXattrUpdate(t *testing.T) {
 
 	t.Skip("Test fails with errors: https://gist.github.com/tleyden/d261fe2b92bdaaa6e78f9f1c00fdfd58.  Needs investigation")
-
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1489,5 +1486,34 @@ func TestApplyViewQueryOptionsWithStrings(t *testing.T) {
 	}
 
 	// if it doesn't blow up, test passes
+
+}
+
+// Validate non-bool stale handling
+func TestApplyViewQueryStaleOptions(t *testing.T) {
+
+	// View query params map (go-couchbase/walrus style)
+	params := map[string]interface{}{
+		ViewQueryParamStale: "false",
+	}
+
+	// Create a new viewquery
+	viewQuery := gocb.NewViewQuery("ddoc", "viewname")
+
+	// if it doesn't blow up, test passes
+	if err := applyViewQueryOptions(viewQuery, params); err != nil {
+		t.Fatalf("Error calling applyViewQueryOptions: %v", err)
+	}
+
+	params = map[string]interface{}{
+		ViewQueryParamStale: "ok",
+	}
+
+	// Create a new viewquery
+	viewQuery = gocb.NewViewQuery("ddoc", "viewname")
+
+	if err := applyViewQueryOptions(viewQuery, params); err != nil {
+		t.Fatalf("Error calling applyViewQueryOptions: %v", err)
+	}
 
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -787,15 +787,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 				if docSequence, err = db.sequences.nextSequence(); err != nil {
 					return
 				}
-				// If the newly allocated sequence is less than the existing sequence, release it and get a new one
-				if docSequence <= doc.Sequence {
-					// loop through db.sequences.nextSequence(), releasing until you get a valid sequence
-					// Could add a db.Sequences.nextSequenceGreaterThan(doc.Sequence) to push the work down into the sequence allocator
-					//  - sequence allocator is responsible for releasing unused sequences, could optimize
-
-				}
 			}
-
 			doc.Sequence = docSequence
 			doc.UnusedSequences = unusedSequences
 

--- a/db/database.go
+++ b/db/database.go
@@ -887,6 +887,11 @@ func (db *DatabaseContext) DeleteUserSessions(userName string) error {
 // the document to accomplish the same result.
 func (db *Database) Compact() (int, error) {
 
+	// Compact should be a no-op if not running w/ xattrs
+	if !db.UseXattrs() {
+		return 0, nil
+	}
+
 	// Trigger view compaction for all tombstoned documents older than the purge interval
 	opts := Body{}
 	opts["stale"] = "ok"

--- a/db/database.go
+++ b/db/database.go
@@ -48,6 +48,7 @@ var RunStateString = []string{
 
 const (
 	DefaultRevsLimit = 1000
+	DefaultPurgeInterval = 30           // Default metadata purge interval, in days.  Used if server's purge interval is unavailable
 	KSyncKeyPrefix   = "_sync:"         // All special/internal documents the gateway creates have this prefix in their keys.
 	kSyncDataKey     = "_sync:syncdata" // Key used to store sync function
 	KSyncXattrName   = "_sync"          // Name of XATTR used to store sync metadata
@@ -79,6 +80,7 @@ type DatabaseContext struct {
 	State              uint32                  // The runtime state of the DB from a service perspective
 	ExitChanges        chan struct{}           // Active _changes feeds on the DB will close when this channel is closed
 	OIDCProviders      auth.OIDCProviderMap    // OIDC clients
+	PurgeInterval      int                     // Metadata purge interval, in hours
 }
 
 type DatabaseContextOptions struct {
@@ -318,6 +320,20 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	// watchDocChanges is used for bucket shadowing and legacy import - not required when running w/ xattrs.
 	if !context.UseXattrs() {
 		go context.watchDocChanges()
+	} else {
+		// Set the purge interval for tombstone compaction
+		context.PurgeInterval = DefaultPurgeInterval
+		gocbBucket, ok := bucket.(*base.CouchbaseBucketGoCB)
+		if ok {
+			serverPurgeInterval, err := gocbBucket.GetMetadataPurgeInterval()
+			if err != nil {
+				base.Warn("Unable to retrieve server's metadata purge interval - will use default value. %s", err)
+			} else if serverPurgeInterval > 0 {
+				context.PurgeInterval = serverPurgeInterval
+			}
+		}
+		base.Logf("Using metadata purge interval of %.2f days for tombstone compaction.", float64(context.PurgeInterval)/24)
+
 	}
 
 	return context, nil
@@ -544,6 +560,13 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
                      		emit(doc.username, meta.id);}`
 	sessions_map = fmt.Sprintf(sessions_map, len(auth.SessionKeyPrefix), auth.SessionKeyPrefix)
 
+	// Tombstones view - used for view tombstone compaction
+	// Key is purge time; value is docid
+	tombstones_map := `function (doc, meta) {
+                     	var sync = meta.xattrs._sync;
+                     	if (sync !== undefined && sync.tombstoned_at !== undefined)
+                     		emit(sync.tombstoned_at, meta.id);}`
+
 	// All-principals view
 	// Key is name; value is true for user, false for role
 	principals_map := `function (doc, meta) {
@@ -684,11 +707,12 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 
 	designDocMap[DesignDocSyncHousekeeping] = sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
-			ViewAllBits:  sgbucket.ViewDef{Map: allbits_map},
-			ViewAllDocs:  sgbucket.ViewDef{Map: alldocs_map, Reduce: "_count"},
-			ViewImport:   sgbucket.ViewDef{Map: import_map, Reduce: "_count"},
-			ViewOldRevs:  sgbucket.ViewDef{Map: oldrevs_map, Reduce: "_count"},
-			ViewSessions: sgbucket.ViewDef{Map: sessions_map},
+			ViewAllBits:    sgbucket.ViewDef{Map: allbits_map},
+			ViewAllDocs:    sgbucket.ViewDef{Map: alldocs_map, Reduce: "_count"},
+			ViewImport:     sgbucket.ViewDef{Map: import_map, Reduce: "_count"},
+			ViewOldRevs:    sgbucket.ViewDef{Map: oldrevs_map, Reduce: "_count"},
+			ViewSessions:   sgbucket.ViewDef{Map: sessions_map},
+			ViewTombstones: sgbucket.ViewDef{Map: tombstones_map},
 		},
 	}
 
@@ -857,24 +881,48 @@ func (db *DatabaseContext) DeleteUserSessions(userName string) error {
 	return nil
 }
 
-// Deletes old revisions that have been moved to individual docs
+// Trigger tombstone compaction from views.  Several Sync Gateway views index server tombstones (deleted documents with an xattr).
+// There currently isn't a mechanism for server to remove these docs from the index when the tombstone is purged by the server during
+// metadata purge, because metadata purge doesn't trigger a DCP event.
+// When compact is run, Sync Gateway initiates a normal delete operation for the document and xattr (a Sync Gateway purge).  This triggers
+// removal of the document from the view index.  In the event that the document has already been purged by server, we need to recreate and delete
+// the document to accomplish the same result.
 func (db *Database) Compact() (int, error) {
-	opts := Body{"stale": false, "reduce": false}
-	vres, err := db.Bucket.View(DesignDocSyncHousekeeping, ViewOldRevs, opts)
+
+	// Trigger view compaction for all tombstoned documents older than the purge interval
+	opts := Body{}
+	opts["stale"] = "ok"
+	opts["startkey"] = 1
+	purgeIntervalDuration := time.Duration(-db.PurgeInterval) * time.Hour
+	opts["endkey"] = time.Now().Add(purgeIntervalDuration).Unix()
+	vres, err := db.Bucket.View(DesignDocSyncHousekeeping, ViewTombstones, opts)
 	if err != nil {
-		base.Warn("old_revs view returned %v", err)
+		base.Warn("Tombstones view returned error during compact: %v", err)
 		return 0, err
 	}
 
-	//FIX: Is there a way to do this in one operation?
-	base.Logf("Compacting away %d old revs of %q ...", len(vres.Rows), db.Name)
+	base.Logf("Compacting %d purged tombstones from view for %s ...", len(vres.Rows), db.Name)
+	purgeBody := Body{"_purged": true}
 	count := 0
 	for _, row := range vres.Rows {
 		base.LogTo("CRUD", "\tDeleting %q", row.ID)
-		if err := db.Bucket.Delete(row.ID); err != nil {
-			base.Warn("Error deleting %q: %v", row.ID, err)
-		} else {
+		// First, attempt to purge.
+		purgeErr := db.Purge(row.ID)
+		if purgeErr == nil {
 			count++
+		} else if base.IsKeyNotFoundError(db.Bucket, purgeErr) {
+			// If key no longer exists, need to add and remove to trigger removal from view
+			_, addErr := db.Bucket.Add(row.ID, 0, purgeBody)
+			if addErr != nil {
+				base.Warn("Error compacting key %s (add) - tombstone will not be compacted.  %v", row.ID, addErr)
+				continue
+			}
+			if delErr := db.Bucket.Delete(row.ID); delErr != nil {
+				base.Warn("Error compacting key %s (delete) - tombstone will not be compacted.  %v", row.ID, delErr)
+			}
+			count++
+		} else {
+			base.Warn("Error compacting key %s (purge) - tombstone will not be compacted.  %v", row.ID, purgeErr)
 		}
 	}
 	return count, nil

--- a/db/database.go
+++ b/db/database.go
@@ -47,11 +47,11 @@ var RunStateString = []string{
 }
 
 const (
-	DefaultRevsLimit = 1000
-	DefaultPurgeInterval = 30           // Default metadata purge interval, in days.  Used if server's purge interval is unavailable
-	KSyncKeyPrefix   = "_sync:"         // All special/internal documents the gateway creates have this prefix in their keys.
-	kSyncDataKey     = "_sync:syncdata" // Key used to store sync function
-	KSyncXattrName   = "_sync"          // Name of XATTR used to store sync metadata
+	DefaultRevsLimit     = 1000
+	DefaultPurgeInterval = 30               // Default metadata purge interval, in days.  Used if server's purge interval is unavailable
+	KSyncKeyPrefix       = "_sync:"         // All special/internal documents the gateway creates have this prefix in their keys.
+	kSyncDataKey         = "_sync:syncdata" // Key used to store sync function
+	KSyncXattrName       = "_sync"          // Name of XATTR used to store sync metadata
 )
 
 // Basic description of a database. Shared between all Database objects on the same database.
@@ -258,8 +258,6 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 					if options.DBOnlineCallback != nil {
 						options.DBOnlineCallback(context)
 					}
-
-
 				}
 			}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -217,10 +217,6 @@ func TestDatabase(t *testing.T) {
 	assertNoError(t, err, "Couldn't get document")
 	assert.DeepEquals(t, gotbody, body)
 
-	// Compact and check how many obsolete revs were deleted:
-	revsDeleted, err := db.Compact()
-	assertNoError(t, err, "Compact failed")
-	assert.Equals(t, revsDeleted, 2)
 }
 
 func TestGetDeleted(t *testing.T) {

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -25,6 +25,7 @@ const (
 	ViewImport                = "import"
 	ViewOldRevs               = "old_revs"
 	ViewSessions              = "sessions"
+	ViewTombstones            = "tombstones"
 )
 
 func isInternalDDoc(ddocName string) bool {

--- a/db/document.go
+++ b/db/document.go
@@ -38,8 +38,9 @@ type syncData struct {
 	Channels        channels.ChannelMap `json:"channels,omitempty"`
 	Access          UserAccessMap       `json:"access,omitempty"`
 	RoleAccess      UserAccessMap       `json:"role_access,omitempty"`
-	Expiry          *time.Time          `json:"exp,omitempty"` // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
-	Cas             string              `json:"cas"`           // String representation of a cas value, populated via macro expansion
+	Expiry          *time.Time          `json:"exp,omitempty"`           // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
+	Cas             string              `json:"cas"`                     // String representation of a cas value, populated via macro expansion
+	TombstonedAt    int64               `json:"tombstoned_at,omitempty"` // Time the document was tombstoned.  Used for view compaction
 
 	// Fields used by bucket-shadowing:
 	UpstreamCAS *uint64 `json:"upstream_cas,omitempty"` // CAS value of remote doc


### PR DESCRIPTION
Uses _compact endpoint to compact purged tombstones from view.

Adds a new 'tombstoned_at' property to _sync metadata, populated when a document is tombstoned by Sync Gateway.   A new housekeeping view ('tombstones') indexes documents by the tombstoned_at property.  When compact runs, it queries this view to find all tombstones older than the metadata purge interval, then issues a purge to trigger removal from all views.  In the case the key has already been purged (server metadata purge has been triggered), does an add+delete to trigger the view cleanup.

Includes a modification to the stale view parameter in bucket_gocb to support passing stale=ok.

Fixes #2600.