### PR TITLE
MB-26435: Correct directory permissions setting for OpenShift validation

### DIFF
--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -78,8 +78,6 @@ fi
 
 # ln -f -s $RPM_INSTALL_PREFIX0 @@PREFIX@@
 
-chmod a+x $RPM_INSTALL_PREFIX0/examples
-
 if [ -z `id -u @@PRODUCT_EXEC@@ 2>/dev/null` ]; then
   useradd -m @@PRODUCT_EXEC@@
 fi
@@ -198,7 +196,7 @@ exit 0
 
 %dir %attr (0755, bin, bin) @@PREFIX@@/bin
 %dir %attr (0755, bin, bin) @@PREFIX@@/tools
-%dir %attr (0644, bin, bin) @@PREFIX@@/examples
+%dir %attr (0755, bin, bin) @@PREFIX@@/examples
 %dir %attr (0755, bin, bin) @@PREFIX@@/service
 
 # Files


### PR DESCRIPTION
For some strange reason, the 'examples' directory had a mode setting of
0644 in the '%files' section, then post-install it's given a 'chmod a+x'
to correct it.  This is really wrong, and actually causes validation of
the RPM on OpenShift to fail because the permissions of the directory
were modified after installation.  Correcting it in the RPM spec file.