### PR TITLE
Optimize document unmarshalling

### DIFF
--- a/db/assimilator.go
+++ b/db/assimilator.go
@@ -41,7 +41,7 @@ func (c *DatabaseContext) assimilate(docid string) {
 		if err := db.initializeSyncData(doc); err != nil {
 			return nil, nil, err
 		}
-		return doc.body, nil, nil
+		return doc.Body(), nil, nil
 	})
 	if err != nil && err != couchbase.UpdateCancel {
 		base.Warn("Failed to import new doc %q: %v", docid, err)

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -124,7 +124,7 @@ func (db *Database) retrieveAncestorAttachments(doc *document, parentRev string,
 		if commonAncestor != "" {
 			parentAttachments = make(map[string]interface{})
 			commonAncestorGen, _ := base.ToInt64(genOfRevID(commonAncestor))
-			for name, activeAttachment := range BodyAttachments(doc.body) {
+			for name, activeAttachment := range BodyAttachments(doc.Body()) {
 				attachmentMeta, ok := activeAttachment.(map[string]interface{})
 				if ok {
 					activeRevpos, ok := base.ToInt64(attachmentMeta["revpos"])
@@ -145,7 +145,7 @@ func (db *Database) retrieveAncestorAttachments(doc *document, parentRev string,
 // generation or later are loaded.
 func (db *Database) loadBodyAttachments(body Body, minRevpos int, docid string) (Body, error) {
 
-	body = body.ImmutableAttachmentsCopy()
+	body = body.MutableAttachmentsCopy()
 	for attachmentName, value := range BodyAttachments(body) {
 		meta := value.(map[string]interface{})
 		revpos, ok := base.ToInt64(meta["revpos"])

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -254,7 +254,7 @@ func (c *changeCache) CleanSkippedSequenceQueue() bool {
 		entry.Skipped = true
 		// Need to populate the actual channels for this entry - the entry returned from the * channel
 		// view will only have the * channel
-		doc, err := c.context.GetDoc(entry.DocID)
+		doc, err := c.context.GetDocument(entry.DocID, DocUnmarshalNoHistory)
 		if err != nil {
 			base.Warn("Unable to retrieve doc when processing skipped document %q: abandoning sequence %d", entry.DocID, entry.Sequence)
 			continue

--- a/db/changes.go
+++ b/db/changes.go
@@ -92,7 +92,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 	// The document, which may include just the syncMeta or may include syncMeta + Body, depending on circumstances
 	if options.IncludeDocs {
 		// load whole doc
-		doc, err = db.GetDoc(entry.ID)
+		doc, err = db.GetDocument(entry.ID, DocUnmarshalAll)
 		if err != nil {
 			base.Warn("Changes feed: error getting doc %q: %v", entry.ID, err)
 			return

--- a/db/changes.go
+++ b/db/changes.go
@@ -131,7 +131,7 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *documen
 		})
 	}
 	if options.IncludeDocs {
-		if doc.body == nil {
+		if doc.Body() == nil {
 			base.Warn("AddDocInstanceToChangeEntry called with options.IncludeDocs, but doc is missing Body")
 			return
 		}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -292,7 +292,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 }
 
 // Benchmark to validate fix for https://github.com/couchbase/sync_gateway/issues/2428
-func BenchmarkChangesFeedDocUnmarashalling(b *testing.B) {
+func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 	db, testBucket := setupTestDBWithCacheOptions(b, CacheOptions{})
 	defer testBucket.Close()

--- a/db/crud.go
+++ b/db/crud.go
@@ -42,6 +42,10 @@ func realDocID(docid string) string {
 
 // Lowest-level method that reads a document from the bucket.
 func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
+	return db.GetDocument(docid, DocUnmarshalAll)
+}
+
+func (db *DatabaseContext) GetDocument(docid string, unmarshalTo DocumentUnmarshalLevel) (doc *document, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, base.HTTPErrorf(400, "Invalid doc ID")
@@ -49,7 +53,7 @@ func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
 	dbExpvars.Add("document_gets", 1)
 	if db.UseXattrs() {
 		var rawBucketDoc *sgbucket.BucketDocument
-		doc, rawBucketDoc, err = db.GetDocWithXattr(key)
+		doc, rawBucketDoc, err = db.GetDocWithXattr(key, unmarshalTo)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +87,7 @@ func (db *DatabaseContext) GetDoc(docid string) (doc *document, err error) {
 	return doc, nil
 }
 
-func (db *DatabaseContext) GetDocWithXattr(key string) (doc *document, rawBucketDoc *sgbucket.BucketDocument, err error) {
+func (db *DatabaseContext) GetDocWithXattr(key string, unmarshalTo DocumentUnmarshalLevel) (doc *document, rawBucketDoc *sgbucket.BucketDocument, err error) {
 	rawBucketDoc = &sgbucket.BucketDocument{}
 	var getErr error
 	rawBucketDoc.Cas, getErr = db.Bucket.GetWithXattr(key, KSyncXattrName, &rawBucketDoc.Body, &rawBucketDoc.Xattr)
@@ -92,7 +96,7 @@ func (db *DatabaseContext) GetDocWithXattr(key string) (doc *document, rawBucket
 	}
 
 	var unmarshalErr error
-	doc, unmarshalErr = unmarshalDocumentWithXattr(key, rawBucketDoc.Body, rawBucketDoc.Xattr, rawBucketDoc.Cas)
+	doc, unmarshalErr = unmarshalDocumentWithXattr(key, rawBucketDoc.Body, rawBucketDoc.Xattr, rawBucketDoc.Cas, unmarshalTo)
 	if unmarshalErr != nil {
 		return nil, nil, unmarshalErr
 	}
@@ -118,7 +122,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (syncData, error) {
 		}
 
 		// Unmarshal xattr only
-		doc, unmarshalErr := unmarshalDocumentWithXattr(docid, nil, rawXattr, cas)
+		doc, unmarshalErr := unmarshalDocumentWithXattr(docid, nil, rawXattr, cas, DocUnmarshalSync)
 		if unmarshalErr != nil {
 			return emptySyncData, unmarshalErr
 		}
@@ -177,11 +181,17 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 	if doc, err = context.GetDoc(id.DocID); doc == nil {
 		return body, history, channels, err
 	}
+	return context.revCacheLoaderForDocument(doc, id.RevID)
 
-	if body, err = context.getRevision(doc, id.RevID); err != nil {
+}
+
+// Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
+func (context *DatabaseContext) revCacheLoaderForDocument(doc *document, revid string) (body Body, history Body, channels base.Set, err error) {
+
+	if body, err = context.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal.  If so, we want to store as removal in the revision cache
-		removalBody, removalHistory, removalChannels, isRemoval, isRemovalErr := doc.IsChannelRemoval(id.RevID)
+		removalBody, removalHistory, removalChannels, isRemoval, isRemovalErr := doc.IsChannelRemoval(revid)
 		if isRemovalErr != nil {
 			return body, history, channels, isRemovalErr
 		}
@@ -192,16 +202,16 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 			return body, history, channels, err
 		}
 	}
-	if doc.History[id.RevID].Deleted {
+	if doc.History[revid].Deleted {
 		body["_deleted"] = true
 	}
 
-	validatedHistory, getHistoryErr := doc.History.getHistory(id.RevID)
+	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
 		return body, history, channels, getHistoryErr
 	}
 	history = encodeRevisions(validatedHistory)
-	channels = doc.History[id.RevID].Channels
+	channels = doc.History[revid].Channels
 	return body, history, channels, err
 }
 
@@ -238,37 +248,20 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 		// Get a specific revision body and history from the revision cache
 		// (which will load them if necessary, by calling revCacheLoader, above)
 		body, revisions, inChannels, err = db.revisionCache.Get(docid, revid)
-		if body == nil {
-			if err == nil {
-				err = base.HTTPErrorf(404, "missing")
-			}
-			return nil, err
-		}
-		if maxHistory == 0 {
-			revisions = nil
-		}
 	} else {
-		// No rev ID given, so load doc and get its current revision:
-		if doc, err = db.GetDoc(docid); doc == nil {
-			return nil, err
-		}
-		revid = doc.CurrentRev
-		if body, err = db.getRevision(doc, revid); err != nil {
-			return nil, err
-		}
-		if doc.hasFlag(channels.Deleted) {
-			body["_deleted"] = true
-		}
-		if maxHistory != 0 {
-			validatedHistory, getHistoryErr := doc.History.getHistory(revid)
-			if getHistoryErr != nil {
-				return nil, getHistoryErr
-			}
-			revisions = encodeRevisions(validatedHistory)
-		}
-		inChannels = doc.History[revid].Channels
+		// No rev ID given, so load active revision
+		body, revisions, inChannels, revid, err = db.revisionCache.GetActive(docid, db.DatabaseContext)
 	}
 
+	if body == nil {
+		if err == nil {
+			err = base.HTTPErrorf(404, "missing")
+		}
+		return nil, err
+	}
+	if maxHistory == 0 {
+		revisions = nil
+	}
 	if revisions != nil {
 		_, revisions = trimEncodedRevisionsToAncestor(revisions, historyFrom, maxHistory)
 	}
@@ -310,7 +303,7 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 	if showExp {
 		// If doc is nil (we got the rev from the rev cache), look up the doc to find the exp on the doc
 		if doc == nil {
-			if doc, err = db.GetDoc(docid); doc == nil {
+			if doc, err = db.GetDocument(docid, DocUnmarshalSync); doc == nil {
 				return nil, err
 			}
 		}
@@ -324,10 +317,11 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 		minRevpos := 1
 		if len(attachmentsSince) > 0 {
 			if doc == nil { // if rev was in the cache, we don't have the document struct yet
-				if doc, err = db.GetDoc(docid); doc == nil {
+				if doc, err = db.GetDocument(docid, DocUnmarshalSync); doc == nil {
 					return nil, err
 				}
 			}
+
 			ancestor := doc.History.findAncestorFromSet(revid, attachmentsSince)
 			if ancestor != "" {
 				minRevpos, _ = ParseRevID(ancestor)
@@ -377,7 +371,7 @@ func (db *Database) GetRevAndChannels(docid string, revid string, listRevisions 
 
 // Returns an HTTP 403 error if the User is not allowed to access any of this revision's channels.
 func (db *Database) AuthorizeDocID(docid, revid string) error {
-	doc, err := db.GetDoc(docid)
+	doc, err := db.GetDocument(docid, DocUnmarshalSync)
 	if doc == nil {
 		return err
 	}
@@ -523,7 +517,7 @@ func (db *Database) backupAncestorRevs(doc *document, revid string) error {
 
 	// Nil out the rev's body in the document struct:
 	if revid == doc.CurrentRev {
-		doc.body = nil
+		doc.RemoveBody()
 	} else {
 		doc.removeRevisionBody(revid)
 	}
@@ -536,7 +530,7 @@ func (db *Database) backupAncestorRevs(doc *document, revid string) error {
 // Initializes the gateway-specific "_sync_" metadata of a new document.
 // Used when importing an existing Couchbase doc that hasn't been seen by the gateway before.
 func (db *Database) initializeSyncData(doc *document) (err error) {
-	body := doc.body
+	body := doc.Body()
 	doc.CurrentRev = createRevID(1, "", body)
 	body["_rev"] = doc.CurrentRev
 	doc.setFlag(channels.Deleted, false)
@@ -554,7 +548,7 @@ func (db *Database) OnDemandImportForWrite(docid string, doc *document, body Bod
 
 	// Check whether the doc requiring import is an SDK delete
 	isDelete := false
-	if doc.body == nil {
+	if doc.Body() == nil {
 		isDelete = true
 	} else {
 		deletedInBody, ok := body["_deleted"].(bool)
@@ -797,9 +791,9 @@ func (db *Database) updateAndReturnDoc(
 			doc.syncData.TombstonedAt = 0
 		}
 
-		if doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" && doc.body != nil {
+		if doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" && doc.Body() != nil {
 			// Store the doc's previous body into the revision tree:
-			bodyJSON, _ := json.Marshal(doc.body)
+			bodyJSON, _ := doc.MarshalBody()
 			doc.setNonWinningRevisionBody(prevCurrentRev, bodyJSON, db.AllowExternalRevBodyStorage())
 		}
 
@@ -1016,7 +1010,7 @@ func (db *Database) updateAndReturnDoc(
 		// Update the document, storing metadata in extended attribute
 		casOut, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, expiry, existingDoc, func(currentValue []byte, currentXattr []byte, cas uint64) (raw []byte, rawXattr []byte, deleteDoc bool, syncFuncExpiry *uint32, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
-			if doc, err = unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas); err != nil {
+			if doc, err = unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll); err != nil {
 				return
 			}
 
@@ -1394,7 +1388,7 @@ func (context *DatabaseContext) checkForUpgrade(key string) (*document, *sgbucke
 	if context.UseXattrs() {
 		return nil, nil
 	}
-	doc, rawDocument, err := context.GetDocWithXattr(key)
+	doc, rawDocument, err := context.GetDocWithXattr(key, DocUnmarshalCAS)
 	if err != nil || doc == nil || !doc.HasValidSyncData(context.writeSequences()) {
 		return nil, nil
 	}
@@ -1409,7 +1403,7 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 	if strings.HasPrefix(docid, "_design/") && db.user != nil {
 		return // Users can't upload design docs, so ignore them
 	}
-	doc, err := db.GetDoc(docid)
+	doc, err := db.GetDocument(docid, DocUnmarshalSync)
 	if err != nil {
 		if !base.IsDocNotFoundError(err) {
 			base.Warn("RevDiff(%q) --> %T %v", docid, err, err)

--- a/db/database.go
+++ b/db/database.go
@@ -1106,7 +1106,7 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 				if currentValue == nil || len(currentValue) == 0 {
 					return nil, nil, deleteDoc, nil, errors.New("Cancel update")
 				}
-				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas)
+				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll)
 				if err != nil {
 					return nil, nil, deleteDoc, nil, err
 				}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -709,8 +709,8 @@ func TestConflicts(t *testing.T) {
 
 	// Verify the change with the higher revid won:
 	gotBody, err := db.Get("doc")
-	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-b", "n": int64(2),
-		"channels": []interface{}{"all", "2b"}})
+	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-b", "n": 2,
+		"channels": []string{"all", "2b"}})
 
 	// Verify we can still get the other two revisions:
 	gotBody, err = db.GetRev("doc", "1-a", false, nil)
@@ -750,8 +750,8 @@ func TestConflicts(t *testing.T) {
 	log.Printf("post-delete, got raw body: %s", rawBody)
 
 	gotBody, err = db.Get("doc")
-	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-a", "n": int64(3),
-		"channels": []interface{}{"all", "2a"}})
+	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-a", "n": 3,
+		"channels": []string{"all", "2a"}})
 
 	// Verify channel assignments are correct for channels defined by 2-a:
 	doc, _ := db.GetDoc("doc")

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -251,7 +251,7 @@ func TestGetDeleted(t *testing.T) {
 	assert.DeepEquals(t, body, expectedResult)
 
 	// Get the raw doc and make sure the sync data has the current revision
-	doc, err := db.GetDoc("doc1")
+	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assertNoError(t, err, "Err getting doc")
 	assert.Equals(t, doc.syncData.CurrentRev, rev2id)
 
@@ -754,7 +754,7 @@ func TestConflicts(t *testing.T) {
 		"channels": []string{"all", "2a"}})
 
 	// Verify channel assignments are correct for channels defined by 2-a:
-	doc, _ := db.GetDoc("doc")
+	doc, _ := db.GetDocument("doc", DocUnmarshalAll)
 	chan2a, found := doc.Channels["2a"]
 	assert.True(t, found)
 	assert.True(t, chan2a == nil)             // currently in 2a
@@ -875,7 +875,7 @@ func TestSyncFnOnPush(t *testing.T) {
 	assertNoError(t, err, "PutExistingRev failed")
 
 	// Check that the doc has the correct channel (test for issue #300)
-	doc, err := db.GetDoc("doc1")
+	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assert.DeepEquals(t, doc.Channels, channels.ChannelMap{
 		"clibup": nil, // i.e. it is currently in this channel (no removal)
 		"public": &channels.ChannelRemoval{Seq: 2, RevID: "4-four"},
@@ -1089,7 +1089,7 @@ func TestImport(t *testing.T) {
 	}
 
 	// Make sure they aren't visible thru the gateway:
-	doc, err := db.GetDoc("alreadyHere1")
+	doc, err := db.GetDocument("alreadyHere1", DocUnmarshalAll)
 	assert.Equals(t, doc, (*document)(nil))
 	assert.Equals(t, err.(*base.HTTPError).Status, 404)
 
@@ -1099,7 +1099,7 @@ func TestImport(t *testing.T) {
 	assert.Equals(t, count, 20)
 
 	// Now they're visible:
-	doc, err = db.GetDoc("alreadyHere1")
+	doc, err = db.GetDocument("alreadyHere1", DocUnmarshalAll)
 	base.Logf("doc = %+v", doc)
 	assert.True(t, doc != nil)
 	assertNoError(t, err, "can't get doc")
@@ -1121,7 +1121,7 @@ func TestPostWithExistingId(t *testing.T) {
 	assertNoError(t, err, "Couldn't create document")
 
 	// Test retrieval
-	doc, err := db.GetDoc(customDocId)
+	doc, err := db.GetDocument(customDocId, DocUnmarshalAll)
 	assert.True(t, doc != nil)
 	assertNoError(t, err, "Unable to retrieve doc using custom id")
 
@@ -1134,7 +1134,7 @@ func TestPostWithExistingId(t *testing.T) {
 	assertNoError(t, err, "Couldn't create document")
 
 	// Test retrieval
-	doc, err = db.GetDoc(docid)
+	doc, err = db.GetDocument(docid, DocUnmarshalAll)
 	assert.True(t, doc != nil)
 	assertNoError(t, err, "Unable to retrieve doc using generated uuid")
 
@@ -1190,7 +1190,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	assertNoError(t, err, "Couldn't create document")
 
 	// Test retrieval
-	doc, err := db.GetDoc(customDocId)
+	doc, err := db.GetDocument(customDocId, DocUnmarshalAll)
 	assert.True(t, doc != nil)
 	assertNoError(t, err, "Unable to retrieve doc using custom id")
 
@@ -1202,7 +1202,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	assert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
 
 	// Test retrieval gets rev1
-	doc, err = db.GetDoc(docid)
+	doc, err = db.GetDocument(docid, DocUnmarshalAll)
 	assert.True(t, doc != nil)
 	assert.True(t, doc.CurrentRev == rev1id)
 	assertNoError(t, err, "Unable to retrieve doc using generated uuid")
@@ -1245,7 +1245,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 	revid, err := db.Put("doc1", body)
 
 	assert.True(t, revid != "")
-	doc, err := db.GetDoc("doc1")
+	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assert.True(t, err == nil)
 	assert.DeepEquals(t, doc.RecentSequences, []uint64{1})
 
@@ -1254,7 +1254,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 		revid, err = db.Put("doc1", body)
 	}
 
-	doc, err = db.GetDoc("doc1")
+	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
 	assert.True(t, err == nil)
 	assert.DeepEquals(t, doc.RecentSequences, []uint64{1, 2, 3, 4})
 
@@ -1268,7 +1268,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 
 	db.changeCache.waitForSequence(24)
 	revid, err = db.Put("doc1", body)
-	doc, err = db.GetDoc("doc1")
+	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
 	assert.True(t, err == nil)
 	log.Printf("recent:%d, max:%d", len(doc.RecentSequences), kMaxRecentSequences)
 	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
@@ -1282,7 +1282,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 
 	db.changeCache.waitForSequence(64)
 	revid, err = db.Put("doc1", body)
-	doc, err = db.GetDoc("doc1")
+	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
 	assert.True(t, err == nil)
 	log.Printf("Recent sequences: %v (shouldn't exceed %v)", len(doc.RecentSequences), kMaxRecentSequences)
 	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
@@ -1340,7 +1340,7 @@ func CouchbaseTestConcurrentImport(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			doc, err := db.GetDoc("directWrite")
+			doc, err := db.GetDocument("directWrite", DocUnmarshalAll)
 			assert.True(t, doc != nil)
 			assertNoError(t, err, "Document retrieval error")
 			assert.Equals(t, doc.syncData.CurrentRev, "1-36fa688dc2a2c39a952ddce46ab53d12")

--- a/db/document.go
+++ b/db/document.go
@@ -29,6 +29,17 @@ import (
 // Non-winning bodies smaller than this size are more efficient to store inline.
 const MaximumInlineBodySize = 250
 
+type DocumentUnmarshalLevel uint8
+
+const (
+	DocUnmarshalAll       = DocumentUnmarshalLevel(iota) // Unmarshals sync metadata and body
+	DocUnmarshalSync                                     // Unmarshals all sync metadata
+	DocUnmarshalNoHistory                                // Unmarshals sync metadata excluding history
+	DocUnmarshalRev                                      // Unmarshals rev + CAS only
+	DocUnmarshalCAS                                      // Unmarshals CAS (for import check) only
+	DocUnmarshalNone                                     // No unmarshalling (skips import/upgrade check)
+)
+
 // Maps what users have access to what channels or roles, and when they got that access.
 type UserAccessMap map[string]channels.TimedSet
 
@@ -38,7 +49,7 @@ type syncData struct {
 	NewestRev       string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
 	Flags           uint8               `json:"flags,omitempty"`
 	Sequence        uint64              `json:"sequence,omitempty"`
-	UnusedSequences []uint64            `json:"unused_sequences,omitempty"` // unused due to update conflicts
+	UnusedSequences []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
 	RecentSequences []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
 	History         RevTree             `json:"history"`
 	Channels        channels.ChannelMap `json:"channels,omitempty"`
@@ -66,10 +77,20 @@ type syncData struct {
 // In its JSON form, the body's properties are at top-level while the syncData is in a special
 // "_sync" property.
 type document struct {
-	syncData
-	body Body
-	ID   string `json:"-"`
-	Cas  uint64
+	syncData        // Sync metadata
+	_body    Body   // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
+	rawBody  []byte // Raw document body, as retrieved from the bucket
+	ID       string `json:"-"` // Doc id
+	Cas      uint64 // Document cas
+}
+
+type revOnlySyncData struct {
+	casOnlySyncData
+	CurrentRev string `json:"rev"`
+}
+
+type casOnlySyncData struct {
+	Cas string `json:"cas"`
 }
 
 // Returns a new empty document.
@@ -77,7 +98,31 @@ func newDocument(docid string) *document {
 	return &document{ID: docid, syncData: syncData{History: make(RevTree)}}
 }
 
-// Unmarshals a document from JSON data. The doc ID isn't in the data and must be given.
+// Accessors for document properties.  To support lazy unmarshalling of document contents, all access should be done through accessors
+func (doc *document) Body() Body {
+	if doc._body == nil && doc.rawBody != nil {
+		err := json.Unmarshal(doc.rawBody, &doc._body)
+		if err != nil {
+			base.Warn("Unable to unmarshal document body from raw body : %s", err)
+			return nil
+		}
+		doc.rawBody = nil
+	}
+	return doc._body
+}
+
+func (doc *document) RemoveBody() {
+	doc._body = nil
+	doc.rawBody = nil
+}
+
+// TODO: review whether this can just return raw body when available
+func (doc *document) MarshalBody() ([]byte, error) {
+	return json.Marshal(doc.Body())
+}
+
+// Unmarshals a document from JSON data. The doc ID isn't in the data and must be given.  Uses decode to ensure
+// UseNumber handling is applied to numbers in the body.
 func unmarshalDocument(docid string, data []byte) (*document, error) {
 	doc := newDocument(docid)
 	if len(data) > 0 {
@@ -92,14 +137,14 @@ func unmarshalDocument(docid string, data []byte) (*document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas uint64) (doc *document, err error) {
+func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas uint64, unmarshalTo DocumentUnmarshalLevel) (doc *document, err error) {
 
 	if xattrData == nil || len(xattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {
 		doc = newDocument(docid)
-		err = doc.UnmarshalWithXattr(data, xattrData)
+		err = doc.UnmarshalWithXattr(data, xattrData, unmarshalTo)
 	}
 	if err != nil {
 		return nil, err
@@ -226,6 +271,7 @@ func parseXattrStreamData(xattrName string, data []byte) (body []byte, xattr []b
 }
 
 func (doc *syncData) HasValidSyncData(requireSequence bool) bool {
+
 	valid := doc != nil && doc.CurrentRev != "" && (doc.Sequence > 0 || !requireSequence)
 	return valid
 }
@@ -290,7 +336,7 @@ func (db *DatabaseContext) RevisionBodyLoader(key string) ([]byte, error) {
 func (doc *document) getRevisionBody(revid string, loader RevLoaderFunc) Body {
 	var body Body
 	if revid == doc.CurrentRev {
-		body = doc.body
+		body = doc.Body()
 	} else {
 		body = doc.getNonWinningRevisionBody(revid, loader)
 	}
@@ -305,6 +351,7 @@ func (doc *document) getNonWinningRevisionBody(revid string, loader RevLoaderFun
 	if !found {
 		return nil
 	}
+
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
 		base.Warn("Unexpected error parsing body of rev %q", revid)
 		return nil
@@ -316,7 +363,7 @@ func (doc *document) getNonWinningRevisionBody(revid string, loader RevLoaderFun
 func (doc *document) getRevisionBodyJSON(revid string, loader RevLoaderFunc) []byte {
 	var bodyJSON []byte
 	if revid == doc.CurrentRev {
-		bodyJSON, _ = json.Marshal(doc.body)
+		bodyJSON, _ = json.Marshal(doc._body)
 	} else {
 		bodyJSON, _ = doc.History.getRevisionBody(revid, loader)
 	}
@@ -336,8 +383,8 @@ func (doc *document) removeRevisionBody(revID string) {
 // makeBodyActive moves a previously non-winning revision body from the rev tree to the document body
 func (doc *document) promoteNonWinningRevisionBody(revid string, loader RevLoaderFunc) {
 	// If the new revision is not current, transfer the current revision's
-	// body to the top level doc.body:
-	doc.body = doc.getNonWinningRevisionBody(revid, loader)
+	// body to the top level doc._body:
+	doc._body = doc.getNonWinningRevisionBody(revid, loader)
 	doc.removeRevisionBody(revid)
 }
 
@@ -356,7 +403,7 @@ func (doc *document) pruneRevisions(maxDepth uint32, keepRev string) int {
 func (doc *document) setRevisionBody(revid string, body Body, storeInline bool) {
 	strippedBody := stripSpecialProperties(body)
 	if revid == doc.CurrentRev {
-		doc.body = strippedBody
+		doc._body = strippedBody
 	} else {
 		var asJson []byte
 		if len(body) > 0 {
@@ -604,16 +651,16 @@ func (doc *document) UnmarshalJSON(data []byte) error {
 		doc.syncData = *root.SyncData
 	}
 
-	if err := doc.unmarshalBody(data); err != nil {
+	if err := json.Unmarshal(data, &doc._body); err != nil {
 		return err
 	}
 
-	delete(doc.body, "_sync")
+	delete(doc._body, "_sync")
 	return nil
 }
 
 func (doc *document) MarshalJSON() ([]byte, error) {
-	body := doc.body
+	body := doc._body
 	if body == nil {
 		body = Body{}
 	}
@@ -623,33 +670,75 @@ func (doc *document) MarshalJSON() ([]byte, error) {
 	return data, err
 }
 
-func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte) error {
+// UnmarshalWithXattr unmarshals the provided raw document and xattr bytes.  The provided DocumentUnmarshalLevel
+// (unmarshalTo) specifies how much of the provided document/xattr needs to be initially unmarshalled.  If
+// unmarshalTo is anything less than the full document + metadata, the raw data is retained for subsequent
+// lazy unmarshalling as needed.
+func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalTo DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
 		base.Warn("Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
 	}
 
-	// Unmarshal sync metadata
-	doc.syncData = syncData{History: make(RevTree)}
-	if err := json.Unmarshal(xdata, &doc.syncData); err != nil {
-		return err
-	}
-	// Unmarshal document body, if present
-	if len(data) > 0 {
-		return doc.unmarshalBody(data)
+	switch unmarshalTo {
+	case DocUnmarshalAll, DocUnmarshalSync:
+		// Unmarshal full document and/or sync metadata
+		doc.syncData = syncData{History: make(RevTree)}
+		unmarshalErr := json.Unmarshal(xdata, &doc.syncData)
+		if unmarshalErr != nil {
+			return unmarshalErr
+		}
+		// Unmarshal body if requested and present
+		if unmarshalTo == DocUnmarshalAll && len(data) > 0 {
+			return json.Unmarshal(data, &doc._body)
+		} else {
+			doc.rawBody = data
+		}
+
+	case DocUnmarshalNoHistory:
+		// Unmarshal sync metadata only, excluding history
+		doc.syncData = syncData{}
+		unmarshalErr := json.Unmarshal(xdata, &doc.syncData)
+		if unmarshalErr != nil {
+			return unmarshalErr
+		}
+		doc.rawBody = data
+	case DocUnmarshalRev:
+		// Unmarshal only rev and cas from sync metadata
+		var revOnlyMeta revOnlySyncData
+		unmarshalErr := json.Unmarshal(xdata, &revOnlyMeta)
+		if unmarshalErr != nil {
+			return unmarshalErr
+		}
+		doc.syncData = syncData{
+			CurrentRev: revOnlyMeta.CurrentRev,
+			Cas:        revOnlyMeta.Cas,
+		}
+		doc.rawBody = data
+	case DocUnmarshalCAS:
+		// Unmarshal only cas from sync metadata
+		var casOnlyMeta casOnlySyncData
+		unmarshalErr := json.Unmarshal(xdata, &casOnlyMeta)
+		if unmarshalErr != nil {
+			return unmarshalErr
+		}
+		doc.syncData = syncData{
+			Cas: casOnlyMeta.Cas,
+		}
+		doc.rawBody = data
 	}
 
 	// If there's no body, but there is an xattr, set body as {"_deleted":true} to align with non-xattr handling
-	if len(xdata) > 0 {
-		doc.body = Body{}
-		doc.body["_deleted"] = true
+	if len(data) == 0 && len(xdata) > 0 {
+		doc._body = Body{}
+		doc._body["_deleted"] = true
 	}
 	return nil
 }
 
 func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 
-	body := doc.body
+	body := doc._body
 	// If body is non-empty and non-deleted, unmarshal and return
 	if body != nil {
 		deleted, _ := body["_deleted"].(bool)
@@ -667,12 +756,4 @@ func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	}
 
 	return data, xdata, nil
-}
-
-func (doc *document) unmarshalBody(data []byte) error {
-	err := json.Unmarshal([]byte(data), &doc.body)
-	if err != nil {
-		base.Warn("Error unmarshaling body of doc %q: %s", doc.ID, err)
-	}
-	return err
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/couchbaselabs/go.assert"
 )
 
+// TODO: Could consider checking this in as a file and include it into the compiled test binary using something like https://github.com/jteeuwen/go-bindata
+// Review if we need larger test docs in future.
 var doc_1k = `{
     "index": 0,
     "guid": "bc22f4d5-e13f-4b64-9397-2afd5a843c4d",
@@ -107,8 +109,8 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 	doc1k_meta := []byte(doc_meta)
 
 	unmarshalBenchmarks := []struct {
-		name        string
-		unmarshalTo DocumentUnmarshalLevel
+		name           string
+		unmarshalLevel DocumentUnmarshalLevel
 	}{
 		{"All", DocUnmarshalAll},
 		{"Sync", DocUnmarshalSync},
@@ -121,7 +123,7 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 	for _, bm := range unmarshalBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				doc, err := unmarshalDocumentWithXattr("doc_1k", doc1k_body, doc1k_meta, 1, bm.unmarshalTo)
+				doc, err := unmarshalDocumentWithXattr("doc_1k", doc1k_body, doc1k_meta, 1, bm.unmarshalLevel)
 				b.StopTimer()
 				if err != nil {
 					log.Printf("Unexpected error during unmarshal: %s", err)

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -1,11 +1,184 @@
 package db
 
 import (
+	"bytes"
 	"encoding/binary"
+	"encoding/json"
+	"log"
 	"testing"
 
 	"github.com/couchbaselabs/go.assert"
 )
+
+var doc_1k = `{
+    "index": 0,
+    "guid": "bc22f4d5-e13f-4b64-9397-2afd5a843c4d",
+    "isActive": false,
+    "balance": "$1,168.62",
+    "picture": "http://placehold.it/32x32",
+    "age": 20,
+    "eyeColor": "green",
+    "name": "Miranda Kline",
+    "company": "COMTREK",
+    "email": "mirandakline@comtrek.com",
+    "phone": "+1 (831) 408-2162",
+    "address": "701 Devon Avenue, Ballico, Alabama, 9673",
+    "about": "Minim ea esse dolor ex laborum do velit cupidatat tempor do qui. Aliqua consequat consectetur esse officia ullamco velit labore irure ea non proident. Tempor elit nostrud deserunt in ullamco pariatur enim pariatur et. Veniam fugiat ad mollit ut mollit aute adipisicing aliquip veniam consectetur incididunt. Id cupidatat duis cupidatat quis amet elit sit sit esse velit pariatur do. Excepteur tempor labore esse adipisicing laborum sit enim incididunt quis sint fugiat commodo Lorem. Dolore laboris quis ex do.\r\n",
+    "registered": "2016-09-16T12:08:17 +07:00",
+    "latitude": -14.616751,
+    "longitude": 175.689016,
+    "channels": [
+      "channel_1",
+      "channel_2",
+      "channel_3",
+      "channel_4",
+      "channel_5",
+      "channel_6",
+      "channel_7"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Wise Hewitt"
+      },
+      {
+        "id": 1,
+        "name": "Winnie Schultz"
+      },
+      {
+        "id": 2,
+        "name": "Browning Carlson"
+      }
+    ],
+    "greeting": "Hello, Miranda Kline! You have 4 unread messages.",
+    "favoriteFruit": "strawberry"
+  }`
+
+var doc_meta = `{
+    "rev": "3-89758294abc63157354c2b08547c2d21",
+    "sequence": 7,
+    "recent_sequences": [
+      5,
+      6,
+      7
+    ],
+    "history": {
+      "revs": [
+        "1-fc591a068c153d6c3d26023d0d93dcc1",
+        "2-0eab03571bc55510c8fc4bfac9fe4412",
+        "3-89758294abc63157354c2b08547c2d21"
+      ],
+      "parents": [
+        -1,
+        0,
+        1
+      ],
+      "channels": [
+        [
+          "ABC",
+          "DEF"
+        ],
+        [
+          "ABC",
+          "DEF",
+          "GHI"
+        ],
+        [
+          "ABC",
+          "GHI"
+        ]
+      ]
+    },
+    "channels": {
+      "ABC": null,
+      "DEF": {
+        "seq": 7,
+        "rev": "3-89758294abc63157354c2b08547c2d21"
+      },
+      "GHI": null
+    },
+    "cas": "",
+    "time_saved": "2017-10-25T12:45:29.622450174-07:00"
+  }`
+
+func BenchmarkDocUnmarshal(b *testing.B) {
+
+	doc1k_body := []byte(doc_1k)
+	doc1k_meta := []byte(doc_meta)
+
+	unmarshalBenchmarks := []struct {
+		name        string
+		unmarshalTo DocumentUnmarshalLevel
+	}{
+		{"All", DocUnmarshalAll},
+		{"Sync", DocUnmarshalSync},
+		{"NoHistory", DocUnmarshalNoHistory},
+		{"Rev", DocUnmarshalRev},
+		{"CAS", DocUnmarshalCAS},
+		{"None", DocUnmarshalNone},
+	}
+
+	for _, bm := range unmarshalBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				doc, err := unmarshalDocumentWithXattr("doc_1k", doc1k_body, doc1k_meta, 1, bm.unmarshalTo)
+				b.StopTimer()
+				if err != nil {
+					log.Printf("Unexpected error during unmarshal: %s", err)
+				} else if doc == nil {
+					log.Printf("Post-unmarshal, document is nil.")
+				}
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalBody(b *testing.B) {
+	doc1k_body := []byte(doc_1k)
+	unmarshalBenchmarks := []struct {
+		name           string
+		useDecode      bool
+		fixJSONNumbers bool
+	}{
+		{"UnmarshalAndFixNumbers", false, true},
+		{"Unmarshal", false, false},
+		{"Decode", true, false},
+		{"DecodeUseNumber", true, true},
+	}
+
+	for _, bm := range unmarshalBenchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				doc := newDocument("testDocID")
+				b.StartTimer()
+				var err error
+				if bm.useDecode {
+					decoder := json.NewDecoder(bytes.NewBuffer(doc1k_body))
+					if bm.fixJSONNumbers {
+						decoder.UseNumber()
+					}
+					err = decoder.Decode(&doc._body)
+				} else {
+					err = json.Unmarshal(doc1k_body, &doc._body)
+					if bm.fixJSONNumbers {
+						doc.Body().FixJSONNumbers()
+					}
+				}
+				b.StopTimer()
+				if err != nil {
+					log.Printf("Unmarshal error: %s", err)
+				}
+
+				if len(doc.Body()) == 0 {
+					log.Printf("Empty body")
+				}
+
+			}
+		})
+	}
+}
 
 func TestParseXattr(t *testing.T) {
 	zeroByte := byte(0)

--- a/db/revision.go
+++ b/db/revision.go
@@ -12,7 +12,6 @@ package db
 import (
 	"crypto/md5"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -23,12 +22,8 @@ import (
 type Body map[string]interface{}
 
 func (b *Body) Unmarshal(data []byte) error {
-
 	if err := json.Unmarshal(data, &b); err != nil {
 		return err
-	}
-	if b == nil {
-		return errors.New("Unable to unmarshal null document as Body")
 	}
 	return nil
 }
@@ -41,7 +36,9 @@ func (body Body) ShallowCopy() Body {
 	return copied
 }
 
-func (body Body) ImmutableAttachmentsCopy() Body {
+// Creates a mutable copy that does a deep copy of the _attachments property in the body,
+// suitable for modification by the caller
+func (body Body) MutableAttachmentsCopy() Body {
 	if body == nil {
 		return nil
 	}

--- a/db/revision_cache.go
+++ b/db/revision_cache.go
@@ -62,6 +62,30 @@ func (rc *RevisionCache) Get(docid, revid string) (Body, Body, base.Set, error) 
 	return body, history, channels, err
 }
 
+// Attempts to retrieve the active revision for a document from the cache.  Requires retrieval
+// of the document from the bucket to guarantee the current active revision, but does minimal unmarshalling
+// of the retrieved document to get the current rev from _sync metadata.  If active rev is already in the
+// rev cache, will use it.  Otherwise will add to the rev cache using the raw document obtained in the
+// initial retrieval.
+func (rc *RevisionCache) GetActive(docid string, context *DatabaseContext) (Body, Body, base.Set, string, error) {
+
+	// Look up active rev for doc
+	bucketDoc, err := context.GetDocument(docid, DocUnmarshalSync)
+	if bucketDoc == nil {
+		return nil, nil, nil, "", nil
+	}
+
+	currentRev := bucketDoc.CurrentRev
+
+	// Retrieve from or add to rev cache
+	value := rc.getValue(docid, currentRev, true)
+	body, history, channels, err := value.loadForDoc(bucketDoc, context)
+	if err != nil {
+		rc.removeValue(value) // don't keep failed loads in the cache
+	}
+	return body, history, channels, currentRev, err
+}
+
 // Adds a revision to the cache.
 func (rc *RevisionCache) Put(body Body, history Body, channels base.Set) {
 	if history == nil {
@@ -116,6 +140,24 @@ func (value *revCacheValue) load(loaderFunc RevisionCacheLoaderFunc) (Body, Body
 		if loaderFunc != nil {
 			value.body, value.history, value.channels, value.err = loaderFunc(value.key)
 		}
+	} else {
+		base.StatsExpvars.Add("revisionCache_hits", 1)
+	}
+	body := value.body
+	if body != nil {
+		body = body.ShallowCopy() // Never let the caller mutate the stored body
+	}
+	return body, value.history, value.channels, value.err
+}
+
+// Retrieves the body etc. out of a revCacheValue.  If they aren't already present, loads into the cache value using
+// the provided document.
+func (value *revCacheValue) loadForDoc(doc *document, context *DatabaseContext) (Body, Body, base.Set, error) {
+	value.lock.Lock()
+	defer value.lock.Unlock()
+	if value.body == nil && value.err == nil {
+		base.StatsExpvars.Add("revisionCache_misses", 1)
+		value.body, value.history, value.channels, value.err = context.revCacheLoaderForDocument(doc, value.key.RevID)
 	} else {
 		base.StatsExpvars.Add("revisionCache_hits", 1)
 	}

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -63,8 +63,8 @@ func TestShadowerPull(t *testing.T) {
 		seq, _ := db.LastSequence()
 		return seq >= 2
 	})
-	doc1, _ = db.GetDoc("key1")
-	doc2, _ = db.GetDoc("key2")
+	doc1, _ = db.GetDocument("key1", DocUnmarshalAll)
+	doc2, _ = db.GetDocument("key2", DocUnmarshalAll)
 	assert.DeepEquals(t, doc1.Body(), Body{"foo": float64(1)})
 	assert.DeepEquals(t, doc2.Body(), Body{"bar": float64(-1)})
 
@@ -76,7 +76,7 @@ func TestShadowerPull(t *testing.T) {
 		return seq >= 3
 	})
 
-	doc1, _ = db.GetDoc("key1")
+	doc1, _ = db.GetDocument("key1", DocUnmarshalAll)
 	assert.True(t, doc1.hasFlag(channels.Deleted))
 	_, err = db.Get("key1")
 	assert.DeepEquals(t, err, &base.HTTPError{Status: 404, Message: "deleted"})
@@ -239,7 +239,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 	})
 
 	// Make sure the echoed pull didn't create a new revision:
-	doc, _ := db.GetDoc("foo")
+	doc, _ := db.GetDocument("foo", DocUnmarshalAll)
 	assert.Equals(t, len(doc.History), 1)
 }
 
@@ -339,10 +339,10 @@ func TestShadowerPattern(t *testing.T) {
 		seq, _ := db.LastSequence()
 		return seq >= 2
 	})
-	doc1, err := db.GetDoc("key1")
+	doc1, err := db.GetDocument("key1", DocUnmarshalAll)
 	assertNoError(t, err, fmt.Sprintf("Error getting key1: %v", err))
-	docI, _ := db.GetDoc("ignorekey")
-	doc2, err := db.GetDoc("key2")
+	docI, _ := db.GetDocument("ignorekey", DocUnmarshalAll)
+	doc2, err := db.GetDocument("key2", DocUnmarshalAll)
 	assertNoError(t, err, fmt.Sprintf("Error getting key2: %v", err))
 
 	assert.DeepEquals(t, doc1.Body(), Body{"foo": float64(1)})

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -46,7 +46,6 @@ func TestShadowerPull(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-
 	bucket.Set("key1", 0, Body{"foo": 1})
 	bucket.Set("key2", 0, Body{"bar": -1})
 	bucket.SetRaw("key3", 0, []byte("qwertyuiop")) //will be ignored
@@ -66,8 +65,8 @@ func TestShadowerPull(t *testing.T) {
 	})
 	doc1, _ = db.GetDoc("key1")
 	doc2, _ = db.GetDoc("key2")
-	assert.DeepEquals(t, doc1.body, Body{"foo": float64(1)})
-	assert.DeepEquals(t, doc2.body, Body{"bar": float64(-1)})
+	assert.DeepEquals(t, doc1.Body(), Body{"foo": float64(1)})
+	assert.DeepEquals(t, doc2.Body(), Body{"bar": float64(-1)})
 
 	base.Log("Deleting remote doc")
 	bucket.Delete("key1")
@@ -346,9 +345,9 @@ func TestShadowerPattern(t *testing.T) {
 	doc2, err := db.GetDoc("key2")
 	assertNoError(t, err, fmt.Sprintf("Error getting key2: %v", err))
 
-	assert.DeepEquals(t, doc1.body, Body{"foo": float64(1)})
+	assert.DeepEquals(t, doc1.Body(), Body{"foo": float64(1)})
 	assert.True(t, docI == nil)
-	assert.DeepEquals(t, doc2.body, Body{"bar": float64(-1)})
+	assert.DeepEquals(t, doc2.Body(), Body{"bar": float64(-1)})
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&shadower.pullCount) >= 2

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -317,7 +317,7 @@ func (h *handler) handleActiveTasks() error {
 func (h *handler) handleGetRawDoc() error {
 	h.assertAdminOnly()
 	docid := h.PathVar("docid")
-	doc, err := h.db.GetDoc(docid)
+	doc, err := h.db.GetDocument(docid, db.DocUnmarshalAll)
 	if doc != nil {
 		h.writeJSON(doc)
 	}
@@ -327,7 +327,7 @@ func (h *handler) handleGetRawDoc() error {
 func (h *handler) handleGetRevTree() error {
 	h.assertAdminOnly()
 	docid := h.PathVar("docid")
-	doc, err := h.db.GetDoc(docid)
+	doc, err := h.db.GetDocument(docid, db.DocUnmarshalAll)
 
 	if doc != nil {
 		h.writeText([]byte(doc.History.RenderGraphvizDot()))

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -146,10 +146,12 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 		{"Admin_Simple", "/db/_changes?since=1", ""},
 		{"Admin_Longpoll", "/db/_changes?since=1&feed=longpoll", ""},
 		{"Admin_StyleAllDocs", "/db/_changes?since=1&style=all_docs", ""},
+		{"Admin_StyleAllDocsChannelFilter", "/db/_changes?since=1&style=all_docs&filter=sync_gateway/bychannel&channels=channel_1", ""},
 		{"Admin_IncludeDocs", "/db/_changes?since=1&include_docs=true", ""},
 		{"User_Simple", "/db/_changes?since=1", username},
 		{"User_Longpoll", "/db/_changes?since=1&feed=longpoll", username},
 		{"User_StyleAllDocs", "/db/_changes?since=1&style=all_docs", username},
+		{"User_StyleAllDocsChannelFilter", "/db/_changes?since=1&style=all_docs&filter=sync_gateway/bychannel&channels=channel_1", username},
 		{"User_IncludeDocs", "/db/_changes?since=1&include_docs=true", username},
 	}
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -86,7 +86,7 @@ func (h *handler) handleGetDoc() error {
 
 		if openRevs == "all" {
 			// open_revs=all
-			doc, err := h.db.GetDoc(docid)
+			doc, err := h.db.GetDocument(docid, db.DocUnmarshalSync)
 			if err != nil {
 				return err
 			}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -159,7 +159,7 @@ func (rt *RestTester) SequenceForDoc(docid string) (seq uint64, err error) {
 	if database == nil {
 		return 0, fmt.Errorf("No database found")
 	}
-	doc, err := database.GetDoc(docid)
+	doc, err := database.GetDocument(docid, db.DocUnmarshalAll)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Reduces unmarshalling work done by Sync Gateway with two enhancements:

1. Support retrieval of current rev using revision cache

Adds revisionCache.GetActive(), which does the following:
- retrieves the document from the bucket and unmarshals metadata
- if the current rev is present in the rev cache, retrieves unmarshalled document data from the rev cache
- if the current rev is not present in the rev cache, adds to rev cache using the already retrieved document

Avoids unmarshalling of document body during Get, BulkGet when rev isn't provided, and changes w/ doc id filter.

2. Lazy body unmarshalling by document

Document retrieval supports an optional UnmarshalTo parameter.  If the body is not unmarshalled, the raw body is stored in the document, and only unmarshalled when requested

Avoids unmarshalling of document body during RevsDiff, and is an optimization in cases where unmarshalling the body may or may not be required (open_revs=all, etc)

Fixes #2928