### PR TITLE
Fixes #3068 Excessive retries in WaitForNViewResults

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -445,6 +445,19 @@ func CreateDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs int) RetrySl
 
 }
 
+// Create a sleeper function that sleeps up to maxNumAttempts, sleeping timeToSleepMs each attempt
+func CreateSleeperFunc(maxNumAttempts, timeToSleepMs int) RetrySleeper {
+
+	sleeper := func(numAttempts int) (bool, int) {
+		if numAttempts > maxNumAttempts {
+			return false, -1
+		}
+		return true, timeToSleepMs
+	}
+	return sleeper
+
+}
+
 // Uint64Slice attaches the methods of sort.Interface to []uint64, sorting in increasing order.
 type Uint64Slice []uint64
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -346,7 +346,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 	}
 
 	description := fmt.Sprintf("Wait for %d view results for query to %v", numResultsExpected, viewUrlPath)
-	sleeper := base.CreateSleeperFunc(20, 100)
+	sleeper := base.CreateSleeperFunc(200, 100)
 	err, returnVal := base.RetryLoop(description, worker, sleeper)
 
 	if err != nil {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -280,7 +280,7 @@ func (rt *RestTester) WaitForChanges(numChangesExpected int, changesUrl, usernam
 
 	waitForChangesWorker := rt.CreateWaitForChangesRetryWorker(numChangesExpected, changesUrl, username, useAdminPort)
 
-	sleeper := base.CreateDoublingSleeperFunc(20, 10)
+	sleeper := base.CreateSleeperFunc(200, 100)
 
 	err, changesVal := base.RetryLoop("Wait for changes", waitForChangesWorker, sleeper)
 	if err != nil {
@@ -346,7 +346,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 	}
 
 	description := fmt.Sprintf("Wait for %d view results for query to %v", numResultsExpected, viewUrlPath)
-	sleeper := base.CreateDoublingSleeperFunc(20, 10)
+	sleeper := base.CreateSleeperFunc(20, 100)
 	err, returnVal := base.RetryLoop(description, worker, sleeper)
 
 	if err != nil {


### PR DESCRIPTION
No need for backoff retry in WaitForNViewResults() or WaitForChanges()

## Integration tests

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/234/
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/235/