### PR TITLE
Implemented "no-conflicts" mode (rebased)

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -50,7 +50,8 @@ const (
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"
 
-	DefaultUseXattrs = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config
 
 	DefaultOldRevExpirySeconds = 300
   

--- a/db/crud.go
+++ b/db/crud.go
@@ -599,6 +599,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 	return db.updateDoc(docid, allowImport, expiry, func(doc *document) (Body, AttachmentData, error) {
 
+		// (Be careful: this block can be invoked multiple times if there are races!)
 		// If the existing doc isn't an SG write, import prior to updating
 		if doc != nil && !doc.IsSGWrite() && db.UseXattrs() {
 			err := db.OnDemandImportForWrite(docid, doc, body)
@@ -607,7 +608,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 			}
 		}
 
-		// (Be careful: this block can be invoked multiple times if there are races!)
 		// First, make sure matchRev matches an existing leaf revision:
 		if matchRev == "" {
 			matchRev = doc.CurrentRev
@@ -620,7 +620,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 				generation, _ = ParseRevID(matchRev)
 				generation++
 			}
-		} else if !doc.History.isLeaf(matchRev) {
+		} else if !doc.History.isLeaf(matchRev) || (!db.AllowConflicts() && matchRev != doc.CurrentRev) {
 			return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 		}
 
@@ -660,6 +660,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 
 	allowImport := db.UseXattrs()
 	_, err = db.updateDoc(docid, allowImport, expiry, func(doc *document) (Body, AttachmentData, error) {
+		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		// If the existing doc isn't an SG write, import prior to updating
 		if doc != nil && !doc.IsSGWrite() && db.UseXattrs() {
@@ -669,7 +670,6 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 			}
 		}
 
-		// (Be careful: this block can be invoked multiple times if there are races!)
 		// Find the point where this doc's history branches from the current rev:
 		currentRevIndex := len(docHistory)
 		parent := ""
@@ -683,6 +683,18 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 		if currentRevIndex == 0 {
 			base.LogTo("CRUD+", "PutExistingRev(%q): No new revisions to add", docid)
 			return nil, nil, couchbase.UpdateCancel // No new revisions to add
+		}
+
+		if !db.AllowConflicts() {
+			// Conflict-free mode: If doc exists, its current rev must be the new rev's parent...
+			if parent != doc.CurrentRev && doc.CurrentRev != "" {
+				if len(docHistory) == 1 && doc.History[doc.CurrentRev].Deleted {
+					// ...unless the doc is currently deleted and the new rev has no parent.
+					parent = doc.CurrentRev
+				} else {
+					return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
+				}
+			}
 		}
 
 		// Add all the new-to-me revisions to the rev tree:
@@ -1430,4 +1442,40 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 		}
 	}
 	return
+}
+
+// Status code returned by CheckProposedRev
+type ProposedRevStatus int
+
+const (
+	ProposedRev_OK       ProposedRevStatus = 0   // Rev can be added without conflict
+	ProposedRev_Exists   ProposedRevStatus = 304 // Rev already exists locally
+	ProposedRev_Conflict ProposedRevStatus = 409 // Rev would cause conflict
+	ProposedRev_Error    ProposedRevStatus = 500 // Error occurred reading local doc
+)
+
+// Given a docID/revID to be pushed by a client, check whether it can be added _without conflict_.
+// This is used by the BLIP replication code in "allow_conflicts=false" mode.
+func (db *Database) CheckProposedRev(docid string, revid string, parentRevID string) ProposedRevStatus {
+	doc, err := db.GetDoc(docid)
+	if err != nil {
+		if !base.IsDocNotFoundError(err) {
+			base.Warn("CheckProposedRev(%q) --> %T %v", docid, err, err)
+			return ProposedRev_Error
+		}
+		// Doc doesn't exist locally; adding it is OK (even if it has a history)
+		return ProposedRev_OK
+	} else if doc.CurrentRev == revid {
+		// Proposed rev already exists here:
+		return ProposedRev_Exists
+	} else if doc.CurrentRev == parentRevID {
+		// Proposed rev's parent is my current revision; OK to add:
+		return ProposedRev_OK
+	} else if parentRevID == "" && doc.History[doc.CurrentRev].Deleted {
+		// Proposed rev has no parent and doc is currently deleted; OK to add:
+		return ProposedRev_OK
+	} else {
+		// Parent revision mismatch, so this is a conflict:
+		return ProposedRev_Conflict
+	}
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -686,14 +686,9 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 		}
 
 		if !db.AllowConflicts() {
-			// Conflict-free mode: If doc exists, its current rev must be the new rev's parent...
+			// Conflict-free mode: If doc exists, its current rev must be the new rev's parent.
 			if parent != doc.CurrentRev && doc.CurrentRev != "" {
-				if len(docHistory) == 1 && doc.History[doc.CurrentRev].Deleted {
-					// ...unless the doc is currently deleted and the new rev has no parent.
-					parent = doc.CurrentRev
-				} else {
-					return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
-				}
+				return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 			}
 		}
 

--- a/db/database.go
+++ b/db/database.go
@@ -112,6 +112,7 @@ type UnsupportedOptions struct {
 	UserViews        UserViewsOptions        `json:"user_views,omitempty"`         // Config settings for user views
 	Replicator2      bool                    `json:"replicator_2,omitempty"`       // Enable new replicator (_blipsync)
 	OidcTestProvider OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
+	AllowConflicts   *bool                   `json:"allow_conflicts"`              // False forbids creating conflicts
 }
 
 // Options associated with the import of documents not written by Sync Gateway
