### PR TITLE
Fixes #3194 Unit test to reproducing issue with not calling ReloadUse…

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/couchbase/go-blip"
-	"github.com/couchbaselabs/go.assert"
-	"sync/atomic"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/go.assert"
 )
 
 // This test performs the following steps against the Sync Gateway passive blip replicator:
@@ -341,7 +341,6 @@ func AssertChangeEquals(t *testing.T, change []interface{}, expectedChange Expec
 	}
 }
 
-
 // Test adding / retrieving attachments
 func TestAttachments(t *testing.T) {
 
@@ -370,8 +369,133 @@ func TestNoConflictsModeReplication(t *testing.T) {
 }
 
 // Reproduce issue where ReloadUser was not being called, and so it was
-// using a stale channel access grant for the user
-// See: https://github.com/couchbase/sync_gateway/issues/2717
+// using a stale channel access grant for the user.
+// Reproduces https://github.com/couchbase/sync_gateway/issues/2717
 func TestReloadUser(t *testing.T) {
+
+	syncFn := `
+		function(doc) {
+			if (doc._id == "access1") {
+				// if its an access grant doc, grant access
+				access(doc.accessUser, doc.accessChannel);
+			} else {
+                // otherwise if its a normal access doc, require access then add to channels
+				requireAccess("PBS");
+				channel(doc.channels);
+			}
+		}
+    `
+
+	// Setup
+	rt := RestTester{
+		SyncFn:       syncFn,
+		noAdminParty: true,
+	}
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+		restTester:         &rt,
+	})
+	assertNoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+
+	// Put document that triggers access grant for user to channel PBS
+	response := rt.SendAdminRequest("PUT", "/db/access1", `{"accessUser":"user1", "accessChannel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	// Add a doc in the PBS channel
+	_, _, addRevResponse := bt.SendRev(
+		"foo",
+		"1-abc",
+		[]byte(`{"key": "val", "channels": ["PBS"]}`),
+	)
+
+	// Make assertions on response to make sure the change was accepted
+	addRevResponseBody, err := addRevResponse.Body()
+	assertNoError(t, err, "Unexpected error")
+	errorCode, hasErrorCode := addRevResponse.Properties["Error-Code"]
+	assert.False(t, hasErrorCode)
+	if hasErrorCode {
+		t.Fatalf("Unexpected error sending revision.  Error code: %v.  Response body: %s", errorCode, addRevResponseBody)
+	}
+
+}
+
+// Grant a user access to a channel via the Sync Function and a doc change, and make sure
+// it shows up in the user's changes feed
+func TestAccessGrantViaSyncFunction(t *testing.T) {
+
+	// Setup
+	rt := RestTester{
+		SyncFn:       `function(doc) {channel(doc.channels); access(doc.accessUser, doc.accessChannel);}`,
+		noAdminParty: true,
+	}
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+		restTester:         &rt,
+	})
+	assertNoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+
+	// Add a doc in the PBS channel
+	bt.SendRev(
+		"foo",
+		"1-abc",
+		[]byte(`{"key": "val", "channels": ["PBS"]}`),
+	)
+
+	// Put document that triggers access grant for user to channel PBS
+	response := rt.SendAdminRequest("PUT", "/db/access1", `{"accessUser":"user1", "accessChannel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	// Add another doc in the PBS channel
+	bt.SendRev(
+		"foo2",
+		"1-abc",
+		[]byte(`{"key": "val", "channels": ["PBS"]}`),
+	)
+
+	// Make sure we can see it by getting changes
+	changes := bt.GetChanges()
+	log.Printf("changes: %+v", changes)
+	assert.True(t, len(changes) == 2)
+
+}
+
+// Grant a user access to a channel via the REST Admin API, and make sure
+// it shows up in the user's changes feed
+func TestAccessGrantViaAdminApi(t *testing.T) {
+
+	// Create blip tester
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
+		noAdminParty:       true,
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+	})
+	assertNoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+
+	// Add a doc in the PBS channel
+	bt.SendRev(
+		"foo",
+		"1-abc",
+		[]byte(`{"key": "val", "channels": ["PBS"]}`),
+	)
+
+	// Update the user doc to grant access to PBS
+	response := bt.restTester.SendAdminRequest("PUT", "/db/_user/user1", `{"admin_channels":["user1", "PBS"]}`)
+	assertStatus(t, response, 200)
+
+	// Add another doc in the PBS channel
+	bt.SendRev(
+		"foo2",
+		"1-abc",
+		[]byte(`{"key": "val", "channels": ["PBS"]}`),
+	)
+
+	// Make sure we can see both docs in the changes
+	changes := bt.GetChanges()
+	assert.True(t, len(changes) == 2)
 
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2,18 +2,17 @@ package rest
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"runtime/debug"
 	"sync"
 	"testing"
 	"time"
-
-	"encoding/base64"
-	"net/url"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sg-bucket"


### PR DESCRIPTION
…r() in blip sync

Fixes #3194 

I verified that commenting the reloadUser fix reproduces a test failure.