### PR TITLE
Uptake xattr fixes from server

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 
 	"reflect"
-	"time"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -567,8 +566,8 @@ func SkipXattrTestsIfNotEnabled(t *testing.T) {
 	}
 }
 
-// TestWriteCasXATTR.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
-func TestWriteCasXattrSimple(t *testing.T) {
+// TestXattrWriteCasSimple.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
+func TestXattrWriteCasSimple(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -609,8 +608,8 @@ func TestWriteCasXattrSimple(t *testing.T) {
 	assert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
 }
 
-// TestWriteCasXATTR.  Validates basic write of document with xattr,  retrieval of the same doc w/ xattr, update of the doc w/ xattr, retrieval of the doc w/ xattr.
-func TestWriteCasXattrUpsert(t *testing.T) {
+// TestXattrWriteCasUpsert.  Validates basic write of document with xattr,  retrieval of the same doc w/ xattr, update of the doc w/ xattr, retrieval of the doc w/ xattr.
+func TestXattrWriteCasUpsert(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -681,7 +680,7 @@ func TestWriteCasXattrUpsert(t *testing.T) {
 }
 
 // TestWriteCasXATTRRaw.  Validates basic write of document and xattr as raw bytes.
-func TestWriteCasXattrRaw(t *testing.T) {
+func TestXattrWriteCasRaw(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -732,11 +731,9 @@ func TestWriteCasXattrRaw(t *testing.T) {
 }
 
 // TestWriteCasTombstoneResurrect.  Verifies writing a new document body and xattr to a logically deleted document (xattr still exists)
-// TODO: This fails with key not found trying to do a CAS-safe rewrite of the doc.  Updating the doc via subdoc (with access_deleted) is
-// expected to work - need to retry when GOCBC-181 is available.
-func TestWriteCasXattrTombstoneResurrect(t *testing.T) {
+func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 
-	t.Skip("Test fails with errors: https://gist.github.com/tleyden/c64bc7c473c74e241a2a05f138c8be6e.  Needs investigation")
+	//t.Skip("Test fails with errors: https://gist.github.com/tleyden/c64bc7c473c74e241a2a05f138c8be6e.  Needs investigation")
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -815,8 +812,8 @@ func TestWriteCasXattrTombstoneResurrect(t *testing.T) {
 
 }
 
-// TestWriteCasXATTRDeleted.  Validates update of xattr on logically deleted document.
-func TestWriteCasXattrTombstoneXattrUpdate(t *testing.T) {
+// TestXattrWriteCasTombstoneUpdate.  Validates update of xattr on logically deleted document.
+func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 
 	t.Skip("Test fails with errors: https://gist.github.com/tleyden/d261fe2b92bdaaa6e78f9f1c00fdfd58.  Needs investigation")
 
@@ -900,8 +897,8 @@ func TestWriteCasXattrTombstoneXattrUpdate(t *testing.T) {
 
 }
 
-// TestWriteUpdateXATTR.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
-func TestWriteUpdateXattr(t *testing.T) {
+// TestXattrWriteUpdateXattr.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
+func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1013,8 +1010,8 @@ func TestWriteUpdateXattr(t *testing.T) {
 
 }
 
-// TestDeleteDocumentHavingXATTR.  Delete document that has a system xattr.  System XATTR should be retained and retrievable.
-func TestDeleteDocumentHavingXattr(t *testing.T) {
+// TestXattrDeleteDocument.  Delete document that has a system xattr.  System XATTR should be retained and retrievable.
+func TestXattrDeleteDocument(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1066,8 +1063,8 @@ func TestDeleteDocumentHavingXattr(t *testing.T) {
 
 }
 
-// TestDeleteDocumentUpdateXATTR.  Delete document that has a system xattr along with an xattr update.
-func TestDeleteDocumentUpdateXattr(t *testing.T) {
+// TestXattrDeleteDocumentUpdate.  Delete a document that has a system xattr along with an xattr update.
+func TestXattrDeleteDocumentUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1138,8 +1135,8 @@ func TestDeleteDocumentUpdateXattr(t *testing.T) {
 
 }
 
-// TestDeleteDocumentAndXATTR.  Delete document and XATTR, ensure it's not available
-func TestDeleteDocumentAndXATTR(t *testing.T) {
+// TestXattrDeleteDocumentWithXattr.  Delete document and XATTR, ensure it's not available
+func TestXattrDeleteDocumentWithXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1184,12 +1181,14 @@ func TestDeleteDocumentAndXATTR(t *testing.T) {
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
 	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
-	assert.Equals(t, err, gocbcore.ErrKeyNotFound)
+	if err != gocbcore.ErrKeyNotFound {
+		t.Errorf("Unexpected error calling GetWithXattr: %+v", err)
+	}
 
 }
 
-// TestDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Pending https://issues.couchbase.com/browse/MB-24098
-func TestDeleteDocumentAndUpdateXATTR(t *testing.T) {
+// TestXattrDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Pending https://issues.couchbase.com/browse/MB-24098
+func TestXattrDeleteDocumentAndUpdateXATTR(t *testing.T) {
 
 	t.Skip("Failing, see https://github.com/couchbase/sync_gateway/issues/2561#issuecomment-305330059")
 
@@ -1243,8 +1242,8 @@ func TestDeleteDocumentAndUpdateXATTR(t *testing.T) {
 
 }
 
-// CouchbaseTestRetrieveDocumentAndXattr.  Pending https://issues.couchbase.com/browse/MB-24152
-func TestRetrieveDocumentAndXattr(t *testing.T) {
+// TestXattrRetrieveDocumentAndXattr.
+func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1255,19 +1254,20 @@ func TestRetrieveDocumentAndXattr(t *testing.T) {
 		return
 	}
 
+	key1 := "DocExistsXattrExists"
+	key2 := "DocExistsNoXattr"
+	key3 := "XattrExistsNoDoc"
+	key4 := "NoDocNoXattr"
+
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
-	val["type"] = "docExistsXattrExists"
+	val["type"] = key1
 
 	xattrName := "_sync"
 	xattrVal := make(map[string]interface{})
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key1 := "DocExistsXattrExists"
-	key2 := "DocExistsNoXattr"
-	key3 := "XattrExistsNoDoc"
-	key4 := "NoDocNoXattr"
 	var err error
 
 	// Create w/ XATTR
@@ -1279,12 +1279,12 @@ func TestRetrieveDocumentAndXattr(t *testing.T) {
 
 	// 2. Create document with no XATTR
 	val = make(map[string]interface{})
-	val["type"] = "DocExistsNoXattr"
+	val["type"] = key2
 	_, err = bucket.Add(key2, 0, val)
 
 	// 3. Xattr, no document
 	val = make(map[string]interface{})
-	val["type"] = "xattrExistsNoDoc"
+	val["type"] = key3
 
 	xattrVal = make(map[string]interface{})
 	xattrVal["seq"] = 456
@@ -1302,38 +1302,147 @@ func TestRetrieveDocumentAndXattr(t *testing.T) {
 	// 4. No xattr, no document
 
 	// Attempt to retrieve all 4 docs
-	res1, key1err := bucket.Bucket.LookupInEx(key1, gocb.SubdocDocFlagAccessDeleted).
-		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
-		GetEx("", gocb.SubdocFlagNone).         // Get the document body
-		Execute()
-	log.Printf("key1err: %v", key1err)
-	log.Printf("key1res: %+v", res1)
+	var key1DocResult map[string]interface{}
+	var key1XattrResult map[string]interface{}
+	_, key1err := bucket.GetWithXattr(key1, xattrName, &key1DocResult, &key1XattrResult)
+	assertNoError(t, key1err, "Unexpected error retrieving doc w/ xattr")
+	assert.Equals(t, key1DocResult["type"], key1)
+	assert.Equals(t, key1XattrResult["rev"], "1-1234")
 
-	time.Sleep(100 * time.Millisecond)
-	res2, key2err := bucket.Bucket.LookupInEx(key2, gocb.SubdocDocFlagAccessDeleted).
-		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
-		GetEx("", gocb.SubdocFlagNone).         // Get the document body
-		Execute()
-	log.Printf("key2err: %v", key2err)
-	log.Printf("key2res: %+v", res2)
+	var key2DocResult map[string]interface{}
+	var key2XattrResult map[string]interface{}
+	_, key2err := bucket.GetWithXattr(key2, xattrName, &key2DocResult, &key2XattrResult)
+	assertNoError(t, key2err, "Unexpected error retrieving doc w/out xattr")
+	assert.Equals(t, key2DocResult["type"], key2)
+	assert.True(t, key2XattrResult == nil)
 
-	time.Sleep(100 * time.Millisecond)
-	res3, key3err := bucket.Bucket.LookupInEx(key3, gocb.SubdocDocFlagAccessDeleted).
-		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
-		GetEx("", gocb.SubdocFlagNone).         // Get the document body
-		Execute()
-	log.Printf("key3err: %v", key3err)
-	log.Printf("key3res: %+v", res3)
+	var key3DocResult map[string]interface{}
+	var key3XattrResult map[string]interface{}
+	_, key3err := bucket.GetWithXattr(key3, xattrName, &key3DocResult, &key3XattrResult)
+	assertNoError(t, key3err, "Unexpected error retrieving doc w/out xattr")
+	assert.True(t, key3DocResult == nil)
+	assert.Equals(t, key3XattrResult["rev"], "1-1234")
 
-	time.Sleep(100 * time.Millisecond)
-	res4, key4err := bucket.Bucket.LookupInEx(key4, gocb.SubdocDocFlagAccessDeleted).
-		GetEx(xattrName, gocb.SubdocFlagXattr). // Get the xattr
-		GetEx("", gocb.SubdocFlagNone).         // Get the document body
-		Execute()
-	log.Printf("key4err: %v", key4err)
-	log.Printf("key4res: %+v", res4)
+	var key4DocResult map[string]interface{}
+	var key4XattrResult map[string]interface{}
+	_, key4err := bucket.GetWithXattr(key4, xattrName, &key4DocResult, &key4XattrResult)
+	assert.Equals(t, key4err, gocb.ErrKeyNotFound)
+	assert.True(t, key4DocResult == nil)
+	assert.True(t, key4XattrResult == nil)
 
 }
+
+// TestXattrMutateDocAndXattr.  Validates mutation of doc + xattr in various possible previous states of the document.
+func TestXattrMutateDocAndXattr(t *testing.T) {
+
+	SkipXattrTestsIfNotEnabled(t)
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	key1 := "DocExistsXattrExists"
+	key2 := "DocExistsNoXattr"
+	key3 := "XattrExistsNoDoc"
+	key4 := "NoDocNoXattr"
+
+	// 1. Create document with XATTR
+	val := make(map[string]interface{})
+	val["type"] = key1
+
+	xattrName := "_sync"
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	var err error
+
+	// Create w/ XATTR
+	cas1 := uint64(0)
+	cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// 2. Create document with no XATTR
+	val = make(map[string]interface{})
+	val["type"] = key2
+	cas2 := gocb.Cas(0)
+	cas2, err = bucket.Bucket.Insert(key2, val, uint32(0))
+
+	// 3. Xattr, no document
+	val = make(map[string]interface{})
+	val["type"] = key3
+
+	xattrVal = make(map[string]interface{})
+	xattrVal["seq"] = 456
+	xattrVal["rev"] = "1-1234"
+
+	// Create w/ XATTR
+	cas3int := uint64(0)
+	cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+	// Delete the doc body
+	var cas3 gocb.Cas
+	cas3, err = bucket.Bucket.Remove(key3, 0)
+	if err != nil {
+		t.Errorf("Error removing doc body: %+v", err)
+	}
+
+	// 4. No xattr, no document
+	cas4 := 0
+	updatedVal := make(map[string]interface{})
+	updatedVal["type"] = "updated"
+
+	updatedXattrVal := make(map[string]interface{})
+	updatedXattrVal["seq"] = 123
+	updatedXattrVal["rev"] = "2-1234"
+
+	// Attempt to mutate all 4 docs
+	exp := 0
+	updatedVal["type"] = fmt.Sprintf("updated_%s", key1)
+	_, key1err := bucket.WriteCasWithXattr(key1, xattrName, exp, cas1, &updatedVal, &updatedXattrVal)
+	assertNoError(t, key1err, fmt.Sprintf("Unexpected error mutating %s", key1))
+	var key1DocResult map[string]interface{}
+	var key1XattrResult map[string]interface{}
+	_, key1err = bucket.GetWithXattr(key1, xattrName, &key1DocResult, &key1XattrResult)
+	assert.Equals(t, key1DocResult["type"], fmt.Sprintf("updated_%s", key1))
+	assert.Equals(t, key1XattrResult["rev"], "2-1234")
+
+	updatedVal["type"] = fmt.Sprintf("updated_%s", key2)
+	_, key2err := bucket.WriteCasWithXattr(key2, xattrName, exp, uint64(cas2), &updatedVal, &updatedXattrVal)
+	assertNoError(t, key2err, fmt.Sprintf("Unexpected error mutating %s", key2))
+	var key2DocResult map[string]interface{}
+	var key2XattrResult map[string]interface{}
+	_, key2err = bucket.GetWithXattr(key2, xattrName, &key2DocResult, &key2XattrResult)
+	assert.Equals(t, key2DocResult["type"], fmt.Sprintf("updated_%s", key2))
+	assert.Equals(t, key2XattrResult["rev"], "2-1234")
+
+	updatedVal["type"] = fmt.Sprintf("updated_%s", key3)
+	_, key3err := bucket.WriteCasWithXattr(key3, xattrName, exp, uint64(cas3), &updatedVal, &updatedXattrVal)
+	assertNoError(t, key3err, fmt.Sprintf("Unexpected error mutating %s", key3))
+	var key3DocResult map[string]interface{}
+	var key3XattrResult map[string]interface{}
+	_, key3err = bucket.GetWithXattr(key3, xattrName, &key3DocResult, &key3XattrResult)
+	assert.Equals(t, key3DocResult["type"], fmt.Sprintf("updated_%s", key3))
+	assert.Equals(t, key3XattrResult["rev"], "2-1234")
+
+	updatedVal["type"] = fmt.Sprintf("updated_%s", key4)
+	_, key4err := bucket.WriteCasWithXattr(key4, xattrName, exp, uint64(cas4), &updatedVal, &updatedXattrVal)
+	assertNoError(t, key4err, fmt.Sprintf("Unexpected error mutating %s", key4))
+	var key4DocResult map[string]interface{}
+	var key4XattrResult map[string]interface{}
+	_, key4err = bucket.GetWithXattr(key4, xattrName, &key4DocResult, &key4XattrResult)
+	assert.Equals(t, key4DocResult["type"], fmt.Sprintf("updated_%s", key4))
+	assert.Equals(t, key4XattrResult["rev"], "2-1234")
+
+}
+
 func TestApplyViewQueryOptions(t *testing.T) {
 
 	// ------------------- Inline Helper functions ---------------------------

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -368,7 +368,7 @@ func (c *changeCache) DocChanged(event sgbucket.TapEvent) {
 						rawBody = nil
 					}
 					db := Database{DatabaseContext: c.context, user: nil}
-					_, err := db.ImportRawDoc(docID, rawBody, isDelete)
+					_, err := db.ImportDocRaw(docID, rawBody, isDelete)
 					if err != nil {
 						base.Warn("Unable to import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", docID, err)
 					}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -60,7 +60,7 @@
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="bf740f17ea6cd6a1bbd5ca3583266c8f74692524"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="0dfef9335fa13e903afb34eec66471f1ba48fce2"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="cfd05d858efb2899132a1bf18cba441ca307cc78"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="9ff4edc65ca879f404421978fd375a3439401133"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="d5b5fbe3b54eecaf0a656c10b22c7d28ccfe8f97"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="4aaaca921a7ef64900f3b569c33ad87e9e8df065"/>

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1,0 +1,225 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbaselabs/go.assert"
+)
+
+func SkipImportTestsIfNotEnabled(t *testing.T) {
+
+	if !base.TestUseXattrs() {
+		t.Skip("XATTR based tests not enabled.  Enable via SG_TEST_USE_XATTRS=true environment variable")
+	}
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
+	}
+}
+
+type simpleSync struct {
+	Channels map[string]interface{}
+	Rev      string
+}
+
+type rawResponse struct {
+	Sync simpleSync `json:"_sync"`
+}
+
+func hasActiveChannel(channelSet map[string]interface{}, channelName string) bool {
+	if channelSet == nil {
+		return false
+	}
+	value, ok := channelSet[channelName]
+	if !ok || value != nil { // An entry for the channel name with a nil value represents an active channel
+		return false
+	}
+
+	return true
+}
+
+// Test import of an SDK delete.
+func TestXattrImportOldDoc(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{SyncFn: `
+		function(doc, oldDoc) {
+			if (oldDoc == null) {
+				channel("oldDocNil")
+			} 
+			if (doc._deleted) {
+				channel("docDeleted")
+			}
+		}`}
+	defer rt.Close()
+
+	bucket := rt.Bucket()
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+
+	// 1. Test oldDoc behaviour during SDK insert
+	key := "TestImportDelete"
+	docBody := make(map[string]interface{})
+	docBody["test"] = "TestImportDelete"
+	docBody["channels"] = "ABC"
+
+	_, err := bucket.Add(key, 0, docBody)
+	assertNoError(t, err, "Unable to insert doc TestImportDelete")
+
+	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
+	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
+	assert.Equals(t, response.Code, 200)
+	var rawInsertResponse rawResponse
+	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	assertNoError(t, err, "Unable to unmarshal raw response")
+	assertTrue(t, rawInsertResponse.Sync.Channels != nil, "Expected channels not returned for SDK insert")
+	log.Printf("insert channels: %+v", rawInsertResponse.Sync.Channels)
+	assertTrue(t, hasActiveChannel(rawInsertResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK insert")
+
+	// 2. Test oldDoc behaviour during SDK update
+
+	updatedBody := make(map[string]interface{})
+	updatedBody["test"] = "TestImportDelete"
+	updatedBody["channels"] = "HBO"
+
+	err = bucket.Set(key, 0, updatedBody)
+	assertNoError(t, err, "Unable to update doc TestImportDelete")
+
+	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
+	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
+	assert.Equals(t, response.Code, 200)
+	var rawUpdateResponse rawResponse
+	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
+	assertNoError(t, err, "Unable to unmarshal raw response")
+	assertTrue(t, rawUpdateResponse.Sync.Channels != nil, "Expected channels not returned for SDK update")
+	log.Printf("update channels: %+v", rawUpdateResponse.Sync.Channels)
+	assertTrue(t, hasActiveChannel(rawUpdateResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK update")
+
+	// 3. Test oldDoc behaviour during SDK delete
+	err = bucket.Delete(key)
+	assertNoError(t, err, "Unable to delete doc TestImportDelete")
+
+	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
+	assert.Equals(t, response.Code, 200)
+	var rawDeleteResponse rawResponse
+	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
+	log.Printf("Post-delete: %s", response.Body.Bytes())
+	assertNoError(t, err, "Unable to unmarshal raw response")
+	assertTrue(t, hasActiveChannel(rawDeleteResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK delete")
+	assertTrue(t, hasActiveChannel(rawDeleteResponse.Sync.Channels, "docDeleted"), "doc did not set _deleted:true for SDK delete")
+
+}
+
+// Attempt to delete then recreate a document through SG
+func TestXattrResurrectViaSG(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{SyncFn: `
+		function(doc, oldDoc) { channel(doc.channels) }`}
+	defer rt.Close()
+
+	log.Printf("Starting get bucket....")
+
+	rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+
+	// 1. Create and import doc
+	key := "TestResurrectViaSG"
+	docBody := make(map[string]interface{})
+	docBody["test"] = key
+	docBody["channels"] = "ABC"
+
+	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"channels":"ABC"}`)
+	assert.Equals(t, response.Code, 201)
+	log.Printf("insert response: %s", response.Body.Bytes())
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId := body["rev"].(string)
+
+	// 2. Delete the doc through SG
+	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
+	assert.Equals(t, response.Code, 200)
+	log.Printf("delete response: %s", response.Body.Bytes())
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId = body["rev"].(string)
+
+	// 3. Recreate the doc through the SG (with different data)
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", key, revId), `{"channels":"ABC"}`)
+	assert.Equals(t, response.Code, 201)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	assert.Equals(t, body["rev"], "3-70c113f08c6622cd87af68f4f60d12e3")
+
+}
+
+// Attempt to delete then recreate a document through the SDK
+func TestXattrResurrectViaSDK(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{SyncFn: `
+		function(doc, oldDoc) { channel(doc.channels) }`}
+	defer rt.Close()
+
+	log.Printf("Starting get bucket....")
+
+	bucket := rt.Bucket()
+	log.Printf("Got bucket....'")
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+
+	// 1. Create and import doc
+	key := "TestResurrectViaSDK"
+	docBody := make(map[string]interface{})
+	docBody["test"] = key
+	docBody["channels"] = "ABC"
+
+	_, err := bucket.Add(key, 0, docBody)
+	assertNoError(t, err, "Unable to insert doc TestResurrectViaSDK")
+
+	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
+	rawPath := fmt.Sprintf("/db/_raw/%s", key)
+	response := rt.SendAdminRequest("GET", rawPath, "")
+	assert.Equals(t, response.Code, 200)
+	var rawInsertResponse rawResponse
+	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	assertNoError(t, err, "Unable to unmarshal raw response")
+
+	// 2. Delete the doc through the SDK
+	err = bucket.Delete(key)
+	assertNoError(t, err, "Unable to delete doc TestResurrectViaSDK")
+
+	response = rt.SendAdminRequest("GET", rawPath, "")
+	assert.Equals(t, response.Code, 200)
+	var rawDeleteResponse rawResponse
+	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
+	log.Printf("Post-delete: %s", response.Body.Bytes())
+	assertNoError(t, err, "Unable to unmarshal raw response")
+
+	// 3. Recreate the doc through the SDK (with different data)
+	updatedBody := make(map[string]interface{})
+	updatedBody["test"] = key
+	updatedBody["channels"] = "HBO"
+
+	err = bucket.Set(key, 0, updatedBody)
+	assertNoError(t, err, "Unable to update doc TestResurrectViaSDK")
+
+	// Attempt to get the document via Sync Gateway, to trigger import.
+	response = rt.SendAdminRequest("GET", rawPath, "")
+	assert.Equals(t, response.Code, 200)
+	var rawUpdateResponse rawResponse
+	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
+	assertNoError(t, err, "Unable to unmarshal raw response")
+	_, ok := rawUpdateResponse.Sync.Channels["HBO"]
+	assertTrue(t, ok, "Didn't find expected channel (HBO) on resurrected doc")
+
+}


### PR DESCRIPTION
Uptake changes made by server and SDK to better support single-op lookup and mutate of doc+xattr.

Fixes #2641 (doc resurrection failure).
Also fixes #2565 (oldDoc handling during import).

Includes unit test enhancements for these scenarios.