### PR TITLE
Feature/issue 2747 dcp helo

### DIFF
--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -504,6 +504,14 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		dataSourceOptions.IncludeXAttrs = true
 	}
 
+	// Create a prefix that will be used to create the dcp stream name, which must be globally unique
+	// in order to avoid https://issues.couchbase.com/browse/MB-24237.  It's also useful to have the Sync Gateway
+	// version number for debugging purposes
+	dcpStreamNamePrefix := fmt.Sprintf(
+		"SyncGateway-%v-%v",
+	)
+	dataSourceOptions.Name = dcpStreamNamePrefix
+
 	LogTo("Feed+", "Connecting to new bucket datasource.  URLs:%s, pool:%s, bucket:%s", urls, poolName, bucketName)
 	bds, err := cbdatasource.NewBucketDataSource(
 		urls,

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -547,7 +547,7 @@ func GenerateDcpStreamName(product string) string {
 	// require the random number generator to be seeded), so that it's more likely to be unique across different processes.
 	uuidComponent := uuid.NewV2(uuid.DomainPerson).String()
 
-	commitTruncated := SafeSlice(GitCommit, 7)
+	commitTruncated := StringPrefix(GitCommit, 7)
 
 	return fmt.Sprintf(
 		"%v-v-%v-commit-%v-uuid-%v",

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -547,10 +547,13 @@ func GenerateDcpStreamName(product string) string {
 	// require the random number generator to be seeded), so that it's more likely to be unique across different processes.
 	uuidComponent := uuid.NewV2(uuid.DomainPerson).String()
 
+	commitTruncated := SafeSlice(GitCommit, 7)
+
 	return fmt.Sprintf(
-		"%v-commit-%v-uuid-%v",
+		"%v-v-%v-commit-%v-uuid-%v",
 		product,
-		GitCommit,
+		VersionNumber,
+		commitTruncated,
 		uuidComponent,
 	)
 

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -19,6 +19,7 @@ import (
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/satori/go.uuid"
 )
 
 var dcpExpvars *expvar.Map
@@ -498,9 +499,8 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		dcpReceiver.SeedSeqnos(vbuuids, startSeqnos)
 	}
 
-	var dataSourceOptions *cbdatasource.BucketDataSourceOptions
+	dataSourceOptions := cbdatasource.DefaultBucketDataSourceOptions
 	if spec.UseXattrs {
-		dataSourceOptions = cbdatasource.DefaultBucketDataSourceOptions
 		dataSourceOptions.IncludeXAttrs = true
 	}
 
@@ -508,7 +508,9 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	// in order to avoid https://issues.couchbase.com/browse/MB-24237.  It's also useful to have the Sync Gateway
 	// version number for debugging purposes
 	dcpStreamNamePrefix := fmt.Sprintf(
-		"SyncGateway-%v-%v",
+		"SyncGateway-%v-%x",
+		LongVersionString,
+		uuid.NewV4().String(),
 	)
 	dataSourceOptions.Name = dcpStreamNamePrefix
 

--- a/base/git_info.go
+++ b/base/git_info.go
@@ -1,4 +1,4 @@
-package rest
+package base
 
 // The git commit that was compiled. This will be filled in by the compiler.
 const GitProductName = ""

--- a/base/util.go
+++ b/base/util.go
@@ -667,3 +667,13 @@ func SingleHostCouchbaseURIToHttpURL(couchbaseUri string) (httpUrl string) {
 	return result.String()
 
 }
+
+// Slice a string to be less than or equal to desiredSze
+func SafeSlice(s string, desiredSize int) string {
+	if len(s) <= desiredSize {
+		return s
+	}
+
+	return s[:desiredSize]
+
+}

--- a/base/util.go
+++ b/base/util.go
@@ -669,7 +669,7 @@ func SingleHostCouchbaseURIToHttpURL(couchbaseUri string) (httpUrl string) {
 }
 
 // Slice a string to be less than or equal to desiredSze
-func SafeSlice(s string, desiredSize int) string {
+func StringPrefix(s string, desiredSize int) string {
 	if len(s) <= desiredSize {
 		return s
 	}

--- a/base/version.go
+++ b/base/version.go
@@ -1,0 +1,44 @@
+package base
+
+import (
+	"strings"
+	"fmt"
+)
+
+const ServerName = "@PRODUCT_NAME@"                  // DO NOT CHANGE; clients check this
+const VersionNumber float64 = 1.5                    // API/feature level
+const VersionBuildNumberString = "@PRODUCT_VERSION@" // Real string substituted by Gerrit
+const VersionCommitSHA = "@COMMIT_SHA@"              // Real string substituted by Gerrit
+
+// This appears in the "Server:" header of HTTP responses.
+// This should be changed only very cautiously, because Couchbase Lite parses the header value
+// to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version. This in turn
+// determines what replication API features it will use.
+var VersionString string
+
+// This includes build number; appears in the response of "GET /" and the initial log message
+var LongVersionString string
+
+// Either comes from Gerrit (jenkins builds) or Git (dev builds)
+var ProductName string
+
+func init() {
+	if VersionBuildNumberString[0] != '@' {
+		//Split version number and build number (optional)
+		versionTokens := strings.Split(VersionBuildNumberString, "-")
+		BuildVersionString := versionTokens[0]
+		var BuildNumberString string
+		if len(versionTokens) > 1 {
+			BuildNumberString = fmt.Sprintf("%s;", versionTokens[1])
+		}
+		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s)",
+			ServerName, BuildVersionString, BuildNumberString, VersionCommitSHA)
+
+		VersionString = fmt.Sprintf("%s/%s", ServerName, BuildVersionString)
+		ProductName = ServerName
+	} else {
+		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s)", GitProductName, GitBranch, GitCommit, GitDirty)
+		VersionString = fmt.Sprintf("%s/%g branch/%s commit/%.7s%s", GitProductName, VersionNumber, GitBranch, GitCommit, GitDirty)
+		ProductName = GitProductName
+	}
+}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="33cc694cdd79b7430534e7c4b6f7eb87a927636a"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7ade7ebafd04743b1a9f71bf7a1a0f9da52271a7"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="7ade7ebafd04743b1a9f71bf7a1a0f9da52271a7"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="05e15952028d65da00ac493f93c16037fb3b8ca0"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -15,6 +15,7 @@
   <remote fetch="https://github.com/kardianos/" name="kardianos"/>
   <remote fetch="https://github.com/coreos/" name="coreos"/>
   <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
+  <remote fetch="https://github.com/satori/" name="satori"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
@@ -117,6 +118,8 @@
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
   <project name="go-blip" path="godeps/src/github.com/snej/go-blip" remote="snej" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+
+  <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
 </manifest>
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -11,7 +11,6 @@ package rest
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	httpprof "net/http/pprof"
@@ -19,7 +18,6 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strconv"
-	"strings"
 
 	"sync/atomic"
 
@@ -28,50 +26,12 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
-const ServerName = "@PRODUCT_NAME@"                  // DO NOT CHANGE; clients check this
-const VersionNumber float64 = 1.5                    // API/feature level
-const VersionBuildNumberString = "@PRODUCT_VERSION@" // Real string substituted by Gerrit
-const VersionCommitSHA = "@COMMIT_SHA@"              // Real string substituted by Gerrit
-
-// This appears in the "Server:" header of HTTP responses.
-// This should be changed only very cautiously, because Couchbase Lite parses the header value
-// to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version. This in turn
-// determines what replication API features it will use.
-var VersionString string
-
-// This includes build number; appears in the response of "GET /" and the initial log message
-var LongVersionString string
-
-// Either comes from Gerrit (jenkins builds) or Git (dev builds)
-var ProductName string
-
-func init() {
-	if VersionBuildNumberString[0] != '@' {
-		//Split version number and build number (optional)
-		versionTokens := strings.Split(VersionBuildNumberString, "-")
-		BuildVersionString := versionTokens[0]
-		var BuildNumberString string
-		if len(versionTokens) > 1 {
-			BuildNumberString = fmt.Sprintf("%s;", versionTokens[1])
-		}
-		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s)",
-			ServerName, BuildVersionString, BuildNumberString, VersionCommitSHA)
-
-		VersionString = fmt.Sprintf("%s/%s", ServerName, BuildVersionString)
-		ProductName = ServerName
-	} else {
-		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s)", GitProductName, GitBranch, GitCommit, GitDirty)
-		VersionString = fmt.Sprintf("%s/%g branch/%s commit/%.7s%s", GitProductName, VersionNumber, GitBranch, GitCommit, GitDirty)
-		ProductName = GitProductName
-	}
-}
-
 // HTTP handler for the root ("/")
 func (h *handler) handleRoot() error {
 	response := map[string]interface{}{
 		"couchdb": "Welcome",
-		"version": LongVersionString,
-		"vendor":  db.Body{"name": ProductName, "version": VersionNumber},
+		"version": base.LongVersionString,
+		"vendor":  db.Body{"name": base.ProductName, "version": base.VersionNumber},
 	}
 	if h.privs == adminPrivs {
 		response["ADMIN"] = true

--- a/rest/config.go
+++ b/rest/config.go
@@ -745,7 +745,7 @@ func (config *ServerConfig) NumIndexWriters() int {
 func RunServer(config *ServerConfig) {
 	PrettyPrint = config.Pretty
 
-	base.Logf("==== %s ====", LongVersionString)
+	base.Logf("==== %s ====", base.LongVersionString)
 
 	if os.Getenv("GOMAXPROCS") == "" && runtime.GOMAXPROCS(0) == 1 {
 		cpus := runtime.NumCPU()

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -149,7 +149,7 @@ func (h *handler) invoke(method handlerMethod) error {
 		return base.HTTPErrorf(http.StatusUnsupportedMediaType, "Unsupported Content-Encoding; use gzip")
 	}
 
-	h.setHeader("Server", VersionString)
+	h.setHeader("Server", base.VersionString)
 
 	// If there is a "db" path variable, look up the database context:
 	var dbContext *db.DatabaseContext
@@ -599,8 +599,6 @@ func (h *handler) writeTextStatus(status int, value []byte) {
 	h.response.Write(value)
 
 }
-
-
 
 func (h *handler) addJSON(value interface{}) {
 	encoder := json.NewEncoder(h.response)

--- a/set-version-stamp.sh
+++ b/set-version-stamp.sh
@@ -4,7 +4,7 @@
 # git version to the Sync Gateway binary
 
 ## Update the version
-BUILD_INFO="./rest/git_info.go"
+BUILD_INFO="./base/git_info.go"
 
 #tell git to ignore any local changes to git_info.go, we don't want to commit them to the repo
 git update-index --assume-unchanged ${BUILD_INFO}


### PR DESCRIPTION
Fixes #2747 

# Changes

- Move version constants from rest -> base
- Update scripts that update version constants
- Customize cbdatasource name to include
    - SG Version (1.5)
    - SG Commit hash 
    - A UUID that should be unique for each sync gw instance, even when running as different processes on the same machine 

# PR tasks

- [ ] Merge SG Accel companion PR: https://github.com/couchbaselabs/sync-gateway-accel/pull/167
- [ ] Update manifest to point to latest SG Accel commit
- [x] [Unit integration test xattr=true](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/175/console)
- [x] [Unit integration test xattr=false](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/176/console)