### PR TITLE
Add expiry() built-in to sync function

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -53,8 +53,8 @@ const (
 	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config
 
-	DefaultOldRevExpirySeconds = 300
-  
+	DefaultOldRevExpirySeconds = uint32(300)
+
 	// Default value of _local document expiry
 	DefaultLocalDocExpirySecs = uint32(60 * 60 * 24 * 90) //90 days in seconds
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -47,22 +47,22 @@ func (b *LeakyBucket) GetRaw(k string) (v []byte, cas uint64, err error) {
 func (b *LeakyBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
 	return b.bucket.GetBulkRaw(keys)
 }
-func (b *LeakyBucket) GetAndTouchRaw(k string, exp int) (v []byte, cas uint64, err error) {
+func (b *LeakyBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64, err error) {
 	return b.bucket.GetAndTouchRaw(k, exp)
 }
-func (b *LeakyBucket) Add(k string, exp int, v interface{}) (added bool, err error) {
+func (b *LeakyBucket) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	return b.bucket.Add(k, exp, v)
 }
-func (b *LeakyBucket) AddRaw(k string, exp int, v []byte) (added bool, err error) {
+func (b *LeakyBucket) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	return b.bucket.AddRaw(k, exp, v)
 }
 func (b *LeakyBucket) Append(k string, data []byte) error {
 	return b.bucket.Append(k, data)
 }
-func (b *LeakyBucket) Set(k string, exp int, v interface{}) error {
+func (b *LeakyBucket) Set(k string, exp uint32, v interface{}) error {
 	return b.bucket.Set(k, exp, v)
 }
-func (b *LeakyBucket) SetRaw(k string, exp int, v []byte) error {
+func (b *LeakyBucket) SetRaw(k string, exp uint32, v []byte) error {
 	return b.bucket.SetRaw(k, exp, v)
 }
 func (b *LeakyBucket) Delete(k string) error {
@@ -71,23 +71,23 @@ func (b *LeakyBucket) Delete(k string) error {
 func (b *LeakyBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
 	return b.bucket.Remove(k, cas)
 }
-func (b *LeakyBucket) Write(k string, flags int, exp int, v interface{}, opt sgbucket.WriteOptions) error {
+func (b *LeakyBucket) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
 	return b.bucket.Write(k, flags, exp, v, opt)
 }
-func (b *LeakyBucket) WriteCas(k string, flags int, exp int, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
+func (b *LeakyBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
-func (b *LeakyBucket) Update(k string, exp int, callback sgbucket.UpdateFunc) (err error) {
+func (b *LeakyBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (err error) {
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *LeakyBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpdateFunc) (err error) {
+func (b *LeakyBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (err error) {
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
 func (b *LeakyBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
 	return b.bucket.SetBulk(entries)
 }
 
-func (b *LeakyBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {
+func (b *LeakyBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
 
 	if b.config.IncrTemporaryFailCount > 0 {
 		if b.incrCount < b.config.IncrTemporaryFailCount {
@@ -124,11 +124,11 @@ func (b *LeakyBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
-func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
-func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }
 

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -25,7 +25,7 @@ func (b *LoggingBucket) GetRaw(k string) (v []byte, cas uint64, err error) {
 	defer func() { LogTo("Bucket", "GetRaw(%q) [%v]", k, time.Since(start)) }()
 	return b.bucket.GetRaw(k)
 }
-func (b *LoggingBucket) GetAndTouchRaw(k string, exp int) (v []byte, cas uint64, err error) {
+func (b *LoggingBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64, err error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "GetAndTouchRaw(%q) [%v]", k, time.Since(start)) }()
 	return b.bucket.GetAndTouchRaw(k, exp)
@@ -35,12 +35,12 @@ func (b *LoggingBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
 	defer func() { LogTo("Bucket", "GetBulkRaw(%q) [%v]", keys, time.Since(start)) }()
 	return b.bucket.GetBulkRaw(keys)
 }
-func (b *LoggingBucket) Add(k string, exp int, v interface{}) (added bool, err error) {
+func (b *LoggingBucket) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Add(%q, %d, ...) [%v]", k, exp, time.Since(start)) }()
 	return b.bucket.Add(k, exp, v)
 }
-func (b *LoggingBucket) AddRaw(k string, exp int, v []byte) (added bool, err error) {
+func (b *LoggingBucket) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "AddRaw(%q, %d, ...) [%v]", k, exp, time.Since(start)) }()
 	return b.bucket.AddRaw(k, exp, v)
@@ -50,12 +50,12 @@ func (b *LoggingBucket) Append(k string, data []byte) error {
 	defer func() { LogTo("Bucket", "Append(%q, ...) [%v]", k, time.Since(start)) }()
 	return b.bucket.Append(k, data)
 }
-func (b *LoggingBucket) Set(k string, exp int, v interface{}) error {
+func (b *LoggingBucket) Set(k string, exp uint32, v interface{}) error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Set(%q, %d, ...) [%v]", k, exp, time.Since(start)) }()
 	return b.bucket.Set(k, exp, v)
 }
-func (b *LoggingBucket) SetRaw(k string, exp int, v []byte) error {
+func (b *LoggingBucket) SetRaw(k string, exp uint32, v []byte) error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "SetRaw(%q, %d, ...) [%v]", k, exp, time.Since(start)) }()
 	return b.bucket.SetRaw(k, exp, v)
@@ -70,40 +70,40 @@ func (b *LoggingBucket) Remove(k string, cas uint64) (casOut uint64, err error) 
 	defer func() { LogTo("Bucket", "Remove(%q) [%v]", k, time.Since(start)) }()
 	return b.bucket.Remove(k, cas)
 }
-func (b *LoggingBucket) Write(k string, flags int, exp int, v interface{}, opt sgbucket.WriteOptions) error {
+func (b *LoggingBucket) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Write(%q, 0x%x, %d, ..., 0x%x) [%v]", k, flags, exp, opt, time.Since(start)) }()
 	return b.bucket.Write(k, flags, exp, v, opt)
 }
-func (b *LoggingBucket) WriteCas(k string, flags int, exp int, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
+func (b *LoggingBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
 	start := time.Now()
 	defer func() {
 		LogTo("Bucket", "WriteCas(%q, 0x%x, %d, %d, ..., 0x%x) [%v]", k, flags, exp, cas, opt, time.Since(start))
 	}()
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
-func (b *LoggingBucket) Update(k string, exp int, callback sgbucket.UpdateFunc) (err error) {
+func (b *LoggingBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (err error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Update(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start)) }()
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *LoggingBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpdateFunc) (err error) {
+func (b *LoggingBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (err error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "WriteUpdate(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start)) }()
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
 
-func (b *LoggingBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {
+func (b *LoggingBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "Incr(%q, %d, %d, %d) [%v]", k, amt, def, exp, time.Since(start)) }()
 	return b.bucket.Incr(k, amt, def, exp)
 }
-func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() { LogTo("Bucket", "WriteCasWithXattr(%q, ...) [%v]", k, time.Since(start)) }()
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() {
 		LogTo("Bucket", "WriteUpdateWithXattr(%q, %d, ...) --> %v [%v]", k, exp, err, time.Since(start))

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -100,7 +100,7 @@ func (b *StatsBucket) GetRaw(k string) (v []byte, cas uint64, err error) {
 	b.docRead(1, len(v))
 	return v, cas, err
 }
-func (b *StatsBucket) GetAndTouchRaw(k string, exp int) (v []byte, cas uint64, err error) {
+func (b *StatsBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64, err error) {
 	v, cas, err = b.bucket.GetAndTouchRaw(k, exp)
 	b.docRead(1, len(v))
 	return v, cas, err
@@ -112,7 +112,7 @@ func (b *StatsBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
 	}
 	return results, err
 }
-func (b *StatsBucket) Add(k string, exp int, v interface{}) (added bool, err error) {
+func (b *StatsBucket) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	if vBytes, ok := v.([]byte); ok {
 		defer b.docWrite(1, len(vBytes))
 	} else {
@@ -120,7 +120,7 @@ func (b *StatsBucket) Add(k string, exp int, v interface{}) (added bool, err err
 	}
 	return b.bucket.Add(k, exp, v)
 }
-func (b *StatsBucket) AddRaw(k string, exp int, v []byte) (added bool, err error) {
+func (b *StatsBucket) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	defer b.docWrite(1, len(v))
 	return b.bucket.AddRaw(k, exp, v)
 }
@@ -128,7 +128,7 @@ func (b *StatsBucket) Append(k string, data []byte) error {
 	defer b.docWrite(1, len(data))
 	return b.bucket.Append(k, data)
 }
-func (b *StatsBucket) Set(k string, exp int, v interface{}) error {
+func (b *StatsBucket) Set(k string, exp uint32, v interface{}) error {
 	if vBytes, ok := v.([]byte); ok {
 		defer b.docWrite(1, len(vBytes))
 	} else {
@@ -136,7 +136,7 @@ func (b *StatsBucket) Set(k string, exp int, v interface{}) error {
 	}
 	return b.bucket.Set(k, exp, v)
 }
-func (b *StatsBucket) SetRaw(k string, exp int, v []byte) error {
+func (b *StatsBucket) SetRaw(k string, exp uint32, v []byte) error {
 	defer b.docWrite(1, len(v))
 	return b.bucket.SetRaw(k, exp, v)
 }
@@ -146,7 +146,7 @@ func (b *StatsBucket) Delete(k string) error {
 func (b *StatsBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
 	return b.bucket.Remove(k, cas)
 }
-func (b *StatsBucket) Write(k string, flags int, exp int, v interface{}, opt sgbucket.WriteOptions) error {
+func (b *StatsBucket) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
 	if vBytes, ok := v.([]byte); ok {
 		defer b.docWrite(1, len(vBytes))
 	} else {
@@ -154,7 +154,7 @@ func (b *StatsBucket) Write(k string, flags int, exp int, v interface{}, opt sgb
 	}
 	return b.bucket.Write(k, flags, exp, v, opt)
 }
-func (b *StatsBucket) WriteCas(k string, flags int, exp int, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
+func (b *StatsBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
 	if vBytes, ok := v.([]byte); ok {
 		defer b.docWrite(1, len(vBytes))
 	} else {
@@ -162,18 +162,18 @@ func (b *StatsBucket) WriteCas(k string, flags int, exp int, cas uint64, v inter
 	}
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
-func (b *StatsBucket) Update(k string, exp int, callback sgbucket.UpdateFunc) (err error) {
+func (b *StatsBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (err error) {
 	defer b.docWrite(1, -1)
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *StatsBucket) WriteUpdate(k string, exp int, callback sgbucket.WriteUpdateFunc) (err error) {
+func (b *StatsBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (err error) {
 	defer b.docWrite(1, -1)
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
-func (b *StatsBucket) Incr(k string, amt, def uint64, exp int) (uint64, error) {
+func (b *StatsBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
 	return b.bucket.Incr(k, amt, def, exp)
 }
-func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
 	if vBytes, ok := v.([]byte); ok {
 		defer b.docWrite(1, len(vBytes))
 	} else {
@@ -181,7 +181,7 @@ func (b *StatsBucket) WriteCasWithXattr(k string, xattr string, exp int, cas uin
 	}
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
-func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp int, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *StatsBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	defer b.docWrite(1, -1)
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }

--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -18,11 +18,11 @@ import (
 
 /** Result of running a channel-mapper function. */
 type ChannelMapperOutput struct {
-	Channels  base.Set
+	Channels  base.Set  // channels assigned to the document via channel() callback
 	Roles     AccessMap // roles granted to users via role() callback
-	Access    AccessMap
-	Rejection error
-	Expiry    *uint32
+	Access    AccessMap // channels granted to users via access() callback
+	Rejection error     // Error associated with failed validate (require callbacks, etc)
+	Expiry    *uint32   // Expiry value specified by expiry() callback.  Standard CBS expiry format: seconds if less than 30 days, epoch time otherwise
 }
 
 type ChannelMapper struct {

--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -22,6 +22,7 @@ type ChannelMapperOutput struct {
 	Roles     AccessMap // roles granted to users via role() callback
 	Access    AccessMap
 	Rejection error
+	Expiry    *uint32
 }
 
 type ChannelMapper struct {

--- a/db/database.go
+++ b/db/database.go
@@ -88,7 +88,7 @@ type DatabaseContextOptions struct {
 	IndexOptions          *ChannelIndexOptions
 	SequenceHashOptions   *SequenceHashOptions
 	RevisionCacheCapacity uint32
-	OldRevExpirySeconds   int
+	OldRevExpirySeconds   uint32
 	AdminInterface        *string
 	UnsupportedOptions    UnsupportedOptions
 	TrackDocs             bool // Whether doc tracking channel should be created (used for autoImport, shadowing)
@@ -991,7 +991,7 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 		Sync string
 	}
 
-	err = context.Bucket.Update(kSyncDataKey, 0, func(currentValue []byte) ([]byte, error) {
+	err = context.Bucket.Update(kSyncDataKey, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// The first time opening a new db, currentValue will be nil. Don't treat this as a change.
 		if currentValue != nil {
 			parseErr := json.Unmarshal(currentValue, &syncData)
@@ -1001,9 +1001,10 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 		}
 		if changed || currentValue == nil {
 			syncData.Sync = syncFun
-			return json.Marshal(syncData)
+			bytes, err := json.Marshal(syncData)
+			return bytes, nil, err
 		} else {
-			return nil, couchbase.UpdateCancel // value unchanged, no need to save
+			return nil, nil, couchbase.UpdateCancel // value unchanged, no need to save
 		}
 	})
 
@@ -1050,21 +1051,21 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		docid := rowKey[1].(string)
 		key := realDocID(docid)
 
-		documentUpdateFunc := func(doc *document) (updatedDoc *document, shouldUpdate bool, err error) {
+		documentUpdateFunc := func(doc *document) (updatedDoc *document, shouldUpdate bool, updatedExpiry *uint32, err error) {
 			imported := false
 			if !doc.HasValidSyncData(db.writeSequences()) {
 				// This is a document not known to the sync gateway. Ignore or import it:
 				if !doImportDocs {
-					return nil, false, couchbase.UpdateCancel
+					return nil, false, nil, couchbase.UpdateCancel
 				}
 				imported = true
 				if err = db.initializeSyncData(doc); err != nil {
-					return nil, false, err
+					return nil, false, nil, err
 				}
 				base.LogTo("CRUD", "\tImporting document %q --> rev %q", docid, doc.CurrentRev)
 			} else {
 				if !doCurrentDocs {
-					return nil, false, couchbase.UpdateCancel
+					return nil, false, nil, couchbase.UpdateCancel
 				}
 				base.LogTo("CRUD", "\tRe-syncing document %q", docid)
 			}
@@ -1073,7 +1074,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 			changed := 0
 			doc.History.forEachLeaf(func(rev *RevInfo) {
 				body, _ := db.getRevFromDoc(doc, rev.ID, false)
-				channels, access, roles, _, err := db.getChannelsAndAccess(doc, body, rev.ID)
+				channels, access, roles, syncExpiry, _, err := db.getChannelsAndAccess(doc, body, rev.ID)
 				if err != nil {
 					// Probably the validator rejected the doc
 					base.Warn("Error calling sync() on doc %q: %v", docid, err)
@@ -1086,54 +1087,73 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 					changed = len(doc.Access.updateAccess(doc, access)) +
 						len(doc.RoleAccess.updateAccess(doc, roles)) +
 						len(doc.updateChannels(channels))
+					// Only update document expiry based on the current (active) rev
+					if syncExpiry != nil {
+						doc.UpdateExpiry(*syncExpiry)
+						updatedExpiry = syncExpiry
+					}
 				}
 			})
 			shouldUpdate = changed > 0 || imported
-			return doc, shouldUpdate, nil
+			return doc, shouldUpdate, updatedExpiry, nil
 		}
 		var err error
 		if db.UseXattrs() {
-			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, err error) {
-				// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing, so deleteDoc is always returned as false.
-				if currentValue == nil || len(currentValue) == 0 {
-					return nil, nil, deleteDoc, errors.New("Cancel update")
-				}
-				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas)
-				if err != nil {
-					return nil, nil, deleteDoc, err
-				}
+			_, err = db.Bucket.WriteUpdateWithXattr(
+				key,
+				KSyncXattrName,
+				0,
+				nil,
+				func(currentValue []byte, currentXattr []byte, cas uint64) (
+					raw []byte, rawXattr []byte, deleteDoc bool, expiry *uint32, err error) {
+					// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
+					// so deleteDoc is always returned as false.
+					if currentValue == nil || len(currentValue) == 0 {
+						return nil, nil, deleteDoc, nil, errors.New("Cancel update")
+					}
+					doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas)
+					if err != nil {
+						return nil, nil, deleteDoc, nil, err
+					}
 
-				updatedDoc, shouldUpdate, err := documentUpdateFunc(doc)
-				if err != nil {
-					return nil, nil, deleteDoc, err
-				}
-				if shouldUpdate {
-					base.LogTo("Access", "Saving updated channels and access grants of %q", docid)
-					raw, rawXattr, err = updatedDoc.MarshalWithXattr()
-					return raw, rawXattr, deleteDoc, err
-				} else {
-					return nil, nil, deleteDoc, errors.New("Cancel update")
-				}
-			})
+					updatedDoc, shouldUpdate, updatedExpiry, err := documentUpdateFunc(doc)
+					if err != nil {
+						return nil, nil, deleteDoc, nil, err
+					}
+					if shouldUpdate {
+						base.LogTo("Access", "Saving updated channels and access grants of %q", docid)
+						if updatedExpiry != nil {
+							updatedDoc.UpdateExpiry(*updatedExpiry)
+						}
+						raw, rawXattr, err = updatedDoc.MarshalWithXattr()
+						return raw, rawXattr, deleteDoc, updatedExpiry, err
+					} else {
+						return nil, nil, deleteDoc, nil, errors.New("Cancel update")
+					}
+				})
 		} else {
-			err = db.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, error) {
+			err = db.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 				// Be careful: this block can be invoked multiple times if there are races!
 				if currentValue == nil {
-					return nil, couchbase.UpdateCancel // someone deleted it?!
+					return nil, nil, couchbase.UpdateCancel // someone deleted it?!
 				}
 				doc, err := unmarshalDocument(docid, currentValue)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
-				updatedDoc, shouldUpdate, err := documentUpdateFunc(doc)
+				updatedDoc, shouldUpdate, updatedExpiry, err := documentUpdateFunc(doc)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				if shouldUpdate {
 					base.LogTo("Access", "Saving updated channels and access grants of %q", docid)
-					return json.Marshal(updatedDoc)
+					if updatedExpiry != nil {
+						updatedDoc.UpdateExpiry(*updatedExpiry)
+					}
+					updatedBytes, marshalErr := json.Marshal(updatedDoc)
+					return updatedBytes, updatedExpiry, marshalErr
 				} else {
-					return nil, couchbase.UpdateCancel
+					return nil, nil, couchbase.UpdateCancel
 				}
 			})
 		}

--- a/examples/basic-sync-function.json
+++ b/examples/basic-sync-function.json
@@ -19,6 +19,9 @@
 	} else {
 	    // all other documents just go into all channels listed in the doc["channels"] field
 	    channel(doc.channels)
+
+      // Expire documents based on document "expiry" property
+      expiry(doc.expiry)    
 	}
       }
     `

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -54,7 +54,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f4d3402e136f9220642ae9524e45bd4108b6f60f"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
 
@@ -70,7 +70,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cafd6f12f21d446d49ec1dfb16b7cdc878e5b907"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="4c8ee1181f74802a03304a71f5bd5d04c16cc747"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -54,7 +54,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f4d3402e136f9220642ae9524e45bd4108b6f60f"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="371e984a8612f8ae853dfaf74752e9e5779b5e7d"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
 
@@ -70,7 +70,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="4c8ee1181f74802a03304a71f5bd5d04c16cc747"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="befa4a9dc7ef85b54bc464f8735754eb90950b29"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -286,9 +286,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	if config.OldRevExpirySeconds != nil && *config.OldRevExpirySeconds >= 0 {
-		oldRevExpirySeconds = int(*config.OldRevExpirySeconds)
-  }
-  
+		oldRevExpirySeconds = *config.OldRevExpirySeconds
+	}
+
 	localDocExpirySecs := base.DefaultLocalDocExpirySecs
 	if config.LocalDocExpirySecs != nil && *config.LocalDocExpirySecs >= 0 {
 		localDocExpirySecs = *config.LocalDocExpirySecs


### PR DESCRIPTION
Calling expiry(value) from within the sync function will set the expiry value for a document, in the same way as if the _exp property were set in the document.

In addition to adding the new function to sync runner, required modification to the Update and WriteUpdate bucket methods to support passing the (potentially) modified expiry back along with the document body.

Also refactored sg-bucket and it's implementations to standardize expiry as uint32 - matches gocb and the underlying Couchbase binary protocol, and cleans up inconsistent usage/casting in SG (originally due to the go-couchbase API using int).

Fixes #3015.

Depends on:
https://github.com/couchbase/sg-bucket/pull/28
https://github.com/couchbaselabs/walrus/pull/33