### PR TITLE
Go 1.10: Fix Sprintf formatting directive

### DIFF
--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -611,7 +611,7 @@ func WaitForViews(bucket base.Bucket) error {
 // Issues stale=false view queries to determine when view indexing is complete.  Retries on timeout
 func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) error {
 	var vres interface{}
-	opts := map[string]interface{}{"stale": false, "key": fmt.Sprintf("view_%d_ready_check", viewName), "limit": 1}
+	opts := map[string]interface{}{"stale": false, "key": fmt.Sprintf("view_%s_ready_check", viewName), "limit": 1}
 	for {
 		err := bucket.ViewCustom(ddocName, viewName, opts, &vres)
 		// Retry on timeout error, otherwise return

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -35,7 +35,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="67f00d5478fb4c749022221b0ae6c61a61f2e763"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="266fdfe7c8a663735c2b9a737469bd5b86df6e5f"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="eb79bf552d0992f5d790b25b6ebba9b633a259a2"/>
@@ -118,7 +118,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="0eaaeb7a960f0f614dd6479fc281b62f8167afd2"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="099c5b676b103d4b79b23caae5194cb462c98cd1"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
@@ -127,5 +127,3 @@
   <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="go-sourcemap" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
 </manifest>
-
-


### PR DESCRIPTION
Incorrect formatting directives cause tests to fail in Go 1.10