### PR TITLE
Fixes #2651 SG gets killed due to excessive memory usage with continu…

### DIFF
--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -21,26 +21,180 @@ import (
 	"github.com/couchbaselabs/go.assert"
 )
 
+// 1-one -- 2-two -- 3-three
 var testmap = RevTree{"3-three": {ID: "3-three", Parent: "2-two", Body: []byte("{}")},
 	"2-two": {ID: "2-two", Parent: "1-one", Channels: base.SetOf("ABC", "CBS")},
 	"1-one": {ID: "1-one", Channels: base.SetOf("ABC")}}
 
-// 1-one -- 2-two -- 3-three
-
+//               / 3-three
+// 1-one -- 2-two
+//               \ 3-drei
 var branchymap = RevTree{"3-three": {ID: "3-three", Parent: "2-two"},
 	"2-two":  {ID: "2-two", Parent: "1-one"},
 	"1-one":  {ID: "1-one"},
 	"3-drei": {ID: "3-drei", Parent: "2-two"}}
 
-//               / 3-three
-// 1-one -- 2-two
-//               \ 3-drei
+var multiroot = RevTree{"3-a": {ID: "3-a", Parent: "2-a"},
+	"2-a": {ID: "2-a", Parent: "1-a"},
+	"1-a": {ID: "1-a"},
+	"7-b": {ID: "7-b", Parent: "6-b"},
+	"6-b": {ID: "6-b"},
+}
+
+type BranchSpec struct {
+	NumRevs                 int
+	LastRevisionIsTombstone bool
+	Digest                  string
+}
+
+//            / 3-a -- 4-a -- 5-a ...... etc (winning branch)
+// 1-a -- 2-a
+//            \ 3-b -- 4-b ... etc (losing branch)
+//
+// NOTE: the 1-a -- 2-a unconflicted branch can be longer, depending on value of unconflictedBranchNumRevs
+func getTwoBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, losingBranchNumRevs int, tombstoneLosingBranch bool) RevTree {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 losingBranchNumRevs,
+			Digest:                  "b",
+			LastRevisionIsTombstone: tombstoneLosingBranch,
+		},
+	}
+
+	return getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, branchSpecs)
+
+}
+
+//            / 3-a -- 4-a -- 5-a ...... etc (winning branch)
+// 1-a -- 2-a
+//            \ 3-b -- 4-b ... etc (losing branch #1)
+//            \ 3-c -- 4-c ... etc (losing branch #2)
+//            \ 3-d -- 4-d ... etc (losing branch #n)
+//
+// NOTE: the 1-a -- 2-a unconflicted branch can be longer, depending on value of unconflictedBranchNumRevs
+func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs int, losingBranches []BranchSpec) RevTree {
+
+	if unconflictedBranchNumRevs < 1 {
+		panic(fmt.Sprintf("Must have at least 1 unconflictedBranchNumRevs"))
+	}
+
+	winningBranchDigest := "winning"
+
+	const testJSON = `{
+		   "revs":[
+			  "1-winning"
+		   ],
+		   "parents":[
+			  -1
+		   ],
+		   "channels":[
+			  null
+		   ]
+		}`
+
+	revTree := RevTree{}
+	if err := json.Unmarshal([]byte(testJSON), &revTree); err != nil {
+		panic(fmt.Sprintf("Error: %v", err))
+	}
+
+	if unconflictedBranchNumRevs > 1 {
+		// Add revs to unconflicted branch
+		addRevs(
+			revTree,
+			"1-winning",
+			unconflictedBranchNumRevs-1,
+			winningBranchDigest,
+		)
+	}
+
+	if winningBranchNumRevs > 0 {
+
+		// Figure out which generation the conflicting branches will start at
+		generation := unconflictedBranchNumRevs
+
+		// Figure out the starting revision id on winning and losing branches
+		winningBranchStartRev := fmt.Sprintf("%d-%s", generation, winningBranchDigest)
+
+		// Add revs to winning branch
+		addRevs(
+			revTree,
+			winningBranchStartRev,
+			winningBranchNumRevs,
+			winningBranchDigest,
+		)
+
+	}
+
+	for _, losingBranchSpec := range losingBranches {
+
+		if losingBranchSpec.NumRevs > 0 {
+
+			// Figure out which generation the conflicting branches will start at
+			generation := unconflictedBranchNumRevs
+
+			losingBranchStartRev := fmt.Sprintf("%d-%s", generation, winningBranchDigest) // Start on last revision of the non-conflicting branch
+
+			// Add revs to losing branch
+			addRevs(
+				revTree,
+				losingBranchStartRev,
+				losingBranchSpec.NumRevs, // Subtract 1 since we already added initial
+				losingBranchSpec.Digest,
+			)
+
+			generation += losingBranchSpec.NumRevs
+
+			if losingBranchSpec.LastRevisionIsTombstone {
+
+				newRevId := fmt.Sprintf("%v-%v", generation+1, losingBranchSpec.Digest)
+				parentRevId := fmt.Sprintf("%v-%v", generation, losingBranchSpec.Digest)
+
+				revInfo := RevInfo{
+					ID:      newRevId,
+					Parent:  parentRevId,
+					Deleted: true,
+				}
+				revTree.addRevision(revInfo)
+
+			}
+
+		}
+
+	}
+
+	return revTree
+
+}
 
 func testUnmarshal(t *testing.T, jsonString string) RevTree {
 	gotmap := RevTree{}
 	assertNoError(t, json.Unmarshal([]byte(jsonString), &gotmap), "Couldn't parse RevTree from JSON")
 	assert.DeepEquals(t, gotmap, testmap)
 	return gotmap
+}
+
+// Make sure that the getMultiBranchTestRevtree1() helper works as expected
+// (added in reaction to bug where it created broken trees/forests)
+func TestGetMultiBranchTestRevtree(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 60,
+			Digest:                  "left",
+			LastRevisionIsTombstone: false,
+		},
+		{
+			NumRevs:                 25,
+			Digest:                  "right",
+			LastRevisionIsTombstone: true,
+		},
+	}
+	revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
+	leaves := revTree.GetLeaves()
+	sort.Strings(leaves)
+	assert.DeepEquals(t, leaves, []string{"110-left", "150-winning", "76-right"})
+
 }
 
 func TestRevTreeUnmarshalOldFormat(t *testing.T) {
@@ -140,11 +294,29 @@ func TestRevTreeWinningRev(t *testing.T) {
 }
 
 func TestPruneRevisions(t *testing.T) {
-	tempmap := branchymap.copy()
+
+	tempmap := testmap.copy()
+	tempmap.computeDepths()
+	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
+	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
+	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
+
+	tempmap = branchymap.copy()
+	tempmap.computeDepths()
+	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
+	assert.Equals(t, tempmap["3-drei"].depth, uint32(1))
+	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
+	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
+
 	tempmap["4-vier"] = &RevInfo{ID: "4-vier", Parent: "3-drei"}
-	//               / 3-three
-	// 1-one -- 2-two
-	//               \ 3-drei -- 4-vier
+	tempmap.computeDepths()
+	assert.Equals(t, tempmap["4-vier"].depth, uint32(1))
+	assert.Equals(t, tempmap["3-drei"].depth, uint32(2))
+	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
+	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
+	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
+
+	// Prune:
 	assert.Equals(t, tempmap.pruneRevisions(1000, ""), 0)
 	assert.Equals(t, tempmap.pruneRevisions(3, ""), 0)
 	assert.Equals(t, tempmap.pruneRevisions(2, ""), 1)
@@ -152,42 +324,251 @@ func TestPruneRevisions(t *testing.T) {
 	assert.Equals(t, tempmap["1-one"], (*RevInfo)(nil))
 	assert.Equals(t, tempmap["2-two"].Parent, "")
 
-	// Make sure leaves are never pruned: (note: by now 1-one is already gone)
-	assert.Equals(t, tempmap.pruneRevisions(1, ""), 1)
-	assert.Equals(t, len(tempmap), 3)
+	// Make sure leaves are never pruned:
+	assert.Equals(t, tempmap.pruneRevisions(1, ""), 2)
+	assert.Equals(t, len(tempmap), 2)
 	assert.True(t, tempmap["3-three"] != nil)
 	assert.Equals(t, tempmap["3-three"].Parent, "")
 	assert.True(t, tempmap["4-vier"] != nil)
-	assert.Equals(t, tempmap["4-vier"].Parent, "3-drei")
-	assert.Equals(t, tempmap["3-drei"].Parent, "")
+	assert.Equals(t, tempmap["4-vier"].Parent, "")
 
-	// Make sure old merged conflicts don't prevent pruning:
-	tempmap = branchymap.copy()
-	tempmap["4-vier"] = &RevInfo{ID: "4-vier", Parent: "3-drei", Deleted: true}
-	tempmap["4-four"] = &RevInfo{ID: "4-four", Parent: "3-three"}
-	tempmap["5-five"] = &RevInfo{ID: "5-five", Parent: "4-four"}
-	tempmap["6-six"] = &RevInfo{ID: "6-six", Parent: "5-five"}
-	//               / 3-three -- 4-four -- 5-five -- 6-six
-	// 1-one -- 2-two
-	//               \ 3-drei -- [4-vier]
-	assert.Equals(t, tempmap.pruneRevisions(3, "1-one"), 0)
-	assert.Equals(t, tempmap.pruneRevisions(3, "2-two"), 1)
-	assert.Equals(t, tempmap.pruneRevisions(3, ""), 3)
-	assert.Equals(t, len(tempmap), 4)
-	assert.Equals(t, tempmap.pruneRevisions(2, ""), 2)
-	assert.Equals(t, len(tempmap), 2)
-	assert.Equals(t, tempmap["5-five"].Parent, "")
-	assert.Equals(t, tempmap["6-six"].Parent, "5-five")
 
-	// Check what happens when all revs are deleted:
-	tempmap = branchymap.copy()
-	tempmap["3-three"].Deleted = true
-	tempmap["3-drei"].Deleted = true
-	//               / [3-three]
-	// 1-one -- 2-two
-	//               \ [3-drei]
-	assert.Equals(t, tempmap.pruneRevisions(3, ""), 0)
-	assert.Equals(t, tempmap.pruneRevisions(2, ""), 1)
+}
+
+
+func TestPruneRevsSingleBranch(t *testing.T) {
+
+	numRevs := 100
+
+	revTree := getMultiBranchTestRevtree1(numRevs, 0, []BranchSpec{})
+
+	maxDepth := uint32(20)
+	expectedNumPruned := numRevs - int(maxDepth)
+
+	numPruned := revTree.pruneRevisions(maxDepth, "")
+	assert.Equals(t, numPruned, expectedNumPruned)
+
+}
+
+func TestPruneRevsOneWinningOneNonwinningBranch(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 1,
+			Digest:                  "non-winning unresolved",
+			LastRevisionIsTombstone: false,
+		},
+	}
+
+	unconflictedBranchNumRevs := 2
+	winningBranchNumRevs := 4
+
+	revTree := getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, branchSpecs)
+
+	maxDepth := uint32(2)
+
+	revTree.pruneRevisions(maxDepth, "")
+
+	assert.Equals(t, revTree.LongestBranch(), int(maxDepth))
+
+
+}
+
+func TestPruneRevsOneWinningOneOldTombstonedBranch(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 1,
+			Digest:                  "non-winning tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+	}
+
+	unconflictedBranchNumRevs := 1
+	winningBranchNumRevs := 5
+
+	revTree := getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, branchSpecs)
+
+	maxDepth := uint32(2)
+
+	revTree.pruneRevisions(maxDepth, "")
+
+	assert.True(t, revTree.LongestBranch() == int(maxDepth))
+
+	// we shouldn't have any tombstoned branches, since the tombstoned branch was so old
+	// it should have been pruned away
+	assert.Equals(t, revTree.GenerationLongestTombstonedBranch(), 0)
+
+
+}
+
+func TestPruneRevsOneWinningOneOldAndOneRecentTombstonedBranch(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 1,
+			Digest:                  "non-winning low-gen tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+		{
+			NumRevs:                 4,
+			Digest:                  "non-winning high-gen tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+	}
+
+	unconflictedBranchNumRevs := 1
+	winningBranchNumRevs := 5
+
+	revTree := getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs, branchSpecs)
+
+	maxDepth := uint32(2)
+
+	revTree.pruneRevisions(maxDepth, "")
+
+	assert.True(t, revTree.LongestBranch() == int(maxDepth))
+
+	// the "non-winning high-gen tombstoned" branch should still be around, but pruned to maxDepth
+	tombstonedLeaves := revTree.GetTombstonedLeaves()
+	assert.Equals(t, len(tombstonedLeaves), 1)
+	tombstonedLeaf := tombstonedLeaves[0]
+
+	tombstonedBranch := revTree.getHistory(tombstonedLeaf)
+	assert.Equals(t, len(tombstonedBranch), int(maxDepth))
+
+	// The generation of the longest deleted branch is 97:
+	// 1 unconflictedBranchNumRevs
+	// +
+	// 4 revs in branchspec
+	// +
+	// 1 extra rev in branchspec since LastRevisionIsTombstone (that variable name is misleading)
+	expectedGenLongestTSd := 6
+	assert.Equals(t, revTree.GenerationLongestTombstonedBranch(), expectedGenLongestTSd)
+
+}
+
+
+
+func TestGenerationShortestNonTombstonedBranch(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 4,
+			Digest:                  "non-winning unresolved",
+			LastRevisionIsTombstone: false,
+		},
+		{
+			NumRevs:                 2,
+			Digest:                  "non-winning tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+	}
+
+	revTree := getMultiBranchTestRevtree1(3, 7, branchSpecs)
+
+	generationShortestNonTombstonedBranch := revTree.GenerationShortestNonTombstonedBranch()
+
+	// The "non-winning unresolved" branch has 7 revisions due to:
+	// 3 unconflictedBranchNumRevs
+	// +
+	// 4 from it's BranchSpec
+	// Since the "non-winning tombstoned" is a deleted branch, it will be ignored by GenerationShortestNonTombstonedBranch()
+	// Also, the winning branch has more revisions (10 total), and so will be ignored too
+	expectedGenerationShortestNonTombstonedBranch := 7
+
+	assert.Equals(t, generationShortestNonTombstonedBranch, expectedGenerationShortestNonTombstonedBranch)
+
+}
+
+
+func TestGenerationLongestTombstonedBranch(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 4,
+			Digest:                  "non-winning unresolved",
+			LastRevisionIsTombstone: false,
+		},
+		{
+			NumRevs:                 2,
+			Digest:                  "non-winning tombstoned #1",
+			LastRevisionIsTombstone: true,
+		},
+		{
+			NumRevs:                 100,
+			Digest:                  "non-winning tombstoned #2",
+			LastRevisionIsTombstone: true,
+		},
+	}
+
+	revTree := getMultiBranchTestRevtree1(3, 7, branchSpecs)
+	generationLongestTombstonedBranch := revTree.GenerationLongestTombstonedBranch()
+
+	// The generation of the longest deleted branch is:
+	// 3 unconflictedBranchNumRevs
+	// +
+	// 100 revs in branchspec
+	// +
+	// 1 extra rev in branchspec since LastRevisionIsTombstone (that variable name is misleading)
+	expectedGenerationLongestTombstonedBranch :=  3 + 100 + 1
+
+	assert.Equals(t, generationLongestTombstonedBranch, expectedGenerationLongestTombstonedBranch)
+
+
+}
+
+
+// Tests for updated pruning algorithm, post https://github.com/couchbase/sync_gateway/issues/2651
+func TestPruneRevisionsPostIssue2651ThreeBranches(t *testing.T) {
+
+	// Try large rev tree with multiple branches
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 60,
+			Digest:                  "non-winning unresolved",
+			LastRevisionIsTombstone: false,
+		},
+		{
+			NumRevs:                 25,
+			Digest:                  "non-winning tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+	}
+	revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
+
+	maxDepth := uint32(50)
+	numPruned := revTree.pruneRevisions(maxDepth, "")
+	fmt.Printf("numPruned: %v", numPruned)
+	fmt.Printf("LongestBranch: %v", revTree.LongestBranch())
+
+	assert.True(t, uint32(revTree.LongestBranch()) == maxDepth)
+
+}
+
+func TestLongestBranch1(t *testing.T) {
+
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 60,
+			Digest:                  "non-winning unresolved",
+			LastRevisionIsTombstone: false,
+		},
+		{
+			NumRevs:                 25,
+			Digest:                  "non-winning tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+	}
+	revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
+
+	assert.True(t, revTree.LongestBranch() == 150)
+
+}
+
+func TestLongestBranch2(t *testing.T) {
+
+	assert.True(t, multiroot.LongestBranch() == 3)
+
 }
 
 func TestParseRevisions(t *testing.T) {
@@ -237,7 +618,7 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 	assert.True(t, result)
 	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
 
-	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs,  []string{"3-walter", "3-louie", "1-fooey"}, 3)
+	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 3)
 	assert.True(t, result)
 	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
 
