### PR TITLE
Compact obsolete tombstones from accel's channel index

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -53,7 +53,7 @@ func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
 	case IndexBucket:
 		return GoCB
 	case ShadowBucket:
-		return GoCB  // NOTE: should work against against both GoCouchbase and GoCB
+		return GoCB // NOTE: should work against against both GoCouchbase and GoCB
 	default:
 		// If a new bucket type is added and this method isn't updated, flag a warning (or, could panic)
 		Warn("Unexpected bucket type: %v", bucketType)

--- a/base/sg_transcoding.go
+++ b/base/sg_transcoding.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"encoding/json"
+	"github.com/couchbase/gocb"
 
 	"gopkg.in/couchbase/gocbcore.v7"
 )
@@ -61,11 +62,8 @@ func (t SGTranscoder) Decode(bytes []byte, flags uint32, out interface{}) error 
 		*typedOut = bytes
 		return nil
 	default:
-		err := json.Unmarshal(bytes, &out)
-		if err != nil {
-			return err
-		}
-		return nil
+		defaultTranscoder := gocb.DefaultTranscoder{}
+		return defaultTranscoder.Decode(bytes, flags, out)
 
 	}
 

--- a/channels/change_log.go
+++ b/channels/change_log.go
@@ -16,6 +16,7 @@ const (
 	LogEntryPrincipal
 	LogEntryCheckpoint
 	LogEntryRollback
+	LogEntryPurge
 )
 
 type LogEntry struct {
@@ -79,6 +80,16 @@ func (channelMap ChannelMap) ChannelsRemovedAtSequence(seq uint64) (ChannelMap, 
 		}
 	}
 	return channelsRemoved, revIdRemoved
+}
+
+func (channelMap ChannelMap) KeySet() []string {
+	result := make([]string, len(channelMap))
+	i := 0
+	for key, _ := range channelMap {
+		result[i] = key
+		i++
+	}
+	return result
 }
 
 func (cp *ChangeLog) LastSequence() uint64 {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -79,7 +79,7 @@ type CacheOptions struct {
 // Initializes a new changeCache.
 // lastSequence is the last known database sequence assigned.
 // onChange is an optional function that will be called to notify of channel changes.
-func (c *changeCache) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChangeIndexOptions) error {
+func (c *changeCache) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) error {
 	c.context = context
 	c.initialSequence = lastSequence.Seq
 	c.nextSequence = lastSequence.Seq + 1

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -25,7 +25,7 @@ import (
 type ChangeIndex interface {
 
 	// Initialize the index
-	Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), cacheOptions *CacheOptions, indexOptions *ChangeIndexOptions) error
+	Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), cacheOptions *CacheOptions, indexOptions *ChannelIndexOptions) error
 
 	// Stop the index
 	Stop()
@@ -72,14 +72,15 @@ const (
 	MemoryCache
 )
 
