### PR TITLE
Fixes resource close issue when using leakybucket

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -631,6 +631,8 @@ func GetFeedType(bucket Bucket) (feedType string) {
 		} else {
 			return DcpFeedType
 		}
+	case *LeakyBucket:
+		return GetFeedType(typedBucket.bucket)
 	default:
 		return TapFeedType
 	}


### PR DESCRIPTION
The problem was discovered here: https://github.com/couchbase/sync_gateway/issues/2938#issuecomment-336293672

It was incorrectly determining the feed type (tap vs dcp), based on bucket type, when using a leakybucket.

Fixed by digging into the underlying bucket that a leakybucket is wrapping, and using that to determine feed type.