### PR TITLE
bumped sg-replicate commit hash to pick up changes for attachments

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -97,7 +97,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="c0f1596c21b3a99295163257ffa4795c2f3665be"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="1490c89b7299046c431e442b6231db28a3b5c0bc"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="ef844635a21403c0a5115bfdbbfb416cc57dae51"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -97,7 +97,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="aef460b9ed0e88ca0e1014bc601c0ffec954c942"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="c0f1596c21b3a99295163257ffa4795c2f3665be"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="ef844635a21403c0a5115bfdbbfb416cc57dae51"/>
 


### PR DESCRIPTION
fixes #2884
bumped sg-replicate commit hash to pick up changes for attachments with no Content-Type: header