### PR TITLE
Updated new replicator to BLIP 3 protocol (INCOMPATIBLE)

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -110,7 +110,6 @@ type UserViewsOptions struct {
 
 type UnsupportedOptions struct {
 	UserViews        UserViewsOptions        `json:"user_views,omitempty"`         // Config settings for user views
-	Replicator2      bool                    `json:"replicator_2,omitempty"`       // Enable new replicator (_blipsync)
 	OidcTestProvider OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
 	AllowConflicts   *bool                   `json:"allow_conflicts"`              // False forbids creating conflicts
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="6856a5bf4180bbcc2018498d0bc442f32ca44a45"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="169397c83b14c589c6452565f7ce7fa9201c6103"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="25286c29f0e025cd31b0ec73a88f5fdb8dca0f0c"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="6856a5bf4180bbcc2018498d0bc442f32ca44a45"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="9cbef5227a0304d736e34387b65e5344502312f3"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="25286c29f0e025cd31b0ec73a88f5fdb8dca0f0c"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="e6fc23e55f6a0907378f93a5d610f4f56c179879"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3926f1bf2b311c79befc3cf08758695a5579d9cc"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3926f1bf2b311c79befc3cf08758695a5579d9cc"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="9cbef5227a0304d736e34387b65e5344502312f3"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -86,7 +86,10 @@ func (h *handler) handleBLIPSync() error {
 	server.Handler = func(conn *websocket.Conn) {
 		h.logStatus(101, "Upgraded to BLIP+WebSocket protocol")
 		defer func() {
-			conn.Close()
+			if err := conn.Close(); err != nil {
+				base.Warn("WebSocket connection (#%03d) closed with error %v",
+					h.serialNumber, err)
+			}
 			base.LogTo("HTTP+", "#%03d:     --> BLIP+WebSocket connection closed", h.serialNumber)
 		}()
 		defaultHandler(conn)

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -711,7 +711,10 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 	handler := func(conn *websocket.Conn) {
 		h.logStatus(101, "Upgraded to WebSocket protocol")
 		defer func() {
-			conn.Close()
+			if err := conn.Close(); err != nil {
+				base.Warn("WebSocket connection (#%03d) closed with error %v",
+					h.serialNumber, err)
+			}
 			base.LogTo("HTTP+", "#%03d:     --> WebSocket closed", h.serialNumber)
 		}()
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -87,6 +87,7 @@ type ServerConfig struct {
 	SkipRunmodeValidation          bool                     `json:"skip_runmode_validation,omitempty"` // If this is true, skips any config validation regarding accel vs normal mode
 	Unsupported                    *UnsupportedServerConfig `json:"unsupported,omitempty"`             // Config for unsupported features
 	RunMode                        SyncGatewayRunMode       `json:"runmode,omitempty"`                 // Whether this is an SG reader or an SG Accelerator
+	ReplicatorCompression          *int                     `json:"replicator_compression,omitempty"`  // BLIP data compression level (0-9)
 }
 
 // Bucket configuration elements - used by db, shadow, index


### PR DESCRIPTION
This is an INCOMPATIBLE REPLICATOR CHANGE, not interoperable with Couchbase Lite 2 until the LiteCore `feature/compression_297` branch is merged (couchbase/couchbase-lite-core#297)

* New replicator is always enabled (no more 'replicator_2' config.)
* Replicator uses BLIP 3 protocol with inter-message compression.
* Compression level can be set with 'replicator_compression' config option (range is 0-9)

Fixes #3136
  
Before merging:

- [ ] Merge couchbase/couchbase-lite-core#328
- [ ] Merge cblite-ios / android / .net 