### PR TITLE
Re-enable TestChannelIndexSimpleReadSingle since GoCB.Append() was impld

### DIFF
--- a/db/channel_index_test.go
+++ b/db/channel_index_test.go
@@ -486,11 +486,6 @@ func TestChannelIndexBulkGet10(t *testing.T) {
 
 func TestChannelIndexSimpleReadSingle(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is only working against Walrus currently, since GoCB.Append() not impl'd. " +
-			"Fails with logs: https://gist.github.com/tleyden/8bf960cac555feff66425a3ffdaabed9")
-	}
-
 	log.Printf("Test single...")
 	// num vbuckets
 	vbCount := 1024

--- a/db/channel_index_test.go
+++ b/db/channel_index_test.go
@@ -516,11 +516,6 @@ func TestChannelIndexSimpleReadBulk(t *testing.T) {
 
 func TestChannelIndexPartitionReadSingle(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is only working against Walrus currently, since GoCB.Append() not impl'd. " +
-			"Fails with logs: https://gist.github.com/tleyden/8bf960cac555feff66425a3ffdaabed9")
-	}
-
 	log.Printf("Test single...")
 	// num vbuckets
 	vbCount := 16
@@ -538,11 +533,6 @@ func TestChannelIndexPartitionReadSingle(t *testing.T) {
 }
 
 func TestChannelIndexPartitionReadBulk(t *testing.T) {
-
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is only working against Walrus currently, since GoCB.Append() not impl'd. " +
-			"Fails with logs: https://gist.github.com/tleyden/8bf960cac555feff66425a3ffdaabed9")
-	}
 
 	log.Printf("Test single...")
 	// num vbuckets


### PR DESCRIPTION
According to the test comments: This test is only working against Walrus currently, since GoCB.Append() not impl'd.  Since GoCB.Append() was impld, this test now passes.  I tested locally.