### PR TITLE
Resume DCP feed on restart for import nodes

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -18,10 +18,10 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
-
-	"net/url"
+	"strings"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -1839,7 +1839,6 @@ func (bucket CouchbaseBucketGoCB) Refresh() error {
 
 }
 
-// TODO: Change to StartMutationFeed
 func (bucket CouchbaseBucketGoCB) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 	return nil, fmt.Errorf("GoCB bucket doesn't support TAP - use DCP feed type")
 }

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -11,13 +11,21 @@ package base
 
 import (
 	"encoding/json"
-	"log"
+	"errors"
+	"expvar"
+	"fmt"
 	"sync"
 
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 )
+
+var dcpExpvars *expvar.Map
+
+func init() {
+	dcpExpvars = expvar.NewMap("syncGateway_dcp")
+}
 
 // Memcached binary protocol datatype bit flags (https://github.com/couchbase/memcached/blob/master/docs/BinaryProtocol.md#data-types),
 // used in MCRequest.DataType
@@ -27,16 +35,24 @@ const (
 	MemcachedDataTypeXattr
 )
 
+const DCPCheckpointPrefix = "_sync:dcp_ck:" // Prefix used for DCP checkpoint persistence (is appended with vbno)
+
+// Number of non-checkpoint updates per vbucket required to trigger metadata persistence.  Must be greater than zero to avoid
+// retriggering persistence solely based on checkpoint doc echo.
+// Based on ad-hoc testing w/ travel-sample bucket, increasing this value doesn't significantly improve performance, since under load
+// DCP will already be sending more documents per snapshot.
+const kCheckpointThreshold = 1
+
 type couchbaseDCPFeedImpl struct {
 	bds    cbdatasource.BucketDataSource
-	events chan sgbucket.TapEvent
+	events chan sgbucket.FeedEvent
 }
 
