### PR TITLE
Upgrade to Go 1.9

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 build:
-  image: golang
+  image: golang:1.9
   commands:
     - cd $GOPATH
     - rm -rf *

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="bd91bbf73e9a4a801adbfb97133c992678533126"/>
 
   <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
 


### PR DESCRIPTION
Fixes #2706 via the following changes:

- [x] Bump the version of golang/text to a version that compiles with Go 1.9
- [x] Update the `drone.yml` file to use Go 1.9 when building and testing Sync Gateway
- [ ] We will need to update the jenkins jobs for the unit integration test machine 

This PR might need to wait until some of the mobile jenkins changes get in.  See the description in  #2706 for details.

