### PR TITLE
Mobile opt-in using import filter

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -25,8 +25,9 @@ const (
 	alreadyImported  = sgErrorCode(0x00)
 	importCancelled  = sgErrorCode(0x01)
 	importCasFailure = sgErrorCode(0x02)
-	importCancelledFilter = sgErrorCode(0x03)
-	revTreeAddRevFailure = sgErrorCode(0x04)
+
+	revTreeAddRevFailure  = sgErrorCode(0x04)
+	importCancelledFilter = sgErrorCode(0x05)
 )
 
 type SGError struct {
@@ -34,10 +35,10 @@ type SGError struct {
 }
 
 var (
-	ErrRevTreeAddRevFailure = &SGError{revTreeAddRevFailure}
-	ErrImportCancelled  = &SGError{importCancelled}
-	ErrAlreadyImported  = &SGError{alreadyImported}
-	ErrImportCasFailure = &SGError{importCasFailure}
+	ErrRevTreeAddRevFailure  = &SGError{revTreeAddRevFailure}
+	ErrImportCancelled       = &SGError{importCancelled}
+	ErrAlreadyImported       = &SGError{alreadyImported}
+	ErrImportCasFailure      = &SGError{importCasFailure}
 	ErrImportCancelledFilter = &SGError{importCancelledFilter}
 )
 

--- a/base/error.go
+++ b/base/error.go
@@ -25,6 +25,7 @@ const (
 	alreadyImported  = sgErrorCode(0x00)
 	importCancelled  = sgErrorCode(0x01)
 	importCasFailure = sgErrorCode(0x02)
+	importCancelledFilter = sgErrorCode(0x03)
 	revTreeAddRevFailure = sgErrorCode(0x04)
 )
 
@@ -37,6 +38,7 @@ var (
 	ErrImportCancelled  = &SGError{importCancelled}
 	ErrAlreadyImported  = &SGError{alreadyImported}
 	ErrImportCasFailure = &SGError{importCasFailure}
+	ErrImportCancelledFilter = &SGError{importCancelledFilter}
 )
 
 func (e SGError) Error() string {
@@ -45,6 +47,8 @@ func (e SGError) Error() string {
 		return "Document already imported"
 	case importCancelled:
 		return "Import cancelled"
+	case importCancelledFilter:
+		return "Import cancelled based on import filter"
 	case importCasFailure:
 		return "CAS failure during import"
 	case revTreeAddRevFailure:

--- a/db/database.go
+++ b/db/database.go
@@ -93,6 +93,7 @@ type DatabaseContextOptions struct {
 	TrackDocs             bool // Whether doc tracking channel should be created (used for autoImport, shadowing)
 	OIDCOptions           *auth.OIDCOptions
 	DBOnlineCallback      DBOnlineCallback // Callback function to take the DB back online
+	ImportOptions         ImportOptions
 }
 
 type OidcTestProviderOptions struct {
@@ -103,11 +104,17 @@ type OidcTestProviderOptions struct {
 type UserViewsOptions struct {
 	Enabled *bool `json:"enabled,omitempty"` // Whether pass-through view query is supported through public API
 }
+
 type UnsupportedOptions struct {
 	UserViews        UserViewsOptions        `json:"user_views,omitempty"`         // Config settings for user views
 	Replicator2      bool                    `json:"replicator_2,omitempty"`       // Enable new replicator (_blipsync)
 	OidcTestProvider OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
 	EnableXattr      *bool                   `json:"enable_extended_attributes"`   // Use xattr for _sync
+}
+
+// Options associated with the import of documents not written by Sync Gateway
+type ImportOptions struct {
+	ImportFilter *ImportFilterFunction // Opt-in filter for document import
 }
 
 // Represents a simulated CouchDB database. A new instance is created for each HTTP request,

--- a/db/import.go
+++ b/db/import.go
@@ -187,7 +187,7 @@ func (i *ImportFilterFunction) EvaluateFunction(doc Body) (bool, error) {
 		}
 		return boolResult, nil
 	default:
-		base.Warn("Import filter function returned non-boolean result %v", result)
+		base.Warn("Import filter function returned non-boolean result %v Type: %T", result, result)
 		return false, errors.New("Import filter function returned non-boolean value.")
 	}
 }

--- a/db/import.go
+++ b/db/import.go
@@ -1,0 +1,193 @@
+package db
+
+import (
+	"errors"
+	"strconv"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/robertkrimen/otto"
+)
+
+type ImportMode uint8
+
+const (
+	ImportFromFeed = ImportMode(iota) // Feed-based import.  Attempt to import once - cancels import on cas write failure of the imported doc.
+	ImportOnDemand                    // On-demand import. Reattempt import on cas write failure of the imported doc until either the import succeeds, or existing doc is an SG write.
+)
+
+// Imports a document that was written by someone other than sync gateway.
+func (db *Database) ImportDocRaw(docid string, value []byte, isDelete bool, cas uint64, mode ImportMode) (docOut *document, err error) {
+
+	var body Body
+	if isDelete {
+		body = Body{"_deleted": true}
+	} else {
+		err := body.Unmarshal(value)
+		if err != nil {
+			base.LogTo("Import", "Unmarshal error during importDoc %v", err)
+			return nil, err
+		}
+	}
+
+	return db.ImportDoc(docid, body, isDelete, cas, mode)
+}
+
+func (db *Database) ImportDoc(docid string, body Body, isDelete bool, importCas uint64, mode ImportMode) (docOut *document, err error) {
+
+	base.LogTo("Import+", "Attempting to import doc %q...", docid)
+
+	var newRev string
+	var alreadyImportedDoc *document
+	docOut, _, err = db.updateAndReturnDoc(docid, true, 0, func(doc *document) (Body, AttachmentData, error) {
+
+		// Check if the doc has been deleted
+		if doc.Cas == 0 {
+			base.LogTo("Import+", "Document has been removed from the bucket before it could be imported - cancelling import.")
+			return nil, nil, base.ErrImportCancelled
+		}
+
+		// If this is a delete, and there is no xattr on the existing doc,
+		// we shouldn't import.  (SG purge arriving over DCP feed)
+		if isDelete && doc.CurrentRev == "" {
+			base.LogTo("Import+", "Import not required for delete mutation with no existing SG xattr (SG purge): %s", docid)
+			return nil, nil, base.ErrImportCancelled
+		}
+
+		// If the current version of the doc is an SG write, document has been updated by SG subsequent to the update that triggered this import.
+		// Cancel update
+		if doc.IsSGWrite() {
+			base.LogTo("Import+", "During import, existing doc (%s) identified as SG write.  Canceling import.", docid)
+			alreadyImportedDoc = doc
+			return nil, nil, base.ErrAlreadyImported
+		}
+
+		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  This is an SDK write (since we checked
+		// for SG write above).  How to handle depends on import mode.
+		if doc.Cas != importCas {
+			// If this is a feed import, cancel on cas failure (doc has been updated )
+			if mode == ImportFromFeed {
+				return nil, nil, base.ErrImportCasFailure
+			}
+			// If this is an on-demand import, we want to switch to importing the current version doc
+			if mode == ImportOnDemand {
+				body = doc.body
+			}
+		}
+
+		// If there's a filter function defined, evaluate to determine whether we should import this doc
+		if db.DatabaseContext.Options.ImportOptions.ImportFilter != nil {
+			shouldImport, err := db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(body)
+			if err != nil {
+				base.LogTo("Import+", "Error returned for doc %s while evaluating import function - will not be imported.", docid)
+				return nil, nil, base.ErrImportCancelledFilter
+			}
+			if shouldImport == false {
+				base.LogTo("Import+", "Doc %s excluded by document import function - will not be imported.", docid)
+				// TODO: If this document has a current revision (this is a document that was previously mobile-enabled), do additional opt-out processing
+				// pending https://github.com/couchbase/sync_gateway/issues/2750
+				return nil, nil, base.ErrImportCancelledFilter
+			}
+		}
+
+		// The active rev is the parent for an import
+		parentRev := doc.CurrentRev
+		generation, _ := ParseRevID(parentRev)
+		generation++
+		newRev = createRevID(generation, parentRev, body)
+		base.LogTo("Import", "Created new rev ID %v", newRev)
+		body["_rev"] = newRev
+		doc.History.addRevision(docid, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete})
+
+		// During import, oldDoc (doc.Body) is nil (since it's no longer available)
+		doc.body = nil
+
+		// Note - no attachments processing is done during ImportDoc.  We don't (currently) support writing attachments through anything but SG.
+
+		return body, nil, nil
+	})
+
+	switch err {
+	case base.ErrAlreadyImported:
+		// If the doc was already imported, we want to return the imported version
+		docOut = alreadyImportedDoc
+	case nil:
+		base.LogTo("Import+", "Imported %s (delete=%v) as rev %s", docid, isDelete, newRev)
+	case base.ErrImportCancelled:
+		// Import was cancelled (SG purge) - don't return error.
+	case base.ErrImportCancelledFilter:
+		// Import was cancelled based on import filter.  Return error but don't log as error/warning.
+		return nil, err
+	case base.ErrImportCasFailure:
+		// Import was cancelled due to CAS failure.
+		return nil, err
+	default:
+		base.LogTo("Import", "Error importing doc %q: %v", docid, err)
+		return nil, err
+
+	}
+
+	return docOut, nil
+}
+
+//////// Import Filter Function
+
+// A compiled JavaScript event function.
+type jsImportFilterRunner struct {
+	sgbucket.JSRunner
+	response bool
+}
+
+// Compiles a JavaScript event function to a jsImportFilterRunner object.
+func newImportFilterRunner(funcSource string) (sgbucket.JSServerTask, error) {
+	importFilterRunner := &jsEventTask{}
+	err := importFilterRunner.Init(funcSource)
+	if err != nil {
+		return nil, err
+	}
+
+	importFilterRunner.After = func(result otto.Value, err error) (interface{}, error) {
+		nativeValue, _ := result.Export()
+		return nativeValue, err
+	}
+
+	return importFilterRunner, nil
+}
+
+type ImportFilterFunction struct {
+	*sgbucket.JSServer
+}
+
+func NewImportFilterFunction(fnSource string) *ImportFilterFunction {
+
+	base.LogTo("Import+", "Creating new ImportFilterFunction")
+	return &ImportFilterFunction{
+		JSServer: sgbucket.NewJSServer(fnSource, kTaskCacheSize,
+			func(fnSource string) (sgbucket.JSServerTask, error) {
+				return newImportFilterRunner(fnSource)
+			}),
+	}
+}
+
+// Calls a jsEventFunction returning an interface{}
+func (i *ImportFilterFunction) EvaluateFunction(doc Body) (bool, error) {
+
+	result, err := i.Call(doc)
+	if err != nil {
+		base.Warn("Unexpected error invoking import filter for document %s - processing aborted, document will not be imported.  Error: %v", err)
+		return false, err
+	}
+	switch result := result.(type) {
+	case bool:
+		return result, nil
+	case string:
+		boolResult, err := strconv.ParseBool(result)
+		if err != nil {
+			return false, err
+		}
+		return boolResult, nil
+	default:
+		base.Warn("Import filter function returned non-boolean result %v", result)
+		return false, errors.New("Import filter function returned non-boolean value.")
+	}
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -774,7 +774,6 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	//We want a sync function that will reject some docs, create two to simulate two SG instances
 	rt1 := RestTester{SyncFn: `function(doc) {if(doc.type == "failed") {throw("Rejecting failed doc")}}`}
 
-
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "failed"}, {"_id": "bulk3", "n": 3}]}`
 	response := rt1.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
@@ -803,11 +802,10 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 		BucketConfig: BucketConfig{
 			Server: &server,
 			Bucket: &bucketName},
-		Name:        "db",
-		CacheConfig: rt2.CacheConfig,
+		Name: "db",
 	})
 
-	assertNoError(t, err,"Failed to add database to rest tester")
+	assertNoError(t, err, "Failed to add database to rest tester")
 
 	//send another _bulk_docs to rt2 and validate the sequences used
 	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}]}`
@@ -861,14 +859,12 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//Get the revID for doc "bulk1"
 	doc1RevID := doc1Rev.CurrentRev
 
-
-		doc3Rev, _ := rt1.GetDatabase().GetDocSyncData("bulk3")
+	doc3Rev, _ := rt1.GetDatabase().GetDocSyncData("bulk3")
 	assert.Equals(t, doc3Rev.Sequence, uint64(2))
 
 	//Get current sequence number, this will be 3, as SG allocates enough sequences to process all bulk docs
 	lastSequence, _ := rt1.GetDatabase().LastSequence()
 	assert.Equals(t, lastSequence, uint64(3))
-
 
 	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "failed") {throw("Rejecting failed doc")}}`}
 
@@ -884,14 +880,13 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 		BucketConfig: BucketConfig{
 			Server: &server,
 			Bucket: &bucketName},
-		Name:        "db",
-		CacheConfig: rt2.CacheConfig,
+		Name: "db",
 	})
 
-	assertNoError(t, err,"Failed to add database to rest tester")
+	assertNoError(t, err, "Failed to add database to rest tester")
 
 	//send another _bulk_docs to rt2, including an update to doc "bulk1" and validate the sequences used
-	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}, {"_id": "bulk1", "_rev": "`+doc1RevID+`", "n": 2}]}`
+	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}, {"_id": "bulk1", "_rev": "` + doc1RevID + `", "n": 2}]}`
 	response = rt2.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 
@@ -917,7 +912,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	assert.Equals(t, lastSequence, uint64(7))
 
 	//Now send a bulk_doc to rt1 to update doc bulk1 again
-	input = `{"docs": [{"_id": "bulk1", "_rev": "`+doc1RevID2+`", "n": 2}]}`
+	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID2 + `", "n": 2}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 
@@ -933,7 +928,6 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	assert.Equals(t, rs[2], uint64(8))
 
 }
