### PR TITLE
Non-inline storage of non-winning revision bodies

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -29,6 +29,7 @@ const (
 )
 
 var FlushOrRecreateTestBucket = FlushBetweenTests
+var TestExternalRevStorage = false
 
 func init() {
 	// Prevent https://issues.couchbase.com/browse/MB-24237
@@ -405,4 +406,15 @@ func (tbm *TestBucketManager) CreateTestBucket() error {
 	}
 
 	return nil
+}
+
+// Generates a string of size int
+const alphaNumeric = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+func CreateProperty(size int) (result string) {
+	resultBytes := make([]byte, size)
+	for i := 0; i < size; i++ {
+		resultBytes[i] = alphaNumeric[i%len(alphaNumeric)]
+	}
+	return string(resultBytes)
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1,0 +1,330 @@
+package db
+
+import (
+	"encoding/json"
+	"log"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/go.assert"
+)
+
+type treeDoc struct {
+	Meta treeMeta `json:"_sync"`
+}
+
+type treeMeta struct {
+	RevTree revTreeList `json:"history"`
+}
+
+// Retrieve the raw doc from the bucket, and unmarshal sync history as revTreeList, to validate low-level  storage
+func getRevTreeList(bucket base.Bucket, key string) (revTreeList, error) {
+	rawDoc, _, err := bucket.GetRaw(key)
+	if err != nil {
+		return revTreeList{}, err
+	}
+	var doc treeDoc
+	err = json.Unmarshal(rawDoc, &doc)
+	return doc.Meta.RevTree, err
+}
+
+// TestRevisionStorageConflictAndTombstones
+// Tests permutations of inline and external storage of conflicts and tombstones
+func TestRevisionStorageConflictAndTombstones(t *testing.T) {
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+	base.TestExternalRevStorage = true
+
+	prop_1000_bytes := base.CreateProperty(1000)
+
+	// Create rev 2-a
+	log.Printf("Create rev 1-a")
+	body := Body{"key1": "value1", "version": "1a"}
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}), "add 1-a")
+
+	// Create rev 2-a
+	// 1-a
+	//  |
+	// 2-a
+	log.Printf("Create rev 2-a with a large body")
+	rev2a_body := Body{}
+	rev2a_body["key1"] = prop_1000_bytes
+	rev2a_body["version"] = "2a"
+	assertNoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}), "add 2-a")
+
+	// Retrieve the document:
+	log.Printf("Retrieve doc 2-a...")
+	gotbody, err := db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2a_body)
+
+	// Create rev 2-b
+	//    1-a
+	//   /  \
+	// 2-a  2-b
+	log.Printf("Create rev 2-b with a large body")
+	rev2b_body := Body{}
+	rev2b_body["key1"] = prop_1000_bytes
+	rev2b_body["version"] = "2b"
+	assertNoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}), "add 2-b")
+
+	// Retrieve the document:
+	log.Printf("Retrieve doc, verify rev 2-b")
+	gotbody, err = db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2b_body)
+
+	// Retrieve the raw document, and verify 2-a isn't stored inline
+	log.Printf("Retrieve doc, verify rev 2-a not inline")
+	revTree, err := getRevTreeList(db.Bucket, "doc1")
+	assertNoError(t, err, "Couldn't get revtree for raw document")
+	assert.Equals(t, len(revTree.BodyMap), 0)
+	assert.Equals(t, len(revTree.BodyKeyMap), 1)
+
+	// Retrieve the raw revision body backup of 2-a, and verify it's intact
+	log.Printf("Verify document storage of 2-a")
+	var revisionBody Body
+	rawRevision, _, err := db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
+	assertNoError(t, err, "Couldn't get raw backup revision")
+	json.Unmarshal(rawRevision, &revisionBody)
+	assert.Equals(t, revisionBody["version"], rev2a_body["version"])
+	assert.Equals(t, revisionBody["value"], rev2a_body["value"])
+
+	// Retrieve the non-inline revision
+	db.FlushRevisionCache()
+	rev2aGet, err := db.GetRev("doc1", "2-a", false, nil)
+	assertNoError(t, err, "Couldn't get rev 2-a")
+	assert.DeepEquals(t, rev2aGet, rev2a_body)
+
+	// Tombstone 2-b (with rev 3-b, minimal tombstone)
+	//    1-a
+	//   /  \
+	// 2-a  2-b
+	//       |
+	//      3-b(t)
+
+	log.Printf("Create tombstone 3-b")
+	rev3b_body := Body{}
+	rev3b_body["version"] = "3b"
+	rev3b_body["_deleted"] = true
+	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}), "add 3-b (tombstone)")
+
+	// Retrieve tombstone
+	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
+	assertNoError(t, err, "Couldn't get rev 3-b")
+	assert.DeepEquals(t, rev3bGet, rev3b_body)
+
+	// Retrieve the document, validate that we get 2-a
+	log.Printf("Retrieve doc, expect 2-a")
+	gotbody, err = db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2a_body)
+
+	// Ensure previous revision body backup has been removed
+	_, _, err = db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
+	assertTrue(t, base.IsKeyNotFoundError(db.Bucket, err), "Revision should be not found")
+
+	// Validate the tombstone is stored inline (due to small size)
+	revTree, err = getRevTreeList(db.Bucket, "doc1")
+	assertNoError(t, err, "Couldn't get revtree for raw document")
+	assert.Equals(t, len(revTree.BodyMap), 1)
+	assert.Equals(t, len(revTree.BodyKeyMap), 0)
+
+	// Create another conflict (2-c)
+	//      1-a
+	//    /  |   \
+	// 2-a  2-b  2-c
+	//       |
+	//      3-b(t)
+	log.Printf("Create rev 2-c with a large body")
+	rev2c_body := Body{}
+	rev2c_body["key1"] = prop_1000_bytes
+	rev2c_body["version"] = "2c"
+	assertNoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}), "add 2-c")
+
+	// Retrieve the document:
+	log.Printf("Retrieve doc, verify rev 2-c")
+	gotbody, err = db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2c_body)
+
+	// Tombstone with a large tombstone
+	//      1-a
+	//    /  |  \
+	// 2-a  2-b  2-c
+	//       |    \
+	//     3-b(t) 3-c(t)
+	log.Printf("Create tombstone 3-c")
+	rev3c_body := Body{}
+	rev3c_body["version"] = "3c"
+	rev3c_body["key1"] = prop_1000_bytes
+	rev3c_body["_deleted"] = true
+	assertNoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}), "add 3-c (large tombstone)")
+
+	// Validate the tombstone is not stored inline (due to small size)
+	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
+	newRevTree, err := getRevTreeList(db.Bucket, "doc1")
+	assertNoError(t, err, "Couldn't get revtree for raw document")
+	assert.Equals(t, len(newRevTree.BodyMap), 1)    // tombstone 3-b
+	assert.Equals(t, len(newRevTree.BodyKeyMap), 1) // tombstone 3-c
+
+	// Retrieve the non-inline tombstone revision
+	db.FlushRevisionCache()
+	rev3cGet, err := db.GetRev("doc1", "3-c", false, nil)
+	assertNoError(t, err, "Couldn't get rev 3-c")
+	assert.DeepEquals(t, rev3cGet, rev3c_body)
+
+	log.Printf("Retrieve doc, verify active rev is 2-a")
+	gotbody, err = db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2a_body)
+
+	// Add active revision, ensure all revisions remain intact
+	log.Printf("Create rev 3-a with a large body")
+	rev3a_body := Body{}
+	rev3a_body["key1"] = prop_1000_bytes
+	rev3a_body["version"] = "3a"
+	assertNoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}), "add 3-a")
+
+	revTree, err = getRevTreeList(db.Bucket, "doc1")
+	assertNoError(t, err, "Couldn't get revtree for raw document")
+	assert.Equals(t, len(revTree.BodyMap), 1)    // tombstone 3-b
+	assert.Equals(t, len(revTree.BodyKeyMap), 1) // tombstone 3-c
+}
+
+// TestRevisionStoragePruneTombstone - tests cleanup of external tombstone bodies when pruned.
+func TestRevisionStoragePruneTombstone(t *testing.T) {
+	db := setupTestDB(t)
+	defer tearDownTestDB(t, db)
+	base.TestExternalRevStorage = true
+
+	prop_1000_bytes := base.CreateProperty(1000)
+
+	// Create rev 2-a
+	log.Printf("Create rev 1-a")
+	body := Body{"key1": "value1", "version": "1a"}
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}), "add 1-a")
+
+	// Create rev 2-a
+	// 1-a
+	//  |
+	// 2-a
+	log.Printf("Create rev 2-a with a large body")
+	rev2a_body := Body{}
+	rev2a_body["key1"] = prop_1000_bytes
+	rev2a_body["version"] = "2a"
+	assertNoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}), "add 2-a")
+
+	// Retrieve the document:
+	log.Printf("Retrieve doc 2-a...")
+	gotbody, err := db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2a_body)
+
+	// Create rev 2-b
+	//    1-a
+	//   /  \
+	// 2-a  2-b
+	log.Printf("Create rev 2-b with a large body")
+	rev2b_body := Body{}
+	rev2b_body["key1"] = prop_1000_bytes
+	rev2b_body["version"] = "2b"
+	assertNoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}), "add 2-b")
+
+	// Retrieve the document:
+	log.Printf("Retrieve doc, verify rev 2-b")
+	gotbody, err = db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2b_body)
+
+	// Retrieve the raw document, and verify 2-a isn't stored inline
+	log.Printf("Retrieve doc, verify rev 2-a not inline")
+	revTree, err := getRevTreeList(db.Bucket, "doc1")
+	assertNoError(t, err, "Couldn't get revtree for raw document")
+	assert.Equals(t, len(revTree.BodyMap), 0)
+	assert.Equals(t, len(revTree.BodyKeyMap), 1)
+
+	// Retrieve the raw revision body backup of 2-a, and verify it's intact
+	log.Printf("Verify document storage of 2-a")
+	var revisionBody Body
+	rawRevision, _, err := db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
+	assertNoError(t, err, "Couldn't get raw backup revision")
+	json.Unmarshal(rawRevision, &revisionBody)
+	assert.Equals(t, revisionBody["version"], rev2a_body["version"])
+	assert.Equals(t, revisionBody["value"], rev2a_body["value"])
+
+	// Retrieve the non-inline revision
+	db.FlushRevisionCache()
+	rev2aGet, err := db.GetRev("doc1", "2-a", false, nil)
+	assertNoError(t, err, "Couldn't get rev 2-a")
+	assert.DeepEquals(t, rev2aGet, rev2a_body)
+
+	// Tombstone 2-b (with rev 3-b, large tombstone)
+	//    1-a
+	//   /  \
+	// 2-a  2-b
+	//       |
+	//      3-b(t)
+
+	log.Printf("Create tombstone 3-b")
+	rev3b_body := Body{}
+	rev3b_body["version"] = "3b"
+	rev3b_body["key1"] = prop_1000_bytes
+	rev3b_body["_deleted"] = true
+	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}), "add 3-b (tombstone)")
+
+	// Retrieve tombstone
+	db.FlushRevisionCache()
+	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
+	assertNoError(t, err, "Couldn't get rev 3-b")
+	assert.DeepEquals(t, rev3bGet, rev3b_body)
+
+	// Retrieve the document, validate that we get 2-a
+	log.Printf("Retrieve doc, expect 2-a")
+	gotbody, err = db.Get("doc1")
+	assertNoError(t, err, "Couldn't get document")
+	assert.DeepEquals(t, gotbody, rev2a_body)
+
+	// Retrieve the raw document, and verify 2-a isn't stored inline
+	log.Printf("Retrieve doc, verify rev 2-a not inline")
+	revTree, err = getRevTreeList(db.Bucket, "doc1")
+	assertNoError(t, err, "Couldn't get revtree for raw document")
+	assert.Equals(t, len(revTree.BodyMap), 0)
+	assert.Equals(t, len(revTree.BodyKeyMap), 1)
+	log.Printf("revTree.BodyKeyMap:%v", revTree.BodyKeyMap)
+
+	revTree, err = getRevTreeList(db.Bucket, "doc1")
+	log.Printf("revtree before additional revisions: %v", revTree.BodyKeyMap)
+
+	// Add revisions until 3-b is pruned
+	db.RevsLimit = 5
+	activeRevBody := Body{}
+	activeRevBody["version"] = "...a"
+	activeRevBody["key1"] = prop_1000_bytes
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}), "add 3-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}), "add 4-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}), "add 5-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}), "add 6-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}), "add 7-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}), "add 8-a")
+
+	// Verify that 3-b is still present at this point
+	db.FlushRevisionCache()
+	rev3bGet, err = db.GetRev("doc1", "3-b", false, nil)
+	assertNoError(t, err, "Rev 3-b should still exist")
+
+	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}), "add 9-a")
+
+	// Verify that 3-b has been pruned
+	log.Printf("Attempt to retrieve 3-b, expect pruned")
+	db.FlushRevisionCache()
+	rev3bGet, err = db.GetRev("doc1", "3-b", false, nil)
+	assert.Equals(t, err.Error(), "404 missing")
+
+	// Ensure previous tombstone body backup has been removed
+	log.Printf("Verify revision body doc has been removed from bucket")
+	_, _, err = db.Bucket.GetRaw("_sync:rb:ULDLuEgDoKFJeET2hojeFANXM8SrHdVfAGONki+kPxM=")
+	assertTrue(t, base.IsKeyNotFoundError(db.Bucket, err), "Revision should be not found")
+
+}

