### PR TITLE
Fixes #3307: Pushing yet-unseen tombstoned doc to Sync Gateway returns error in XATTR mode

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1094,28 +1094,42 @@ func (bucket CouchbaseBucketGoCB) WriteCasWithXattr(k string, xattrKey string, e
 	return cas, err
 }
 
+func GetUpdateXattrSubdocMutationFlags(deleteBody bool, cas uint64) (mutateFlag gocb.SubdocDocFlag) {
+
+	if deleteBody {
+
+		// If the body exists (and we're trying to delete it), use SubdocDocFlagNone
+		mutateFlag = gocb.SubdocDocFlagNone
+
+	} else {
+
+		if cas == 0 {
+
+			// If the cas is 0, that means the document doesn't exist, in which case we are trying to set
+			// Xattrs on a non-existent document, so we must set the SubdocDocFlagMkDoc flag
+			mutateFlag = gocb.SubdocDocFlagMkDoc
+
+		} else {
+
+			// If the body doesn't exist, we need to set the AccessDelete flag to mutate the xattr.
+			mutateFlag = gocb.SubdocDocFlagAccessDeleted
+		}
+
+	}
+
+	return mutateFlag
+
+}
+
 // CAS-safe update of a document's xattr (only).  Deletes the document body if deleteBody is true.
 func (bucket CouchbaseBucketGoCB) UpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}, deleteBody bool) (casOut uint64, err error) {
-
-	// TEMP EXPERIMENT
-	// deleteBody = true
 
 	// WriteCasWithXattr always stamps the xattr with the new cas using macro expansion, into a top-level property called 'cas'.
 	// This is the only use case for macro expansion today - if more cases turn up, should change the sg-bucket API to handle this more generically.
 	xattrCasProperty := fmt.Sprintf("%s.cas", xattrKey)
 	worker := func() (shouldRetry bool, err error, value interface{}) {
-		// If the body doesn't exist, we need to set the AccessDelete flag to mutate the xattr.  If the body exists (and we're trying to delete it), revert
-		// to SubdocDocFlagNone
 
-		// mutateFlag := gocb.SubdocDocFlagAccessDeleted
-		mutateFlag := gocb.SubdocDocFlagMkDoc
-
-		if deleteBody {
-			mutateFlag = gocb.SubdocDocFlagNone
-		} else {
-			mutateFlag = mutateFlag|gocb.SubdocDocFlagMkDoc
-		}
-
+		mutateFlag := GetUpdateXattrSubdocMutationFlags(deleteBody, cas)
 
 		builder := bucket.Bucket.MutateInEx(k, mutateFlag, gocb.Cas(cas), exp).
 			UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                // Update the xattr

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1104,15 +1104,14 @@ func (bucket CouchbaseBucketGoCB) UpdateXattr(k string, xattrKey string, exp uin
 
 		var mutateFlag gocb.SubdocDocFlag
 		if deleteBody {
-			// If the body exists (and we're trying to delete it), use SubdocDocFlagNone
+			// Since the body exists, we don't need to set a SubdocDocFlag
 			mutateFlag = gocb.SubdocDocFlagNone
 		} else {
 			if cas == 0 {
-				// If the cas is 0, that means the document doesn't exist, in which case we are trying to set
-				// Xattrs on a non-existent document, so we must set the SubdocDocFlagMkDoc flag
+				// If the doc doesn't exist, set SubdocDocFlagMkDoc to allow us to write the xattr
 				mutateFlag = gocb.SubdocDocFlagMkDoc
 			} else {
-				// If the body doesn't exist, we need to set the AccessDelete flag to mutate the xattr.
+				// Since the body _may_ not exist, we need to set SubdocDocFlagAccessDeleted
 				mutateFlag = gocb.SubdocDocFlagAccessDeleted
 			}
 		}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1441,11 +1441,11 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 		assertTrue(t, verifyDocDeletedXattrExists(bucket, key, xattrName), fmt.Sprintf("Expected doc %s to be deleted", key))
 	}
 
-	// Now attempt to delete key4 (NoDocNoXattr), which is expected to return a Key Not Found error
+	// Now attempt to tombstone key4 (NoDocNoXattr), should not return an error (see TestXattrTombstoneNonExistentXattrDoc for more detailed test)
 	log.Printf("Deleting key: %v", key4)
 	_, errDelete := bucket.UpdateXattr(key4, xattrName, 0, uint64(0), &updatedXattrVal, false)
-	assertTrue(t, bucket.IsKeyNotFoundError(errDelete), "Exepcted keynotfound error")
-	assertTrue(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
+	assertNoError(t, errDelete, "Unexpected error tombstoning non-existent doc")
+	assertTrue(t, verifyDocDeletedXattrExists(bucket, key4, xattrName), "Expected doc to be deleted, but xattrs to exist")
 
 }
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1285,6 +1285,23 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 }
 
+func TestXattrTombstoneNonExistentXattrDoc(t *testing.T) {
+
+	SkipXattrTestsIfNotEnabled(t)
+
+	LogKeys["CRUD+"] = true
+
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+
+	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		log.Printf("Can't cast to bucket")
+		return
+	}
+
+}
+
 // Validates tombstone of doc + xattr in a matrix of various possible previous states of the document.
 func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1285,6 +1285,9 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 }
 
