### PR TITLE
Permit tombstoning of existing conflicts when allow_conflicts=false

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -845,6 +845,60 @@ func TestNoConflictsMode(t *testing.T) {
 	assertHTTPError(t, err, 409)
 }
 
+// Test tombstoning of existing conflicts after AllowConflicts is set to false
+func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
+	db, testBucket := setupTestDB(t)
+	defer testBucket.Close()
+	defer tearDownTestDB(t, db)
+
+	// Create documents with multiple non-deleted branches
+	log.Printf("Creating docs")
+	body := Body{"n": 1}
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}), "add 1-a")
+	assertNoError(t, db.PutExistingRev("doc2", body, []string{"1-a"}), "add 1-a")
+	assertNoError(t, db.PutExistingRev("doc3", body, []string{"1-a"}), "add 1-a")
+
+	// Create two conflicting changes:
+	body["n"] = 2
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"2-b", "1-a"}), "add 2-b")
+	assertNoError(t, db.PutExistingRev("doc2", body, []string{"2-b", "1-a"}), "add 2-b")
+	assertNoError(t, db.PutExistingRev("doc3", body, []string{"2-b", "1-a"}), "add 2-b")
+	body["n"] = 3
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"2-a", "1-a"}), "add 2-a")
+	assertNoError(t, db.PutExistingRev("doc2", body, []string{"2-a", "1-a"}), "add 2-a")
+	assertNoError(t, db.PutExistingRev("doc3", body, []string{"2-a", "1-a"}), "add 2-a")
+
+	// Set AllowConflicts to false
+	db.Options.UnsupportedOptions.AllowConflicts = base.BooleanPointer(false)
+	delete(body, "n")
+	body["_deleted"] = true
+
+	// Attempt to tombstone a non-leaf node of a conflicted document
+	err := db.PutExistingRev("doc1", body, []string{"2-c", "1-a"})
+	assertTrue(t, err != nil, "expected error tombstoning non-leaf")
+
+	// Tombstone the non-winning branch of a conflicted document
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"3-a", "2-a"}), "add 3-a (tombstone)")
+	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
+	assertNoError(t, err, "Retrieve doc post-tombstone")
+	assert.Equals(t, doc.CurrentRev, "2-b")
+
+	// Tombstone the winning branch of a conflicted document
+	assertNoError(t, db.PutExistingRev("doc2", body, []string{"3-b", "2-b"}), "add 3-b (tombstone)")
+	doc, err = db.GetDocument("doc2", DocUnmarshalAll)
+	assertNoError(t, err, "Retrieve doc post-tombstone")
+	assert.Equals(t, doc.CurrentRev, "2-a")
+
+	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
+	db.RevsLimit = uint32(1)
+	assertNoError(t, db.PutExistingRev("doc3", body, []string{"3-a", "2-a"}), "add 3-a (tombstone)")
+	doc, err = db.GetDocument("doc3", DocUnmarshalAll)
+	assertNoError(t, err, "Retrieve doc post-tombstone")
+	assert.Equals(t, doc.CurrentRev, "2-b")
+
+	log.Printf("tombstoned conflicts: %+v", doc)
+}
+
 func TestSyncFnOnPush(t *testing.T) {
 
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})


### PR DESCRIPTION
Fixes #3049 

Enables tombstoning of conflicts created prior to allow_conflicts=false being enabled.