### PR TITLE
Defensive handling for empty DCP xattr payload

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -30,6 +30,7 @@ const (
 	importCancelledFilter = sgErrorCode(0x05)
 	documentMigrated      = sgErrorCode(0x06)
 	fatalBucketConnection = sgErrorCode(0x07)
+	emptyMetadata         = sgErrorCode(0x08)
 )
 
 type SGError struct {
@@ -45,6 +46,7 @@ var (
 	ErrImportCancelledFilter = &SGError{importCancelledFilter}
 	ErrDocumentMigrated      = &SGError{documentMigrated}
 	ErrFatalBucketConnection = &SGError{fatalBucketConnection}
+	ErrEmptyMetadata         = &SGError{emptyMetadata}
 )
 
 func (e SGError) Error() string {
@@ -65,6 +67,8 @@ func (e SGError) Error() string {
 		return "Timeout performing ViewQuery - could indicate that views are still reindexing"
 	case fatalBucketConnection:
 		return "Fatal error connecting to bucket"
+	case emptyMetadata:
+		return "Empty Sync Gateway metadata"
 	default:
 		return "Unknown error"
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -387,6 +387,9 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 		if event.DataType != base.MemcachedDataTypeRaw {
 			base.LogTo("Cache+", "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", docID, err)
 		}
+		if err == base.ErrEmptyMetadata {
+			base.Warn("Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", event.Key, event.Opcode, event.DataType)
+		}
 		return
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -237,6 +237,10 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory 
 
 func parseXattrStreamData(xattrName string, data []byte) (body []byte, xattr []byte, err error) {
 
+	if len(data) < 4 {
+		return nil, nil, base.ErrEmptyMetadata
+	}
+
 	xattrsLen := binary.BigEndian.Uint32(data[0:4])
 	body = data[xattrsLen+4:]
 	if xattrsLen == 0 {

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbaselabs/go.assert"
 )
 
@@ -211,6 +212,12 @@ func TestParseXattr(t *testing.T) {
 	assertNoError(t, err, "Unexpected error parsing dcp body")
 	assert.Equals(t, string(resultBody), string(body))
 	assert.Equals(t, string(resultXattr), "")
+
+	// Attempt to retrieve xattr from empty dcp body
+	emptyBody, emptyXattr, emptyErr := parseXattrStreamData("_sync", []byte{})
+	assert.Equals(t, emptyErr, base.ErrEmptyMetadata)
+	assertTrue(t, emptyBody == nil, "Nil body expected")
+	assertTrue(t, emptyXattr == nil, "Nil xattr expected")
 }
 
 func TestParseDocumentCas(t *testing.T) {


### PR DESCRIPTION
Fixes #3009.  Avoids panic, includes better diagnostic logging.