### PR TITLE
Fixes #3150 TestCustomHandler race condition

### DIFF
--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -271,6 +271,7 @@ func TestUnhandledEvent(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, "", channels)
 	}
 
+	// Validate that no events were handled
 	assertChannelLengthWithTimeout(t, resultChannel, 0, 10*time.Second)
 
 }

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -734,18 +734,15 @@ func assertChannelLengthWithTimeout(t *testing.T, c chan Body, expectedLength in
 			// Make sure there are no additional items on the channel after a short wait.
 			// This avoids relying on the longer timeout value for the final check.
 			time.Sleep(timeout / 100)
-			if count+len(c) > expectedLength {
-				assert.Equals(t, count+len(c), expectedLength)
-			} else {
-				return
-			}
+			assert.Equals(t, count+len(c), expectedLength)
+			return
 		}
 
 		select {
 		case _ = <-c:
 			count++
 		case <-time.After(timeout):
-			t.Fatal("timed out waiting for items on channel... got: %d, expected: %d", count, expectedLength)
+			t.Fatalf("timed out waiting for items on channel... got: %d, expected: %d", count, expectedLength)
 		}
 	}
 }


### PR DESCRIPTION
Fixes intermittent tests seen in #3150 due to timing issues by using sleeps.