### PR TITLE
Fixes #2851 Require explicit log key for PerfStats logging

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -421,7 +421,7 @@ func WriteHistogram(expvarMap *expvar.Map, since time.Time, prefix string) {
 
 func WriteHistogramForDuration(expvarMap *expvar.Map, duration time.Duration, prefix string) {
 
-	if LogEnabled("PerfStats") {
+	if LogEnabledExcludingLogStar("PerfStats") {
 		var durationMs int
 		if duration < 1*time.Second {
 			durationMs = int(duration/(100*time.Millisecond)) * 100


### PR DESCRIPTION
Fixes #2851 