### PR TITLE
Fixes #2383 : Return ErrPartialViewErrors if any partial errors are present from a view

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,4 +10,4 @@ build:
     - ./bootstrap.sh -c $$COMMIT -p sg
     - ./build.sh -v
     - ./test.sh
-    - ./test.sh -race
+    - ./test.sh -race -timeout 20m

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"strings"
 
+	"sync"
+
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 	"gopkg.in/couchbase/gocbcore.v7"
-	"sync"
 )
 
 var gocbExpvars *expvar.Map
@@ -1883,6 +1884,8 @@ func (bucket CouchbaseBucketGoCB) View(ddoc, name string, params map[string]inte
 				}
 				viewResult.Errors = append(viewResult.Errors, viewErr)
 			}
+			// Any kind of partial errors should be bubbled up for the caller to either handle or ignore.
+			return viewResult, err
 		}
 
 	}
@@ -1975,7 +1978,8 @@ func (bucket CouchbaseBucketGoCB) ViewCustom(ddoc, name string, params map[strin
 		return err
 	}
 
-	return nil
+	// Any kind of partial errors should be bubbled up for the caller to either handle or ignore.
+	return errClose
 }
 
 func getTotalRows(goCbViewResult gocb.ViewResults) int {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1884,8 +1884,8 @@ func (bucket CouchbaseBucketGoCB) View(ddoc, name string, params map[string]inte
 				}
 				viewResult.Errors = append(viewResult.Errors, viewErr)
 			}
-			// Any kind of partial errors should be bubbled up for the caller to either handle or ignore.
-			return viewResult, err
+
+			return viewResult, ErrPartialViewErrors
 		}
 
 	}
@@ -1978,8 +1978,13 @@ func (bucket CouchbaseBucketGoCB) ViewCustom(ddoc, name string, params map[strin
 		return err
 	}
 
-	// Any kind of partial errors should be bubbled up for the caller to either handle or ignore.
-	return errClose
+	// Checking and returning down here as we still need to
+	// marshal/unmarshal into vres with partial errors present.
+	if errClose != nil {
+		return ErrPartialViewErrors
+	}
+
+	return nil
 }
 
 func getTotalRows(goCbViewResult gocb.ViewResults) int {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
 	"sync"
 
 	"github.com/couchbase/gocb"
@@ -1884,10 +1883,14 @@ func (bucket CouchbaseBucketGoCB) View(ddoc, name string, params map[string]inte
 				}
 				viewResult.Errors = append(viewResult.Errors, viewErr)
 			}
-
-			return viewResult, ErrPartialViewErrors
 		}
 
+	}
+
+	// Indicate the view response contained partial errors so consumers can determine
+	// if the result is valid to their particular use-case (see SG issue #2383)
+	if len(viewResult.Errors) > 0 {
+		return viewResult, ErrPartialViewErrors
 	}
 
 	return viewResult, nil
