### PR TITLE
Feature/issue 3208 blip user context

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -797,3 +797,7 @@ func StringSliceContains(set []string, target string) bool {
 	}
 	return false
 }
+
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="517b37d332081295493c53be21aa43a750495d86"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="110bb7e85d7841d1eb321c5e01cede154ac69952"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="edec8b23e4996f73ce216140a9b6febd1d6709c2"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="b8a42555c93a60d32410782ea964464e4ebd3637"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="110bb7e85d7841d1eb321c5e01cede154ac69952"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="edec8b23e4996f73ce216140a9b6febd1d6709c2"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -283,23 +283,39 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 // Connect to public port with authentication
 func TestPublicPortAuthentication(t *testing.T) {
 
-	btSpecUser1 := BlipTesterSpec{
+	// Create bliptester that is connected as user1, with access to the user1 channel
+	btUser1 := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
-		connectingUserChannelGrants: []string{"*"}, // test, no channels
-	}
-	btUser1 := NewBlipTesterFromSpec(btSpecUser1)
+		// connectingUserChannelGrants: []string{"user1"}, // test, no channels
+	})
 	defer btUser1.Close()
 
-	// Send the doc
+	// Send the user1 doc
 	btUser1.SendRev(
 		"foo",
 		"1-abc",
-		[]byte(`{"key": "val", "channels": "[foo]"}`),
+		[]byte(`{"key": "val", "channels": ["user1"]}`),
 	)
 
-	// Assert that user1 received their expected change
+	// Create bliptester that is connected as user2, with access to the * channel
+	//btUser2 := NewBlipTesterFromSpec(BlipTesterSpec{
+	//	noAdminParty:                true,
+	//	connectingUsername:          "user2",
+	//	connectingPassword:          "1234",
+	//	connectingUserChannelGrants: []string{"*"}, // test, no channels
+	//})
+	//defer btUser2.Close()
+	//
+	//// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access
+	//btUser2.SendRev(
+	//	"foo2",
+	//	"1-abcd",
+	//	[]byte(`{"key": "val", "channels": "[whatever]"}`),
+	//)
+
+	// Assert that user1 received a single expected change
 	changesChannelUser1 := btUser1.GetChanges()
 	assert.True(t, len(changesChannelUser1) == 1)
 	change := changesChannelUser1[0]
