### PR TITLE
Skip import processing for binary documents

### DIFF
--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -36,6 +36,9 @@ const (
 	MemcachedDataTypeXattr
 )
 
+// Memcached datatype for raw (binary) document (non-flag)
+const MemcachedDataTypeRaw = 0
+
 const DCPCheckpointPrefix = "_sync:dcp_ck:" // Prefix used for DCP checkpoint persistence (is appended with vbno)
 
 // Number of non-checkpoint updates per vbucket required to trigger metadata persistence.  Must be greater than zero to avoid

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -370,7 +370,7 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 	if err != nil {
 		// Avoid log noise related to failed unmarshaling of binary documents.
 		if event.DataType != base.MemcachedDataTypeRaw {
-			base.Warn("changeCache: Error unmarshaling doc %q: %v", docID, err)
+			base.LogTo("Cache+", "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", docID, err)
 		}
 		return
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -359,11 +359,19 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 		return
 	}
 
+	// If this is a binary document (and not one of the above types), we can ignore.  Currently only performing this check when xattrs
+	// are enabled, because walrus doesn't support DataType on feed.
+	if c.context.UseXattrs() && event.DataType == base.MemcachedDataTypeRaw {
+		return
+	}
+
 	// First unmarshal the doc (just its metadata, to save time/memory):
 	syncData, rawBody, rawXattr, err := UnmarshalDocumentSyncDataFromFeed(docJSON, event.DataType, false)
-
 	if err != nil {
-		base.Warn("changeCache: Error unmarshaling doc %q: %v", docID, err)
+		// Avoid log noise related to failed unmarshaling of binary documents.
+		if event.DataType != base.MemcachedDataTypeRaw {
+			base.Warn("changeCache: Error unmarshaling doc %q: %v", docID, err)
+		}
 		return
 	}
 


### PR DESCRIPTION
Binary docs were previously triggering a log warning when arriving over the DCP feed.

Fixes #2780