### PR TITLE
Avoid redundant GET during import processing

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -209,7 +209,7 @@ func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.W
 	return bucket.Bucket.WriteUpdate(k, exp, cbCallback)
 }
 
-func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, currentCas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	Warn("WriteUpdateWithXattr not implemented by CouchbaseBucket")
 	return 0, errors.New("WriteUpdateWithXattr not implemented by CouchbaseBucket")
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -209,7 +209,7 @@ func (bucket CouchbaseBucket) WriteUpdate(k string, exp int, callback sgbucket.W
 	return bucket.Bucket.WriteUpdate(k, exp, cbCallback)
 }
 
-func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (bucket CouchbaseBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, currentCas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	Warn("WriteUpdateWithXattr not implemented by CouchbaseBucket")
 	return 0, errors.New("WriteUpdateWithXattr not implemented by CouchbaseBucket")
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1398,33 +1398,45 @@ func (bucket CouchbaseBucketGoCB) WriteUpdate(k string, exp int, callback sgbuck
 	}
 }
 
-func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+// WriteUpdateWithXattr retrieves the existing doc from the bucket, invokes the callback to update the document, then writes the new document to the bucket.  Will repeat this process on cas
+// failure.  If previousValue/xattr/cas are provided, will use those on the first iteration instead of retrieving from the bucket.
+func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, exp int, currentValue []byte, currentXattr []byte, currentCas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+
+	var value []byte
+	var xattrValue []byte
+	var cas uint64
+	emptyCas := uint64(0)
+
+	// If an existing value has been provided, use that as the initial value
+	if currentValue != nil && currentCas > 0 {
+		value = currentValue
+		xattrValue = currentXattr
+		cas = currentCas
+	}
 
 	for {
-		var value []byte
-		var xattrValue []byte
 		var err error
-		var cas uint64
-		emptyCas := uint64(0)
+		// If no existing value has been provided, retrieve the current value from the bucket
+		if cas == 0 {
+			// Load the existing value.
+			gocbExpvars.Add("Update_GetWithXattr", 1)
+			cas, err = bucket.GetWithXattr(k, xattrKey, &value, &xattrValue)
 
-		// Load the existing value.
-		gocbExpvars.Add("Update_GetWithXattr", 1)
-		cas, err = bucket.GetWithXattr(k, xattrKey, &value, &xattrValue)
+			if err != nil {
+				if !bucket.IsKeyNotFoundError(err) {
+					// Unexpected error, cancel writeupdate
+					LogTo("CRUD", "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", k, xattrKey, err)
+					return emptyCas, err
+				}
+				// Key not found - initialize cas and values
 
-		if err != nil {
-			if !bucket.IsKeyNotFoundError(err) {
-				// Unexpected error, cancel writeupdate
-				LogTo("CRUD", "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", k, xattrKey, err)
-				return emptyCas, err
+				LogTo("CRUD+", "WriteUpdateWithXattr for key=%s. GetWithXattr err: %v.  Treating as insert.", k, cas)
+				cas = 0
+				value = nil
+				xattrValue = nil
+			} else {
+				LogTo("CRUD+", "WriteUpdateWithXattr for key=%s. GetWithXattr successful - cas: %v  len(value):%d", k, cas, len(value))
 			}
-			// Key not found - initialize cas and values
-
-			LogTo("CRUD+", "WriteUpdateWithXattr for key=%s. GetWithXattr err: %v.  Treating as insert.", k, cas)
-			cas = 0
-			value = nil
-			xattrValue = nil
-		} else {
-			LogTo("CRUD+", "WriteUpdateWithXattr for key=%s. GetWithXattr successful - cas: %v  len(value):%d", k, cas, len(value))
 		}
 
 		// Invoke callback to get updated value
@@ -1443,7 +1455,11 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 			case nil:
 				return deleteCas, deleteErr
 			case gocb.ErrKeyExists:
-				continue // Retry on CAS failure
+				// Retry on CAS failure.  Reset loaded value and set cas=0
+				value = nil
+				xattrValue = nil
+				cas = 0
+				continue
 			default:
 				// UpdateXattr already does retry on recoverable errors, so return any error here
 				LogTo("CRUD", "Delete and update of xattr during WriteUpdateWithXattr failed for key %s: %v", k, deleteErr)
@@ -1564,7 +1580,7 @@ func (bucket CouchbaseBucketGoCB) GetDDoc(docname string, into interface{}) erro
 func (bucket CouchbaseBucketGoCB) getBucketManager() (*gocb.BucketManager, error) {
 
 	username, password := bucket.GetBucketCredentials()
-	
+
 	manager := bucket.Bucket.Manager(username, password)
 	if manager == nil {
 		return nil, fmt.Errorf("Unable to obtain manager for bucket %s", bucket.GetName())

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1400,7 +1400,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdate(k string, exp int, callback sgbuck
 
 // WriteUpdateWithXattr retrieves the existing doc from the bucket, invokes the callback to update the document, then writes the new document to the bucket.  Will repeat this process on cas
 // failure.  If previousValue/xattr/cas are provided, will use those on the first iteration instead of retrieving from the bucket.
-func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, exp int, currentValue []byte, currentXattr []byte, currentCas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 
 	var value []byte
 	var xattrValue []byte
@@ -1408,10 +1408,10 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 	emptyCas := uint64(0)
 
 	// If an existing value has been provided, use that as the initial value
-	if currentValue != nil && currentCas > 0 {
-		value = currentValue
-		xattrValue = currentXattr
-		cas = currentCas
+	if previous != nil && previous.Cas > 0 {
+		value = previous.Body
+		xattrValue = previous.Xattr
+		cas = previous.Cas
 	}
 
 	for {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1455,10 +1455,7 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 			case nil:
 				return deleteCas, deleteErr
 			case gocb.ErrKeyExists:
-				// Retry on CAS failure.  Reset loaded value and set cas=0
-				value = nil
-				xattrValue = nil
-				cas = 0
+				// Retry on CAS failure.
 				continue
 			default:
 				// UpdateXattr already does retry on recoverable errors, so return any error here
@@ -1482,6 +1479,11 @@ func (bucket CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string
 				return casOut, nil
 			}
 		}
+		// Reset value, xattr, cas for cas retry
+		value = nil
+		xattrValue = nil
+		cas = 0
+
 	}
 
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1042,7 +1042,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	}
 
 	// Insert
-	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
+	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, nil, nil, 0, writeUpdateFunc)
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}
@@ -1058,7 +1058,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	assert.Equals(t, retrievedXattr["seq"], float64(1))
 
 	// Update
-	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, writeUpdateFunc)
+	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, nil, nil, 0, writeUpdateFunc)
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1042,7 +1042,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	}
 
 	// Insert
