### PR TITLE
Reload active user context on change to their role's channel set

### DIFF
--- a/auth/role.go
+++ b/auth/role.go
@@ -98,7 +98,7 @@ func (role *roleImpl) DocID() string {
 
 // Key used in 'access' view (not same meaning as doc ID)
 func (role *roleImpl) accessViewKey() string {
-	return "role:" + role.Name_
+	return ch.RoleAccessPrefix + role.Name_
 }
 
 //////// ACCESSORS:

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -19,6 +19,9 @@ import (
 	_ "github.com/robertkrimen/otto/underscore"
 )
 
+// Prefix used to identify roles in access grants
+const RoleAccessPrefix = "role:"
+
 const funcWrapper = `
 	function() {
 
@@ -189,7 +192,7 @@ func NewSyncRunner(funcSource string) (*SyncRunner, error) {
 			if err == nil {
 				output.Access, err = compileAccessMap(runner.access, "")
 				if err == nil {
-					output.Roles, err = compileAccessMap(runner.roles, "role:")
+					output.Roles, err = compileAccessMap(runner.roles, RoleAccessPrefix)
 				}
 			}
 			if runner.expiry != nil {
@@ -236,6 +239,14 @@ func compileAccessMap(input map[string][]string, prefix string) (AccessMap, erro
 		}
 	}
 	return access, nil
+}
+
+// If the provided principal name (in access grant format) is a role, returns the role name without prefix
+func AccessNameToPrincipalName(accessPrincipalName string) (principalName string, isRole bool) {
+	if strings.HasPrefix(accessPrincipalName, RoleAccessPrefix) {
+		return accessPrincipalName[len(RoleAccessPrefix):], true
+	}
+	return accessPrincipalName, false
 }
 
 // Converts a JS string or array into a Go string array.

--- a/db/database.go
+++ b/db/database.go
@@ -1202,10 +1202,12 @@ func (db *Database) invalRoleChannels(rolename string) {
 }
 
 func (db *Database) invalUserOrRoleChannels(name string) {
-	if strings.HasPrefix(name, "role:") {
-		db.invalRoleChannels(name[5:])
+
+	principalName, isRole := channels.AccessNameToPrincipalName(name)
+	if isRole {
+		db.invalRoleChannels(principalName)
 	} else {
-		db.invalUserChannels(name)
+		db.invalUserChannels(principalName)
 	}
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1201,6 +1201,44 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 		map[string]interface{}{"rev": "1-4d79588b9fe9c38faae61f0c1b9471c0", "id": "bulk2"})
 }
 
+func TestBulkDocsChangeToRoleAccess(t *testing.T) {
+
+	var logKeys = map[string]bool{
+		"Access":  true,
+		"Access+": true,
+	}
+
+	base.UpdateLogKeys(logKeys, true)
+
+	rt := RestTester{SyncFn: `function(doc) {if(doc.type == "roleaccess") {channel(doc.channel); access(doc.grantTo, doc.grantChannel);} else { requireAccess(doc.mustHaveAccess)}}`}
+	defer rt.Close()
+
+	// Create a role with no channels assigned to it
+	authenticator := rt.ServerContext().Database("db").Authenticator()
+	role, err := authenticator.NewRole("role1", nil)
+	authenticator.Save(role)
+
+	// Create a user with an explicit role grant for role1
+	user, err := authenticator.NewUser("user1", "letmein", nil)
+	user.SetExplicitRoles(channels.TimedSet{"role1": channels.NewVbSimpleSequence(1)})
+	err = authenticator.Save(user)
+	assert.Equals(t, err, nil)
+
+	// Bulk docs with 2 docs.  First doc grants role1 access to chan1.  Second requires chan1 for write.
+	input := `{"docs": [{"_id": "bulk1", "type" : "roleaccess", "grantTo":"role:role1" , "grantChannel":"chan1"}, {"_id": "bulk2" , "mustHaveAccess":"chan1"}]}`
+
+	response := rt.Send(requestByUser("POST", "/db/_bulk_docs", input, "user1"))
+	assertStatus(t, response, 201)
+
+	var docs []interface{}
+	json.Unmarshal(response.Body.Bytes(), &docs)
+	assert.Equals(t, len(docs), 2)
+	assert.DeepEquals(t, docs[0],
+		map[string]interface{}{"rev": "1-17424d2a21bf113768dfdbcd344741ac", "id": "bulk1"})
+	assert.DeepEquals(t, docs[1],
+		map[string]interface{}{"rev": "1-f120ccb33c0a6ef43ef202ade28f98ef", "id": "bulk2"})
+}
+
 func TestBulkDocsNoEdits(t *testing.T) {
 	var rt RestTester
 	defer rt.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1210,7 +1210,15 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 
 	base.UpdateLogKeys(logKeys, true)
 
-	rt := RestTester{SyncFn: `function(doc) {if(doc.type == "roleaccess") {channel(doc.channel); access(doc.grantTo, doc.grantChannel);} else { requireAccess(doc.mustHaveAccess)}}`}
+	rt := RestTester{SyncFn: `
+		function(doc) {
+			if(doc.type == "roleaccess") {
+				channel(doc.channel); 
+				access(doc.grantTo, doc.grantChannel);
+			} else { 
+				requireAccess(doc.mustHaveAccess)
+			}
+		}`}
 	defer rt.Close()
 
 	// Create a role with no channels assigned to it
@@ -1225,7 +1233,18 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	assert.Equals(t, err, nil)
 
 	// Bulk docs with 2 docs.  First doc grants role1 access to chan1.  Second requires chan1 for write.
-	input := `{"docs": [{"_id": "bulk1", "type" : "roleaccess", "grantTo":"role:role1" , "grantChannel":"chan1"}, {"_id": "bulk2" , "mustHaveAccess":"chan1"}]}`
+	input := `{"docs": [
+				{
+					"_id": "bulk1", 
+				 	"type" : "roleaccess", 
+				 	"grantTo":"role:role1", 
+				 	"grantChannel":"chan1"
+				 }, 
+				{
+					"_id": "bulk2",
+					"mustHaveAccess":"chan1"
+				}
+				]}`
 
 	response := rt.Send(requestByUser("POST", "/db/_bulk_docs", input, "user1"))
 	assertStatus(t, response, 201)

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/channels"
+	ch "github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	pkgerrors "github.com/pkg/errors"
 )
@@ -67,13 +67,13 @@ func (h *handler) handleAllDocs() error {
 	}
 
 	// Get the set of channels the user has access to; nil if user is admin or has access to user "*"
-	var availableChannels channels.TimedSet
+	var availableChannels ch.TimedSet
 	if h.user != nil {
 		availableChannels = h.user.InheritedChannels()
 		if availableChannels == nil {
 			panic("no channels for user?")
 		}
-		if availableChannels.Contains(channels.UserStarChannel) {
+		if availableChannels.Contains(ch.UserStarChannel) {
 			availableChannels = nil
 		}
 	}
@@ -95,7 +95,7 @@ func (h *handler) handleAllDocs() error {
 		}
 		return channels[0:dst]
 	}
-	filterChannelSet := func(channelMap channels.ChannelMap) []string {
+	filterChannelSet := func(channelMap ch.ChannelMap) []string {
 		var result []string
 		if availableChannels == nil {
 			result = []string{}
@@ -165,7 +165,7 @@ func (h *handler) handleAllDocs() error {
 					value.Access[userName] = channels.AsSet()
 				}
 				for roleName, channels := range roleAccess {
-					value.Access["role:"+roleName] = channels.AsSet()
+					value.Access[ch.RoleAccessPrefix+roleName] = channels.AsSet()
 				}
 			}
 		}


### PR DESCRIPTION
When a user writes a document that triggers a change to the set of channels on a role they have been granted, reload the user context.  This ensures that the user context is updated to include the changed channels for subsequent writes in the same bulk_docs request.

Fixes #3108