### PR TITLE
Inclusive_end should be true if not specified

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2145,7 +2145,9 @@ func applyViewQueryOptions(viewQuery *gocb.ViewQuery, params map[string]interfac
 	if _, ok := params[ViewQueryParamEndKey]; ok {
 		endKey = params[ViewQueryParamEndKey]
 	}
-	inclusiveEnd := false
+
+	// Default value of inclusiveEnd in Couchbase Server is true (if not specified)
+	inclusiveEnd := true
 	if _, ok := params[ViewQueryParamInclusiveEnd]; ok {
 		inclusiveEnd = asBool(params[ViewQueryParamInclusiveEnd])
 	}

--- a/base/util.go
+++ b/base/util.go
@@ -742,3 +742,18 @@ func SafeSlice(data []byte, from int, to int) ([]byte, error) {
 	}
 	return data[from:to], nil
 }
+
+// Returns string representation of an expvar, given map name and key name
+func GetExpvarAsString(mapName string, name string) string {
+	mapVar := expvar.Get(mapName)
+	expvarMap, ok := mapVar.(*expvar.Map)
+	if !ok {
+		return ""
+	}
+	value := expvarMap.Get(name)
+	if value != nil {
+		return value.String()
+	} else {
+		return ""
+	}
+}

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -38,11 +38,11 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	entries := make(LogEntries, 0)
 	activeEntryCount := 0
 
+	base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, options.Since.SafeSequence()+1, endSeq, options.Limit)
 	// Loop for active-only and limit handling.
 	// The set of changes we get back from the view applies the limit, but includes both active and non-active entries.  When retrieving changes w/ activeOnly=true and a limit,
 	// this means we may need multiple view calls to get a total of [limit] active entries.
 	for {
-		base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, options.Since.SafeSequence()+1, endSeq, options.Limit)
 		vres := channelsViewResult{}
 		err := dbc.Bucket.ViewCustom(DesignDocSyncGateway, ViewChannels, optMap, &vres)
 		if err != nil {
@@ -57,6 +57,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 		}
 
 		// Convert the output to LogEntries:
+		highSeq := uint64(0)
 		for _, row := range vres.Rows {
 			entry := &LogEntry{
 				Sequence:     uint64(row.Key[1].(float64)),
@@ -74,14 +75,22 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 				}
 			}
 			entries = append(entries, entry)
-			optMap["startkey"] = []interface{}{channelName, entry.Sequence + 1}
+			highSeq = entry.Sequence
 		}
 
-		// If active-only, loop until we've retrieved at least (Limit) active entries
+		// If active-only, loop until either retrieve (limit) entries, or reach endSeq
 		if options.ActiveOnly {
+			// If we've reached limit, we're done
 			if activeEntryCount >= options.Limit || options.Limit == 0 {
 				break
 			}
+			// If we've reached endSeq, we're done
+			if endSeq > 0 && highSeq >= endSeq {
+				break
+			}
+			// Otherwise update startkey and re-query
+			optMap["startkey"] = []interface{}{channelName, highSeq + 1}
+			base.LogTo("Cache", "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", channelName, highSeq+1, endSeq, options.Limit)
 		} else {
 			// If not active-only, we only need one iteration of the loop - the limit applied to the view query is sufficient
 			break

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -751,11 +751,6 @@ func TestSessionExtension(t *testing.T) {
 
 func TestSessionAPI(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is currently not passing against a Couchbase server bucket.  Needs investigation." +
-			"Logs: https://gist.github.com/tleyden/a0956455be0130ba22f2aef56a346de2")
-	}
-
 	var rt RestTester
 	defer rt.Close()
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1151,6 +1151,74 @@ func changesActiveOnly(t *testing.T, it indexTester) {
 	}
 }
 
+// Tests view backfill and validates that results are prepended to cache
+func TestChangesViewBackfill(t *testing.T) {
+	rt := RestTester{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	defer rt.Close()
+
+	response := rt.SendAdminRequest("PUT", "/_logging", `{"HTTP":true, "Changes":true, "Changes+":true, "Cache":true, "Cache+":true}`)
+	assert.True(t, response != nil)
+
+	// Create user:
+	a := rt.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("PBS", "ABC"))
+	assert.True(t, err == nil)
+	a.Save(bernard)
+
+	// Put several documents
+	response = rt.SendAdminRequest("PUT", "/db/doc1", `{"channels":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
+	assertStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/db/doc3", `{"channels":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	testDb := rt.ServerContext().Database("db")
+	testDb.WaitForSequence(3)
+
+	// Flush the channel cache
+	testDb.FlushChannelCache()
+
+	// Add a few more docs (to increment the channel cache's validFrom)
+	response = rt.SendAdminRequest("PUT", "/db/doc4", `{"channels":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	response = rt.SendAdminRequest("PUT", "/db/doc5", `{"channels":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	testDb.WaitForSequence(5)
+
+	// Issue a since=0 changes request.  Validate that there's a view-based backfill
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+	changesJSON := `{"since":0}`
+	changes.Results = nil
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 5)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	queryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
+	log.Printf("After initial changes request, query count is :%s", queryCount)
+
+	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
+	changes.Results = nil
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 5)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	// Validate that there haven't been any more view queries
+	assert.Equals(t, base.GetExpvarAsString("syncGateway_changeCache", "view_queries"), queryCount)
+
+}
+
 func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -282,10 +282,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 	assertStatus(t, response, 201)
 	wg.Wait()
 
-
 }
-
-
 
 // Tests race between waking up the changes feed, and detecting that the user doc has changed
 // This test can sporadically reproduce issue #2068, as reported in #2999#issuecomment-342681828
@@ -346,7 +343,6 @@ func DisabledTestPostChangesUserTiming(t *testing.T) {
 	wg.Wait()
 
 }
-
 
 func TestPostChangesSinceInteger(t *testing.T) {
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
@@ -1515,7 +1511,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	///it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	//defer it.Close()
 
-	response := rt.SendAdminRequest("PUT", "/_logging", `{"HTTP":true, "Changes":true}`)
+	response := rt.SendAdminRequest("PUT", "/_logging", `{"HTTP":true, "Changes":true, "Cache":true}`)
 	assert.True(t, response != nil)
 
 	// Create user:


### PR DESCRIPTION
Default value of inclusive_end in Couchbase Server, if not specified, is true.

Fixes #3032, #3078 
