### PR TITLE
#3279 BLIP: proposeChanges conflict free mode

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -105,7 +105,7 @@ func TestAttachments(t *testing.T) {
 	var body2B Body
 	err = json.Unmarshal([]byte(rev2Bstr), &body2B)
 	assertNoError(t, err, "bad JSON")
-	err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id})
+	err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id}, false)
 	assertNoError(t, err, "Couldn't update document")
 }
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -19,6 +19,7 @@ import (
 
 	"bytes"
 	"fmt"
+
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 )
@@ -331,14 +332,14 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 		// Create child rev 1
 		docBody["child"] = "A"
-		err = db.PutExistingRev(docid, docBody, []string{"2-A", revId})
+		err = db.PutExistingRev(docid, docBody, []string{"2-A", revId}, false)
 		if err != nil {
 			b.Fatalf("Error creating child1 rev: %v", err)
 		}
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		err = db.PutExistingRev(docid, docBody, []string{"2-B", revId})
+		err = db.PutExistingRev(docid, docBody, []string{"2-B", revId}, false)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -613,7 +613,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 				generation, _ = ParseRevID(matchRev)
 				generation++
 			}
-		} else if !doc.History.isLeaf(matchRev) || db.IsIllegalConflict(doc, matchRev, deleted) {
+		} else if !doc.History.isLeaf(matchRev) || db.IsIllegalConflict(doc, matchRev, deleted, false) {
 			return nil, nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 		}
 
@@ -638,7 +638,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
 // This is equivalent to the "new_edits":false mode of CouchDB.
-func (db *Database) PutExistingRev(docid string, body Body, docHistory []string) error {
+func (db *Database) PutExistingRev(docid string, body Body, docHistory []string, noConflicts bool) error {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(newRev)
 	if generation < 0 {
@@ -680,7 +680,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 		}
 
 		// Conflict-free mode check
-		if db.IsIllegalConflict(doc, parent, deleted) {
+		if db.IsIllegalConflict(doc, parent, deleted, noConflicts) {
 			return nil, nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 		}
 
@@ -711,8 +711,8 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string)
 }
 
 // Allow-conflicts=false handling
-func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted bool) bool {
-	if db.AllowConflicts() {
+func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted, noConflicts bool) bool {
+	if db.AllowConflicts() && !noConflicts {
 		return false
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -716,7 +716,6 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 noconflicts=true    continue checks         continue checks
 noconflicts=false   return false            continue checks */
 func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted, noConflicts bool) bool {
-	fmt.Printf("     bbrks - IsIllegalConflict: nocConflicts: %v\n", noConflicts)
 
 	if db.AllowConflicts() && !noConflicts {
 		return false

--- a/db/crud.go
+++ b/db/crud.go
@@ -711,7 +711,13 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 }
 
 // Allow-conflicts=false handling
+/* Truth table for AllowConflicts and noconflicts flag:
+                    Allow-conflicts=true    Allow-conflicts=false
+noconflicts=true    continue checks         continue checks
+noconflicts=false   return false            continue checks */
 func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted, noConflicts bool) bool {
+	fmt.Printf("     bbrks - IsIllegalConflict: nocConflicts: %v\n", noConflicts)
+
 	if db.AllowConflicts() && !noConflicts {
 		return false
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -638,7 +638,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
 // This is equivalent to the "new_edits":false mode of CouchDB.
-// noConflicts is passed from LiteCore's rev.noconflicts flag.
 func (db *Database) PutExistingRev(docid string, body Body, docHistory []string, noConflicts bool) error {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(newRev)
@@ -712,13 +711,14 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 }
 
 // IsIllegalConflict returns true if the given operation is forbidden due to conflicts.
+// AllowConflicts is whether or not the database allows conflicts,
+// and 'noConflicts' is whether or not the request should allow conflicts to occurr.
 /*
-Truth table for Allow-conflicts and noConflicts combinations:
+Truth table for AllowConflicts and noConflicts combinations:
 
-                       Allow-conflicts=true    Allow-conflicts=false
+                       AllowConflicts=true     AllowConflicts=false
    noConflicts=true    continue checks         continue checks
-   noConflicts=false   return false            continue checks
-*/
+   noConflicts=false   return false            continue checks */
 func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted, noConflicts bool) bool {
 
 	if db.AllowConflicts() && !noConflicts {

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -61,7 +61,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}), "add 1-a")
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -71,7 +71,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	assertNoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}), "add 2-a")
+	assertNoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -87,7 +87,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	assertNoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}), "add 2-b")
+	assertNoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
@@ -128,7 +128,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body["_deleted"] = true
-	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}), "add 3-b (tombstone)")
+	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
 
 	// Retrieve tombstone
 	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
