### PR TITLE
Fixes #3249 RunTime error , nil pointer deference error in DI mode

### DIFF
--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -311,12 +311,6 @@ func (s *SequenceID) unmarshalClockSequence(data []byte) error {
 	return err
 }
 
-func ParseSequenceIDFromJSON(data []byte) (SequenceID, error) {
-	var seq SequenceID
-	err := json.Unmarshal(data, &seq)
-	return seq, err
-}
-
 func (s SequenceID) SafeSequence() uint64 {
 	if s.LowSeq > 0 {
 		return s.LowSeq

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -211,8 +211,8 @@ func (bh *blipHandler) handleSubscribeToChanges(rq *blip.Message) error {
 	if sinceStr, found := rq.Properties["since"]; found {
 		var err error
 		if since, err = bh.db.ParseSequenceID(sinceStr); err != nil {
-			bh.blipSyncContext.LogTo("Sync", "%s: Invalid sequence ID in 'since': %s ... %s", rq, sinceStr, bh.effectiveUsername)
-			since = bh.db.CreateZeroSinceValue()
+			bh.blipSyncContext.LogTo("Sync", "%s: Error parsing sequence ID in 'since': %s.  Error: %v ... %s", rq, sinceStr, err, bh.effectiveUsername)
+			return base.HTTPErrorf(http.StatusBadRequest, "Invalid sequence ID in 'since': %s", sinceStr)
 		}
 	}
 	bh.batchSize = int(getRestrictedIntFromString(rq.Properties["batch"], 200, 10, math.MaxUint64, true))

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -210,9 +210,9 @@ func (bh *blipHandler) handleSubscribeToChanges(rq *blip.Message) error {
 
 	if sinceStr, found := rq.Properties["since"]; found {
 		var err error
-		if since, err = db.ParseSequenceIDFromJSON([]byte(sinceStr)); err != nil {
+		if since, err = bh.db.ParseSequenceID(sinceStr); err != nil {
 			bh.blipSyncContext.LogTo("Sync", "%s: Invalid sequence ID in 'since': %s ... %s", rq, sinceStr, bh.effectiveUsername)
-			since = db.SequenceID{}
+			since = bh.db.CreateZeroSinceValue()
 		}
 	}
 	bh.batchSize = int(getRestrictedIntFromString(rq.Properties["batch"], 200, 10, math.MaxUint64, true))


### PR DESCRIPTION
Fixes #3249 

- Remove call to `ParseSequenceIDFromJSON()` since it does not use the correct `SequenceHasher`.  Replace with call to `bh.db.ParseSequenceID()`, which has db context and uses correct `SequenceHasher`
- Remove unused `ParseSequenceIDFromJSON()` 