### PR TITLE
Feature/issue 2639 release 1411 backport better view errmsg

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"log"
 	"time"
 
 	"github.com/couchbase/go-couchbase"

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -133,12 +133,9 @@ func (bucket CouchbaseBucket) ViewCustom(ddoc, name string, params map[string]in
 		return shouldRetry, err, nil
 	}
 
-	// Set NumRetries to 1, since before the change to override ViewCustom, it was passing through directly
-	// to the go-couchbase ViewCustom.
-	maxNumRetries := 1
 	sleeper := CreateDoublingSleeperFunc(
-		maxNumRetries,
-		bucket.spec.InitialRetrySleepTimeMS, // Since MaxNumRetries is 0, this is ignored
+		bucket.spec.MaxNumRetries,
+		bucket.spec.InitialRetrySleepTimeMS,
 	)
 
 	// Kick off retry loop with a timeout

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -144,10 +144,9 @@ func (bucket CouchbaseBucket) ViewCustom(ddoc, name string, params map[string]in
 	timeout := time.Second * 75 // Same timeout as gocb default view query timeout
 	err, _ := RetryLoopTimeout(description, worker, sleeper, timeout)
 
-	// If it's a timeout error, return a specific error string
-	if err != nil && strings.Contains(err.Error(), "timeout") {
-		return fmt.Errorf("Timeout performing ViewQuery.  This could indicate that views are still reindexing. "+
-			" Underlying error: %v", err)
+	// If it's a timeout error, return a specific error
+	if err != nil && err == ErrRetryTimeoutError {
+		return ErrViewTimeoutError
 	}
 
 	return err
@@ -181,9 +180,8 @@ func (bucket CouchbaseBucket) View(ddoc, name string, params map[string]interfac
 	err, result := RetryLoopTimeout(description, worker, sleeper, timeout)
 
 	// If it's a timeout error, return a specific error string
-	if err != nil && strings.Contains(err.Error(), "timeout") {
-		return sgbucket.ViewResult{}, fmt.Errorf("Timeout performing ViewQuery.  This could indicate that views are still reindexing. "+
-			" Underlying error: %v", err)
+	if err != nil && err == ErrRetryTimeoutError {
+		return sgbucket.ViewResult{}, ErrViewTimeoutError
 	}
 
 	if err != nil {

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -122,7 +122,7 @@ func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.W
 
 func (bucket CouchbaseBucket) ViewCustom(ddoc, name string, params map[string]interface{}, vres interface{}) error {
 
-	// Wrap in a worker function to leverage RetryLoopTimeout, even though it doesn't actually retry
+	// RetryLoopTimeout worker function
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 
 		err = bucket.Bucket.ViewCustom(ddoc, name, params, &vres)

--- a/base/util.go
+++ b/base/util.go
@@ -344,6 +344,7 @@ func WrapRetryWorkerTimeout(worker RetryWorker, timeoutPerInvocation time.Durati
 
 }
 
+// Retry loop with a timeout.  The timeout is per individual worker invocation
 func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleeper, timeoutPerInvocation time.Duration) (error, interface{}) {
 
 	numAttempts := 1

--- a/base/util.go
+++ b/base/util.go
@@ -322,7 +322,7 @@ func (w WorkerResult) Unwrap() (ShouldRetry bool, Error error, Value interface{}
 	return w.ShouldRetry, w.Error, w.Value
 }
 
-func WrapRetryWorkerTimeout(worker RetryWorker, timeoutPerInvocation time.Duration) (timeoutWorker TimeoutWorker, resultChan chan WorkerResult) {
+func WrapRetryWorkerTimeout(worker RetryWorker) (timeoutWorker TimeoutWorker, resultChan chan WorkerResult) {
 
 	resultChan = make(chan WorkerResult)
 
@@ -352,7 +352,7 @@ func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleep
 
 		// Wrap the retry worker into a "timeout worker" function that can be run async and will write it's
 		// result to a channel
-		timeoutWorker, chWorkerResult := WrapRetryWorkerTimeout(worker, timeoutPerInvocation)
+		timeoutWorker, chWorkerResult := WrapRetryWorkerTimeout(worker)
 
 		// Kick off the timeout worker in it's own goroutine
 		go timeoutWorker()

--- a/base/util.go
+++ b/base/util.go
@@ -384,7 +384,8 @@ func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleep
 			numAttempts += 1
 
 		case <-time.After(timeoutPerInvocation):
-			return fmt.Errorf("Invocation timeout after waiting %v for worker to complete", timeoutPerInvocation), nil
+			Warn("RetryLoopTimeout() timeout after waiting %v for %v worker to complete", description, timeoutPerInvocation)
+			return ErrRetryTimeoutError, nil
 		}
 
 	}

--- a/base/util.go
+++ b/base/util.go
@@ -312,11 +312,10 @@ func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (er
 	}
 }
 
-
 type WorkerResult struct {
 	ShouldRetry bool
-	Error error
-	Value interface{}
+	Error       error
+	Value       interface{}
 }
 
 func (w WorkerResult) Unwrap() (ShouldRetry bool, Error error, Value interface{}) {
@@ -333,8 +332,8 @@ func WrapRetryWorkerTimeout(worker RetryWorker, timeoutPerInvocation time.Durati
 
 		result := WorkerResult{
 			ShouldRetry: shouldRetry,
-			Error: err,
-			Value: value,
+			Error:       err,
+			Value:       value,
 		}
 		resultChan <- result
 
@@ -361,7 +360,7 @@ func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleep
 		// Wait for either the timeout worker to send it's result on the channel, or for the timeout to expire
 		select {
 
-		case workerResult := <- chWorkerResult:
+		case workerResult := <-chWorkerResult:
 			shouldRetry, err, value := workerResult.Unwrap()
 
 			if !shouldRetry {
@@ -384,7 +383,7 @@ func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleep
 
 			numAttempts += 1
 
-		case <- time.After(timeoutPerInvocation):
+		case <-time.After(timeoutPerInvocation):
 			return fmt.Errorf("Invocation timeout after waiting %v for worker to complete", timeoutPerInvocation), nil
 		}
 

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -14,10 +14,11 @@ import (
 	"log"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
 	"net/url"
-	"time"
 	"strings"
+	"time"
+
+	"github.com/couchbaselabs/go.assert"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -140,7 +141,6 @@ func TestRetryLoop(t *testing.T) {
 
 }
 
-
 // Make sure that the RetryLoopTimeout doesn't break existing RetryLoop functionality
 func TestRetryLoopTimeoutSafe(t *testing.T) {
 
@@ -186,14 +186,13 @@ func TestRetryLoopTimeoutEffective(t *testing.T) {
 
 	// Kick off timeout loop that expects lazy worker to return in 100 ms, even though it takes a week
 	description := fmt.Sprintf("TestRetryLoop")
-	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond * 100)
+	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond*100)
 
 	// We should get a timeout error
 	assert.True(t, err != nil)
 	assert.True(t, strings.Contains(err.Error(), "timeout"))
 
 }
-
 
 func TestSyncSourceFromURL(t *testing.T) {
 	u, err := url.Parse("http://www.test.com:4985/mydb")
@@ -233,7 +232,6 @@ func TestHighSeqNosToSequenceClock(t *testing.T) {
 	// leave a gap and don't specify a high seq for vbno 4
 	highSeqs[5] = 250
 
-
 	var seqClock SequenceClock
 	var err error
 
@@ -248,6 +246,3 @@ func TestHighSeqNosToSequenceClock(t *testing.T) {
 	assert.True(t, seqClock.GetSequence(5) == 250)
 
 }
-
-
-

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/couchbaselabs/go.assert"
 	"net/url"
+	"time"
+	"strings"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -137,6 +139,61 @@ func TestRetryLoop(t *testing.T) {
 	assert.True(t, numTimesInvoked == 4)
 
 }
+
+
+// Make sure that the RetryLoopTimeout doesn't break existing RetryLoop functionality
+func TestRetryLoopTimeoutSafe(t *testing.T) {
+
+	numTimesInvoked := 0
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		log.Printf("Worker invoked")
+		numTimesInvoked += 1
+		if numTimesInvoked <= 3 {
+			log.Printf("Worker returning shouldRetry true, fake error")
+			return true, fmt.Errorf("Fake error"), nil
+		}
+		return false, nil, "result"
+	}
+
+	sleeper := func(numAttempts int) (bool, int) {
+		if numAttempts > 10 {
+			return false, -1
+		}
+		return true, 0
+	}
+
+	// Kick off retry loop
+	description := fmt.Sprintf("TestRetryLoop")
+	err, result := RetryLoopTimeout(description, worker, sleeper, time.Hour)
+
+	// We shouldn't get an error, because it will retry a few times and then succeed
+	assert.True(t, err == nil)
+	assert.Equals(t, result, "result")
+	assert.True(t, numTimesInvoked == 4)
+
+}
+
+// Make sure that the RetryLoopTimeout enforces timeout on worker functions that block for too long
+func TestRetryLoopTimeoutEffective(t *testing.T) {
+
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		// The laziest worker ever .. sleeps for a week before returning a value
+		time.Sleep(time.Hour * 24 * 7)
+		return false, nil, "result"
+	}
+
+	sleeper := CreateDoublingSleeperFunc(10, 100)
+
+	// Kick off timeout loop that expects lazy worker to return in 100 ms, even though it takes a week
+	description := fmt.Sprintf("TestRetryLoop")
+	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond * 100)
+
+	// We should get a timeout error
+	assert.True(t, err != nil)
+	assert.True(t, strings.Contains(err.Error(), "timeout"))
+
+}
+
 
 func TestSyncSourceFromURL(t *testing.T) {
 	u, err := url.Parse("http://www.test.com:4985/mydb")

--- a/db/crud.go
+++ b/db/crud.go
@@ -1049,6 +1049,7 @@ func (context *DatabaseContext) ComputeSequenceRolesForUser(user auth.User) (cha
 	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewRoleAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
+
 	// Merge the TimedSets from the view result:
 	var result channels.TimedSet
 	for _, row := range vres.Rows {


### PR DESCRIPTION
Fix for go-couchbase case.  Fixed by:

- Intercepting calls to go-couchbase `ViewCustom()`, which previously was just passing through via embedded struct
- Calling the `TimeoutRetryLoop()` with MaxRetries = 1, since there is no need to introduce a retry loop here (there wasn't one before this change).  In some cases like the `View()` call, we **do** want a retry loop, since it was pre-existing.  