-
 
 func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 
@@ -951,14 +945,12 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Get the revID for doc "bulk1"
 	doc1RevID := doc1Rev.CurrentRev
 
-
 	doc3Rev, _ := rt1.GetDatabase().GetDocSyncData("bulk3")
 	assert.Equals(t, doc3Rev.Sequence, uint64(2))
 
 	//Get current sequence number, this will be 3, as SG allocates enough sequences to process all bulk docs
 	lastSequence, _ := rt1.GetDatabase().LastSequence()
 	assert.Equals(t, lastSequence, uint64(3))
-
 
 	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "failed") {throw("Rejecting failed doc")}}`}
 
@@ -974,14 +966,13 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 		BucketConfig: BucketConfig{
 			Server: &server,
 			Bucket: &bucketName},
-		Name:        "db",
-		CacheConfig: rt2.CacheConfig,
+		Name: "db",
 	})
 
-	assertNoError(t, err,"Failed to add database to rest tester")
+	assertNoError(t, err, "Failed to add database to rest tester")
 
 	//send another _bulk_docs to rt2, including an update to doc "bulk1" and another failed rev to create an unused sequence
-	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23, "type": "failed"}, {"_id": "bulk1", "_rev": "`+doc1RevID+`", "n": 2}]}`
+	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23, "type": "failed"}, {"_id": "bulk1", "_rev": "` + doc1RevID + `", "n": 2}]}`
 	response = rt2.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 
@@ -1004,7 +995,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	assert.Equals(t, lastSequence, uint64(7))
 
 	//Now send a bulk_doc to rt1 to update doc bulk1 again
-	input = `{"docs": [{"_id": "bulk1", "_rev": "`+doc1RevID2+`", "n": 2}]}`
+	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID2 + `", "n": 2}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 
@@ -1016,7 +1007,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	doc1RevID3 := doc1Rev3.CurrentRev
 
 	//Now send a bulk_doc to rt2 to update doc bulk1 again
