### PR TITLE
Update golang text dependency to latest commit  HASH

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -121,6 +121,7 @@
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
+  
 </manifest>
 
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="bd91bbf73e9a4a801adbfb97133c992678533126"/>
 
   <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
 


### PR DESCRIPTION
Update golang text dependency to latest commit  HASH bd91bbf73e9a4a801adbfb97133c992678533126

To support Go 1.9 builds

Note: This has been tested locally with Go 1.9 on macOS but not via a Jenkins build with 1.9 as we currently have no VM's with Go 1.9 installed.