### PR TITLE
Feature/issue 2626 processentry notification

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -735,7 +735,7 @@ func (c *changeCache) getOldestSkippedSequence() uint64 {
 	}
 }
 
-//////// LOG PRIORITY QUEUE
+//////// LOG PRIORITY QUEUE -- container/heap callbacks that should not be called directly.   Use heap.Init/Push/etc()
 
 func (h LogPriorityQueue) Len() int           { return len(h) }
 func (h LogPriorityQueue) Less(i, j int) bool { return h[i].Sequence < h[j].Sequence }


### PR DESCRIPTION
Fixes #2626 

Regression tests:

- [build-sync-gateway/92](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/92/) 
- [build-sync-gateway/93](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/93/)
- [cen7-sync-gateway-functional-tests-base-cc/697](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-base-cc/697/)
- [cen7-sync-gateway-functional-tests-topology-specific-cc/544](http://uberjenkins.sc.couchbase.com/job/cen7-sync-gateway-functional-tests-topology-specific-cc/544/)