### PR TITLE
Don't store incoming _revisions property in rev cache

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1286,7 +1286,7 @@ func TestOpenRevs(t *testing.T) {
 	response = rt.SendRequestWithHeaders("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "", reqHeaders)
 	assertStatus(t, response, 200)
 	assert.Equals(t, response.Body.String(), `[
-{"ok":{"_id":"or1","_rev":"12-abc","_revisions":{"ids":["abc","eleven","ten","nine"],"start":12},"n":1}}
+{"ok":{"_id":"or1","_rev":"12-abc","n":1}}
 ,{"missing":"10-ten"}
 ]`)
 }

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1157,7 +1157,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	expectedResults[5] = `{"seq":12,"id":"doc_pruned","removed":["alpha"],"doc":{"_id":"doc_pruned","_removed":true,"_rev":"2-5afcb73bd3eb50615470e3ba54b80f00"},"changes":[{"rev":"2-5afcb73bd3eb50615470e3ba54b80f00"}]}`
 	expectedResults[6] = `{"seq":18,"id":"doc_attachment","doc":{"_attachments":{"attach1":{"content_type":"text/plain","digest":"sha1-nq0xWBV2IEkkpY3ng+PEtFnCcVY=","length":30,"revpos":2,"stub":true}},"_id":"doc_attachment","_rev":"2-0db6aecd6b91981e7f97c95ca64b5019","channels":["alpha"],"type":"attachments"},"changes":[{"rev":"2-0db6aecd6b91981e7f97c95ca64b5019"}]}`
 	expectedResults[7] = `{"seq":19,"id":"doc_large_numbers","doc":{"_id":"doc_large_numbers","_rev":"1-2721633d9000e606e9c642e98f2f5ae7","channels":["alpha"],"largefloat":1234567890.1234,"largeint":1234567890,"type":"large_numbers"},"changes":[{"rev":"1-2721633d9000e606e9c642e98f2f5ae7"}]}`
-	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","_revisions":{"ids":["conflicting_rev","19a316235cdd9d695d73765dc527d903"],"start":2},"channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"}]}`
+	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"}]}`
 	expectedResults[9] = `{"seq":24,"id":"doc_resolved_conflict","doc":{"_id":"doc_resolved_conflict","_rev":"2-251ba04e5889887152df5e7a350745b4","channels":["alpha"],"type":"resolved_conflict"},"changes":[{"rev":"2-251ba04e5889887152df5e7a350745b4"}]}`
 	changesResponse := rt.Send(requestByUser("GET", "/db/_changes?include_docs=true", "", "user1"))
 
@@ -1177,9 +1177,6 @@ func TestChangesIncludeDocs(t *testing.T) {
 	testDB.FlushRevisionCache()
 	// Also nuke temporary revision backup of doc_pruned.  Validates that the body for the pruned revision is generated correctly when no longer resident in the rev cache
 	testDB.Bucket.Delete("_sync:rev:doc_pruned:34:2-5afcb73bd3eb50615470e3ba54b80f00")
-
-	// Post-flush, the _revisions property isn't present on the conflicted doc.  See https://github.com/couchbase/sync_gateway/issues/3107
-	expectedResults[8] = `{"seq":22,"id":"doc_conflict","doc":{"_id":"doc_conflict","_rev":"2-conflicting_rev","channels":["alpha"],"type":"conflict"},"changes":[{"rev":"2-conflicting_rev"}]}`
 
 	postFlushChangesResponse := rt.Send(requestByUser("GET", "/db/_changes?include_docs=true", "", "user1"))
 


### PR DESCRIPTION
The only internal properties that should be included in the rev cache version of the body are _id and _rev.  Modified the API on RevisionCache.Put to make this explicit - callers now provide a docid, revid, and body as is stored in the bucket.  _id and _rev are inserted into the body as it's stored in the rev cache.  Ensures any other internal properties (like _revisions) that aren't persisted to the bucket also aren't stored in the rev cache.

Fixes #3107