### PR TITLE
Feature/issue 3281 blip handler cant get doc

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -638,6 +638,16 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
 // This is equivalent to the "new_edits":false mode of CouchDB.
+//
+// The docHistory should be a list of previous revisions in reverse order, not including the revision itself.
+// For example, if the rev tree is currently:
+//
+// 1-abc
+//  |
+// 2-bcd
+//
+// and the new revision being added is "3-cde", then docHistory passed in should be ["2-bcd", "1-abc"].
+//
 func (db *Database) PutExistingRev(docid string, body Body, docHistory []string, noConflicts bool) error {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(newRev)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1020,6 +1020,9 @@ func TestGetRemovedDoc(t *testing.T) {
 	assert.Equals(t, err, nil)                          // no error
 	assert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
+	// Flush rev cache
+	rt.GetDatabase().FlushRevisionCache()
+
 	// Try to get rev 3 via REST API, and assert that _removed == true
 	headers := map[string]string{}
 	headers["Authorization"] = "Basic "+ base64.StdEncoding.EncodeToString([]byte(btSpec.connectingUsername+":"+btSpec.connectingPassword))

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1022,7 +1022,7 @@ func TestGetRemovedDoc(t *testing.T) {
 		RevisionID("2-bcd"),
 		RevisionID("1-abc"),
 	}
-	sent, _, resp, err = bt.SendRevWithHistory("foo", "4-def", history, []byte(`{"key": "val", "channels": ["another_channel"]}"`), blip.Properties{"noconflicts": "true"})
+	sent, _, resp, err = bt.SendRevWithHistory("foo", "4-def", history, []byte("{}"), blip.Properties{"noconflicts": "true", "deleted": "true"})
 	assert.True(t, sent)
 	assert.Equals(t, err, nil)                          // no error
 	assert.Equals(t, resp.Properties["Error-Code"], "") // no error

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -14,7 +15,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
-	"encoding/base64"
 )
 
 // This test performs the following steps against the Sync Gateway passive blip replicator:
@@ -1034,7 +1034,7 @@ func TestGetRemovedDoc(t *testing.T) {
 
 	// Try to get rev 3 via REST API, and assert that _removed == true
 	headers := map[string]string{}
-	headers["Authorization"] = "Basic "+ base64.StdEncoding.EncodeToString([]byte(btSpec.connectingUsername+":"+btSpec.connectingPassword))
+	headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(btSpec.connectingUsername+":"+btSpec.connectingPassword))
 	response := rt.SendRequestWithHeaders("GET", "/db/foo?rev=3-cde", "", headers)
 	restDocument := response.GetRestDocument()
 	assert.True(t, restDocument.IsRemoved())


### PR DESCRIPTION
Repro attempt for https://github.com/couchbase/sync_gateway/issues/3281

I'm not able to reproduce the issue yet, but I think the test itself adds value.

## Changes

- Adds `TestGetRemovedDoc()` test
- Adds test-only helper methods related to `TestGetRemovedDoc()` test

## Integration test

- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/395/