### PR TITLE
Fixes #2951: 404 Returned when deleting guest user.

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -452,7 +452,15 @@ func (h *handler) putRole() error {
 
 func (h *handler) deleteUser() error {
 	h.assertAdminOnly()
-	user, err := h.db.Authenticator().GetUser(mux.Vars(h.rq)["name"])
+	username := mux.Vars(h.rq)["name"]
+
+	// Can't delete the guest user, only disable.
+	if username == base.GuestUsername {
+		return base.HTTPErrorf(http.StatusMethodNotAllowed,
+			"The %s user cannot be deleted. Only disabled via an update.", base.GuestUsername)
+	}
+
+	user, err := h.db.Authenticator().GetUser(username)
 	if user == nil {
 		if err == nil {
 			err = kNotFoundError


### PR DESCRIPTION
Fixes https://github.com/couchbase/sync_gateway/issues/2951

`DELETE /{db}/_user/GUEST` now returns an error explaining that you should disable the guest account, not delete it.

# Integration Tests
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/254/
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/255/