### PR TITLE
Allow cbdatasource to reconnect to DCP stream

### DIFF
--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -120,10 +120,20 @@ func (r *DCPReceiver) GetOutput() chan sgbucket.TapEvent {
 }
 
 func (r *DCPReceiver) OnError(err error) {
-	Warn("Error processing DCP stream: %v", err)
+	Warn("Error processing DCP stream - will attempt to restart/reconnect: %v", err)
 
-	bucketName := "unknown" // this is currently ignored anyway
-	r.notify(bucketName, err)
+	// From cbdatasource:
+	//  Invoked in advisory fashion by the BucketDataSource when it
+	//  encounters an error.  The BucketDataSource will continue to try
+	//  to "heal" and restart connections, etc, as necessary.  The
+	//  Receiver has a recourse during these error notifications of
+	//  simply Close()'ing the BucketDataSource.
+
+	// Given this, we don't need to restart the feed/take the
+	// database offline, particularly since this only represents an error for a single
+	// vbucket stream, not the entire feed.
+	// bucketName := "unknown" // this is currently ignored anyway
+	// r.notify(bucketName, err)
 
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -222,7 +222,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		base.LogTo("Feed", "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import/bucketshadow)", bucket.GetName())
 		if err = context.tapListener.Start(bucket, options.TrackDocs, xattrImportNode, func(bucket string, err error) {
 
-			msg := fmt.Sprintf("%v lost Mutation (TAP/DCP) feed due to error: %v, taking offline", bucket, err)
+			msg := fmt.Sprintf("%v dropped Mutation Feed (TAP/DCP) due to error: %v, taking offline", bucket, err)
 			base.Warn(msg)
 			errTakeDbOffline := context.TakeDbOffline(msg)
 			if errTakeDbOffline == nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -352,7 +352,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	bucket, err := db.ConnectToBucket(spec, func(bucket string, err error) {
 
-		msg := fmt.Sprintf("%v lost Mutation (TAP/DCP) feed due to error: %v, taking offline", bucket, err)
+		msg := fmt.Sprintf("%v dropped Mutation feed (TAP/DCP) due to error: %v, taking offline", bucket, err)
 		base.Warn(msg)
 
 		if dc := sc.databases_[dbName]; dc != nil {


### PR DESCRIPTION
cbdatasource will automatically attempt to heal/restart after errors on the DCP stream - we shouldn't take the entire bucket offline.

Validated that cbdatasource immediately recovered from a full shutdown and restart of a Couchbase Server cluster.

Not the direct root cause of the panics in #2673 and #2674, but those appear to have been triggered by the db going offline in response to a DCP error.