### PR TITLE
Restores TestChangesIncludeDocs

### DIFF
--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1139,7 +1139,7 @@ func updateTestDoc(rt RestTester, docid string, revid string, body string) (newR
 }
 
 // Validate retrieval of various document body types using include_docs.
-func DisableTestChangesIncludeDocs(t *testing.T) {
+func TestChangesIncludeDocs(t *testing.T) {
 	var logKeys = map[string]bool{
 		"TEST": true,
 	}


### PR DESCRIPTION
No longer needs to be disabled since builds have moved back to go 1.8.5.

Fixes #3294