### PR TITLE
Fixes #2857: Revision tree repair tool 

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -44,6 +44,16 @@ func testBucket() base.Bucket {
 	return bucket
 }
 
+func testBucketWithName(bucketName string) base.Bucket {
+	bucket, err := ConnectToBucket(base.BucketSpec{
+		Server:     kTestURL,
+		BucketName: bucketName}, nil)
+	if err != nil {
+		log.Fatalf("Couldn't connect to bucket: %v", err)
+	}
+	return bucket
+}
+
 func testLeakyBucket(config base.LeakyBucketConfig) base.Bucket {
 	testBucket := testBucket()
 	leakyBucket := base.NewLeakyBucket(testBucket, config)

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -18,8 +18,8 @@ const (
 
 // Params suitable for external (eg, HTTP) invocations to describe a RepairBucket operation
 type RepairBucketParams struct {
-	DryRun          bool
-	RepairJobParams []RepairJobParams
+	DryRun     bool              `json:"dry_run"`
+	RepairJobs []RepairJobParams `json:"repair_jobs"`
 }
 
 // Params suitable for external (eg, HTTP) invocations to describe a specific RepairJob operation
@@ -58,7 +58,7 @@ func (r *RepairBucket) AddRepairJob(repairJob DocTransformer) *RepairBucket {
 func (r *RepairBucket) InitFrom(params RepairBucketParams) *RepairBucket {
 
 	r.SetDryRun(params.DryRun)
-	for _, repairJobParams := range params.RepairJobParams {
+	for _, repairJobParams := range params.RepairJobs {
 		switch repairJobParams.RepairJobType {
 		case RepairRevTreeCycles:
 			r.AddRepairJob(RepairJobRevTreeCycles)

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/sync_gateway/base"
+	"log"
 )
 
 type RepairBucket struct {
@@ -42,6 +43,8 @@ func (r RepairBucket) RepairBucket() (err error) {
 	if err != nil {
 		return err
 	}
+
+	log.Printf("view query returned vres: %+v", vres	)
 
 	for _, row := range vres.Rows {
 		rowKey := row.Key.([]interface{})

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -1,0 +1,103 @@
+package db
+
+import (
+	"encoding/json"
+
+	"github.com/couchbase/go-couchbase"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+type RepairBucket struct {
+	DryRun     bool
+	Bucket     base.Bucket
+	RepairJobs []DocTransformer
+}
+
+// Given a Couchbase Bucket doc, transform the doc in some way to produce a new doc.
+// Also return a boolean to indicate whether a transformation took place, or any errors occurred.
+type DocTransformer func(doc *document) (transformedDoc *document, transformed bool, err error)
+
+func NewRepairBucket(bucket base.Bucket) *RepairBucket {
+	return &RepairBucket{
+		Bucket: bucket,
+	}
+}
+
+func (r *RepairBucket) SetDryRun(dryRun bool) *RepairBucket {
+	r.DryRun = false
+	return r
+}
+
+func (r *RepairBucket) AddRepairJob(repairJob DocTransformer) *RepairBucket {
+	r.RepairJobs = append(r.RepairJobs, repairJob)
+	return r
+}
+
+func (r RepairBucket) RepairBucket() (err error) {
+
+	options := Body{"stale": false, "reduce": false}
+	options["startkey"] = []interface{}{true}
+
+	vres, err := r.Bucket.View(DesignDocSyncHousekeeping, ViewImport, options)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range vres.Rows {
+		rowKey := row.Key.([]interface{})
+		docid := rowKey[1].(string)
+		key := realDocID(docid)
+
+		err = r.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, error) {
+			// Be careful: this block can be invoked multiple times if there are races!
+			if currentValue == nil {
+				return nil, couchbase.UpdateCancel // someone deleted it?!
+			}
+			doc, err := unmarshalDocument(docid, currentValue)
+			if err != nil {
+				return nil, err
+			}
+			updatedDoc, shouldUpdate, err := r.TransformBucketDoc(doc)
+			if err != nil {
+				return nil, err
+			}
+			if shouldUpdate {
+				return json.Marshal(updatedDoc)
+			} else {
+				return nil, couchbase.UpdateCancel
+			}
+		})
+
+	}
+
+	return nil
+}
+
+func (r RepairBucket) TransformBucketDoc(doc *document) (transformedDoc *document, transformed bool, err error) {
+
+	transformed = false
+	for _, repairJob := range r.RepairJobs {
+
+		repairedDoc, repairedDocTxformed, repairDocErr := repairJob(doc)
+		if repairDocErr != nil {
+			return nil, false, repairDocErr
+		}
+
+		if !repairedDocTxformed {
+			continue
+		}
+
+		// Update output value to indicate this doc was transformed by at least one of the underlying repair jobs
+		transformed = true
+
+		// Update output value with latest result from repair job, which may be overwritten by later loop iterations
+		transformedDoc = repairedDoc
+
+		// Update doc that is being transformed to be the output of the last repair job, in order
+		// that the next iteration of the loop use this as input
+		doc = repairedDoc
+
+	}
+
+	return transformedDoc, transformed, nil
+}

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -25,7 +25,7 @@ func NewRepairBucket(bucket base.Bucket) *RepairBucket {
 }
 
 func (r *RepairBucket) SetDryRun(dryRun bool) *RepairBucket {
-	r.DryRun = false
+	r.DryRun = dryRun
 	return r
 }
 
@@ -61,10 +61,15 @@ func (r RepairBucket) RepairBucket() (err error) {
 				return nil, err
 			}
 			updatedDoc, shouldUpdate, err := r.TransformBucketDoc(doc)
+			log.Printf("TransformBucketDoc returned updatedDoc: %v, shouldUpdate: %v, err: %v.  dryRun: %v", updatedDoc, shouldUpdate, err, r.DryRun)
 			if err != nil {
 				return nil, err
 			}
-			if shouldUpdate {
+			if shouldUpdate && r.DryRun {
+				// TODO: write marshalled val to temp files?
+				base.LogTo("RepairBucket", "Update disabled for dry run.  Original doc: %+v, Post-repair doc: %+v", doc, updatedDoc)
+			}
+			if shouldUpdate && !r.DryRun {
 				return json.Marshal(updatedDoc)
 			} else {
 				return nil, couchbase.UpdateCancel

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -112,11 +112,11 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 					base.LogTo("CRUD", "Updated doc after repair: %s", updatedDoc)
 				}
 
-				result :=  RepairBucketResult{
-					DryRun: r.DryRun,
+				result := RepairBucketResult{
+					DryRun:              r.DryRun,
 					BackupOrDryRunDocId: backupOrDryRunDocId,
-					DocId: key,
-					RepairJobTypes: repairJobs,
+					DocId:               key,
+					RepairJobTypes:      repairJobs,
 				}
 
 				results = append(results, result)

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -26,8 +26,8 @@ type RepairBucketParams struct {
 
 // Params suitable for external (eg, HTTP) invocations to describe a specific RepairJob operation
 type RepairJobParams struct {
-	RepairJobType   RepairJobType          `json:"repair_job_type"`
-	RepairJobParams map[string]interface{} `json:"repair_job_params"`
+	RepairJobType   RepairJobType          `json:"type"`
+	RepairJobParams map[string]interface{} `json:"params"`
 }
 
 // Given a Couchbase Bucket doc, transform the doc in some way to produce a new doc.

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -226,7 +226,7 @@ func RepairJobRevTreeCycles(docId string, originalCBDoc []byte) (transformedCBDo
 	}
 
 	// Repair it
-	if err := doc.History.Repair(); err != nil {
+	if err := doc.History.RepairCycles(); err != nil {
 		return nil, false, err
 	}
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"fmt"
 	"sync"
+	"log"
 )
 
 
@@ -11,12 +12,17 @@ import (
 func TestRepairBucket(t *testing.T) {
 
 	bucket := testBucket()
-	bucket.Add("foo", 0, map[string]interface{}{"foo": "bar"})
+	log.Printf("installing views")
+	installViews(bucket)
+	log.Printf("installed views")
+	testSyncData := syncData{}
+	bucket.Add("foo", 0, map[string]interface{}{"foo": "bar", "_sync": testSyncData})
 
 	repairJobWaitGroup := sync.WaitGroup{}
 
 	repairJob := func(doc *document) (transformedDoc *document, transformed bool, err error) {
 		defer repairJobWaitGroup.Done()
+		log.Printf("repairJob called back")
 		return nil, false, nil
 	}
 	repairBucket := NewRepairBucket(bucket).
@@ -28,8 +34,7 @@ func TestRepairBucket(t *testing.T) {
 
 	assertNoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
 
+	log.Printf("waiting for waitgroup to be finished")
 	repairJobWaitGroup.Wait()
-
-
 
 }

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -14,10 +14,10 @@ const (
 	docIdProblematicRevTree2 = "docIdProblematicRevTree2"
 )
 
-func testBucketWithViewsAndBrokenDoc() (bucket base.Bucket, numDocs int) {
+func testBucketWithViewsAndBrokenDoc() (bucketName string, bucket base.Bucket, numDocs int) {
 
 	numDocsAdded := 0
-	bucket = testBucket()
+	bucket = testBucketWithName(bucketName)
 	installViews(bucket)
 
 	// Add a harmless doc
@@ -49,7 +49,7 @@ func TestRepairBucket(t *testing.T) {
 
 	base.EnableLogKey("CRUD")
 
-	bucket, _ := testBucketWithViewsAndBrokenDoc()
+	bucket, _ := testBucketWithViewsAndBrokenDoc("TestRepairBucket")
 
 	repairJob := func(docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
 		log.Printf("repairJob called back")
@@ -63,8 +63,8 @@ func TestRepairBucket(t *testing.T) {
 
 	assertNoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
 
-	// Both docs will be repaired due to the repairJob function that indiscriminately repairs all docs
-	assert.True(t, len(repairedDocs) == 2)
+	// All docs will be repaired due to the repairJob function that indiscriminately repairs all docs
+	assert.True(t, len(repairedDocs) == 3)
 
 }
 
@@ -72,7 +72,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	base.EnableLogKey("CRUD")
 
-	bucket, _ := testBucketWithViewsAndBrokenDoc()
+	bucket, _ := testBucketWithViewsAndBrokenDoc("TestRepairBucketRevTreeCycles")
 
 	repairBucket := NewRepairBucket(bucket)
 
@@ -117,7 +117,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 
 	base.EnableLogKey("CRUD")
 
-	bucket, _ := testBucketWithViewsAndBrokenDoc()
+	bucket, _ := testBucketWithViewsAndBrokenDoc("TestRepairBucketDryRun")
 
 	repairBucket := NewRepairBucket(bucket)
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -41,7 +41,7 @@ func testBucketWithViewsAndBrokenDoc() (bucket base.Bucket, numDocs int) {
 
 func TestRepairBucket(t *testing.T) {
 
-	base.EnableLogKey("RepairBucket")
+	base.EnableLogKey("CRUD")
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc()
 
@@ -64,15 +64,22 @@ func TestRepairBucket(t *testing.T) {
 
 func TestRepairBucketRevTreeCycles(t *testing.T) {
 
-	base.EnableLogKey("RepairBucket")
+	base.EnableLogKey("CRUD")
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc()
 
-	repairJob := RepairJobRevTreeCycles
 
-	repairBucket := NewRepairBucket(bucket).
-		SetDryRun(false).
-		AddRepairJob(repairJob)
+	repairBucket := NewRepairBucket(bucket)
+
+	repairBucket.InitFrom(RepairBucketParams{
+		DryRun: false,
+		RepairJobs: []RepairJobParams{
+			{
+				RepairJobType: RepairRevTreeCycles,
+			},
+		},
+	})
+	repairBucket.WriteRepairedDocsToDisk = false
 
 	repairedDocs, err := repairBucket.RepairBucket()
 
@@ -92,5 +99,6 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	// Since doc was repaired, should contain no cycles
 	assert.False(t, repairedDoc.History.ContainsCycles())
+
 
 }

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -1,19 +1,18 @@
 package db
 
 import (
-	"testing"
+	"encoding/json"
 	"fmt"
-	"sync"
 	"log"
+	"sync"
+	"testing"
+
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbaselabs/go.assert"
-	"encoding/json"
 )
-
 
 const (
 	docIdProblematicRevTree = "docIdProblematicRevTree"
-
 )
 
 func testBucketWithViewsAndBrokenDoc() (bucket base.Bucket, numDocs int) {
@@ -74,25 +73,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc()
 
-	repairJob := func(doc *document) (transformedDoc *document, transformed bool, err error) {
-
-		// Check if rev history has cycles
-		containsCycles := doc.History.ContainsCycles()
-
-		if !containsCycles {
-			// nothing to repair
-			return nil, false, nil
-		}
-
-		// Repair it
-		if err := doc.History.Repair(); err != nil {
-			return nil, false, err
-		}
-
-		// Return original doc pointer since it was repaired in place
-		return doc, true, nil
-
-	}
+	repairJob := RepairJobRevTreeCycles
 
 	repairBucket := NewRepairBucket(bucket).
 		SetDryRun(false).
@@ -115,7 +96,5 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	// Since doc was repaired, should contain no cycles
 	assert.False(t, repairedDoc.History.ContainsCycles())
-
-
 
 }

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"sync"
 	"log"
+	"github.com/couchbase/sync_gateway/base"
 )
 
 
 
 func TestRepairBucket(t *testing.T) {
+
+	base.EnableLogKey("RepairBucket")
 
 	bucket := testBucket()
 	log.Printf("installing views")
@@ -23,7 +26,7 @@ func TestRepairBucket(t *testing.T) {
 	repairJob := func(doc *document) (transformedDoc *document, transformed bool, err error) {
 		defer repairJobWaitGroup.Done()
 		log.Printf("repairJob called back")
-		return nil, false, nil
+		return nil, true, nil
 	}
 	repairBucket := NewRepairBucket(bucket).
 		SetDryRun(true).

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"testing"
+	"fmt"
+	"sync"
+)
+
+
+
+func TestRepairBucket(t *testing.T) {
+
+	bucket := testBucket()
+	bucket.Add("foo", 0, map[string]interface{}{"foo": "bar"})
+
+	repairJobWaitGroup := sync.WaitGroup{}
+
+	repairJob := func(doc *document) (transformedDoc *document, transformed bool, err error) {
+		defer repairJobWaitGroup.Done()
+		return nil, false, nil
+	}
+	repairBucket := NewRepairBucket(bucket).
+		SetDryRun(true).
+		AddRepairJob(repairJob)
+
+	repairJobWaitGroup.Add(1)
+	err := repairBucket.RepairBucket()
+
+	assertNoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
+
+	repairJobWaitGroup.Wait()
+
+
+
+}

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -68,7 +68,6 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc()
 
-
 	repairBucket := NewRepairBucket(bucket)
 
 	repairBucket.InitFrom(RepairBucketParams{
@@ -99,6 +98,5 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	// Since doc was repaired, should contain no cycles
 	assert.False(t, repairedDoc.History.ContainsCycles())
-
 
 }

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -14,7 +14,7 @@ const (
 	docIdProblematicRevTree2 = "docIdProblematicRevTree2"
 )
 
-func testBucketWithViewsAndBrokenDoc() (bucketName string, bucket base.Bucket, numDocs int) {
+func testBucketWithViewsAndBrokenDoc(bucketName string) (bucket base.Bucket, numDocs int) {
 
 	numDocsAdded := 0
 	bucket = testBucketWithName(bucketName)

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -45,7 +45,7 @@ func TestRepairBucket(t *testing.T) {
 
 	bucket, _ := testBucketWithViewsAndBrokenDoc()
 
-	repairJob := func(doc *document) (transformedDoc *document, transformed bool, err error) {
+	repairJob := func(docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
 		log.Printf("repairJob called back")
 		return nil, true, nil
 	}

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -12,27 +12,34 @@ import (
 
 const (
 	docIdProblematicRevTree = "docIdProblematicRevTree"
+	docIdProblematicRevTree2 = "docIdProblematicRevTree2"
 )
 
 func testBucketWithViewsAndBrokenDoc() (bucket base.Bucket, numDocs int) {
 
 	numDocsAdded := 0
 	bucket = testBucket()
-	log.Printf("installing views")
 	installViews(bucket)
-	log.Printf("installed views")
 
 	// Add a harmless doc
 	testSyncData := syncData{}
 	bucket.Add("foo", 0, map[string]interface{}{"foo": "bar", "_sync": testSyncData})
 	numDocsAdded++
 
-	// Add a doc that should be repaired
+	// Add doc that should be repaired
 	rawDoc, err := unmarshalDocument(docIdProblematicRevTree, []byte(testdocProblematicRevTree))
 	if err != nil {
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
 	bucket.Add(docIdProblematicRevTree, 0, rawDoc)
+	numDocsAdded++
+
+	// Add 2nd doc that should be repaired
+	rawDoc, err = unmarshalDocument(docIdProblematicRevTree2, []byte(testdocProblematicRevTree))
+	if err != nil {
+		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
+	}
+	bucket.Add(docIdProblematicRevTree2, 0, rawDoc)
 	numDocsAdded++
 
 	return bucket, numDocsAdded
@@ -82,7 +89,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	repairedDocs, err := repairBucket.RepairBucket()
 
 	assertNoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
-	assert.True(t, len(repairedDocs) == 1)
+	assert.True(t, len(repairedDocs) == 2)
 
 	// Now get the doc from the bucket
 	var value interface{}
@@ -98,9 +105,9 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	// Since doc was repaired, should contain no cycles
 	assert.False(t, repairedDoc.History.ContainsCycles())
 
-	// There should be a backup doc in the bucket with ID sync:repair:backup:docIdProblematicRevTree
+	// There should be a backup doc in the bucket with ID _sync:repair:backup:docIdProblematicRevTree
 	var backupDocRaw interface{}
-	_, errGetDoc = bucket.Get("sync:repair:backup:docIdProblematicRevTree", &backupDocRaw)
+	_, errGetDoc = bucket.Get("_sync:repair:backup:docIdProblematicRevTree", &backupDocRaw)
 	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
 
 	marshalledBackup, _ := json.MarshalIndent(backupDocRaw, "", "")

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -78,7 +78,6 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 			},
 		},
 	})
-	repairBucket.WriteRepairedDocsToDisk = false
 
 	repairedDocs, err := repairBucket.RepairBucket()
 
@@ -89,8 +88,11 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	var value interface{}
 	_, errGetDoc := bucket.Get(docIdProblematicRevTree, &value)
 	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting doc: %v", errGetDoc))
+	log.Printf("Got doc with docIdProblematicRevTree: %+v", value)
+
 
 	marshalled, errMarshal := json.Marshal(value)
+	log.Printf("marshalled docIdProblematicRevTree: %s", marshalled)
 	assertNoError(t, errMarshal, fmt.Sprintf("Error marshalling doc: %v", errMarshal))
 
 	repairedDoc, errUnmarshal := unmarshalDocument(docIdProblematicRevTree, marshalled)

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -6,20 +6,46 @@ import (
 	"sync"
 	"log"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/go.assert"
+	"encoding/json"
 )
 
 
+const (
+	docIdProblematicRevTree = "docIdProblematicRevTree"
+
+)
+
+func testBucketWithViewsAndBrokenDoc() (bucket base.Bucket, numDocs int) {
+
+	numDocsAdded := 0
+	bucket = testBucket()
+	log.Printf("installing views")
+	installViews(bucket)
+	log.Printf("installed views")
+
+	// Add a harmless doc
+	testSyncData := syncData{}
+	bucket.Add("foo", 0, map[string]interface{}{"foo": "bar", "_sync": testSyncData})
+	numDocsAdded++
+
+	// Add a doc that should be repaired
+	rawDoc, err := unmarshalDocument(docIdProblematicRevTree, []byte(testdocProblematicRevTree))
+	if err != nil {
+		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
+	}
+	bucket.Add(docIdProblematicRevTree, 0, rawDoc)
+	numDocsAdded++
+
+	return bucket, numDocsAdded
+
+}
 
 func TestRepairBucket(t *testing.T) {
 
 	base.EnableLogKey("RepairBucket")
 
-	bucket := testBucket()
-	log.Printf("installing views")
-	installViews(bucket)
-	log.Printf("installed views")
-	testSyncData := syncData{}
-	bucket.Add("foo", 0, map[string]interface{}{"foo": "bar", "_sync": testSyncData})
+	bucket, numdocs := testBucketWithViewsAndBrokenDoc()
 
 	repairJobWaitGroup := sync.WaitGroup{}
 
@@ -32,12 +58,64 @@ func TestRepairBucket(t *testing.T) {
 		SetDryRun(true).
 		AddRepairJob(repairJob)
 
-	repairJobWaitGroup.Add(1)
+	repairJobWaitGroup.Add(numdocs)
 	err := repairBucket.RepairBucket()
 
 	assertNoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
 
 	log.Printf("waiting for waitgroup to be finished")
 	repairJobWaitGroup.Wait()
+
+}
+
+func TestRepairBucketRevTreeCycles(t *testing.T) {
+
+	base.EnableLogKey("RepairBucket")
+
+	bucket, _ := testBucketWithViewsAndBrokenDoc()
+
+	repairJob := func(doc *document) (transformedDoc *document, transformed bool, err error) {
+
+		// Check if rev history has cycles
+		containsCycles := doc.History.ContainsCycles()
+
+		if !containsCycles {
+			// nothing to repair
+			return nil, false, nil
+		}
+
+		// Repair it
+		if err := doc.History.Repair(); err != nil {
+			return nil, false, err
+		}
+
+		// Return original doc pointer since it was repaired in place
+		return doc, true, nil
+
+	}
+
+	repairBucket := NewRepairBucket(bucket).
+		SetDryRun(false).
+		AddRepairJob(repairJob)
+
+	err := repairBucket.RepairBucket()
+
+	assertNoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
+
+	// Now get the doc from the bucket
+	var value interface{}
+	_, errGetDoc := bucket.Get(docIdProblematicRevTree, &value)
+	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting doc: %v", errGetDoc))
+
+	marshalled, errMarshal := json.Marshal(value)
+	assertNoError(t, errMarshal, fmt.Sprintf("Error marshalling doc: %v", errMarshal))
+
+	repairedDoc, errUnmarshal := unmarshalDocument(docIdProblematicRevTree, marshalled)
+	assertNoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
+
+	// Since doc was repaired, should contain no cycles
+	assert.False(t, repairedDoc.History.ContainsCycles())
+
+
 
 }

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -138,6 +138,17 @@ func (tree RevTree) UnmarshalJSON(inputjson []byte) (err error) {
 	return
 }
 
+func (tree RevTree) ContainsCycles() bool {
+	containsCycles := false
+	for _, leafRevision := range tree.GetLeaves() {
+		_, revHistoryErr := tree.getHistory(leafRevision)
+		if revHistoryErr != nil {
+			containsCycles = true
+		}
+	}
+	return containsCycles
+}
+
 // Repair rev trees that have cycles introduced by SG Issue #2847
 func (tree RevTree) Repair() (err error) {
 

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -138,6 +138,52 @@ func (tree RevTree) UnmarshalJSON(inputjson []byte) (err error) {
 	return
 }
 
+// Repair rev trees that have cycles introduced by SG Issue #2847
+func (tree RevTree) Repair() (err error) {
+
+	// This function will be called back for every leaf node in tree
+	leafProcessor := func(leaf *RevInfo) {
+
+		// Walk up the tree until we find a root, and append each node
+		node := leaf
+		if node.IsRoot() {
+			return
+		}
+
+		for {
+
+			if node.ParentGenLargerNodeGen() {
+				base.Warn("Node %+v detected to have invalid parent rev.  Repairing by designating as a root node.", node)
+				node.Parent = ""
+				break
+			}
+
+			node = tree[node.Parent]
+
+			// Reached a root, we're done -- there's no need
+			// to call appendNodeToResult() on the root, since
+			// the child of the root will have already added a node
+			// pointing to the root.
+			if node.IsRoot() {
+				break
+			}
+
+		}
+	}
+
+	// Iterate over leaves
+	tree.forEachLeaf(leafProcessor)
+
+	return nil
+}
+
+// Detect situations like:
+//     node: &{ID:10-684759c169c75629d02b90fe10b56925 Parent:184-a6b3f72a2bc1f988bfb720fec8db3a1d Deleted:fa...
+// where the parent generation is *higher* than the node generation, which is never a valid scenario.
+func (node RevInfo) ParentGenLargerNodeGen() bool {
+	return genOfRevID(node.Parent) > genOfRevID(node.ID)
+}
+
 // Returns true if the RevTree has an entry for this revid.
 func (tree RevTree) contains(revid string) bool {
 	_, exists := tree[revid]

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -10,14 +10,12 @@
 package db
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
-
-	"errors"
-
-	"bytes"
 
 	"github.com/couchbase/sync_gateway/base"
 )

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -148,7 +148,7 @@ func (tree RevTree) ContainsCycles() bool {
 }
 
 // Repair rev trees that have cycles introduced by SG Issue #2847
-func (tree RevTree) Repair() (err error) {
+func (tree RevTree) RepairCycles() (err error) {
 
 	// This function will be called back for every leaf node in tree
 	leafProcessor := func(leaf *RevInfo) {

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -690,7 +690,6 @@ func TestRepairRevsHistoryWithCycles(t *testing.T) {
 		t.Fatalf("Error unmarshalling doc: %v", err)
 	}
 
-
 	if err := rawDoc.History.Repair(); err != nil {
 		t.Fatalf("Unable to repair doc.  Err: %v", err)
 	}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -680,6 +680,37 @@ func TestRevsHistoryInfiniteLoop(t *testing.T) {
 
 }
 
+// Repair tool for https://github.com/couchbase/sync_gateway/issues/2847
+func TestRepairRevsHistoryWithCycles(t *testing.T) {
+
+	docId := "testdocProblematicRevTree"
+
+	rawDoc, err := unmarshalDocument(docId, []byte(testdocProblematicRevTree))
+	if err != nil {
+		t.Fatalf("Error unmarshalling doc: %v", err)
+	}
+
+
+	if err := rawDoc.History.Repair(); err != nil {
+		t.Fatalf("Unable to repair doc.  Err: %v", err)
+	}
+
+	// This function will be called back for every leaf node in tree
+	leafProcessor := func(leaf *RevInfo) {
+
+		_, err := rawDoc.History.getHistory(leaf.ID)
+		if err != nil {
+			t.Fatalf("GetHistory() returned error: %v", err)
+		}
+
+	}
+
+	// Iterate over leaves and make sure none of them have a history with cycles
+	rawDoc.History.forEachLeaf(leafProcessor)
+
+}
+
+
 // TODO: add test for two tombstone branches getting pruned at once
 
 // Repro case for https://github.com/couchbase/sync_gateway/issues/2847

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -690,7 +690,7 @@ func TestRepairRevsHistoryWithCycles(t *testing.T) {
 		t.Fatalf("Error unmarshalling doc: %v", err)
 	}
 
-	if err := rawDoc.History.Repair(); err != nil {
+	if err := rawDoc.History.RepairCycles(); err != nil {
 		t.Fatalf("Unable to repair doc.  Err: %v", err)
 	}
 

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -709,7 +709,6 @@ func TestRepairRevsHistoryWithCycles(t *testing.T) {
 
 }
 
-
 // TODO: add test for two tombstone branches getting pruned at once
 
 // Repro case for https://github.com/couchbase/sync_gateway/issues/2847

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -264,9 +264,8 @@ func (h *handler) handleRepair() error {
 	}
 
 	repairBucket := db.NewRepairBucket(h.db.Bucket)
-	if err := repairBucket.InitFrom(repairBucketParams); err != nil {
-		return fmt.Errorf("Error initializing from %+v.  Error: %v", repairBucketParams, err)
-	}
+
+	repairBucket.InitFrom(repairBucketParams)
 
 	if err := repairBucket.RepairBucket(); err != nil {
 		return fmt.Errorf("Error repairing bucket: %v", err)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -267,7 +267,8 @@ func (h *handler) handleRepair() error {
 
 	repairBucket.InitFrom(repairBucketParams)
 
-	if err := repairBucket.RepairBucket(); err != nil {
+	_, repairDocsErr := repairBucket.RepairBucket()
+	if repairDocsErr != nil {
 		return fmt.Errorf("Error repairing bucket: %v", err)
 	}
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -244,6 +244,37 @@ func (h *handler) handleDump() error {
 	return nil
 }
 
+
+// HTTP handler for _repair
+func (h *handler) handleRepair() error {
+
+	base.LogTo("HTTP", "Repair bucket")
+
+	// Todo: is this actually needed or does something else in the handler do it?  I can't find that..
+	defer h.requestBody.Close()
+
+	body, err := h.readBody()
+	if err != nil {
+		return err
+	}
+
+	repairBucketParams := db.RepairBucketParams{}
+	if err := json.Unmarshal(body, &repairBucketParams); err != nil {
+		return fmt.Errorf("Error unmarsalling %v into RepairJobParams.  Err: %v", string(body), err)
+	}
+
+	repairBucket := db.NewRepairBucket(h.db.Bucket)
+	if err := repairBucket.InitFrom(repairBucketParams); err != nil {
+		return fmt.Errorf("Error initializing from %+v.  Error: %v", repairBucketParams, err)
+	}
+
+	if err := repairBucket.RepairBucket(); err != nil {
+		return fmt.Errorf("Error repairing bucket: %v", err)
+	}
+
+	return nil
+}
+
 // HTTP handler for _dumpchannel
 func (h *handler) handleDumpChannel() error {
 	channelName := h.PathVar("channel")

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -244,7 +244,6 @@ func (h *handler) handleDump() error {
 	return nil
 }
 
-
 // HTTP handler for _repair
 func (h *handler) handleRepair() error {
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -267,12 +267,20 @@ func (h *handler) handleRepair() error {
 
 	repairBucket.InitFrom(repairBucketParams)
 
-	_, repairDocsErr := repairBucket.RepairBucket()
+	repairBucketResult, repairDocsErr := repairBucket.RepairBucket()
 	if repairDocsErr != nil {
 		return fmt.Errorf("Error repairing bucket: %v", err)
 	}
 
-	return nil
+	resultMarshalled, err := json.Marshal(repairBucketResult)
+	if err != nil {
+		return fmt.Errorf("Error marshalling repairBucketResult: %+v", repairBucketResult)
+	}
+
+	h.setHeader("Content-Type", "application/json")
+	_, err = h.response.Write(resultMarshalled)
+
+	return err
 }
 
 // HTTP handler for _dumpchannel

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -262,6 +262,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, (*handler).handleIndexChannel)).Methods("GET")
 	dbr.Handle("/_index/channels",
 		makeHandler(sc, adminPrivs, (*handler).handleIndexAllChannels)).Methods("GET")
+	dbr.Handle("/_repair",
+		makeHandler(sc, adminPrivs, (*handler).handleRepair)).Methods("POST")
 
 	// The routes below are part of the CouchDB REST API but should only be available to admins,
 	// so the handlers are moved to the admin port.


### PR DESCRIPTION

Adds a tool to repair the revision trees with cycles caused by https://github.com/couchbase/sync_gateway/issues/2847

Instructions + Test Instructions are [in the beginning of issue 2847](https://github.com/couchbase/sync_gateway/issues/2857#issue-253501830) 