@@ -310,7 +326,16 @@ func TestPublicPortAuthentication(t *testing.T) {
 	assert.True(t, strings.Contains(bodyAsString, "foo"))
 	assert.True(t, strings.Contains(bodyAsString, "1-abc"))
 
-
+	// Assert that user2 received a single expected change
+	//changesChannelUser2 := btUser2.GetChanges()
+	//assert.True(t, len(changesChannelUser2) == 1)
+	//change = changesChannelUser2[0]
+	//body, err = change.Body()
+	//assertNoError(t, err, "Unexpected error")
+	//bodyAsString = string(body)
+	//log.Printf("Got change: %s", body)
+	//assert.True(t, strings.Contains(bodyAsString, "foo2"))
+	//assert.True(t, strings.Contains(bodyAsString, "1-abcd"))
 
 
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -296,15 +296,21 @@ func TestPublicPortAuthentication(t *testing.T) {
 	btUser1.SendRev(
 		"foo",
 		"1-abc",
-		[]byte(`{"key": "val", "channels": "[user1]"}`),
+		[]byte(`{"key": "val", "channels": "[foo]"}`),
 	)
 
-	changesChannel := btUser1.SubscribeToChanges(true)
-	for change := range changesChannel {
-		body, err := change.Body()
-		assertNoError(t, err, "Unexpected error")
-		log.Printf("Got change: %s", body)
-	}
+	// Assert that user1 received their expected change
+	changesChannelUser1 := btUser1.GetChanges()
+	assert.True(t, len(changesChannelUser1) == 1)
+	change := changesChannelUser1[0]
+	body, err := change.Body()
+	assertNoError(t, err, "Unexpected error")
+	bodyAsString := string(body)
+	log.Printf("Got change: %s", body)
+	assert.True(t, strings.Contains(bodyAsString, "foo"))
+	assert.True(t, strings.Contains(bodyAsString, "1-abc"))
+
+
 
 
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -304,7 +304,8 @@ func TestPublicPortAuthentication(t *testing.T) {
 		noAdminParty:                true,
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
-		connectingUserChannelGrants: []string{"*"}, // test, no channels
+		connectingUserChannelGrants: []string{"*"}, // TODO: revert to *
+		restTester:                  btUser1.restTester,
 	})
 	defer btUser2.Close()
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -300,20 +300,20 @@ func TestPublicPortAuthentication(t *testing.T) {
 	)
 
 	// Create bliptester that is connected as user2, with access to the * channel
-	//btUser2 := NewBlipTesterFromSpec(BlipTesterSpec{
-	//	noAdminParty:                true,
-	//	connectingUsername:          "user2",
-	//	connectingPassword:          "1234",
-	//	connectingUserChannelGrants: []string{"*"}, // test, no channels
-	//})
-	//defer btUser2.Close()
-	//
-	//// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access
-	//btUser2.SendRev(
-	//	"foo2",
-	//	"1-abcd",
-	//	[]byte(`{"key": "val", "channels": "[whatever]"}`),
-	//)
+	btUser2 := NewBlipTesterFromSpec(BlipTesterSpec{
+		noAdminParty:                true,
+		connectingUsername:          "user2",
+		connectingPassword:          "1234",
+		connectingUserChannelGrants: []string{"*"}, // test, no channels
+	})
+	defer btUser2.Close()
+
+	// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access
+	btUser2.SendRev(
+		"foo2",
+		"1-abcd",
+		[]byte(`{"key": "val", "channels": ["NBC"]}`),
+	)
 
 	// Assert that user1 received a single expected change
 	changesChannelUser1 := btUser1.GetChanges()
@@ -326,16 +326,16 @@ func TestPublicPortAuthentication(t *testing.T) {
 	assert.True(t, strings.Contains(bodyAsString, "foo"))
 	assert.True(t, strings.Contains(bodyAsString, "1-abc"))
 
-	// Assert that user2 received a single expected change
-	//changesChannelUser2 := btUser2.GetChanges()
-	//assert.True(t, len(changesChannelUser2) == 1)
-	//change = changesChannelUser2[0]
-	//body, err = change.Body()
-	//assertNoError(t, err, "Unexpected error")
-	//bodyAsString = string(body)
-	//log.Printf("Got change: %s", body)
-	//assert.True(t, strings.Contains(bodyAsString, "foo2"))
-	//assert.True(t, strings.Contains(bodyAsString, "1-abcd"))
+	// Assert that user2 received user1's change as well as it's own change
+	changesChannelUser2 := btUser2.GetChanges()
+	assert.True(t, len(changesChannelUser2) == 2)
+	change = changesChannelUser2[1]
+	body, err = change.Body()
+	assertNoError(t, err, "Unexpected error")
+	bodyAsString = string(body)
+	log.Printf("Got change: %s", body)
+	assert.True(t, strings.Contains(bodyAsString, "foo2"))
+	assert.True(t, strings.Contains(bodyAsString, "1-abcd"))
 
 
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -329,9 +329,6 @@ func TestReloadUser(t *testing.T) {
 	}
 	defer bt.Close()
 
-	//bt := CreateBlipTesterPublicPort(t, false)
-	//defer bt.Close()
-
 	var changeList [][]interface{}
 	changesRequest := blip.NewRequest()
 	changesRequest.SetProfile("changes")                             // TODO: make a constant for "changes" and use it everywhere

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -28,7 +28,8 @@ import (
 // Replication Spec: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges
 func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
-	bt := NewBlipTester()
+	bt, err := NewBlipTester()
+	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Verify Sync Gateway will accept the doc revision that is about to be sent
@@ -137,7 +138,8 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinousChangesSubscription(t *testing.T) {
 
-	bt := NewBlipTester()
+	bt, err := NewBlipTester()
+	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Counter/Waitgroup to help ensure that all callbacks on continuous changes handler are received
@@ -245,9 +247,10 @@ func TestContinousChangesSubscription(t *testing.T) {
 // 4. Make sure that the server responds to accept the changes (empty array)
 func TestProposedChangesNoConflictsMode(t *testing.T) {
 
-	bt := NewBlipTesterFromSpec(BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
 	})
+	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	proposeChangesRequest := blip.NewRequest()
@@ -282,11 +285,12 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 func TestPublicPortAuthentication(t *testing.T) {
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
-	btUser1 := NewBlipTesterFromSpec(BlipTesterSpec{
+	btUser1, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
+	assertNoError(t, err, "Error creating BlipTester")
 	defer btUser1.Close()
 
 	// Send the user1 doc
@@ -297,13 +301,14 @@ func TestPublicPortAuthentication(t *testing.T) {
 	)
 
 	// Create bliptester that is connected as user2, with access to the * channel
-	btUser2 := NewBlipTesterFromSpec(BlipTesterSpec{
+	btUser2, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"},      // user2 has access to all channels
 		restTester:                  btUser1.restTester, // re-use rest tester, otherwise it will create a new underlying bucket in walrus case
 	})
+	assertNoError(t, err, "Error creating BlipTester")
 	defer btUser2.Close()
 
 	// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -48,18 +48,12 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	assert.True(t, len(changeRow) == 0) // Should be empty, meaning the server is saying it doesn't have the revision yet
 
 	// Send the doc revision in a rev request
-	revRequest := blip.NewRequest()
-	revRequest.SetCompressed(true)
-	revRequest.SetProfile("rev")
-	revRequest.Properties["id"] = "foo"
-	revRequest.Properties["rev"] = "1-abc"
-	revRequest.Properties["deleted"] = "false"
-	revRequest.SetBody([]byte(`{"key": "val"}`))
-	sent = bt.sender.Send(revRequest)
-	assert.True(t, sent)
-	revResponse := revRequest.Response()
-	assert.Equals(t, revResponse.SerialNumber(), revRequest.SerialNumber())
-	body, err = revResponse.Body()
+	_, _, revResponse := bt.SendRev(
+		"foo",
+		"1-abc",
+		[]byte(`{"key": "val"}`),
+	)
+	_, err = revResponse.Body()
 	assertNoError(t, err, "Error unmarshalling response body")
 
 	// Call changes with a hypothetical new revision, assert that it returns last pushed revision
@@ -337,7 +331,13 @@ func TestPublicPortAuthentication(t *testing.T) {
 
 }
 
+// Test adding / retrieving attachments
+func TestAttachments(t *testing.T) {
+
+}
+
 // Make sure it's not possible to have two outstanding subChanges w/ continuous=true.
+// Expected behavior is that the first continous change subscription should get discarded in favor of 2nd.
 func TestConcurrentChangesSubscriptions(t *testing.T) {
 
 }
@@ -358,11 +358,9 @@ func TestNoConflictsModeReplication(t *testing.T) {
 
 }
 
-// Test adding / retrieving attachments
-func TestAttachments(t *testing.T) {
-
-}
-
+// Reproduce issue where ReloadUser was not being called, and so it was
+// using a stale channel access grant for the user
+// See: https://github.com/couchbase/sync_gateway/issues/2717
 func TestReloadUser(t *testing.T) {
 
 }

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -314,3 +314,29 @@ func TestAttachments(t *testing.T) {
 func TestPublicPortAuthentication(t *testing.T) {
 
 }
+
+func TestReloadUser(t *testing.T) {
+
+	bt := CreateBlipTesterPublicPort(t, false)
+	defer bt.Close()
+
+
+	var changeList [][]interface{}
+	changesRequest := blip.NewRequest()
+	changesRequest.SetProfile("changes")                             // TODO: make a constant for "changes" and use it everywhere
+	changesRequest.SetBody([]byte(`[["1", "foo", "1-abc", false]]`)) // [sequence, docID, revID]
+	sent := bt.sender.Send(changesRequest)
+	assert.True(t, sent)
+	changesResponse := changesRequest.Response()
+	assert.Equals(t, changesResponse.SerialNumber(), changesRequest.SerialNumber())
+	body, err := changesResponse.Body()
+	assertNoError(t, err, "Error reading changes response body")
+	err = json.Unmarshal(body, &changeList)
+	assertNoError(t, err, "Error unmarshalling response body")
+	assert.True(t, len(changeList) == 1) // Should be 1 row, corresponding to the single doc that was queried in changes
+	changeRow := changeList[0]
+	assert.True(t, len(changeRow) == 0) // Should be empty, meaning the server is saying it doesn't have the revision yet
+
+
+
+}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbaselabs/go.assert"
+	"sync/atomic"
 )
 
 // This test performs the following steps against the Sync Gateway passive blip replicator:
@@ -149,6 +150,7 @@ func TestContinousChangesSubscription(t *testing.T) {
 
 	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
 	lastReceivedSeq := float64(0)
+	var numbatchesReceived int32
 	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
 
 		log.Printf("got changes message: %+v", request)
@@ -157,6 +159,8 @@ func TestContinousChangesSubscription(t *testing.T) {
 		log.Printf("changes body: %v, err: %v", string(body), err)
 
 		if string(body) != "null" {
+
+			atomic.AddInt32(&numbatchesReceived, 1)
 
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
@@ -208,6 +212,7 @@ func TestContinousChangesSubscription(t *testing.T) {
 	subChangesRequest := blip.NewRequest()
 	subChangesRequest.SetProfile("subChanges")
 	subChangesRequest.Properties["continuous"] = "true"
+	subChangesRequest.Properties["batch"] = "10" // default batch size is 200, lower this to 10 to make sure we get multiple batches
 	subChangesRequest.SetCompressed(false)
 	sent := bt.sender.Send(subChangesRequest)
 	assert.True(t, sent)
@@ -215,27 +220,25 @@ func TestContinousChangesSubscription(t *testing.T) {
 	assert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 
 	for i := 1; i < 1500; i++ {
-
-		// Add a change: Send an unsolicited doc revision in a rev request
+		//// Add a change: Send an unsolicited doc revision in a rev request
 		receviedChangesWg.Add(1)
-		revRequest := blip.NewRequest()
-		revRequest.SetCompressed(true)
-		revRequest.SetProfile("rev")
-		revRequest.Properties["id"] = fmt.Sprintf("foo-%d", i)
-		revRequest.Properties["rev"] = "1-abc"
-		revRequest.Properties["deleted"] = "false"
-		revRequest.SetBody([]byte(`{"key": "val"}`))
-		sent = bt.sender.Send(revRequest)
-		assert.True(t, sent)
-		revResponse := revRequest.Response()
-		assert.Equals(t, revResponse.SerialNumber(), revRequest.SerialNumber())
-		body, err := revResponse.Body()
+		_, _, revResponse := bt.SendRev(
+			fmt.Sprintf("foo-%d", i),
+			"1-abc",
+			[]byte(`{"key": "val"}`),
+		)
+
+		_, err := revResponse.Body()
 		assertNoError(t, err, "Error unmarshalling response body")
-		log.Printf("rev response body: %s", body)
 
 	}
 
+	// Wait until all expected changes are received by change handler
 	receviedChangesWg.Wait()
+
+	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
+	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
+	assert.True(t, numBatchesReceivedSnapshot >= 2)
 
 }
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -317,9 +317,20 @@ func TestPublicPortAuthentication(t *testing.T) {
 
 func TestReloadUser(t *testing.T) {
 
-	bt := CreateBlipTesterPublicPort(t, false)
+	btSpec := BlipTesterSpec{
+		noConflictsMode: false,
+		enableGuestUser: false,
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+	}
+	bt, err := CreateBlipTesterFromSpec(btSpec)
+	if err != nil {
+		t.Fatalf("Error creating blip tester: %v", err)
+	}
 	defer bt.Close()
 
+	//bt := CreateBlipTesterPublicPort(t, false)
+	//defer bt.Close()
 
 	var changeList [][]interface{}
 	changesRequest := blip.NewRequest()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -310,7 +310,8 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]i
 		sender.Send(outrq)
 	}
 	if len(changeArray) > 0 {
-		base.LogTo("Sync", "Sent %d changes to client, from seq %v ... %s", len(changeArray), changeArray[0][0], bh.effectiveUsername)
+		sequence := changeArray[0][0].(db.SequenceID)
+		base.LogTo("Sync", "Sent %d changes to client, from seq %s ... %s", len(changeArray), sequence.String(), bh.effectiveUsername)
 	} else {
 		base.LogTo("Sync", "Sent all changes to client. ... %s", bh.effectiveUsername)
 	}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -141,9 +141,9 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 			if response := rq.Response(); response != nil {
 				response.SetError("HTTP", status, msg)
 			}
-			base.LogTo("Sync", "%s    --> %d %s ... %s", rq, status, msg, ctx.effectiveUsername)
+			base.LogTo("Sync", "%s %q   --> %d %s ... %s", rq, profile, status, msg, ctx.effectiveUsername)
 		} else {
-			base.LogTo("Sync+", "%s    --> OK ... %s", rq, ctx.effectiveUsername)
+			base.LogTo("Sync+", "%s %q   --> OK ... %s", rq, profile, ctx.effectiveUsername)
 		}
 	}
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -722,8 +722,7 @@ func (bt *BlipTester) GetChanges() (changes [][]interface{}) {
 
 }
 
-
-func (bt *BlipTester) SubscribeToChanges(continuous bool, changes chan<- *blip.Message) () {
+func (bt *BlipTester) SubscribeToChanges(continuous bool, changes chan<- *blip.Message) {
 
 	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
 	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -600,15 +600,18 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 		}
 		adminChannelsStr := fmt.Sprintf("%s", adminChannelsJson)
 
+		userDocBody := fmt.Sprintf(`{"name":"%s", "password":"%s", "admin_channels":%s}`,
+			spec.connectingUsername,
+			spec.connectingPassword,
+			adminChannelsStr,
+		)
+		log.Printf("UserDoc: %v", userDocBody)
+
 		// Create a user.  NOTE: this must come *after* the bt.rt.TestPublicHandler() call, otherwise it will end up getting ignored
 		response := bt.restTester.SendAdminRequest(
 			"POST",
 			"/db/_user/",
-			fmt.Sprintf(`{"name":"%s", "password":"%s", "admin_channels":%s}`,
-				spec.connectingUsername,
-				spec.connectingPassword,
-				adminChannelsStr,
-			),
+			userDocBody,
 		)
 		if response.Code != 201 {
 			panic(fmt.Sprintf("Expected 201 response.  Got: %v", response.Code))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -679,6 +679,7 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte) (sent bool, req
 	if revResponse.SerialNumber() != revRequest.SerialNumber() {
 		panic(fmt.Sprintf("revResponse.SerialNumber() != revRequest.SerialNumber().  %v != %v", revResponse.SerialNumber(), revRequest.SerialNumber()))
 	}
+
 	return sent, revRequest, revResponse
 
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"encoding/base64"
+	"net/url"
+
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
@@ -21,7 +23,6 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
 	"golang.org/x/net/websocket"
-	"net/url"
 )
 
 // Testing utilities that have been included in the rest package so that they
@@ -504,65 +505,121 @@ func (s *SlowResponseRecorder) Write(buf []byte) (int, error) {
 	return numBytesWritten, err
 }
 
-type BlipTester struct {
-	rt          RestTester
-	sender      *blip.Sender
-	blipContext *blip.Context
-	server      *httptest.Server
-}
-
-func (bt BlipTester) Close() {
-	bt.rt.Close()
-	if bt.server != nil {
-		bt.server.Close()
-	}
-
-}
-
+// The parameters used to create a BlipTester
 type BlipTesterSpec struct {
-	noConflictsMode    bool
-	enableGuestUser    bool
-	connectingUsername string // or empty to indicate connect as admin
+
+	// Run Sync Gateway in "No conflicts" mode.  Will be propgated to the underyling RestTester
+	noConflictsMode bool
+
+	// If an underlying RestTester is created, it will propagate this setting to the underlying RestTester.
+	noAdminParty bool
+
+	// The Sync Gateway username and password to connect with.  If set, then you
+	// may want to disable "Admin Party" mode, which will allow guest user access.
+	// By default, the created user will have access to a single channel that matches their username.
+	// If you need to grant the user access to more channels, you can override this behavior with the
+	// connectingUserChannelGrants field
+	connectingUsername string
 	connectingPassword string
+
+	// By default, the created user will have access to a single channel that matches their username.
+	// If you need to grant the user access to more channels, you can override this behavior by specifying
+	// the channels the user should have access in this string slice
+	connectingUserChannelGrants []string
+
+	// Allow tests to further customized a RestTester or re-use it across multiple BlipTesters if needed.
+	// If a RestTester is passed in, certain properties of the BlipTester such as noAdminParty will be ignored, since
+	// those properties only affect the creation of the RestTester.
+	// If nil, a default restTester will be created based on the properties in this spec
+	restTester *RestTester
 }
 
-func CreateBlipTesterFromSpec(spec BlipTesterSpec) (bt BlipTester, err error) {
+// State associated with a BlipTester
+type BlipTester struct {
+
+	// The underlying RestTester which is used to bootstrap the initial blip websocket creation,
+	// as well as providing a way for tests to access Sync Gateway over REST to hit admin-only endpoints
+	// which are not available via blip.  Since a test may need to create multiple BlipTesters for multiple
+	// user contexts, a single RestTester may be shared among multiple BlipTester instances.
+	restTester *RestTester
+
+	// The blip context which contains blip related state and the sender/reciever goroutines associated
+	// with this websocket connection
+	blipContext *blip.Context
+
+	// The blip sender that can be used for sending messages over the websocket connection
+	sender *blip.Sender
+}
+
+// Close the bliptester
+func (bt BlipTester) Close() {
+	bt.restTester.Close()
+}
+
+// Create a BlipTester using the default spec
+func NewBlipTester() *BlipTester {
+	defaultSpec := BlipTesterSpec{}
+	return NewBlipTesterFromSpec(defaultSpec)
+}
+
+// Create a BlipTester using the given spec
+func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 
 	EnableBlipSyncLogs()
 
+	bt := &BlipTester{}
+
+	if spec.restTester != nil {
+		bt.restTester = spec.restTester
+	} else {
+		rt := RestTester{
+			EnableNoConflictsMode: spec.noConflictsMode,
+			noAdminParty:          spec.noAdminParty,
+		}
+		bt.restTester = &rt
+	}
+
 	// Since blip requests all go over the public handler, wrap the public handler with the httptest server
-	publicHandler := bt.rt.TestPublicHandler()
+	publicHandler := bt.restTester.TestPublicHandler()
 
 	if len(spec.connectingUsername) > 0 {
-		// Create a user.
-		// NOTE: this must come *after* the bt.rt.TestPublicHandler() call, otherwise it will end up getting ignored
-		response := bt.rt.SendAdminRequest(
+
+		// By default, the user will be granted access to a single channel equal to their username
+		adminChannels := []string{spec.connectingUsername}
+
+		// If the caller specified a list of channels to grant the user access to, then use that instead.
+		if len(spec.connectingUserChannelGrants) > 0 {
+			adminChannels = []string{} // empty it
+			adminChannels = append(adminChannels, spec.connectingUserChannelGrants...)
+		}
+
+		// Create a user.  NOTE: this must come *after* the bt.rt.TestPublicHandler() call, otherwise it will end up getting ignored
+		response := bt.restTester.SendAdminRequest(
 			"POST",
 			"/db/_user/",
-			fmt.Sprintf(`{"name":"%s", "password":"%s"}`, spec.connectingUsername, spec.connectingPassword),
+			fmt.Sprintf(`{"name":"%s", "password":"%s", "admin_channels":["%s"]}`,
+				spec.connectingUsername,
+				spec.connectingPassword,
+				adminChannels,
+			),
 		)
 		if response.Code != 201 {
-			return bt, fmt.Errorf("Expected 201 response.  Got: %v", response.Code)
+			panic(fmt.Sprintf("Expected 201 response.  Got: %v", response.Code))
 		}
 	}
 
-	if !spec.enableGuestUser {
-		// Disable guest access on public port
-		bt.rt = RestTester{noAdminParty: true}
-	}
-
-	bt.rt.EnableNoConflictsMode = spec.noConflictsMode
-
-
-	// Create a test server and close it when the test is complete
+	// Create a _temporary_ test server bound to an actual port that is used to make the blip connection.
+	// This is needed because the mock-based approach fails with a "Connection not hijackable" error when
+	// trying to do the websocket upgrade.  Since it's only needed to setup the websocket, it can be closed
+	// as soon as the websocket is established, hence the defer srv.Close() call.
 	srv := httptest.NewServer(publicHandler)
-	bt.server = srv
+	defer srv.Close()
 
 	// Construct URL to connect to blipsync target endpoint
 	destUrl := fmt.Sprintf("%s/db/_blipsync", srv.URL)
 	u, err := url.Parse(destUrl)
 	if err != nil {
-		return bt, err
+		panic(fmt.Sprintf("Error parsing url: %v", err))
 	}
 	u.Scheme = "ws"
 
@@ -577,7 +634,7 @@ func CreateBlipTesterFromSpec(spec BlipTesterSpec) (bt BlipTester, err error) {
 
 	config, err := websocket.NewConfig(u.String(), origin)
 	if err != nil {
-		return bt, err
+		panic(fmt.Sprintf("Error creating websocket config: %v", err))
 	}
 
 	if len(spec.connectingUsername) > 0 {
@@ -588,12 +645,87 @@ func CreateBlipTesterFromSpec(spec BlipTesterSpec) (bt BlipTester, err error) {
 
 	bt.sender, err = bt.blipContext.DialConfig(config)
 	if err != nil {
-		return bt, err
+		panic(fmt.Sprintf("Error dialing websocket: %v", err))
 	}
 
-	return bt, nil
+	return bt
 
 }
+
+func (bt *BlipTester) SendRev(docId, docRev string, body []byte) (sent bool, req, res *blip.Message) {
+
+	revRequest := blip.NewRequest()
+	revRequest.SetCompressed(true)
+	revRequest.SetProfile("rev")
+	revRequest.Properties["id"] = docId
+	revRequest.Properties["rev"] = docRev
+	revRequest.Properties["deleted"] = "false"
+	revRequest.SetBody(body)
+	sent = bt.sender.Send(revRequest)
+	if !sent {
+		panic(fmt.Sprintf("Failed to send revRequest for doc: %v", docId))
+	}
+	revResponse := revRequest.Response()
+	if revResponse.SerialNumber() != revRequest.SerialNumber() {
+		panic(fmt.Sprintf("revResponse.SerialNumber() != revRequest.SerialNumber().  %v != %v", revResponse.SerialNumber(), revRequest.SerialNumber()))
+	}
+	return sent, revRequest, revResponse
+
+}
+
+func (bt *BlipTester) SubscribeToChanges(continuous bool) (changes chan *blip.Message) {
+
+	changes = make(chan *blip.Message)
+
+	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
+	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+
+		body, err := request.Body()
+		if err != nil {
+			panic(fmt.Sprintf("Error getting request body: %v", err))
+		}
+
+		if string(body) != "null" {
+			changes <- request
+		}
+
+		if !request.NoReply() {
+			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
+			response := request.Response()
+			emptyResponseVal := []interface{}{}
+			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			if err != nil {
+				panic(fmt.Sprintf("Error marshalling response: %v", err))
+			}
+			response.SetBody(emptyResponseValBytes)
+		}
+
+	}
+
+	// Send subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
+	subChangesRequest := blip.NewRequest()
+	subChangesRequest.SetProfile("subChanges")
+	switch continuous {
+	case true:
+		subChangesRequest.Properties["continuous"] = "true"
+	default:
+		subChangesRequest.Properties["continuous"] = "false"
+
+	}
+	sent := bt.sender.Send(subChangesRequest)
+	if !sent {
+		panic(fmt.Sprintf("Unable to subscribe to changes."))
+	}
+	subChangesResponse := subChangesRequest.Response()
+	if subChangesResponse.SerialNumber() != subChangesRequest.SerialNumber() {
+		panic(fmt.Sprintf("subChangesResponse.SerialNumber() != subChangesRequest.SerialNumber().  %v != %v", subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber()))
+	}
+
+	return changes
+
+}
+
+// SubscribeToChanges
 
 func EnableBlipSyncLogs() {
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -557,13 +557,13 @@ func (bt BlipTester) Close() {
 }
 
 // Create a BlipTester using the default spec
-func NewBlipTester() *BlipTester {
+func NewBlipTester() (*BlipTester, error) {
 	defaultSpec := BlipTesterSpec{}
 	return NewBlipTesterFromSpec(defaultSpec)
 }
 
 // Create a BlipTester using the given spec
-func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
+func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 
 	EnableBlipSyncLogs()
 
@@ -596,7 +596,7 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 		// serialize admin channels to json array
 		adminChannelsJson, err := json.Marshal(adminChannels)
 		if err != nil {
-			panic(fmt.Sprintf("Error marshalling adming channels: %v", err))
+			return nil, err
 		}
 		adminChannelsStr := fmt.Sprintf("%s", adminChannelsJson)
 
@@ -614,7 +614,7 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 			userDocBody,
 		)
 		if response.Code != 201 {
-			panic(fmt.Sprintf("Expected 201 response.  Got: %v", response.Code))
+			return nil, fmt.Errorf("Expected 201 response.  Got: %v", response.Code)
 		}
 	}
 
@@ -629,7 +629,7 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 	destUrl := fmt.Sprintf("%s/db/_blipsync", srv.URL)
 	u, err := url.Parse(destUrl)
 	if err != nil {
-		panic(fmt.Sprintf("Error parsing url: %v", err))
+		return nil, err
 	}
 	u.Scheme = "ws"
 
@@ -644,7 +644,7 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 
 	config, err := websocket.NewConfig(u.String(), origin)
 	if err != nil {
-		panic(fmt.Sprintf("Error creating websocket config: %v", err))
+		return nil, err
 	}
 
 	if len(spec.connectingUsername) > 0 {
@@ -655,10 +655,10 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) *BlipTester {
 
 	bt.sender, err = bt.blipContext.DialConfig(config)
 	if err != nil {
-		panic(fmt.Sprintf("Error dialing websocket: %v", err))
+		return nil, err
 	}
 
-	return bt
+	return bt, nil
 
 }
 


### PR DESCRIPTION
Fixes #3208 

- BlipTester helper class enhancements
    - Create a spec so that multiple scenarios can be reproduced
    - Can re-use an underlying RestTester 
    - Add documentation regarding the reason behind the temporary httptest server bound to a port 
- Adds test which authenticates under a user context and goes over public port

## Integration tests

- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/313/
- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/311/