### PR TITLE
Feature/issue 2999 test post changes user timing

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -50,7 +50,7 @@ type syncData struct {
 	Flags           uint8               `json:"flags,omitempty"`
 	Sequence        uint64              `json:"sequence,omitempty"`
 	UnusedSequences []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
-	RecentSequences []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
+	RecentSequences []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling (dcp coalescing)
 	History         RevTree             `json:"history"`
 	Channels        channels.ChannelMap `json:"channels,omitempty"`
 	Access          UserAccessMap       `json:"access,omitempty"`

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -897,10 +897,6 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 
 }
 
-// Open two databases that will share the same _sync:seq
-// Create a hole in the sequence allocation since one bulk doc is rejected
-// Make sure that sequences on docs are always monotonically increasing
-// Added to verify SG Issue 2724
 func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 
 	//We want a sync function that will reject some docs, create two to simulate two SG instances
@@ -958,17 +954,17 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	//Sequence 3 does not get used here as its using a different sequence allocator
-	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
+	doc21Rev, _ := rt2.GetDatabase().GetDocSyncData("bulk21")
 	assert.Equals(t, doc21Rev.Sequence, uint64(4))
 
-	doc22Rev, err := rt2.GetDatabase().GetDocSyncData("bulk22")
+	doc22Rev, _ := rt2.GetDatabase().GetDocSyncData("bulk22")
 	assert.Equals(t, doc22Rev.Sequence, uint64(5))
 
-	doc23Rev, err := rt2.GetDatabase().GetDocSyncData("bulk23")
+	doc23Rev, _ := rt2.GetDatabase().GetDocSyncData("bulk23")
 	assert.Equals(t, doc23Rev.Sequence, uint64(6))
 
 	//Validate rev2 of doc "bulk1" has a new revision
-	doc1Rev2, err := rt2.GetDatabase().GetDocSyncData("bulk1")
+	doc1Rev2, _ := rt2.GetDatabase().GetDocSyncData("bulk1")
 	assert.Equals(t, doc1Rev2.Sequence, uint64(7))
 
 	//Get the revID for doc "bulk1"
@@ -987,7 +983,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	doc1Rev3, _ := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assert.Equals(t, doc1Rev3.Sequence, uint64(8))
 
-	// validate the doc _sync metadata, should not see last sequence lower than previous sequence
+	//validate the doc _sync metadata, should see last sequence lower than previous sequence
 	rs := doc1Rev3.RecentSequences
 	assert.Equals(t, len(rs), 3)
 	assert.Equals(t, rs[0], uint64(1))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -897,6 +897,10 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 
 }
 
+// Open two databases that will share the same _sync:seq
+// Create a hole in the sequence allocation since one bulk doc is rejected
+// Make sure that sequences on docs are always monotonically increasing
+// Added to verify SG Issue 2724
 func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 
 	//We want a sync function that will reject some docs, create two to simulate two SG instances
@@ -954,17 +958,17 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	//Sequence 3 does not get used here as its using a different sequence allocator
-	doc21Rev, _ := rt2.GetDatabase().GetDocSyncData("bulk21")
+	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
 	assert.Equals(t, doc21Rev.Sequence, uint64(4))
 
-	doc22Rev, _ := rt2.GetDatabase().GetDocSyncData("bulk22")
+	doc22Rev, err := rt2.GetDatabase().GetDocSyncData("bulk22")
 	assert.Equals(t, doc22Rev.Sequence, uint64(5))
 
-	doc23Rev, _ := rt2.GetDatabase().GetDocSyncData("bulk23")
+	doc23Rev, err := rt2.GetDatabase().GetDocSyncData("bulk23")
 	assert.Equals(t, doc23Rev.Sequence, uint64(6))
 
 	//Validate rev2 of doc "bulk1" has a new revision
-	doc1Rev2, _ := rt2.GetDatabase().GetDocSyncData("bulk1")
+	doc1Rev2, err := rt2.GetDatabase().GetDocSyncData("bulk1")
 	assert.Equals(t, doc1Rev2.Sequence, uint64(7))
 
 	//Get the revID for doc "bulk1"
@@ -983,7 +987,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	doc1Rev3, _ := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assert.Equals(t, doc1Rev3.Sequence, uint64(8))
 