-type ChangeIndexOptions struct {
-	Type          IndexType       // Index type
-	Spec          base.BucketSpec // Indexing bucket spec
-	Bucket        base.Bucket     // Indexing bucket
-	Writer        bool            // Cache Writer
-	Options       CacheOptions    // Caching options
-	NumShards     uint16          // The number of CBGT shards to use]
-	HashFrequency uint16          // Hash frequency for changes feeds
+type ChannelIndexOptions struct {
+	Type                      IndexType       // Index type
+	Spec                      base.BucketSpec // Indexing bucket spec
+	Bucket                    base.Bucket     // Indexing bucket
+	Writer                    bool            // Cache Writer
+	Options                   CacheOptions    // Caching options
+	NumShards                 uint16          // The number of CBGT shards
+	HashFrequency             uint16          // Hash frequency for changes feeds (in changes entries)
+	TombstoneCompactFrequency *int            // Tombstone Compaction frequency (in hours)
 }
 
 type SequenceHashOptions struct {
@@ -107,7 +108,7 @@ func (entry *LogEntry) SetRemoved() {
 	entry.Flags |= channels.Removed
 }
 
-func (c ChangeIndexOptions) ValidateOrPanic() {
+func (c ChannelIndexOptions) ValidateOrPanic() {
 	if c.NumShards == 0 {
 		base.LogPanic("The number of shards must be greater than 0")
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -85,7 +85,7 @@ type DatabaseContext struct {
 
 type DatabaseContextOptions struct {
 	CacheOptions          *CacheOptions
-	IndexOptions          *ChangeIndexOptions
+	IndexOptions          *ChannelIndexOptions
 	SequenceHashOptions   *SequenceHashOptions
 	RevisionCacheCapacity uint32
 	AdminInterface        *string

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -46,7 +46,7 @@ func init() {
 	IndexExpvars = expvar.NewMap("syncGateway_index")
 }
 
-func (k *kvChangeIndex) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChangeIndexOptions) (err error) {
+func (k *kvChangeIndex) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) (err error) {
 
 	k.context = context
 	k.reader = &kvChangeIndexReader{}

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -60,7 +60,7 @@ func init() {
 	base.StatsExpvars.Set("indexReader.getChanges.UseIndexed", &indexReaderGetChangesUseIndexed)
 }
 
-func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChangeIndexOptions, onChange func(base.Set), indexPartitionsCallback IndexPartitionsFunc, context *DatabaseContext) (err error) {
+func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChannelIndexOptions, onChange func(base.Set), indexPartitionsCallback IndexPartitionsFunc, context *DatabaseContext) (err error) {
 
 	k.channelIndexReaders = make(map[string]*KvChannelIndex)
 	k.indexPartitionsCallback = indexPartitionsCallback

--- a/db/kv_dense_channel_storage_reader.go
+++ b/db/kv_dense_channel_storage_reader.go
@@ -83,7 +83,6 @@ func (ds *DenseStorageReader) GetChanges(sinceClock base.SequenceClock, toClock 
 	// Identify what's changed:
 	//  changedVbuckets: ordered list of vbuckets that have changes, based on the clock comparison
 	//  partitionRanges: array of PartitionRange, indexed by partitionNo
-
 	changedVbuckets, partitionRanges := ds.calculateChanged(sinceClock, toClock)
 
 	// changed partitions is a cache of changes for a partition, for reuse by multiple vbs

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="d5b5fbe3b54eecaf0a656c10b22c7d28ccfe8f97"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7e4f6b042e7a829acc777edc07ffcb8efffcfb81"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="4aaaca921a7ef64900f3b569c33ad87e9e8df065"/>

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1094,34 +1094,6 @@ func assertTrue(t *testing.T, success bool, message string) {
 	}
 }
 
-/*
-// Index partitions for testing
-func SeedPartitionMap(bucket base.Bucket, numPartitions uint16) error {
-	maxVbNo := uint16(1024)
-	partitionDefs := make(base.PartitionStorageSet, numPartitions)
-	vbPerPartition := maxVbNo / numPartitions
-	for partition := uint16(0); partition < numPartitions; partition++ {
-		storage := base.PartitionStorage{
-			Index: partition,
-			VbNos: make([]uint16, vbPerPartition),
-		}
-		for index := uint16(0); index < vbPerPartition; index++ {
-			vb := partition*vbPerPartition + index
-			storage.VbNos[index] = append(storage.VbNos, vb)
-		}
-		partitionDefs[partition] = storage
-	}
-
-	// Persist to bucket
-	value, err := json.Marshal(partitionDefs)
-	if err != nil {
-		return err
-	}
-	bucket.SetRaw(base.KIndexPartitionKey, 0, value)
-	return nil
-}
-*/
-
 func WriteDirect(testDb *db.DatabaseContext, channelArray []string, sequence uint64) {
 	docId := fmt.Sprintf("doc-%v", sequence)
 	WriteDirectWithKey(testDb, docId, channelArray, sequence)

--- a/rest/config.go
+++ b/rest/config.go
@@ -182,9 +182,10 @@ type CacheConfig struct {
 
 type ChannelIndexConfig struct {
 	BucketConfig
-	IndexWriter        bool                `json:"writer,omitempty"`      // Whether SG node is a channel index writer
-	NumShards          uint16              `json:"num_shards,omitempty"`  // Number of partitions in the channel index
-	SequenceHashConfig *SequenceHashConfig `json:"seq_hashing,omitempty"` // Sequence hash configuration
+	IndexWriter               bool                `json:"writer,omitempty"`       // Whether SG node is a channel index writer
+	NumShards                 uint16              `json:"num_shards,omitempty"`   // Number of partitions in the channel index
+	SequenceHashConfig        *SequenceHashConfig `json:"seq_hashing,omitempty"`  // Sequence hash configuration
+	TombstoneCompactFrequency *int                `json:"tombstone_compact_freq"` // How often sg-accel attempts to compact purged tombstones
 }
 
 type SequenceHashConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -399,7 +399,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	// Channel index definition, if present
-	channelIndexOptions := &db.ChangeIndexOptions{} // TODO: this is confusing!  why is it called both a "change index" and a "channel index"?
+	channelIndexOptions := &db.ChannelIndexOptions{}
 	sequenceHashOptions := &db.SequenceHashOptions{}
 	if config.ChannelIndex != nil {
 		indexServer := "http://localhost:8091"
@@ -439,6 +439,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 		channelIndexOptions.Spec = indexSpec
 		channelIndexOptions.Writer = config.ChannelIndex.IndexWriter
+		channelIndexOptions.TombstoneCompactFrequency = config.ChannelIndex.TombstoneCompactFrequency
 
 		// Hash bucket defaults to index bucket, but can be customized.
 		sequenceHashOptions.Size = 32


### PR DESCRIPTION
When a tombstone is purged by Couchbase Server, no DCP notification is issued.  To remove obsolete tombstones from the index bucket, accel needs to do the work to track tombstones and remove them.

To identify tombstones that should be compacted, and the set of channels those tombstones are associated with, accel now maintains a doc-based tombstone index in the index bucket.  Each time accel indexes a tombstone in the channel index, it now also writes a tombstone index entry to this index, specifying the tombstone time, the vbucket and sequence, and the set of channels the tombstone was indexed to.  See tombstone.go for implementation details.

Periodically a scheduled process queries that index (for vbuckets assigned to the accel node) to identify any tombstones that are older than the server's metadata purge interval.  These tombstones are then purged from the channel index and the new tombstone index.  This process runs every 24h by default, but can be customized using the new channel_index.tombstone_compact_freq property in the config.

Associated with https://github.com/couchbaselabs/sync-gateway-accel/pull/148