### PR TITLE
Uptake gocbc-210 changes to atomically delete doc + xattrs

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -985,7 +985,7 @@ func (bucket CouchbaseBucketGoCB) DeleteAndUpdateXattr(k string, xattrKey string
 	// This is the only use case for macro expansion today - if more cases turn up, should change the sg-bucket API to handle this more generically.
 	xattrCasProperty := fmt.Sprintf("%s.cas", xattrKey)
 	worker := func() (shouldRetry bool, err error, value interface{}) {
-
+		
 		docFragment, removeErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(exp)).
 			UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                 // Update the xattr
 			UpsertEx(xattrCasProperty, "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
@@ -994,7 +994,7 @@ func (bucket CouchbaseBucketGoCB) DeleteAndUpdateXattr(k string, xattrKey string
 
 		if removeErr != nil {
 			shouldRetry = isRecoverableGoCBError(removeErr)
-			return shouldRetry, err, uint64(0)
+			return shouldRetry, removeErr, uint64(0)
 		}
 		return false, nil, uint64(docFragment.Cas())
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -979,6 +979,45 @@ func (bucket CouchbaseBucketGoCB) WriteCasWithXattr(k string, xattrKey string, e
 	return cas, err
 }
 
+// CAS-safe delete of a document, and update of it's corresponding xattr
+func (bucket CouchbaseBucketGoCB) DeleteAndUpdateXattr(k string, xattrKey string, exp int, cas uint64, xv interface{}) (casOut uint64, err error) {
+
+	// WriteCasWithXattr always stamps the xattr with the new cas using macro expansion, into a top-level property called 'cas'.
+	// This is the only use case for macro expansion today - if more cases turn up, should change the sg-bucket API to handle this more generically.
+	xattrCasProperty := fmt.Sprintf("%s.cas", xattrKey)
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+
+		docFragment, removeErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
+			UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                 // Update the xattr
+			UpsertEx(xattrCasProperty, "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+			RemoveEx("", gocb.SubdocFlagNone).                                                            // Delete the document body
+			Execute()
+
+		if removeErr != nil {
+			shouldRetry = isRecoverableGoCBError(removeErr)
+			return shouldRetry, err, uint64(0)
+		}
+		return false, nil, uint64(docFragment.Cas())
+	}
+
+	// Kick off retry loop
+	description := fmt.Sprintf("DeleteAndUpdateXattr with key %v", k)
+	err, result := RetryLoop(description, worker, bucket.spec.RetrySleeper())
+
+	// If the retry loop returned a nil result, set to 0 to prevent type assertion on nil error
+	if result == nil {
+		result = uint64(0)
+	}
+
+	// Type assertion of result
+	cas, ok := result.(uint64)
+	if !ok {
+		return 0, fmt.Errorf("DeleteAndUpdateXattr: Error doing type assertion of %v into a uint64,  Key: %v", result, k)
+	}
+
+	return cas, err
+}
+
 // Retrieve a document and it's associated named xattr
 func (bucket CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, rv interface{}, xv interface{}) (cas uint64, err error) {
 
@@ -1349,47 +1388,17 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 		// If this is a tombstone, we want to delete the document and update the xattr
 		if deleteDoc {
 
-			LogTo("CRUD+", "gocb WriteUpdateWithXattr() deleteDoc=true, going to call MutateInEx for key: %v", k)
-
-			// TODO: review subdoc flags -- same as TestXattrDeleteDocumentAndUpdateXATTR
-
-			// TODO: should this be gocb.SubdocDocFlagReplaceDoc|gocb.SubdocDocFlagAccessDeleted instead?
-			// TODO: leaving as-is for now, since it matches flags used in TestXattrDeleteDocumentAndUpdateXATTR
-
-			// flags := gocb.SubdocDocFlagReplaceDoc|gocb.SubdocDocFlagAccessDeleted -- fails with xattr: invalid arguments
-			// flags := gocb.SubdocDocFlagNone // -- passes local smoke test and functional test, but what about doc ressurection?  Don't we need SubdocDocFlagAccessDeleted?
-
-			flags := gocb.SubdocDocFlagAccessDeleted // passes local smoke test with doc ressurrection and purging
-
-			docFragment, mutateErr := bucket.Bucket.MutateInEx(k, flags, gocb.Cas(cas), uint32(0)).
-				UpsertEx(xattrKey, updatedXattrValue, gocb.SubdocFlagXattr).                             // Update the xattr
-				UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
-				RemoveEx("", gocb.SubdocFlagNone).                                                       // Delete the document body
-				Execute()
-
-			casOut := emptyCas
-
-			if mutateErr == nil {
-				// Successful
-				casOut = uint64(docFragment.Cas())
-			} else if mutateErr == gocb.ErrKeyNotFound {
-				// Document body has already been removed
-				// TODO: what should we do in this case?
-				Warn("MutateInEx returned mutateErr == gocb.ErrKeyNotFound for key: %v", k)
-				return emptyCas, mutateErr
-			} else if isRecoverableGoCBError(mutateErr) {
-				// Recoverable error - retry WriteUpdateWithXattr
-				continue
-			} else {
-				// Non-recoverable error - return
-				Warn("MutateInEx returned Non-recoverable error for key: %v.  Err: %v", k, mutateErr)
-
-				return emptyCas, mutateErr
+			deleteCas, deleteErr := bucket.DeleteAndUpdateXattr(k, xattrKey, exp, cas, updatedXattrValue)
+			switch deleteErr {
+			case nil:
+				return deleteCas, deleteErr
+			case gocb.ErrKeyExists:
+				continue // Retry on CAS failure
+			default:
+				// DeleteAndUpdateXattr already does retry on recoverable errors, so return any error here
+				LogTo("CRUD", "Delete and update of xattr during WriteUpdateWithXattr failed for key %s: %v", k, deleteErr)
+				return emptyCas, deleteErr
 			}
-
-			LogTo("CRUD+", "called bucket.WriteCasWithXattr() with key: %v, xattrkey: %v.  casOut: %v writeErr: %v", k, xattrKey, casOut, writeErr)
-
-			return casOut, nil
 
 		} else {
 			// Not a delete - update the body and xattr

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -986,7 +986,7 @@ func (bucket CouchbaseBucketGoCB) DeleteAndUpdateXattr(k string, xattrKey string
 	xattrCasProperty := fmt.Sprintf("%s.cas", xattrKey)
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 
-		docFragment, removeErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
+		docFragment, removeErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(exp)).
 			UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                 // Update the xattr
 			UpsertEx(xattrCasProperty, "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
 			RemoveEx("", gocb.SubdocFlagNone).                                                            // Delete the document body

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1092,8 +1092,12 @@ func (bucket CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, rv int
 
 }
 
-// Delete doc + xattrs -- called for Purge operations
-// The doc can be in any of these states
+
+// Delete a document and it's associated named xattr.  Couchbase server will preserve system xattrs as part of the (CBS)
+// tombstone when a document is deleted.  To remove the system xattr as well, an explicit subdoc delete operation is required.
+// This is currently called only for Purge operations.
+//
+// The doc existing doc is expected to be in one of the following states:
 //   - DocExists and XattrExists
 //   - DocExists but NoXattr
 //   - XattrExists but NoDoc

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1789,7 +1789,7 @@ func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 		panic(fmt.Sprintf("Expected empty bucket"))
 	}
 
-	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+	// Create w/ doc and XATTR
 	cas := uint64(0)
 	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
 	if err != nil {
@@ -1798,7 +1798,7 @@ func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 
 	flags := gocb.SubdocDocFlagAccessDeleted
 
-	// Soft-delete (tombstone)
+	// Create tombstone revision which deletes doc body but preserves XATTR
 	_, mutateErr := bucket.Bucket.MutateInEx(key, flags, gocb.Cas(cas), uint32(0)).
 		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                     // Update the xattr
 		UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1253,6 +1253,99 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 }
 
+
+
+// Validates deletion of doc + xattr in various possible previous states of the document.
+func TestXattrDeleteDocAndXattr(t *testing.T) {
+
+	SkipXattrTestsIfNotEnabled(t)
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	key1 := "DocExistsXattrExists"
+	key2 := "DocExistsNoXattr"
+	key3 := "XattrExistsNoDoc"
+	key4 := "NoDocNoXattr"
+
+	// 1. Create document with XATTR
+	val := make(map[string]interface{})
+	val["type"] = key1
+
+	xattrName := "_sync"
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	var err error
+
+	// Create w/ XATTR
+	cas1 := uint64(0)
+	cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// 2. Create document with no XATTR
+	val = make(map[string]interface{})
+	val["type"] = key2
+	_, err = bucket.Bucket.Insert(key2, val, uint32(0))
+
+	// 3. Xattr, no document
+	val = make(map[string]interface{})
+	val["type"] = key3
+
+	xattrVal = make(map[string]interface{})
+	xattrVal["seq"] = 456
+	xattrVal["rev"] = "1-1234"
+
+	// Create w/ XATTR
+	cas3int := uint64(0)
+	cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+	// Delete the doc body
+	var cas3 gocb.Cas
+	cas3, err = bucket.Bucket.Remove(key3, 0)
+	if err != nil {
+		t.Errorf("Error removing doc body: %+v.  Cas: %v", err, cas3)
+	}
+
+	// 4. No xattr, no document
+	updatedVal := make(map[string]interface{})
+	updatedVal["type"] = "updated"
+
+	updatedXattrVal := make(map[string]interface{})
+	updatedXattrVal["seq"] = 123
+	updatedXattrVal["rev"] = "2-1234"
+
+	// Attempt to delete all 4 docs
+	keys := []string{key1, key2, key3, key4}
+	for _, key := range keys {
+		errDelete := bucket.DeleteWithXattr(key, xattrName)
+		assertNoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+		assertTrue(t, verifyDocAndXattrDeleted(bucket, key, xattrName), "Expected doc to be deleted")
+	}
+
+
+
+}
+
+func verifyDocAndXattrDeleted(bucket *CouchbaseBucketGoCB, key, xattrName string) bool {
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if err != gocbcore.ErrKeyNotFound {
+		return false
+	}
+	return true
+}
+
 // TestXattrDeleteDocumentWithXattr.  Delete document and XATTR, ensure it's not available
 // Todo: add equivalent of TestXattrMutateDocAndXattr  (combine a few existing tests)
 func TestXattrDeleteDocumentWithXattr(t *testing.T) {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1326,8 +1326,9 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 	updatedXattrVal["seq"] = 123
 	updatedXattrVal["rev"] = "2-1234"
 
-	// Attempt to delete all 4 docs
-	keys := []string{key1, key2, key3, key4}
+	// Attempt to delete DocExistsXattrExists, DocExistsNoXattr, and XattrExistsNoDoc
+	// No errors should be returned when deleting these.
+	keys := []string{key1, key2, key3}
 	for _, key := range keys {
 		log.Printf("Deleting key: %v", key)
 		errDelete := bucket.DeleteWithXattr(key, xattrName)
@@ -1335,9 +1336,13 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 		assertTrue(t, verifyDocAndXattrDeleted(bucket, key, xattrName), "Expected doc to be deleted")
 	}
 
+	// Now attempt to delete key4 (NoDocNoXattr), which is expected to return a Key Not Found error
+	log.Printf("Deleting key: %v", key4)
+	errDelete := bucket.DeleteWithXattr(key4, xattrName)
+	assertTrue(t, bucket.IsKeyNotFoundError(errDelete), "Exepcted keynotfound error")
+	assertTrue(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
 
 }
-
 
 
 // This simulates a race condition by calling deleteWithXattrInternal() and passing a custom

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1253,7 +1253,7 @@ func TestXattrDeleteDocumentWithXattr(t *testing.T) {
 }
 
 // TestXattrDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Pending https://issues.couchbase.com/browse/MB-24098
-func TestXattrDeleteDocumentAndUpdateXATTR(t *testing.T) {
+func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1287,8 +1287,7 @@ func TestXattrDeleteDocumentAndUpdateXATTR(t *testing.T) {
 		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
 	}
 
-	// TODO: review flags.  Looks like invalid use to & these together, will end up with 0 (or was that intention?)
-	_, mutateErr := bucket.Bucket.MutateInEx(key, gocb.SubdocDocFlagReplaceDoc&gocb.SubdocDocFlagAccessDeleted, gocb.Cas(cas), uint32(0)).
+	_, mutateErr := bucket.Bucket.MutateInEx(key, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
 		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                     // Update the xattr
 		UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
 		RemoveEx("", gocb.SubdocFlagNone).                                                       // Delete the document body

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1347,7 +1347,7 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 
 // This simulates a race condition by calling deleteWithXattrInternal() and passing a custom
 // callback function
-func TestDeleteWithXattrWithSimulatedRaceRessurect(t *testing.T) {
+func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1224,8 +1224,7 @@ func TestXattrDeleteDocumentWithXattr(t *testing.T) {
 	key := "TestDeleteDocumentAndXATTR"
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		bucket.Delete(key)
+		t.Fatalf("Key should not exist yet, expected error but got nil.")
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
@@ -1245,7 +1244,8 @@ func TestXattrDeleteDocumentWithXattr(t *testing.T) {
 	// Verify delete of body and XATTR
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	cas, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	log.Printf("GetWithXattr returned cas: %v err: %v", cas, err)
 	if err != gocbcore.ErrKeyNotFound {
 		t.Errorf("Unexpected error calling GetWithXattr: %+v", err)
 	}
@@ -1254,8 +1254,6 @@ func TestXattrDeleteDocumentWithXattr(t *testing.T) {
 
 // TestXattrDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Pending https://issues.couchbase.com/browse/MB-24098
 func TestXattrDeleteDocumentAndUpdateXATTR(t *testing.T) {
-
-	t.Skip("Failing, see https://github.com/couchbase/sync_gateway/issues/2561#issuecomment-305330059")
 
 	SkipXattrTestsIfNotEnabled(t)
 
@@ -1289,6 +1287,7 @@ func TestXattrDeleteDocumentAndUpdateXATTR(t *testing.T) {
 		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
 	}
 
+	// TODO: review flags.  Looks like invalid use to & these together, will end up with 0 (or was that intention?)
 	_, mutateErr := bucket.Bucket.MutateInEx(key, gocb.SubdocDocFlagReplaceDoc&gocb.SubdocDocFlagAccessDeleted, gocb.Cas(cas), uint32(0)).
 		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                     // Update the xattr
 		UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
@@ -1304,6 +1303,159 @@ func TestXattrDeleteDocumentAndUpdateXATTR(t *testing.T) {
 	assert.Equals(t, retrievedXattr["seq"], float64(123))
 	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
 	log.Printf("MutateInEx cas: %v", mutateCas)
+
+}
+
+func TestSoftDeleteFollowedByHardDelete(t *testing.T) {
+
+
+	SkipXattrTestsIfNotEnabled(t)
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// Create document with XATTR
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	key := "TestSoftDeleteFollowedByPurge"
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		t.Fatalf("Expected empty bucket")
+	}
+
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	// flags := gocb.SubdocDocFlagNone  // Passes
+	flags := gocb.SubdocDocFlagAccessDeleted  // With this, get Unexpected error calling DeleteWithXattr(): key not found
+	// flags := gocb.SubdocDocFlagReplaceDoc&gocb.SubdocDocFlagAccessDeleted // With this, also get Unexpected error calling DeleteWithXattr(): key not found
+	// flags := gocb.SubdocDocFlagReplaceDoc|gocb.SubdocDocFlagAccessDeleted // With this, get Unexpected mutateErr: invalid arguments -- could be due to not ordering xattr ops before normal ops
+
+	_, mutateErr := bucket.Bucket.MutateInEx(key, flags, gocb.Cas(cas), uint32(0)).
+		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                     // Update the xattr
+		UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+		RemoveEx("", gocb.SubdocFlagNone).                                                       // Delete the document body
+		Execute()
+
+	log.Printf("MutateInEx error: %v", mutateErr)
+	assertNoError(t, mutateErr, "Unexpected mutateErr")
+
+	// Verify delete of body and XATTR
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	mutateCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	log.Printf("retrievedVal: %+v", retrievedVal)
+	assert.Equals(t, len(retrievedVal), 0)
+	assert.Equals(t, retrievedXattr["seq"], float64(123))
+	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
+	log.Printf("MutateInEx cas: %v", mutateCas)
+
+	err = bucket.DeleteWithXattr(key, xattrName)
+	assertNoError(t, err, "Unexpected error calling DeleteWithXattr()")
+
+	getCas, getErr := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	log.Printf("GetWithXattr returned cas: %v err: %v", getCas, getErr)
+	if getErr != gocbcore.ErrKeyNotFound {
+		t.Errorf("Unexpected error calling GetWithXattr: %+v", getErr)
+	}
+
+
+}
+
+
+// This simulates a race condition by calling deleteWithXattrInternal() and passing a custom
+// callback function, which has the effect of deleting the doc body in between the "check status"
+// and the mutation phase of deleteWithXattrInternal()
+func TestDeleteWithXattrInternal(t *testing.T) {
+
+	SkipXattrTestsIfNotEnabled(t)
+
+	b := GetBucketOrPanic()
+	bucket, ok := b.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+	// Create document with XATTR
+	xattrName := "_sync"
+	val := make(map[string]interface{})
+	val["body_field"] = "1234"
+
+	xattrVal := make(map[string]interface{})
+	xattrVal["seq"] = 123
+	xattrVal["rev"] = "1-1234"
+
+	key := "TestDeleteWithXattrInternal"
+	_, _, err := bucket.GetRaw(key)
+	if err == nil {
+		t.Fatalf("Expected empty bucket")
+	}
+
+	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+	cas := uint64(0)
+	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+	if err != nil {
+		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+	}
+
+	numTimesCalledBack := 0
+	callback := func(b CouchbaseBucketGoCB, k string, xattrKey string, bodyExists, xattrsExist bool) {
+
+		//// Delete doc (what does this do about xattrs?)
+		//_, err := bucket.Remove(key, cas)
+		//assertNoError(t, err, "Unexpected error removing doc from bucket")
+
+		// Only want the callback to execute once.  Should be called multiple times (twice) due to expected
+		// cas failure due to using stale cas
+		if numTimesCalledBack >= 1 {
+			return
+		}
+		numTimesCalledBack += 1
+
+		// Delete the doc body, but preserve xattrs
+		flags := gocb.SubdocDocFlagAccessDeleted // passes local smoke test with doc ressurrection and purging
+
+		updatedDoc, mutateErr := bucket.Bucket.MutateInEx(k, flags, gocb.Cas(cas), uint32(0)).
+			UpsertEx(xattrKey, xattrVal, gocb.SubdocFlagXattr).                             // Keep the same xattr
+			UpsertEx("_sync.cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+			RemoveEx("", gocb.SubdocFlagNone).                                                       // Delete the document body
+			Execute()
+
+		assertNoError(t, mutateErr, "Got unexpected mutateErr tryng to delete doc body")
+
+		log.Printf("Updated doc after deleting doc body.  Cas: %v", updatedDoc.Cas())
+
+
+
+	}
+
+	deleteErr := bucket.deleteWithXattrInternal(key, xattrName, callback)
+	assertNoError(t, deleteErr, "Unexpected error calling DeleteWithXattr()")
+
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, getErr := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	if getErr != gocbcore.ErrKeyNotFound {
+		t.Errorf("Unexpected error calling GetWithXattr: %+v", getErr)
+	}
+	log.Printf("retrievedXattr: %+v", retrievedXattr)
+	assert.True(t, len(retrievedXattr) == 0)
+
 
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -241,6 +241,11 @@ func TestGetDeleted(t *testing.T) {
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
+	// Get the raw doc and make sure the sync data has the current revision
+	doc, err := db.GetDoc("doc1")
+	assertNoError(t, err, "Err getting doc")
+	assert.Equals(t, doc.syncData.CurrentRev, rev2id)
+	
 	// Try again but with a user who doesn't have access to this revision (see #179)
 	authenticator := auth.NewAuthenticator(db.Bucket, db)
 	db.user, err = authenticator.GetUser("")

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -58,9 +58,9 @@
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="98e48116286caa5c3ba06d9bb197f94498c97e89"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="bf740f17ea6cd6a1bbd5ca3583266c8f74692524"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="0cd63ba8b594091ea0005ec50ee21299e0b22d97"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="cfd05d858efb2899132a1bf18cba441ca307cc78"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="6b3fcad8ac5e2212fad55e57d481cb056b99f3c0"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -88,7 +88,7 @@
 
   <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
 
-  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="7006f7a1abbda37f3276216302f9eb7425e1dfa5"/>
+  <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
 
   <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
 


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/2681 + https://github.com/couchbase/sync_gateway/issues/2648

Still remaining before this can get merged:

- [x] [gocbc-210 changes](http://review.couchbase.org/#/c/80076/) Must be merged to gocb master
- [x] Update manifest to point to changes
- [x] Resolve test failure mentioned in https://github.com/couchbase/sync_gateway/pull/2721#issuecomment-316540807
- [x] [Passing unit/integration tests against xattr-enabled Couchbase Server bucket](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/145/parameters/)
- [x] [Passing unit/integration tests against non-xattr Couchbase Server bucket](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/146/parameters/)
- [x] [Passing functional test re-run](https://github.com/couchbase/sync_gateway/pull/2721#issuecomment-316793008)