### PR TITLE
Feature/issue 2695 rev tree pruning tombstoned branch

### DIFF
--- a/db/revtree.go
+++ b/db/revtree.go
@@ -17,9 +17,9 @@ import (
 
 	"errors"
 
-	"github.com/couchbase/sync_gateway/base"
 	"bytes"
-	"log"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 type RevKey string
@@ -174,9 +174,6 @@ func (tree RevTree) GetLeaves() []string {
 	}
 	return tree.GetLeavesFiltered(acceptAllLeavesFilter)
 }
-
-
-
 
 func (tree RevTree) GetLeavesFiltered(filter func(revId string) bool) []string {
 
@@ -346,7 +343,7 @@ func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int)
 	// Calculate tombstoneGenerationThreshold
 	genShortestNonTSBranch, foundShortestNonTSBranch := tree.FindShortestNonTombstonedBranch()
 	tombstoneGenerationThreshold := -1
-	if (foundShortestNonTSBranch) {
+	if foundShortestNonTSBranch {
 		// Only set the tombstoneGenerationThreshold if a genShortestNonTSBranch was found.  (fixes #2695)
 		tombstoneGenerationThreshold = genShortestNonTSBranch - int(maxDepth)
 	}
@@ -369,7 +366,6 @@ func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int)
 			}
 		}
 	}
-
 
 	// If we have a valid tombstoneGenerationThreshold, delete any tombstoned branches that are too old
 	if tombstoneGenerationThreshold != -1 {
@@ -574,7 +570,6 @@ func (tree RevTree) RenderGraphvizDot() string {
 
 }
 
-
 //////// ENCODED REVISION LISTS (_revisions):
 
 // Parses a CouchDB _rev or _revisions property into a list of revision IDs
@@ -663,4 +658,3 @@ func trimEncodedRevisionsToAncestor(revs Body, ancestors []string, maxUnmatchedL
 	return true, trimmedRevs
 
 }
-

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"bytes"
+	"log"
 )
 
 type RevKey string
@@ -343,8 +344,12 @@ func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int)
 	}
 
 	// Calculate tombstoneGenerationThreshold
-	genShortestNonTSBranch := tree.FindShortestNonTombstonedBranch()
-	tombstoneGenerationThreshold := genShortestNonTSBranch - int(maxDepth)
+	genShortestNonTSBranch, foundShortestNonTSBranch := tree.FindShortestNonTombstonedBranch()
+	tombstoneGenerationThreshold := -1
+	if (foundShortestNonTSBranch) {
+		// Only set the tombstoneGenerationThreshold if a genShortestNonTSBranch was found.  (fixes #2695)
+		tombstoneGenerationThreshold = genShortestNonTSBranch - int(maxDepth)
+	}
 
 	// Delete nodes whose depth is greater than maxDepth:
 	for revid, node := range tree {
@@ -365,15 +370,18 @@ func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int)
 		}
 	}
 