@@ -161,7 +161,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	assertNoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}), "add 2-c")
+	assertNoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}, false), "add 2-c")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-c")
@@ -180,7 +180,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body["_deleted"] = true
-	assertNoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}), "add 3-c (large tombstone)")
+	assertNoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}, false), "add 3-c (large tombstone)")
 
 	// Validate the tombstone is not stored inline (due to small size)
 	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
@@ -205,7 +205,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	assertNoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}), "add 3-a")
+	assertNoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}, false), "add 3-a")
 
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
@@ -227,7 +227,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}), "add 1-a")
+	assertNoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -237,7 +237,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	assertNoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}), "add 2-a")
+	assertNoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -253,7 +253,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	assertNoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}), "add 2-b")
+	assertNoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
@@ -295,7 +295,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body["_deleted"] = true
-	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}), "add 3-b (tombstone)")
+	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
 
 	// Retrieve tombstone
 	db.FlushRevisionCache()
@@ -325,12 +325,12 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}), "add 3-a")
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}), "add 4-a")
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}), "add 5-a")
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}), "add 6-a")
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}), "add 7-a")
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}), "add 8-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}, false), "add 3-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}, false), "add 4-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}, false), "add 5-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}, false), "add 6-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}, false), "add 7-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}, false), "add 8-a")
 
 	// Verify that 3-b is still present at this point
 	db.FlushRevisionCache()
@@ -338,7 +338,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assertNoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}), "add 9-a")
+	assertNoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}, false), "add 9-a")
 
 	// Verify that 3-b has been pruned
 	log.Printf("Attempt to retrieve 3-b, expect pruned")

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -233,7 +233,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 	assertNoError(t, err, "NewShadower")
 
 	// Push an existing doc revision (the way a client's push replicator would)
-	db.PutExistingRev("foo", Body{"a": "b"}, []string{"1-madeup"})
+	db.PutExistingRev("foo", Body{"a": "b"}, []string{"1-madeup"}, false)
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&db.Shadower.pullCount) >= 1
 	})
@@ -272,7 +272,7 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 	assertNoError(t, err, "NewShadower")
 
 	// Push an existing doc revision (the way a client's push replicator would)