-	//validate the doc _sync metadata, should see last sequence lower than previous sequence
+	// validate the doc _sync metadata, should not see last sequence lower than previous sequence
 	rs := doc1Rev3.RecentSequences
 	assert.Equals(t, len(rs), 3)
 	assert.Equals(t, rs[0], uint64(1))


### PR DESCRIPTION
Attempt to rework `TestPostChangesUserTiming` and remove unreliable `time.Sleep(2 * time.Second)` call.

Note the timing in the test output:

```
2017-11-07 14:09:08.775265 I | TEST: ChangesLongPoller calling _changes API
.. 1 second
.. 2 seconds
.. 5 seconds
2017-11-07 14:09:13.775242 I | TEST: Put a doc in channel bernard, that also grants bernard access to channel PBS
2017-11-07 14:09:13.778520 I | TEST: Got changes response from changesLongPoller.ResultChan
```

which shows that the test blocks a full five seconds before granting channel access, which should be plenty of time for the `NewChangesLongPoller` to get into a blocking longpoll changes request.  

I also put a comment that describes where the test can have an invalid passing result, which would require 5 seconds to pass between these two function calls:

```
	c.AboutToCallChangesWg.Done()  // If > 5 seconds passes in between this call and the next call getting into a blocking longpoll changes feed, the test passing result will be invalid
	changesResponse := c.IndexTester.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
```

So it's not 100% reliable, but the cases where it takes 5 seconds between those method calls should be extremely rare, and probably indicates some other problems like a completely CPU starved system.  Also, those cases will be "No-op passes" rather than sporadic failures.

There is a double-check that ensures that the changes response is returned only *after* the channel grant has happened, which would catch bugs where Sync Gateway returned the docs erroneously and didn't even block.

Full test output:

