### PR TITLE
Add requireAdmin() to Sync Function (Fixes #3276)

### DIFF
--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -56,6 +56,11 @@ const funcWrapper = `
 			return false;
 		}
 
+		function requireAdmin() {
+			if (shouldValidate)
+				throw({forbidden: "admin required"});
+		}
+
 		function requireUser(names) {
 				if (!shouldValidate) return;
 				names = makeArray(names);

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -46,6 +46,21 @@ func TestRequireAccess(t *testing.T) {
 	assertRejected(t, result, base.HTTPErrorf(403, "missing channel access"))
 }
 
+func TestRequireAdmin(t *testing.T) {
+	const funcSource = `function(doc, oldDoc) { requireAdmin() }`
+	runner, err := NewSyncRunner(funcSource)
+	assert.Equals(t, err, nil)
+	var result interface{}
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{}`))
+	assertNotRejected(t, result)
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{"name": ""}`))
+	assertRejected(t, result, base.HTTPErrorf(403, "admin required"))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{"name": "GUEST"}`))
+	assertRejected(t, result, base.HTTPErrorf(403, "admin required"))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{"name": "beta"}`))
+	assertRejected(t, result, base.HTTPErrorf(403, "admin required"))
+}
+
 // Helpers
 func assertRejected(t *testing.T, result interface{}, err *base.HTTPError) {
 	r, ok := result.(*ChannelMapperOutput)


### PR DESCRIPTION
Fixes #3276 This adds a new callback to the Sync Function:

```
requireAdmin();
```

This allows rejecting mutations that don't come via the Admin port.