### PR TITLE
Backfill statistics and improved recovery during backfill

### DIFF
--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -95,6 +95,7 @@ type DCPReceiver struct {
 	notify                 sgbucket.BucketNotifyFn        // Function to callback when we lose our dcp feed
 	callback               sgbucket.FeedEventCallbackFunc // Function to callback for mutation processing
 	backfill               backfillStatus                 // Backfill state and stats
+}
 
 func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, backfillType uint64) (Receiver, error) {
 
@@ -198,8 +199,8 @@ func makeFeedEvent(rq *gomemcached.MCRequest, vbucketId uint16, opcode sgbucket.
 func (r *DCPReceiver) SnapshotStart(vbucketId uint16,
 	snapStart, snapEnd uint64, snapType uint32) error {
 	// During initial backfill, we persist snapshot information to support resuming the DCP
-	// stream midway through a snapshot.  This is primarily for the import when initially 
-	// connection to a populated bucket, to avoid restarting the import from 
+	// stream midway through a snapshot.  This is primarily for the import when initially
+	// connection to a populated bucket, to avoid restarting the import from
 	// zero if SG is terminated before completing processing of the initial snapshots.
 	if r.backfill.isActive() && r.backfill.isVbActive(vbucketId) {
 		r.backfill.snapshotStart(vbucketId, snapStart, snapEnd)

--- a/base/util.go
+++ b/base/util.go
@@ -772,6 +772,15 @@ func GetExpvarAsString(mapName string, name string) string {
 	}
 }
 
+// Returns int representation of an expvar, given map name and key name
+func GetExpvarAsInt(mapName string, name string) (int, error) {
+	stringVal := GetExpvarAsString(mapName, name)
+	if stringVal == "" {
+		return 0, nil
+	}
+	return strconv.Atoi(stringVal)
+}
+
 // TODO: temporary workaround until https://issues.couchbase.com/browse/MB-27026 is implemented
 func ExtractExpiryFromDCPMutation(rq *gomemcached.MCRequest) (expiry uint32) {
 	if len(rq.Extras) < 24 {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -39,6 +39,7 @@ type RestTester struct {
 	PublicHandler           http.Handler
 	leakyBucketConfig       *base.LeakyBucketConfig
 	EnableNoConflictsMode   bool // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
+	NoFlush                 bool // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
 }
 
 func (rt *RestTester) Bucket() base.Bucket {
@@ -46,8 +47,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 	if rt.RestTesterBucket == nil {
 
 		// Initialize the bucket.  For couchbase-backed tests, triggers with creation/flushing of the bucket
-		tempBucket := base.GetTestBucketOrPanic() // side effect of creating/flushing bucket
-		tempBucket.Close()
+		if !rt.NoFlush {
+			tempBucket := base.GetTestBucketOrPanic() // side effect of creating/flushing bucket
+			tempBucket.Close()
+		}
 
 		spec := base.GetTestBucketSpec(base.DataBucket)
 


### PR DESCRIPTION
Adds DCP backfill statistics in logs and expvars.  These can be used to monitor the progress of long-running initial DCP feed processing.  Also includes support for resuming an incomplete backfill snapshot at the last sequence processed, instead of having to reprocess from the beginning of the snapshot.

This functionality is particularly useful for the following scenarios:
 - initial migration of Sync Gateway metadata from doc._sync to extended attribute
 - initial import of an non-mobile enabled bucket

Fixes #2976 and #2825.