+// Reproduce SG #3307.  Try to write a doc with no body but with an XATTR that has metadata
+// that indicates the doc was deleted.  Originally failing because the doc doesn't exist,
+// and it wasn't passing the right subdoc flags.
 func TestXattrTombstoneNonExistentXattrDoc(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
@@ -1299,6 +1302,50 @@ func TestXattrTombstoneNonExistentXattrDoc(t *testing.T) {
 		log.Printf("Can't cast to bucket")
 		return
 	}
+
+	key := "NoDocNoXattr"
+	xattrName := "_sync"
+
+	xattrVal := `
+{
+   "rev":"2-466a1fab90a810dc0a63565b70680e4e",
+   "flags":1,
+   "sequence":1,
+   "recent_sequences":[
+      1
+   ],
+   "history":{
+      "revs":[
+         "1-9e1084304cd2e60c5c106b308a82f40e",
+         "2-466a1fab90a810dc0a63565b70680e4e"
+      ],
+      "parents":[
+         -1,
+         0
+      ],
+      "deleted":[
+         1
+      ],
+      "channels":[
+         null,
+         null
+      ]
+   },
+   "cas":"",
+   "tombstoned_at":1518731178,
+   "time_saved":"2018-02-15T13:46:18.446791-08:00"
+}
+`
+
+	_, err := bucket.UpdateXattr(key, xattrName, 0, uint64(0), xattrVal, false)
+	assertNoError(t, err, "Unexpected Error")
+
+	// Fetch the xattr and make sure it contains the above value
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	assertNoError(t, err, "Unexpected Error")
+	assert.True(t, retrievedXattr["rev"].(string) == "2-466a1fab90a810dc0a63565b70680e4e")
 
 }
 
@@ -1399,6 +1446,7 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 	_, errDelete := bucket.UpdateXattr(key4, xattrName, 0, uint64(0), &updatedXattrVal, false)
 	assertTrue(t, bucket.IsKeyNotFoundError(errDelete), "Exepcted keynotfound error")
 	assertTrue(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
+
 }
 
 // Validates deletion of doc + xattr in a matrix of various possible previous states of the document.

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1285,41 +1285,6 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 }
 
