### PR TITLE
Feature/issue 163 sg accel cbgt multiple url

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -668,18 +668,8 @@ func SingleHostCouchbaseURIToHttpURL(couchbaseUri string) (httpUrl string) {
 
 }
 
-// Take this array of strings and return a single semi-colon delimited string
-// ["http://host1", "http://host2"] -> "http://host1;http://host2"
-func SemicolonDelimited(originalStrings []string) (semicolonDelimited string) {
-	buffer := bytes.NewBufferString("")
-	for i, url := range originalStrings {
-		buffer.WriteString(url)
-		if i < (len(originalStrings) - 1) {
-			buffer.WriteString(";")
-		}
-	}
-	return buffer.String()
-}
+
+
 // Slice a string to be less than or equal to desiredSze
 func StringPrefix(s string, desiredSize int) string {
 	if len(s) <= desiredSize {

--- a/base/util.go
+++ b/base/util.go
@@ -668,6 +668,18 @@ func SingleHostCouchbaseURIToHttpURL(couchbaseUri string) (httpUrl string) {
 
 }
 
+// Take this array of strings and return a single semi-colon delimited string
+// ["http://host1", "http://host2"] -> "http://host1;http://host2"
+func SemicolonDelimited(originalStrings []string) (semicolonDelimited string) {
+	buffer := bytes.NewBufferString("")
+	for i, url := range originalStrings {
+		buffer.WriteString(url)
+		if i < (len(originalStrings) - 1) {
+			buffer.WriteString(";")
+		}
+	}
+	return buffer.String()
+}
 // Slice a string to be less than or equal to desiredSze
 func StringPrefix(s string, desiredSize int) string {
 	if len(s) <= desiredSize {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -37,7 +37,7 @@
   <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="8411555ab31944a2369c2dc97ddd8e1d4725fa6c"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>
+  <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>
   
   <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -57,7 +57,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="38214ff773a7fa8df2789558ebea9b3f86379324"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6c44a8829958bfe71283ed9fec2c28d722a3be27"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="0cd63ba8b594091ea0005ec50ee21299e0b22d97"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="37da2e05f155fb8b302c92c4270187e18a6748b2"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="8774801db2a031d368c23e9db7fd303ad0b5fe43"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="8774801db2a031d368c23e9db7fd303ad0b5fe43"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="f7d610905a0a50b8b871b0ca0440d49b61a5c222"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="8411555ab31944a2369c2dc97ddd8e1d4725fa6c"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="ba1f0aa65395942ab50fa61e2490690466ae7e1f"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="4ee93dc5a0bc12efa242fd837a1d7606e82dd656"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="37da2e05f155fb8b302c92c4270187e18a6748b2"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="ba1f0aa65395942ab50fa61e2490690466ae7e1f"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="4ee93dc5a0bc12efa242fd837a1d7606e82dd656"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b60872fdda3d826acb96e536a882a094e8e07f45"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="8411555ab31944a2369c2dc97ddd8e1d4725fa6c"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="489e5ffbbd0dd63db68682529564ee8938ec77e2"/>


### PR DESCRIPTION
Fixes https://github.com/couchbaselabs/sync-gateway-accel/issues/163

# Changes 

- Pass multiple urls to CBGT
- Attempt to initialized CBGT autofailover / heartbeat based on all of the urls, and use the first one that works (this could get fixed at a deeper level which would require cbheartbeat changes, and since that uses go-couchbase it might not be feasible)

# PR checklist

- [ ] [Merge sg-accel companion PR](https://github.com/couchbaselabs/sync-gateway-accel/pull/169)
- [ ] Bump sg-accel manifest commit hash post-merge
- [ ] [unit integration xattrs=true](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/185/)
- [ ] [unit integration xattrs=false](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/186/)