### PR TITLE
Fixed #3270 Update tests that wait on waitgroups to have timeout

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
+	"time"
 )
 
 // This test performs the following steps against the Sync Gateway passive blip replicator:
@@ -130,7 +131,8 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	receviedChangesRequestWg.Add(1)
 
 	// Wait until we got the expected callback on the "changes" profile handler
-	receviedChangesRequestWg.Wait()
+	timeoutErr := WaitWithTimeout(&receviedChangesRequestWg, time.Second * 60)
+	assertNoError(t, timeoutErr, "Timed out waiting")
 
 }
 
@@ -229,7 +231,9 @@ func TestContinuousChangesSubscription(t *testing.T) {
 	}
 
 	// Wait until all expected changes are received by change handler
-	receviedChangesWg.Wait()
+	// receviedChangesWg.Wait()
+	timeoutErr := WaitWithTimeout(&receviedChangesWg, time.Second * 60)
+	assertNoError(t, timeoutErr, "Timed out waiting for all changes.")
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1136,3 +1136,22 @@ func (d RestDocument) GetAttachments() (db.AttachmentMap, error) {
 
 }
 
+// Wait for the WaitGroup, or return an error if the wg.Wait() doesn't return within timeout
+func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
+
+	// Create a channel so that a goroutine waiting on the waitgroup can send it's result (if any)
+	wgFinished := make(chan bool)
+
+	go func() {
+		wg.Wait()
+		wgFinished <- true
+	}()
+
+	select {
+	case <-wgFinished:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("Timed out waiting after %v", timeout)
+	}
+
+}


### PR DESCRIPTION
Fixes #3270 

Times out test after 1 minute rather than blocking indefinitely on waitgroup