### PR TITLE
Correct CAS retry handling for import based on import type

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -22,8 +22,9 @@ import (
 type sgErrorCode uint16
 
 const (
-	alreadyImported = sgErrorCode(0x00)
-	importCancelled = sgErrorCode(0x01)
+	alreadyImported  = sgErrorCode(0x00)
+	importCancelled  = sgErrorCode(0x01)
+	importCasFailure = sgErrorCode(0x02)
 )
 
 type SGError struct {
@@ -31,8 +32,9 @@ type SGError struct {
 }
 
 var (
-	ErrAlreadyImported = &SGError{alreadyImported}
-	ErrImportCancelled = &SGError{importCancelled}
+	ErrImportCancelled  = &SGError{importCancelled}
+	ErrAlreadyImported  = &SGError{alreadyImported}
+	ErrImportCasFailure = &SGError{importCasFailure}
 )
 
 func (e SGError) Error() string {
@@ -41,6 +43,8 @@ func (e SGError) Error() string {
 		return "Document already imported"
 	case importCancelled:
 		return "Import cancelled"
+	case importCasFailure:
+		return "CAS failure during import"
 	default:
 		return "Unknown error"
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -368,9 +368,13 @@ func (c *changeCache) DocChanged(event sgbucket.TapEvent) {
 						rawBody = nil
 					}
 					db := Database{DatabaseContext: c.context, user: nil}
-					_, err := db.ImportDocRaw(docID, rawBody, isDelete)
+					_, err := db.ImportDocRaw(docID, rawBody, isDelete, event.Cas, ImportFromFeed)
 					if err != nil {
-						base.Warn("Unable to import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", docID, err)
+						if err == base.ErrImportCasFailure {
+							base.LogTo("Import+", "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", docID)
+						} else {
+							base.Warn("Unable to import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", docID, err)
+						}
 					}
 				}
 				return

--- a/db/crud.go
+++ b/db/crud.go
@@ -62,7 +62,7 @@ func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
 			isDelete := rawDoc == nil
 			db := Database{DatabaseContext: db, user: nil}
 			var importErr error
-			doc, importErr = db.ImportDocRaw(docid, rawDoc, isDelete)
+			doc, importErr = db.ImportDocRaw(docid, rawDoc, isDelete, cas, ImportOnDemand)
 			if importErr != nil {
 				return nil, importErr
 			}
@@ -486,7 +486,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 			// Use an admin-scoped database for import
 			importDb := Database{DatabaseContext: db.DatabaseContext, user: nil}
 			var importErr error
-			doc, importErr = importDb.ImportDoc(docid, doc.body, isDelete)
+			doc, importErr = importDb.ImportDoc(docid, doc.body, isDelete, doc.Cas, ImportOnDemand)
 			if importErr != nil {
 				return nil, nil, importErr
 			}
@@ -547,7 +547,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 			// Use an admin-scoped database for import
 			importDb := Database{DatabaseContext: db.DatabaseContext, user: nil}
 			var importErr error
-			doc, importErr = importDb.ImportDoc(docid, doc.body, isDelete)
+			doc, importErr = importDb.ImportDoc(docid, doc.body, isDelete, doc.Cas, ImportOnDemand)
 			if importErr != nil {
 				return nil, nil, importErr
 			}
@@ -590,8 +590,15 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 	return err
 }
 
+type ImportMode uint8
+
+const (
+	ImportFromFeed = ImportMode(iota) // Feed-based import.  Attempt to import once - cancels import on cas write failure of the imported doc.
+	ImportOnDemand                    // On-demand import. Reattempt import on cas write failure of the imported doc until either the import succeeds, or existing doc is an SG write.
+)
+
 // Imports a document that was written by someone other than sync gateway.
-func (db *Database) ImportDocRaw(docid string, value []byte, isDelete bool) (docOut *document, err error) {
+func (db *Database) ImportDocRaw(docid string, value []byte, isDelete bool, cas uint64, mode ImportMode) (docOut *document, err error) {
 
 	var body Body
 	if isDelete {
@@ -604,10 +611,10 @@ func (db *Database) ImportDocRaw(docid string, value []byte, isDelete bool) (doc
 		}
 	}
 
-	return db.ImportDoc(docid, body, isDelete)
+	return db.ImportDoc(docid, body, isDelete, cas, mode)
 }
 
-func (db *Database) ImportDoc(docid string, body Body, isDelete bool) (docOut *document, err error) {
+func (db *Database) ImportDoc(docid string, body Body, isDelete bool, importCas uint64, mode ImportMode) (docOut *document, err error) {
 
 	base.LogTo("Import+", "Attempting to import doc %q...", docid)
 	var newRev string
@@ -635,6 +642,18 @@ func (db *Database) ImportDoc(docid string, body Body, isDelete bool) (docOut *d
 			return nil, nil, base.ErrAlreadyImported
 		}
 
+		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode
+		if doc.Cas != importCas {
+			// If this is a feed import, cancel on cas failure (doc has been updated )
+			if mode == ImportFromFeed {
+				return nil, nil, base.ErrImportCasFailure
+			}
+			// If this is an on-demand import, we want to switch to importing the current version doc
+			if mode == ImportOnDemand {
+				body = doc.body
+			}
+		}
+
 		// The active rev is the parent for an import
 		parentRev := doc.CurrentRev
 		generation, _ := ParseRevID(parentRev)
@@ -660,6 +679,9 @@ func (db *Database) ImportDoc(docid string, body Body, isDelete bool) (docOut *d
 		base.LogTo("Import+", "Imported %s (delete=%v) as rev %s", docid, isDelete, newRev)
 	case base.ErrImportCancelled:
 		// Import was cancelled (SG purge) - don't return error.
+	case base.ErrImportCasFailure:
+		// Import was cancelled due to CAS failure.
+		return nil, err
 	default:
 		base.LogTo("Import", "Error importing doc %q: %v", docid, err)
 		return nil, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -642,7 +642,8 @@ func (db *Database) ImportDoc(docid string, body Body, isDelete bool, importCas 
 			return nil, nil, base.ErrAlreadyImported
 		}
 
-		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode
+		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  This is an SDK write (since we checked
+		// for SG write above).  How to handle depends on import mode.
 		if doc.Cas != importCas {
 			// If this is a feed import, cancel on cas failure (doc has been updated )
 			if mode == ImportFromFeed {

--- a/db/document.go
+++ b/db/document.go
@@ -247,7 +247,7 @@ func (s *syncData) IsSGWrite(cas uint64) bool {
 func (doc *document) IsSGWrite() bool {
 	result := doc.syncData.IsSGWrite(doc.Cas)
 	if result == false {
-		base.LogTo("Import+", "Doc %s is not an SG write, based on cas. cas:%x syncCas:%q", doc.ID, doc.Cas, doc.syncData.Cas)
+		base.LogTo("CRUD+", "Doc %s is not an SG write, based on cas. cas:%x syncCas:%q", doc.ID, doc.Cas, doc.syncData.Cas)
 	}
 	return result
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7e4f6b042e7a829acc777edc07ffcb8efffcfb81"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b5185b1407e6893e3a871e1f4b76eed448ef6870"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="4aaaca921a7ef64900f3b569c33ad87e9e8df065"/>


### PR DESCRIPTION
Feed-based imports shouldn't be retried on CAS failures - the subsequent mutation will be imported if needed.

On-demand imports need to be retried on CAS failure, so that the subsequent SG operation is working against the correct version of the document.

Fixes #2672

Requires https://github.com/couchbaselabs/sync-gateway-accel/pull/152