### PR TITLE
Feature/issue 2615 default changes feed limit (#2616)

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -87,7 +87,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="24b8252856d71a541cbfeb2203cf7c0ce3634b2b"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="3a178dfab983e40487e45f1ec6f0b90f5aa946f2"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="eebc98233c3e032eb6b9036575d51324ab5932e6"/>
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -173,7 +173,7 @@ type ReplicationConfig struct {
 	QueryParams      interface{} `json:"query_params"`
 	Cancel           bool        `json:"cancel"`
 	Async            bool        `json:"async"`
-	ChangesFeedLimit int         `json:"changes_feed_limit"`
+	ChangesFeedLimit *int        `json:"changes_feed_limit"`
 	ReplicationId    string      `json:"replication_id"`
 }
 
@@ -247,7 +247,12 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 	}
 
 	params.Async = requestParams.Async
-	params.ChangesFeedLimit = requestParams.ChangesFeedLimit
+	if (requestParams.ChangesFeedLimit != nil) {
+		params.ChangesFeedLimit = *requestParams.ChangesFeedLimit
+	} else {
+		params.ChangesFeedLimit = sgreplicate.DefaultChangesFeedLimit
+	}
+
 
 	if requestParams.Filter != "" {
 		if requestParams.Filter == "sync_gateway/bychannel" {


### PR DESCRIPTION
* Fixes #2615 Default changes_feed_limit to 50 if not passed in config

Also there is an sg-replicate fix here: https://github.com/couchbaselabs/sg-replicate/tree/feature/issue_2615_default_changes_feed_limit

* Point to updated sg-replicate

* It was ignoring the “disabled” replication config param

* Point to latest sg-replicate

* Point to latest sg-replicate

* Revert "It was ignoring the “disabled” replication config param"

This reverts commit 6d700331da539e9bd5a859eed60544d708773da7.

* Point to newer sg-replicate

* Point to latest sg-replicate master

# Conflicts:
#	manifest/default.xml