```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/tleyden/Development/sync_gateway/godeps #gosetup
/usr/local/go/bin/go test -c -i -o /private/var/folders/l7/hr7n2gb52nz0vn9lq_x2prcr0000gn/T/___TestPostChangesUserTiming_in_changes_api_test_go github.com/couchbase/sync_gateway/rest #gosetup
/private/var/folders/l7/hr7n2gb52nz0vn9lq_x2prcr0000gn/T/___TestPostChangesUserTiming_in_changes_api_test_go -test.v -test.run ^TestPostChangesUserTiming$ #gosetup

2017-11-07T14:09:08.692-08:00 Opening db /db as bucket "sg_bucket", pool "default", server <walrus:>
2017-11-07T14:09:08.692-08:00 Opening Walrus database sg_bucket on <walrus:>
2017-11-07T14:09:08.773-08:00 HTTP:  #002: PUT http://localhost/db/pbs1  (ADMIN)
2017-11-07T14:09:08.773-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{_sync:user:bernard}") count=2
2017-11-07T14:09:08.774-08:00 HTTP:  #003: PUT http://localhost/db/pbs2  (ADMIN)
2017-11-07T14:09:08.775-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{*, PBS}") count=3
2017-11-07T14:09:08.775-08:00 HTTP:  #004: PUT http://localhost/db/pbs3  (ADMIN)
2017-11-07T14:09:08.775-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{*, PBS}") count=4
2017-11-07 14:09:08.775265 I | TEST: ChangesLongPoller calling _changes API
2017-11-07T14:09:08.775-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{*, PBS}") count=5
2017-11-07T14:09:08.849-08:00 HTTP:  #005: POST http://localhost/db/_changes  (as bernard)
2017-11-07T14:09:08.849-08:00 Changes+: Changes POST request.  URL: http://localhost/db/_changes, feed: longpoll, options: {Since:0 Limit:50 Conflicts:true IncludeDocs:false Wait:false Continuous:false Terminator:<nil> HeartbeatMs:0 TimeoutMs:6000 ActiveOnly:false}, filter: , bychannel: [], docIds: []   (to bernard)
2017-11-07T14:09:08.849-08:00 Changes+: Int sequence multi changes feed...
2017-11-07T14:09:08.849-08:00 Changes: MultiChangesFeed(channels: {*}, options: {Since:0 Limit:50 Conflicts:true IncludeDocs:false Wait:true Continuous:false Terminator:0xc420082cc0 HeartbeatMs:0 TimeoutMs:6000 ActiveOnly:false}) ...   (to bernard)
2017-11-07T14:09:08.850-08:00 Changes: simple changes cannot get Close Notifier from ResponseWriter
2017-11-07T14:09:08.850-08:00 Changes+: MultiChangesFeed: channels expand to "!:1,bernard:1" ...   (to bernard)
2017-11-07T14:09:08.850-08:00 Changes+: [changesFeed] Found 0 changes for channel !
2017-11-07T14:09:08.850-08:00 Changes+: [changesFeed] Found 0 changes for channel bernard
2017-11-07T14:09:08.850-08:00 Changes+: MultiChangesFeed waiting...   (to bernard)
2017-11-07T14:09:08.850-08:00 Changes+: No new changes to send to change listener.  Waiting for "sg_bucket"'s count to pass 2
2017-11-07 14:09:13.775242 I | TEST: Put a doc in channel bernard, that also grants bernard access to channel PBS

2017-11-07T14:09:13.775-08:00 HTTP:  #006: PUT http://localhost/db/grant1  (ADMIN)

2017-11-07T14:09:13.775-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{*, bernard}") count=6

2017-11-07T14:09:13.775-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{_sync:user:bernard}") count=7

2017-11-07T14:09:13.775-08:00 Changes+: MultiChangesFeed reloading user &{roleImpl:{Name_:bernard ExplicitChannels_:bernard:1 Channels_:!:1,bernard:1 Sequence_:0 PreviousChannels_: vbNo:<nil>} userImplBody:{Email_: Disabled_:false PasswordHash_:[36 50 97 36 49 48 36 49 78 118 105 57 85 115 88 110 49 118 46 116 119 112 84 72 70 81 88 53 101 57 98 98 73 108 78 82 82 57 114 57 50 110 116 120 90 107 102 79 70 55 109 53 83 74 119 72 51 108 75 75] OldPasswordHash_:<nil> ExplicitRoles_: RolesSince_: OldExplicitRoles_:[]} auth:0xc42017d4e0 roles:[]}

2017-11-07T14:09:13.778-08:00 Changes+: New channels found after user reload: {PBS}

2017-11-07T14:09:13.778-08:00 Changes+: MultiChangesFeed: channels expand to "!:1,PBS:4,bernard:1" ...   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: [changesFeed] Found 3 changes for channel PBS

2017-11-07T14:09:13.778-08:00 Changes+: Notifying that "sg_bucket" changed (keys="{_sync:user:bernard}") count=8

2017-11-07T14:09:13.778-08:00 Changes+: [changesFeed] Found 0 changes for channel !

2017-11-07T14:09:13.778-08:00 Changes+: [changesFeed] Found 1 changes for channel bernard

2017-11-07T14:09:13.778-08:00 Changes+: Channel feed processing seq:4 in channel bernard   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: Channel feed processing seq:4:1 in channel PBS   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: Channel feed processing seq:4:2 in channel PBS   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: Channel feed processing seq:4:3 in channel PBS   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: MultiChangesFeed sending {Seq:4:1, ID:pbs1, Changes:[map[rev:1-d0a8b968f2a1f73e217e86fc9d305f33]]}   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: MultiChangesFeed sending {Seq:4:2, ID:pbs2, Changes:[map[rev:1-df10685db181133cd153bad582ce0053]]}   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: MultiChangesFeed sending {Seq:4:3, ID:pbs3, Changes:[map[rev:1-4cbdda0337b3802796c6267ca3f833d2]]}   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes+: MultiChangesFeed sending {Seq:4, ID:grant1, Changes:[map[rev:1-e2ffba3f9615502da24772a2f1d82756]]}   (to bernard)

2017-11-07T14:09:13.778-08:00 Changes: MultiChangesFeed done   (to bernard)

2017-11-07 14:09:13.778520 I | TEST: Got changes response from changesLongPoller.ResultChan

2017-11-07T14:09:13.778-08:00 Changes+: changeListener.Stop() called

2017-11-07T14:09:13.778-08:00 Changes+: Notifying that changeListener is stopping

Process finished with exit code 0
```
