### PR TITLE
Fixes #3002 Sporadic test failure: TestDBOnlineConcurrent

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1054,12 +1054,10 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	//They may not have been processed at this point
 	wg.Wait()
 
-	time.Sleep(1500 * time.Millisecond)
+	// Wait for DB to come online (retry loop)
+	errDbOnline := rt.WaitForDBOnline()
+	assertNoError(t, errDbOnline, "Error waiting for db to come online")
 
-	response = rt.SendAdminRequest("GET", "/db/", "")
-	body = nil
-	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
 }
 
 // Test bring DB online with delay of 1 second
@@ -1090,12 +1088,13 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	assert.True(t, body["state"].(string) == "Offline")
 
+	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
 	time.Sleep(1500 * time.Millisecond)
 
-	response = rt.SendAdminRequest("GET", "/db/", "")
-	body = nil
-	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	// Wait for DB to come online (retry loop)
+	errDbOnline := rt.WaitForDBOnline()
+	assertNoError(t, errDbOnline, "Error waiting for db to come online")
+
 }
 
 // Test bring DB online with delay of 2 seconds
@@ -1137,12 +1136,13 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	assert.True(t, body["state"].(string) == "Online")
 
+	// Wait until after the 2 second delay, since the online request explicitly asked for a delay
 	time.Sleep(2500 * time.Millisecond)
 
-	response = rt.SendAdminRequest("GET", "/db/", "")
-	body = nil
-	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	// Wait for DB to come online (retry loop)
+	errDbOnline := rt.WaitForDBOnline()
+	assertNoError(t, errDbOnline, "Error waiting for db to come online")
+
 }
 
 // Test bring DB online concurrently with delay of 1 second

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1128,8 +1128,9 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	rt.SendAdminRequest("POST", "/db/_online", "")
 	assertStatus(t, response, 200)
 
-	//Allow online goroutine to get scheduled
-	time.Sleep(500 * time.Millisecond)
+	// Wait for DB to come online (retry loop)
+	errDbOnline := rt.WaitForDBOnline()
+	assertNoError(t, errDbOnline, "Error waiting for db to come online")
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1140,7 +1141,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	time.Sleep(2500 * time.Millisecond)
 
 	// Wait for DB to come online (retry loop)
-	errDbOnline := rt.WaitForDBOnline()
+	errDbOnline = rt.WaitForDBOnline()
 	assertNoError(t, errDbOnline, "Error waiting for db to come online")
 
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -353,7 +353,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 
 func (rt *RestTester) WaitForDBOnline() (err error) {
 
-	maxTries := 50
+	maxTries := 20
 
 	for i := 0; i < maxTries; i++ {
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -351,6 +351,29 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 
 }
 
+func (rt *RestTester) WaitForDBOnline() (err error) {
+
+	maxTries := 50
+
+	for i := 0; i < maxTries; i++ {
+
+		response := rt.SendAdminRequest("GET", "/db/", "")
+		var body db.Body
+		json.Unmarshal(response.Body.Bytes(), &body)
+
+		if body["state"].(string) == "Online" {
+			return
+		}
+
+		// Otherwise, sleep and try again
+		time.Sleep(500 * time.Millisecond)
+
+	}
+
+	return fmt.Errorf("Give up waiting for DB to come online after %d attempts", maxTries)
+
+}
+
 func (rt *RestTester) SendAdminRequestWithHeaders(method, resource string, body string, headers map[string]string) *TestResponse {
 	input := bytes.NewBufferString(body)
 	request, _ := http.NewRequest(method, "http://localhost"+resource, input)


### PR DESCRIPTION
Fixes #3002 by doing a retry loop to wait until the db is online (waits up to 25 seconds)