### PR TITLE
Fixes #2836 - unit test code coverage

### DIFF
--- a/test_with_coverage.sh
+++ b/test_with_coverage.sh
@@ -1,0 +1,30 @@
+set -e
+
+## Go Tests
+echo "Testing code with 'go test' ..."
+
+if [ -d "godeps" ]; then
+  export GOPATH=`pwd`/godeps
+fi
+
+# Make sure gocoverutil is in path
+path_to_gocoverutil=$(which gocoverutil)
+if [ -x "$path_to_gocoverutil" ] ; then
+    echo "Using gocoverutil: $path_to_gocoverutil"
+else
+    echo "Please install gocoverutil by running 'go get -u github.com/AlekSi/gocoverutil'"
+fi
+
+echo "Running Sync Gateway unit tests"
+gocoverutil -coverprofile=cover_sg.out test -v "$@" -covermode=count github.com/couchbase/sync_gateway/...
+
+echo "Generating Sync Gateway HTML coverage report to coverage_sync_gateway.html"
+go tool cover -html=cover_sg.out -o coverage_sync_gateway.html
+
+if [ -d godeps/src/github.com/couchbaselabs/sync-gateway-accel ]; then
+    echo "Running Sync Gateway Accel unit tests"
+    gocoverutil -coverprofile=cover_sga.out test -v "$@" -covermode=count github.com/couchbaselabs/sync-gateway-accel/...
+
+    echo "Generating SG Accel HTML coverage report to coverage_sg_accel.html"
+    go tool cover -html=cover_sga.out -o coverage_sg_accel.html
+fi


### PR DESCRIPTION
Fixes #2836

- [x] Update unit integration to have a flag (generate coverage report)
- [x] Attach HTML coverage report to results for SG + SGA
- [x] Attach coverage aggregation tool output to job

## Changes in this PR:

- Consolidates `test.sh` and `test_integration.sh` into single script
- `test.sh` now takes CLI args to customize the behavior with respect to running unit tests vs unit integration tests, as well as optionally generating code coverage reports in either case
- `test.sh` propagates any CLI args after a `--` to the underlying `go tool` or `gocoverutil` command


Example Jenkins run: http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway-w-coverage/15/

## Jenkins changes needed post-merge

- Replace [unit integration jenkins job](http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway/) with config/script from http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway-w-coverage
- Remove http://uberjenkins.sc.couchbase.com/view/Build/job/build-sync-gateway-w-coverage