### PR TITLE
Support running generateChanges in one-shot mode

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -443,6 +443,12 @@ func EnableLogKey(key string) {
 	LogKeys[key] = true
 }
 
+func DisableLogKey(key string) {
+	logLock.Lock()
+	defer logLock.Unlock()
+	LogKeys[key] = false
+}
+
 func LogEnabled(key string) bool {
 	logLock.RLock()
 	defer logLock.RUnlock()

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -282,6 +282,14 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 	base.EnableLogKey("Changes")
 	base.EnableLogKey("Changes+")
 	base.EnableLogKey("DCP")
+	defer func() {
+		base.DisableLogKey("Cache")
+		base.DisableLogKey("Cache+")
+		base.DisableLogKey("Changes")
+		base.DisableLogKey("Changes+")
+		base.DisableLogKey("DCP")
+	}()
+
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer tearDownTestDB(t, db)
 	defer testBucket.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2694,6 +2694,10 @@ func TestStarAccess(t *testing.T) {
 	assert.Equals(t, allDocsResult.Rows[1].ID, "doc3")
 	assert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"!"})
 
+	// Ensure docs have been processed before issuing changes requests
+	expectedSeq := uint64(6)
+	rt.WaitForSequence(expectedSeq)
+
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -122,7 +122,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	// Send subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
 	subChangesRequest := blip.NewRequest()
 	subChangesRequest.SetProfile("subChanges")
-	subChangesRequest.Properties["continuous"] = "false"
+	subChangesRequest.Properties["continuous"] = "true"
 	sent = bt.sender.Send(subChangesRequest)
 	assert.True(t, sent)
 	receivedChangesRequestWg.Add(1)
@@ -249,8 +249,10 @@ func TestContinuousChangesSubscription(t *testing.T) {
 // Make several updates
 // Start subChanges w/ continuous=false, batchsize=20
 // Validate we get the expected updates and changes ends
-func TestOneShotChangesSubscription(t *testing.T) {
+func TestBlipOneShotChangesSubscription(t *testing.T) {
 
+	base.EnableLogKey("Cache")
+	base.EnableLogKey("Cache+")
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -320,7 +322,7 @@ func TestOneShotChangesSubscription(t *testing.T) {
 	// Increment waitgroup to account for the expected 'caught up' nil changes entry.
 	receivedChangesWg.Add(1)
 
-	// Add a few batches worth of documents
+	// Add documents
 	for docID, _ := range docIdsReceived {
 		//// Add a change: Send an unsolicited doc revision in a rev request
 		_, _, revResponse, err := bt.SendRev(
@@ -334,6 +336,11 @@ func TestOneShotChangesSubscription(t *testing.T) {
 		assertNoError(t, err, "Error unmarshalling response body")
 		receivedChangesWg.Add(1)
 	}
+
+	// Wait for documents to be processed and available for changes
+	// 105 docs +
+	expectedSequence := uint64(104)
+	bt.restTester.WaitForSequence(expectedSequence)
 
 	// Send subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
 	subChangesRequest := blip.NewRequest()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -313,7 +313,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, since db.SequenceID) {
 		}
 	}
 
-	_, forceClose := generateContinuousChanges(bh.db, channelSet, options, nil, func(changes []*db.ChangeEntry) error {
+	_, forceClose := generateBlipSyncChanges(bh.db, channelSet, options, func(changes []*db.ChangeEntry) error {
 		bh.LogTo("Sync+", "    Sending %d changes. User:%s", len(changes), bh.effectiveUsername)
 		for _, change := range changes {
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1041,7 +1041,6 @@ func TestImportBinaryDoc(t *testing.T) {
 func TestDcpBackfill(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
-	base.EnableLogKey("DCP")
 
 	rt := RestTester{}
 

--- a/test.sh
+++ b/test.sh
@@ -15,13 +15,8 @@ if [ "$SG_TEST_BACKING_STORE" == "Couchbase" ] || [ "$SG_TEST_BACKING_STORE" == 
     EXTRA_FLAGS="-p 1"  # force this to run in serial, otherwise packages run in parallel and interfere with each other
 fi
 
-# Check for race flag and extend timeout
-for val in "$@"; do
-  if [ $val = "-race" ]; then
-    echo "Running tests with -race. Extending timeout."
-    EXTRA_FLAGS="$EXTRA_FLAGS -timeout=20m"
-  fi
-done
+# Extend timeout 
+EXTRA_FLAGS="$EXTRA_FLAGS -timeout=20m"
 
 echo "Running Sync Gateway unit tests"
 go test "$@" $EXTRA_FLAGS github.com/couchbase/sync_gateway/...


### PR DESCRIPTION
Non-continuous replications made via blip-sync will now avoid continuous processing overhead (changeWaiters, recovery from dropped client connections).

Fixes #3301