### PR TITLE
Updated go-blip, and added BLIP fatal-error handler that logs to SG

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="169397c83b14c589c6452565f7ce7fa9201c6103"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="517b37d332081295493c53be21aa43a750495d86"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 


### PR DESCRIPTION
Picked up bug-fixes in go-blip, plus the ability to set a FatalError
handler.

Added a FatalError handler that logs to "HTTP". This will show things
like go-blip panics, or fatal protocol errors, in the SG log.

Also took the error logging out of the conn.Close() call in the defer
block -- I found that the only errors that it ever logged were
"closing an already-closed socket", if go-blip had already closed
the connection, so the log call was just noise.

Fixes #3192