### PR TITLE
Optimize view and design doc usage

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1672,6 +1672,9 @@ func (bucket CouchbaseBucketGoCB) putDDocForTombstones(ddoc *gocb.DesignDocument
 
 	// Use the bucket's HTTP client to make the request
 	resp, err := goCBClient.HttpClient().Do(req)
+	if err != nil {
+		return err
+	}
 
 	if resp.StatusCode != 201 {
 		data, err := ioutil.ReadAll(resp.Body)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1262,7 +1262,7 @@ func (context *DatabaseContext) ComputeSequenceRolesForUser(user auth.User) (cha
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayRoleAccess, ViewRoleAccess, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayAccess, ViewRoleAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	// Merge the TimedSets from the view result:
@@ -1287,7 +1287,7 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayRoleAccessVbSeq, ViewRoleAccessVbSeq, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGatewayAccessVbSeq, ViewRoleAccessVbSeq, opts, &vres); verr != nil {
 		return nil, verr
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -708,24 +708,14 @@ func installViews(bucket base.Bucket, useXattrs bool) error {
 
 	designDocMap[DesignDocSyncGatewayAccess] = sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
-			ViewAccess: sgbucket.ViewDef{Map: access_map},
+			ViewAccess:     sgbucket.ViewDef{Map: access_map},
+			ViewRoleAccess: sgbucket.ViewDef{Map: roleAccess_map},
 		},
 	}
 
 	designDocMap[DesignDocSyncGatewayAccessVbSeq] = sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
-			ViewAccessVbSeq: sgbucket.ViewDef{Map: access_vbSeq_map},
-		},
-	}
-
-	designDocMap[DesignDocSyncGatewayRoleAccess] = sgbucket.DesignDoc{
-		Views: sgbucket.ViewMap{
-			ViewRoleAccess: sgbucket.ViewDef{Map: roleAccess_map},
-		},
-	}
-
-	designDocMap[DesignDocSyncGatewayRoleAccessVbSeq] = sgbucket.DesignDoc{
-		Views: sgbucket.ViewMap{
+			ViewAccessVbSeq:     sgbucket.ViewDef{Map: access_vbSeq_map},
 			ViewRoleAccessVbSeq: sgbucket.ViewDef{Map: roleAccess_vbSeq_map},
 		},
 	}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -12,25 +12,23 @@ import (
 )
 
 const (
-	DesignDocSyncGateway                = "sync_gateway" // Legacy design doc, obsolete in SG 1.5 and later.  Used to remove if present during view installation
-	DesignDocSyncGatewayChannels        = "sync_gateway_channels"
-	DesignDocSyncGatewayAccess          = "sync_gateway_access"
-	DesignDocSyncGatewayAccessVbSeq     = "sync_gateway_access_vbseq"
-	DesignDocSyncGatewayRoleAccess      = "sync_gateway_role_access"
-	DesignDocSyncGatewayRoleAccessVbSeq = "sync_gateway_role_access_vbseq"
-	DesignDocSyncHousekeeping           = "sync_housekeeping"
-	ViewPrincipals                      = "principals"
-	ViewChannels                        = "channels"
-	ViewAccess                          = "access"
-	ViewAccessVbSeq                     = "access_vbseq"
-	ViewRoleAccess                      = "role_access"
-	ViewRoleAccessVbSeq                 = "role_access_vbseq"
-	ViewAllBits                         = "all_bits"
-	ViewAllDocs                         = "all_docs"
-	ViewImport                          = "import"
-	ViewOldRevs                         = "old_revs"
-	ViewSessions                        = "sessions"
-	ViewTombstones                      = "tombstones"
+	DesignDocSyncGateway            = "sync_gateway" // Legacy design doc, obsolete in SG 1.5 and later.  Used to remove if present during view installation
+	DesignDocSyncGatewayChannels    = "sync_gateway_channels"
+	DesignDocSyncGatewayAccess      = "sync_gateway_access"
+	DesignDocSyncGatewayAccessVbSeq = "sync_gateway_access_vbseq"
+	DesignDocSyncHousekeeping       = "sync_housekeeping"
+	ViewPrincipals                  = "principals"
+	ViewChannels                    = "channels"
+	ViewAccess                      = "access"
+	ViewAccessVbSeq                 = "access_vbseq"
+	ViewRoleAccess                  = "role_access"
+	ViewRoleAccessVbSeq             = "role_access_vbseq"
+	ViewAllBits                     = "all_bits"
+	ViewAllDocs                     = "all_docs"
+	ViewImport                      = "import"
+	ViewOldRevs                     = "old_revs"
+	ViewSessions                    = "sessions"
+	ViewTombstones                  = "tombstones"
 )
 
 func GetDesignDocForView(viewName string) (designDocName string) {
@@ -44,9 +42,9 @@ func GetDesignDocForView(viewName string) (designDocName string) {
 	case ViewAccessVbSeq:
 		return DesignDocSyncGatewayAccessVbSeq
 	case ViewRoleAccess:
-		return DesignDocSyncGatewayRoleAccess
+		return DesignDocSyncGatewayAccess
 	case ViewRoleAccessVbSeq:
-		return DesignDocSyncGatewayRoleAccessVbSeq
+		return DesignDocSyncGatewayAccessVbSeq
 	default:
 		return ""
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -548,8 +548,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	}
 
-
-
 	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
 
 	if dbcontext.ChannelMapper == nil {
@@ -563,7 +561,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, err
 	}
 
-	emitAccessRelatedWarnings(config, dbcontext)
+	// Note: disabling access-related warnings, because they potentially block startup during view reindexing trying to query the principals view, which outweighs the usability benefit
+	//emitAccessRelatedWarnings(config, dbcontext)
 
 	// Install bucket-shadower if any:
 	if shadow := config.Shadow; shadow != nil {


### PR DESCRIPTION
View engine team suggests that there are decreasing performance benefits when using more than 4 design docs - the performance overhead to add the additional DCP streams on the view index nodes outweighs the benefits seen by concurrent indexing.

Also removes the on-startup view query related to user warnings.