### PR TITLE
Versioning of SG design docs

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1643,6 +1643,7 @@ func (bucket CouchbaseBucketGoCB) GetDDoc(docname string, into interface{}) erro
 		return err
 	}
 
+	// TODO: Retry here for recoverable gocb errors?
 	designDocPointer, err := bucketManager.GetDesignDocument(docname)
 	if err != nil {
 		return err

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1846,7 +1846,7 @@ func (bucket CouchbaseBucketGoCB) View(ddoc, name string, params map[string]inte
 
 	// If it's any other error, return it as-is
 	if err != nil {
-		return viewResult, err
+		return viewResult, pkgerrors.Wrapf(err, "Unexpected error querying design doc %q, view %q with params:%+v", ddoc, name, params)
 	}
 
 	if goCbViewResult != nil {
@@ -1919,7 +1919,7 @@ func (bucket CouchbaseBucketGoCB) ViewCustom(ddoc, name string, params map[strin
 
 	// If it's any other error, return it as-is
 	if err != nil {
-		return err
+		return pkgerrors.Wrapf(err, "Unexpected error querying design doc %q, view %q with params:%+v", ddoc, name, params)
 	}
 
 	// Define a struct to store the rows as raw bytes

--- a/base/util.go
+++ b/base/util.go
@@ -788,3 +788,12 @@ func ExtractExpiryFromDCPMutation(rq *gomemcached.MCRequest) (expiry uint32) {
 	}
 	return binary.BigEndian.Uint32(rq.Extras[20:24])
 }
+
+func StringSliceContains(set []string, target string) bool {
+	for _, val := range set {
+		if val == target {
+			return true
+		}
+	}
+	return false
+}

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -44,8 +44,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	// this means we may need multiple view calls to get a total of [limit] active entries.
 	for {
 		vres := channelsViewResult{}
-		err := dbc.Bucket.ViewCustom(DesignDocSyncGateway, ViewChannels, optMap, &vres)
-
+		err := dbc.Bucket.ViewCustom(DesignDocSyncGateway(), ViewChannels, optMap, &vres)
 		if err != nil {
 			base.Logf("Error from 'channels' view: %v", err)
 			return nil, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -590,7 +590,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 	allowImport := db.UseXattrs()
 
-
 	return db.updateDoc(docid, allowImport, expiry, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 
 		// (Be careful: this block can be invoked multiple times if there are races!)
@@ -676,7 +675,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 		}
 		if currentRevIndex == 0 {
 			base.LogTo("CRUD+", "PutExistingRev(%q): No new revisions to add", docid)
-			body["_rev"] = newRev                   // The _rev field is expected by some callers.  If missing, may cause problems for callers.
+			body["_rev"] = newRev                        // The _rev field is expected by some callers.  If missing, may cause problems for callers.
 			return nil, nil, nil, couchbase.UpdateCancel // No new revisions to add
 		}
 
@@ -1337,7 +1336,7 @@ func (context *DatabaseContext) ComputeSequenceChannelsForPrincipal(princ auth.P
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": key}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewAccess, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway(), ViewAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	channelSet := channels.TimedSet{}
@@ -1362,7 +1361,7 @@ func (context *DatabaseContext) ComputeVbSequenceChannelsForPrincipal(princ auth
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": key}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewAccessVbSeq, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway(), ViewAccessVbSeq, opts, &vres); verr != nil {
 		return nil, verr
 	}
 
@@ -1393,7 +1392,7 @@ func (context *DatabaseContext) ComputeSequenceRolesForUser(user auth.User) (cha
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewRoleAccess, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway(), ViewRoleAccess, opts, &vres); verr != nil {
 		return nil, verr
 	}
 	// Merge the TimedSets from the view result:
@@ -1418,7 +1417,7 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 	}
 
 	opts := map[string]interface{}{"stale": false, "key": user.Name()}
-	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway, ViewRoleAccessVbSeq, opts, &vres); verr != nil {
+	if verr := context.Bucket.ViewCustom(DesignDocSyncGateway(), ViewRoleAccessVbSeq, opts, &vres); verr != nil {
 		return nil, verr
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -34,16 +34,14 @@ const (
 	DBOnline
 	DBStopping
 	DBResyncing
-	DBViewsPending
 )
 
 var RunStateString = []string{
-	DBOffline:      "Offline",
-	DBStarting:     "Starting",
-	DBOnline:       "Online",
-	DBStopping:     "Stopping",
-	DBResyncing:    "Resyncing",
-	DBViewsPending: "Unavailable (waiting for views)",
+	DBOffline:   "Offline",
+	DBStarting:  "Starting",
+	DBOnline:    "Online",
+	DBStopping:  "Stopping",
+	DBResyncing: "Resyncing",
 }
 
 const (

--- a/db/database.go
+++ b/db/database.go
@@ -463,6 +463,11 @@ func (context *DatabaseContext) FlushChannelCache() {
 	context.changeCache.Clear()
 }
 
+// Removes previous versions of Sync Gateway's design docs found on the server
+func (context *DatabaseContext) RemoveObsoleteDesignDocs(previewOnly bool) (removedDesignDocs []string, err error) {
+	return removeObsoleteDesignDocs(context.Bucket, previewOnly)
+}
+
 func (context *DatabaseContext) NotifyUser(username string) {
 	context.tapListener.NotifyCheckForTermination(base.SetOf(auth.UserKeyPrefix + username))
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -92,10 +92,8 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database,
 
 func testBucket() base.TestBucket {
 
-	spec := base.GetTestBucketSpec(base.DataBucket)
 	testBucket := base.GetTestBucketOrPanic()
-	bucket := testBucket.Bucket
-	err := installViews(bucket, spec.UseXattrs)
+	err := installViews(testBucket.Bucket)
 	if err != nil {
 		log.Fatalf("Couldn't connect to bucket: %v", err)
 	}
@@ -1498,7 +1496,7 @@ func TestViewCustom(t *testing.T) {
 	// query all docs using ViewCustom query.
 	opts := Body{"stale": false, "reduce": false}
 	viewResult := sgbucket.ViewResult{}
-	errViewCustom := db.Bucket.ViewCustom(DesignDocSyncHousekeeping, ViewAllDocs, opts, &viewResult)
+	errViewCustom := db.Bucket.ViewCustom(DesignDocSyncHousekeeping(), ViewAllDocs, opts, &viewResult)
 	assert.True(t, errViewCustom == nil)
 
 	// assert that the doc added earlier is in the results

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -573,9 +573,9 @@ func installViews(bucket base.Bucket) error {
 
 // Issue a stale=false queries against critical views to guarantee indexing is complete and views are ready
 func WaitForViews(bucket base.Bucket) error {
-	viewErrors := make(chan error, 3)
 	var viewsWg sync.WaitGroup
 	views := []string{ViewChannels, ViewAccess, ViewRoleAccess}
+	viewErrors := make(chan error, len(views))
 
 	base.Logf("Verifying view availability for bucket %s...", bucket.GetName())
 

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestRemoveObsoleteDesignDocs(t *testing.T) {
+
+	testBucket := testBucket()
+	defer testBucket.Close()
+	bucket := testBucket.Bucket
+	mapFunction := `function (doc, meta) { emit(); }`
+
+	// Add some design docs in the old format
+	err := bucket.PutDDoc(DesignDocSyncGatewayPrefix, sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			"channels": sgbucket.ViewDef{Map: mapFunction},
+		},
+	})
+	assertNoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
+
+	err = bucket.PutDDoc(DesignDocSyncHousekeepingPrefix, sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			"all_docs": sgbucket.ViewDef{Map: mapFunction},
+		},
+	})
+	assertNoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
+
+	// Add some user design docs that shouldn't be removed
+	err = bucket.PutDDoc("sync_gateway_user_ddoc", sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			"channels_custom": sgbucket.ViewDef{Map: mapFunction},
+		},
+	})
+	assertNoError(t, err, "Unable to create design doc (sync_gateway_user_created)")
+
+	// Verify creation was successful
+	assertTrue(t, designDocExists(bucket, DesignDocSyncGatewayPrefix), "Design doc doesn't exist")
+	assertTrue(t, designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Design doc doesn't exist")
+	assertTrue(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc doesn't exist")
+
+	// Invoke removal in preview mode
+	removedDDocs, removeErr := removeObsoleteDesignDocs(bucket, true)
+	assertNoError(t, removeErr, "Error removing previous design docs")
+	assert.Equals(t, len(removedDDocs), 2)
+	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
+	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
+
+	// Re-verify ddocs still exist (preview)
+	assertTrue(t, designDocExists(bucket, DesignDocSyncGatewayPrefix), "Design doc doesn't exist")
+	assertTrue(t, designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Design doc doesn't exist")
+	assertTrue(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc should exist")
+
+	// Invoke removal in non-preview mode
+	removedDDocs, removeErr = removeObsoleteDesignDocs(bucket, false)
+	assertNoError(t, removeErr, "Error removing previous design docs")
+	assert.Equals(t, len(removedDDocs), 2)
+	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
+	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
+
+	// Verify ddocs are in expected state
+	assertTrue(t, !designDocExists(bucket, DesignDocSyncGatewayPrefix), "Removed design doc still exists")
+	assertTrue(t, !designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Removed design doc still exists")
+	assertTrue(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc should exist")
+
+}
+
+func designDocExists(bucket base.Bucket, ddocName string) bool {
+	var retrievedDDoc interface{}
+	err := bucket.GetDDoc(ddocName, &retrievedDDoc)
+	if err != nil {
+		return false
+	}
+	if retrievedDDoc == nil {
+		return false
+	}
+
+	return true
+}

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/sync_gateway/base"
-	"time"
 	pkgerrors "github.com/pkg/errors"
+	"time"
 )
 
 // Enum for the different repair jobs (eg, repairing rev tree cycles)
@@ -149,7 +149,7 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 		options["limit"] = r.ViewQueryPageSize
 
 		base.LogTo("CRUD", "RepairBucket() querying view with options: %+v", options)
-		vres, err := r.Bucket.View(DesignDocSyncHousekeeping, ViewImport, options)
+		vres, err := r.Bucket.View(DesignDocSyncHousekeeping(), ViewImport, options)
 		base.LogTo("CRUD", "RepairBucket() queried view and got %d results", len(vres.Rows))
 		if err != nil {
 			return results, err

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -20,7 +20,7 @@ func testBucketWithViewsAndBrokenDoc() (tBucket base.TestBucket, numDocs int) {
 	tBucket = testBucket()
 	bucket := tBucket.Bucket
 
-	installViews(bucket, false)
+	installViews(bucket)
 
 	// Add harmless docs
 	for i := 0; i < base.DefaultViewQueryPageSize+1; i++ {

--- a/rest/api.go
+++ b/rest/api.go
@@ -104,6 +104,29 @@ func (h *handler) handleResync() error {
 	return nil
 }
 
+type PostUpgradeResponse struct {
+	Result  PostUpgradeResult `json:"post_upgrade_results"`
+	Preview bool              `json:"preview,omitempty"`
+}
+
+func (h *handler) handlePostUpgrade() error {
+
+	preview := h.getBoolQuery("preview")
+
+	postUpgradeResults, err := h.server.PostUpgrade(preview)
+	if err != nil {
+		return err
+	}
+
+	result := &PostUpgradeResponse{
+		Result:  postUpgradeResults,
+		Preview: preview,
+	}
+
+	h.writeJSON(result)
+	return nil
+}
+
 func (h *handler) instanceStartTime() json.Number {
 	return json.Number(strconv.FormatInt(h.db.StartTime.UnixNano()/1000, 10))
 }

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -235,7 +235,7 @@ func (h *handler) handleDump() error {
 	viewName := h.PathVar("view")
 	base.LogTo("HTTP", "Dump view %q", viewName)
 	opts := db.Body{"stale": false, "reduce": false}
-	result, err := h.db.Bucket.View(db.DesignDocSyncGateway, viewName, opts)
+	result, err := h.db.Bucket.View(db.DesignDocSyncGateway(), viewName, opts)
 	if err != nil {
 		return err
 	}
@@ -262,6 +262,7 @@ func (h *handler) handleDump() error {
 // HTTP handler for _repair
 func (h *handler) handleRepair() error {
 
+	// TODO: If repair is re-enabled, it may need to be modified to support xattrs
 	if true == true {
 		return errors.New("_repair endpoint disabled")
 	}

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -233,6 +233,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/trace",
 		makeHandler(sc, adminPrivs, (*handler).handlePprofTrace)).Methods("GET", "POST")
+	r.Handle("/_post_upgrade",
+		makeHandler(sc, adminPrivs, (*handler).handlePostUpgrade)).Methods("POST")
 
 	// Database-relative handlers:
 	dbr.Handle("/_config",

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -236,6 +236,32 @@ func (sc *ServerContext) HasIndexWriters() bool {
 	return numIndexWriters > 0
 }
 
+type PostUpgradeResult map[string]PostUpgradeDatabaseResult
+
+type PostUpgradeDatabaseResult struct {
+	RemovedDDocs []string `json:"removed_design_docs"`
+}
+
+// PostUpgrade performs post-upgrade processing for each database
+func (sc *ServerContext) PostUpgrade(preview bool) (postUpgradeResults PostUpgradeResult, err error) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
+	postUpgradeResults = make(map[string]PostUpgradeDatabaseResult, len(sc.databases_))
+
+	for name, database := range sc.databases_ {
+		// View cleanup
+		removedDDocs, err := database.RemoveObsoleteDesignDocs(preview)
+		if err != nil {
+			return nil, err
+		}
+		postUpgradeResults[name] = PostUpgradeDatabaseResult{
+			RemovedDDocs: removedDDocs,
+		}
+	}
+	return postUpgradeResults, nil
+}
+
 // Adds a database to the ServerContext.  Attempts a read after it gets the write
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -624,6 +624,25 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
+	// Set database state to DBViewsPending until views are available
+	base.Logf("Verifying view availability for database %q...", dbName)
+	previousState := atomic.SwapUint32(&dbcontext.State, db.DBViewsPending)
+	// Don't restore the database state until views are ready, but don't block
+	go func() {
+		viewCheckStart := time.Now()
+		viewReadyErr := db.WaitForViews(bucket)
+		if viewReadyErr == nil {
+			swapOk := atomic.CompareAndSwapUint32(&dbcontext.State, db.DBViewsPending, previousState)
+			if swapOk {
+				base.Logf("Views check complete for database %q (%s) - database state is %s.", dbName, time.Since(viewCheckStart), db.RunStateString[previousState])
+			} else {
+				base.Logf("Views check complete for database %q (%s).  Database state was changed during view check - leaving database state as %s.", dbName, time.Since(viewCheckStart), db.RunStateString[atomic.LoadUint32(&dbcontext.State)])
+			}
+		} else {
+			base.LogFatal("View readiness check returned error for database %s: %+v", dbName, viewReadyErr)
+		}
+	}()
+
 	return dbcontext, nil
 }
 
@@ -1013,7 +1032,7 @@ func collectAccessRelatedWarnings(config *DbConfig, context *db.DatabaseContext)
 		viewOptions := db.Body{
 			"limit": 1,
 		}
-		vres, err := currentDb.Bucket.View(db.DesignDocSyncGateway, db.ViewPrincipals, viewOptions)
+		vres, err := currentDb.Bucket.View(db.DesignDocSyncGateway(), db.ViewPrincipals, viewOptions)
 		if err != nil {
 			base.Warn("Error trying to query ViewPrincipals: %v", err)
 			return []string{}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -105,6 +106,14 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		if !rt.noAdminParty {
 			rt.SetAdminParty(true)
+		}
+
+		// Wait for bucket to be ready
+		for i := 0; i < 100; i++ {
+			if atomic.LoadUint32(&rt.RestTesterServerContext.Database("db").State) != db.DBViewsPending {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
 		}
 
 		// If given a leakyBucketConfig we'll return a leaky bucket.

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"runtime/debug"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -106,14 +105,6 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		if !rt.noAdminParty {
 			rt.SetAdminParty(true)
-		}
-
-		// Wait for bucket to be ready
-		for i := 0; i < 100; i++ {
-			if atomic.LoadUint32(&rt.RestTesterServerContext.Database("db").State) != db.DBViewsPending {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
 		}
 
 		// If given a leakyBucketConfig we'll return a leaky bucket.

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -17,7 +17,7 @@ func (h *handler) handleGetDesignDoc() error {
 	ddocID := h.PathVar("ddoc")
 	base.TEMP("GetDesignDoc %q", ddocID)
 	var result interface{}
-	if ddocID == db.DesignDocSyncGateway {
+	if ddocID == db.DesignDocSyncGateway() {
 		// we serve this content here so that CouchDB 1.2 has something to
 		// hash into the replication-id, to correspond to our filter.
 		filter := "ok"
@@ -64,7 +64,7 @@ func (h *handler) handleView() error {
 	ddocName := h.PathVar("ddoc")
 	viewName := h.PathVar("view")
 	if ddocName == "" {
-		ddocName = db.DesignDocSyncGateway
+		ddocName = db.DesignDocSyncGateway()
 	}
 	opts := db.Body{}
 

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -410,3 +410,58 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 	value := row.Value.(float64)
 	assert.Equals(t, value, 99.0)
 }
+
+func TestPostInstallCleanup(t *testing.T) {
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
+	defer rt.Close()
+
+	bucket := rt.Bucket()
+	mapFunction := `function (doc, meta) { emit(); }`
+	// Create design docs in obsolete format
+	err := bucket.PutDDoc(db.DesignDocSyncGatewayPrefix, sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			"channels": sgbucket.ViewDef{Map: mapFunction},
+		},
+	})
+	assertNoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
+
+	err = bucket.PutDDoc(db.DesignDocSyncHousekeepingPrefix, sgbucket.DesignDoc{
+		Views: sgbucket.ViewMap{
+			"all_docs": sgbucket.ViewDef{Map: mapFunction},
+		},
+	})
+	assertNoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
+
+	// Run post-upgrade in preview mode
+	var postUpgradeResponse PostUpgradeResponse
+	response := rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
+	assertStatus(t, response, 200)
+	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.Equals(t, postUpgradeResponse.Preview, true)
+	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
+
+	// Run post-upgrade in non-preview mode
+	postUpgradeResponse = PostUpgradeResponse{}
+	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
+	assertStatus(t, response, 200)
+	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.Equals(t, postUpgradeResponse.Preview, false)
+	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
+
+	// Run post-upgrade in preview mode again, expect no results for database
+	postUpgradeResponse = PostUpgradeResponse{}
+	response = rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
+	assertStatus(t, response, 200)
+	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.Equals(t, postUpgradeResponse.Preview, true)
+	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
+
+	// Run post-upgrade in non-preview mode again, expect no results for database
+	postUpgradeResponse = PostUpgradeResponse{}
+	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
+	assertStatus(t, response, 200)
+	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.Equals(t, postUpgradeResponse.Preview, false)
+	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
+
+}

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
-	"github.com/couchbase/sync_gateway/channels"
-
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
 )
 
@@ -50,9 +50,9 @@ func TestDesignDocs(t *testing.T) {
 	assertStatus(t, response, 200)
 	response = rt.SendAdminRequest("DELETE", "/db/_design/foo", "")
 	assertStatus(t, response, 200)
-	response = rt.SendAdminRequest("PUT", "/db/_design/sync_gateway", "{}")
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_design/%s", db.DesignDocSyncGateway()), "{}")
 	assertStatus(t, response, 403)
-	response = rt.SendAdminRequest("GET", "/db/_design/sync_gateway", "")
+	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_design/%s", db.DesignDocSyncGateway()), "")
 	assertStatus(t, response, 200)
 }
 


### PR DESCRIPTION
Adds versioning to SG design docs, to provide the ability to avoid downtime due to view indexing during Sync Gateway upgrade.  Includes the following enhancements:
 - Add major/minor version to the design doc names, based on the ViewVersion constant
 - On Sync Gateway startup, check whether the desired design docs are already present.  If not present, install them.
 - Sync Gateway nodes issue a view query against their expected design docs on startup.   SG will not start serving requests until the view is available
- Adds a new /_post_upgrade endpoint that removes any previous view definitions, for each database defined in the config.   Intended to be run after the entire SG cluster has been upgraded.

Fixes #3169, #3170, #3171 
