### PR TITLE
Feature/issue 3026 cleanup test change index concurrent writers

### DIFF
--- a/base/sequence_clock.go
+++ b/base/sequence_clock.go
@@ -620,6 +620,16 @@ func (clock PartitionClock) GetSequence(vbNo uint16) uint64 {
 	}
 }
 
+func (clock PartitionClock) IsZero() bool {
+	isZero := true
+	for _, seq := range clock {
+		if seq > 0 {
+			isZero = false
+		}
+	}
+	return isZero
+}
+
 func (clock PartitionClock) AddToClock(seqClock SequenceClock) {
 	for vbNo, seq := range clock {
 		seqClock.SetSequence(vbNo, seq)

--- a/channels/change_log.go
+++ b/channels/change_log.go
@@ -34,6 +34,17 @@ type LogEntry struct {
 	PrevSequence uint64       // Sequence of previous active revision
 }
 
+func (l LogEntry) String() string {
+	return fmt.Sprintf(
+		"LogEntry(DCP message) seq: %d docid: %s revid: %s vbno: %d type: %v",
+		l.Sequence,
+		l.DocID,
+		l.RevID,
+		l.VbNo,
+		l.Type,
+	)
+}
+
 type ChannelMap map[string]*ChannelRemoval
 type ChannelRemoval struct {
 	Seq     uint64 `json:"seq,omitempty"`

--- a/channels/change_log.go
+++ b/channels/change_log.go
@@ -36,7 +36,7 @@ type LogEntry struct {
 
 func (l LogEntry) String() string {
 	return fmt.Sprintf(
-		"LogEntry(DCP message) seq: %d docid: %s revid: %s vbno: %d type: %v",
+		"seq: %d docid: %s revid: %s vbno: %d type: %v",
 		l.Sequence,
 		l.DocID,
 		l.RevID,

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -55,6 +55,17 @@ type changeCache struct {
 
 type LogEntry channels.LogEntry
 
+func (l LogEntry) String() string {
+	return fmt.Sprintf(
+		"LogEntry(DCP message) seq: %d docid: %s revid: %s vbno: %d type: %v",
+		l.Sequence,
+		l.DocID,
+		l.RevID,
+		l.VbNo,
+		l.Type,
+	)
+}
+
 type LogEntries []*LogEntry
 
 // A priority-queue of LogEntries, kept ordered by increasing sequence #.

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -56,14 +56,7 @@ type changeCache struct {
 type LogEntry channels.LogEntry
 
 func (l LogEntry) String() string {
-	return fmt.Sprintf(
-		"LogEntry(DCP message) seq: %d docid: %s revid: %s vbno: %d type: %v",
-		l.Sequence,
-		l.DocID,
-		l.RevID,
-		l.VbNo,
-		l.Type,
-	)
+	return channels.LogEntry(l).String()
 }
 
 type LogEntries []*LogEntry

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -195,6 +195,7 @@ func (k *KvChannelIndex) GetChanges(sinceClock base.SequenceClock, toClock base.
 
 	chanClock, err := k.getChannelClock()
 	if err != nil {
+		base.LogTo("Changes+", "getChannelClock() returned error: %v", err)
 		// Note: gocb returns "Key not found.", go-couchbase returns "MCResponse status=KEY_ENOENT, opcode=GET, opaque=0, msg: Not found"
 		// Using string matching to identify key not found for now - really need a better API in go-couchbase/gocb for gets that allows us to distinguish
 		// between errors and key not found with something more robust than string matching.
@@ -205,6 +206,8 @@ func (k *KvChannelIndex) GetChanges(sinceClock base.SequenceClock, toClock base.
 			return results, err
 		}
 	}
+
+	base.LogTo("Changes+", "getChannelClock() returned: %+v", chanClock.ValueAsMap())
 
 	// If requested clock is later than the channel clock, return empty
 	if sinceClock.AllAfter(chanClock) {

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -195,7 +195,6 @@ func (k *KvChannelIndex) GetChanges(sinceClock base.SequenceClock, toClock base.
 
 	chanClock, err := k.getChannelClock()
 	if err != nil {
-		base.LogTo("Changes+", "getChannelClock() returned error: %v", err)
 		// Note: gocb returns "Key not found.", go-couchbase returns "MCResponse status=KEY_ENOENT, opcode=GET, opaque=0, msg: Not found"
 		// Using string matching to identify key not found for now - really need a better API in go-couchbase/gocb for gets that allows us to distinguish
 		// between errors and key not found with something more robust than string matching.
@@ -206,8 +205,6 @@ func (k *KvChannelIndex) GetChanges(sinceClock base.SequenceClock, toClock base.
 			return results, err
 		}
 	}
-
-	base.LogTo("Changes+", "getChannelClock() returned: %+v", chanClock.ValueAsMap())
 
 	// If requested clock is later than the channel clock, return empty
 	if sinceClock.AllAfter(chanClock) {

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -59,7 +59,7 @@ func NewDenseBlock(key string, startClock base.PartitionClock) *DenseBlock {
 }
 
 func (d DenseBlock) String() string {
-	return fmt.Sprintf("key: %s, count: %d clock=zeroclock: %v", d.Key, d.Count(), d.clock.IsZero())
+	return fmt.Sprintf("key: %s, count: %d clock=zeroclock: %v startClock=zeroclock: %v", d.Key, d.Count(), d.clock.IsZero(), d.startClock.IsZero())
 }
 
 func (d *DenseBlock) Count() uint16 {

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -58,6 +58,10 @@ func NewDenseBlock(key string, startClock base.PartitionClock) *DenseBlock {
 	}
 }
 
+func (d DenseBlock) String() string {
+	return fmt.Sprintf("key: %s, count: %d", d.Key, d.Count())
+}
+
 func (d *DenseBlock) Count() uint16 {
 	return d.getEntryCount()
 }
@@ -82,6 +86,9 @@ func (d *DenseBlock) getClock() base.PartitionClock {
 func (d *DenseBlock) getCumulativeClock() base.PartitionClock {
 	cumulativeClock := d.startClock.Copy()
 	cumulativeClock.Set(d.clock)
+	if d.clock.IsZero() {
+		base.LogTo("ChannelStorage+", "WARNING2:  getCumulativeClock() returning a zero clock.  DenseBlock key: %v count: %d", d.Key, d.Count())
+	}
 	return cumulativeClock
 }
 
@@ -116,7 +123,7 @@ func (d *DenseBlock) AddEntrySet(entries []*LogEntry, bucket base.Bucket) (overf
 	casFailure = false
 	// Check if block is already full.  If so, return all entries as overflow.
 	if len(d.value) > MaxBlockSize {
-		base.LogTo("ChannelStorage+", "Block full - returning entries as overflow.  #entries:[%d]", len(entries))
+		base.LogTo("ChannelStorage+", "DenseBlock (%s) full - returning entries as overflow.  #entries:[%d]", d, len(entries))
 		return entries, pendingRemoval, nil, casFailure, nil
 	}
 

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -70,6 +70,9 @@ func (d *DenseBlock) Count() uint16 {
 }
 
 func (d *DenseBlock) getEntryCount() uint16 {
+	if len(d.value) < 2 {
+		return 0
+	}
 	return binary.BigEndian.Uint16(d.value[0:2])
 }
 

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -90,7 +90,7 @@ func (d *DenseBlock) getClock() base.PartitionClock {
 // the starting clock for this block, plus any changes made in this block
 func (d *DenseBlock) getCumulativeClock() base.PartitionClock {
 	cumulativeClock := d.startClock.Copy()
-	cumulativeClock.Set(d.clock)
+	cumulativeClock.Set(d.getClock())
 	return cumulativeClock
 }
 

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -12,9 +12,9 @@ package db
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
-	"errors"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -103,6 +103,7 @@ func (d *DenseBlock) loadBlock(bucket base.Bucket) error {
 	d.value = value
 	d.cas = cas
 	d.clock = nil
+	d.initClock()  // WORKAROUND attempt for https://github.com/couchbase/sync_gateway/issues/3026
 	IndexExpvars.Add("indexReader.blocksLoaded", 1)
 	return nil
 }

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -135,6 +135,7 @@ func (d *DenseBlock) AddEntrySet(entries []*LogEntry, bucket base.Bucket) (overf
 	casOut, err := bucket.WriteCas(d.Key, 0, 0, d.cas, d.value, sgbucket.Raw)
 	if err != nil {
 		casFailure = true
+		// TODO: why is updateClock nil?
 		base.LogTo("ChannelStorage+", "CAS error writing block to database. %v", err)
 		return entries, []*LogEntry{}, nil, casFailure, nil
 	}

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -59,11 +59,9 @@ func NewDenseBlock(key string, startClock base.PartitionClock) *DenseBlock {
 }
 
 func (d DenseBlock) String() string {
-	return fmt.Sprintf("key: %s, count: %d clock=zeroclock: %v startClock=zeroclock: %v",
+	return fmt.Sprintf("key: %s, count: %d",
 		d.Key,
 		d.Count(),
-		d.getClock().IsZero(),
-		d.startClock.IsZero(),
 	)
 }
 
@@ -103,7 +101,7 @@ func (d *DenseBlock) loadBlock(bucket base.Bucket) error {
 	d.value = value
 	d.cas = cas
 
-	// Intentionally set to nil for lazy-loading, and unsafe to read directly.  See comments on d.clock field definition.
+	// Intentionally set to nil for lazy-loading, and unsafe to read directly.  See comments on d._clock field definition.
 	d._clock = nil
 
 	IndexExpvars.Add("indexReader.blocksLoaded", 1)

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -105,7 +105,9 @@ func (d *DenseBlock) loadBlock(bucket base.Bucket) error {
 
 	// Init the clock as soon as we load the block to protect against
 	// cases where the clock is accessed before it is loaded.  See SG #3026 for details.
-	d.initClock()
+	// TEMP DISABLE as experiment d.initClock()
+
+	d.clock = nil  // will be lazy loaded when getClock() is called
 
 	IndexExpvars.Add("indexReader.blocksLoaded", 1)
 	return nil

--- a/db/kv_dense_block.go
+++ b/db/kv_dense_block.go
@@ -105,9 +105,7 @@ func (d *DenseBlock) loadBlock(bucket base.Bucket) error {
 
 	// Init the clock as soon as we load the block to protect against
 	// cases where the clock is accessed before it is loaded.  See SG #3026 for details.
-	// TEMP DISABLE as experiment d.initClock()
-
-	d.clock = nil  // will be lazy loaded when getClock() is called
+	d.initClock()
 
 	IndexExpvars.Add("indexReader.blocksLoaded", 1)
 	return nil

--- a/db/kv_dense_channel_storage.go
+++ b/db/kv_dense_channel_storage.go
@@ -158,7 +158,6 @@ func (l *DenseBlockList) AddBlock() (*DenseBlock, error) {
 		nextStartClock = l.activeBlock.getCumulativeClock()
 	}
 
-
 	base.LogTo("ChannelStorage+", "Adding block to list. channel:[%s] partition:[%d] index:[%d]", l.channelName, l.partition, nextIndex)
 
 	nextBlockKey := l.generateBlockKey(nextIndex)

--- a/db/kv_dense_channel_storage.go
+++ b/db/kv_dense_channel_storage.go
@@ -351,8 +351,24 @@ func (l *DenseBlockList) marshalAsStorage() (*DenseBlockListStorage, error) {
 	// When initializing an empty active block list (no blocks), activeStartIndex > len(l.blocks). Only
 	// include blocks in the output when this isn't the case.
 	if l.activeStartIndex <= len(l.blocks) {
+		base.LogTo("DIndex+", "DenseBlockList marshalAsStorage. l.activeStartIndex (%d) <= len(l.blocks) (%d)", l.activeStartIndex, len(l.blocks))
 		activeBlock.Blocks = l.blocks[l.activeStartIndex:]
+	} else {
+		base.LogTo("DIndex+", "DenseBlockList marshalAsStorage. l.activeStartIndex (%d) > len(l.blocks) (%d)", l.activeStartIndex, len(l.blocks))
 	}
+
+	// Only the first block in the list of blocks should have an empty start clock.  Otherwise, treat it as an error and panic
+	for blockIndex, block := range activeBlock.Blocks {
+		if blockIndex == 0 {
+			continue
+		}
+		if block.StartClock.IsZero() {
+			panic(fmt.Sprintf("DenseBlockList %v has a block after the first block with an empty start clock.  Block list: %+v, Block entry: %+v",
+				l, activeBlock, block))
+		}
+	}
+
+
 	return activeBlock, nil
 }
 

--- a/db/kv_dense_channel_storage.go
+++ b/db/kv_dense_channel_storage.go
@@ -149,21 +149,21 @@ func (l *DenseBlockList) AddBlock() (*DenseBlock, error) {
 	base.LogTo("ChannelStorage+", "DenseBlockList %s (%p) Determining nextStartClock.", l, l)
 
 	if l.activeBlock == nil { // TODO: investigate if this causes the empty clock
-		base.LogTo("ChannelStorage+", "Determining nextStartClock, l.activeBlock == nil so creating new clock")
+		base.LogTo("ChannelStorage+", "Determining nextStartClock for DenseBlockList %s, l.activeBlock == nil so creating new clock", l)
 		if len(l.blocks) > 0 {
 			panic(fmt.Sprintf("How can there be a nil activeBlock if there is more than 1 block already?"))
 		}
 		// No previous active block - new block list
 		nextStartClock = make(base.PartitionClock)
 	} else {
-		base.LogTo("ChannelStorage+", "Determining nextStartClock, l.activeBlock != nil so Determine index and startclock from previous active block")
+		base.LogTo("ChannelStorage+", "Determining nextStartClock for DenseBlockList %s, l.activeBlock != nil so Determine index and startclock from previous active block", l)
 
 		// Determine index and startclock from previous active block
 		nextStartClock = l.activeBlock.getCumulativeClock()
 
 		if nextStartClock.IsZero() {
 			// This will result in the new block having an empty start clock, which shouldn't happen.
-			base.LogTo("ChannelStorage+", "WARNING2: Determining nextStartClock.  l.activeBlock.getCumulativeClock() returned a zero clock")
+			base.LogTo("ChannelStorage+", "WARNING2: Determining nextStartClock for DenseBlockList %s.  l.activeBlock.getCumulativeClock() returned a zero clock.", l)
 		}
 	}
 

--- a/db/kv_dense_channel_storage.go
+++ b/db/kv_dense_channel_storage.go
@@ -141,7 +141,7 @@ func (l *DenseBlockList) AddBlock() (*DenseBlock, error) {
 
 	nextIndex := l.generateNextBlockIndex()
 	var nextStartClock base.PartitionClock
-	if l.activeBlock == nil {
+	if l.activeBlock == nil { // TODO: investigate if this causes the empty clock
 		// No previous active block - new block list
 		nextStartClock = make(base.PartitionClock)
 	} else {
@@ -175,6 +175,7 @@ func (l *DenseBlockList) AddBlock() (*DenseBlock, error) {
 	}
 	casOut, err := l.indexBucket.WriteCas(l.activeKey, 0, 0, l.activeCas, storageValue, 0)
 	if err != nil {
+		// TODO: add logging for this cas error.  is reload working correctly?
 		// CAS error.  If there's a concurrent writer for this partition, assume they have created the new block.
 		//  Re-initialize the current block list, and get the active block key from there.
 		found, err := l.loadDenseBlockList()

--- a/db/kv_dense_channel_storage.go
+++ b/db/kv_dense_channel_storage.go
@@ -55,6 +55,10 @@ type DenseBlockListEntry struct {
 	key        string              // Used for key helper function
 }
 
+func (d DenseBlockListEntry) String() string {
+	return fmt.Sprintf("blockindex: %d key: %s ", d.BlockIndex, d.key, d.StartClock.IsZero())
+}
+
 func (e *DenseBlockListEntry) Key(parentList *DenseBlockList) string {
 	if parentList == nil {
 		base.Warn("Attempted to generate key without parent list")
@@ -383,9 +387,12 @@ func (l *DenseBlockList) marshalAsStorage() (*DenseBlockListStorage, error) {
 			continue
 		}
 		if block.StartClock.IsZero() {
-			msg := fmt.Sprintf("WARNING2: DenseBlockList %s (%p) has a block after the first block with an empty start clock.  Block list: %+v, Block entry: %+v",
+			msg := fmt.Sprintf("WARNING2: DenseBlockList %s (%p) has a block after the first block with an empty start clock.  Block list: %+v, Block entry: %+v.  Dumping block list.",
 				l, l, activeBlock, block)
 			base.LogTo("DIndex+", "%s", msg)
+			for innerBlockIndex, innerBlock := range activeBlock.Blocks {
+				base.LogTo("DIndex+", "block list %s block %d: %s" , l, innerBlockIndex, innerBlock)
+			}
 
 			// panic(msg)
 		}

--- a/db/kv_dense_channel_storage_reader.go
+++ b/db/kv_dense_channel_storage_reader.go
@@ -538,18 +538,12 @@ func (pr *DensePartitionStorageReader) getIndexedChanges(partitionRange base.Par
 		return nil, err
 	}
 
-	base.LogTo("DIndex+", "DensePartitionStorageReader [%s] looping over %d blocks", pr, len(blockList.blocks))
 	changes = NewPartitionChanges()
 	keySet := make(map[string]bool, 0)
 	for i := len(blockList.blocks) - 1; i >= 0; i-- {
 
-
-
 		blockListEntry := blockList.blocks[i]
 		blockKey := blockListEntry.Key(blockList)
-
-		base.LogTo("DIndex+", "DensePartitionStorageReader [%s] processing blockKey: %s.  Loading block with startclock for vb100: %v",
-			pr, blockKey, blockListEntry.StartClock.GetSequence(100))
 
 		currBlock, err := pr.loadBlock(blockKey, blockListEntry.StartClock)
 		if err != nil {
@@ -582,24 +576,12 @@ func (pr *DensePartitionStorageReader) getIndexedChanges(partitionRange base.Par
 			}
 		}
 
-		base.LogTo("DIndex+", "DensePartitionStorageReader [%s] prepending %d changes to %d accumulated changes", pr, blockChanges.Count(), changes.Count())
-
 		// Prepend partition changes with the results for this block
 		changes.PrependChanges(blockChanges)
 
 		// If we've reached a block with a startclock earlier than our since value, we're done
-		base.LogTo("DIndex+",
-			"DensePartitionStorageReader [%s] call SinceAfter().  partitionRange sequence range for vb100: %v.  StartClock seq for vb100: %v",
-			pr,
-			partitionRange.GetSequenceRange(100),
-			blockListEntry.StartClock.GetSequence(100),
-		)
-
 		if partitionRange.SinceAfter(blockListEntry.StartClock) {
-			base.LogTo("DIndex+", "DensePartitionStorageReader [%s] reached a block with a startclock earlier than our since value, so we're done", pr)
 			break
-		} else {
-			base.LogTo("DIndex+", "DensePartitionStorageReader [%s] hasn't reached a block with a startclock earlier than our since value, keep going", pr)
 		}
 	}
 	return changes, nil

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -96,7 +96,14 @@ func TestDenseBlockMultipleInserts(t *testing.T) {
 	defer testIndexBucket.Close()
 	indexBucket := testIndexBucket.Bucket
 
-	block := NewDenseBlock("block1", nil)
+	block := DenseBlock{}
+	block.Key = "block1"
+
+	// Make sure we can safely call getEntryCount() on uninitialized DenseBlock
+	assert.Equals(t, block.getEntryCount(), uint16(0))
+
+	// Initialize the block value 
+	block.value = make([]byte, DB_HEADER_LEN, 400)
 
 	// Inserts
 	entries := make([]*LogEntry, 10)


### PR DESCRIPTION
Fixes #3026 

- Fix: change call from `denseBlock.clock` -> `denseBlock.getClock()` in `denseBlock.getCumulativeClock()`
    - Upside: no perf hit
    - Downside: it's fairly easy for this bug to resurface, since there's no protection against calling `denseBlock.clock` instead of `denseBlock.getClock()`
   - Testing: running this 50 times, passing so far `$ SG_TEST_BACKING_STORE=Couchbase SG_TEST_COUCHBASE_SERVER_URL=http://localhost:8091 SG_TEST_USE_XATTRS=true repeat 50 ./test.sh -run ^TestChangeIndexConcurrentWriters$`

Other changes:

- Add Stringer interface to structs to make it easy to inspect via logging.  These aren't perfect, but I think it's a good start and we can refine these going forward (or as part of this PR)
- A few extra logging statements

Merge tasks:

- [ ] Merge https://github.com/couchbaselabs/sync-gateway-accel/pull/186
- [ ] Update manifest
- [ ] This PR
