### PR TITLE
Fix for on-demand import of SDK deletes

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -482,7 +482,17 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 		// If doc isn't an SG write, import it before updating.
 		if doc != nil && !doc.IsSGWrite() {
-			isDelete := doc.body == nil
+			// Check whether the doc requiring import is an SDK delete
+			isDelete := false
+			if doc.body == nil {
+				isDelete = true
+			} else {
+				deletedInBody, ok := body["_deleted"].(bool)
+				if ok {
+					isDelete = deletedInBody
+				}
+			}
+
 			// Use an admin-scoped database for import
 			importDb := Database{DatabaseContext: db.DatabaseContext, user: nil}
 			var importErr error


### PR DESCRIPTION
On-demand imports of SDK deletes weren't correctly identifying the document to be imported as a tombstone.  The subsequent attempt to import resulted in a malformed subdoc multi-mutation, returning an 'invalid arguments' error.

Fixes #2663