### PR TITLE
Implemented "no-conflicts" mode

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -33,8 +33,8 @@ const (
 	DefaultTestShadowPassword   = DefaultTestPassword
 
 	DefaultTestIndexBucketname = "test_indexbucket"
-	DefaultTestIndexUsername = DefaultTestIndexBucketname
-	DefaultTestIndexPassword = DefaultTestPassword
+	DefaultTestIndexUsername   = DefaultTestIndexBucketname
+	DefaultTestIndexPassword   = DefaultTestPassword
 
 	// Env variable to enable user to override the Couchbase Server URL used in tests
 	TestEnvCouchbaseServerUrl = "SG_TEST_COUCHBASE_SERVER_URL"
@@ -50,7 +50,8 @@ const (
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"
 
-	DefaultUseXattrs = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config
 
 )
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -481,6 +481,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 	}
 
 	return db.updateDoc(docid, true, expiry, func(doc *document) (Body, AttachmentData, error) {
+		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		// If doc isn't an SG write, import it before updating.
 		if doc != nil && !doc.IsSGWrite() {
@@ -504,7 +505,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 			}
 		}
 
-		// (Be careful: this block can be invoked multiple times if there are races!)
 		// First, make sure matchRev matches an existing leaf revision:
 		if matchRev == "" {
 			matchRev = doc.CurrentRev
@@ -517,7 +517,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 				generation, _ = ParseRevID(matchRev)
 				generation++
 			}
-		} else if !doc.History.isLeaf(matchRev) {
+		} else if !doc.History.isLeaf(matchRev) || (!db.AllowConflicts() && matchRev != doc.CurrentRev) {
 			return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 		}
 
@@ -552,6 +552,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 	}
 
 	_, err = db.updateDoc(docid, true, expiry, func(doc *document) (Body, AttachmentData, error) {
+		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		// If doc isn't an SG write, import it before updating.
 		if doc != nil && !doc.IsSGWrite() {
@@ -565,7 +566,6 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 			}
 		}
 
-		// (Be careful: this block can be invoked multiple times if there are races!)
 		// Find the point where this doc's history branches from the current rev:
 		currentRevIndex := len(docHistory)
 		parent := ""
@@ -579,6 +579,18 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 		if currentRevIndex == 0 {
 			base.LogTo("CRUD+", "PutExistingRev(%q): No new revisions to add", docid)
 			return nil, nil, couchbase.UpdateCancel // No new revisions to add
+		}
+
+		if !db.AllowConflicts() {
+			// Conflict-free mode: If doc exists, its current rev must be the new rev's parent...
+			if parent != doc.CurrentRev && doc.CurrentRev != "" {
+				if len(docHistory) == 1 && doc.History[doc.CurrentRev].Deleted {
+					// ...unless the doc is currently deleted and the new rev has no parent.
+					parent = doc.CurrentRev
+				} else {
+					return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
+				}
+			}
 		}
 
 		// Add all the new-to-me revisions to the rev tree:
@@ -1377,4 +1389,40 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 		}
 	}
 	return
+}
+
+// Status code returned by CheckProposedRev
+type ProposedRevStatus int
+
+const (
+	ProposedRev_OK       ProposedRevStatus = 0   // Rev can be added without conflict
+	ProposedRev_Exists   ProposedRevStatus = 304 // Rev already exists locally
+	ProposedRev_Conflict ProposedRevStatus = 409 // Rev would cause conflict
+	ProposedRev_Error    ProposedRevStatus = 500 // Error occurred reading local doc
+)
+
+// Given a docID/revID to be pushed by a client, check whether it can be added _without conflict_.
+// This is used by the BLIP replication code in "allow_conflicts=false" mode.
+func (db *Database) CheckProposedRev(docid string, revid string, parentRevID string) ProposedRevStatus {
+	doc, err := db.GetDoc(docid)
+	if err != nil {
+		if !base.IsDocNotFoundError(err) {
+			base.Warn("CheckProposedRev(%q) --> %T %v", docid, err, err)
+			return ProposedRev_Error
+		}
+		// Doc doesn't exist locally; adding it is OK (even if it has a history)
+		return ProposedRev_OK
+	} else if doc.CurrentRev == revid {
+		// Proposed rev already exists here:
+		return ProposedRev_Exists
+	} else if doc.CurrentRev == parentRevID {
+		// Proposed rev's parent is my current revision; OK to add:
+		return ProposedRev_OK
+	} else if parentRevID == "" && doc.History[doc.CurrentRev].Deleted {
+		// Proposed rev has no parent and doc is currently deleted; OK to add:
+		return ProposedRev_OK
+	} else {
+		// Parent revision mismatch, so this is a conflict:
+		return ProposedRev_Conflict
+	}
 }

--- a/db/database.go
+++ b/db/database.go
@@ -108,6 +108,7 @@ type UnsupportedOptions struct {
 	Replicator2      bool                    `json:"replicator_2,omitempty"`       // Enable new replicator (_blipsync)
 	OidcTestProvider OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
 	EnableXattr      *bool                   `json:"enable_extended_attributes"`   // Use xattr for _sync
+	AllowConflicts   *bool                   `json:"allow_conflicts"`              // False forbids creating conflicts
 }
 
 // Represents a simulated CouchDB database. A new instance is created for each HTTP request,
