### PR TITLE
Point to latest go-blip

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -118,7 +118,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="b9a71c7b711e49911510bbe30d0ea3832178f665"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="bcf86e53dc54a354dcb81ab3c2f6f030e073ac21"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 


### PR DESCRIPTION
Pick up fix for https://github.com/couchbase/go-blip/pull/22