### PR TITLE
Feature/issue 3210 blip data race

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -217,7 +217,7 @@ func TestContinousChangesSubscription(t *testing.T) {
 	subChangesResponse := subChangesRequest.Response()
 	assert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
 
-	for i := 1; i < 5; i++ {
+	for i := 1; i < 1500; i++ {
 
 		// Add a change: Send an unsolicited doc revision in a rev request
 		receviedChangesWg.Add(1)


### PR DESCRIPTION
Fixes #3210 which found a data race.

The approach I took was to completely do away with the `blipSyncContext.sender` reference, and instead pass the sender down the call stack.  This avoids the race condition, as well as removes the need for adding additional mutex locking.

@snej some questions on this code that came out of discussions w/ @adamcfraser about line 128 where it sets `ctx.sender = rq.Sender`:

https://github.com/couchbase/sync_gateway/blob/43afdd2422c9dacd291c30c01308e80a66427e54/rest/blip_sync.go#L126-L130

- Is there any chance that `rq.sender` would change over the lifetime of the blip context / client connection?  From what I can tell the answer is no, but I just wanted to confirm

- It looks like `blip.Context` doesn't hold any references to it's sender or receiver, but rather the sender and receivers have pointers back to the `blip.Context`, and circular references are avoided.  In the current code (before this PR), it looks like there's sort of a "semi-circular reference":

**Before PR**

![screen shot 2018-01-18 at 3 32 59 pm](https://user-images.githubusercontent.com/296876/35127020-f4d9fdb6-fc64-11e7-8c33-fc6020f1e0a6.png)

**After PR**

![screen shot 2018-01-18 at 3 33 13 pm](https://user-images.githubusercontent.com/296876/35127023-f86cb14e-fc64-11e7-8cbe-7fa0fe99c175.png)
