### PR TITLE
Avoid Sync Gateway panic when unmarshaling null document body

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -329,7 +329,7 @@ func (db *DatabaseContext) getRevision(doc *document, revid string) (Body, error
 			return nil, base.HTTPErrorf(404, "missing")
 		} else if data, err := db.getOldRevisionJSON(doc.ID, revid); data == nil {
 			return nil, err
-		} else if err = json.Unmarshal(data, &body); err != nil {
+		} else if err = body.Unmarshal(data); err != nil {
 			return nil, err
 		}
 	}
@@ -598,7 +598,7 @@ func (db *Database) ImportRawDoc(docid string, value []byte, isDelete bool) (doc
 	if isDelete {
 		body = Body{"_deleted": true}
 	} else {
-		err := json.Unmarshal(value, &body)
+		err := body.Unmarshal(value)
 		if err != nil {
 			base.LogTo("Import", "Unmarshal error during importDoc %v", err)
 			return nil, err

--- a/db/revision.go
+++ b/db/revision.go
@@ -12,6 +12,7 @@ package db
 import (
 	"crypto/md5"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -22,6 +23,17 @@ import (
 
 // The body of a CouchDB document/revision as decoded from JSON.
 type Body map[string]interface{}
+
+func (b *Body) Unmarshal(data []byte) error {
+
+	if err := json.Unmarshal(data, &b); err != nil {
+		return err
+	}
+	if b == nil {
+		return errors.New("Unable to unmarshal null document as Body")
+	}
+	return nil
+}
 
 func (body Body) ShallowCopy() Body {
 	copied := make(Body, len(body))

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -97,7 +96,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 	if isDeletion {
 		body = Body{"_deleted": true}
 	} else {
-		if err := json.Unmarshal(value, &body); err != nil {
+		if err := body.Unmarshal(value); err != nil {
 			base.LogTo("Shadow", "Doc %q is not JSON; skipping", key)
 			return nil
 		}


### PR DESCRIPTION
null is valid JSON, and previously returned a nil map (not an empty map) when unmarshalled as Body.  This caused subsequent attempted writes to the map to panic.

Sync Gateway doesn't support null documents - modified the unmarshalling to return an error in this scenario, which will result in the doc being ignored by Import/Shadowing.

Fixes #2618.