### PR TITLE
Fix username handling in GetBucketCredentials

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -145,9 +145,9 @@ func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err e
 func (bucket CouchbaseBucketGoCB) GetBucketCredentials() (username, password string) {
 
 	if bucket.spec.Auth != nil {
-		_, password, _ = bucket.spec.Auth.GetCredentials()
+		username, password, _ = bucket.spec.Auth.GetCredentials()
 	}
-	return bucket.spec.BucketName, password
+	return username, password
 }
 
 // Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not


### PR DESCRIPTION
The call to bucket.spec.Auth.GetCredentials is already doing the empty username check - can just use what's returned as-is.

Fixes #2637