### PR TITLE
Feature/issue 3113 sgreplicate resources

### DIFF
--- a/base/replicator.go
+++ b/base/replicator.go
@@ -245,6 +245,8 @@ func (r *Replicator) populateActiveTaskFromReplication(replication sgreplicate.S
 }
 
 func (r *Replicator) StopReplications() error {
+	 r.lock.Lock()
+	 defer r.lock.Unlock()
 	for replicationId, replication := range r.replications {
 		LogTo("Replicate", "Stopping replication %s", replicationId)
 		if err := replication.Stop(); err != nil {

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sgreplicate "github.com/couchbaselabs/sg-replicate"
+	pkgerrors "github.com/pkg/errors"
 )
 
 const (
@@ -241,4 +242,14 @@ func (r *Replicator) populateActiveTaskFromReplication(replication sgreplicate.S
 	}
 
 	return
+}
+
+func (r *Replicator) StopReplications() error {
+	for replicationId, replication := range r.replications {
+		LogTo("Replicate", "Stopping replication %s", replicationId)
+		if err := replication.Stop(); err != nil {
+			return pkgerrors.Wrapf(err, "Error stopping sg-replicate replication with id: %s", replicationId)
+		}
+	}
+	return nil
 }

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -246,6 +246,8 @@ func (r *Replicator) populateActiveTaskFromReplication(replication sgreplicate.S
 
 func (r *Replicator) StopReplications() error {
 
+	// Get the replication id's in a separate method call to avoid trying to grab the lock in a
+	// nested fashion.  When r.stopReplication() is called, no locks on r will be held.
 	replicationIds := r.GetReplicationIds()
 
 	for _, replicationId := range replicationIds {

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sgreplicate "github.com/couchbaselabs/sg-replicate"
-	pkgerrors "github.com/pkg/errors"
 )
 
 const (

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -253,7 +253,7 @@ func (r *Replicator) StopReplications() error {
 	for _, replicationId := range replicationIds {
 		LogTo("Replicate", "Stopping replication %s", replicationId)
 		if _, err := r.stopReplication(replicationId); err != nil {
-			return pkgerrors.Wrapf(err, "Error stopping sg-replicate replication with id: %s", replicationId)
+			Warn("Error stopping replication %s.  It's possible that the replication was already stopped and this can be safely ignored. Error: %v.", replicationId, err)
 		}
 		LogTo("Replicate", "Stopped replication %s", replicationId)
 	}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1482,6 +1482,7 @@ func TestDocumentChangeReplicate(t *testing.T) {
 	var rt RestTester
 	defer rt.Close() // Close RestTester, which closes ServerContext, which stops all replications
 
+	base.EnableLogKey("Replicate")
 	base.EnableLogKey("Replicate+")
 	base.EnableSgReplicateLogging()
 
@@ -1517,5 +1518,6 @@ func TestDocumentChangeReplicate(t *testing.T) {
 
 	//Cancel a replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"replication_id":"ABC", "cancel":true}`), 404)
+
 
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
+	"runtime"
 )
 
 // Reproduces #3048 Panic when attempting to make invalid update to a conflicting document
@@ -1471,8 +1472,7 @@ func TestReplicateErrorConditions(t *testing.T) {
 }
 
 //These tests validate request parameters not actual replication
-// TODO: Disabled until https://github.com/couchbase/sync_gateway/issues/3113 is fixed.  When re-enabled, 10s sleep must be removed.
-func DisableTestDocumentChangeReplicate(t *testing.T) {
+func TestDocumentChangeReplicate(t *testing.T) {
 
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skip replication tests during integration tests, since they might be leaving replications running in background")
@@ -1480,8 +1480,6 @@ func DisableTestDocumentChangeReplicate(t *testing.T) {
 
 	var rt RestTester
 	defer rt.Close()
-
-	time.Sleep(10 * time.Second)
 
 	//Initiate synchronous one shot replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db", "target":"http://localhost:4985/db"}`), 500)
@@ -1515,5 +1513,15 @@ func DisableTestDocumentChangeReplicate(t *testing.T) {
 
 	//Cancel a replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"replication_id":"ABC", "cancel":true}`), 404)
+
+
+	// Dump goroutines
+	rawStackTrace := make([]byte, 1<<20)
+	runtime.Stack(rawStackTrace, true)
+	log.Printf("Stacks")
+	log.Printf("%s", string(rawStackTrace))
+
+
+
 
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/clog"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -1481,12 +1480,10 @@ func TestDocumentChangeReplicate(t *testing.T) {
 	}
 
 	var rt RestTester
-	defer rt.Close()  // Close RestTester, which closes ServerContext, which stops all replications
+	defer rt.Close() // Close RestTester, which closes ServerContext, which stops all replications
 
-	base.EnableLogKey("Replicate")
 	base.EnableLogKey("Replicate+")
-	clog.EnableKey("Replicate")
-	clog.EnableKey("Replicate+")
+	base.EnableSgReplicateLogging()
 
 	//Initiate synchronous one shot replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db", "target":"http://localhost:4985/db"}`), 500)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -135,6 +135,10 @@ func (sc *ServerContext) Close() {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 
+	if err := sc.replicator.StopReplications(); err != nil {
+		base.Warn("Error stopping replications: %+v.  This could cause a resource leak.  Please restart Sync Gateway to cleanup leaked resources.", err)
+	}
+
 	sc.stopStatsReporter()
 	for _, ctx := range sc.databases_ {
 		ctx.Close()
@@ -142,11 +146,10 @@ func (sc *ServerContext) Close() {
 			ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
 		}
 	}
+
 	sc.databases_ = nil
 
-	if err := sc.replicator.StopReplications(); err != nil {
-		base.Warn("Error stopping replications: %+v.  This could cause a resource leak.  Please restart Sync Gateway to cleanup leaked resources.", err)
-	}
+
 
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -143,6 +143,11 @@ func (sc *ServerContext) Close() {
 		}
 	}
 	sc.databases_ = nil
+
+	if err := sc.replicator.StopReplications(); err != nil {
+		base.Warn("Error stopping replications: %+v.  This could cause a resource leak.  Please restart Sync Gateway to cleanup leaked resources.", err)
+	}
+
 }
 
 // Returns the DatabaseContext with the given name


### PR DESCRIPTION
Fixed #3113

With [this version](https://gist.github.com/tleyden/e70cbd293d4db91e6d12bc99926469bd) of the test:

Logs before fix:

https://gist.github.com/tleyden/bfb0a7b0a684bb48a2d13ca610d29326#file-gistfile1-txt-L195

(Note the amount of logs that come after the `rt.Close()` call)

Logs after fix:

https://gist.github.com/tleyden/c7e35d4a13b19363150481f950af75d9

(very few logs after the `rt.Close()` call)

## Integration tests

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/250/
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/251/