### PR TITLE
Return removed=true for non-resident channel removal revisions

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -179,7 +179,15 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 	}
 
 	if body, err = context.getRevision(doc, id.RevID); err != nil {
-		return
+		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
+		// the revision was a channel removal.  If so, we want to store as removal in the revision cache
+		removalBody, removalHistory, removalChannels, isRemoval := doc.IsChannelRemoval(id.RevID)
+		if isRemoval {
+			return removalBody, removalHistory, removalChannels, nil
+		} else {
+			// If this wasn't a removal, return the original error from getRevision
+			return body, history, channels, err
+		}
 	}
 	if doc.History[id.RevID].Deleted {
 		body["_deleted"] = true
@@ -438,7 +446,7 @@ func (db *Database) getRevFromDoc(doc *document, revid string, listRevisions boo
 		// usually aren't on any channels at all!) But don't show the full body. (See #59)
 		// Update: this applies to non-deletions too, since the client may have lost access to
 		// the channel and gotten a "removed" entry in the _changes feed. It then needs to
-		// incorporate that tombsone and for that it needs to see the _revisions property.
+		// incorporate that tombstone and for that it needs to see the _revisions property.
 		if revid == "" || doc.History[revid] == nil /*|| !doc.History[revid].Deleted*/ {
 			return nil, err
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -175,7 +175,7 @@ func (db *DatabaseContext) OnDemandImportForGet(docid string, rawDoc []byte, raw
 func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history Body, channels base.Set, err error) {
 	var doc *document
 	if doc, err = context.GetDoc(id.DocID); doc == nil {
-		return
+		return body, history, channels, err
 	}
 
 	if body, err = context.getRevision(doc, id.RevID); err != nil {
@@ -194,7 +194,7 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 	}
 	history = encodeRevisions(doc.History.getHistory(id.RevID))
 	channels = doc.History[id.RevID].Channels
-	return
+	return body, history, channels, err
 }
 
 // Returns the body of the current revision of a document

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -257,6 +257,79 @@ func TestGetDeleted(t *testing.T) {
 	assert.DeepEquals(t, body, expectedResult)
 }
 
+// Test retrieval of a channel removal revision, when the revision is not otherwise available
+func TestGetRemoved(t *testing.T) {
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+
+	rev1body := Body{
+		"key1":     1234,
+		"channels": []string{"ABC"},
+	}
+	rev1id, err := db.Put("doc1", rev1body)
+	assertNoError(t, err, "Put")
+
+	rev2body := Body{
+		"key1":     1234,
+		"channels": []string{"NBC"},
+		"_rev":     rev1id,
+	}
+	rev2id, err := db.Put("doc1", rev2body)
+	assertNoError(t, err, "Put Rev 2")
+
+	// Add another revision, so that rev 2 is obsolete
+	rev3body := Body{
+		"key1":     12345,
+		"channels": []string{"NBC"},
+		"_rev":     rev2id,
+	}
+	_, err = db.Put("doc1", rev3body)
+	assertNoError(t, err, "Put Rev 3")
+
+	// Get the deleted doc with its history; equivalent to GET with ?revs=true, while still resident in the rev cache
+	body, err := db.GetRev("doc1", rev2id, true, nil)
+	assertNoError(t, err, "GetRev")
+	rev2digest := rev2id[2:]
+	rev1digest := rev1id[2:]
+	expectedResult := Body{
+		"key1":     1234,
+		"channels": []string{"NBC"},
+		"_revisions": map[string]interface{}{
+			"start": 2,
+			"ids":   []string{rev2digest, rev1digest}},
+		"_id":  "doc1",
+		"_rev": rev2id,
+	}
+	assert.DeepEquals(t, body, expectedResult)
+
+	// Manually remove the temporary backup doc from the bucket
+	// Manually flush the rev cache
+	// After expiry from the rev cache and removal of doc backup, try again
+	db.DatabaseContext.revisionCache = NewRevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext.revCacheLoader)
+	err = db.purgeOldRevisionJSON("doc1", rev2id)
+	assertNoError(t, err, "Purge old revision JSON")
+
+	// Get the deleted doc with its history; equivalent to GET with ?revs=true
+	body, err = db.GetRev("doc1", rev2id, true, nil)
+	assertNoError(t, err, "GetRev")
+	expectedResult = Body{
+		"_id":      "doc1",
+		"_rev":     rev2id,
+		"_removed": true,
+		"_revisions": map[string]interface{}{
+			"start": 2,
+			"ids":   []string{rev2digest, rev1digest}},
+	}
+	assert.DeepEquals(t, body, expectedResult)
+
+	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
+	err = db.purgeOldRevisionJSON("doc1", rev1id)
+	assertNoError(t, err, "Purge old revision JSON")
+
+	_, err = db.GetRev("doc1", rev1id, true, nil)
+	assertHTTPError(t, err, 404)
+}
+
 type AllDocsEntry struct {
 	IDAndRev
 	Channels []string

--- a/db/document.go
+++ b/db/document.go
@@ -357,6 +357,49 @@ func (doc *document) updateChannels(newChannels base.Set) (changedChannels base.
 	return
 }
 
+// Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
+// removal notification (_removed=true)
+func (doc *document) IsChannelRemoval(revID string) (body Body, history Body, channels base.Set, isRemoval bool) {
+
+	channels = make(base.Set)
+
+	// Iterate over the document's channel history, looking for channels that were removed at revID.  If found, also identify whether the removal was a tombstone.
+	isDelete := false
+	for channel, removal := range doc.Channels {
+		if removal != nil && removal.RevID == revID {
+			channels[channel] = struct{}{}
+			if removal.Deleted == true {
+				isDelete = true
+			}
+		}
+	}
+
+	// If no matches found, return isRemoval=false
+	if len(channels) == 0 {
+		return nil, nil, nil, false
+	}
+
+	// Construct removal body
+	body = Body{
+		"_id":      doc.ID,
+		"_rev":     revID,
+		"_removed": true,
+	}
+	if isDelete {
+		body["_deleted"] = true
+	}
+
+	// Build revision history for revID
+	revHistory := doc.History.getHistory(revID)
+	// If there's no history (because the revision has been pruned from the rev tree), treat revision history as only the specified rev id.
+	if len(revHistory) == 0 {
+		revHistory = []string{revID}
+	}
+	history = encodeRevisions(revHistory)
+
+	return body, history, channels, true
+}
+
 // Updates a document's channel/role UserAccessMap with new access settings from an AccessMap.
 // Returns an array of the user/role names whose access has changed as a result.
 func (accessMap *UserAccessMap) updateAccess(doc *document, newAccess channels.AccessMap) (changedUsers []string) {

--- a/db/document.go
+++ b/db/document.go
@@ -373,7 +373,6 @@ func (doc *document) IsChannelRemoval(revID string) (body Body, history Body, ch
 			}
 		}
 	}
-
 	// If no matches found, return isRemoval=false
 	if len(channels) == 0 {
 		return nil, nil, nil, false

--- a/db/revision.go
+++ b/db/revision.go
@@ -150,6 +150,12 @@ func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte) 
 	return db.Bucket.SetRaw(oldRevisionKey(docid, revid), 300, base.BinaryDocument(body))
 }
 
+// Currently only used by unit tests - deletes an archived old revision from the database
+func (db *Database) purgeOldRevisionJSON(docid string, revid string) error {
+	base.LogTo("CRUD+", "Purging old revision backup %q / %q ", docid, revid)
+	return db.Bucket.Delete(oldRevisionKey(docid, revid))
+}
+
 //////// UTILITY FUNCTIONS:
 
 func oldRevisionKey(docid string, revid string) string {

--- a/test_integration.sh
+++ b/test_integration.sh
@@ -206,7 +206,10 @@ declare -a arr=(
     "TestParseHTTPRangeHeader"
     "TestSanitizeURL"
     "TestVerifyHTTPSSupport",
-    "TestChangesIncludeConflicts")
+    "TestChangesIncludeConflicts",
+    "TestGetRemoved",
+    "TestGetRemovedAndDeleted",
+    "TestGetRemovedAsUser")
 
 
 # --------------------------------- SG Accel tests -----------------------------------------


### PR DESCRIPTION
When an revision is requested, but that revision's body is no longer available (it's not resident in the rev cache, and the temporary revision backup has expired), check whether that revision is associated with a channel removal based on the document's channel history.  If it's a removal, return the standard removal notification body (_removed=true) instead of 404 missing.

Fixes #2815.