-	input = `{"docs": [{"_id": "bulk1", "_rev": "`+doc1RevID3+`", "n": 2}]}`
+	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID3 + `", "n": 2}]}`
 	response = rt1.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 
@@ -1033,7 +1024,6 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	assert.Equals(t, rs[3], uint64(9))
 
 }
-
 
 func TestBulkDocsEmptyDocs(t *testing.T) {
 	var rt RestTester

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -540,13 +540,14 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	maxNum := 50
 	skippedMaxWait := uint32(120000)
 
-	shortWaitCache := &CacheConfig{
-		CachePendingSeqMaxWait: &pendingMaxWait,
-		CachePendingSeqMaxNum:  &maxNum,
-		CacheSkippedSeqMaxWait: &skippedMaxWait,
+	shortWaitConfig := &DbConfig{
+		CacheConfig: &CacheConfig{
+			CachePendingSeqMaxWait: &pendingMaxWait,
+			CachePendingSeqMaxNum:  &maxNum,
+			CacheSkippedSeqMaxWait: &skippedMaxWait,
+		},
 	}
-
-	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`, CacheConfig: shortWaitCache}
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
 	defer rt.Close()
 
 	testDb := rt.ServerContext().Database("db")

--- a/rest/config.go
+++ b/rest/config.go
@@ -118,6 +118,7 @@ type DbConfig struct {
 	Roles              map[string]*db.PrincipalConfig `json:"roles,omitempty"`                // Initial roles
 	RevsLimit          *uint32                        `json:"revs_limit,omitempty"`           // Max depth a document's revision tree can grow to
 	ImportDocs         interface{}                    `json:"import_docs,omitempty"`          // false, true, or "continuous"
+	ImportFilter       *string                        `json:"import_filter,omitempty"`        // Filter function (import)
 	Shadow             *ShadowConfig                  `json:"shadow,omitempty"`               // External bucket to shadow
 	EventHandlers      interface{}                    `json:"event_handlers,omitempty"`       // Event handlers (webhook)
 	FeedType           string                         `json:"feed_type,omitempty"`            // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -306,6 +306,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, fmt.Errorf("Unrecognized value for ImportDocs: %#v", config.ImportDocs)
 	}
 
+	importOptions := db.ImportOptions{}
+	if config.ImportFilter != nil {
+		importOptions.ImportFilter = db.NewImportFilterFunction(*config.ImportFilter)
+	}
+
 	feedType := strings.ToLower(config.FeedType)
 
 	couchbaseDriver := base.ChooseCouchbaseDriver(base.DataBucket)
@@ -499,6 +504,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		TrackDocs:             trackDocs,
 		OIDCOptions:           config.OIDCConfig,
 		DBOnlineCallback:      dbOnlineCallback,
+		ImportOptions:         importOptions,
 	}
 
 	// Create the DB Context


### PR DESCRIPTION
Allows definition of an javascript import filter function in the Sync Gateway config, which is used to determine whether an SDK write should be available to mobile (imported).  The filter function takes the document body as an input parameter, and is expected to return a boolean to indicate whether the document should be imported.

The filter is defined in the Sync Gateway config under a new 'import_filter' property on the database configuration.

 Additional details on the opt-in use cases here: https://docs.google.com/document/d/1XxLIBsjuj_UxTTJs4Iu7C7uZdos8ZEzeckrVc17y3sw

Added a new import.go to help organize the import-related functionality.

Fixes #2507