### PR TITLE
Uptake go-blip change: Update WebSocket protocol to “BLIP_3"

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -118,7 +118,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="bcf86e53dc54a354dcb81ab3c2f6f030e073ac21"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="5407b2e16f5e3ad0eb6a1f785160a3197347aa45"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -25,7 +25,12 @@ const (
 
 	// Blip default vals
 	BlipDefaultBatchSize = uint64(200)
+
 	BlipMinimumBatchSize = uint64(10) // Not in the replication spec - is this required?
+
+	// The AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore)
+	BlipCBMobileReplication = "CBMobile_2"
+
 )
 
 // Represents one BLIP connection (socket) opened by a client.
@@ -90,7 +95,7 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	// Create a BLIP context:
-	blipContext := blip.NewContext()
+	blipContext := blip.NewContext(BlipCBMobileReplication)
 	blipContext.Logger = DefaultBlipLogger(blipContext.ID)
 	blipContext.LogMessages = base.LogEnabledExcludingLogStar("WS+")
 	blipContext.LogFrames = base.LogEnabledExcludingLogStar("WS++")

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -28,7 +28,7 @@ const (
 
 	BlipMinimumBatchSize = uint64(10) // Not in the replication spec - is this required?
 
-	// The AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore)
+	// The AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore).
 	BlipCBMobileReplication = "CBMobile_2"
 
 )

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -29,6 +29,7 @@ const (
 	BlipMinimumBatchSize = uint64(10) // Not in the replication spec - is this required?
 
 	// The AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore).
+	// At some point this will need to be able to support an array of protocols.  See go-blip/issues/27.
 	BlipCBMobileReplication = "CBMobile_2"
 
 )

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -634,7 +634,7 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 	u.Scheme = "ws"
 
 	// Make BLIP/Websocket connection
-	bt.blipContext = blip.NewContext()
+	bt.blipContext = blip.NewContext(BlipCBMobileReplication)
 	bt.blipContext.Logger = DefaultBlipLogger(bt.blipContext.ID)
 
 	bt.blipContext.LogMessages = base.LogEnabledExcludingLogStar("WS+")


### PR DESCRIPTION
Fixes #3324

Integration tests:

- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/429/
- http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/430/