### PR TITLE
Fixes #3247 Delay sg-replicate startup until REST APIs are available

### DIFF
--- a/base/replicator.go
+++ b/base/replicator.go
@@ -134,12 +134,12 @@ func (r *Replicator) removeReplication(repId string) {
 // Starts a replication based on the provided replication config.
 func (r *Replicator) startReplication(parameters sgreplicate.ReplicationParameters) (sgreplicate.SGReplication, error) {
 
-	LogTo("Replicate", "Starting replication with parameters %+v", parameters)
-
 	// Generate ID for the new replication, and add to the map of active replications
 	if parameters.ReplicationId == "" {
 		parameters.ReplicationId = CreateUUID()
 	}
+
+	LogTo("Replicate", "Starting replication with parameters %+v", parameters)
 
 	switch parameters.Lifecycle {
 	case sgreplicate.ONE_SHOT:

--- a/rest/config.go
+++ b/rest/config.go
@@ -870,6 +870,7 @@ func waitForResponse(addr string) error {
 
 		base.RetryWorker(func() (bool, error, interface{}) {
 			resp, err := http.Get(url)
+			defer resp.Body.Close()
 			shouldRetry := err != nil || resp.StatusCode != http.StatusOK
 			return shouldRetry, nil, nil
 		}),

--- a/rest/config.go
+++ b/rest/config.go
@@ -864,19 +864,21 @@ func localhostAddr(addr string) string {
 
 // waitForResponse blocks until the given address returns a HTTP 200 response at the root
 func waitForResponse(addr string) error {
+	// TODO: Could this ever be https-only?
 	url := "http://" + localhostAddr(addr) + "/"
 
-	// This could take a long time to start working if views are being re-calculated
-	// 100ms * 64^2 == ~6.8 minutes longest wait
 	err, _ := base.RetryLoop(
 		"GET "+url,
+
 		base.RetryWorker(func() (bool, error, interface{}) {
-			// TODO: Could this be https-only? What if config.Interface provides a full address???
 			resp, err := http.Get(url)
 			shouldRetry := err != nil || resp.StatusCode != http.StatusOK
 			return shouldRetry, nil, nil
 		}),
-		base.CreateDoublingSleeperFunc(64, 100))
+
+		// 100ms * 64^2 == ~6.8 minutes longest wait
+		base.CreateDoublingSleeperFunc(64, 100),
+	)
 
 	return err
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -870,8 +870,11 @@ func waitForResponse(addr string) error {
 
 		base.RetryWorker(func() (bool, error, interface{}) {
 			resp, err := http.Get(url)
+			if err != nil {
+				return true, nil, nil
+			}
 			defer resp.Body.Close()
-			shouldRetry := err != nil || resp.StatusCode != http.StatusOK
+			shouldRetry := resp.StatusCode != http.StatusOK
 			return shouldRetry, nil, nil
 		}),
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -792,7 +792,8 @@ func RunServer(config *ServerConfig) {
 	}
 
 	go func() {
-		// The APIs could take a long time to start if they're blocked on view re-indexing
+		// The APIs might not be ready to serve requests instantly, and anything
+		// depending on them could fail. We'll kick those off in PostStartup.
 		if err := waitForResponse(*config.AdminInterface); err != nil {
 			base.LogFatal("Error waiting for admin REST API: %v", err)
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -867,7 +867,7 @@ func waitForResponse(addr string) error {
 	url := "http://" + localhostAddr(addr) + "/"
 
 	err, _ := base.RetryLoop(
-		"GET "+url,
+		"Waiting until REST API is available on "+url,
 
 		base.RetryWorker(func() (bool, error, interface{}) {
 			resp, err := http.Get(url)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1,0 +1,29 @@
+package rest
+
+import (
+	"testing"
+
+	assert "github.com/couchbaselabs/go.assert"
+)
+
+func TestLocalhostAddr(t *testing.T) {
+	tests := []struct {
+		input, expected string
+	}{
+		{":4984", "localhost:4984"},
+		{"localhost:4984", "localhost:4984"},
+		{"sg.couchbase.com:4984", "sg.couchbase.com:4984"},
+
+		{"0.0.0.0:4984", "0.0.0.0:4984"},
+		{"127.0.0.1:4984", "127.0.0.1:4984"},
+		{"203.0.113.5:4984", "203.0.113.5:4984"},
+
+		{"[::]:4984", "[::]:4984"},
+		{"[::1]:4984", "[::1]:4984"},
+		{"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4984", "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4984"},
+	}
+
+	for _, test := range tests {
+		assert.Equals(t, localhostAddr(test.input), test.expected)
+	}
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -109,11 +109,9 @@ func (sc *ServerContext) startReplicators() {
 			params.Async = true
 
 			// Run single replication, cancel parameter will always be false
-			go func() {
-				if _, err := sc.replicator.Replicate(params, false); err != nil {
-					base.Warn("Error running replication: %v", err)
-				}
-			}()
+			if _, err := sc.replicator.Replicate(params, false); err != nil {
+				base.Warn("Error starting replication: %v", err)
+			}
 		}
 
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -103,17 +103,20 @@ func (sc *ServerContext) StartReplicators() {
 				continue
 			}
 
-			//Force one-shot replications to run Async
-			//to avoid blocking server startup
+			// Force one-shot replications to run Async
+			// to avoid blocking server startup
 			params.Async = true
 
-			//Run single replication, cancel parameter will always be false
+			// Run single replication, cancel parameter will always be false
 			go func() {
-				sc.replicator.Replicate(params, false)
+				if _, err := sc.replicator.Replicate(params, false); err != nil {
+					base.Warn("Error running replication: %v", err)
+				}
 			}()
 		}
 
 	}
+
 }
 
 func (sc *ServerContext) FindDbByBucketName(bucketName string) string {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -89,9 +89,6 @@ func NewServerContext(config *ServerConfig) *ServerContext {
 }
 
 func (sc *ServerContext) PostStartup() {
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
-
 	sc.startReplicators()
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -34,7 +34,6 @@ import (
 const kStatsReportURL = "http://localhost:9999/stats"
 const kStatsReportInterval = time.Hour
 const kDefaultSlowServerCallWarningThreshold = 200 // ms
-const kOneShotLocalDbReplicateWait = 10 * time.Second
 const KDefaultNumShards = 16
 
 // Shared context of HTTP handlers: primarily a registry of databases by name. It also stores

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -88,9 +88,14 @@ func NewServerContext(config *ServerConfig) *ServerContext {
 	return sc
 }
 
-func (sc *ServerContext) StartReplicators() {
+func (sc *ServerContext) PostStartup() {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
+
+	sc.startReplicators()
+}
+
+func (sc *ServerContext) startReplicators() {
 
 	if sc.config.Replications != nil {
 


### PR DESCRIPTION
Closes #3247

Happy to hear both your thoughts on this @tleyden @adamcfraser

I don't know if a more callback-based approach is preferred, or explicitly stating post-startup functions as I've done here.