@@ -1217,6 +1218,13 @@ func (context *DatabaseContext) UseXattrs() bool {
 func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 
 	context.Options.UnsupportedOptions.UserViews.Enabled = &value
+}
+
+func (context *DatabaseContext) AllowConflicts() bool {
+	if context.Options.UnsupportedOptions.AllowConflicts != nil {
+		return *context.Options.UnsupportedOptions.AllowConflicts
+	}
+	return base.DefaultAllowConflicts
 }
 
 //////// SEQUENCE ALLOCATION:

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -514,6 +514,77 @@ func TestConflicts(t *testing.T) {
 		branched: true})
 }
 
+func TestNoConflictsMode(t *testing.T) {
+
+	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
+		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Error: https://gist.github.com/tleyden/3549e4010abff88f2531706887c67271")
+	}
+
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+	// Strictly speaking, this flag should be set before opening the database, but it only affects
+	// Put operations and replication, so it doesn't make a difference if we do it afterwards.
+	db.Options.UnsupportedOptions.AllowConflicts = base.BooleanPointer(false)
+
+	/*
+		var logKeys = map[string]bool {
+			"Cache": true,
+			"Changes": true,
+			"Changes+": true,
+		}
+
+		base.UpdateLogKeys(logKeys, true)
+	*/
+
+	// Create revs 1 and 2 of "doc":
+	body := Body{"n": 1, "channels": []string{"all", "1"}}
+	assertNoError(t, db.PutExistingRev("doc", body, []string{"1-a"}), "add 1-a")
+	body["n"] = 2
+	assertNoError(t, db.PutExistingRev("doc", body, []string{"2-a", "1-a"}), "add 2-a")
+
+	// Try to create a conflict branching from rev 1:
+	err := db.PutExistingRev("doc", body, []string{"2-b", "1-a"})
+	assertHTTPError(t, err, 409)
+
+	// Try to create a conflict with no common ancestor:
+	err = db.PutExistingRev("doc", body, []string{"2-c", "1-c"})
+	assertHTTPError(t, err, 409)
+
+	// Try to create a conflict with a longer history:
+	err = db.PutExistingRev("doc", body, []string{"4-d", "3-d", "2-d", "1-a"})
+	assertHTTPError(t, err, 409)
+
+	// Try to create a conflict with no history:
+	err = db.PutExistingRev("doc", body, []string{"1-e"})
+	assertHTTPError(t, err, 409)
+
+	// Create a non-conflict with a longer history, ending in a deletion:
+	body["_deleted"] = true
+	assertNoError(t, db.PutExistingRev("doc", body, []string{"4-a", "3-a", "2-a", "1-a"}), "add 4-a")
+	delete(body, "_deleted")
+
+	// Create a non-conflict with no history (re-creating the document):
+	assertNoError(t, db.PutExistingRev("doc", body, []string{"1-f"}), "add 1-f")
+
+	// Create a new document with a longer history:
+	assertNoError(t, db.PutExistingRev("COD", body, []string{"4-a", "3-a", "2-a", "1-a"}), "add COD")
+	delete(body, "_deleted")
+
+	// Now use Put instead of PutExistingRev:
+
+	// Successfully add a new revision:
+	_, err = db.Put("doc", Body{"_rev": "1-f", "foo": -1})
+	assertNoError(t, err, "Put rev after 1-f")
+
+	// Try to create a conflict:
+	_, err = db.Put("doc", Body{"_rev": "3-a", "foo": 7})
+	assertHTTPError(t, err, 409)
+
+	// Conflict with no ancestry:
+	_, err = db.Put("doc", Body{"foo": 7})
+	assertHTTPError(t, err, 409)
+}
+
 func TestSyncFnOnPush(t *testing.T) {
 	db := setupTestDB(t)
 	defer tearDownTestDB(t, db)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -437,6 +437,14 @@ func (bh *blipHandler) sendRevision(seq db.SequenceID, docID string, revID strin
 	outrq := blip.NewRequest()
 	outrq.SetProfile("rev")
 	seqJSON, _ := json.Marshal(seq)
+	outrq.Properties["id"] = docID
+	delete(body, "_id")
+	outrq.Properties["rev"] = revID
+	delete(body, "_rev")
+	if del, _ := body["_deleted"].(bool); del {
+		outrq.Properties["deleted"] = "1"
+		delete(body, "deleted")
+	}
 	outrq.Properties["sequence"] = string(seqJSON)
 	if len(history) > 0 {
 		outrq.Properties["history"] = strings.Join(history, ",")
@@ -463,10 +471,14 @@ func (bh *blipHandler) handleAddRevision(rq *blip.Message) error {
 		return err
 	}
 
-	docID, found := body["_id"].(string)
-	revID, rfound := body["_rev"].(string)
+	// Doc metadata comes from the BLIP message metadata, not magic document properties:
+	docID, found := rq.Properties["id"]
+	revID, rfound := rq.Properties["rev"]
 	if !found || !rfound {
-		return base.HTTPErrorf(http.StatusBadRequest, "Missing doc _id or _rev")
+		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or revID")
+	}
+	if del, found := rq.Properties["deleted"]; found && del != "0" && del != "false" {
+		body["_deleted"] = true // (PutExistingRev expects deleted flag in the body)
 	}
 
 	history := []string{revID}


### PR DESCRIPTION
* Added unsupported flag "allow_conflicts", which defaults to true.
* When flag is set to false, Database.Put and Database.PutExistingRev will fail with a conflict (409) status if the new revision isn't a child of the current revision.
* Unit tests for PutExistingRev and Put
* Implemented BLIP replicator [protocol changes](https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges) for no-conflicts mode
* Other minor changes to update to latest BLIP replication protocol

(It's probably best to look at the 3 commits individually.)

Fixes #2709