### PR TITLE
Enable tombstone indexing for Sync Gateway design docs

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -692,15 +692,12 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 
 	designDocMap := map[string]sgbucket.DesignDoc{}
 
-	designDocMap[DesignDocSyncGatewayPrincipals] = sgbucket.DesignDoc{
-		Views: sgbucket.ViewMap{
-			ViewPrincipals: sgbucket.ViewDef{Map: principals_map},
-		},
-	}
-
 	designDocMap[DesignDocSyncGatewayChannels] = sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			ViewChannels: sgbucket.ViewDef{Map: channels_map},
+		},
+		Options: &sgbucket.DesignDocOptions{
+			IndexXattrOnTombstones: true,
 		},
 	}
 
@@ -736,6 +733,10 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 			ViewOldRevs:    sgbucket.ViewDef{Map: oldrevs_map, Reduce: "_count"},
 			ViewSessions:   sgbucket.ViewDef{Map: sessions_map},
 			ViewTombstones: sgbucket.ViewDef{Map: tombstones_map},
+			ViewPrincipals: sgbucket.ViewDef{Map: principals_map},
+		},
+		Options: &sgbucket.DesignDocOptions{
+			IndexXattrOnTombstones: true, // For ViewTombstones
 		},
 	}
 
@@ -831,7 +832,7 @@ func (db *Database) ForEachDocID(callback ForEachDocIDFunc, resultsOpts ForEachD
 
 // Returns the IDs of all users and roles
 func (db *DatabaseContext) AllPrincipalIDs() (users, roles []string, err error) {
-	vres, err := db.Bucket.View(DesignDocSyncGatewayPrincipals, ViewPrincipals, Body{"stale": false})
+	vres, err := db.Bucket.View(DesignDocSyncHousekeeping, ViewPrincipals, Body{"stale": false})
 	if err != nil {
 		return
 	}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -14,7 +14,6 @@ import (
 const (
 	DesignDocSyncGateway                = "sync_gateway" // Legacy design doc, obsolete in SG 1.5 and later.  Used to remove if present during view installation
 	DesignDocSyncGatewayChannels        = "sync_gateway_channels"
-	DesignDocSyncGatewayPrincipals      = "sync_gateway_principals"
 	DesignDocSyncGatewayAccess          = "sync_gateway_access"
 	DesignDocSyncGatewayAccessVbSeq     = "sync_gateway_access_vbseq"
 	DesignDocSyncGatewayRoleAccess      = "sync_gateway_role_access"
@@ -37,7 +36,7 @@ const (
 func GetDesignDocForView(viewName string) (designDocName string) {
 	switch viewName {
 	case ViewPrincipals:
-		return DesignDocSyncGatewayPrincipals
+		return DesignDocSyncHousekeeping
 	case ViewChannels:
 		return DesignDocSyncGatewayChannels
 	case ViewAccess:

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -68,7 +68,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="1f30cbc110d3f6a525188ae7d87b84fa5b3751a5"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="d6a1b73dec2cb5eaa09562bf8495d1829b7cbb04"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="be7119def82a501f75272f2e3233173377d2a7c4"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -937,7 +937,7 @@ func collectAccessRelatedWarnings(config *DbConfig, context *db.DatabaseContext)
 		viewOptions := db.Body{
 			"limit": 1,
 		}
-		vres, err := currentDb.Bucket.View(db.DesignDocSyncGatewayPrincipals, db.ViewPrincipals, viewOptions)
+		vres, err := currentDb.Bucket.View(db.DesignDocSyncHousekeeping, db.ViewPrincipals, viewOptions)
 		if err != nil {
 			base.Warn("Error trying to query ViewPrincipals: %v", err)
 			return []string{}


### PR DESCRIPTION
View Engine now requires an additional property (index_xattr_on_deleted_docs) to be set when creating a design doc, if any views in that design doc need to index tombstones.  This property is intended to be internal, and so isn't supported via the SDK (gocb).

Extracted the relevant code into bucket_gocb to allow Sync Gateway to write a design doc while setting the new property.

Includes an additional fix to move ViewPrincipals into the housekeeping design doc, as it's no longer a core processing view.

Fixes #2649