### PR TITLE
Manifest updates for 1.5.1

### DIFF
--- a/manifest/1.5.1.xml
+++ b/manifest/1.5.1.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+    <remote fetch="https://github.com/elazarl/" name="elazarl"/>
+    <remote fetch="https://github.com/gorilla/" name="gorilla"/>
+    <remote fetch="https://github.com/natefinch/" name="natefinch"/>
+    <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
+    <remote fetch="https://github.com/samuel/" name="samuel"/>
+    <remote fetch="https://github.com/snej/" name="snej"/>
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+    <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
+    <remote fetch="https://github.com/kardianos/" name="kardianos"/>
+    <remote fetch="https://github.com/coreos/" name="coreos"/>
+    <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
+    <remote fetch="https://github.com/satori/" name="satori"/>
+
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+
+    <default remote="couchbase" revision="master"/>
+
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="build" path="cbbuild" remote="couchbase" revision="2693c160e604c17daa838c151b35ffcf7ddcc1b6">
+        <annotation name="VERSION" value="1.5.1"     keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
+
+
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/1.5.1"/>
+
+
+    <!-- Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="e3be96359a026d15fac974162956bc377ea88b1d"/>
+
+    <!-- Dependencies specific to Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>
+
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
+
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
+
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+
+
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="5970c6334fc429dc648b802ef97736902755c94b" remote="couchbaselabs"/>
+
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a24c61bd2da6e4930a415e550d68086f7e8c7f75"/>
+
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
+
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="6382451e5ef472cd19e4eba6e82e3c1957e4cc09"/>
+
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="c93b867917a3058506fcab2d6948a918776a9374"/>
+
+    <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
+
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cafd6f12f21d446d49ec1dfb16b7cdc878e5b907"/>
+
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="gorilla" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="gorilla" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="natefinch" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="dd45e6a67c53f673bb49ca8a001fd3a63ceb640e"/>
+
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="5282a5a45ba989692b3ae22f730fa6b9dd67662f"/>
+
+    <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="c980adc4a823548817b9c47d38c6ca6b7d7d8b6a"/>
+
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="8968c61983e8f51a91b8c0ef25bf739278c89634"/>
+
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="9d4e42a20653790449273b3c85e67d6d8bae6e2e"/>
+
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
+
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="1490c89b7299046c431e442b6231db28a3b5c0bc"/>
+
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="ef844635a21403c0a5115bfdbbfb416cc57dae51"/>
+
+    <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
+
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="kardianos" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="kardianos" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
+
+    <project name="go-blip" path="godeps/src/github.com/snej/go-blip" remote="snej" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+
+    <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
+
+</manifest>
+
+

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -22,7 +22,7 @@
 
   <!-- Build Scripts (required on CI servers) -->
   <project name="build" path="cbbuild" remote="couchbase">
-    <annotation name="VERSION" value="1.5.1"     keep="true"/>
+    <annotation name="VERSION" value="2.0.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -36,6 +36,13 @@
             "interval": 120,
             "start_build": 587
         },
+        "manifest/1.5.1.xml": {
+            "release": "1.5.1.0",
+            "release_name": "Couchbase Sync Gateway 1.5.1.0",
+            "production": true,
+            "interval": 120,
+            "start_build": 1
+        },
         "manifest/dev.xml": {
             "release": "dev",
             "release_name": "Couchbase Sync Gateway Dev",


### PR DESCRIPTION
 - Adds 1.5.1 manifest and product-config entry.  Manifest points at branch release/1.5.1, which was branched from release/1.5.0
 - Updates version in default manifest to 2.0.0