### PR TITLE
Avoid duplicate parsing of request query string

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -346,7 +346,7 @@ func (h *handler) handleSetLogging() error {
 		return nil
 	}
 	if h.getQuery("level") != "" {
-		base.SetLogLevel(int(getRestrictedIntQuery(h.rq.URL.Query(), "level", uint64(base.LogLevel()), 1, 3, false)))
+		base.SetLogLevel(int(getRestrictedIntQuery(h.getQueryValues(), "level", uint64(base.LogLevel()), 1, 3, false)))
 		if len(body) == 0 {
 			return nil // empty body is OK if request is just setting the log level
 		}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -76,7 +76,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 		return channelsArray, docIdsArray, nil
 	}
 
-	values := h.rq.URL.Query()
+	values := h.getQueryValues()
 
 	if _, ok := values["feed"]; ok {
 		*feed = h.getQuery("feed")
@@ -134,7 +134,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 
 	if _, ok := values["heartbeat"]; ok {
 		options.HeartbeatMs = getRestrictedIntQuery(
-			h.rq.URL.Query(),
+			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
@@ -145,7 +145,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 
 	if _, ok := values["timeout"]; ok {
 		options.TimeoutMs = getRestrictedIntQuery(
-			h.rq.URL.Query(),
+			h.getQueryValues(),
 			"timeout",
 			kDefaultTimeoutMS,
 			0,
@@ -203,7 +203,7 @@ func (h *handler) handleChanges() error {
 		}
 
 		options.HeartbeatMs = getRestrictedIntQuery(
-			h.rq.URL.Query(),
+			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
@@ -211,7 +211,7 @@ func (h *handler) handleChanges() error {
 			true,
 		)
 		options.TimeoutMs = getRestrictedIntQuery(
-			h.rq.URL.Query(),
+			h.getQueryValues(),
 			"timeout",
 			kDefaultTimeoutMS,
 			0,

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -76,6 +76,7 @@ type handler struct {
 	serialNumber   uint64
 	loggedDuration bool
 	runOffline     bool
+	queryValues    url.Values // Copy of results of rq.URL.Query()
 }
 
 type handlerPrivs int
@@ -376,8 +377,15 @@ func (h *handler) SetPathVar(name string, value string) {
 	mux.Vars(h.rq)[name] = url.QueryEscape(value)
 }
 
+func (h *handler) getQueryValues() url.Values {
+	if h.queryValues == nil {
+		h.queryValues = h.rq.URL.Query()
+	}
+	return h.queryValues
+}
+
 func (h *handler) getQuery(query string) string {
-	return h.rq.URL.Query().Get(query)
+	return h.getQueryValues().Get(query)
 }
 
 func (h *handler) getJSONStringQuery(query string) string {
@@ -405,7 +413,7 @@ func (h *handler) getOptBoolQuery(query string, defaultValue bool) bool {
 
 // Returns the integer value of a URL query, defaulting to 0 if unparseable
 func (h *handler) getIntQuery(query string, defaultValue uint64) (value uint64) {
-	return getRestrictedIntQuery(h.rq.URL.Query(), query, defaultValue, 0, 0, false)
+	return getRestrictedIntQuery(h.getQueryValues(), query, defaultValue, 0, 0, false)
 }
 
 func (h *handler) getJSONQuery(query string) (value interface{}, err error) {

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -149,7 +149,7 @@ func (h *handler) handleOidcTestProviderAuthorize() error {
 
 	base.LogTo("OIDC", "handleOidcTestProviderAuthorize() raw authorize request raw query params = %v", requestParams)
 
-	scope := h.rq.URL.Query().Get("scope")
+	scope := h.getQueryValues().Get("scope")
 	if scope == "" {
 		return base.HTTPErrorf(http.StatusBadRequest, "missing scope parameter")
 	}
@@ -263,7 +263,7 @@ func (h *handler) handleOidcTestProviderAuthenticate() error {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
-	requestParams := h.rq.URL.Query()
+	requestParams := h.getQueryValues()
 	username := h.rq.FormValue("username")
 	tokenttl, err := strconv.Atoi(h.rq.FormValue("tokenttl"))
 	if err != nil {


### PR DESCRIPTION
Stores the results of rq.URL.Query() on the handler for reuse when processing a request with multiple query string parameters.

Fixes #1850