### PR TITLE
Bump admin ui in manifest

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -52,7 +52,7 @@
 
   <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
 
-  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="4195073f3c64830ca5bad14016dc5de732211c32" remote="couchbaselabs"/>
+  <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f9d52719c4f55dcb08b944a96cebe8a49d548085"/>
 


### PR DESCRIPTION
Picks up the fix for issue #2066 that was made in the sync gateway admin ui project.

Fixes #2066.