### PR TITLE
Support xattr in GetDocSyncData

### DIFF
--- a/test_integration.sh
+++ b/test_integration.sh
@@ -205,7 +205,8 @@ declare -a arr=(
     "TestGetRestrictedIntQuery"
     "TestParseHTTPRangeHeader"
     "TestSanitizeURL"
-    "TestVerifyHTTPSSupport")
+    "TestVerifyHTTPSSupport",
+    "TestChangesIncludeConflicts")
 
 
 # --------------------------------- SG Accel tests -----------------------------------------


### PR DESCRIPTION
Adds xattr support for sync data retrieval in GetDocSyncData (currently used for changes with style=all_docs).

Includes on-demand import handling.

Fixes #2764