-	db.PutExistingRev("foo", Body{"a": "b"}, []string{"1-madeup"})
+	db.PutExistingRev("foo", Body{"a": "b"}, []string{"1-madeup"}, false)
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&db.Shadower.pullCount) >= 1
 	})

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -73,12 +73,13 @@ func userBlipHandler(underlyingMethod blipHandlerMethod) blipHandlerMethod {
 
 // Maps the profile (verb) of an incoming request to the method that handles it.
 var kHandlersByProfile = map[string]blipHandlerMethod{
-	"getCheckpoint": (*blipHandler).handleGetCheckpoint,
-	"setCheckpoint": (*blipHandler).handleSetCheckpoint,
-	"subChanges":    userBlipHandler((*blipHandler).handleSubChanges),
-	"changes":       userBlipHandler((*blipHandler).handleChanges),
-	"rev":           userBlipHandler((*blipHandler).handleRev),
-	"getAttachment": userBlipHandler((*blipHandler).handleGetAttachment),
+	"getCheckpoint":  (*blipHandler).handleGetCheckpoint,
+	"setCheckpoint":  (*blipHandler).handleSetCheckpoint,
+	"subChanges":     userBlipHandler((*blipHandler).handleSubChanges),
+	"changes":        userBlipHandler((*blipHandler).handleChanges),
+	"rev":            userBlipHandler((*blipHandler).handleRev),
+	"getAttachment":  userBlipHandler((*blipHandler).handleGetAttachment),
+	"proposeChanges": (*blipHandler).handleProposedChanges,
 }
 
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
@@ -106,9 +107,6 @@ func (h *handler) handleBLIPSync() error {
 	blipContext.DefaultHandler = ctx.notFound
 	for profile, handlerFn := range kHandlersByProfile {
 		ctx.register(profile, handlerFn)
-	}
-	if !h.db.AllowConflicts() {
-		ctx.register("proposeChanges", (*blipHandler).handleProposedChanges)
 	}
 
 	ctx.blipContext.FatalErrorHandler = func(err error) {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -561,6 +561,15 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	}
 	body["_deleted"] = addRevisionParams.deleted()
 
+	var noConflicts bool
+	if val, ok := rq.Properties["noconflicts"]; ok {
+		var err error
+		noConflicts, err = strconv.ParseBool(val)
+		if err != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("Incorrect value for noconflicts: %s", err))
+		}
+	}
+
 	history := []string{revID}
 	if historyStr := rq.Properties["history"]; historyStr != "" {
 		history = append(history, strings.Split(historyStr, ",")...)
@@ -579,7 +588,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	}
 
 	// Finally, save the revision (with the new attachments inline)
-	return bh.db.PutExistingRev(docID, body, history)
+	return bh.db.PutExistingRev(docID, body, history, noConflicts)
 }
 
 //////// ATTACHMENTS:

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -561,12 +561,14 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	}
 	body["_deleted"] = addRevisionParams.deleted()
 
+	// noconflicts flag from LiteCore
+	// https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#rev
 	var noConflicts bool
 	if val, ok := rq.Properties["noconflicts"]; ok {
 		var err error
 		noConflicts, err = strconv.ParseBool(val)
 		if err != nil {
-			return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("Incorrect value for noconflicts: %s", err))
+			return base.HTTPErrorf(http.StatusBadRequest, fmt.Sprintf("Invalid value for noconflicts: %s", err))
 		}
 	}
 

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -511,7 +511,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				err = h.db.PutExistingRev(docid, doc, revisions)
+				err = h.db.PutExistingRev(docid, doc, revisions, false)
 			}
 		}
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -12,13 +12,14 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"math"
 	"mime/multipart"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 )
 
 // HTTP handler for a GET of a document
@@ -276,7 +277,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		err = h.db.PutExistingRev(docid, body, revisions)
+		err = h.db.PutExistingRev(docid, body, revisions, false)
 		if err != nil {
 			return err
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -661,32 +661,39 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 
 }
 