-func (feed *couchbaseDCPFeedImpl) Events() <-chan sgbucket.TapEvent {
+func (feed *couchbaseDCPFeedImpl) Events() <-chan sgbucket.FeedEvent {
 	return feed.events
 }
 
-func (feed *couchbaseDCPFeedImpl) WriteEvents() chan<- sgbucket.TapEvent {
+func (feed *couchbaseDCPFeedImpl) WriteEvents() chan<- sgbucket.FeedEvent {
 	return feed.events
 }
 
@@ -45,51 +61,55 @@ func (feed *couchbaseDCPFeedImpl) Close() error {
 }
 
 type SimpleFeed struct {
-	eventFeed chan sgbucket.TapEvent
+	eventFeed chan sgbucket.FeedEvent
 }
 
-func (s *SimpleFeed) Events() <-chan sgbucket.TapEvent {
+func (s *SimpleFeed) Events() <-chan sgbucket.FeedEvent {
 	return s.eventFeed
 }
 
-func (s *SimpleFeed) WriteEvents() chan<- sgbucket.TapEvent {
+func (s *SimpleFeed) WriteEvents() chan<- sgbucket.FeedEvent {
 	return s.eventFeed
 }
 
-func (s *SimpleFeed) Close() error { // TODO
-	log.Fatalf("SimpleFeed.Close() called but not implemented")
+func (s *SimpleFeed) Close() error {
+	LogFatal("SimpleFeed.Close() called but not implemented")
 	return nil
 }
 
 type Receiver interface {
 	cbdatasource.Receiver
 	SeedSeqnos(map[uint16]uint64, map[uint16]uint64)
-	GetEventFeed() <-chan sgbucket.TapEvent
-	SetEventFeed(chan sgbucket.TapEvent)
-	GetOutput() chan sgbucket.TapEvent
 	updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo bool)
 	SetBucketNotifyFn(sgbucket.BucketNotifyFn)
 	GetBucketNotifyFn() sgbucket.BucketNotifyFn
+	initMetadata(maxVbNo uint16)
 }
 
 // DCPReceiver implements cbdatasource.Receiver to manage updates coming from a
 // cbdatasource BucketDataSource.  See go-couchbase/cbdatasource for
 // additional details
 type DCPReceiver struct {
-	m         sync.Mutex
-	seqs      map[uint16]uint64 // To track max seq #'s we received per vbucketId.
-	meta      map[uint16][]byte // To track metadata blob's per vbucketId.
-	eventFeed <-chan sgbucket.TapEvent
-	output    chan sgbucket.TapEvent  // Same as EventFeed but writeably-typed
-	notify    sgbucket.BucketNotifyFn // Function to callback when we lose our dcp feed
+	m                      sync.Mutex
+	bucket                 Bucket                         // For metadata persistence/retrieval
+	persistCheckpoints     bool                           // Whether this DCPReceiver should persist metadata to the bucket
+	seqs                   []uint64                       // To track max seq #'s we received per vbucketId.
+	meta                   [][]byte                       // To track metadata blob's per vbucketId.
+	updatesSinceCheckpoint []uint64                       // Number of updates since the last checkpoint. Used to avoid checkpoint persistence feedback loop
+	notify                 sgbucket.BucketNotifyFn        // Function to callback when we lose our dcp feed
+	callback               sgbucket.FeedEventCallbackFunc // Function to callback for mutation processing
 }
 
-func NewDCPReceiver() Receiver {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool) Receiver {
+	// TODO: set using maxvbno
 	r := &DCPReceiver{
-		output: make(chan sgbucket.TapEvent, 10),
+		bucket:             bucket,
+		persistCheckpoints: persistCheckpoints,
+		seqs:               make([]uint64, maxVbNo),
+		meta:               make([][]byte, maxVbNo),
+		updatesSinceCheckpoint: make([]uint64, maxVbNo),
 	}
-	r.eventFeed = r.output
-	//r.SetEventFeed(r.GetOutput())
+	r.callback = callback
 
 	if LogEnabledExcludingLogStar("DCP") {
 		LogTo("DCP", "Using DCP Logging Receiver")
@@ -107,18 +127,6 @@ func (r *DCPReceiver) GetBucketNotifyFn() sgbucket.BucketNotifyFn {
 	return r.notify
 }
 
-func (r *DCPReceiver) SetEventFeed(c chan sgbucket.TapEvent) {
-	r.output = c
-}
-
-func (r *DCPReceiver) GetEventFeed() <-chan sgbucket.TapEvent {
-	return r.eventFeed
-}
-
-func (r *DCPReceiver) GetOutput() chan sgbucket.TapEvent {
-	return r.output
-}
-
 func (r *DCPReceiver) OnError(err error) {
 	Warn("Error processing DCP stream - will attempt to restart/reconnect: %v", err)
 
@@ -134,34 +142,50 @@ func (r *DCPReceiver) OnError(err error) {
 	// vbucket stream, not the entire feed.
 	// bucketName := "unknown" // this is currently ignored anyway
 	// r.notify(bucketName, err)
+	dcpExpvars.Add("onError_count", 1)
 
 }
 
 func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
+	dcpExpvars.Add("dataUpdate_count", 1)
 	r.updateSeq(vbucketId, seq, true)
-	r.output <- makeFeedEvent(req, vbucketId, sgbucket.TapMutation)
+	shouldPersistCheckpoint := r.callback(makeFeedEvent(req, vbucketId, sgbucket.FeedOpMutation))
+	if shouldPersistCheckpoint {
+		r.incrementCheckpointCount(vbucketId)
+	}
 	return nil
 }
 
 func (r *DCPReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
+	dcpExpvars.Add("dataDelete_count", 1)
 	r.updateSeq(vbucketId, seq, true)
-	r.output <- makeFeedEvent(req, vbucketId, sgbucket.TapDeletion)
+	shouldPersistCheckpoint := r.callback(makeFeedEvent(req, vbucketId, sgbucket.FeedOpDeletion))
+	if shouldPersistCheckpoint {
+		r.incrementCheckpointCount(vbucketId)
+	}
 	return nil
 }
 
-func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16, opcode sgbucket.TapOpcode) sgbucket.TapEvent {
+func (r *DCPReceiver) incrementCheckpointCount(vbucketId uint16) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.updatesSinceCheckpoint[vbucketId]++
+}
+
+func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 	// not currently doing rq.Extras handling (as in gocouchbase/upr_feed, makeUprEvent) as SG doesn't use
 	// expiry/flags information, and snapshot handling is done by cbdatasource and sent as
 	// SnapshotStart, SnapshotEnd
-	event := sgbucket.TapEvent{
-		Opcode:   opcode,
-		Key:      rq.Key,
-		Value:    rq.Body,
-		Sequence: rq.Cas,
-		DataType: rq.DataType,
-		Cas:      rq.Cas,
+	event := sgbucket.FeedEvent{
+		Opcode:      opcode,
+		Key:         rq.Key,
+		Value:       rq.Body,
+		Sequence:    rq.Cas,
+		DataType:    rq.DataType,
+		Cas:         rq.Cas,
+		Synchronous: true,
 	}
 	return event
 }
@@ -182,11 +206,17 @@ func (r *DCPReceiver) SetMetaData(vbucketId uint16, value []byte) error {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	if r.meta == nil {
-		r.meta = make(map[uint16][]byte)
-	}
+	dcpExpvars.Add("setMetadata_count", 1)
 	r.meta[vbucketId] = value
 
+	// Check persistMeta to avoids persistence if the only feed events we've seen are the DCP echo of DCP checkpoint docs
+	if r.persistCheckpoints && r.updatesSinceCheckpoint[vbucketId] >= kCheckpointThreshold {
+		err := r.persistCheckpoint(vbucketId, value)
+		if err != nil {
+			Warn("Unable to persist DCP metadata - will retry next snapshot. Error: %v", err)
+		}
+		r.updatesSinceCheckpoint[vbucketId] = 0
+	}
 	return nil
 }
 
@@ -212,6 +242,8 @@ func (r *DCPReceiver) GetMetaData(vbucketId uint16) (
 // vbucket to unblock the DCP stream.
 func (r *DCPReceiver) Rollback(vbucketId uint16, rollbackSeq uint64) error {
 	Warn("DCP Rollback request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x", vbucketId, rollbackSeq)
+
+	dcpExpvars.Add("rollback_count", 1)
 	r.updateSeq(vbucketId, rollbackSeq, false)
 	return nil
 }
@@ -225,9 +257,6 @@ func (r *DCPReceiver) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo b
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	if r.seqs == nil {
-		r.seqs = make(map[uint16]uint64)
-	}
 	if seq < r.seqs[vbucketId] && warnOnLowerSeqNo == true {
 		Warn("Setting to _lower_ sequence number than previous: %v -> %v", r.seqs[vbucketId], seq)
 	}
@@ -243,7 +272,9 @@ func (r *DCPReceiver) SeedSeqnos(uuids map[uint16]uint64, seqs map[uint16]uint64
 	defer r.m.Unlock()
 
 	// Set the high seqnos as-is
-	r.seqs = seqs
+	for vbNo, seq := range seqs {
+		r.seqs[vbNo] = seq
+	}
 
 	// For metadata, we need to do more work to build metadata based on uuid and map values.  This
 	// isn't strictly to the design of cbdatasource.Receiver, which intends metadata to be opaque, but
@@ -263,10 +294,61 @@ func (r *DCPReceiver) SeedSeqnos(uuids map[uint16]uint64, seqs map[uint16]uint64
 		}
 		buf, err := json.Marshal(metadata)
 		if err == nil {
-			if r.meta == nil {
-				r.meta = make(map[uint16][]byte)
-			}
 			r.meta[vbucketId] = buf
+		}
+	}
+}
+
+// TODO: Convert checkpoint persistence to an asynchronous batched process, since
+//       restarting w/ an older checkpoint:
+//         - Would only result in some repeated entry processing, which is already handled by the indexer
+//         - Is a relatively infrequent operation (occurs when vbuckets are initially assigned to an accel node)
+func (r *DCPReceiver) persistCheckpoint(vbNo uint16, value []byte) error {
+	dcpExpvars.Add("persistCheckpoint_count", 1)
+	return r.bucket.SetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix, vbNo), 0, BinaryDocument(value))
+}
+
+// loadCheckpoint retrieves previously persisted DCP metadata.  Need to unmarshal metadata to determine last sequence processed.
+// We always restart the feed from the last persisted snapshot start (as opposed to a sequence we may have processed
+// midway through the checkpoint), because:
+//   - We don't otherwise persist the last sequence we processed
+//   - For SG feed processing, there's no harm if we receive feed events for mutations we've previously seen
+//   - The ongoing performance overhead of persisting last sequence outweighs the minor performance benefit of not reprocessing a few
+//    sequences in a checkpoint on startup
+func (r *DCPReceiver) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStartSeq uint64, err error) {
+	dcpExpvars.Add("loadCheckpoint_count", 1)
+	rawValue, _, err := r.bucket.GetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix, vbNo))
+	if err != nil {
+		// On a key not found error, metadata hasn't been persisted for this vbucket
+		if IsKeyNotFoundError(r.bucket, err) {
+			return []byte{}, 0, nil
+		} else {
+			return []byte{}, 0, err
+		}
+	}
+
+	var snapshotMetadata cbdatasource.VBucketMetaData
+	unmarshalErr := json.Unmarshal(rawValue, &snapshotMetadata)
+	if unmarshalErr != nil {
+		return []byte{}, 0, err
+	}
+	return rawValue, snapshotMetadata.SnapStart, nil
+
+}
+
+func (r *DCPReceiver) initMetadata(maxVbNo uint16) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	for i := uint16(0); i < maxVbNo; i++ {
+		metadata, lastSeq, err := r.loadCheckpoint(i)
+		if err != nil {
+			// TODO: instead of failing here, should log warning and init zero metadata/seq
+			Warn("Unexpected error attempting to load DCP checkpoint for vbucket %d.  Will restart DCP for that checkpoint from zero.  Error: %v", err)
+			r.meta[i] = []byte{}
+			r.seqs[i] = 0
+		} else {
+			r.meta[i] = metadata
+			r.seqs[i] = lastSeq
 		}
 	}
 }