-// Reproduce SG #3307.  Try to write a doc with no body but with an XATTR that has metadata
-// that indicates the doc was deleted.  Originally failing because the doc doesn't exist,
-// and it wasn't passing the right subdoc flags.
-//func TestXattrTombstoneNonExistentXattrDoc(t *testing.T) {
-//
-//	SkipXattrTestsIfNotEnabled(t)
-//
-//	LogKeys["CRUD+"] = true
-//
-//	testBucket := GetTestBucketOrPanic()
-//	defer testBucket.Close()
-//
-//	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-//	if !ok {
-//		log.Printf("Can't cast to bucket")
-//		return
-//	}
-//
-//	key := "-21SK00U-ujxUO9fU2HezxL"
-//	xattrName := "_sync"
-//
-//	xattrVal := `{"rev":"2-466a1fab90a810dc0a63565b70680e4e","flags":1,"sequence":1,"recent_sequences":[1],"history":{"revs":["2-466a1fab90a810dc0a63565b70680e4e","1-9e1084304cd2e60c5c106b308a82f40e"],"parents":[1,-1],"deleted":[0],"channels":[null,null]},"cas":"","tombstoned_at":1518734734,"time_saved":"2018-02-15T14:45:34.39457-08:00"}`
-//
-//	_, err := bucket.UpdateXattr(key, xattrName, 0, uint64(0), xattrVal, false)
-//	assertNoError(t, err, "Unexpected Error")
-//
-//	// Fetch the xattr and make sure it contains the above value
-//	var retrievedVal map[string]interface{}
-//	var retrievedXattr map[string]interface{}
-//	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
-//	assertNoError(t, err, "Unexpected Error")
-//	assert.True(t, retrievedXattr["rev"].(string) == "2-466a1fab90a810dc0a63565b70680e4e")
-//
-//}
-
 // Validates tombstone of doc + xattr in a matrix of various possible previous states of the document.
 func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3307,6 +3307,57 @@ func TestDocSyncFunctionExpiry(t *testing.T) {
 	log.Printf("value: %v", value)
 }
 
+
+// Repro attempt for SG #3307.  Before fix for #3307, fails when SG_TEST_USE_XATTRS=true and run against an actual couchbase server
+func TestWriteTombstonedDoc(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
+	}
+
+	// This doesn't need to specify XATTR's because that is controlled by the test
+	// env variable: SG_TEST_USE_XATTRS
+	rt := RestTester{}
+	defer rt.Close()
+
+	bulkDocsBody := `
+{
+  "docs": [
+  	{
+         "_id":"-21SK00U-ujxUO9fU2HezxL",
+         "_rev":"2-466a1fab90a810dc0a63565b70680e4e",
+         "_deleted":true,
+         "_revisions":{
+            "ids":[
+               "466a1fab90a810dc0a63565b70680e4e",
+               "9e1084304cd2e60c5c106b308a82f40e"
+            ],
+            "start":2
+         }
+  	}
+  ],
+  "new_edits": false
+}
+`
+
+	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", bulkDocsBody)
+	log.Printf("Response: %s", response.Body)
+
+	bulkDocsResponse := []map[string]interface{}{}
+	err := json.Unmarshal(response.Body.Bytes(), &bulkDocsResponse)
+	assertNoError(t, err, "Unexpected error")
+	log.Printf("bulkDocsResponse: %+v", bulkDocsResponse)
+	for _, bulkDocResponse := range bulkDocsResponse {
+		bulkDocErr, gotErr := bulkDocResponse["error"]
+		if gotErr && bulkDocErr.(string) == "not_found" {
+			t.Errorf("The bulk docs response had an embedded error: %v.  Response for this doc: %+v", bulkDocErr, bulkDocsResponse)
+		}
+	}
+
+}
+
+
+
 // Reproduces https://github.com/couchbase/sync_gateway/issues/916.  The test-only RestartListener operation used to simulate a
 // SG restart isn't race-safe, so disabling the test for now.  Should be possible to reinstate this as a proper unit test
 // once we add the ability to take a bucket offline/online.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3354,6 +3354,17 @@ func TestWriteTombstonedDoc(t *testing.T) {
 		}
 	}
 
+
+	// Fetch the xattr and make sure it contains the above value
+	baseBucket := rt.GetDatabase().Bucket
+	gocbBucket := baseBucket.(*base.CouchbaseBucketGoCB)
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	_, err = gocbBucket.GetWithXattr("-21SK00U-ujxUO9fU2HezxL", "_sync", &retrievedVal, &retrievedXattr)
+	assertNoError(t, err, "Unexpected Error")
+	assert.True(t, retrievedXattr["rev"].(string) == "2-466a1fab90a810dc0a63565b70680e4e")
+
+
 }
 
 


### PR DESCRIPTION
Fixes #3307 

Integration test:

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/399/console (XATTR)