### PR TITLE
view: support include_docs flag on view query

### DIFF
--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -157,6 +157,10 @@ func (db *Database) QueryDesignDoc(ddocName string, viewName string, options map
 			for _, row := range result.Rows {
 				var doc *interface{}
 				_, err := db.Bucket.Get(row.ID, &doc)
+				(*doc).(map[string]interface{})["_id"] = row.ID
+				(*doc).(map[string]interface{})["_rev"] = (*doc).(map[string]interface{})["_sync"].(map[string]interface{})["rev"]
+				delete((*doc).(map[string]interface{}), "_sync")
+
 				if err == nil {
 					resultWithDoc.Rows = append(resultWithDoc.Rows, &sgbucket.ViewRow{
 						Key:   row.Key,


### PR DESCRIPTION
This flags help retreive full original docs on design views on CouchDB

Supporting it would help portability on library coded for CouchDB (I'm porting superlogin custom auth)

Also see https://github.com/couchbase/sync_gateway/issues/676 which might be related

I personally think it would be better to support this flag directly on couchbase though if indented to be supported in production environment, but this is also a kind of hack in API, so there are pros and cons.