### PR TITLE
Add RetryLoopTimeout — related to #2639

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -273,6 +273,8 @@ type RetrySleeper func(retryCount int) (shouldContinue bool, timeTosleepMs int)
 // even if it returns shouldRetry = true.
 type RetryWorker func() (shouldRetry bool, err error, value interface{})
 
+type TimeoutWorker func()
+
 func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (error, interface{}) {
 
 	numAttempts := 1
@@ -298,6 +300,84 @@ func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (er
 		<-time.After(time.Millisecond * time.Duration(sleepMs))
 
 		numAttempts += 1
+
+	}
+}
+
+
+type WorkerResult struct {
+	ShouldRetry bool
+	Error error
+	Value interface{}
+}
+
+func (w WorkerResult) Unwrap() (ShouldRetry bool, Error error, Value interface{}) {
+	return w.ShouldRetry, w.Error, w.Value
+}
+
+func WrapRetryWorkerTimeout(worker RetryWorker, timeoutPerInvocation time.Duration) (timeoutWorker TimeoutWorker, resultChan chan WorkerResult) {
+
+	resultChan = make(chan WorkerResult)
+
+	timeoutWorker = func() {
+
+		shouldRetry, err, value := worker()
+
+		result := WorkerResult{
+			ShouldRetry: shouldRetry,
+			Error: err,
+			Value: value,
+		}
+		resultChan <- result
+
+	}
+
+	return timeoutWorker, resultChan
+
+}
+
+func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleeper, timeoutPerInvocation time.Duration) (error, interface{}) {
+
+	numAttempts := 1
+
+	for {
+
+		// Wrap the retry worker into a "timeout worker" function that can be run async and will write it's
+		// result to a channel
+		timeoutWorker, chWorkerResult := WrapRetryWorkerTimeout(worker, timeoutPerInvocation)
+
+		// Kick off the timeout worker in it's own goroutine
+		go timeoutWorker()
+
+		// Wait for either the timeout worker to send it's result on the channel, or for the timeout to expire
+		select {
+
+		case workerResult := <- chWorkerResult:
+			shouldRetry, err, value := workerResult.Unwrap()
+
+			if !shouldRetry {
+				if err != nil {
+					return err, nil
+				}
+				return nil, value
+			}
+			shouldContinue, sleepMs := sleeper(numAttempts)
+			if !shouldContinue {
+				if err == nil {
+					err = fmt.Errorf("RetryLoop for %v giving up after %v attempts", description, numAttempts)
+				}
+				Warn("RetryLoop for %v giving up after %v attempts", description, numAttempts)
+				return err, value
+			}
+			LogTo("Debug", "RetryLoop retrying %v after %v ms.", description, sleepMs)
+
+			<-time.After(time.Millisecond * time.Duration(sleepMs))
+
+			numAttempts += 1
+
+		case <- time.After(timeoutPerInvocation):
+			return fmt.Errorf("Invocation timeout after waiting %v for worker to complete", timeoutPerInvocation), nil
+		}
 
 	}
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/couchbaselabs/go.assert"
 	"net/url"
+	"time"
+	"strings"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -137,6 +139,61 @@ func TestRetryLoop(t *testing.T) {
 	assert.True(t, numTimesInvoked == 4)
 
 }
+
+
+// Make sure that the RetryLoopTimeout doesn't break existing RetryLoop functionality
+func TestRetryLoopTimeoutSafe(t *testing.T) {
+
+	numTimesInvoked := 0
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		log.Printf("Worker invoked")
+		numTimesInvoked += 1
+		if numTimesInvoked <= 3 {
+			log.Printf("Worker returning shouldRetry true, fake error")
+			return true, fmt.Errorf("Fake error"), nil
+		}
+		return false, nil, "result"
+	}
+
+	sleeper := func(numAttempts int) (bool, int) {
+		if numAttempts > 10 {
+			return false, -1
+		}
+		return true, 0
+	}
+
+	// Kick off retry loop
+	description := fmt.Sprintf("TestRetryLoop")
+	err, result := RetryLoopTimeout(description, worker, sleeper, time.Hour)
+
+	// We shouldn't get an error, because it will retry a few times and then succeed
+	assert.True(t, err == nil)
+	assert.Equals(t, result, "result")
+	assert.True(t, numTimesInvoked == 4)
+
+}
+
+// Make sure that the RetryLoopTimeout enforces timeout on worker functions that block for too long
+func TestRetryLoopTimeoutEffective(t *testing.T) {
+
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		// The laziest worker ever .. sleeps for a week before returning a value
+		time.Sleep(time.Hour * 24 * 7)
+		return false, nil, "result"
+	}
+
+	sleeper := CreateDoublingSleeperFunc(10, 100)
+
+	// Kick off timeout loop that expects lazy worker to return in 100 ms, even though it takes a week
+	description := fmt.Sprintf("TestRetryLoop")
+	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond * 100)
+
+	// We should get a timeout error
+	assert.True(t, err != nil)
+	assert.True(t, strings.Contains(err.Error(), "timeout"))
+
+}
+
 
 func TestSyncSourceFromURL(t *testing.T) {
 	u, err := url.Parse("http://www.test.com:4985/mydb")


### PR DESCRIPTION
This is a generic addition to the `RetryLoop` functionality, that adds timeout functionality.  

I'm putting up this PR as a reminder that this needs to get merged to master once https://github.com/couchbase/sync_gateway/pull/2746 is merged to the `release/1.4.1.1` branch.

For 1.4.1, needs to be a go-couchbase variant of https://github.com/couchbase/sync_gateway/pull/2746

