### PR TITLE
Fixes #3241 Improve logging for 2.0 replication functional debugging

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -60,7 +60,6 @@ const (
 
 	DefaultViewQueryPageSize = 5000 // This must be greater than 1, or the code won't work due to windowing method
 
-	FilterByChannel = "sync_gateway/bychannel"
 )
 
 func UnitTestUrl() string {

--- a/base/constants.go
+++ b/base/constants.go
@@ -60,6 +60,7 @@ const (
 
 	DefaultViewQueryPageSize = 5000 // This must be greater than 1, or the code won't work due to windowing method
 
+	FilterByChannel = "sync_gateway/bychannel"
 )
 
 func UnitTestUrl() string {

--- a/base/logging.go
+++ b/base/logging.go
@@ -421,6 +421,11 @@ func GetCallersName(depth int) string {
 	return fmt.Sprintf("%s() at %s:%d", lastComponent(fnname), lastComponent(file), line)
 }
 
+// Partial interface for the SGLogger
+type SGLogger interface {
+	LogTo(key string, format string, args ...interface{})
+}
+
 // Logs a message to the console, but only if the corresponding key is true in LogKeys.
 func LogTo(key string, format string, args ...interface{}) {
 	logLock.RLock()
@@ -703,7 +708,6 @@ func LogColor() {
 	bgWhite = "\x1b[47m"
 }
 
-
 // Prepend a context ID to each blip logging message.  The contextID uniquely identifies the blip context, and
 // is useful for grouping the blip connections in the log output.
 func PrependContextID(contextID, format string, params ...interface{}) (newFormat string, newParams []interface{}) {
@@ -716,6 +720,5 @@ func PrependContextID(contextID, format string, params ...interface{}) (newForma
 	params[0] = contextID
 
 	return formatWithContextID, params
-
 
 }

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
 )
 
@@ -35,7 +36,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	// Verify Sync Gateway will accept the doc revision that is about to be sent
 	var changeList [][]interface{}
 	changesRequest := blip.NewRequest()
-	changesRequest.SetProfile("changes")                             // TODO: make a constant for "changes" and use it everywhere
+	changesRequest.SetProfile("changes")
 	changesRequest.SetBody([]byte(`[["1", "foo", "1-abc", false]]`)) // [sequence, docID, revID]
 	sent := bt.sender.Send(changesRequest)
 	assert.True(t, sent)
@@ -136,7 +137,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Start subChanges w/ continuous=true, batchsize=20
 // Make several updates
 // Wait until we get the expected updates
-func TestContinousChangesSubscription(t *testing.T) {
+func TestContinuousChangesSubscription(t *testing.T) {
 
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
@@ -150,10 +151,7 @@ func TestContinousChangesSubscription(t *testing.T) {
 	var numbatchesReceived int32
 	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
 
-		log.Printf("got changes message: %+v", request)
-
 		body, err := request.Body()
-		log.Printf("changes body: %v, err: %v", string(body), err)
 
 		if string(body) != "null" {
 
@@ -497,5 +495,69 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	// Make sure we can see both docs in the changes
 	changes := bt.GetChanges()
 	assert.True(t, len(changes) == 2)
+
+}
+
+func TestCheckpoint(t *testing.T) {
+
+	// Create blip tester
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
+		noAdminParty:       true,
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+	})
+	assertNoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+
+	client := "testClient"
+
+	// Get the checkpoint -- expect to be missing at this point
+	request := blip.NewRequest()
+	request.SetCompressed(true)
+	request.SetProfile("getCheckpoint")
+	request.Properties["client"] = client
+	sent := bt.sender.Send(request)
+	if !sent {
+		panic(fmt.Sprintf("Failed to get checkpoint for client: %v", client))
+	}
+	checkpointResponse := request.Response()
+
+	// Expect to get no checkpoint
+	errorcode, ok := checkpointResponse.Properties["Error-Code"]
+	assert.True(t, ok)
+	assert.Equals(t, errorcode, "404")
+
+	// Set a checkpoint
+	requestSetCheckpoint := blip.NewRequest()
+	requestSetCheckpoint.SetCompressed(true)
+	requestSetCheckpoint.SetProfile("setCheckpoint")
+	requestSetCheckpoint.Properties["client"] = client
+	checkpointBody := db.Body{"Key": "Value"}
+	requestSetCheckpoint.SetJSONBody(checkpointBody)
+	// requestSetCheckpoint.Properties["rev"] = "rev1"
+	sent = bt.sender.Send(requestSetCheckpoint)
+	if !sent {
+		panic(fmt.Sprintf("Failed to set checkpoint for client: %v", client))
+	}
+	checkpointResponse = requestSetCheckpoint.Response()
+	body, err := checkpointResponse.Body()
+	assertNoError(t, err, "Unexpected error")
+	log.Printf("responseSetCheckpoint body: %s", body)
+
+	// Get the checkpoint and make sure it has the expected value
+	requestGetCheckpoint2 := blip.NewRequest()
+	requestGetCheckpoint2.SetCompressed(true)
+	requestGetCheckpoint2.SetProfile("getCheckpoint")
+	requestGetCheckpoint2.Properties["client"] = client
+	sent = bt.sender.Send(requestGetCheckpoint2)
+	if !sent {
+		panic(fmt.Sprintf("Failed to get checkpoint for client: %v", client))
+	}
+	checkpointResponse = requestGetCheckpoint2.Response()
+	body, err = checkpointResponse.Body()
+	assertNoError(t, err, "Unexpected error")
+	log.Printf("body: %s", body)
+	assert.True(t, strings.Contains(string(body), "Key"))
+	assert.True(t, strings.Contains(string(body), "Value"))
 
 }

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -193,7 +193,7 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 		return err
 	}
 	if value == nil {
-		return base.HTTPErrorf(401, "Not found")
+		return base.HTTPErrorf(http.StatusNotFound, http.StatusText(http.StatusNotFound))
 	}
 	response.Properties["rev"] = value["_rev"].(string)
 	delete(value, "_rev")

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -130,7 +130,8 @@ func (h *handler) handleBLIPSync() error {
 // Includes the outer handler as a nested function.
 func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler, *blip.Message) error) {
 
-	ctx.blipContext.HandlerForProfile[profile] = func(rq *blip.Message) {
+	// Wrap the handler function with a function that adds handling needed by all handlers
+	handlerFnWrapper := func(rq *blip.Message) {
 
 		startTime := time.Now()
 
@@ -156,6 +157,9 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 			}
 		}
 	}
+
+	ctx.blipContext.HandlerForProfile[profile] = handlerFnWrapper
+
 }
 
 // Handler for unknown requests

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -545,9 +545,7 @@ func (bh *blipHandler) handleAddRevision(rq *blip.Message) error {
 	if !found || !rfound {
 		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or revID")
 	}
-	if del, found := addRevision.deleted(); found && del != "0" && del != "false" {
-		body["_deleted"] = true // (PutExistingRev expects deleted flag in the body)
-	}
+	body["_deleted"] = addRevision.deleted()
 
 	history := []string{revID}
 	if historyStr := rq.Properties["history"]; historyStr != "" {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -231,7 +231,7 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 // Received a "subChanges" subscription request
 func (bh *blipHandler) handleSubscribeToChanges(rq *blip.Message) error {
 
-	subChanges := newSubChanges(rq, bh.blipSyncContext, bh.db.CreateZeroSinceValue, bh.db.ParseSequenceID)
+	subChanges := newSubChanges(rq, bh.blipSyncContext, bh.db.CreateZeroSinceValue(), bh.db.ParseSequenceID)
 	bh.logEndpointEntry(rq.Profile(), subChanges)
 
 	since, err := subChanges.since()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -193,7 +193,7 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 		return err
 	}
 	if value == nil {
-		return base.HTTPErrorf(404, "Not found")
+		return base.HTTPErrorf(401, "Not found")
 	}
 	response.Properties["rev"] = value["_rev"].(string)
 	delete(value, "_rev")

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -243,7 +243,7 @@ func (bh *blipHandler) handleSubscribeToChanges(rq *blip.Message) error {
 	bh.continuous = subChanges.continuous()
 	bh.activeOnly = subChanges.activeOnly()
 
-	if filter := subChanges.filter(); filter == base.FilterByChannel {
+	if filter := subChanges.filter(); filter == "sync_gateway/bychannel" {
 		var err error
 
 		bh.channels, err = subChanges.channelsExpandedSet()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/auth"
@@ -18,6 +19,12 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"golang.org/x/net/websocket"
+)
+
+const (
+
+	// Blip default vals
+	BlipDefaultBatchSize = uint64(200)
 )
 
 // Represents one BLIP connection (socket) opened by a client.
@@ -33,6 +40,7 @@ type blipSyncContext struct {
 	channels           base.Set
 	lock               sync.Mutex
 	allowedAttachments map[string]int
+	blipSerialNumber   uint64
 }
 
 type blipHandler struct {
@@ -80,8 +88,8 @@ func (h *handler) handleBLIPSync() error {
 	// Create a BLIP context:
 	blipContext := blip.NewContext()
 	blipContext.Logger = DefaultBlipLogger(blipContext.ID)
-	blipContext.LogMessages = base.LogEnabledExcludingLogStar("Sync+")
-	blipContext.LogFrames = base.LogEnabledExcludingLogStar("Sync++")
+	blipContext.LogMessages = base.LogEnabledExcludingLogStar("WS+")
+	blipContext.LogFrames = base.LogEnabledExcludingLogStar("WS++")
 
 	// Create a BLIP-sync context and register handlers:
 	ctx := blipSyncContext{
@@ -106,7 +114,7 @@ func (h *handler) handleBLIPSync() error {
 	server := blipContext.WebSocketServer()
 	defaultHandler := server.Handler
 	server.Handler = func(conn *websocket.Conn) {
-		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol %s.", blipContext.ID, h.currentEffectiveUserName()))
+		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol. User:%s.", blipContext.ID, h.currentEffectiveUserName()))
 		defer func() {
 			conn.Close() // in case it wasn't closed already
 			ctx.LogTo("HTTP+", "#%03d:    --> BLIP+WebSocket connection closed", h.serialNumber)
@@ -124,7 +132,7 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 
 	ctx.blipContext.HandlerForProfile[profile] = func(rq *blip.Message) {
 
-		ctx.LogTo("Sync", "%s %q ... %s", rq, profile, ctx.effectiveUsername)
+		startTime := time.Now()
 
 		db, _ := db.GetDatabase(ctx.dbc, ctx.user)
 		handler := blipHandler{
@@ -132,22 +140,28 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 			db:              db,
 		}
 
+		ctx.incrementSerialNumber()
+
 		if err := handlerFn(&handler, rq); err != nil {
 			status, msg := base.ErrorAsHTTPStatus(err)
 			if response := rq.Response(); response != nil {
 				response.SetError("HTTP", status, msg)
 			}
-			ctx.LogTo("Sync", "%s %q   --> %d %s ... %s", rq, profile, status, msg, ctx.effectiveUsername)
+			ctx.LogTo("SyncMsg", "#%03d: Type:%s   --> %d %s Time:%v User:%s", ctx.getSerialNumber(), profile, status, msg, time.Since(startTime), ctx.effectiveUsername)
 		} else {
-			ctx.LogTo("Sync+", "%s %q   --> OK ... %s", rq, profile, ctx.effectiveUsername)
+
+			// Log the fact that the handler has finished, except for the "subChanges" special case which does it's own termination related logging
+			if profile != "subChanges" {
+				ctx.LogTo("SyncMsg+", "#%03d: Type:%s   --> OK Time:%v User:%s ", ctx.getSerialNumber(), profile, time.Since(startTime), ctx.effectiveUsername)
+			}
 		}
 	}
 }
 
 // Handler for unknown requests
 func (ctx *blipSyncContext) notFound(rq *blip.Message) {
-	ctx.LogTo("Sync", "%s %q ... %s", rq, rq.Profile(), ctx.effectiveUsername)
-	ctx.LogTo("Sync", "%s    --> 404 Unknown profile ... %s", rq, ctx.effectiveUsername)
+	ctx.LogTo("Sync", "%s Type:%q User:%s", rq, rq.Profile(), ctx.effectiveUsername)
+	ctx.LogTo("Sync", "%s    --> 404 Unknown profile. User:%s", rq, ctx.effectiveUsername)
 	blip.Unhandled(rq)
 }
 
@@ -160,7 +174,11 @@ func (ctx *blipSyncContext) LogTo(key string, format string, args ...interface{}
 
 // Received a "getCheckpoint" request
 func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
-	docID := "checkpoint/" + rq.Properties["client"]
+
+	client := rq.Properties["client"]
+	bh.logEndpointEntry(rq.Profile(), NewAdhocStringer(fmt.Sprintf("Client:%s", client)))
+
+	docID := fmt.Sprintf("checkpoint/%s", client)
 	response := rq.Response()
 	if response == nil {
 		return nil
@@ -171,7 +189,7 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 		return err
 	}
 	if value == nil {
-		return base.HTTPErrorf(401, "Not found")
+		return base.HTTPErrorf(404, "Not found")
 	}
 	response.Properties["rev"] = value["_rev"].(string)
 	delete(value, "_rev")
@@ -183,13 +201,17 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 
 // Received a "setCheckpoint" request
 func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
-	docID := "checkpoint/" + rq.Properties["client"]
+
+	setCheckpoint := newSetCheckpoint(rq)
+	bh.logEndpointEntry(rq.Profile(), setCheckpoint)
+
+	docID := fmt.Sprintf("checkpoint/%s", setCheckpoint.client())
 
 	var checkpoint db.Body
 	if err := rq.ReadJSONBody(&checkpoint); err != nil {
 		return err
 	}
-	if revID := rq.Properties["rev"]; revID != "" {
+	if revID := setCheckpoint.rev(); revID != "" {
 		checkpoint["_rev"] = revID
 	}
 	revID, err := bh.db.PutSpecial("local", docID, checkpoint)
@@ -205,39 +227,44 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 // Received a "subChanges" subscription request
 func (bh *blipHandler) handleSubscribeToChanges(rq *blip.Message) error {
 
-	// Depeding on the db sequence type, use correct zero sequence for since value
-	since := bh.db.CreateZeroSinceValue()
+	subChanges := newSubChanges(rq, bh.blipSyncContext, bh.db.CreateZeroSinceValue, bh.db.ParseSequenceID)
+	bh.logEndpointEntry(rq.Profile(), subChanges)
 
-	if sinceStr, found := rq.Properties["since"]; found {
+	since, err := subChanges.since()
+	if err != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "Invalid sequence ID in 'since'")
+	}
+
+	bh.batchSize = subChanges.batchSize()
+	bh.continuous = subChanges.continuous()
+	bh.activeOnly = subChanges.activeOnly()
+
+	if filter := subChanges.filter(); filter == base.FilterByChannel {
 		var err error
-		if since, err = bh.db.ParseSequenceID(sinceStr); err != nil {
-			bh.blipSyncContext.LogTo("Sync", "%s: Error parsing sequence ID in 'since': %s.  Error: %v ... %s", rq, sinceStr, err, bh.effectiveUsername)
-			return base.HTTPErrorf(http.StatusBadRequest, "Invalid sequence ID in 'since': %s", sinceStr)
-		}
-	}
-	bh.batchSize = int(getRestrictedIntFromString(rq.Properties["batch"], 200, 10, math.MaxUint64, true))
-	bh.continuous = false
-	if val, found := rq.Properties["continuous"]; found && val != "false" {
-		bh.continuous = true
-	}
-	bh.activeOnly = (rq.Properties["active_only"] == "true")
-	if filter := rq.Properties["filter"]; filter == "sync_gateway/bychannel" {
-		if channelsParam, found := rq.Properties["channels"]; !found {
-			return base.HTTPErrorf(http.StatusBadRequest, "Missing 'channels' filter parameter")
-		} else {
-			channelsArray := strings.Split(channelsParam, ",")
-			var err error
-			bh.channels, err = channels.SetFromArray(channelsArray, channels.ExpandStar)
-			if err != nil {
-				return err
-			} else if len(bh.channels) == 0 {
-				return base.HTTPErrorf(http.StatusBadRequest, "Empty channel list")
-			}
+
+		bh.channels, err = subChanges.channelsExpandedSet()
+		if err != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, "%s", err)
+		} else if len(bh.channels) == 0 {
+			return base.HTTPErrorf(http.StatusBadRequest, "Empty channel list")
+
 		}
 	} else if filter != "" {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unknown filter; try sync_gateway/bychannel")
 	}
-	go bh.sendChanges(rq.Sender, since) // TODO: does this ever end?
+
+	// Kick off async goroutine to send (possibly continuous) changes to other side
+	go func() {
+
+		startTime := time.Now()
+
+		// Send changes
+		bh.sendChanges(rq.Sender, since)
+
+		bh.LogTo("SyncMsg+", "#%03d: Type:%s   --> Time:%v User:%s ", bh.getSerialNumber(), rq.Profile(), time.Since(startTime), bh.effectiveUsername)
+
+	}()
+
 	return nil
 }
 
@@ -249,7 +276,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, since db.SequenceID) {
 		}
 	}()
 
-	bh.blipSyncContext.LogTo("Sync", "Sending changes since %v ... %s", since, bh.effectiveUsername)
+	bh.LogTo("Sync", "Sending changes since %v. User:%s", since, bh.effectiveUsername)
 	options := db.ChangesOptions{
 		Since:      since,
 		Conflicts:  true,
@@ -274,8 +301,9 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, since db.SequenceID) {
 	}
 
 	generateContinuousChanges(bh.db, channelSet, options, nil, func(changes []*db.ChangeEntry) error {
-		bh.blipSyncContext.LogTo("Sync+", "    Sending %d changes ... %s", len(changes), bh.effectiveUsername)
+		bh.LogTo("Sync+", "    Sending %d changes. User:%s", len(changes), bh.effectiveUsername)
 		for _, change := range changes {
+
 			if !strings.HasPrefix(change.ID, "_") {
 				for _, item := range change.Changes {
 					changeRow := []interface{}{change.Seq, change.ID, item["rev"], change.Deleted}
@@ -312,9 +340,9 @@ func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]i
 	}
 	if len(changeArray) > 0 {
 		sequence := changeArray[0][0].(db.SequenceID)
-		bh.blipSyncContext.LogTo("Sync", "Sent %d changes to client, from seq %s ... %s", len(changeArray), sequence.String(), bh.effectiveUsername)
+		bh.LogTo("Sync", "Sent %d changes to client, from seq %s.  User:%s", len(changeArray), sequence.String(), bh.effectiveUsername)
 	} else {
-		bh.blipSyncContext.LogTo("Sync", "Sent all changes to client. ... %s", bh.effectiveUsername)
+		bh.LogTo("Sync", "Sent all changes to client. User:%s", bh.effectiveUsername)
 	}
 }
 
@@ -328,7 +356,7 @@ func (bh *blipHandler) handleChangesResponse(sender *blip.Sender, response *blip
 
 	var answer []interface{}
 	if err := response.ReadJSONBody(&answer); err != nil {
-		bh.blipSyncContext.LogTo("Sync", "Invalid response to 'changes' message: %s -- %s ... %s", response, err, bh.effectiveUsername)
+		bh.LogTo("Sync", "Invalid response to 'changes' message: %s -- %s.  User:%s", response, err, bh.effectiveUsername)
 		return
 	}
 
@@ -357,7 +385,7 @@ func (bh *blipHandler) handleChangesResponse(sender *blip.Sender, response *blip
 				if revID, ok := rev.(string); ok {
 					knownRevs[revID] = true
 				} else {
-					bh.blipSyncContext.LogTo("Sync", "Invalid response to 'changes' message ... %s", bh.effectiveUsername)
+					bh.LogTo("Sync", "Invalid response to 'changes' message.  User:%s", bh.effectiveUsername)
 					return
 				}
 			}
@@ -371,12 +399,12 @@ func (bh *blipHandler) handlePushedChanges(rq *blip.Message) error {
 	if !bh.db.AllowConflicts() {
 		return base.HTTPErrorf(http.StatusConflict, "Use 'proposeChanges' instead")
 	}
-
 	var changeList [][]interface{}
 	if err := rq.ReadJSONBody(&changeList); err != nil {
 		return err
 	}
-	bh.blipSyncContext.LogTo("Sync", "Received %d changes from client ... %s", len(changeList), bh.effectiveUsername)
+
+	bh.logEndpointEntry(rq.Profile(), NewAdhocStringer(fmt.Sprintf("#Changes:%d", len(changeList))))
 	if len(changeList) == 0 {
 		return nil
 	}
@@ -413,7 +441,7 @@ func (bh *blipHandler) handleProposedChanges(rq *blip.Message) error {
 	if err := rq.ReadJSONBody(&changeList); err != nil {
 		return err
 	}
-	bh.blipSyncContext.LogTo("Sync", "Received %d changes from client", len(changeList))
+	bh.logEndpointEntry(rq.Profile(), NewAdhocStringer(fmt.Sprintf("#Changes: %d", len(changeList))))
 	if len(changeList) == 0 {
 		return nil
 	}
@@ -451,7 +479,7 @@ func (bh *blipHandler) handleProposedChanges(rq *blip.Message) error {
 
 // Pushes a revision body to the client
 func (bh *blipHandler) sendRevision(sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int) {
-	bh.blipSyncContext.LogTo("Sync+", "Sending rev %q %s based on %d known ... %s", docID, revID, len(knownRevs), bh.effectiveUsername)
+	bh.LogTo("Sync+", "Sending rev %q %s based on %d known.  User:%s", docID, revID, len(knownRevs), bh.effectiveUsername)
 	body, err := bh.db.GetRev(docID, revID, true, nil)
 	if err != nil {
 		base.Warn("[%s] blipHandler can't get doc %q/%s: %v", bh.blipContext.ID, docID, revID, err)
@@ -503,18 +531,21 @@ func (bh *blipHandler) sendRevision(sender *blip.Sender, seq db.SequenceID, docI
 // Received a "rev" request, i.e. client is pushing a revision body
 func (bh *blipHandler) handleAddRevision(rq *blip.Message) error {
 
+	addRevision := newAddRevision(rq)
+	bh.logEndpointEntry(rq.Profile(), addRevision)
+
 	var body db.Body
 	if err := rq.ReadJSONBody(&body); err != nil {
 		return err
 	}
 
 	// Doc metadata comes from the BLIP message metadata, not magic document properties:
-	docID, found := rq.Properties["id"]
-	revID, rfound := rq.Properties["rev"]
+	docID, found := addRevision.id()
+	revID, rfound := addRevision.rev()
 	if !found || !rfound {
 		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or revID")
 	}
-	if del, found := rq.Properties["deleted"]; found && del != "0" && del != "false" {
+	if del, found := addRevision.deleted(); found && del != "0" && del != "false" {
 		body["_deleted"] = true // (PutExistingRev expects deleted flag in the body)
 	}
 
@@ -522,7 +553,6 @@ func (bh *blipHandler) handleAddRevision(rq *blip.Message) error {
 	if historyStr := rq.Properties["history"]; historyStr != "" {
 		history = append(history, strings.Split(historyStr, ",")...)
 	}
-	bh.blipSyncContext.LogTo("Sync+", "Inserting rev %q %s history=%q, array = %#v ... %s", docID, revID, rq.Properties["history"], history, bh.effectiveUsername)
 
 	// Look at attachments with revpos > the last common ancestor's
 	minRevpos := 1
@@ -544,7 +574,11 @@ func (bh *blipHandler) handleAddRevision(rq *blip.Message) error {
 
 // Received a "getAttachment" request
 func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
-	digest := rq.Properties["digest"]
+
+	getAttachment := newGetAttachment(rq)
+	bh.logEndpointEntry(rq.Profile(), getAttachment)
+
+	digest := getAttachment.digest()
 	if digest == "" {
 		return base.HTTPErrorf(http.StatusBadRequest, "Missing 'digest'")
 	}
@@ -555,7 +589,7 @@ func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
 	if err != nil {
 		return err
 	}
-	bh.blipSyncContext.LogTo("Sync+", "Sending attachment with digest=%q (%dkb) ... %s", digest, len(attachment)/1024, bh.effectiveUsername)
+	bh.LogTo("Sync+", "Sending attachment with digest=%q (%dkb) User:%s", digest, len(attachment)/1024, bh.effectiveUsername)
 	response := rq.Response()
 	response.SetBody(attachment)
 	response.SetCompressed(rq.Properties["compress"] == "true")
@@ -572,7 +606,7 @@ func (bh *blipHandler) downloadOrVerifyAttachments(body db.Body, minRevpos int, 
 				// security purposes I do need the client to _prove_ it has the data, otherwise if
 				// it knew the digest it could acquire the data by uploading a document with the
 				// claimed attachment, then downloading it.
-				bh.blipSyncContext.LogTo("Sync+", "    Verifying attachment %q (digest %s)  ... %s", name, digest, bh.effectiveUsername)
+				bh.LogTo("Sync+", "    Verifying attachment %q (digest %s).  User:%s", name, digest, bh.effectiveUsername)
 				nonce, proof := db.GenerateProofOfAttachment(knownData)
 				outrq := blip.NewRequest()
 				outrq.Properties = map[string]string{"Profile": "proveAttachment", "digest": digest}
@@ -581,13 +615,13 @@ func (bh *blipHandler) downloadOrVerifyAttachments(body db.Body, minRevpos int, 
 				if body, err := outrq.Response().Body(); err != nil {
 					return nil, err
 				} else if string(body) != proof {
-					bh.blipSyncContext.LogTo("Sync+", "Error: Incorrect proof for attachment %s : I sent nonce %x, expected proof %q, got %q ... %s", digest, nonce, proof, body, bh.effectiveUsername)
+					bh.LogTo("Sync+", "Error: Incorrect proof for attachment %s : I sent nonce %x, expected proof %q, got %q.  User:%s", digest, nonce, proof, body, bh.effectiveUsername)
 					return nil, base.HTTPErrorf(http.StatusForbidden, "Incorrect proof for attachment %s", digest)
 				}
 				return nil, nil
 			} else {
 				// If I don't have the attachment, I will request it from the client:
-				bh.blipSyncContext.LogTo("Sync+", "    Asking for attachment %q (digest %s)  ... %s", name, digest, bh.effectiveUsername)
+				bh.LogTo("Sync+", "    Asking for attachment %q (digest %s). User:%s", name, digest, bh.effectiveUsername)
 				outrq := blip.NewRequest()
 				outrq.Properties = map[string]string{"Profile": "getAttachment", "digest": digest}
 				if isCompressible(name, meta) {
@@ -597,6 +631,14 @@ func (bh *blipHandler) downloadOrVerifyAttachments(body db.Body, minRevpos int, 
 				return outrq.Response().Body()
 			}
 		})
+}
+
+func (ctx *blipSyncContext) incrementSerialNumber() {
+	ctx.blipSerialNumber = atomic.AddUint64(&ctx.blipSerialNumber, 1)
+}
+
+func (ctx *blipSyncContext) getSerialNumber() uint64 {
+	return atomic.LoadUint64(&ctx.blipSerialNumber)
 }
 
 func (ctx *blipSyncContext) addAllowedAttachments(atts map[string]interface{}) {
@@ -665,17 +707,33 @@ func isCompressible(filename string, meta map[string]interface{}) bool {
 	return true // be optimistic by default
 }
 
+func (bh *blipHandler) logEndpointEntry(profile string, endpoint fmt.Stringer) {
+	bh.LogTo("SyncMsg", "#%03d: Prof:%s %s User:%s", bh.getSerialNumber(), profile, endpoint, bh.effectiveUsername)
+}
+
+type AdhocStringer struct {
+	s string
+}
+
+func NewAdhocStringer(s string) *AdhocStringer {
+	return &AdhocStringer{s: s}
+}
+
+func (a AdhocStringer) String() string {
+	return a.s
+}
+
 func DefaultBlipLogger(contextID string) blip.LogFn {
 	return func(eventType blip.LogEventType, format string, params ...interface{}) {
 		formatWithContextID, paramsWithContextID := base.PrependContextID(contextID, format, params...)
 
 		switch eventType {
 		case blip.LogMessage:
-			base.LogTo("Sync+", formatWithContextID, paramsWithContextID...)
+			base.LogTo("WS+", formatWithContextID, paramsWithContextID...)
 		case blip.LogFrame:
-			base.LogTo("Sync++", formatWithContextID, paramsWithContextID...)
+			base.LogTo("WS++", formatWithContextID, paramsWithContextID...)
 		default:
-			base.LogTo("Sync", formatWithContextID, paramsWithContextID...)
+			base.LogTo("WS", formatWithContextID, paramsWithContextID...)
 		}
 	}
 }

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -707,8 +707,7 @@ func isCompressible(filename string, meta map[string]interface{}) bool {
 }
 
 func (bh *blipHandler) logEndpointEntry(profile, endpoint string) {
-	// Prof is short for "Profile", which is basically the blip message type
-	bh.LogTo("SyncMsg", "#%03d: Prof:%s %s User:%s", bh.serialNumber, profile, endpoint, bh.effectiveUsername)
+	bh.LogTo("SyncMsg", "#%03d: Type:%s %s User:%s", bh.serialNumber, profile, endpoint, bh.effectiveUsername)
 }
 
 

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -181,9 +181,17 @@ func (a *addRevision) rev() (rev string, found bool) {
 	return rev, found
 }
 
-func (a *addRevision) deleted() (deleted string, found bool) {
-	deleted, found = a.rq.Properties["deleted"]
-	return deleted, found
+func (a *addRevision) deleted() bool {
+	deleted, found := a.rq.Properties["deleted"]
+	if !found {
+		return false
+	}
+	return deleted != "0" && deleted != "false"
+}
+
+func (a *addRevision) hasDeletedPropery() bool {
+	_, found := a.rq.Properties["deleted"]
+	return found
 }
 
 func (a *addRevision) sequence() (sequence string, found bool) {
@@ -203,8 +211,8 @@ func (a *addRevision) String() string {
 		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
 	}
 
-	if deleted, foundDeleted := a.deleted(); foundDeleted {
-		buffer.WriteString(fmt.Sprintf("Deleted:%v ", deleted))
+	if a.hasDeletedPropery() {
+		buffer.WriteString(fmt.Sprintf("Deleted:%v ", a.deleted()))
 	}
 
 	if sequence, foundSequence := a.sequence(); foundSequence == true {

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -1,0 +1,234 @@
+package rest
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"bytes"
+
+	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/channels"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+// Function signature for something that generates a sequence id
+type SequenceIDGenerator func() db.SequenceID
+
+// Function signature for something that parses a sequence id from a string
+type SequenceIDParser func(since string) (db.SequenceID, error)
+
+// Helper for handling BLIP subChanges requests.  Supports Stringer() interface to log aspects of the request.
+type subChanges struct {
+	rq                    *blip.Message       // The underlying BLIP message
+	logger                base.SGLogger       // A logger object which might encompass more state (eg, blipContext id)
+	sinceZeroValueCreator SequenceIDGenerator // A sequence generator for creating zero'd since values
+	sequenceIDParser SequenceIDParser
+}
+
+// Create a new subChanges helper
+func newSubChanges(rq *blip.Message, logger base.SGLogger, sinceZeroValueCreator SequenceIDGenerator, sequenceIDParser SequenceIDParser) *subChanges {
+	return &subChanges{
+		rq:                    rq,
+		logger:                logger,
+		sinceZeroValueCreator: sinceZeroValueCreator,
+		sequenceIDParser: sequenceIDParser,
+	}
+}
+
+func (s *subChanges) since() (db.SequenceID, error) {
+
+	// Depending on the db sequence type, use correct zero sequence for since value
+	sinceSequenceId := s.sinceZeroValueCreator()
+
+	if sinceStr, found := s.rq.Properties["since"]; found {
+		var err error
+		if sinceSequenceId, err = s.sequenceIDParser(sinceStr); err != nil {
+			s.logger.LogTo("Sync", "%s: Invalid sequence ID in 'since': %s", s.rq, sinceStr)
+			return db.SequenceID{}, err
+		}
+	}
+
+	return sinceSequenceId, nil
+
+}
+
+func (s *subChanges) batchSize() int {
+	return int(getRestrictedIntFromString(s.rq.Properties["batch"], BlipDefaultBatchSize, 10, math.MaxUint64, true))
+}
+
+func (s *subChanges) continuous() bool {
+	continuous := false
+	if val, found := s.rq.Properties["continuous"]; found && val != "false" {
+		continuous = true
+	}
+	return continuous
+}
+
+func (s *subChanges) activeOnly() bool {
+	return (s.rq.Properties["active_only"] == "true")
+}
+
+func (s *subChanges) filter() string {
+	return s.rq.Properties["filter"]
+}
+
+func (s *subChanges) channels() (channels string, found bool) {
+	channels, found = s.rq.Properties["channels"]
+	return channels, found
+}
+
+func (s *subChanges) channelsExpandedSet() (resultChannels base.Set, err error) {
+	channelsParam, found := s.rq.Properties["channels"]
+	if !found {
+		return nil, fmt.Errorf("Missing 'channels' filter parameter")
+	}
+	channelsArray := strings.Split(channelsParam, ",")
+	return channels.SetFromArray(channelsArray, channels.ExpandStar)
+}
+
+// Satisfy fmt.Stringer interface for dumping attributes of this subChanges request to logs
+func (s *subChanges) String() string {
+
+	buffer := bytes.NewBufferString("")
+
+	buffer.WriteString(fmt.Sprintf("Since:%v ", s.since()))
+
+	continuous := s.continuous()
+	if continuous {
+		buffer.WriteString(fmt.Sprintf("Continuous:%v ", continuous))
+	}
+
+	activeOnly := s.activeOnly()
+	if activeOnly {
+		buffer.WriteString(fmt.Sprintf("ActiveOnly:%v ", activeOnly))
+	}
+
+	filter := s.filter()
+	if len(filter) > 0 {
+		buffer.WriteString(fmt.Sprintf("Filter:%v ", filter))
+		channels, found := s.channels()
+		if found {
+			buffer.WriteString(fmt.Sprintf("Channels:%v ", channels))
+		}
+	}
+
+	batchSize := s.batchSize()
+	if batchSize != int(BlipDefaultBatchSize) {
+		buffer.WriteString(fmt.Sprintf("BatchSize:%v ", s.batchSize()))
+	}
+
+	return buffer.String()
+
+}
+
+type setCheckpoint struct {
+	rq *blip.Message // The underlying BLIP message
+}
+
+func newSetCheckpoint(rq *blip.Message) *setCheckpoint {
+	return &setCheckpoint{
+		rq: rq,
+	}
+}
+
+func (s *setCheckpoint) client() string {
+	return s.rq.Properties["client"]
+}
+
+func (s *setCheckpoint) rev() string {
+	return s.rq.Properties["rev"]
+}
+
+func (s *setCheckpoint) String() string {
+
+	buffer := bytes.NewBufferString("")
+
+	buffer.WriteString(fmt.Sprintf("Client:%v ", s.client()))
+
+	rev := s.rev()
+	if len(rev) > 0 {
+		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
+	}
+
+	return buffer.String()
+
+}
+
+type addRevision struct {
+	rq *blip.Message // The underlying BLIP message
+}
+
+func newAddRevision(rq *blip.Message) *addRevision {
+	return &addRevision{
+		rq: rq,
+	}
+}
+
+func (a *addRevision) id() (id string, found bool) {
+	id, found = a.rq.Properties["id"]
+	return id, found
+}
+
+func (a *addRevision) rev() (rev string, found bool) {
+	rev, found = a.rq.Properties["rev"]
+	return rev, found
+}
+
+func (a *addRevision) deleted() (deleted string, found bool) {
+	deleted, found = a.rq.Properties["deleted"]
+	return deleted, found
+}
+
+func (a *addRevision) sequence() (sequence string, found bool) {
+	sequence, found = a.rq.Properties["sequence"]
+	return sequence, found
+}
+
+func (a *addRevision) String() string {
+
+	buffer := bytes.NewBufferString("")
+
+	if id, foundId := a.id(); foundId {
+		buffer.WriteString(fmt.Sprintf("Id:%v ", id))
+	}
+
+	if rev, foundRev := a.rev(); foundRev {
+		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
+	}
+
+	if deleted, foundDeleted := a.deleted(); foundDeleted {
+		buffer.WriteString(fmt.Sprintf("Deleted:%v ", deleted))
+	}
+
+	if sequence, foundSequence := a.sequence(); foundSequence == true {
+		buffer.WriteString(fmt.Sprintf("Sequence:%v ", sequence))
+	}
+
+	return buffer.String()
+
+}
+
+type getAttachment struct {
+	rq *blip.Message // The underlying BLIP message
+}
+
+func newGetAttachment(rq *blip.Message) *getAttachment {
+	return &getAttachment{
+		rq: rq,
+	}
+}
+
+func (g *getAttachment) digest() string {
+	return g.rq.Properties["digest"]
+}
+
+func (g *getAttachment) String() string {
+
+	buffer := bytes.NewBufferString("")
+
+	buffer.WriteString(fmt.Sprintf("Digest:%v ", g.digest()))
+
+	return buffer.String()
+
+}

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -92,7 +92,13 @@ func (s *subChanges) String() string {
 
 	buffer := bytes.NewBufferString("")
 
-	buffer.WriteString(fmt.Sprintf("Since:%v ", s.since()))
+	since, err := s.since()
+	if err != nil {
+		base.Warn("Error discovering since value from subchanges.  Err: %v", err)
+	} else {
+		buffer.WriteString(fmt.Sprintf("Since:%v ", since))
+	}
+
 
 	continuous := s.continuous()
 	if continuous {

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -48,7 +48,7 @@ func TestAddRevision(t *testing.T) {
 		if testCase.deletedPropertyValue != "nil" {
 			blipMessage.Properties["deleted"] = testCase.deletedPropertyValue
 		}
-		addRevision := newAddRevision(&blipMessage)
+		addRevision := newAddRevisionParams(&blipMessage)
 		assert.Equals(t, addRevision.deleted(), testCase.expectedDeletedVal)
 	}
 

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -1,0 +1,56 @@
+package rest
+
+import (
+	"testing"
+	"github.com/couchbase/go-blip"
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestAddRevision(t *testing.T) {
+
+	testCases := []struct{
+		deletedPropertyValue string
+		expectedDeletedVal bool
+	} {
+		{
+			deletedPropertyValue: "true",
+			expectedDeletedVal: true,
+		},
+		{
+			deletedPropertyValue: "truedat",
+			expectedDeletedVal: true,
+		},
+		{
+			deletedPropertyValue: "0",
+			expectedDeletedVal: false,
+		},
+		{
+			deletedPropertyValue: "false",
+			expectedDeletedVal: false,
+		},
+		{
+			deletedPropertyValue: "False",
+			expectedDeletedVal: true,  // Counter-intuitive!  deleted() should probably lowercase the string before comparing
+		},
+		{
+			deletedPropertyValue: "",
+			expectedDeletedVal: true,  // It's not false, so it's true
+		},
+		{
+			deletedPropertyValue: "nil",
+			expectedDeletedVal: false,  // was not set, so it's false
+		},
+	}
+
+	for _, testCase := range testCases {
+		blipMessage := blip.Message{}
+		blipMessage.Properties = blip.Properties{}
+		if testCase.deletedPropertyValue != "nil" {
+			blipMessage.Properties["deleted"] = testCase.deletedPropertyValue
+		}
+		addRevision := newAddRevision(&blipMessage)
+		assert.Equals(t, addRevision.deleted(), testCase.expectedDeletedVal)
+	}
+
+
+}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -380,13 +380,13 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			case <-heartbeat:
 				_, err = h.response.Write([]byte("\n"))
 				h.flush()
-				base.LogTo("Heartbeat", "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserName())
+				base.LogTo("Heartbeat", "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserNameAsUser())
 			case <-timeout:
 				message = "OK (timeout)"
 				forceClose = true
 				break loop
 			case <-closeNotify:
-				base.LogTo("Changes", "Connection lost from client: %v", h.currentEffectiveUserName())
+				base.LogTo("Changes", "Connection lost from client: %v", h.currentEffectiveUserNameAsUser())
 				forceClose = true
 				break loop
 			case <-h.db.ExitChanges:
@@ -653,13 +653,13 @@ loop:
 		case <-heartbeat:
 			err = send(nil)
 			if h != nil {
-				base.LogTo("Heartbeat", "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserName())
+				base.LogTo("Heartbeat", "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserNameAsUser())
 			}
 		case <-timeout:
 			forceClose = true
 			break loop
 		case <-closeNotify:
-			base.LogTo("Changes", "Connection lost from client: %v", h.currentEffectiveUserName())
+			base.LogTo("Changes", "Connection lost from client: %v", h.currentEffectiveUserNameAsUser())
 			forceClose = true
 			break loop
 		case <-database.ExitChanges:

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -523,7 +523,7 @@ func (h *handler) currentEffectiveUserName() string {
 		effectiveName = "ADMIN"
 	} else if h.user != nil {
 		if h.user.Name() != "" {
-			effectiveName = fmt.Sprintf("%s", h.user.Name())
+			effectiveName = h.user.Name()
 		} else {
 			effectiveName = "GUEST"
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -226,7 +226,7 @@ func (h *handler) logRequestLine() {
 	if !base.LogEnabled("HTTP") {
 		return
 	}
-	as := h.currentEffectiveUserName()
+	as := h.currentEffectiveUserNameAsUser()
 	proto := ""
 	if h.rq.ProtoMajor >= 2 {
 		proto = " HTTP/2"
@@ -515,20 +515,25 @@ func (h *handler) getBearerToken() string {
 	return ""
 }
 
+
 func (h *handler) currentEffectiveUserName() string {
 	var effectiveName string
 
 	if h.privs == adminPrivs {
-		effectiveName = " (as ADMIN)"
+		effectiveName = "ADMIN"
 	} else if h.user != nil {
 		if h.user.Name() != "" {
-			effectiveName = fmt.Sprintf(" (as %s)", h.user.Name())
+			effectiveName = fmt.Sprintf("%s", h.user.Name())
 		} else {
-			effectiveName = " (as GUEST)"
+			effectiveName = "GUEST"
 		}
 	}
 
 	return effectiveName
+}
+
+func (h *handler) currentEffectiveUserNameAsUser() string {
+	return fmt.Sprintf(" (as %s)", h.currentEffectiveUserName())
 }
 
 //////// RESPONSES:

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -813,7 +813,4 @@ func EnableBlipSyncLogs() {
 	base.EnableLogKey("HTTP+")
 	base.EnableLogKey("Sync")
 	base.EnableLogKey("Sync+")
-	base.EnableLogKey("SyncMsg")
-	base.EnableLogKey("SyncMsg+")
-	base.EnableLogKey("WS")
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -636,8 +636,8 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 	bt.blipContext = blip.NewContext()
 	bt.blipContext.Logger = DefaultBlipLogger(bt.blipContext.ID)
 
-	bt.blipContext.LogMessages = base.LogEnabledExcludingLogStar("Sync+")
-	bt.blipContext.LogFrames = base.LogEnabledExcludingLogStar("Sync++")
+	bt.blipContext.LogMessages = base.LogEnabledExcludingLogStar("WS+")
+	bt.blipContext.LogFrames = base.LogEnabledExcludingLogStar("WS++")
 
 	origin := "http://localhost" // TODO: what should be used here?
 
@@ -813,6 +813,7 @@ func EnableBlipSyncLogs() {
 	base.EnableLogKey("HTTP+")
 	base.EnableLogKey("Sync")
 	base.EnableLogKey("Sync+")
-	base.EnableLogKey("Sync++")
-
+	base.EnableLogKey("SyncMsg")
+	base.EnableLogKey("SyncMsg+")
+	base.EnableLogKey("WS")
 }


### PR DESCRIPTION

Fixed #3241 

This code in particular might need some explaining/justification:

```
+type SGLogger interface {
+	LogTo(key string, format string, args ...interface{})
+}
```

and it's use in:

```
// Helper for handling BLIP subChanges requests.  Supports Stringer() interface to log aspects of the request.
type subChanges struct {
	rq                    *blip.Message       // The underlying BLIP message
	logger                base.SGLogger       // A logger object which might encompass more state (eg, blipContext id)
	sinceZeroValueCreator SequenceIDGenerator // A sequence generator for creating zero'd since values
}

```

The idea was to refactor out the `subChanges` code from the handler so that `subChanges` could easily dump it's "state" as a `fmt.Stringer()` -- where the state here is the parameters in the `*blip.Request`.  

However, there was some code in particular that needed a logger:

```
func (s *subChanges) since() db.SequenceID {

	// Depending on the db sequence type, use correct zero sequence for since value
	sinceSequenceId := s.sinceZeroValueCreator()

	if sinceStr, found := s.rq.Properties["since"]; found {
		var err error
		if sinceSequenceId, err = db.ParseSequenceIDFromJSON([]byte(sinceStr)); err != nil {
			s.logger.LogTo("Sync", "%s: Invalid sequence ID in 'since': %s", s.rq, sinceStr)
			sinceSequenceId = db.SequenceID{}
		}
	}

	return sinceSequenceId

}
```

and it felt "right" to move the `since()` method code out of the handler and into `subChanges`, since `subChanges` could be tested in isolation (and possibly used elsewhere).   Since the logger in the handler was being wrapped to emit the blip context id, it wasn't possible to just call `base.LogTo()` from `subChanges`, and so that's why a handler is being passed in.

I only implemented the minimal log related messages in the `SGLogger` interface, but if we want to go this route then maybe it would make sense to flesh out that interface a bit more.