### PR TITLE
Use separate design docs for non-housekeeping views

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -37,7 +37,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	optMap := changesViewOptions(channelName, endSeq, options)
 	base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, options.Since.SafeSequence()+1, endSeq, options.Limit)
 	vres := channelsViewResult{}
-	err := dbc.Bucket.ViewCustom(DesignDocSyncGateway, ViewChannels, optMap, &vres)
+	err := dbc.Bucket.ViewCustom(DesignDocSyncGatewayChannels, ViewChannels, optMap, &vres)
 	if err != nil {
 		base.Logf("Error from 'channels' view: %v", err)
 		return nil, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -1185,7 +1185,7 @@ func (context *DatabaseContext) ComputeSequenceChannelsForPrincipal(princ auth.P
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": key}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewAccess, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayAccess, ViewAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	channelSet := channels.TimedSet{}
@@ -1210,7 +1210,7 @@ func (context *DatabaseContext) ComputeVbSequenceChannelsForPrincipal(princ auth
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": key}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewAccessVbSeq, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayAccessVbSeq, ViewAccessVbSeq, opts, &vres); verr != nil {
 		return nil, verr
 	}
 
@@ -1241,7 +1241,7 @@ func (context *DatabaseContext) ComputeSequenceRolesForUser(user auth.User) (cha
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewRoleAccess, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayRoleAccess, ViewRoleAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	// Merge the TimedSets from the view result:
@@ -1266,7 +1266,7 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewRoleAccessVbSeq, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayRoleAccessVbSeq, ViewRoleAccessVbSeq, opts, &vres); verr != nil {
 		return nil, verr
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -692,13 +692,38 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 
 	designDocMap := map[string]sgbucket.DesignDoc{}
 
-	designDocMap[DesignDocSyncGateway] = sgbucket.DesignDoc{
+	designDocMap[DesignDocSyncGatewayPrincipals] = sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
-			ViewPrincipals:      sgbucket.ViewDef{Map: principals_map},
-			ViewChannels:        sgbucket.ViewDef{Map: channels_map},
-			ViewAccess:          sgbucket.ViewDef{Map: access_map},
-			ViewAccessVbSeq:     sgbucket.ViewDef{Map: access_vbSeq_map},
-			ViewRoleAccess:      sgbucket.ViewDef{Map: roleAccess_map},
+			ViewPrincipals: sgbucket.ViewDef{Map: principals_map},
+		},
+	}
+
+	designDocMap[DesignDocSyncGatewayChannels] = sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			ViewChannels: sgbucket.ViewDef{Map: channels_map},
+		},
+	}
+
+	designDocMap[DesignDocSyncGatewayAccess] = sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			ViewAccess: sgbucket.ViewDef{Map: access_map},
+		},
+	}
+
+	designDocMap[DesignDocSyncGatewayAccessVbSeq] = sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			ViewAccessVbSeq: sgbucket.ViewDef{Map: access_vbSeq_map},
+		},
+	}
+
+	designDocMap[DesignDocSyncGatewayRoleAccess] = sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			ViewRoleAccess: sgbucket.ViewDef{Map: roleAccess_map},
+		},
+	}
+
+	designDocMap[DesignDocSyncGatewayRoleAccessVbSeq] = sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
 			ViewRoleAccessVbSeq: sgbucket.ViewDef{Map: roleAccess_vbSeq_map},
 		},
 	}
@@ -718,6 +743,9 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 		11, //MaxNumRetries approx 10 seconds total retry duration
 		5,  //InitialRetrySleepTimeMS
 	)