--- a/db/database.go
+++ b/db/database.go
@@ -1194,9 +1194,23 @@ func (context *DatabaseContext) UseXattrs() bool {
 	return context.Options.EnableXattr
 }
 
+func (context *DatabaseContext) AllowExternalRevBodyStorage() bool {
+
+	// Support unit testing w/out xattrs enabled
+	if base.TestExternalRevStorage {
+		return false
+	}
+	return !context.UseXattrs()
+}
+
 func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 
 	context.Options.UnsupportedOptions.UserViews.Enabled = &value
+}
+
+// For test usage
+func (context *DatabaseContext) FlushRevisionCache() {
+	context.revisionCache = NewRevisionCache(context.Options.RevisionCacheCapacity, context.revCacheLoader)
 }
 
 //////// SEQUENCE ALLOCATION:

--- a/db/document.go
+++ b/db/document.go
@@ -11,6 +11,8 @@ package db
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -22,6 +24,10 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 )
+
+// When external revision storage is used, maximum body size (in bytes) to store inline.
+// Non-winning bodies smaller than this size are more efficient to store inline.
+const MaximumInlineBodySize = 250
 
 // Maps what users have access to what channels or roles, and when they got that access.
 type UserAccessMap map[string]channels.TimedSet
@@ -51,6 +57,9 @@ type syncData struct {
 
 	// Backward compatibility (the "deleted" field was, um, deleted in commit 4194f81, 2/17/14)
 	Deleted_OLD bool `json:"deleted,omitempty"`
+
+	addedRevisionBodies     []string          // revIDs of non-winning revision bodies that have been added (and so require persistence)
+	removedRevisionBodyKeys map[string]string // keys of non-winning revisions that have been removed (and so may require deletion), indexed by revID
 }
 
 // A document as stored in Couchbase. Contains the body of the current revision plus metadata.
