### PR TITLE
#3157 Updates gocb and dependencies in manifest for IPv6 support

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -17,6 +17,7 @@
   <remote fetch="https://github.com/satori/" name="satori"/>
   <remote fetch="https://github.com/pkg/" name="pkg"/>
   <remote fetch="https://github.com/go-sourcemap/" name="go-sourcemap"/>
+  <remote fetch="https://github.com/google/" name="google"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
@@ -60,15 +61,15 @@
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="195945aa8fd23ea4772883396fd6b31730035eff"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="6382451e5ef472cd19e4eba6e82e3c1957e4cc09"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="72b08dc5389b2536dd073f16a093a964edce65eb"/>
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="e5fbe974fa2c297b36bda375d742ba1419eff25f"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="de2ebfbb130fe9df6ffdacde73f799f17a72e70b"/>
 
-  <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+  <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
-  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="f601f521a1ab1c99260c63441e1bbdbbc48b1bd9"/>
+  <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="39fe61b0969ae38f8c6841e9c19c5ad9e57d2b75"/>
 
@@ -125,5 +126,7 @@
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="pkg" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
   <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="go-sourcemap" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+
+  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="google" revision="dec09d789f3dba190787f8b4454c7d3c936fed9e"/>
 
 </manifest>


### PR DESCRIPTION
Closes #3157 Updates gocb and dependencies to latest versions in manifest for IPv6 support.

## Integration Tests

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/332/
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/333/

## Manual Testing

Tested with a SG build inside a docker container with the following config (easiest way to get an IPv6 CB server up and running - [using this guide](https://hub.internal.couchbase.com/confluence/display/JP/Setup+IPv6+environment+using+Docker))

#### config.json

```json
{
  "log": ["*"],
  "databases": {
    "db": {
      "server": "http://[::FFFF:172.17.0.3]:8091",
      "bucket": "sg-test",
      "username": "Administrator",
      "password": "password",
      "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } }
    }
  }
}

```

#### Startup before gocb updates
```
13:25 $ docker run sg
2018-01-29T13:26:02.427Z Enabling logging: [*]
2018-01-29T13:26:02.427Z ==== /() ====
2018-01-29T13:26:02.427Z requestedSoftFDLimit < currentSoftFdLimit (5000 < 1048576) no action needed
2018-01-29T13:26:02.427Z Opening db /db as bucket "sg-test", pool "default", server <http://[::FFFF:172.17.0.3]:8091>
2018-01-29T13:26:02.427Z GoCBCustomSGTranscoder Opening Couchbase database sg-test on <http://[::FFFF:172.17.0.3]:8091> as user "Administrator"
2018-01-29T13:26:02.805Z Debug: RetryLoop retrying Attempt to connect to bucket : sg-test after 5 ms.
2018-01-29T13:26:02.812Z GoCBCustomSGTranscoder Opening Couchbase database sg-test on <http://[::FFFF:172.17.0.3]:8091> as user "Administrator"
2018-01-29T13:26:02.818Z Debug: RetryLoop retrying Attempt to connect to bucket : sg-test after 10 ms.
...
```

#### Startup after gocb+deps update

```
13:09 $ docker run sg
2018-01-29T13:09:25.831Z Enabling logging: [*]
2018-01-29T13:09:25.831Z ==== /() ====
2018-01-29T13:09:25.832Z requestedSoftFDLimit < currentSoftFdLimit (5000 < 1048576) no action needed
2018-01-29T13:09:25.832Z Opening db /db as bucket "sg-test", pool "default", server <http://[::FFFF:172.17.0.3]:8091>
2018-01-29T13:09:25.832Z GoCBCustomSGTranscoder Opening Couchbase database sg-test on <http://[::FFFF:172.17.0.3]:8091> as user "Administrator"
2018-01-29T13:09:25.890Z Design docs for current view version (2.0) do not exist - creating...
2018-01-29T13:09:26.341Z Design docs successfully created for view version 2.0.
2018-01-29T13:09:26.341Z Verifying view availability for bucket sg-test...
2018-01-29T13:09:26.634Z Views ready for bucket sg-test.
2018-01-29T13:09:26.635Z Cache: Initializing changes cache with options {ChannelCacheOptions:{ChannelCacheMinLength:0 ChannelCacheMaxLength:0 ChannelCacheAge:0s} CachePendingSeqMaxWait:5s CachePendingSeqMaxNum:10000 CacheSkippedSeqMaxWait:1h0m0s}
2018-01-29T13:09:26.635Z Initializing changes cache for database db with sequence: 0
2018-01-29T13:09:26.635Z Feed: Starting mutation feed on bucket sg-test due to either channel cache mode or doc tracking (auto-import/bucketshadow)
2018-01-29T13:09:26.636Z Feed: Using DCP feed for bucket: "sg-test" (based on feed_type specified in config file)
2018-01-29T13:09:26.686Z Feed+: Initializing DCP with no backfill - seeding seqnos: map[]
2018-01-29T13:09:26.741Z Feed+: Initializing DCP with no backfill - seeding seqnos: map[]
2018-01-29T13:09:26.741Z Feed+: Connecting to new bucket datasource.  URLs:[http://[::FFFF:172.17.0.3]:8091 http://[::FFFF:172.17.0.4]:8091], pool:default, bucket:sg-test
2018-01-29T13:09:26.743Z Using default sync function 'channel(doc.channels)' for database "db"
2018-01-29T13:09:26.745Z Auth: Saved _sync:user:: &{{ *:1  %!s(uint64=1)  %!s(*uint16=<nil>)} { %!s(bool=false)  <nil>   []} %!s(*auth.Authenticator=&{0xc4202ec1e0 0xc4202eadc0 SyncGatewaySession}) []}
2018-01-29T13:09:26.745Z     Reset guest user to config
2018-01-29T13:09:26.745Z Starting admin server on 127.0.0.1:4985
2018-01-29T13:09:26.752Z Starting server on :4984 ...
_time=2018-01-29T13:09:26.768+00:00 _level=INFO _msg=Using plain authentication for user Administrator
_time=2018-01-29T13:09:26.768+00:00 _level=INFO _msg=Using plain authentication for user Administrator
2018-01-29T13:09:26.810Z Cache: Received #1 ("_user/")
2018-01-29T13:09:26.810Z Cache: Initialized cache for channel "*" with options: &{ChannelCacheMinLength:50 ChannelCacheMaxLength:500 ChannelCacheAge:1m0s}
2018-01-29T13:09:26.810Z Cache:     #1 ==> channel "*"
2018-01-29T13:09:26.811Z Changes+: Notifying that "sg-test" changed (keys="{*}") count=2
2018-01-29T13:09:26.811Z Changes+: Notifying that "sg-test" changed (keys="{_sync:user:}") count=3
```