### PR TITLE
Add REST operation benchmarks

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -12,17 +12,18 @@ package base
 import (
 	"errors"
 	"fmt"
-	"github.com/couchbase/clog"
-	"github.com/natefinch/lumberjack"
 	"log"
 	"math"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
-	"net/http"
+
+	"github.com/couchbase/clog"
 	"github.com/couchbase/goutils/logging"
+	"github.com/natefinch/lumberjack"
 )
 
 var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
@@ -71,7 +72,7 @@ const (
 // and then a division by 2 and return the ceil of the result
 // to round to nearest int sgLevel value
 func (l Level) sgLevel() int {
-	return int(math.Ceil(float64(l + 2) / float64(2)))
+	return int(math.Ceil(float64(l+2) / float64(2)))
 }
 
 // cgLevel returns a compatible go-couchbase/golog Log Level for
@@ -306,7 +307,7 @@ func ParseLogFlags(flags []string) {
 				EnableSgReplicateLogging()
 			}
 			for strings.HasSuffix(key, "+") {
-				key = key[0: len(key) - 1]
+				key = key[0 : len(key)-1]
 				LogKeys[key] = true // "foo+" also enables "foo"
 			}
 		}
@@ -488,9 +489,9 @@ func printf(format string, args ...interface{}) {
 
 func lastComponent(path string) string {
 	if index := strings.LastIndex(path, "/"); index >= 0 {
-		path = path[index + 1:]
+		path = path[index+1:]
 	} else if index = strings.LastIndex(path, "\\"); index >= 0 {
-		path = path[index + 1:]
+		path = path[index+1:]
 	}
 	return path
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
-	"time"
-
 	"math/rand"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/couchbase/gocb"
 )
@@ -158,10 +157,10 @@ func TestUseXattrs() bool {
 	useXattrs := os.Getenv(TestEnvSyncGatewayUseXattrs)
 	switch {
 	case strings.ToLower(useXattrs) == strings.ToLower(TestEnvSyncGatewayTrue):
-		log.Printf("Using xattrs: strings.ToLower(useXattrs) == strings.ToLower(TestEnvSyncGatewayTrue).  |%v| == |%v|", strings.ToLower(useXattrs), strings.ToLower(TestEnvSyncGatewayTrue))
+		Log(fmt.Sprintf("Using xattrs: strings.ToLower(useXattrs) == strings.ToLower(TestEnvSyncGatewayTrue).  |%v| == |%v|", strings.ToLower(useXattrs), strings.ToLower(TestEnvSyncGatewayTrue)))
 		return true
 	default:
-		log.Printf("NOT Using xattrs: strings.ToLower(useXattrs) != strings.ToLower(TestEnvSyncGatewayTrue).  |%v| != |%v|", strings.ToLower(useXattrs), strings.ToLower(TestEnvSyncGatewayTrue))
+		Log(fmt.Sprintf("NOT Using xattrs: strings.ToLower(useXattrs) != strings.ToLower(TestEnvSyncGatewayTrue).  |%v| != |%v|", strings.ToLower(useXattrs), strings.ToLower(TestEnvSyncGatewayTrue)))
 	}
 	// Otherwise fallback to hardcoded default
 	return DefaultUseXattrs

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/couchbase/go-couchbase"
-
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 )

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -1,0 +1,241 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/couchbase/goutils/logging"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+var doc_1k_format = `{%s
+    "index": 0,
+    "guid": "bc22f4d5-e13f-4b64-9397-2afd5a843c4d",
+    "isActive": false,
+    "balance": "$1,168.62",
+    "picture": "http://placehold.it/32x32",
+    "age": 20,
+    "eyeColor": "green",
+    "name": "Miranda Kline",
+    "company": "COMTREK",
+    "email": "mirandakline@comtrek.com",
+    "phone": "+1 (831) 408-2162",
+    "address": "701 Devon Avenue, Ballico, Alabama, 9673",
+    "about": "Minim ea esse dolor ex laborum do velit cupidatat tempor do qui. Aliqua consequat consectetur esse officia ullamco velit labore irure ea non proident. Tempor elit nostrud deserunt in ullamco pariatur enim pariatur et. Veniam fugiat ad mollit ut mollit aute adipisicing aliquip veniam consectetur incididunt. Id cupidatat duis cupidatat quis amet elit sit sit esse velit pariatur do. Excepteur tempor labore esse adipisicing laborum sit enim incididunt quis sint fugiat commodo Lorem. Dolore laboris quis ex do.\r\n",
+    "registered": "2016-09-16T12:08:17 +07:00",
+    "latitude": -14.616751,
+    "longitude": 175.689016,
+    "channels": [
+      "channel_1",
+      "channel_2",
+      "channel_3",
+      "channel_4",
+      "channel_5",
+      "channel_6",
+      "channel_7"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Wise Hewitt"
+      },
+      {
+        "id": 1,
+        "name": "Winnie Schultz"
+      },
+      {
+        "id": 2,
+        "name": "Browning Carlson"
+      }
+    ],
+    "greeting": "Hello, Miranda Kline! You have 4 unread messages.",
+    "favoriteFruit": "strawberry"
+  }`
+
+func BenchmarkReadOps_Get(b *testing.B) {
+
+	initBenchmarkLogging()
+	var rt RestTester
+	defer PurgeDoc(rt, "doc1k")
+
+	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
+	response := rt.SendAdminRequest("PUT", "/db/doc1k", doc1k_putDoc)
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	revid := body["rev"].(string)
+
+	// Create user
+	username := "user1"
+	rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", "admin_channels":["channel_1"]}`, username))
+
+	getBenchmarks := []struct {
+		name   string
+		URI    string
+		asUser string
+	}{
+		{"Admin_Simple", "/db/doc1k", ""},
+		{"Admin_WithRev", fmt.Sprintf("/db/doc1k?rev=%s", revid), ""},
+		{"Admin_OpenRevsAll", fmt.Sprintf("/db/doc1k?open_revs=all&rev=%s", revid), ""},
+		{"User_Simple", "/db/doc1k", username},
+		{"User_WithRev", fmt.Sprintf("/db/doc1k?rev=%s", revid), username},
+		{"User_OpenRevsAll", fmt.Sprintf("/db/doc1k?open_revs=all&rev=%s", revid), username},
+	}
+
+	for _, bm := range getBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			var getResponse *TestResponse
+			for i := 0; i < b.N; i++ {
+				if bm.asUser == "" {
+					getResponse = rt.SendAdminRequest("GET", bm.URI, "")
+				} else {
+					getResponse = rt.Send(requestByUser("GET", bm.URI, "", bm.asUser))
+				}
+				b.StopTimer()
+				if getResponse.Code != 200 {
+					log.Printf("Unexpected response: %s", getResponse)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkReadOps_Changes(b *testing.B) {
+
+	initBenchmarkLogging()
+	var rt RestTester
+	defer PurgeDoc(rt, "doc1k")
+
+	// Create user
+	username := "user1"
+	rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", "admin_channels":["channel_1"]}`, username))
+
+	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
+
+	// Create branched doc
+	response := rt.SendAdminRequest("PUT", "/db/doc1k", doc1k_putDoc)
+	if response.Code != 201 {
+		log.Printf("Unexpected create response: %d  %s", response.Code, response.Body.Bytes())
+	}
+
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	revid := body["rev"].(string)
+	_, rev1_digest := db.ParseRevID(revid)
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc1k?rev=%s", revid), doc1k_putDoc)
+	if response.Code != 201 {
+		log.Printf("Unexpected add rev response: %d  %s", response.Code, response.Body.Bytes())
+	}
+
+	doc1k_rev2_meta := fmt.Sprintf(`"_revisions":{"start":2, "ids":["two", "%s"]},`, rev1_digest)
+	doc1k_rev2 := fmt.Sprintf(doc_1k_format, doc1k_rev2_meta)
+	response = rt.SendAdminRequest("PUT", "/db/doc1k?new_edits=false", doc1k_rev2)
+	if response.Code != 201 {
+		log.Printf("Unexpected add conflicting rev response: %d  %s", response.Code, response.Body.Bytes())
+	}
+
+	// Changes benchmarks use since=1 to exclude the user doc from the response
+	changesBenchmarks := []struct {
+		name   string
+		URI    string
+		asUser string
+	}{
+		{"Admin_Simple", "/db/_changes?since=1", ""},
+		{"Admin_Longpoll", "/db/_changes?since=1&feed=longpoll", ""},
+		{"Admin_StyleAllDocs", "/db/_changes?since=1&style=all_docs", ""},
+		{"Admin_IncludeDocs", "/db/_changes?since=1&include_docs=true", ""},
+		{"User_Simple", "/db/_changes?since=1", username},
+		{"User_Longpoll", "/db/_changes?since=1&feed=longpoll", username},
+		{"User_StyleAllDocs", "/db/_changes?since=1&style=all_docs", username},
+		{"User_IncludeDocs", "/db/_changes?since=1&include_docs=true", username},
+	}
+
+	for _, bm := range changesBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			var changesResponse *TestResponse
+			for i := 0; i < b.N; i++ {
+				if bm.asUser == "" {
+					changesResponse = rt.SendAdminRequest("GET", bm.URI, "")
+				} else {
+					changesResponse = rt.Send(requestByUser("GET", bm.URI, "", bm.asUser))
+				}
+				b.StopTimer()
+				if changesResponse.Code != 200 {
+					log.Printf("Unexpected response: %s", changesResponse.Code)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkReadOps_RevsDiff(b *testing.B) {
+
+	initBenchmarkLogging()
+	var rt RestTester
+	defer PurgeDoc(rt, "doc1k")
+
+	// Create target doc for revs_diff:
+	doc1k_bulkDocs_meta := `"_id":"doc1k", 
+	"_rev":"12-abc", 
+	"_revisions":{
+		"start": 12, 
+		"ids": ["abc", "eleven", "ten", "nine"]
+		},`
+
+	doc1k_bulkDocs_entry := fmt.Sprintf(doc_1k_format, doc1k_bulkDocs_meta)
+	bulkDocs_body := fmt.Sprintf(`{"new_edits":false, "docs": [%s]}`, doc1k_bulkDocs_entry)
+	response := rt.SendRequest("POST", "/db/_bulk_docs", bulkDocs_body)
+	if response.Code != 201 {
+		log.Printf("Unexpected response: %d", response.Code)
+		log.Printf("Response:%s", response.Body.Bytes())
+	}
+
+	// Create user
+	username := "user1"
+	rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_user/%s", username), fmt.Sprintf(`{"name":"%s", "password":"letmein", "admin_channels":["channel_1"]}`, username))
+
+	revsDiffBody := `{"doc1k": ["10-ten", "9-nine"]}`
+	revsDiffBenchmarks := []struct {
+		name   string
+		URI    string
+		asUser string
+	}{
+		{"Admin", "/db/_revs_diff", ""},
+		{"User", "/db/_revs_diff", username},
+	}
+
+	for _, bm := range revsDiffBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			var getResponse *TestResponse
+			for i := 0; i < b.N; i++ {
+				if bm.asUser == "" {
+					getResponse = rt.SendAdminRequest("POST", bm.URI, revsDiffBody)
+				} else {
+					getResponse = rt.Send(requestByUser("POST", bm.URI, revsDiffBody, bm.asUser))
+				}
+				b.StopTimer()
+				if getResponse.Code != 200 {
+					log.Printf("Unexpected response: %s", getResponse)
+				}
+				b.StartTimer()
+			}
+		})
+	}
+
+}
+
+func initBenchmarkLogging() {
+	base.SetLogLevel(2) // disables logging
+	logging.SetLogger(nil)
+}
+
+func PurgeDoc(rt RestTester, docid string) {
+	response := rt.SendAdminRequest("POST", "/db/_purge", fmt.Sprintf(`{"%s":["*"]}`, docid))
+	if response.Code != 200 {
+		log.Printf("Unexpected purge response: %d  %s", response.Code, response.Body.Bytes())
+	}
+}


### PR DESCRIPTION
Adds a benchmark suite for REST read operations used during replication, to be used to evaluate benefit of performance enhancements.  

Sample output:
```
$ SG_TEST_BACKING_STORE=Couchbase ./test.sh -bench=BenchmarkReadOps -run=XXX -benchmem
Testing code with 'go test' ...
Running Sync Gateway unit tests
?   	github.com/couchbase/sync_gateway	[no test files]
PASS
ok  	github.com/couchbase/sync_gateway/auth	0.012s
PASS
ok  	github.com/couchbase/sync_gateway/base	0.013s
PASS
ok  	github.com/couchbase/sync_gateway/channels	0.013s
PASS
ok  	github.com/couchbase/sync_gateway/db	0.014s
BenchmarkReadOps_Get/Admin_Simple-8         	    5000	    275828 ns/op	   30917 B/op	     647 allocs/op
BenchmarkReadOps_Get/Admin_WithRev-8        	   20000	     69212 ns/op	   15663 B/op	     193 allocs/op
BenchmarkReadOps_Get/Admin_OpenRevsAll-8    	    5000	    303449 ns/op	   36862 B/op	     686 allocs/op
BenchmarkReadOps_Get/User_Simple-8          	    5000	    384768 ns/op	   37543 B/op	     776 allocs/op
BenchmarkReadOps_Get/User_WithRev-8         	   10000	    192175 ns/op	   22297 B/op	     321 allocs/op
BenchmarkReadOps_Get/User_OpenRevsAll-8     	    3000	    414627 ns/op	   43485 B/op	     814 allocs/op
BenchmarkReadOps_Changes/Admin_Simple-8     	   30000	     56928 ns/op	   11665 B/op	     137 allocs/op
BenchmarkReadOps_Changes/Admin_Longpoll-8   	   20000	     65312 ns/op	   12275 B/op	     155 allocs/op
BenchmarkReadOps_Changes/Admin_StyleAllDocs-8         	    5000	    267709 ns/op	   29128 B/op	     429 allocs/op
BenchmarkReadOps_Changes/Admin_IncludeDocs-8          	    3000	    418417 ns/op	   48551 B/op	     855 allocs/op
BenchmarkReadOps_Changes/User_Simple-8                	   10000	    177982 ns/op	   19207 B/op	     289 allocs/op
BenchmarkReadOps_Changes/User_Longpoll-8              	    5000	    293869 ns/op	   25682 B/op	     424 allocs/op
BenchmarkReadOps_Changes/User_StyleAllDocs-8          	    5000	    398177 ns/op	   36648 B/op	     580 allocs/op
BenchmarkReadOps_Changes/User_IncludeDocs-8           	    3000	    541308 ns/op	   56077 B/op	    1006 allocs/op
BenchmarkReadOps_RevsDiff/Admin-8                     	    5000	    250380 ns/op	   25843 B/op	     571 allocs/op
BenchmarkReadOps_RevsDiff/User-8                      	    5000	    361606 ns/op	   32426 B/op	     699 allocs/op
PASS
ok  	github.com/couchbase/sync_gateway/rest	61.291s
Running Sync Gateway Accel unit tests
?   	github.com/couchbaselabs/sync-gateway-accel	[no test files]
PASS
ok  	github.com/couchbaselabs/sync-gateway-accel/indexwriter	0.016s
?   	github.com/couchbaselabs/sync-gateway-accel/sg_accel	[no test files]

```
