### PR TITLE
Add expvar, fix termination of async changes goroutines

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -353,8 +353,12 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 	output := make(chan *ChangeEntry, 50)
 
 	go func() {
+
+		base.StatsExpvars.Add("simpleChanges_total", 1)
+		base.StatsExpvars.Add("simpleChanges_active", 1)
 		defer func() {
 			base.LogTo("Changes", "MultiChangesFeed done %s", to)
+			base.StatsExpvars.Add("simpleChanges_active", -1)
 			close(output)
 		}()
 

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -35,11 +35,14 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 	output := make(chan *ChangeEntry, 50)
 
 	go func() {
+		base.StatsExpvars.Add("vectorChanges_total", 1)
+		base.StatsExpvars.Add("vectorChanges_active", 1)
 		var cumulativeClock *base.SyncSequenceClock
 		var lastHashedValue string
 		hashedEntryCount := 0
 		defer func() {
 			base.LogTo("Changes+", "MultiChangesFeed done %s", to)
+			base.StatsExpvars.Add("vectorChanges_active", -1)
 			close(output)
 		}()
 


### PR DESCRIPTION
Adds expvars for blip continuous changes goroutines (subChanges_total, subChanges_active), as well as the goroutine launched for internal changes processing (simpleChanges_total, simpleChanges_active).  The latter is used by both blipsync and normal continuous replication.

Fixes terminator handling for continuous changes started by blip, and fixes teardown processing.

Fixes #3225