### PR TITLE
Fixes #2197 Missing docs in changes feed after auto failover (channel…

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -57,7 +57,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="6c44a8829958bfe71283ed9fec2c28d722a3be27"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="6382451e5ef472cd19e4eba6e82e3c1957e4cc09"/>
 


### PR DESCRIPTION
…-cache not updating)

Fixes #2197 

Fixed by uptaking fix for https://issues.couchbase.com/browse/MB-25912