### PR TITLE
Remove unnecessary []byte copy in bucket_gocb GetRaw

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -235,11 +235,8 @@ func (bucket CouchbaseBucketGoCB) GetRaw(k string) (rv []byte, cas uint64, err e
 	if returnVal == nil {
 		return nil, cas, err
 	}
-	// Take a copy of the returned value until gocb issue is fixed http://review.couchbase.org/#/c/72059/
-	rv = make([]byte, len(returnVal))
-	copy(rv, returnVal)
 
-	return rv, cas, err
+	return returnVal, cas, err
 
 }
 


### PR DESCRIPTION
With http://review.couchbase.org/#/c/72059/ fixed, this is no longer necessary.

Fixes #2325.