### PR TITLE
Document caveat when cross-compiling Sync Gateway to Linux

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -78,7 +78,8 @@ Cross-compiling for Linux
 **x86 Linux**
 
 ```
-GOOS=linux GOARCH=amd64 ./build.sh
+$ ls $(go env GOROOT)/pkg && sudo chown -R $USER $(go env GOROOT)/pkg
+$ GOOS=linux GOARCH=amd64 ./build.sh
 ```
 
 **ARM Linux**


### PR DESCRIPTION
Works around error

```
go install runtime/internal/sys: mkdir /usr/local/go/pkg/linux_amd64: permission denied
````

by changing permissions of go dir as described in https://github.com/golang/go/issues/14213