### PR TITLE
Feature/issue 3283 repl invalid seq

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -89,6 +89,19 @@ func FixJSONNumbers(value interface{}) interface{} {
 	return value
 }
 
+
+// Convert a JSON string, which has extra double quotes (eg, `"thing"`) into a normal string
+// with the extra double quotes removed (eg "thing")
+func ConvertJSONString(s string) string {
+	var jsonString string
+	err := json.Unmarshal([]byte(s), &jsonString)
+	if err != nil {
+		return s
+	} else {
+		return jsonString
+	}
+}
+
 var kBackquoteStringRegexp *regexp.Regexp
 
 // Preprocesses a string containing `...`-delimited strings. Converts the backquotes into double-quotes,

--- a/base/util.go
+++ b/base/util.go
@@ -90,8 +90,12 @@ func FixJSONNumbers(value interface{}) interface{} {
 }
 
 
+
 // Convert a JSON string, which has extra double quotes (eg, `"thing"`) into a normal string
-// with the extra double quotes removed (eg "thing")
+// with the extra double quotes removed (eg "thing").  Normal strings will be returned as-is.
+//
+// `"thing"` -> "thing"
+// "thing" -> "thing"
 func ConvertJSONString(s string) string {
 	var jsonString string
 	err := json.Unmarshal([]byte(s), &jsonString)

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -36,6 +36,7 @@ func TestFixJSONNumbers(t *testing.T) {
 
 func TestConvertJSONString(t *testing.T) {
 	assert.Equals(t, ConvertJSONString(`"blah"`), "blah")
+	assert.Equals(t, ConvertJSONString("blah"), "blah")
 }
 
 func TestBackQuotedStrings(t *testing.T) {

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -34,6 +34,10 @@ func TestFixJSONNumbers(t *testing.T) {
 		map[string]interface{}{"foo": int64(123456)})
 }
 
+func TestConvertJSONString(t *testing.T) {
+	assert.Equals(t, ConvertJSONString(`"blah"`), "blah")
+}
+
 func TestBackQuotedStrings(t *testing.T) {
 	input := `{"foo": "bar"}`
 	output := ConvertBackQuotedStrings([]byte(input))

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -111,7 +111,10 @@ func (s SequenceID) clockSeqToString() string {
 	}
 }
 
+// Currently accepts a plain string, but in the future might accept generic JSON objects.
+// Calling this with a JSON string will result in an error.
 func (dbc *DatabaseContext) ParseSequenceID(str string) (s SequenceID, err error) {
+
 	// If there's a sequence hasher defined, we're expecting clock-based sequences
 	if dbc.SequenceHasher != nil {
 		return parseClockSequenceID(str, dbc.SequenceHasher)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -239,7 +239,12 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 // Received a "subChanges" subscription request
 func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 
-	subChangesParams := newSubChangesParams(rq, bh.blipSyncContext, bh.db.CreateZeroSinceValue(), bh.db.ParseSequenceID)
+	subChangesParams := newSubChangesParams(
+		rq,
+		bh.blipSyncContext,
+		bh.db.CreateZeroSinceValue(),
+		bh.db.ParseSequenceID,
+	)
 	bh.logEndpointEntry(rq.Profile(), subChangesParams.String())
 
 	since, err := subChangesParams.since()

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -40,7 +40,7 @@ func (s *subChangesParams) since() (db.SequenceID, error) {
 
 	if sinceStr, found := s.rq.Properties["since"]; found {
 		var err error
-		if sinceSequenceId, err = s.sequenceIDParser(sinceStr); err != nil {
+		if sinceSequenceId, err = s.sequenceIDParser(base.ConvertJSONString(sinceStr)); err != nil {
 			s.logger.LogTo("Sync", "%s: Invalid sequence ID in 'since': %s", s.rq, sinceStr)
 			return db.SequenceID{}, err
 		}

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -1,11 +1,11 @@
 package rest
 
 import (
+	"testing"
+
 	"github.com/couchbase/go-blip"
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
-	"testing"
 )
 
 func TestAddRevision(t *testing.T) {
@@ -56,6 +56,8 @@ func TestAddRevision(t *testing.T) {
 
 }
 
+// Make sure that the subChangesParams helper deals correctly with JSON strings.
+// Reproduces SG #3283
 func TestSubChangesSince(t *testing.T) {
 
 	var rt RestTester
@@ -64,11 +66,9 @@ func TestSubChangesSince(t *testing.T) {
 	testDb := rt.GetDatabase()
 
 	rq := blip.NewRequest()
-	rq.Properties["since"] = `"3-0::20.1"`
+	rq.Properties["since"] = `"1"`
 
 	zeroSinceVal := db.SequenceID{}
-	zeroSinceVal.SeqType = db.ClockSequenceType
-	zeroSinceVal.Clock = base.NewSequenceClockImpl()
 
 	subChangesParams := newSubChangesParams(
 		rq,
@@ -78,7 +78,7 @@ func TestSubChangesSince(t *testing.T) {
 	)
 	seqId, err := subChangesParams.since()
 	assert.True(t, err == nil)
-	assert.True(t, seqId.SeqType == db.ClockSequenceType)
-
+	assert.True(t, seqId.SeqType == db.IntSequenceType)
+	assert.True(t, seqId.Seq == 1)
 
 }

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -1,44 +1,46 @@
 package rest
 
 import (
-	"testing"
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
+	"testing"
 )
 
 func TestAddRevision(t *testing.T) {
 
-	testCases := []struct{
+	testCases := []struct {
 		deletedPropertyValue string
-		expectedDeletedVal bool
-	} {
+		expectedDeletedVal   bool
+	}{
 		{
 			deletedPropertyValue: "true",
-			expectedDeletedVal: true,
+			expectedDeletedVal:   true,
 		},
 		{
 			deletedPropertyValue: "truedat",
-			expectedDeletedVal: true,
+			expectedDeletedVal:   true,
 		},
 		{
 			deletedPropertyValue: "0",
-			expectedDeletedVal: false,
+			expectedDeletedVal:   false,
 		},
 		{
 			deletedPropertyValue: "false",
-			expectedDeletedVal: false,
+			expectedDeletedVal:   false,
 		},
 		{
 			deletedPropertyValue: "False",
-			expectedDeletedVal: true,  // Counter-intuitive!  deleted() should probably lowercase the string before comparing
+			expectedDeletedVal:   true, // Counter-intuitive!  deleted() should probably lowercase the string before comparing
 		},
 		{
 			deletedPropertyValue: "",
-			expectedDeletedVal: true,  // It's not false, so it's true
+			expectedDeletedVal:   true, // It's not false, so it's true
 		},
 		{
 			deletedPropertyValue: "nil",
-			expectedDeletedVal: false,  // was not set, so it's false
+			expectedDeletedVal:   false, // was not set, so it's false
 		},
 	}
 
@@ -51,6 +53,32 @@ func TestAddRevision(t *testing.T) {
 		addRevision := newAddRevisionParams(&blipMessage)
 		assert.Equals(t, addRevision.deleted(), testCase.expectedDeletedVal)
 	}
+
+}
+
+func TestSubChangesSince(t *testing.T) {
+
+	var rt RestTester
+	defer rt.Close()
+
+	testDb := rt.GetDatabase()
+
+	rq := blip.NewRequest()
+	rq.Properties["since"] = `"3-0::20.1"`
+
+	zeroSinceVal := db.SequenceID{}
+	zeroSinceVal.SeqType = db.ClockSequenceType
+	zeroSinceVal.Clock = base.NewSequenceClockImpl()
+
+	subChangesParams := newSubChangesParams(
+		rq,
+		StdIoLogger{},
+		zeroSinceVal,
+		testDb.ParseSequenceID,
+	)
+	seqId, err := subChangesParams.since()
+	assert.True(t, err == nil)
+	assert.True(t, seqId.SeqType == db.ClockSequenceType)
 
 
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -392,14 +392,7 @@ func (h *handler) getQuery(query string) string {
 }
 
 func (h *handler) getJSONStringQuery(query string) string {
-	var jsonString string
-	rawString := h.getQuery(query)
-	err := json.Unmarshal([]byte(rawString), &jsonString)
-	if err != nil {
-		return rawString
-	} else {
-		return jsonString
-	}
+	return base.ConvertJSONString(h.getQuery(query))
 }
 
 func (h *handler) getBoolQuery(query string) bool {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1155,3 +1155,9 @@ func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	}
 
 }
+
+type StdIoLogger struct {}
+
+func (s StdIoLogger) LogTo(key string, format string, args ...interface{}) {
+	base.LogTo(key, format, args...)
+}


### PR DESCRIPTION
Fixes #3283 by unmarshalling JSON string before parsing into sequence, avoiding trying to parse a string that has extra double-quotes, which was throwing an error

- Adds unit test to repro
- Minor refactoring to re-use some code
- Retested by hand with mobile-todo app

Integration test:

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/392/