-	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, nil, nil, 0, writeUpdateFunc)
+	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, nil, writeUpdateFunc)
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}
@@ -1058,7 +1058,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	assert.Equals(t, retrievedXattr["seq"], float64(1))
 
 	// Update
-	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, nil, nil, 0, writeUpdateFunc)
+	_, err = bucket.WriteUpdateWithXattr(key, xattrName, 0, nil, writeUpdateFunc)
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -128,8 +128,8 @@ func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
-func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, cas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, currentValue, currentXattr, cas, callback)
+func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }
 
 func (b *LeakyBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -128,8 +128,8 @@ func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
-func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
+func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, cas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, currentValue, currentXattr, cas, callback)
 }
 
 func (b *LeakyBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -103,12 +103,12 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp int, cas u
 	defer func() { LogTo("Bucket", "WriteCasWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, cas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() {
 		LogTo("Bucket", "WriteUpdateWithXattr(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start))
 	}()
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, currentValue, currentXattr, cas, callback)
 }
 func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
 	start := time.Now()

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -103,12 +103,12 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp int, cas u
 	defer func() { LogTo("Bucket", "WriteCasWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, cas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() {
 		LogTo("Bucket", "WriteUpdateWithXattr(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start))
 	}()
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, currentValue, currentXattr, cas, callback)
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }
 func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
 	start := time.Now()

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -181,9 +181,9 @@ func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	}
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, cas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	defer b.docWrite(1, -1)
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, currentValue, currentXattr, cas, callback)
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }
 func (b *StatsBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
 	cas, err = b.bucket.GetWithXattr(k, xattr, rv, xv)

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -181,9 +181,9 @@ func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	}
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, currentValue []byte, currentXattr []byte, cas uint64, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	defer b.docWrite(1, -1)
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, callback)
+	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, currentValue, currentXattr, cas, callback)
 }
 func (b *StatsBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
 	cas, err = b.bucket.GetWithXattr(k, xattr, rv, xv)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -360,7 +360,7 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 	}
 
 	// First unmarshal the doc (just its metadata, to save time/memory):
