### PR TITLE
Use gocb bucket to retrieve Couchbase API endpoints used by DCP

### DIFF
--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -453,7 +453,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 
 	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
 	// reusing the bucket connection we've already established.
-	urls, errConvertServerSpec := CouchbaseURIToHttpURL(spec.Server)
+	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/couchbaselabs/go.assert"
 	"net/url"
-	"time"
 	"strings"
+	"time"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -140,7 +140,6 @@ func TestRetryLoop(t *testing.T) {
 
 }
 
-
 // Make sure that the RetryLoopTimeout doesn't break existing RetryLoop functionality
 func TestRetryLoopTimeoutSafe(t *testing.T) {
 
@@ -186,14 +185,13 @@ func TestRetryLoopTimeoutEffective(t *testing.T) {
 
 	// Kick off timeout loop that expects lazy worker to return in 100 ms, even though it takes a week
 	description := fmt.Sprintf("TestRetryLoop")
-	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond * 100)
+	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond*100)
 
 	// We should get a timeout error
 	assert.True(t, err != nil)
 	assert.True(t, strings.Contains(err.Error(), "timeout"))
 
 }
-
 
 func TestSyncSourceFromURL(t *testing.T) {
 	u, err := url.Parse("http://www.test.com:4985/mydb")
@@ -263,7 +261,7 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 			expected: []string{"https://host1:18091"},
 		},
 		{
-			input:    "couchbase://host1,host2",
+			input: "couchbase://host1,host2",
 			expected: []string{
 				"http://host1:8091",
 				"http://host2:8091",
@@ -277,7 +275,7 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 			},
 		},
 		{
-			input: "couchbase://host1:8091,host2,",  // trailing comma
+			input: "couchbase://host1:8091,host2,", // trailing comma
 			expected: []string{
 				"http://host1:8091",
 				"http://host2:8091",
@@ -312,7 +310,7 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 	}
 
 	for _, inputAndExpected := range inputsAndExpected {
-		actual, err := CouchbaseURIToHttpURL(inputAndExpected.input)
+		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input)
 		assertNoError(t, err, "Unexpected error")
 		assert.DeepEquals(t, actual, inputAndExpected.expected)
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
-	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -142,7 +141,6 @@ func ConnectToBucket(spec base.BucketSpec, callback sgbucket.BucketNotifyFn) (bu
 	//start a retry loop to connect to the bucket backing off double the delay each time
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		bucket, err = base.GetBucket(spec, callback)
-		log.Printf("getBucket return error: %v", err)
 		return err != nil, err, bucket
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -141,6 +142,7 @@ func ConnectToBucket(spec base.BucketSpec, callback sgbucket.BucketNotifyFn) (bu
 	//start a retry loop to connect to the bucket backing off double the delay each time
 	worker := func() (shouldRetry bool, err error, value interface{}) {
 		bucket, err = base.GetBucket(spec, callback)
+		log.Printf("getBucket return error: %v", err)
 		return err != nil, err, bucket
 	}
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="e5774b635e03d0560194236d35d25cccac073163"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="589654909ef253439ad87563fb1b30a41263b295"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="589654909ef253439ad87563fb1b30a41263b295"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="1320d5495738b6ffa17dd716390c2f89f584f7da"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -34,7 +34,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="1320d5495738b6ffa17dd716390c2f89f584f7da"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="2de2dae58443c7255b2f06001f819d4542cf2968"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>

--- a/rest/config.go
+++ b/rest/config.go
@@ -386,6 +386,11 @@ func (channelIndexConfig *ChannelIndexConfig) GetCredentials() (string, string, 
 	return base.TransformBucketCredentials(channelIndexConfig.Username, channelIndexConfig.Password, *channelIndexConfig.Bucket)
 }
 
+// Implementation of AuthHandler interface for ClusterConfig
+func (clusterConfig *ClusterConfig) GetCredentials() (string, string, string) {
+	return base.TransformBucketCredentials(clusterConfig.Username, clusterConfig.Password, *clusterConfig.Bucket)
+}
+
 // Reads a ServerConfig from raw data
 func ReadServerConfigFromData(runMode SyncGatewayRunMode, data []byte) (*ServerConfig, error) {
 


### PR DESCRIPTION
When using a gocb bucket, retrieve the set of Admin API endpoints from the cluster, instead of trying to build manually.

Fixes #2810.

Requires https://github.com/couchbaselabs/sync-gateway-accel/pull/175