### PR TITLE
Fixes #3174 sgcollect_info crashes if error encountered getting expvars

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -149,6 +149,7 @@ class PythonTask(object):
         self.callable = callable
         self.command = "pythontask"
         self.timeout = timeout
+        self.log_exception = False  # default to false, may be overridden by val in **kwargs
         self.__dict__.update(kwargs)
 
     def execute(self, fp):


### PR DESCRIPTION
Fixes #3174 

Tested on the python CLI.  

## Before fix

```
>>> curl_task = tasks.make_curl_task("foo", "nonexistenturl34343.com")
>>> curl_task.execute(tmpfile)
log_file: python_curl.log.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "tasks.py", line 162, in execute
    if self.log_exception is not None and self.log_exception:
AttributeError: 'PythonTask' object has no attribute 'log_exception'
```

## After fix w/ default params

```
>>> curl_task = tasks.make_curl_task("foo", "nonexistenturl34343.com")
>>> curl_task.execute(tmpfile)
log_file: python_curl.log.
1
```

## After fix w/ log_exception=True

```
>>> curl_task = tasks.make_curl_task("foo", "nonexistenturl34343.com", log_exception=True)
>>> curl_task.execute(tmpfile)
log_file: python_curl.log.
Exception executing python task: unknown url type: nonexistenturl34343.com
1
```
  