@@ -255,6 +636,37 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, nil, 2)
 	assert.True(t, result)
 	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey"}})
+}
+
+//////// BENCHMARK:
+
+func BenchmarkRevTreePruning(b *testing.B) {
+
+	// Try large rev tree with multiple branches
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 60,
+			Digest:                  "non-winning unresolved",
+			LastRevisionIsTombstone: false,
+		},
+		{
+			NumRevs:                 25,
+			Digest:                  "non-winning tombstoned",
+			LastRevisionIsTombstone: true,
+		},
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+
+		b.StopTimer()
+		revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
+		b.StartTimer()
+
+		revTree.pruneRevisions(50, "")
+	}
+
 }
 
 //////// HELPERS:
@@ -291,4 +703,54 @@ func assertFalse(t *testing.T, failure bool, message string) {
 	if failure {
 		assertFailed(t, message)
 	}
+}
+
+func addRevs(revTree RevTree, startingParentRevId string, numRevs int, revDigest string) {
+
+	docSizeBytes := 1024 * 5
+	body := createBodyContentAsMapWithSize(docSizeBytes)
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		panic(fmt.Sprintf("Error: %v", err))
+	}
+
+	channels := base.SetOf("ABC", "CBS")
+
+	generation, _ := ParseRevID(startingParentRevId)
+
+	for i := 0; i < numRevs; i++ {
+
+		newRevId := fmt.Sprintf("%v-%v", generation+1, revDigest)
+		parentRevId := ""
+		if i == 0 {
+			parentRevId = startingParentRevId
+		} else {
+			parentRevId = fmt.Sprintf("%v-%v", generation, revDigest)
+		}
+
+		revInfo := RevInfo{
+			ID:       newRevId,
+			Parent:   parentRevId,
+			Body:     bodyBytes,
+			Deleted:  false,
+			Channels: channels,
+		}
+		revTree.addRevision(revInfo)
+
+		generation += 1
+
+	}
+
+}
+
+// Create body content as map of 100 byte entries.  Rounds up to the nearest 100 bytes
+func createBodyContentAsMapWithSize(docSizeBytes int) map[string]string {
+
+	numEntries := int(docSizeBytes/100) + 1
+	body := make(map[string]string, numEntries)
+	for i := 0; i < numEntries; i++ {
+		key := fmt.Sprintf("field_%d", i)
+		body[key] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	}
+	return body
 }

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -296,20 +296,20 @@ func TestRevTreeWinningRev(t *testing.T) {
 func TestPruneRevisions(t *testing.T) {
 
 	tempmap := testmap.copy()
-	tempmap.computeDepths()
+	tempmap.computeDepthsAndFindLeaves()
 	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
 	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
 	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
 
 	tempmap = branchymap.copy()
-	tempmap.computeDepths()
+	tempmap.computeDepthsAndFindLeaves()
 	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
 	assert.Equals(t, tempmap["3-drei"].depth, uint32(1))
 	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
 	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
 
 	tempmap["4-vier"] = &RevInfo{ID: "4-vier", Parent: "3-drei"}
-	tempmap.computeDepths()
+	tempmap.computeDepthsAndFindLeaves()
 	assert.Equals(t, tempmap["4-vier"].depth, uint32(1))
 	assert.Equals(t, tempmap["3-drei"].depth, uint32(2))
 	assert.Equals(t, tempmap["3-three"].depth, uint32(1))


### PR DESCRIPTION
…ous doc update

Fixes #2651 

Notes:

- I left out the change to convert fmt.Sscanf() as mentioned in [this comment](https://github.com/couchbase/sync_gateway/issues/2651#issuecomment-309616077), because it seemed like a red herring.
- I put the `RenderGraphvizDot()` change in a [separate PR](https://github.com/couchbase/sync_gateway/pull/2670)

Passing unit tests against couchbase bucket jobs:

- [xattrs=true](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/117/parameters/)
- [xattrs=false](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/115/parameters/)
