### PR TITLE
Issue #3146 : Log request duration correctly for non-blocking handlers

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -633,7 +633,7 @@ func (h *handler) handlePurge() error {
 	}
 
 	h.response.Write([]byte("}\n}\n"))
-	h.logStatus(http.StatusOK, message)
+	h.logStatusWithDuration(http.StatusOK, message)
 
 	return nil
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -633,7 +633,7 @@ func (h *handler) handlePurge() error {
 	}
 
 	h.response.Write([]byte("}\n}\n"))
-	h.logStatus(http.StatusOK, message)
+	h.logStatus(http.StatusOK, message, false)
 
 	return nil
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -633,7 +633,7 @@ func (h *handler) handlePurge() error {
 	}
 
 	h.response.Write([]byte("}\n}\n"))
-	h.logStatus(http.StatusOK, message, false)
+	h.logStatus(http.StatusOK, message)
 
 	return nil
 }

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -79,7 +79,7 @@ func (h *handler) handleBLIPSync() error {
 
 	// Start a WebSocket client and connect it to the BLIP handler:
 	wsHandler := func(conn *websocket.Conn) {
-		h.logStatus(101, "Upgraded to BLIP+WebSocket protocol", true)
+		h.logStatus(101, "Upgraded to BLIP+WebSocket protocol")
 		defer func() {
 			conn.Close()
 			base.LogTo("HTTP+", "#%03d:     --> BLIP+WebSocket connection closed", h.serialNumber)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -79,7 +79,7 @@ func (h *handler) handleBLIPSync() error {
 
 	// Start a WebSocket client and connect it to the BLIP handler:
 	wsHandler := func(conn *websocket.Conn) {
-		h.logStatus(101, "Upgraded to BLIP+WebSocket protocol")
+		h.logStatus(101, "Upgraded to BLIP+WebSocket protocol", true)
 		defer func() {
 			conn.Close()
 			base.LogTo("HTTP+", "#%03d:     --> BLIP+WebSocket connection closed", h.serialNumber)

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -323,9 +323,14 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	h.setHeader("Content-Type", "application/json")
 	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
 	h.response.Write([]byte("{\"results\":[\r\n"))
+
+	logStatus := h.logStatusWithDuration
+
 	if options.Wait {
+		logStatus = h.logStatus
 		h.flush()
 	}
+
 	message := "OK"
 	forceClose := false
 	if feed != nil {
@@ -390,7 +395,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 				break loop
 			}
 			if err != nil {
-				h.logStatus(599, fmt.Sprintf("Write error: %v", err))
+				logStatus(599, fmt.Sprintf("Write error: %v", err))
 				return nil, forceClose // error is probably because the client closed the connection
 			}
 		}
@@ -398,7 +403,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 
 	s := fmt.Sprintf("],\n\"last_seq\":%q}\n", lastSeq.String())
 	h.response.Write([]byte(s))
-	h.logStatus(http.StatusOK, message)
+	logStatus(http.StatusOK, message)
 	return nil, forceClose
 }
 
@@ -516,7 +521,7 @@ func (h *handler) sendChangesForDocIds(userChannels base.Set, explicitDocIds []s
 
 	s := fmt.Sprintf("],\n\"last_seq\":%d}\n", lastSeq)
 	h.response.Write([]byte(s))
-	h.logStatus(http.StatusOK, "OK")
+	h.logStatusWithDuration(http.StatusOK, "OK")
 	return nil, false
 }
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -323,9 +323,14 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	h.setHeader("Content-Type", "application/json")
 	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
 	h.response.Write([]byte("{\"results\":[\r\n"))
+
+	logStatus := h.logStatusWithDuration
+
 	if options.Wait {
+		logStatus = h.logStatus
 		h.flush()
 	}
+
 	message := "OK"
 	forceClose := false
 	if feed != nil {
@@ -390,7 +395,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 				break loop
 			}
 			if err != nil {
-				h.logStatus(599, fmt.Sprintf("Write error: %v", err), options.Wait)
+				logStatus(599, fmt.Sprintf("Write error: %v", err))
 				return nil, forceClose // error is probably because the client closed the connection
 			}
 		}
@@ -398,7 +403,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 
 	s := fmt.Sprintf("],\n\"last_seq\":%q}\n", lastSeq.String())
 	h.response.Write([]byte(s))
-	h.logStatus(http.StatusOK, message, options.Wait)
+	logStatus(http.StatusOK, message)
 	return nil, forceClose
 }
 
@@ -516,7 +521,7 @@ func (h *handler) sendChangesForDocIds(userChannels base.Set, explicitDocIds []s
 
 	s := fmt.Sprintf("],\n\"last_seq\":%d}\n", lastSeq)
 	h.response.Write([]byte(s))
-	h.logStatus(http.StatusOK, "OK", !options.Wait)
+	h.logStatusWithDuration(http.StatusOK, "OK")
 	return nil, false
 }
 
@@ -526,7 +531,7 @@ func (h *handler) sendChangesForDocIds(userChannels base.Set, explicitDocIds []s
 // a periodic heartbeat while waiting.
 func (h *handler) generateContinuousChanges(inChannels base.Set, options db.ChangesOptions, send func([]*db.ChangeEntry) error) (error, bool) {
 	err, forceClose := generateContinuousChanges(h.db, inChannels, options, nil, send)
-	h.logStatus(http.StatusOK, "OK (continuous feed closed)", true)
+	h.logStatus(http.StatusOK, "OK (continuous feed closed)")
 	return err, forceClose
 }
 
@@ -664,7 +669,7 @@ loop:
 
 		if err != nil {
 			if h != nil {
-				h.logStatus(http.StatusOK, fmt.Sprintf("Write error: %v", err), options.Wait)
+				h.logStatus(http.StatusOK, fmt.Sprintf("Write error: %v", err))
 			}
 			return nil, forceClose // error is probably because the client closed the connection
 		}
@@ -679,7 +684,7 @@ func (h *handler) sendContinuousChangesByHTTP(inChannels base.Set, options db.Ch
 	// receiving the response.
 	h.setHeader("Content-Type", "application/octet-stream")
 	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
-	h.logStatus(http.StatusOK, "sending continuous feed", true)
+	h.logStatus(http.StatusOK, "sending continuous feed")
 	return h.generateContinuousChanges(inChannels, options, func(changes []*db.ChangeEntry) error {
 		var err error
 		if changes != nil {
@@ -704,7 +709,7 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 
 	forceClose := false
 	handler := func(conn *websocket.Conn) {
-		h.logStatus(101, "Upgraded to WebSocket protocol", true)
+		h.logStatus(101, "Upgraded to WebSocket protocol")
 		defer func() {
 			conn.Close()
 			base.LogTo("HTTP+", "#%03d:     --> WebSocket closed", h.serialNumber)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -281,12 +281,14 @@ func (h *handler) logDuration(realTime bool) {
 		float64(duration)/float64(time.Millisecond))
 }
 
+// logStatusWithDuration will log the request status and the duration of the request.
 func (h *handler) logStatusWithDuration(status int, message string) {
 	h.setStatus(status, message)
 	h.logDuration(true)
 }
 
-// Used for indefinitely-long handlers like _changes that we don't want to track duration of
+// logStatus will log the request status, but NOT the duration of the request.
+// This is used for indefinitely-long handlers like _changes that we don't want to track duration of
 func (h *handler) logStatus(status int, message string) {
 	h.setStatus(status, message)
 	h.logDuration(false) // don't track actual time

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -281,6 +281,11 @@ func (h *handler) logDuration(realTime bool) {
 		float64(duration)/float64(time.Millisecond))
 }
 
+func (h *handler) logStatusWithDuration(status int, message string) {
+	h.setStatus(status, message)
+	h.logDuration(true)
+}
+
 // Used for indefinitely-long handlers like _changes that we don't want to track duration of
 func (h *handler) logStatus(status int, message string) {
 	h.setStatus(status, message)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -281,11 +281,15 @@ func (h *handler) logDuration(realTime bool) {
 		float64(duration)/float64(time.Millisecond))
 }
 
-// logStatus will log the status of the request, with a message, and an option to hide the duration.
-// hideDuration should be true for indefinite requests, such as longpoll or continuous connections.
-func (h *handler) logStatus(status int, message string, hideDuration bool) {
+func (h *handler) logStatusWithDuration(status int, message string) {
 	h.setStatus(status, message)
-	h.logDuration(!hideDuration)
+	h.logDuration(true)
+}
+
+// Used for indefinitely-long handlers like _changes that we don't want to track duration of
+func (h *handler) logStatus(status int, message string) {
+	h.setStatus(status, message)
+	h.logDuration(false) // don't track actual time
 }
 
 func (h *handler) checkAuth(context *db.DatabaseContext) error {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -281,15 +281,11 @@ func (h *handler) logDuration(realTime bool) {
 		float64(duration)/float64(time.Millisecond))
 }
 
-func (h *handler) logStatusWithDuration(status int, message string) {
+// logStatus will log the status of the request, with a message, and an option to hide the duration.
+// hideDuration should be true for indefinite requests, such as longpoll or continuous connections.
+func (h *handler) logStatus(status int, message string, hideDuration bool) {
 	h.setStatus(status, message)
-	h.logDuration(true)
-}
-
-// Used for indefinitely-long handlers like _changes that we don't want to track duration of
-func (h *handler) logStatus(status int, message string) {
-	h.setStatus(status, message)
-	h.logDuration(false) // don't track actual time
+	h.logDuration(!hideDuration)
 }
 
 func (h *handler) checkAuth(context *db.DatabaseContext) error {


### PR DESCRIPTION
Closes #3146 

Request duration is now logged correctly for non-blocking requests, and is only omitted for longpoll or continuous connections.