-	// Delete any tombstoned branches that are too old
-	for _, leafRevId := range leaves {
-		leaf := tree[leafRevId]
-		if !leaf.Deleted { // Ignore non-tombstoned leaves
-			continue
-		}
-		leafGeneration, _ := ParseRevID(leaf.ID)
-		if leafGeneration < tombstoneGenerationThreshold {
-			pruned += tree.DeleteBranch(leaf)
+
+	// If we have a valid tombstoneGenerationThreshold, delete any tombstoned branches that are too old
+	if tombstoneGenerationThreshold != -1 {
+		for _, leafRevId := range leaves {
+			leaf := tree[leafRevId]
+			if !leaf.Deleted { // Ignore non-tombstoned leaves
+				continue
+			}
+			leafGeneration, _ := ParseRevID(leaf.ID)
+			if leafGeneration < tombstoneGenerationThreshold {
+				pruned += tree.DeleteBranch(leaf)
+			}
 		}
 	}
 
@@ -425,13 +433,15 @@ func (tree RevTree) computeDepthsAndFindLeaves() (maxDepth uint32, leaves []stri
 // Find the minimum generation that has a non-deleted leaf.  For example in this rev tree:
 //   http://cbmobile-bucket.s3.amazonaws.com/diagrams/example-sync-gateway-revtrees/three_branches.png
 // The minimim generation that has a non-deleted leaf is "7-non-winning unresolved"
-func (tree RevTree) FindShortestNonTombstonedBranch() (generation int) {
+func (tree RevTree) FindShortestNonTombstonedBranch() (generation int, found bool) {
 	return tree.FindShortestNonTombstonedBranchFromLeaves(tree.GetLeaves())
 }
 
-func (tree RevTree) FindShortestNonTombstonedBranchFromLeaves(leaves []string) (generation int) {
+func (tree RevTree) FindShortestNonTombstonedBranchFromLeaves(leaves []string) (generation int, found bool) {
 
+	found = false
 	genShortestNonTSBranch := math.MaxInt32
+
 	for _, revid := range leaves {
 
 		revInfo := tree[revid]
@@ -442,9 +452,10 @@ func (tree RevTree) FindShortestNonTombstonedBranchFromLeaves(leaves []string) (
 		gen := genOfRevID(revid)
 		if gen > 0 && gen < genShortestNonTSBranch {
 			genShortestNonTSBranch = gen
+			found = true
 		}
 	}
-	return genShortestNonTSBranch
+	return genShortestNonTSBranch, found
 }
 
 // Find the generation of the longest deleted branch.  For example in this rev tree:

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbaselabs/go.assert"
+	"log"
 )
 
 // 1-one -- 2-two -- 3-three
@@ -336,6 +337,9 @@ func TestPruneRevisions(t *testing.T) {
 }
 
 
+
+
+
 func TestPruneRevsSingleBranch(t *testing.T) {
 
 	numRevs := 100
@@ -466,7 +470,7 @@ func TestGenerationShortestNonTombstonedBranch(t *testing.T) {
 
 	revTree := getMultiBranchTestRevtree1(3, 7, branchSpecs)
 
-	generationShortestNonTombstonedBranch := revTree.FindShortestNonTombstonedBranch()
+	generationShortestNonTombstonedBranch, _ := revTree.FindShortestNonTombstonedBranch()
 
 	// The "non-winning unresolved" branch has 7 revisions due to:
 	// 3 unconflictedBranchNumRevs
@@ -542,6 +546,33 @@ func TestPruneRevisionsPostIssue2651ThreeBranches(t *testing.T) {
 	fmt.Printf("LongestBranch: %v", revTree.LongestBranch())
 
 	assert.True(t, uint32(revTree.LongestBranch()) == maxDepth)
+
+}
+
+func TestPruneRevsSingleTombstonedBranch(t *testing.T) {
+
+	numRevsTotal := 100
+	numRevsDeletedBranch := 99
+	branchSpecs := []BranchSpec{
+		{
+			NumRevs:                 numRevsDeletedBranch,
+			Digest:                  "single-tombstoned-branch",
+			LastRevisionIsTombstone: true,
+		},
+	}
+
+	revTree := getMultiBranchTestRevtree1(1, 0, branchSpecs)
+
+	maxDepth := uint32(20)
+	expectedNumPruned := numRevsTotal - int(maxDepth)
+
+	expectedNumPruned += 1  // To account for the tombstone revision in the branchspec, which is spearate from NumRevs
+
+	numPruned := revTree.pruneRevisions(maxDepth, "")
+
+	log.Printf("RevTreeAfter pruning: %v", revTree.RenderGraphvizDot())
+
+	assert.Equals(t, numPruned, expectedNumPruned)
 
 }
 


### PR DESCRIPTION
Fixes #2695

https://github.com/couchbase/sync_gateway/issues/2695#issuecomment-311761617 explains the bug.

## Unit tests against couchbase server bucket (in progress)

- [build-sync-gateway/134](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/134/)
- [build-sync-gateway/135](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/135/)

## Functional test re-run (pending)

- http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-base-cc/790/

@sethrosetter can you check the pending functional test [cen7-sync-gateway-functional-tests-base-cc/790](http://uberjenkins.sc.couchbase.com:8080/job/cen7-sync-gateway-functional-tests-base-cc/790/) and see if that looks correct? 