@@ -337,14 +419,87 @@ func (r *DCPLoggingReceiver) updateSeq(vbucketId uint16, seq uint64, warnOnLower
 	r.rec.updateSeq(vbucketId, seq, warnOnLowerSeqNo)
 }
 
-func (r *DCPLoggingReceiver) SetEventFeed(c chan sgbucket.TapEvent) {
-	r.rec.SetEventFeed(c)
+func (r *DCPLoggingReceiver) initMetadata(maxVbNo uint16) {
+	LogTo("DCP", "Initializing metadata:%d", maxVbNo)
+	r.rec.initMetadata(maxVbNo)
 }
 
-func (r *DCPLoggingReceiver) GetEventFeed() <-chan sgbucket.TapEvent {
-	return r.rec.GetEventFeed()
-}
+// This starts a cbdatasource powered DCP Feed using an entirely separate connection to Couchbase Server than anything the existing
+// bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
+func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
 
-func (r *DCPLoggingReceiver) GetOutput() chan sgbucket.TapEvent {
-	return r.rec.GetOutput()
+	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
+	// reusing the bucket connection we've already established.
+	urls := []string{spec.Server}
+	poolName := spec.PoolName
+	if poolName == "" {
+		poolName = "default"
+	}
+	bucketName := spec.BucketName
+
+	vbucketIdsArr := []uint16(nil) // nil means get all the vbuckets.
+
+	maxVbno, err := bucket.GetMaxVbno()
+	if err != nil {
+		return err
+	}
+
+	persistCheckpoints := false
+	if args.Backfill == sgbucket.FeedResume {
+		persistCheckpoints = true
+	}
+
+	dcpReceiver := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints)
+	dcpReceiver.SetBucketNotifyFn(args.Notify)
+
+	// GetStatsVbSeqno retrieves high sequence number for each vbucket, to enable starting
+	// DCP stream from that position.  Also being used as a check on whether the server supports
+	// DCP.
+
+	switch args.Backfill {
+	case sgbucket.FeedNoBackfill:
+		// For non-backfill, use vbucket uuids, high sequence numbers
+		statsUuids, highSeqnos, err := bucket.GetStatsVbSeqno(maxVbno, false)
+		if err != nil {
+			return errors.New("Error retrieving stats-vbseqno - DCP not supported")
+		}
+		LogTo("Feed+", "Seeding seqnos: %v", highSeqnos)
+		dcpReceiver.SeedSeqnos(statsUuids, highSeqnos)
+	case sgbucket.FeedResume:
+		// For resume case, load previously persisted checkpoints from bucket
+		dcpReceiver.initMetadata(maxVbno)
+	default:
+		// Otherwise, start feed from zero
+		startSeqnos := make(map[uint16]uint64, maxVbno)
+		vbuuids := make(map[uint16]uint64, maxVbno)
+		dcpReceiver.SeedSeqnos(vbuuids, startSeqnos)
+	}
+
+	var dataSourceOptions *cbdatasource.BucketDataSourceOptions
+	if spec.UseXattrs {
+		dataSourceOptions = cbdatasource.DefaultBucketDataSourceOptions
+		dataSourceOptions.IncludeXAttrs = true
+	}
+
+	LogTo("Feed+", "Connecting to new bucket datasource.  URLs:%s, pool:%s, bucket:%s", urls, poolName, bucketName)
+	bds, err := cbdatasource.NewBucketDataSource(
+		urls,
+		poolName,
+		bucketName,
+		"",
+		vbucketIdsArr,
+		spec.Auth,
+		dcpReceiver,
+		dataSourceOptions,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err = bds.Start(); err != nil {
+		return err
+	}
+
+	return nil
+
 }

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -449,7 +449,11 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 
 	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
 	// reusing the bucket connection we've already established.
-	urls := []string{spec.Server}
+	urls, errConvertServerSpec := CouchbaseURIToHttpURL(spec.Server)
+	if errConvertServerSpec != nil {
+		return errConvertServerSpec
+	}
+
 	poolName := spec.PoolName
 	if poolName == "" {
 		poolName = "default"

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -140,12 +140,12 @@ func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {
 	return b.bucket.DeleteWithXattr(k, xattr)
 }
 
-func (b *LeakyBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {
+func (b *LeakyBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 
 	if b.config.TapFeedDeDuplication {
 		return b.wrapFeedForDeduplication(args)
 	} else if len(b.config.TapFeedMissingDocs) > 0 {
-		callback := func(event *sgbucket.TapEvent) bool {
+		callback := func(event *sgbucket.FeedEvent) bool {
 			for _, key := range b.config.TapFeedMissingDocs {
 				if string(event.Key) == key {
 					return false
@@ -160,9 +160,9 @@ func (b *LeakyBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed
 		if err != nil {
 			return walrusTapFeed, err
 		}
-		// this is the sgbucket.TapFeed impl we'll return to callers, which
+		// this is the sgbucket.MutationFeed impl we'll return to callers, which
 		// will add vbucket information
-		channel := make(chan sgbucket.TapEvent, 10)
+		channel := make(chan sgbucket.FeedEvent, 10)
 		vbTapFeed := &wrappedTapFeedImpl{
 			channel:        channel,
 			wrappedTapFeed: walrusTapFeed,
@@ -182,9 +182,13 @@ func (b *LeakyBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed
 
 }
 
-type EventUpdateFunc func(event *sgbucket.TapEvent) bool
+func (b *LeakyBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
+	return b.bucket.StartDCPFeed(args, callback)
+}
 
-func (b *LeakyBucket) wrapFeed(args sgbucket.TapArguments, callback EventUpdateFunc) (sgbucket.TapFeed, error) {
+type EventUpdateFunc func(event *sgbucket.FeedEvent) bool
+
+func (b *LeakyBucket) wrapFeed(args sgbucket.FeedArguments, callback EventUpdateFunc) (sgbucket.MutationFeed, error) {
 
 	// kick off the wrapped sgbucket tap feed
 	walrusTapFeed, err := b.bucket.StartTapFeed(args)
@@ -193,9 +197,9 @@ func (b *LeakyBucket) wrapFeed(args sgbucket.TapArguments, callback EventUpdateF
 	}
 
 	// create an output channel
-	channel := make(chan sgbucket.TapEvent, 10)
+	channel := make(chan sgbucket.FeedEvent, 10)
 
-	// this is the sgbucket.TapFeed impl we'll return to callers, which
+	// this is the sgbucket.MutationFeed impl we'll return to callers, which
 	// will have missing entries
 	wrapperFeed := &wrappedTapFeedImpl{
 		channel:        channel,
@@ -213,7 +217,7 @@ func (b *LeakyBucket) wrapFeed(args sgbucket.TapArguments, callback EventUpdateF
 	return wrapperFeed, nil
 }
 
-func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {
+func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 	// create an output channel
 	// start a goroutine which reads off the sgbucket tap feed
 	//   - de-duplicate certain events
@@ -233,9 +237,9 @@ func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.TapArguments) (sgbu
 	}
 
 	// create an output channel for de-duplicated events
-	channel := make(chan sgbucket.TapEvent, 10)
+	channel := make(chan sgbucket.FeedEvent, 10)
 
-	// this is the sgbucket.TapFeed impl we'll return to callers, which
+	// this is the sgbucket.MutationFeed impl we'll return to callers, which
 	// will reead from the de-duplicated events channel
 	dupeTapFeed := &wrappedTapFeedImpl{
 		channel:        channel,
@@ -245,7 +249,7 @@ func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.TapArguments) (sgbu
 	go func() {
 
 		// the buffer to hold tap events that are candidates for de-duplication
-		deDupeBuffer := []sgbucket.TapEvent{}
+		deDupeBuffer := []sgbucket.FeedEvent{}
 
 		for {
 			select {
@@ -254,7 +258,7 @@ func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.TapArguments) (sgbu
 					// channel closed, goroutine is done
 					// dedupe and send what we currently have
 					dedupeAndForward(deDupeBuffer, channel)
-					deDupeBuffer = []sgbucket.TapEvent{}
+					deDupeBuffer = []sgbucket.FeedEvent{}
 					return
 				}
 				deDupeBuffer = append(deDupeBuffer, tapEvent)
@@ -263,7 +267,7 @@ func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.TapArguments) (sgbu
 				// and reset buffer.
 				if len(deDupeBuffer) >= deDuplicationWindowSize {
 					dedupeAndForward(deDupeBuffer, channel)
-					deDupeBuffer = []sgbucket.TapEvent{}
+					deDupeBuffer = []sgbucket.FeedEvent{}
 				}
 
 			case <-time.After(deDuplicationTimeoutMs):
@@ -271,7 +275,7 @@ func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.TapArguments) (sgbu
 				// give up on waiting for the buffer to fill up,
 				// de-dupe and send what we currently have
 				dedupeAndForward(deDupeBuffer, channel)
-				deDupeBuffer = []sgbucket.TapEvent{}
+				deDupeBuffer = []sgbucket.FeedEvent{}
 
 			}
 		}
@@ -317,23 +321,23 @@ func (b *LeakyBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uui
 // tap events on the upstream tap feed to better emulate real world
 // TAP/DCP behavior.
 type wrappedTapFeedImpl struct {
-	channel        chan sgbucket.TapEvent
-	wrappedTapFeed sgbucket.TapFeed
+	channel        chan sgbucket.FeedEvent
+	wrappedTapFeed sgbucket.MutationFeed
 }
 
 func (feed *wrappedTapFeedImpl) Close() error {
 	return feed.wrappedTapFeed.Close()
 }
 
-func (feed *wrappedTapFeedImpl) Events() <-chan sgbucket.TapEvent {
+func (feed *wrappedTapFeedImpl) Events() <-chan sgbucket.FeedEvent {
 	return feed.channel
 }
 
-func (feed *wrappedTapFeedImpl) WriteEvents() chan<- sgbucket.TapEvent {
+func (feed *wrappedTapFeedImpl) WriteEvents() chan<- sgbucket.FeedEvent {
 	return feed.channel
 }
 
-func dedupeAndForward(tapEvents []sgbucket.TapEvent, destChannel chan<- sgbucket.TapEvent) {
+func dedupeAndForward(tapEvents []sgbucket.FeedEvent, destChannel chan<- sgbucket.FeedEvent) {
 
 	deduped := dedupeTapEvents(tapEvents)
 
@@ -343,13 +347,13 @@ func dedupeAndForward(tapEvents []sgbucket.TapEvent, destChannel chan<- sgbucket
 
 }
 
-func dedupeTapEvents(tapEvents []sgbucket.TapEvent) []sgbucket.TapEvent {
+func dedupeTapEvents(tapEvents []sgbucket.FeedEvent) []sgbucket.FeedEvent {
 
 	// For each document key, keep track of the latest seen tapEvent
 	// doc1 -> tapEvent with Seq=1
 	// doc2 -> tapEvent with Seq=5
 	// (if tapEvent with Seq=7 comes in for doc1, it will clobber existing)
-	latestTapEventPerKey := map[string]sgbucket.TapEvent{}
+	latestTapEventPerKey := map[string]sgbucket.FeedEvent{}
 
 	for _, tapEvent := range tapEvents {
 		key := string(tapEvent.Key)
@@ -360,7 +364,7 @@ func dedupeTapEvents(tapEvents []sgbucket.TapEvent) []sgbucket.TapEvent {
 	// is in latestTapEventPerKey, and discard all previous mutations
 	// of that doc.  This will preserve the original
 	// sequence order as read off the feed.
-	deduped := []sgbucket.TapEvent{}
+	deduped := []sgbucket.FeedEvent{}
 	for _, tapEvent := range tapEvents {
 		key := string(tapEvent.Key)
 		latestTapEventForKey := latestTapEventPerKey[key]

--- a/base/leaky_bucket_test.go
+++ b/base/leaky_bucket_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestDedupeTapEventsLaterSeqSameDoc(t *testing.T) {
 
-	tapEvents := []sgbucket.TapEvent{
+	tapEvents := []sgbucket.FeedEvent{
 		{
-			Opcode:   sgbucket.TapMutation,
+			Opcode:   sgbucket.FeedOpMutation,
 			Key:      []byte("doc1"),
 			Value:    []byte(`".."`),
 			Sequence: 1,
 		},
 		{
-			Opcode:   sgbucket.TapMutation,
+			Opcode:   sgbucket.FeedOpMutation,
 			Key:      []byte("doc1"),
 			Value:    []byte(`".."`),
 			Sequence: 2,
@@ -37,15 +37,15 @@ func TestDedupeTapEventsLaterSeqSameDoc(t *testing.T) {
 
 func TestDedupeNoDedupeDifferentDocs(t *testing.T) {
 
-	tapEvents := []sgbucket.TapEvent{
+	tapEvents := []sgbucket.FeedEvent{
 		{
-			Opcode:   sgbucket.TapMutation,
+			Opcode:   sgbucket.FeedOpMutation,
 			Key:      []byte("doc1"),
 			Value:    []byte(`".."`),
 			Sequence: 1,
 		},
 		{
-			Opcode:   sgbucket.TapMutation,
+			Opcode:   sgbucket.FeedOpMutation,
 			Key:      []byte("doc2"),
 			Value:    []byte(`".."`),
 			Sequence: 2,

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -159,11 +159,18 @@ func (b *LoggingBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
-func (b *LoggingBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {
+func (b *LoggingBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "StartTapFeed(...) [%v]", time.Since(start)) }()
 	return b.bucket.StartTapFeed(args)
 }
+
+func (b *LoggingBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
+	start := time.Now()
+	defer func() { LogTo("Bucket", "StartDcpFeed(...) [%v]", time.Since(start)) }()
+	return b.bucket.StartDCPFeed(args, callback)
+}
+
 func (b *LoggingBucket) Close() {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Close() [%v]", time.Since(start)) }()

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -228,6 +228,11 @@ func (b *StatsBucket) Refresh() error {
 func (b *StatsBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 	return b.bucket.StartTapFeed(args)
 }
+
+func (b *StatsBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
+	return b.bucket.StartDCPFeed(args, callback)
+}
+
 func (b *StatsBucket) Close() {
 	b.bucket.Close()
 }

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -225,7 +225,7 @@ func (b *StatsBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
-func (b *StatsBucket) StartTapFeed(args sgbucket.TapArguments) (sgbucket.TapFeed, error) {
+func (b *StatsBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
 	return b.bucket.StartTapFeed(args)
 }
 func (b *StatsBucket) Close() {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -318,6 +318,8 @@ func (c *changeCache) waitForSequenceWithMissing(sequence uint64) {
 
 //////// ADDING CHANGES:
 
+// Given a newly changed document (received from the tap feed), adds change entries to channels.
+// The JSON must be the raw document from the bucket, with the metadata and all.
 func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	if event.Synchronous {
 		c.DocChangedSynchronous(event)
@@ -326,8 +328,6 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 }
 
-// Given a newly changed document (received from the tap feed), adds change entries to channels.
-// The JSON must be the raw document from the bucket, with the metadata and all.
 // Note that DocChangedSynchronous may be executed concurrently for multiple events (in the DCP case, DCP events
 // originating from multiple vbuckets).  Only processEntry is locking - all other functionality needs to support
 // concurrent processing.

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -42,7 +42,7 @@ type ChangeIndex interface {
 	GetCachedChanges(channelName string, options ChangesOptions) (validFrom uint64, entries []*LogEntry)
 
 	// Called to add a document to the index
-	DocChanged(event sgbucket.TapEvent)
+	DocChanged(event sgbucket.FeedEvent)
 
 	// Retrieves stable sequence for index
 	GetStableSequence(docID string) SequenceID

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"log"
 	"math"
 	"strings"
 	"sync"
@@ -15,18 +16,20 @@ import (
 // changes.
 type changeListener struct {
 	bucket                base.Bucket
-	bucketName            string                 // Used for logging
-	tapFeed               base.TapFeed           // Observes changes to bucket
-	tapNotifier           *sync.Cond             // Posts notifications when documents are updated
-	TapArgs               sgbucket.TapArguments  // The Tap Args (backfill, etc)
-	counter               uint64                 // Event counter; increments on every doc update
-	terminateCheckCounter uint64                 // Termination Event counter; increments on every notifyCheckForTermination
-	keyCounts             map[string]uint64      // Latest count at which each doc key was updated
-	DocChannel            chan sgbucket.TapEvent // Passthru channel for doc mutations
-	OnDocChanged          DocChangedFunc         // Called when change arrives on feed
+	bucketName            string                  // Used for logging
+	tapFeed               base.TapFeed            // Observes changes to bucket
+	tapNotifier           *sync.Cond              // Posts notifications when documents are updated
+	FeedArgs              sgbucket.FeedArguments  // The Tap Args (backfill, etc)
+	counter               uint64                  // Event counter; increments on every doc update
+	terminateCheckCounter uint64                  // Termination Event counter; increments on every notifyCheckForTermination
+	keyCounts             map[string]uint64       // Latest count at which each doc key was updated
+	DocChannel            chan sgbucket.FeedEvent // Passthru channel for doc mutations
+	OnDocChanged          DocChangedFunc          // Called when change arrives on feed
+	trackDocs             bool                    // Whether events should be routed to DocChannel passthru
+
 }
 
-type DocChangedFunc func(event sgbucket.TapEvent)
+type DocChangedFunc func(event sgbucket.FeedEvent)
 
 func (listener *changeListener) Init(name string) {
 	listener.bucketName = name
@@ -37,64 +40,86 @@ func (listener *changeListener) Init(name string) {
 }
 
 // Starts a changeListener on a given Bucket.
-func (listener *changeListener) Start(bucket base.Bucket, trackDocs bool, xattrImport bool, bucketStateNotify sgbucket.BucketNotifyFn) error {
+func (listener *changeListener) Start(bucket base.Bucket, trackDocs bool, backfill uint64, bucketStateNotify sgbucket.BucketNotifyFn) error {
 	listener.bucket = bucket
 	listener.bucketName = bucket.GetName()
-	listener.TapArgs = sgbucket.TapArguments{
-		Backfill: sgbucket.TapNoBackfill,
+	listener.FeedArgs = sgbucket.FeedArguments{
+		Backfill: backfill,
 		Notify:   bucketStateNotify,
 	}
 
-	// TODO: for xattr import nodes, we're forcing full backfill.  Pending #2484
-	if xattrImport {
-		listener.TapArgs.Backfill = 0
-	}
-
-	tapFeed, err := bucket.StartTapFeed(listener.TapArgs)
-	if err != nil {
-		return err
-	}
-
-	listener.tapFeed = tapFeed
 	if trackDocs {
-		listener.DocChannel = make(chan sgbucket.TapEvent, 100)
+		listener.DocChannel = make(chan sgbucket.FeedEvent, 100)
+		listener.trackDocs = true
 	}
 
-	// Start a goroutine to broadcast to the tapNotifier whenever a channel or user/role changes:
-	go func() {
-		defer func() {
-			listener.notifyStopping()
-			if listener.DocChannel != nil {
-				close(listener.DocChannel)
+	return listener.StartMutationFeed(bucket)
+}
+
+func (listener *changeListener) StartMutationFeed(bucket base.Bucket) error {
+
+	// Uses DCP by default, unless TAP is explicitly specified
+	feedType := base.GetFeedType(bucket)
+	switch feedType {
+	case base.TapFeedType:
+		// TAP Feed
+		//    TAP feed is a go-channel of Tap events served by the bucket.  Start the feed, then
+		//    start a goroutine to work the event channel, calling ProcessEvent for each event
+		var err error
+		log.Printf("Calling start tap feed from StartMutationFeed")
+		listener.tapFeed, err = bucket.StartTapFeed(listener.FeedArgs)
+		if err != nil {
+			return err
+		}
+		go func() {
+			defer func() {
+				listener.notifyStopping()
+				if listener.DocChannel != nil {
+					close(listener.DocChannel)
+				}
+			}()
+			for event := range listener.tapFeed.Events() {
+				listener.ProcessEvent(event)
 			}
 		}()
-		for event := range tapFeed.Events() {
-			if event.Opcode == sgbucket.TapMutation || event.Opcode == sgbucket.TapDeletion {
-				key := string(event.Key)
-				if strings.HasPrefix(key, auth.UserKeyPrefix) ||
-					strings.HasPrefix(key, auth.RoleKeyPrefix) {
-					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(event)
-					}
-					listener.Notify(base.SetOf(key))
-				} else if strings.HasPrefix(key, UnusedSequenceKeyPrefix) {
-					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(event)
-					}
-				} else if !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, base.KIndexPrefix) {
-					if listener.OnDocChanged != nil {
-						listener.OnDocChanged(event)
-					}
-					if trackDocs {
-						listener.DocChannel <- event
-					}
+		return nil
+	default:
+		// DCP Feed
+		//    DCP receiver isn't go-channel based - DCPReceiver calls ProcessEvent directly.
+		base.LogTo("Feed", "Using DCP feed for bucket: %q (based on feed_type specified in config file", bucket.GetName())
+		return bucket.StartDCPFeed(listener.FeedArgs, listener.ProcessEvent)
+	}
+}
 
-				}
+func (listener *changeListener) ProcessEvent(event sgbucket.FeedEvent) bool {
+	requiresCheckpointPersistence := true
+	if event.Opcode == sgbucket.FeedOpMutation || event.Opcode == sgbucket.FeedOpDeletion {
+		key := string(event.Key)
+		if strings.HasPrefix(key, auth.UserKeyPrefix) ||
+			strings.HasPrefix(key, auth.RoleKeyPrefix) {
+			if listener.OnDocChanged != nil {
+				listener.OnDocChanged(event)
 			}
-		}
-	}()
+			listener.Notify(base.SetOf(key))
+		} else if strings.HasPrefix(key, UnusedSequenceKeyPrefix) {
+			if listener.OnDocChanged != nil {
+				listener.OnDocChanged(event)
+			}
+		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix) {
+			// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
+			// we'll end up in a feedback loop for their vbucket
+			requiresCheckpointPersistence = false
+		} else if !strings.HasPrefix(key, KSyncKeyPrefix) && !strings.HasPrefix(key, base.KIndexPrefix) {
+			if listener.OnDocChanged != nil {
+				listener.OnDocChanged(event)
+			}
+			if listener.trackDocs {
+				listener.DocChannel <- event
+			}
 
-	return nil
+		}
+	}
+	return requiresCheckpointPersistence
 }
 
 // Stops a changeListener. Any pending Wait() calls will immediately return false.

--- a/db/document.go
+++ b/db/document.go
@@ -119,6 +119,9 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*syncData, error)
 // Unmarshals sync metadata for a document arriving via DCP.  Includes handling for xattr content
 // being included in data.  If not present in either xattr or document body, returns nil but no error.
 // Returns the raw body, in case it's needed for import.
+
+// TODO: Use pool of unmarshal workers to manage throughput spikes
+
 func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory bool) (result *syncData, rawBody []byte, err error) {
 
 	var body []byte

--- a/db/document.go
+++ b/db/document.go
@@ -120,8 +120,7 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*syncData, error)
 // being included in data.  If not present in either xattr or document body, returns nil but no error.
 // Returns the raw body, in case it's needed for import.
 
-// TODO: Use pool of unmarshal workers to manage throughput spikes
-
+// TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
 func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory bool) (result *syncData, rawBody []byte, err error) {
 
 	var body []byte

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -175,7 +175,7 @@ func (k *kvChangeIndex) setIndexPartitionMap(partitionMap base.IndexPartitionMap
 	}
 }
 
-func (k *kvChangeIndex) DocChanged(event sgbucket.TapEvent) {
+func (k *kvChangeIndex) DocChanged(event sgbucket.FeedEvent) {
 	// no-op for reader
 	base.Warn("DocChanged called in index reader for doc %s, will be ignored.", event.Key)
 }

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"log"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -28,7 +29,9 @@ type Shadower struct {
 
 // Creates a new Shadower.
 func NewShadower(context *DatabaseContext, bucket base.Bucket, docIDPattern *regexp.Regexp) (*Shadower, error) {
-	tapFeed, err := bucket.StartTapFeed(sgbucket.TapArguments{Backfill: 0, Notify: func(bucket string, err error) {
+
+	log.Printf("Calling start tap feed from NewShadower")
+	tapFeed, err := bucket.StartTapFeed(sgbucket.FeedArguments{Backfill: 0, Notify: func(bucket string, err error) {
 		context.TakeDbOffline("Lost shadower TAP Feed")
 	}})
 	if err != nil {
@@ -61,18 +64,18 @@ func (s *Shadower) readTapFeed() {
 	vbucketsFilling := 0
 	for event := range s.tapFeed.Events() {
 		switch event.Opcode {
-		case sgbucket.TapBeginBackfill:
+		case sgbucket.FeedOpBeginBackfill:
 			if vbucketsFilling == 0 {
 				base.LogTo("Shadow", "Reading history of external bucket")
 			}
 			vbucketsFilling++
 			//base.LogTo("Shadow", "Reading history of external bucket")
-		case sgbucket.TapMutation, sgbucket.TapDeletion:
+		case sgbucket.FeedOpMutation, sgbucket.FeedOpDeletion:
 			key := string(event.Key)
 			if !s.docIDMatches(key) {
 				break
 			}
-			isDeletion := event.Opcode == sgbucket.TapDeletion
+			isDeletion := event.Opcode == sgbucket.FeedOpDeletion
 			if !isDeletion && event.Expiry > 0 {
 				break // ignore ephemeral documents
 			}
@@ -81,7 +84,7 @@ func (s *Shadower) readTapFeed() {
 				base.Warn("Error applying change %q from external bucket: %v", key, err)
 			}
 			atomic.AddUint64(&s.pullCount, 1)
-		case sgbucket.TapEndBackfill:
+		case sgbucket.FeedOpEndBackfill:
 			if vbucketsFilling--; vbucketsFilling == 0 {
 				base.LogTo("Shadow", "Caught up with history of external bucket")
 			}

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"log"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -30,7 +29,6 @@ type Shadower struct {
 // Creates a new Shadower.
 func NewShadower(context *DatabaseContext, bucket base.Bucket, docIDPattern *regexp.Regexp) (*Shadower, error) {
 
-	log.Printf("Calling start tap feed from NewShadower")
 	tapFeed, err := bucket.StartTapFeed(sgbucket.FeedArguments{Backfill: 0, Notify: func(bucket string, err error) {
 		context.TakeDbOffline("Lost shadower TAP Feed")
 	}})

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -70,7 +70,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f135dba8e41932090ae95a2323da28ea1f2a86dc"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="a98ba07c7c61b064ec267291e8c9ce837439bd96"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -54,7 +54,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f9d52719c4f55dcb08b944a96cebe8a49d548085"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="197eb2700027a025f3395f240a0eb7f3e4ddae68"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="38214ff773a7fa8df2789558ebea9b3f86379324"/>
 
@@ -70,7 +70,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="be7119def82a501f75272f2e3233173377d2a7c4"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f135dba8e41932090ae95a2323da28ea1f2a86dc"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="e3acb7b1aea679b71b86aa5f3dccd2252e76b757"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="33cc694cdd79b7430534e7c4b6f7eb87a927636a"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>
@@ -54,7 +54,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="197eb2700027a025f3395f240a0eb7f3e4ddae68"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="9b0b33b2668d8d424eab6e8110af691761190567"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="38214ff773a7fa8df2789558ebea9b3f86379324"/>
 
@@ -70,7 +70,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="a98ba07c7c61b064ec267291e8c9ce837439bd96"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="109e536952bdc785f60a8023c6d01058b876a146"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b0b84fc5d8efaa831c75ee02fa62a8f40c1280e6"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="e3acb7b1aea679b71b86aa5f3dccd2252e76b757"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>


### PR DESCRIPTION
Previously SG nodes responsible for SDK import were restarting the DCP feed from zero on restart.  To avoid redundant (no-op) reprocessing of documents on restart, this adds persistence of DCP snapshot metadata to the bucket, to support resuming the DCP stream where it was left off.

Requires refactoring of DCP stream handling to ensure that previous mutations are processed/imported before metadata is persisted.  Instead of writing incoming DCP events to a common channel, feed processing is treated as a synchronous (per vbucket) operation.

Includes handling to ensure that persisted checkpoints don't cause a feedback loop when their vbucket is otherwise idle.

Fixes #2484.

Requires:
 https://github.com/couchbaselabs/walrus/pull/31
 https://github.com/couchbase/sg-bucket/pull/26

Needs manifest update after dependencies are merged.