### PR TITLE
#3255 Add recover in blipHandler sendRevision goroutine

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -118,7 +118,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="783feeb6e6a08e740ac764f505f20d766b4da730"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="b9a71c7b711e49911510bbe30d0ea3832178f665"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -535,6 +535,11 @@ func (bh *blipHandler) sendRevision(sender *blip.Sender, seq db.SequenceID, docI
 		bh.addAllowedAttachments(atts)
 		sender.Send(outrq)
 		go func() {
+			defer func() {
+				if panicked := recover(); panicked != nil {
+					base.Warn("[%s] PANIC handling 'sendRevision' response: %v\n%s", bh.blipContext.ID, panicked, debug.Stack())
+				}
+			}()
 			defer bh.removeAllowedAttachments(atts)
 			outrq.Response() // blocks till reply is received
 		}()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -538,6 +538,7 @@ func (bh *blipHandler) sendRevision(sender *blip.Sender, seq db.SequenceID, docI
 			defer func() {
 				if panicked := recover(); panicked != nil {
 					base.Warn("[%s] PANIC handling 'sendRevision' response: %v\n%s", bh.blipContext.ID, panicked, debug.Stack())
+					bh.close()
 				}
 			}()
 			defer bh.removeAllowedAttachments(atts)


### PR DESCRIPTION
#3255 Recover from panic inside blipHandler sendRevision goroutine

- [x] Update manifest revision from go-blip https://github.com/couchbase/go-blip/pull/21