### PR TITLE
Fix cache backfill after active-only view query

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -417,6 +417,12 @@ func (context *DatabaseContext) RestartListener() error {
 	return nil
 }
 
+// Cache flush support.  Currently test-only - added for unit test access from rest package
+func (context *DatabaseContext) FlushChannelCache() {
+	base.LogTo("Cache", "Flushing channel cache")
+	context.changeCache.Clear()
+}
+
 func (context *DatabaseContext) NotifyUser(username string) {
 	context.tapListener.NotifyCheckForTermination(base.SetOf(auth.UserKeyPrefix + username))
 }

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1084,7 +1084,6 @@ func changesActiveOnly(t *testing.T, it indexTester) {
 	}
 }
 
-
 func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
@@ -1111,7 +1110,6 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-
 
 	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
 	json.Unmarshal(response.Body.Bytes(), &body)
@@ -1240,6 +1238,191 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	}
 }
 
+func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
+
+	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
+	defer it.Close()
+
+	response := it.SendAdminRequest("PUT", "/_logging", `{"HTTP":true, "Changes":true, "Changes+":true, "Cache":true, "Cache+":true}`)
+	assert.True(t, response != nil)
+
+	// Create user:
+	a := it.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("PBS", "ABC"))
+	assert.True(t, err == nil)
+	a.Save(bernard)
+
+	// Put several documents
+	var body db.Body
+	response = it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	deletedRev := body["rev"].(string)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	removedRev := body["rev"].(string)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	partialRemovalRev := body["rev"].(string)
+	assertStatus(t, response, 201)
+
+	response = it.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	// Create a conflict, then tombstone it
+	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
+	assertStatus(t, response, 200)
+
+	// Create a conflict, and don't tombstone it
+	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
+	assertStatus(t, response, 201)
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+
+	// Pre-delete changes
+	changesJSON := `{"style":"all_docs"}`
+	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 5)
+
+	// Delete
+	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
+	assertStatus(t, response, 200)
+
+	// Removed
+	response = it.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
+	assertStatus(t, response, 201)
+
+	// Partially removed
+	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
+	assertStatus(t, response, 201)
+
+	//Create additional active docs
+	response = it.SendAdminRequest("PUT", "/db/activeDoc1", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("PUT", "/db/activeDoc2", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("PUT", "/db/activeDoc3", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("PUT", "/db/activeDoc4", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = it.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Normal changes
+	changesJSON = `{"style":"all_docs"}`
+	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 10)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+		if entry.ID == "conflictedDoc" {
+			assert.Equals(t, len(entry.Changes), 3)
+		}
+	}
+
+	// Active only NO Limit, POST
+	testDb := it.ServerContext().Database("db")
+	testDb.FlushChannelCache()
+
+	changesJSON = `{"style":"all_docs", "active_only":true}`
+	changes.Results = nil
+	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 8)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+		// validate conflicted handling
+		if entry.ID == "conflictedDoc" {
+			assert.Equals(t, len(entry.Changes), 2)
+		}
+	}
+
+	// Active only with Limit, POST
+	testDb.FlushChannelCache()
+	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
+	changes.Results = nil
+	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 5)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+		// validate conflicted handling
+		if entry.ID == "conflictedDoc" {
+			assert.Equals(t, len(entry.Changes), 2)
+		}
+	}
+
+	// Active only with Limit, GET
+	testDb.FlushChannelCache()
+	changes.Results = nil
+	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 5)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+		if entry.ID == "conflictedDoc" {
+			assert.Equals(t, len(entry.Changes), 2)
+		}
+	}
+
+	// Active only with Limit set higher than number of revisions, POST
+	testDb.FlushChannelCache()
+	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
+	changes.Results = nil
+	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 8)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+		// validate conflicted handling
+		if entry.ID == "conflictedDoc" {
+			assert.Equals(t, len(entry.Changes), 2)
+		}
+	}
+
+	// No limit active only, GET, followed by normal (https://github.com/couchbase/sync_gateway/issues/2955)
+	testDb.FlushChannelCache()
+	changes.Results = nil
+	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 8)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+		if entry.ID == "conflictedDoc" {
+			assert.Equals(t, len(entry.Changes), 2)
+		}
+	}
+
+	var updatedChanges struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+	changesResponse = it.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &updatedChanges)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(updatedChanges.Results), 10)
+
+}
+
 func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
 	cacheSize := 2
@@ -1277,7 +1460,6 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-
 
 	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
 	json.Unmarshal(response.Body.Bytes(), &body)
@@ -1405,8 +1587,6 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 		}
 	}
 }
-
-
 
 // Test _changes returning conflicts
 func TestChangesIncludeConflicts(t *testing.T) {

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1239,6 +1239,9 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	}
 }
 
+// Test active-only and limit handling during cache backfill from the view.  Flushes the channel cache
+// prior to changes requests in order to force view backfill.  Covers https://github.com/couchbase/sync_gateway/issues/2955 in
+// additional to general view handling.
 func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
@@ -1289,7 +1292,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 		Last_Seq interface{}
 	}
 
-	// Pre-delete changes
+	// Get pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
@@ -1486,7 +1489,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 		Last_Seq interface{}
 	}
 
-	// Pre-delete changes
+	// Get pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1165,6 +1165,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	response = it.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
+	// TODO: Make db.waitForSequence public and use that instead of a sleep here
 	time.Sleep(100 * time.Millisecond)
 
 	// Normal changes
@@ -1319,6 +1320,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	response = it.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
+	// TODO: Make db.waitForSequence public and use that instead of a sleep here
 	time.Sleep(100 * time.Millisecond)
 
 	// Normal changes


### PR DESCRIPTION
Fixes #2955  

Active-only evaluation during channel view query should only be used for limit calculation, and shouldn't determine the set of entries returned (which are prepended to the cache and used for subsequent non-active-only requests).