### PR TITLE
Fix #3144 SG is throwing error "PANIC handling BLIP request"

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -390,7 +390,7 @@ func (bh *blipHandler) handleProposedChanges(rq *blip.Message) error {
 		docID := change[0].(string)
 		revID := change[1].(string)
 		parentRevID := ""
-		if len(change) >= 2 {
+		if len(change) > 2 {
 			parentRevID = change[2].(string)
 		}
 		status := bh.db.CheckProposedRev(docID, revID, parentRevID)


### PR DESCRIPTION
Fixes #3144 

This is fixed on `feature/issue_2653_blip_active_replicator` with an accompanying unit test, however that branch is blocked on https://github.com/couchbase/sync_gateway/pull/3138, which requires coordinating w/ Litecore merge and is semi-blocked on https://github.com/couchbase/go-blip/pull/6

So I'm creating a separate PR for the fix itself. 