### PR TITLE
Fix view parameter for import

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1025,7 +1025,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 	options := Body{"stale": false, "reduce": false}
 	if !doCurrentDocs {
 		options["endkey"] = []interface{}{true}
-		options["endkey_inclusive"] = false // TODO: is this valid?  See https://forums.couchbase.com/t/is-the-endkey-inclusive-view-option-still-valid/12784
+		options["inclusive_end"] = false
 	} else if !doImportDocs {
 		options["startkey"] = []interface{}{true}
 	}


### PR DESCRIPTION
View parameter was incorrectly named for existing import functionality - switched to `inclusive_end`.

Fixes #2728 