@@ -269,33 +278,82 @@ func (doc *document) newestRevID() string {
 	return doc.CurrentRev
 }
 
+// RevLoaderFunc and RevWriterFunc manage persistence of non-winning revision bodies that are stored outside the document.
+type RevLoaderFunc func(key string) ([]byte, error)
+
+func (db *DatabaseContext) RevisionBodyLoader(key string) ([]byte, error) {
+	body, _, err := db.Bucket.GetRaw(key)
+	return body, err
+}
+
 // Fetches the body of a revision as a map, or nil if it's not available.
-func (doc *document) getRevision(revid string) Body {
+func (doc *document) getRevisionBody(revid string, loader RevLoaderFunc) Body {
 	var body Body
 	if revid == doc.CurrentRev {
 		body = doc.body
 	} else {
-		body = doc.History.getParsedRevisionBody(revid)
-		if body == nil {
-			return nil
-		}
+		body = doc.getNonWinningRevisionBody(revid, loader)
+	}
+	return body
+}
+
+// Retrieves a non-winning revision body.  If not already loaded in the document (either because inline,
+// or was previously requested), loader function is used to retrieve from the bucket.
+func (doc *document) getNonWinningRevisionBody(revid string, loader RevLoaderFunc) Body {
+	var body Body
+	bodyBytes, found := doc.History.getRevisionBody(revid, loader)
+	if !found {
+		return nil
+	}
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		base.Warn("Unexpected error parsing body of rev %q", revid)
+		return nil
 	}
 	return body
 }
 
 // Fetches the body of a revision as JSON, or nil if it's not available.