@@ -1230,6 +1231,13 @@ func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 // For test usage
 func (context *DatabaseContext) FlushRevisionCache() {
 	context.revisionCache = NewRevisionCache(context.Options.RevisionCacheCapacity, context.revCacheLoader)
+}
+
+func (context *DatabaseContext) AllowConflicts() bool {
+	if context.Options.UnsupportedOptions.AllowConflicts != nil {
+		return *context.Options.UnsupportedOptions.AllowConflicts
+	}
+	return base.DefaultAllowConflicts
 }
 
 //////// SEQUENCE ALLOCATION:

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -54,7 +54,6 @@ func testLeakyBucket(config base.LeakyBucketConfig) base.Bucket {
 	return leakyBucket
 }
 
-
 func setupTestDBForShadowing(t *testing.T) *Database {
 	dbcOptions := DatabaseContextOptions{
 		TrackDocs: true,
@@ -70,7 +69,11 @@ func setupTestDBForShadowing(t *testing.T) *Database {
 	return db
 }
 
-func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database, base.TestBucket)  {
+func setupTestDB(t testing.TB) (*Database, base.TestBucket) {
+	return setupTestDBWithCacheOptions(t, CacheOptions{})
+}
+
+func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database, base.TestBucket) {
 
 	dbcOptions := DatabaseContextOptions{
 		CacheOptions: &options,
@@ -665,10 +668,6 @@ func TestUpdatePrincipal(t *testing.T) {
 
 func TestConflicts(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
-		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Error: https://gist.github.com/tleyden/3549e4010abff88f2531706887c67271")
-	}
-
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
@@ -775,11 +774,8 @@ func TestConflicts(t *testing.T) {
 
 func TestNoConflictsMode(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
-		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Error: https://gist.github.com/tleyden/3549e4010abff88f2531706887c67271")
-	}
-
-	db := setupTestDB(t)
+	db, testBucket := setupTestDB(t)
+	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 	// Strictly speaking, this flag should be set before opening the database, but it only affects
 	// Put operations and replication, so it doesn't make a difference if we do it afterwards.

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -67,6 +67,9 @@ func (h *handler) handleBLIPSync() error {
 	for profile, handlerFn := range kHandlersByProfile {
 		ctx.register(profile, handlerFn)
 	}
+	if !h.db.AllowConflicts() {
+		ctx.register("proposeChanges", (*blipHandler).handleProposedChanges)
+	}
 
 	ctx.blipContext.Logger = func(fmt string, params ...interface{}) {
 		base.LogTo("BLIP", fmt, params...)
@@ -331,6 +334,10 @@ func (bh *blipHandler) handleChangesResponse(response *blip.Message, changeArray
 
 // Handles a "changes" request, i.e. a set of changes pushed by the client
 func (bh *blipHandler) handlePushedChanges(rq *blip.Message) error {
+	if !bh.db.AllowConflicts() {
+		return base.HTTPErrorf(http.StatusConflict, "Use 'proposeChanges' instead")
+	}
+
 	var changeList [][]interface{}
 	if err := rq.ReadJSONBody(&changeList); err != nil {
 		return err
@@ -358,6 +365,46 @@ func (bh *blipHandler) handlePushedChanges(rq *blip.Message) error {
 			jsonOutput.Encode(possible)
 		}
 		nWritten++
+	}
+	output.Write([]byte("]"))
+	response := rq.Response()
+	response.SetCompressed(true)
+	response.SetBody(output.Bytes())
+	return nil
+}
+
+// Handles a "proposeChanges" request, similar to "changes" but in no-conflicts mode
+func (bh *blipHandler) handleProposedChanges(rq *blip.Message) error {
+	var changeList [][]interface{}
+	if err := rq.ReadJSONBody(&changeList); err != nil {
+		return err
+	}
+	base.LogTo("Sync", "Received %d changes from client", len(changeList))
+	if len(changeList) == 0 {
+		return nil
+	}
+	output := bytes.NewBuffer(make([]byte, 0, 5*len(changeList)))
+	output.Write([]byte("["))
+	nWritten := 0
+	for i, change := range changeList {
+		docID := change[0].(string)
+		revID := change[1].(string)
+		parentRevID := ""
+		if len(change) >= 2 {
+			parentRevID = change[2].(string)
+		}
+		status := bh.db.CheckProposedRev(docID, revID, parentRevID)
+		if status != 0 {
+			// Skip writing trailing zeroes; but if we write a number afterwards we have to catch up
+			if nWritten > 0 {
+				output.Write([]byte(","))
+			}
+			for ; nWritten < i; nWritten++ {
+				output.Write([]byte("0,"))
+			}
+			output.Write([]byte(strconv.FormatInt(int64(status), 10)))
+			nWritten++
+		}
 	}
 	output.Write([]byte("]"))
 	response := rq.Response()


### PR DESCRIPTION
Rebased feature/no_conflicts on master.  From #2710:

* Added unsupported flag "allow_conflicts", which defaults to true.
* When flag is set to false, Database.Put and Database.PutExistingRev will fail with a conflict (409) status if the new revision isn't a child of the current revision.
* Unit tests for PutExistingRev and Put
* Implemented BLIP replicator [protocol changes](https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges) for no-conflicts mode
* Other minor changes to update to latest BLIP replication protocol

(It's probably best to look at the 3 commits individually.)

Fixes #2709