@@ -1978,9 +1981,9 @@ func (bucket CouchbaseBucketGoCB) ViewCustom(ddoc, name string, params map[strin
 		return err
 	}
 
-	// Checking and returning down here as we still need to
-	// marshal/unmarshal into vres with partial errors present.
-	if errClose != nil {
+	// Indicate the view response contained partial errors so consumers can determine
+	// if the result is valid to their particular use-case (see SG issue #2383)
+	if len(viewResponse.Errors) > 0 {
 		return ErrPartialViewErrors
 	}
 

--- a/base/error.go
+++ b/base/error.go
@@ -33,6 +33,7 @@ const (
 	fatalBucketConnection = sgErrorCode(0x07)
 	emptyMetadata         = sgErrorCode(0x08)
 	casFailureShouldRetry = sgErrorCode(0x09)
+	errPartialViewErrors  = sgErrorCode(0x10)
 )
 
 type SGError struct {
@@ -50,6 +51,10 @@ var (
 	ErrFatalBucketConnection = &SGError{fatalBucketConnection}
 	ErrEmptyMetadata         = &SGError{emptyMetadata}
 	ErrCasFailureShouldRetry = &SGError{casFailureShouldRetry}
+
+	// ErrPartialViewErrors is returned if the view call contains any partial errors.
+	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
+	ErrPartialViewErrors = &SGError{errPartialViewErrors}
 )
 
 func (e SGError) Error() string {
@@ -72,6 +77,8 @@ func (e SGError) Error() string {
 		return "Fatal error connecting to bucket"
 	case emptyMetadata:
 		return "Empty Sync Gateway metadata"
+	case errPartialViewErrors:
+		return "Partial errors in view"
 	default:
 		return "Unknown error"
 	}
@@ -188,4 +195,3 @@ func IsDocNotFoundError(err error) bool {
 		return false
 	}
 }
-

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	couchbase "github.com/couchbase/go-couchbase"
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
@@ -27,6 +28,9 @@ type LeakyBucketConfig struct {
 	TapFeedDeDuplication bool
 	TapFeedVbuckets      bool     // Emulate vbucket numbers on feed
 	TapFeedMissingDocs   []string // Emulate entry not appearing on tap feed
+
+	// Returns a partial error the first time ViewCustom is called
+	FirstTimeViewCustomPartialError bool
 }
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
@@ -35,6 +39,7 @@ func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
 		config: config,
 	}
 }
+
 func (b *LeakyBucket) GetName() string {
 	return b.bucket.GetName()
 }
@@ -113,7 +118,14 @@ func (b *LeakyBucket) View(ddoc, name string, params map[string]interface{}) (sg
 	return b.bucket.View(ddoc, name, params)
 }
 func (b *LeakyBucket) ViewCustom(ddoc, name string, params map[string]interface{}, vres interface{}) error {
-	return b.bucket.ViewCustom(ddoc, name, params, vres)
+	err := b.bucket.ViewCustom(ddoc, name, params, vres)
+
+	if b.config.FirstTimeViewCustomPartialError {
+		b.config.FirstTimeViewCustomPartialError = !b.config.FirstTimeViewCustomPartialError
+		err = couchbase.ViewError{From: "partial error from", Reason: "partial error reason"}
+	}
+
+	return err
 }
 
 func (b *LeakyBucket) GetMaxVbno() (uint16, error) {
@@ -315,6 +327,10 @@ func (b *LeakyBucket) CloseAndDelete() error {
 
 func (b *LeakyBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
 	return b.bucket.GetStatsVbSeqno(maxVbno, useAbsHighSeqNo)
+}
+
+func (b *LeakyBucket) SetFirstTimeViewCustomPartialError(val bool) {
+	b.config.FirstTimeViewCustomPartialError = val
 }
 
 // An implementation of a sgbucket tap feed that wraps

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	couchbase "github.com/couchbase/go-couchbase"
 	sgbucket "github.com/couchbase/sg-bucket"
 )
 
@@ -122,7 +121,7 @@ func (b *LeakyBucket) ViewCustom(ddoc, name string, params map[string]interface{
 
 	if b.config.FirstTimeViewCustomPartialError {
 		b.config.FirstTimeViewCustomPartialError = !b.config.FirstTimeViewCustomPartialError
-		err = couchbase.ViewError{From: "partial error from", Reason: "partial error reason"}
+		err = ErrPartialViewErrors
 	}
 
 	return err

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -45,6 +45,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	for {
 		vres := channelsViewResult{}
 		err := dbc.Bucket.ViewCustom(DesignDocSyncGateway, ViewChannels, optMap, &vres)
+
 		if err != nil {
 			base.Logf("Error from 'channels' view: %v", err)
 			return nil, err

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -118,6 +118,11 @@ func (it *indexTester) ServerContext() *ServerContext {
 
 // Reproduces issue #2383 by forcing a partial error from the view on the first changes request.
 func TestReproduce2383(t *testing.T) {
+
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Skip LeakyBucket test when running in integration")
+	}
+
 	rt := RestTester{leakyBucketConfig: &base.LeakyBucketConfig{}}
 
 	response := rt.SendAdminRequest("PUT", "/_logging", `{"*":true, "color":true}`)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -178,6 +178,8 @@ func TestReproduce2383(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/doc4", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
 
+	testDb.WaitForSequence(4)
+
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben"))
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -35,6 +35,7 @@ type RestTester struct {
 	DatabaseConfig          *DbConfig // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
 	AdminHandler            http.Handler
 	PublicHandler           http.Handler
+	leakyBucketConfig       *base.LeakyBucketConfig
 }
 
 func (rt *RestTester) Bucket() base.Bucket {
@@ -93,6 +94,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		if !rt.noAdminParty {
 			rt.SetAdminParty(true)
+		}
+
+		// If given a leakyBucketConfig we'll return a leaky bucket.
+		if rt.leakyBucketConfig != nil {
+			return base.NewLeakyBucket(rt.RestTesterBucket, *rt.leakyBucketConfig)
 		}
 
 	}


### PR DESCRIPTION
Fixes #2383 : Prevents the channel cache from being initilized in an invalid state 

# Changes

- Added test to repro #2383 

- `CouchbaseBucketGoCB.ViewCustom` and `CouchbaseBucketGoCB.View` now return `ErrPartialViewErrors` if any partial errors are present.

- Added the ability to use a `LeakyBucket` in `RestTester` by passing in a `LeakyBucketConfig`.

- Increased drone `test.sh -race` timeout to 20 minutes (from 10m) now we seem to be regularly hitting that limit (currently ~630s on drone)

# Integration Tests

- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/284/
- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/285/