### PR TITLE
Fixes #2760 - Allow Facebook registration without Email address

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -390,19 +390,23 @@ func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider)
 	return user, jwt, nil
 }
 
-// Registers a new user account based on the given verified email address.
-// Username will be the same as the verified email address. Password will be random.
-// The user will have access to no channels.
+// Registers a new user account based on the given verified username and optional email address.
+// Password will be random. The user will have access to no channels.
 func (auth *Authenticator) RegisterNewUser(username, email string) (User, error) {
 	user, err := auth.NewUser(username, base.GenerateRandomSecret(), base.Set{})
 	if err != nil {
 		return nil, err
 	}
-	user.SetEmail(email)
+
+	if len(email) > 0 {
+		user.SetEmail(email)
+	}
+
 	err = auth.Save(user)
 	if err != nil {
 		return nil, err
 	}
+
 	return user, err
 }
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -435,6 +435,21 @@ func TestRegisterUser(t *testing.T) {
 	user, err = auth.GetUserByEmail("bar@example.com")
 	assert.Equals(t, user.Name(), "bar@example.com")
 	assert.Equals(t, err, nil)
+
+	// Register user without an email address
+	user, err = auth.RegisterNewUser("01234567890", "")
+	assert.Equals(t, user.Name(), "01234567890")
+	assert.Equals(t, user.Email(), "")
+	assert.Equals(t, err, nil)
+	// Get above user by username.
+	user, err = auth.GetUser("01234567890")
+	assert.Equals(t, user.Name(), "01234567890")
+	assert.Equals(t, user.Email(), "")
+	assert.Equals(t, err, nil)
+	// Make sure we can't retrieve 01234567890 by supplying empty email.
+	user, err = auth.GetUserByEmail("")
+	assert.Equals(t, user, nil)
+	assert.Equals(t, err, nil)
 }
 
 // 8 cases

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -405,6 +405,7 @@ func TestRoleInheritance(t *testing.T) {
 func TestRegisterUser(t *testing.T) {
 	gTestBucket := base.GetTestBucketOrPanic()
 	defer gTestBucket.Close()
+
 	// Register user based on name, email
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, err := auth.RegisterNewUser("ValidName", "foo@example.com")

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -11,9 +11,10 @@ package rest
 
 import (
 	"encoding/json"
-	"github.com/couchbase/sync_gateway/base"
 	"net/http"
 	"net/url"
+
+	"github.com/couchbase/sync_gateway/base"
 )
 
 const kFacebookOpenGraphURL = "https://graph.facebook.com"
@@ -48,6 +49,12 @@ func (h *handler) handleFacebookPOST() error {
 	}
 
 	createUserIfNeeded := h.server.config.Facebook.Register
+
+	// #2760 Special case for when users have no email registered with Facebook
+	if len(facebookResponse.Email) < 1 {
+		return h.makeSessionFromName(facebookResponse.Id, createUserIfNeeded)
+	}
+
 	return h.makeSessionFromNameAndEmail(facebookResponse.Id, facebookResponse.Email, createUserIfNeeded)
 
 }

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -49,12 +49,6 @@ func (h *handler) handleFacebookPOST() error {
 	}
 
 	createUserIfNeeded := h.server.config.Facebook.Register
-
-	// #2760 Special case for when users have no email registered with Facebook
-	if len(facebookResponse.Email) < 1 {
-		return h.makeSessionFromName(facebookResponse.Id, createUserIfNeeded)
-	}
-
 	return h.makeSessionFromNameAndEmail(facebookResponse.Id, facebookResponse.Email, createUserIfNeeded)
 
 }

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -176,11 +176,13 @@ func (h *handler) makeSessionFromNameAndEmail(username, email string, createUser
 
 	// Attempt email updates/lookups if an email is provided.
 	if len(email) > 0 {
-		// If user found, check whether the email needs to be updated
-		// (e.g. user has changed email in external auth system)
-		if user != nil && email != user.Email() {
-			if err = user.SetEmail(email); err == nil {
-				h.db.Authenticator().Save(user)
+		if user != nil {
+			// User found, check whether the email needs to be updated
+			// (e.g. user has changed email in external auth system)
+			if email != user.Email() {
+				if err = user.SetEmail(email); err == nil {
+					h.db.Authenticator().Save(user)
+				}
 			}
 		} else {
 			// User not found by username. Attempt user lookup by email. This provides backward

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -182,13 +182,12 @@ func (h *handler) makeSessionFromNameAndEmail(username, email string, createUser
 			if err = user.SetEmail(email); err == nil {
 				h.db.Authenticator().Save(user)
 			}
-		}
-
-		// User not found by username. Attempt user lookup by email. This provides backward
-		// compatibility for users that were originally created with id = email
-		user, err = h.db.Authenticator().GetUserByEmail(email)
-		if err != nil {
-			return err
+		} else {
+			// User not found by username. Attempt user lookup by email. This provides backward
+			// compatibility for users that were originally created with id = email
+			if user, err = h.db.Authenticator().GetUserByEmail(email); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #2760 - Allow Facebook registration without Email address

- Modified `handler.makeSessionFromNameAndEmail()` for cases where no email is present
- Fixes some outdated comments

# Integration Tests
- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/258/
- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/259/