### PR TITLE
Fixes #2848 : sgcollect_info ignore HTTPS validation

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -40,8 +40,10 @@ import password_remover
 
 import ssl
 try:
+    # Don't validate HTTPS by default.
     _create_unverified_https_context = ssl._create_unverified_context
 except AttributeError:
+    # Running an older version of Python which won't validate HTTPS anyway.
     pass
 else:
     ssl._create_default_https_context = _create_unverified_https_context

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -38,6 +38,14 @@ from tasks import add_file_task
 
 import password_remover
 
+import ssl
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    pass
+else:
+    ssl._create_default_https_context = _create_unverified_https_context
+
 # Collects the following info from Sync Gateway
 #
 # - System Stats (top, netstat, etc)


### PR DESCRIPTION
Fixes #2848 when sgcollect_info is being run against SG with a self-signed cert. This disables HTTPS validation by default.