### PR TITLE
Go 1.10: Address vet issues

### DIFF
--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -832,7 +832,7 @@ func TestRevisionPruningLoop(t *testing.T) {
 		revID := fmt.Sprintf("%d-foo", generation)
 		parentRevID := fmt.Sprintf("%d-foo", generation-1)
 		err := addAndGet(revTree, revID, parentRevID, nonTombstone)
-		assertNoError(t, err, fmt.Sprintf("Error adding revision 1-foo to tree", revID))
+		assertNoError(t, err, fmt.Sprintf("Error adding revision %s to tree", revID))
 	}
 
 	// Add tombstone children of 3-foo and 4-foo


### PR DESCRIPTION
Two minor fixes for vet issues which causes tests to fail under Go 1.10 beta (mismatched formatting directives)
```
db/change_cache_test.go:482: Printf format %v reads arg #1, but call has only 0 args
db/revtree_test.go:835: Sprintf call has arguments but no formatting directives
```

Apologies for gofmt inflating the diff.