+
+	// Remove legacy sync gateway design doc, if present
+	bucket.DeleteDDoc(DesignDocSyncGateway)
 
 	// add all design docs from map into bucket
 	for designDocName, designDoc := range designDocMap {
@@ -803,7 +831,7 @@ func (db *Database) ForEachDocID(callback ForEachDocIDFunc, resultsOpts ForEachD
 
 // Returns the IDs of all users and roles
 func (db *DatabaseContext) AllPrincipalIDs() (users, roles []string, err error) {
-	vres, err := db.Bucket.View(DesignDocSyncGateway, ViewPrincipals, Body{"stale": false})
+	vres, err := db.Bucket.View(DesignDocSyncGatewayPrincipals, ViewPrincipals, Body{"stale": false})
 	if err != nil {
 		return
 	}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -12,22 +12,46 @@ import (
 )
 
 const (
-	DesignDocSyncGateway      = "sync_gateway"
-	DesignDocSyncHousekeeping = "sync_housekeeping"
-	ViewPrincipals            = "principals"
-	ViewChannels              = "channels"
-	ViewAccess                = "access"
-	ViewAccessVbSeq           = "access_vbseq"
-	ViewRoleAccess            = "role_access"
-	ViewRoleAccessVbSeq       = "role_access_vbseq"
-	ViewAllBits               = "all_bits"
-	ViewAllDocs               = "all_docs"
-	ViewImport                = "import"
-	ViewOldRevs               = "old_revs"
-	ViewSessions              = "sessions"
-	ViewTombstones            = "tombstones"
+	DesignDocSyncGateway                = "sync_gateway" // Legacy design doc, obsolete in SG 1.5 and later.  Used to remove if present during view installation
+	DesignDocSyncGatewayChannels        = "sync_gateway_channels"
+	DesignDocSyncGatewayPrincipals      = "sync_gateway_principals"
+	DesignDocSyncGatewayAccess          = "sync_gateway_access"
+	DesignDocSyncGatewayAccessVbSeq     = "sync_gateway_access_vbseq"
+	DesignDocSyncGatewayRoleAccess      = "sync_gateway_role_access"
+	DesignDocSyncGatewayRoleAccessVbSeq = "sync_gateway_role_access_vbseq"
+	DesignDocSyncHousekeeping           = "sync_housekeeping"
+	ViewPrincipals                      = "principals"
+	ViewChannels                        = "channels"
+	ViewAccess                          = "access"
+	ViewAccessVbSeq                     = "access_vbseq"
+	ViewRoleAccess                      = "role_access"
+	ViewRoleAccessVbSeq                 = "role_access_vbseq"
+	ViewAllBits                         = "all_bits"
+	ViewAllDocs                         = "all_docs"
+	ViewImport                          = "import"
+	ViewOldRevs                         = "old_revs"
+	ViewSessions                        = "sessions"
+	ViewTombstones                      = "tombstones"
 )
 
+func GetDesignDocForView(viewName string) (designDocName string) {
+	switch viewName {
+	case ViewPrincipals:
+		return DesignDocSyncGatewayPrincipals
+	case ViewChannels:
+		return DesignDocSyncGatewayChannels
+	case ViewAccess:
+		return DesignDocSyncGatewayAccess
+	case ViewAccessVbSeq:
+		return DesignDocSyncGatewayAccessVbSeq
+	case ViewRoleAccess:
+		return DesignDocSyncGatewayRoleAccess
+	case ViewRoleAccessVbSeq:
+		return DesignDocSyncGatewayRoleAccessVbSeq
+	default:
+		return ""
+	}
+}
 func isInternalDDoc(ddocName string) bool {
 	return strings.HasPrefix(ddocName, "sync_")
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -932,13 +932,13 @@ func collectAccessRelatedWarnings(config *DbConfig, context *db.DatabaseContext)
 
 		// There are no users in the config, but there might be users in the db.  Find out
 		// by querying the "view principals" view which will return users and roles.  We only want to
-		// find out if there is at least one user (or role) defined, so set limit == 1 to minimize
+		// find out if there is at least one user (or role) defined, so set stale=ok and limit == 1 to minimize
 		// performance hit of query.
 		viewOptions := db.Body{
-			"stale": false,
+			"stale": "ok",
 			"limit": 1,
 		}
-		vres, err := currentDb.Bucket.View(db.DesignDocSyncGateway, db.ViewPrincipals, viewOptions)
+		vres, err := currentDb.Bucket.View(db.DesignDocSyncGatewayPrincipals, db.ViewPrincipals, viewOptions)
 		if err != nil {
 			base.Warn("Error trying to query ViewPrincipals: %v", err)
 			return []string{}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -935,7 +935,6 @@ func collectAccessRelatedWarnings(config *DbConfig, context *db.DatabaseContext)
 		// find out if there is at least one user (or role) defined, so set stale=ok and limit == 1 to minimize
 		// performance hit of query.
 		viewOptions := db.Body{
-			"stale": "ok",
 			"limit": 1,
 		}
 		vres, err := currentDb.Bucket.View(db.DesignDocSyncGatewayPrincipals, db.ViewPrincipals, viewOptions)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -13,8 +13,10 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -151,6 +153,7 @@ func (client *MockClient) RespondToGET(url string, response *http.Response) {
 func TestCollectAccessWarningsNoUsers(t *testing.T) {
 
 	sc := NewServerContext(&ServerConfig{})
+	defer sc.Close()
 
 	dbServer := "walrus:"
 	dbConfig := &DbConfig{
@@ -171,6 +174,7 @@ func TestCollectAccessWarningsNoUsers(t *testing.T) {
 func TestCollectAccessWarningsGuestNoChans(t *testing.T) {
 
 	sc := NewServerContext(&ServerConfig{})
+	defer sc.Close()
 
 	dbServer := "walrus:"
 	dbConfig := &DbConfig{
@@ -196,6 +200,7 @@ func TestCollectAccessWarningsGuestNoChans(t *testing.T) {
 func TestCollectAccessWarningsGuestWithChans(t *testing.T) {
 
 	sc := NewServerContext(&ServerConfig{})
+	defer sc.Close()
 
 	dbServer := "walrus:"
 	dbConfig := &DbConfig{
@@ -222,6 +227,7 @@ func TestCollectAccessWarningsGuestWithChans(t *testing.T) {
 func TestCollectAccessWarningsUsersInDb(t *testing.T) {
 
 	sc := NewServerContext(&ServerConfig{})
+	defer sc.Close()
 
 	dbServer := "walrus:"
 	dbConfig := &DbConfig{
@@ -234,18 +240,29 @@ func TestCollectAccessWarningsUsersInDb(t *testing.T) {
 	}
 	dbContext := sc.Database("db")
 
+	password := "bar"
 	// create user
 	spec := map[string]*db.PrincipalConfig{
 		"foo": {
+			Password:         &password,
 			Disabled:         false,
 			ExplicitChannels: base.SetFromArray([]string{"*"}),
 		},
 	}
 
 	// add a user to the db
-	sc.installPrincipals(dbContext, spec, "user")
+	err = sc.installPrincipals(dbContext, spec, "user")
+	assertNoError(t, err, "Error installing principal")
 
-	warnings := collectAccessRelatedWarnings(dbConfig, dbContext)
+	var warnings []string
+	for i := 1; i <= 10; i++ {
+		log.Printf("View attempt %d/10", i)
+		warnings = collectAccessRelatedWarnings(dbConfig, dbContext)
+		if len(warnings) == 0 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 	assert.Equals(t, len(warnings), 0)
 
 }

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbase/sg-bucket"
 )
 
 // HTTP handler for GET _design/$ddoc
@@ -62,10 +62,10 @@ func (h *handler) handleView() error {
 	// Couchbase Server view API:
 	// http://docs.couchbase.com/admin/admin/REST/rest-views-get.html
 	ddocName := h.PathVar("ddoc")
-	if ddocName == "" {
-		ddocName = db.DesignDocSyncGateway
-	}
 	viewName := h.PathVar("view")
+	if ddocName == "" {
+		ddocName = db.GetDesignDocForView(viewName)
+	}
 	opts := db.Body{}
 
 	// Boolean options:


### PR DESCRIPTION
Splits the sync_gateway design doc into multiple design docs, one per view, to allow the view engine to index these in parallel.

Also switches the startup warning based on view_principals to stale=ok, as correctness of results isn't critical in that scenario (it's just a usability/information warning).

Fixes #2628