### PR TITLE
Fixes #2223 : Wrong name being set for users

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1023,6 +1023,8 @@ func TestDBGetConfigNames(t *testing.T) {
 	var body DbConfig
 	json.Unmarshal(response.Body.Bytes(), &body)
 
+	assert.Equals(t, len(body.Users), len(rt.DatabaseConfig.Users))
+
 	for k, v := range body.Users {
 		assert.Equals(t, *v.Name, k)
 	}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1003,6 +1003,32 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/_config", ""), 404)
 }
 
+// Tests that the users returned in the config endpoint have the correct names
+// Reproduces #2223
+func TestDBGetConfigNames(t *testing.T) {
+
+	var rt RestTester
+	defer rt.Close()
+
+	p := "password"
+
+	rt.DatabaseConfig = &DbConfig{
+		Users: map[string]*db.PrincipalConfig{
+			"alice": &db.PrincipalConfig{Password: &p},
+			"bob":   &db.PrincipalConfig{Password: &p},
+		},
+	}
+
+	response := rt.SendAdminRequest("GET", "/db/_config", "")
+	var body DbConfig
+	json.Unmarshal(response.Body.Bytes(), &body)
+
+	for k, v := range body.Users {
+		assert.Equals(t, *v.Name, k)
+	}
+
+}
+
 //Take DB offline and ensure can post _resync
 func TestDBOfflinePostResync(t *testing.T) {
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -149,8 +149,6 @@ func (sc *ServerContext) Close() {
 
 	sc.databases_ = nil
 
-
-
 }
 
 // Returns the DatabaseContext with the given name
@@ -822,7 +820,8 @@ func (sc *ServerContext) installPrincipals(context *db.DatabaseContext, spec map
 			internalName := ""
 			princ.Name = &internalName
 		} else {
-			princ.Name = &name
+			n := name
+			princ.Name = &n
 		}
 
 		worker := func() (shouldRetry bool, err error, value interface{}) {
@@ -860,13 +859,9 @@ func (sc *ServerContext) installPrincipals(context *db.DatabaseContext, spec map
 			base.Logf("    Created %s %q", what, name)
 		}
 
-
 	}
 	return nil
 }
-
-
-
 
 // Fetch a configuration for a database from the ConfigServer
 func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error) {


### PR DESCRIPTION
As described in #2223, setting the name of a user to a pointer when iterating the principal map was leading to unintended data.

Now we assign a copy of the name and added a test to reproduce.