### PR TITLE
During tombstone, trigger body deletion if previous body non-empty

### DIFF
--- a/test_integration.sh
+++ b/test_integration.sh
@@ -209,7 +209,8 @@ declare -a arr=(
     "TestChangesIncludeConflicts",
     "TestGetRemoved",
     "TestGetRemovedAndDeleted",
-    "TestGetRemovedAsUser")
+    "TestGetRemovedAsUser",
+    "TestXattrSGTombstone")
 
 
 # --------------------------------- SG Accel tests -----------------------------------------


### PR DESCRIPTION
Fixes regression to SG tombstone handling introduced in https://github.com/couchbase/sync_gateway/commit/db39d17b22a44420f5620d9e649d782e4a3650a3.  After refactoring, was determining whether to delete the body based on the current document body, not the previous.

Previous unit tests weren't validating empty document body after tombstone - added additional test (and included that test in integration suite).

Fixes #2827

Integration tests running:
http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/225/   (xattr)
http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/226/   (non-xattr)