### PR TITLE
Fixes #3159 Add -dot format to sgcollect_info

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -149,6 +149,7 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
     ]
 
     format_types = [
+        "dot",
         "pdf",
         "text",
         "raw",


### PR DESCRIPTION
I manually tested on centos7 and was able to render the dot files to PDF's locally via:

```
dot -Tpdf sgcollect_info_ip-172-31-51-246_20171222-012256/heap.dot -o heap.pdf
```

for both heap and cpu profile


[heap.pdf](https://github.com/couchbase/sync_gateway/files/1581206/heap.pdf)

[heap.dot.zip](https://github.com/couchbase/sync_gateway/files/1581208/heap.dot.zip)
