### PR TITLE
Fix to support Ubuntu 17 & Path issue for Examples folder

### DIFF
--- a/service/sg_accel_service_install.sh
+++ b/service/sg_accel_service_install.sh
@@ -4,7 +4,7 @@
 OS=""
 VER=""
 SERVICE_NAME="sg_accel"
-SRCCFGDIR=../examples
+SRCCFGDIR=/opt/couchbase-sg-accel/examples
 SRCCFG=basic_sg_accel_config.json
 RUNAS_TEMPLATE_VAR=sg_accel
 RUNBASE_TEMPLATE_VAR=/home/sg_accel
@@ -210,7 +210,7 @@ case $OS in
                     #service ${SERVICE_NAME} start
                 fi
                 ;;
-            16)
+            16|17)
                 if [ "$SERVICE_CMD_ONLY" = true ]; then
                     echo "systemctl start ${SERVICE_NAME}"
                 else

--- a/service/sg_accel_service_uninstall.sh
+++ b/service/sg_accel_service_uninstall.sh
@@ -4,7 +4,7 @@
 OS=""
 VER=""
 SERVICE_NAME="sg_accel"
-SRCCFGDIR=../examples
+SRCCFGDIR=/opt/couchbase-sg-accel/examples
 SRCCFG=basic_sg_accel_config.json
 RUNAS_TEMPLATE_VAR=sg_accel
 RUNBASE_TEMPLATE_VAR=/home/sg_accel
@@ -86,7 +86,7 @@ case $OS in
                 	rm /etc/init/${SERVICE_NAME}.conf
                 fi
                 ;;
-            16)
+            16|17)
                 systemctl stop ${SERVICE_NAME}
                 systemctl disable ${SERVICE_NAME}
 

--- a/service/sg_accel_service_upgrade.sh
+++ b/service/sg_accel_service_upgrade.sh
@@ -4,7 +4,7 @@
 OS=""
 VER=""
 SERVICE_NAME="sg_accel"
-SRCCFGDIR=../examples
+SRCCFGDIR=/opt/couchbase-sg-accel/examples
 SRCCFG=basic_sg_accel_config.json
 RUNAS_TEMPLATE_VAR=sg_accel
 RUNBASE_TEMPLATE_VAR=/home/sg_accel

--- a/service/sg_accel_service_upgrade.sh
+++ b/service/sg_accel_service_upgrade.sh
@@ -80,7 +80,7 @@ case $OS in
 		service ${SERVICE_NAME} stop
                 service ${SERVICE_NAME} start
                 ;;
-            16)
+            16|17)
                 systemctl stop ${SERVICE_NAME}
                 systemctl start ${SERVICE_NAME}
                 ;;

--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -4,7 +4,7 @@
 OS=""
 VER=""
 SERVICE_NAME="sync_gateway"
-SRCCFGDIR=../examples
+SRCCFGDIR=/opt/couchbase-sg-accel/examples
 SRCCFG=serviceconfig.json
 RUNAS_TEMPLATE_VAR=sync_gateway
 RUNBASE_TEMPLATE_VAR=/home/sync_gateway
@@ -207,7 +207,7 @@ case $OS in
                     service ${SERVICE_NAME} start
                 fi
                 ;;
-            16)
+            16|17)
                 if [ "$SERVICE_CMD_ONLY" = true ]; then
                     echo "systemctl start ${SERVICE_NAME}"
                 else

--- a/service/sync_gateway_service_uninstall.sh
+++ b/service/sync_gateway_service_uninstall.sh
@@ -86,7 +86,7 @@ case $OS in
                 	rm /etc/init/${SERVICE_NAME}.conf
                 fi
                 ;;
-            16)
+            16|17)
                 systemctl stop ${SERVICE_NAME}
                 systemctl disable ${SERVICE_NAME}
                 

--- a/service/sync_gateway_service_upgrade.sh
+++ b/service/sync_gateway_service_upgrade.sh
@@ -4,7 +4,7 @@
 OS=""
 VER=""
 SERVICE_NAME="sync_gateway"
-SRCCFGDIR=../examples
+SRCCFGDIR=/opt/couchbase-sg-accel/examples
 SRCCFG=serviceconfig.json
 RUNAS_TEMPLATE_VAR=sync_gateway
 RUNBASE_TEMPLATE_VAR=/home/sync_gateway
@@ -80,7 +80,7 @@ case $OS in
 				service ${SERVICE_NAME} stop
                 service ${SERVICE_NAME} start
                 ;;
-            16)
+            16|17)
                 systemctl stop ${SERVICE_NAME}
                 systemctl start ${SERVICE_NAME}
                 ;;


### PR DESCRIPTION
1) Ubuntu 17 was not supported and was throwing error during installation
2) Examples fodler is referring ../ which does not work if the script is not being started from current folder. A user can start this from other directory and hence it failed during installation.