### PR TITLE
Temporarily disable single-op tombstone

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1413,10 +1413,34 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 		var writeErr error
 		// If this is a tombstone, we want to delete the document and update the xattr
 		if deleteDoc {
-			deleteBody := len(value) > 0
-			if deleteBody {
-				LogTo("CRUD+", "WriteUpdateWithXattr attempting to delete body and update the xattr for key=%s. Existing value: %s", k, value)
+			removeCas, removeErr := bucket.Remove(k, cas)
+			if removeErr == nil {
+				// Successful removal - update the cas for the xattr operation
+				cas = removeCas
+			} else if removeErr == gocb.ErrKeyNotFound {
+				// Document body has already been removed - continue to xattr processing w/ same cas
+			} else if isRecoverableGoCBError(removeErr) {
+				// Recoverable error - retry WriteUpdateWithXattr
+				continue
+			} else {
+				// Non-recoverable error - return
+				return emptyCas, removeErr
 			}
+
+			// update xattr only
+			casOut, writeErr := bucket.WriteCasWithXattr(k, xattrKey, exp, cas, nil, updatedXattrValue)
+			if writeErr != nil && writeErr != gocb.ErrKeyExists && !isRecoverableGoCBError(writeErr) {
+				LogTo("CRUD", "Update of new value during WriteUpdateWithXattr failed for key %s: %v", k, writeErr)
+				return emptyCas, writeErr
+			}
+
+			// If there was no error, we're done
+			if writeErr == nil {
+				return casOut, nil
+			}
+
+			/* Temporarily disable single-op tombstoning until we have fix for https://issues.couchbase.com/browse/MB-25422
+			deleteBody := len(value) > 0
 			deleteCas, deleteErr := bucket.UpdateXattr(k, xattrKey, exp, cas, updatedXattrValue, deleteBody)
 			switch deleteErr {
 			case nil:
@@ -1428,6 +1452,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 				LogTo("CRUD", "Delete and update of xattr during WriteUpdateWithXattr failed for key %s: %v", k, deleteErr)
 				return emptyCas, deleteErr
 			}
+			*/
 
 		} else {
 			// Not a delete - update the body and xattr

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -85,3 +85,8 @@ func changesViewOptions(channelName string, endSeq uint64, options ChangesOption
 	}
 	return optMap
 }
+
+// Public channel view call - for unit test support
+func (dbc *DatabaseContext) ChannelViewTest(channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
+	return dbc.getChangesInChannelFromView(channelName, endSeq, options)
+}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -333,4 +334,74 @@ func TestXattrDoubleDelete(t *testing.T) {
 	assert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
+}
+
+func TestViewTombstoneRetrieval(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{SyncFn: `
+		function(doc, oldDoc) { channel(doc.channels) }`}
+	defer rt.Close()
+
+	log.Printf("Starting get bucket....")
+
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+
+	// 1. Create and import docs
+	key := "SG_delete"
+	docBody := make(map[string]interface{})
+	docBody["test"] = key
+	docBody["channels"] = "ABC"
+
+	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"channels":"ABC"}`)
+	assert.Equals(t, response.Code, 201)
+	log.Printf("insert response: %s", response.Body.Bytes())
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId := body["rev"].(string)
+
+	sdk_key := "SDK_delete"
+	docBody = make(map[string]interface{})
+	docBody["test"] = sdk_key
+	docBody["channels"] = "ABC"
+
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", sdk_key), `{"channels":"ABC"}`)
+	assert.Equals(t, response.Code, 201)
+	log.Printf("insert response: %s", response.Body.Bytes())
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+
+	// 2. Delete SDK_delete through the SDK
+	log.Printf("...............Delete through SDK.....................................")
+	deleteErr := bucket.Delete(sdk_key)
+	assertNoError(t, deleteErr, "Couldn't delete via SDK")
+
+	// Trigger import via SG retrieval
+	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", sdk_key), "")
+	assert.Equals(t, response.Code, 404) // expect 404 deleted
+
+	// 3.  Delete SG_delete through SG.
+	log.Printf("...............Delete through SG.......................................")
+	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
+	assert.Equals(t, response.Code, 200)
+	log.Printf("delete response: %s", response.Body.Bytes())
+	json.Unmarshal(response.Body.Bytes(), &body)
+	assert.Equals(t, body["ok"], true)
+	revId = body["rev"].(string)
+
+	log.Printf("TestXattrDeleteDCPMutation done")
+
+	// Attempt to retrieve via view.  Above operations were all synchronous (on-demand import of SDK delete, SG delete), so
+	// stale=false view results should be immediately updated.
+	results, err := rt.GetDatabase().ChannelViewTest("ABC", 1000, db.ChangesOptions{})
+	assertNoError(t, err, "Error issuing channel view query")
+	for _, entry := range results {
+		log.Printf("Got view result: %v", entry)
+	}
+	assert.Equals(t, len(results), 2)
+	assertTrue(t, strings.HasPrefix(results[0].RevID, "2-") && strings.HasPrefix(results[1].RevID, "2-"), "Unexpected revisions in view results post-delete")
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -336,7 +336,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 }
 
-func TestViewTombstoneRetrieval(t *testing.T) {
+func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 


### PR DESCRIPTION
Need to disable single-op tombstone until they are properly indexed by the view engine. (https://issues.couchbase.com/browse/MB-25422)