-	syncData, rawBody, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, false)
+	syncData, rawBody, rawXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, false)
 
 	if err != nil {
 		base.Warn("changeCache: Error unmarshaling doc %q: %v", docID, err)
@@ -378,7 +378,7 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 					rawBody = nil
 				}
 				db := Database{DatabaseContext: c.context, user: nil}
-				_, err := db.ImportDocRaw(docID, rawBody, isDelete, event.Cas, ImportFromFeed)
+				_, err := db.ImportDocRaw(docID, rawBody, rawXattr, isDelete, event.Cas, ImportFromFeed)
 				if err != nil {
 					if err == base.ErrImportCasFailure {
 						base.LogTo("Import+", "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", docID)

--- a/db/database.go
+++ b/db/database.go
@@ -1095,7 +1095,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		}
 		var err error
 		if db.UseXattrs() {
-			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
+			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, nil, 0, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
 				// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing, so deleteDoc is always returned as false.
 				if currentValue == nil || len(currentValue) == 0 {
 					return nil, nil, deleteDoc, errors.New("Cancel update")

--- a/db/database.go
+++ b/db/database.go
@@ -1095,7 +1095,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		}
 		var err error
 		if db.UseXattrs() {
-			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, nil, 0, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
+			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
 				// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing, so deleteDoc is always returned as false.
 				if currentValue == nil || len(currentValue) == 0 {
 					return nil, nil, deleteDoc, errors.New("Cancel update")

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fba925c9469fc1b00899d322ad9c29e799096ac5"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="41b5ec01aae9a18263918475e726bcfd1f96a015"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="38214ff773a7fa8df2789558ebea9b3f86379324"/>
 
@@ -71,7 +71,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="3b86f7b33df80129f8b35f027af95ea1cd48111f"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="b4ca40ab5dadfac113bdd211bf31d0aa858b11fd"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="96eaa3c331a18ffcd7df1b5ea48a6db2f671ad80"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b60872fdda3d826acb96e536a882a094e8e07f45"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="41b5ec01aae9a18263918475e726bcfd1f96a015"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="38214ff773a7fa8df2789558ebea9b3f86379324"/>
 
@@ -71,7 +71,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="b4ca40ab5dadfac113bdd211bf31d0aa858b11fd"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cafd6f12f21d446d49ec1dfb16b7cdc878e5b907"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="05e15952028d65da00ac493f93c16037fb3b8ca0"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="96eaa3c331a18ffcd7df1b5ea48a6db2f671ad80"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>
@@ -55,7 +55,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="9b0b33b2668d8d424eab6e8110af691761190567"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="fba925c9469fc1b00899d322ad9c29e799096ac5"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="38214ff773a7fa8df2789558ebea9b3f86379324"/>
 
@@ -71,7 +71,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="109e536952bdc785f60a8023c6d01058b876a146"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="3b86f7b33df80129f8b35f027af95ea1cd48111f"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
Previously WriteUpdateWithXattr didn't support callers passing in the current state of the document, when known.  This meant that import processing incurred an unnecessary GET operation to retrieve the document as part of the standard WriteUpdate iteration.  

Modified WriteUpdateWithXattr to accept current value, current xattr value, and current cas as input, and to use these instead of performing an initial GET when present.  

Fixes #2735

Dependencies:

https://github.com/couchbase/sg-bucket/pull/27
https://github.com/couchbaselabs/walrus/pull/32
https://github.com/couchbaselabs/sync-gateway-accel/pull/166