-func (bt *BlipTester) SendRev(docId, docRev string, body []byte) (sent bool, req, res *blip.Message) {
+func (bt *BlipTester) SendRev(docId, docRev string, body []byte, properties blip.Properties) (sent bool, req, res *blip.Message, err error) {
 
 	revRequest := blip.NewRequest()
 	revRequest.SetCompressed(true)
 	revRequest.SetProfile("rev")
+
 	revRequest.Properties["id"] = docId
 	revRequest.Properties["rev"] = docRev
 	revRequest.Properties["deleted"] = "false"
+
+	// Override any properties which have been supplied explicitly
+	for k, v := range properties {
+		revRequest.Properties[k] = v
+	}
+
 	revRequest.SetBody(body)
 	sent = bt.sender.Send(revRequest)
 	if !sent {
-		panic(fmt.Sprintf("Failed to send revRequest for doc: %v", docId))
+		return sent, revRequest, nil, fmt.Errorf("Failed to send revRequest for doc: %v", docId)
 	}
 	revResponse := revRequest.Response()
 	if revResponse.SerialNumber() != revRequest.SerialNumber() {
-		panic(fmt.Sprintf("revResponse.SerialNumber() != revRequest.SerialNumber().  %v != %v", revResponse.SerialNumber(), revRequest.SerialNumber()))
+		return sent, revRequest, revResponse, fmt.Errorf("revResponse.SerialNumber() != revRequest.SerialNumber().  %v != %v", revResponse.SerialNumber(), revRequest.SerialNumber())
 	}
 
 	// Make sure no errors.  Just panic for now, but if there are tests that expect errors and want
 	// to use SendRev(), this could be returned.
 	if errorCode, ok := revResponse.Properties["Error-Code"]; ok {
 		body, _ := revResponse.Body()
-		panic(fmt.Sprintf("Unexpected error sending rev: %v\n%s", errorCode, body))
+		return sent, revRequest, revResponse, fmt.Errorf("Unexpected error sending rev: %v\n%s", errorCode, body)
 	}
 
-	return sent, revRequest, revResponse
+	return sent, revRequest, revResponse, nil
 
 }
 
@@ -733,11 +740,15 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 
 	// Push a rev with an attachment.
 	getAttachmentWg.Add(1)
-	sent, req, res = bt.SendRev(
+	sent, req, res, err = bt.SendRev(
 		input.docId,
 		input.revId,
 		docBody,
+		blip.Properties{},
 	)
+	if err != nil {
+		panic(fmt.Sprintf("Error sending rev: %v", err))
+	}
 
 	// Expect a callback to the getAttachment endpoint
 	getAttachmentWg.Wait()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -681,9 +681,9 @@ func (bt *BlipTester) SendRev(docId, docRev string, body []byte) (sent bool, req
 
 	// Make sure no errors.  Just panic for now, but if there are tests that expect errors and want
 	// to use SendRev(), this could be returned.
-	errorCode, hasErrorCode := revResponse.Properties["Error-Code"]
-	if hasErrorCode {
-		panic(fmt.Sprintf("Unexpected error sending rev: %v", errorCode))
+	if errorCode, ok := revResponse.Properties["Error-Code"]; ok {
+		body, _ := revResponse.Body()
+		panic(fmt.Sprintf("Unexpected error sending rev: %v\n%s", errorCode, body))
 	}
 
 	return sent, revRequest, revResponse
@@ -807,17 +807,16 @@ func (bt *BlipTester) GetChanges() (changes [][]interface{}) {
 
 }
 
-
 func (bt *BlipTester) WaitForNumDocsViaChanges(numDocsExpected int) (docs map[string]RestDocument) {
 
 	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
-			allDocs := bt.PullDocs()
-			if len(allDocs) >= numDocsExpected {
-				return false, nil, allDocs
-			}
+		allDocs := bt.PullDocs()
+		if len(allDocs) >= numDocsExpected {
+			return false, nil, allDocs
+		}
 
-			// haven't seen numDocsExpected yet, so wait and retry
-			return true, nil, nil
+		// haven't seen numDocsExpected yet, so wait and retry
+		return true, nil, nil
 
 	}
 
@@ -825,7 +824,7 @@ func (bt *BlipTester) WaitForNumDocsViaChanges(numDocsExpected int) (docs map[st
 		"WaitForNumDocsViaChanges",
 		retryWorker,
 		base.CreateDoublingSleeperFunc(10, 10),
-		)
+	)
 
 	return allDocs.(map[string]RestDocument)
 
@@ -873,7 +872,7 @@ func (bt *BlipTester) PullDocs() (docs map[string]RestDocument) {
 			responseVal := [][]interface{}{}
 			for _, change := range changesBatch {
 				revId := change[2].(string)
-				responseVal = append(responseVal, []interface{}{ revId })
+				responseVal = append(responseVal, []interface{}{revId})
 				revsFinishedWg.Add(1)
 			}
 


### PR DESCRIPTION
Fixes #3279 

* proposeChanges BLIP handler now always registered
* `rev.noconflicts` flag now used in IsIllegalConflict