### PR TITLE
Adjust maxRecentSequence handling

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -881,7 +881,7 @@ func (db *Database) updateAndReturnDoc(
 				doc.RecentSequences = make([]uint64, 0, 1+len(unusedSequences))
 			}
 
-			if len(doc.RecentSequences) > kMaxRecentSequences {
+			if len(doc.RecentSequences) >= kMaxRecentSequences {
 				// Prune recent sequences that are earlier than the nextSequence.  The dedup window
 				// on the feed is small - sub-second, so we usually shouldn't care about more than
 				// a few recent sequences.  However, the pruning has some overhead (read lock on nextSequence),

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1308,8 +1308,8 @@ func TestRecentSequenceHistory(t *testing.T) {
 	assert.True(t, err == nil)
 	assert.DeepEquals(t, doc.RecentSequences, expectedRecent)
 
-	// Add kMaxRecentSequences more revisions - validate they are retained when total is less than max
-	for i := 0; i < kMaxRecentSequences; i++ {
+	// Add up to kMaxRecentSequences revisions - validate they are retained when total is less than max
+	for i := 1; i < kMaxRecentSequences; i++ {
 		revid, err = db.Put("doc1", body)
 		seqTracker++
 		expectedRecent = append(expectedRecent, seqTracker)


### PR DESCRIPTION
Previously it pruned when number of recent sequences persisted to the doc exceeded kMaxRecentSequences, which meant that a given doc could store kMaxRecentSequences+1.  Switched to prune at >= kMaxRecentSequences, which is more intuitive behaviour.

Unit test that was previously asserting incorrectly (based on unintuitive behaviour) could fail intermittently (when it happened to land on kMaxRecentSequences+1) - should now pass consistently.

(Re-) Fixes #3004