-func (doc *document) getRevisionJSON(revid string) []byte {
+func (doc *document) getRevisionBodyJSON(revid string, loader RevLoaderFunc) []byte {
 	var bodyJSON []byte
 	if revid == doc.CurrentRev {
 		bodyJSON, _ = json.Marshal(doc.body)
 	} else {
-		bodyJSON, _ = doc.History.getRevisionBody(revid)
+		bodyJSON, _ = doc.History.getRevisionBody(revid, loader)
 	}
 	return bodyJSON
 }
 
-// Adds a revision body to a document.
-func (doc *document) setRevision(revid string, body Body) {
+func (doc *document) removeRevisionBody(revID string) {
+	removedBodyKey := doc.History.removeRevisionBody(revID)
+	if removedBodyKey != "" {
+		if doc.removedRevisionBodyKeys == nil {
+			doc.removedRevisionBodyKeys = make(map[string]string)
+		}
+		doc.removedRevisionBodyKeys[revID] = removedBodyKey
+	}
+}
+
+// makeBodyActive moves a previously non-winning revision body from the rev tree to the document body
+func (doc *document) promoteNonWinningRevisionBody(revid string, loader RevLoaderFunc) {
+	// If the new revision is not current, transfer the current revision's
+	// body to the top level doc.body:
+	doc.body = doc.getNonWinningRevisionBody(revid, loader)
+	doc.removeRevisionBody(revid)
+}
+
+func (doc *document) pruneRevisions(maxDepth uint32, keepRev string) int {
+	numPruned, prunedTombstoneBodyKeys := doc.History.pruneRevisions(maxDepth, keepRev)
+	for revID, bodyKey := range prunedTombstoneBodyKeys {
+		if doc.removedRevisionBodyKeys == nil {
+			doc.removedRevisionBodyKeys = make(map[string]string)
+		}
+		doc.removedRevisionBodyKeys[revID] = bodyKey
+	}
+	return numPruned
+}
+
+// Adds a revision body (as Body) to a document.  Removes special properties first.
+func (doc *document) setRevisionBody(revid string, body Body, storeInline bool) {
 	strippedBody := stripSpecialProperties(body)
 	if revid == doc.CurrentRev {
 		doc.body = strippedBody
@@ -304,8 +362,99 @@ func (doc *document) setRevision(revid string, body Body) {
 		if len(body) > 0 {
 			asJson, _ = json.Marshal(stripSpecialProperties(body))
 		}
-		doc.History.setRevisionBody(revid, asJson)
+		doc.setNonWinningRevisionBody(revid, asJson, storeInline)
 	}
+}
+
+// Adds a revision body (as []byte) to a document.  Flags for external storage when appropriate
+func (doc *document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool) {
+	revBodyKey := ""
+	if !storeInline && len(body) > MaximumInlineBodySize {
+		revBodyKey = generateRevBodyKey(doc.ID, revid)
+		doc.addedRevisionBodies = append(doc.addedRevisionBodies, revid)
+	}
+	doc.History.setRevisionBody(revid, body, revBodyKey)
+}
+
+// persistModifiedRevisionBodies writes new non-inline revisions to the bucket.
+// Should be invoked BEFORE the document is successfully committed.
+func (doc *document) persistModifiedRevisionBodies(bucket base.Bucket) error {
+
+	for _, revID := range doc.addedRevisionBodies {
+		// if this rev is also in the delete set, skip add/delete
+		_, ok := doc.removedRevisionBodyKeys[revID]
+		if ok {
+			delete(doc.removedRevisionBodyKeys, revID)
+			continue
+		}
+
+		revInfo, err := doc.History.getInfo(revID)
+		if revInfo == nil || err != nil {
+			return err
+		}
+		if revInfo.BodyKey == "" || len(revInfo.Body) == 0 {
+			return fmt.Errorf("Missing key or body for revision during external persistence.  doc: %s rev:%s key: %s  len(body): %d", doc.ID, revID, revInfo.BodyKey, len(revInfo.Body))
+		}
+
+		// If addRaw indicates that the doc already exists, can ignore.  Another writer already persisted this rev backup.
+		addErr := doc.persistRevisionBody(bucket, revInfo.BodyKey, revInfo.Body)
+		if addErr != nil {
+			return err
+		}
+	}
+
+	doc.addedRevisionBodies = []string{}
+	return nil
+}
+
+// deleteRemovedRevisionBodies deletes obsolete non-inline revisions from the bucket.
+// Should be invoked AFTER the document is successfully committed.
+func (doc *document) deleteRemovedRevisionBodies(bucket base.Bucket) {
+
+	for _, revBodyKey := range doc.removedRevisionBodyKeys {
+		deleteErr := bucket.Delete(revBodyKey)
+		if deleteErr != nil {
+			base.Warn("Unable to delete old revision body using key %s - will not be deleted from bucket.", revBodyKey)
+		}
+	}
+	doc.removedRevisionBodyKeys = map[string]string{}
+}
+
+func (doc *document) persistRevisionBody(bucket base.Bucket, key string, body []byte) error {
+	_, err := bucket.AddRaw(key, 0, body)
+	return err
+}
+
+// Move any large revision bodies to external document storage
+func (doc *document) migrateRevisionBodies(bucket base.Bucket) error {
+
+	for _, revID := range doc.History.GetLeaves() {
+		revInfo, err := doc.History.getInfo(revID)
+		if err != nil {
+			continue
+		}
+		if len(revInfo.Body) > MaximumInlineBodySize {
+			bodyKey := generateRevBodyKey(doc.ID, revID)
+			persistErr := doc.persistRevisionBody(bucket, bodyKey, revInfo.Body)
+			if persistErr != nil {
+				base.Warn("Unable to store revision body for doc %s, rev %s externally: %v", doc.ID, revID, persistErr)
+				continue
+			}
+			revInfo.BodyKey = bodyKey
+		}
+	}
+	return nil
+}
+
+func generateRevBodyKey(docid, revid string) (revBodyKey string) {
+	return fmt.Sprintf("_sync:rb:%s", generateRevDigest(docid, revid))
+}
+
+func generateRevDigest(docid, revid string) string {
+	digester := sha256.New()
+	digester.Write([]byte(docid))
+	digester.Write([]byte(revid))
+	return base64.StdEncoding.EncodeToString(digester.Sum(nil))
 }
 
 // Updates the expiry for a document

--- a/db/import.go
+++ b/db/import.go
@@ -186,7 +186,6 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 // migration if _sync property exists.  If _sync property is not found, returns doc and sets requiresImport to true
 func (db *Database) migrateMetadata(docid string, body Body, existingDoc *sgbucket.BucketDocument) (docOut *document, requiresImport bool, err error) {
 
-	// TODO: Add unit test for standalone migrateMetadata execution
 	for {
 		// Reload existing doc, if not present
 		if len(existingDoc.Body) == 0 {
@@ -220,6 +219,9 @@ func (db *Database) migrateMetadata(docid string, body Body, existingDoc *sgbuck
 			base.LogTo("Migrate", "During migrate, doc %q doesn't have valid sync data.  Falling back to import handling.  (cas=%d)", docid, doc.Cas)
 			return doc, true, nil
 		}
+
+		// Move any large revision bodies to external storage
+		doc.migrateRevisionBodies(db.Bucket)
 
 		// Persist the document in xattr format
 		value, xattrValue, marshalErr := doc.MarshalWithXattr()

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -353,21 +353,24 @@ func TestPruneRevisions(t *testing.T) {
 	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
 
 	// Prune:
-	assert.Equals(t, tempmap.pruneRevisions(1000, ""), 0)
-	assert.Equals(t, tempmap.pruneRevisions(3, ""), 0)
-	assert.Equals(t, tempmap.pruneRevisions(2, ""), 1)
+	pruned, _ := tempmap.pruneRevisions(1000, "")
+	assert.Equals(t, pruned, 0)
+	pruned, _ = tempmap.pruneRevisions(3, "")
+	assert.Equals(t, pruned, 0)
+	pruned, _ = tempmap.pruneRevisions(2, "")
+	assert.Equals(t, pruned, 1)
 	assert.Equals(t, len(tempmap), 4)
 	assert.Equals(t, tempmap["1-one"], (*RevInfo)(nil))
 	assert.Equals(t, tempmap["2-two"].Parent, "")
 
 	// Make sure leaves are never pruned:
-	assert.Equals(t, tempmap.pruneRevisions(1, ""), 2)
+	pruned, _ = tempmap.pruneRevisions(1, "")
+	assert.Equals(t, pruned, 2)
 	assert.Equals(t, len(tempmap), 2)
 	assert.True(t, tempmap["3-three"] != nil)
 	assert.Equals(t, tempmap["3-three"].Parent, "")
 	assert.True(t, tempmap["4-vier"] != nil)
 	assert.Equals(t, tempmap["4-vier"].Parent, "")
-
 
 }
 
@@ -380,7 +383,7 @@ func TestPruneRevsSingleBranch(t *testing.T) {
 	maxDepth := uint32(20)
 	expectedNumPruned := numRevs - int(maxDepth)
 
-	numPruned := revTree.pruneRevisions(maxDepth, "")
+	numPruned, _ := revTree.pruneRevisions(maxDepth, "")
 	assert.Equals(t, numPruned, expectedNumPruned)
 
 }
@@ -405,7 +408,6 @@ func TestPruneRevsOneWinningOneNonwinningBranch(t *testing.T) {
 	revTree.pruneRevisions(maxDepth, "")
 
 	assert.Equals(t, revTree.LongestBranch(), int(maxDepth))
-
 
 }
 
@@ -433,7 +435,6 @@ func TestPruneRevsOneWinningOneOldTombstonedBranch(t *testing.T) {
 	// we shouldn't have any tombstoned branches, since the tombstoned branch was so old
 	// it should have been pruned away
 	assert.Equals(t, revTree.FindLongestTombstonedBranch(), 0)
-
 
 }
 
@@ -483,8 +484,6 @@ func TestPruneRevsOneWinningOneOldAndOneRecentTombstonedBranch(t *testing.T) {
 
 }
 
-
-
 func TestGenerationShortestNonTombstonedBranch(t *testing.T) {
 
 	branchSpecs := []BranchSpec{
@@ -516,7 +515,6 @@ func TestGenerationShortestNonTombstonedBranch(t *testing.T) {
 
 }
 
-
 func TestGenerationLongestTombstonedBranch(t *testing.T) {
 
 	branchSpecs := []BranchSpec{
@@ -546,13 +544,11 @@ func TestGenerationLongestTombstonedBranch(t *testing.T) {
 	// 100 revs in branchspec
 	// +
 	// 1 extra rev in branchspec since LastRevisionIsTombstone (that variable name is misleading)
-	expectedGenerationLongestTombstonedBranch :=  3 + 100 + 1
+	expectedGenerationLongestTombstonedBranch := 3 + 100 + 1
 
 	assert.Equals(t, generationLongestTombstonedBranch, expectedGenerationLongestTombstonedBranch)
 
-
 }
-
 
 // Tests for updated pruning algorithm, post https://github.com/couchbase/sync_gateway/issues/2651
 func TestPruneRevisionsPostIssue2651ThreeBranches(t *testing.T) {
@@ -573,7 +569,7 @@ func TestPruneRevisionsPostIssue2651ThreeBranches(t *testing.T) {
 	revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
 
 	maxDepth := uint32(50)
-	numPruned := revTree.pruneRevisions(maxDepth, "")
+	numPruned, _ := revTree.pruneRevisions(maxDepth, "")
 	fmt.Printf("numPruned: %v", numPruned)
 	fmt.Printf("LongestBranch: %v", revTree.LongestBranch())
 
@@ -602,7 +598,7 @@ func TestPruneRevsSingleTombstonedBranch(t *testing.T) {
 
 	expectedNumPruned += 1 // To account for the tombstone revision in the branchspec, which is spearate from NumRevs
 
-	numPruned := revTree.pruneRevisions(maxDepth, "")
+	numPruned, _ := revTree.pruneRevisions(maxDepth, "")
 
 	log.Printf("RevTreeAfter pruning: %v", revTree.RenderGraphvizDot())
 
@@ -822,7 +818,7 @@ func addPruneAndGet(revTree RevTree, revID string, parentRevID string, revBody [
 		Body:    revBody,
 		Deleted: tombstone,
 	})
-	numPruned = revTree.pruneRevisions(revsLimit, revID)
+	numPruned, _ = revTree.pruneRevisions(revsLimit, revID)
 
 	// Get history for new rev (checks for loops)
 	history, err := revTree.getHistory(revID)
@@ -1006,7 +1002,6 @@ func (tree RevTree) LongestBranch() int {
 	return longestBranch
 
 }
-
 
 // Create body content as map of 100 byte entries.  Rounds up to the nearest 100 bytes
 func createBodyContentAsMapWithSize(docSizeBytes int) map[string]string {

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -118,7 +118,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		// Compare this body to the current revision body to see if it's an echo:
 		parentRev := doc.UpstreamRev
 		newRev := doc.CurrentRev
-		if !reflect.DeepEqual(body, doc.getRevision(newRev)) {
+		if !reflect.DeepEqual(body, doc.getRevisionBody(newRev, s.context.RevisionBodyLoader)) {
 			// Nope, it's not. Assign it a new rev ID
 			generation, _ := ParseRevID(parentRev)
 			newRev = createRevID(generation+1, parentRev, body)
@@ -167,7 +167,7 @@ func (s *Shadower) PushRevision(doc *document) {
 		err = s.bucket.Delete(doc.ID)
 	} else {
 		base.LogTo("Shadow", "Pushing %q, rev %q", doc.ID, doc.CurrentRev)
-		body := doc.getRevision(doc.CurrentRev)
+		body := doc.getRevisionBody(doc.CurrentRev, s.context.RevisionBodyLoader)
 		if body == nil {
 			base.Warn("Can't get rev %q.%q to push to external bucket", doc.ID, doc.CurrentRev)
 			return


### PR DESCRIPTION
Adds support for storage of non-winning document bodies outside sync metadata.

Currently only used when xattrs are enabled to minimize impact/risk - should be considered for more general use in 2.0.

External bodies are stored as binary documents with the key format _sync:rb:[digest], where digest is a SHA256 hash of the doc id and rev id.

Existing document bodies are migrated to external storage (when appropriate) during convergence metadata migration.

During normal writes, new external revision bodies are written after sync function execution, but prior to doc persistence (similar to attachments).  Obsolete revision bodies are deleted subsequent to doc persistence.

Fixes #2882