### PR TITLE
Fixes #3129: auth panic

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -511,9 +511,12 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 			panic(fmt.Sprintf("Unexpected CouchbaseDriver: %v", spec.CouchbaseDriver))
 		}
 
-		if pkgerrors.Cause(err) == gocb.ErrAuthError {
-			Warn("Unable to authenticate: %v", err)
-			return nil, ErrFatalBucketConnection
+		if err != nil {
+			if pkgerrors.Cause(err) == gocb.ErrAuthError {
+				Warn("Unable to authenticate"+suffix+": %v", err)
+				return nil, ErrFatalBucketConnection
+			}
+			return nil, err
 		}
 
 		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -511,6 +511,11 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 			panic(fmt.Sprintf("Unexpected CouchbaseDriver: %v", spec.CouchbaseDriver))
 		}
 
+		if pkgerrors.Cause(err) == gocb.ErrAuthError {
+			Warn("Unable to authenticate: %v", err)
+			return nil, ErrFatalBucketConnection
+		}
+
 		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1944,6 +1944,18 @@ func TestCouchbaseServerVersion(t *testing.T) {
 
 }
 
+func TestCouchbaseServerIncorrectLogin(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	// Bad auth creds cause a fatal error with logs indicating the reason why.
+	_, err := GetBucketWithInvalidUsernamePassword(DataBucket)
+	assert.Equals(t, err, ErrFatalBucketConnection)
+
+}
+
 func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 
 	// Create document with XATTR

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -143,7 +143,7 @@ func GetBucketOrPanicCommon(bucketType CouchbaseBucketType) TestBucket {
 
 }
 
-func GetBucketWithInvalidUsernamePassword(bucketType CouchbaseBucketType) (*TestBucket, error) {
+func GetBucketWithInvalidUsernamePassword(bucketType CouchbaseBucketType) (TestBucket, error) {
 
 	spec := GetTestBucketSpec(bucketType)
 
@@ -156,11 +156,8 @@ func GetBucketWithInvalidUsernamePassword(bucketType CouchbaseBucketType) (*Test
 
 	// Attempt to open a test bucket with invalid creds. We should expect an error.
 	bucket, err := GetBucket(spec, nil)
-	if err != nil {
-		return nil, err
-	}
+	return TestBucket{Bucket: bucket}, err
 
-	return &TestBucket{Bucket: bucket}, nil
 }
 
 // Convenience function that will cause a bucket to be created if it doesn't already exist.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -123,9 +123,8 @@ func GetBucketOrPanicCommon(bucketType CouchbaseBucketType) TestBucket {
 			// Create a brand new bucket
 			// TODO: in this case, we should still wait until it's empty, just in case there was somehow residue
 			// TODO: in between deleting and recreating it, if it happened in rapid succession
-			createBucketErr := tbm.CreateTestBucket()
-			if createBucketErr != nil {
-				panic(fmt.Sprintf("Could not create bucket.  Spec: %+v Err: %v", spec, createBucketErr))
+			if err := tbm.CreateTestBucket(); err != nil {
+				panic(fmt.Sprintf("Could not create bucket.  Spec: %+v Err: %v", spec, err))
 			}
 		}
 
@@ -142,6 +141,26 @@ func GetBucketOrPanicCommon(bucketType CouchbaseBucketType) TestBucket {
 
 	return TestBucket{Bucket: bucket}
 
+}
+
+func GetBucketWithInvalidUsernamePassword(bucketType CouchbaseBucketType) (*TestBucket, error) {
+
+	spec := GetTestBucketSpec(bucketType)
+
+	// Override spec's auth with invalid creds
+	spec.Auth = TestAuthenticator{
+		Username:   "invalid_username",
+		Password:   "invalid_password",
+		BucketName: spec.BucketName,
+	}
+
+	// Attempt to open a test bucket with invalid creds. We should expect an error.
+	bucket, err := GetBucket(spec, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TestBucket{Bucket: bucket}, nil
 }
 
 // Convenience function that will cause a bucket to be created if it doesn't already exist.
@@ -222,8 +241,13 @@ func (tbm *TestBucketManager) OpenTestBucket() (bucketExists bool, err error) {
 	username, password, _ := tbm.BucketSpec.Auth.GetCredentials()
 	bucket, err := tbm.Cluster.OpenBucket(tbm.BucketSpec.BucketName, password)
 	if err != nil {
-		// Let's assume that if there is an error opening the bucket, it's just because the
-		// bucket does not exist
+		// Authentication failure should return an explicit error as we can't continue from here.
+		if pkgerrors.Cause(err) == gocb.ErrAuthError {
+			log.Printf("Unable to authenticate as %s: %v", username, err)
+			return false, err
+		}
+
+		// There could be other errors here, but we assume the bucket doesn't exist, and may be able to continue.
 		// TODO: should check returned error type
 		log.Printf("GoCB error opening bucket: %v", err)
 		return false, nil


### PR DESCRIPTION
This fixes the panic mentioned in #3129 caused by an uncaught error/uninitialized bucket and adds an integration test for this scenario.

The authentication error is explicitly checked to cause a fatal connection and halt further retries and log the reason.

# Integration Tests

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/252/
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/253/