### PR TITLE
Updated addRevision to return error instead of panicking

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -25,6 +25,7 @@ const (
 	alreadyImported  = sgErrorCode(0x00)
 	importCancelled  = sgErrorCode(0x01)
 	importCasFailure = sgErrorCode(0x02)
+	importRevFailure = sgErrorCode(0x04)
 )
 
 type SGError struct {
@@ -32,6 +33,7 @@ type SGError struct {
 }
 
 var (
+	ErrImportRevFailure = &SGError{importRevFailure}
 	ErrImportCancelled  = &SGError{importCancelled}
 	ErrAlreadyImported  = &SGError{alreadyImported}
 	ErrImportCasFailure = &SGError{importCasFailure}
@@ -45,6 +47,8 @@ func (e SGError) Error() string {
 		return "Import cancelled"
 	case importCasFailure:
 		return "CAS failure during import"
+	case importRevFailure:
+		return "CAS failure during Rev import"
 	default:
 		return "Unknown error"
 	}

--- a/base/error.go
+++ b/base/error.go
@@ -48,7 +48,7 @@ func (e SGError) Error() string {
 	case importCasFailure:
 		return "CAS failure during import"
 	case importRevFailure:
-		return "CAS failure during Rev import"
+		return "Failure during Rev import"
 	default:
 		return "Unknown error"
 	}

--- a/base/error.go
+++ b/base/error.go
@@ -25,7 +25,7 @@ const (
 	alreadyImported  = sgErrorCode(0x00)
 	importCancelled  = sgErrorCode(0x01)
 	importCasFailure = sgErrorCode(0x02)
-	importRevFailure = sgErrorCode(0x04)
+	revTreeAddRevFailure = sgErrorCode(0x04)
 )
 
 type SGError struct {
@@ -33,7 +33,7 @@ type SGError struct {
 }
 
 var (
-	ErrImportRevFailure = &SGError{importRevFailure}
+	ErrRevTreeAddRevFailure = &SGError{revTreeAddRevFailure}
 	ErrImportCancelled  = &SGError{importCancelled}
 	ErrAlreadyImported  = &SGError{alreadyImported}
 	ErrImportCasFailure = &SGError{importCasFailure}
@@ -47,8 +47,8 @@ func (e SGError) Error() string {
 		return "Import cancelled"
 	case importCasFailure:
 		return "CAS failure during import"
-	case importRevFailure:
-		return "Failure during Rev import"
+	case revTreeAddRevFailure:
+		return "Failure adding Rev to RevTree"
 	default:
 		return "Unknown error"
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -456,7 +456,7 @@ func (db *Database) initializeSyncData(doc *document) (err error) {
 	body["_rev"] = doc.CurrentRev
 	doc.setFlag(channels.Deleted, false)
 	doc.History = make(RevTree)
-	if err = doc.History.addRevision(RevInfo{ID: doc.CurrentRev, Parent: "", Deleted: false}); err != nil {
+	if err = doc.History.addRevision(doc.ID, RevInfo{ID: doc.CurrentRev, Parent: "", Deleted: false}); err != nil {
 		return err
 	}
 	if db.writeSequences() {
@@ -533,9 +533,9 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 		// Make up a new _rev, and add it to the history:
 		newRev := createRevID(generation, matchRev, body)
 		body["_rev"] = newRev
-		if err := doc.History.addRevision(RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
-			base.LogTo("Import+", "Import failed to add revision ID: %s, error: %v", newRev, err)
-			return nil, nil, base.ErrImportRevFailure
+		if err := doc.History.addRevision(docid, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
+			base.LogTo("CRUD", "Failed to add revision ID: %s, error: %v", newRev, err)
+			return nil, nil, base.ErrRevTreeAddRevFailure
 		}
 
 		return body, newAttachments, nil
@@ -589,10 +589,13 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 
 		// Add all the new-to-me revisions to the rev tree:
 		for i := currentRevIndex - 1; i >= 0; i-- {
-			if err := doc.History.addRevision(RevInfo{
-				ID:      docHistory[i],
-				Parent:  parent,
-				Deleted: (i == 0 && deleted)}); err != nil {
+			err := doc.History.addRevision(docid,
+				RevInfo{
+					ID:      docHistory[i],
+					Parent:  parent,
+					Deleted: (i == 0 && deleted)})
+
+			if err != nil {
 				return nil, nil, err
 			}
 			parent = docHistory[i]
@@ -682,9 +685,8 @@ func (db *Database) ImportDoc(docid string, body Body, isDelete bool, importCas 
 		newRev = createRevID(generation, parentRev, body)
 		base.LogTo("Import", "Created new rev ID %v", newRev)
 		body["_rev"] = newRev
-		if err := doc.History.addRevision(RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete}); err != nil {
-			base.LogTo("Import+", "Import failed to add revision ID: %s, error: %v", newRev, err)
-			return nil, nil, base.ErrImportRevFailure
+		if err := doc.History.addRevision(docid, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete}); err != nil {
+			return nil, nil, base.ErrRevTreeAddRevFailure
 		}
 
 		// During import, oldDoc (doc.Body) is nil (since it's no longer available)
@@ -705,9 +707,6 @@ func (db *Database) ImportDoc(docid string, body Body, isDelete bool, importCas 
 		// Import was cancelled (SG purge) - don't return error.
 	case base.ErrImportCasFailure:
 		// Import was cancelled due to CAS failure.
-		return nil, err
-	case base.ErrImportRevFailure:
-		// Import was cancelled due to Rev import failure.
 		return nil, err
 	default:
 		base.LogTo("Import", "Error importing doc %q: %v", docid, err)

--- a/db/crud.go
+++ b/db/crud.go
@@ -456,7 +456,9 @@ func (db *Database) initializeSyncData(doc *document) (err error) {
 	body["_rev"] = doc.CurrentRev
 	doc.setFlag(channels.Deleted, false)
 	doc.History = make(RevTree)
-	doc.History.addRevision(RevInfo{ID: doc.CurrentRev, Parent: "", Deleted: false})
+	if err = doc.History.addRevision(RevInfo{ID: doc.CurrentRev, Parent: "", Deleted: false}); err != nil {
+		return err
+	}
 	if db.writeSequences() {
 		doc.Sequence, err = db.sequences.nextSequence()
 	}
@@ -531,7 +533,11 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 		// Make up a new _rev, and add it to the history:
 		newRev := createRevID(generation, matchRev, body)
 		body["_rev"] = newRev
-		doc.History.addRevision(RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted})
+		if err := doc.History.addRevision(RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
+			base.LogTo("Import+", "Import failed to add revision ID: %s, error: %v", newRev, err)
+			return nil, nil, base.ErrImportRevFailure
+		}
+
 		return body, newAttachments, nil
 	})
 }
@@ -583,10 +589,12 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 
 		// Add all the new-to-me revisions to the rev tree:
 		for i := currentRevIndex - 1; i >= 0; i-- {
-			doc.History.addRevision(RevInfo{
+			if err := doc.History.addRevision(RevInfo{
 				ID:      docHistory[i],
 				Parent:  parent,
-				Deleted: (i == 0 && deleted)})
+				Deleted: (i == 0 && deleted)}); err != nil {
+				return nil, nil, err
+			}
 			parent = docHistory[i]
 		}
 

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -260,19 +260,19 @@ func (tree RevTree) findAncestorFromSet(revid string, ancestors []string) string
 }
 
 // Records a revision in a RevTree.
-func (tree RevTree) addRevision(info RevInfo) (err error) {
+func (tree RevTree) addRevision(docid string, info RevInfo) (err error) {
 	revid := info.ID
 	if revid == "" {
-		err = errors.New("empty revid is illegal")
+		err = errors.New(fmt.Sprintf("doc: %v, RevTree addRevision, empty revid is illegal",docid))
 		return
 	}
 	if tree.contains(revid) {
-		err = errors.New(fmt.Sprintf("already contains rev %q", revid))
+		err = errors.New(fmt.Sprintf("doc: %v, RevTree addRevision, already contains rev %q", docid, revid))
 		return
 	}
 	parent := info.Parent
 	if parent != "" && !tree.contains(parent) {
-		err = errors.New(fmt.Sprintf("parent id %q is missing", parent))
+		err = errors.New(fmt.Sprintf("doc: %v, RevTree addRevision, parent id %q is missing", docid, parent))
 		return
 	}
 	tree[revid] = &info

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -260,19 +260,23 @@ func (tree RevTree) findAncestorFromSet(revid string, ancestors []string) string
 }
 
 // Records a revision in a RevTree.
-func (tree RevTree) addRevision(info RevInfo) {
+func (tree RevTree) addRevision(info RevInfo) (err error) {
 	revid := info.ID
 	if revid == "" {
-		panic("empty revid is illegal")
+		err = errors.New("empty revid is illegal")
+		return
 	}
 	if tree.contains(revid) {
-		panic(fmt.Sprintf("already contains rev %q", revid))
+		err = errors.New(fmt.Sprintf("already contains rev %q", revid))
+		return
 	}
 	parent := info.Parent
 	if parent != "" && !tree.contains(parent) {
-		panic(fmt.Sprintf("parent id %q is missing", parent))
+		err = errors.New(fmt.Sprintf("parent id %q is missing", parent))
+		return
 	}
 	tree[revid] = &info
+	return nil
 }
 
 func (tree RevTree) getRevisionBody(revid string) ([]byte, bool) {

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -266,7 +266,7 @@ func TestRevTreeAddRevisionWithEmptyID(t *testing.T) {
 	assert.DeepEquals(t, tempmap, testmap)
 
 	err := tempmap.addRevision("testdoc", RevInfo{Parent: "3-three"})
-	assert.DeepEquals(t, err, errors.New("empty revid is illegal"))
+	assert.DeepEquals(t, err, errors.New(fmt.Sprintf("doc: %v, RevTree addRevision, empty revid is illegal","testdoc")))
 }
 
 func TestRevTreeAddDuplicateRevID(t *testing.T) {
@@ -274,7 +274,7 @@ func TestRevTreeAddDuplicateRevID(t *testing.T) {
 	assert.DeepEquals(t, tempmap, testmap)
 
 	err := tempmap.addRevision("testdoc", RevInfo{ID: "2-two", Parent: "1-one"})
-	assert.DeepEquals(t, err, errors.New(fmt.Sprintf("already contains rev %q", "2-two")))
+	assert.DeepEquals(t, err, errors.New(fmt.Sprintf("doc: %v, RevTree addRevision, already contains rev %q", "testdoc", "2-two")))
 }
 
 func TestRevTreeAddRevisionWithMissingParent(t *testing.T) {
@@ -282,7 +282,7 @@ func TestRevTreeAddRevisionWithMissingParent(t *testing.T) {
 	assert.DeepEquals(t, tempmap, testmap)
 
 	err := tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four"})
-	assert.DeepEquals(t, err, errors.New(fmt.Sprintf("parent id %q is missing", "4-four")))
+	assert.DeepEquals(t, err, errors.New(fmt.Sprintf("doc: %v, RevTree addRevision, parent id %q is missing", "testdoc", "4-four")))
 }
 
 func TestRevTreeCompareRevIDs(t *testing.T) {

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -134,7 +134,9 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 				base.Warn("Shadow: Adding revision as conflict branch, parent id %q is missing", parentRev)
 				parentRev = ""
 			}
-			doc.History.addRevision(RevInfo{ID: newRev, Parent: parentRev, Deleted: isDeletion})
+			if err = doc.History.addRevision(RevInfo{ID: newRev, Parent: parentRev, Deleted: isDeletion}); err != nil {
+				return nil, nil, err
+			}
 			base.LogTo("Shadow", "Pulling %q, CAS=%x --> rev %q", key, cas, newRev)
 		} else {
 			// We already have this rev; but don't cancel, because we do need to update the

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -134,7 +134,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 				base.Warn("Shadow: Adding revision as conflict branch, parent id %q is missing", parentRev)
 				parentRev = ""
 			}
-			if err = doc.History.addRevision(RevInfo{ID: newRev, Parent: parentRev, Deleted: isDeletion}); err != nil {
+			if err = doc.History.addRevision(doc.ID, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDeletion}); err != nil {
 				return nil, nil, err
 			}
 			base.LogTo("Shadow", "Pulling %q, CAS=%x --> rev %q", key, cas, newRev)


### PR DESCRIPTION
fixes #2568 
fixes #2261
Updated addRevision to return error instead of panicing and handle error in calling code.