### PR TITLE
Fix for failing TestRevsDiff test

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -534,6 +534,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 			if err != nil {
 				return nil, nil, err
 			}
+			parent = docHistory[i]
 		}
 
 		// Process the attachments, replacing bodies with digests.


### PR DESCRIPTION
The running update of the parent when adding multiple revisions appears to have been the victim of a cut-and-paste error when backporting this change.