### PR TITLE
Feature/issue 3006 test user access race

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -366,6 +366,9 @@ func TestLogging(t *testing.T) {
 	var rt RestTester
 	defer rt.Close()
 
+	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
+	rt.SendAdminRequest("PUT", "/_logging", `{}`)
+
 	//Assert default log channels are enabled
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]interface{}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -292,12 +292,15 @@ function(doc, oldDoc) {
 
 	// Start changes feed
 	var wg sync.WaitGroup
+
+	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
-		wg.Add(1)
+
 		// Timeout allows us to read continuous changes after processing is complete.  Needs to be long enough to
 		// ensure it doesn't terminate before the first change is sent.
-		changesResponse := rt.Send(requestByUser("GET", "/db/_changes?feed=continuous&since=0&timeout=20000", "", "bernard"))
+		changesResponse := rt.Send(requestByUser("GET", "/db/_changes?feed=continuous&since=0&timeout=10000", "", "bernard"))
 
 		changes, err := readContinuousChanges(changesResponse)
 		assert.Equals(t, err, nil)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -302,8 +302,7 @@ function(doc, oldDoc) {
 	go func() {
 		defer wg.Done()
 
-		var since uint64
-		since = 0
+		since := ""
 
 		maxTries := 10
 		numTries := 0
@@ -314,7 +313,7 @@ function(doc, oldDoc) {
 
 			// Timeout allows us to read continuous changes after processing is complete.  Needs to be long enough to
 			// ensure it doesn't terminate before the first change is sent.
-			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%d&timeout=5000", since), "", "bernard"))
+			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%d&timeout=2000", since), "", "bernard"))
 
 			changes, err := readContinuousChanges(changesResponse)
 			assert.Equals(t, err, nil)
@@ -328,7 +327,7 @@ function(doc, oldDoc) {
 
 			// Advance the since value if we got any changes
 			if len(changes) > 0 {
-				since = changes[len(changes) - 1].Seq.Seq
+				since = changes[len(changes) - 1].Seq.String()
 			}
 
 			numTries++

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -269,6 +269,7 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/_logging", `{"HTTP":true}`)
+	defer rt.SendAdminRequest("PUT", "/_logging", `{}`)  // reset logging to initial state
 
 	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["profile-bernard"]}`)
 	assertStatus(t, response, 201)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -239,7 +239,7 @@ func TestUserAllowEmptyPassword(t *testing.T) {
 }
 
 // Test user access grant while that user has an active changes feed.  (see issue #880)
-func DisabledTestUserAccessRace(t *testing.T) {
+func TestUserAccessRace(t *testing.T) {
 
 	syncFunction := `
 function(doc, oldDoc) {
@@ -297,7 +297,7 @@ function(doc, oldDoc) {
 		wg.Add(1)
 		// Timeout allows us to read continuous changes after processing is complete.  Needs to be long enough to
 		// ensure it doesn't terminate before the first change is sent.
-		changesResponse := rt.Send(requestByUser("GET", "/db/_changes?feed=continuous&since=0&timeout=2000", "", "bernard"))
+		changesResponse := rt.Send(requestByUser("GET", "/db/_changes?feed=continuous&since=0&timeout=20000", "", "bernard"))
 
 		changes, err := readContinuousChanges(changesResponse)
 		assert.Equals(t, err, nil)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -313,7 +313,7 @@ function(doc, oldDoc) {
 
 			// Timeout allows us to read continuous changes after processing is complete.  Needs to be long enough to
 			// ensure it doesn't terminate before the first change is sent.
-			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%d&timeout=2000", since), "", "bernard"))
+			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard"))
 
 			changes, err := readContinuousChanges(changesResponse)
 			assert.Equals(t, err, nil)


### PR DESCRIPTION
Fixes #3006 

Changes:

- Increase the timeout from 2s -> 5s on the changes feed
- Add retry loop for getting changes for cases where the system is extremely slow
- I tested that this fixes the artificial failing scenario reported in https://github.com/couchbase/sync_gateway/issues/3006#issuecomment-343026684, using an appropriately scaled `maxRetries` setting
- Pull out the `wg.Add(1)` outside of the goroutine as a best practice (doesn't cause any real issues)

Integration test:

- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/95 (passing)
