### PR TITLE
#3229 Rework sg-replicate startup

### DIFF
--- a/base/replicator.go
+++ b/base/replicator.go
@@ -122,10 +122,11 @@ func (r *Replicator) startReplication(parameters sgreplicate.ReplicationParamete
 }
 
 func (r *Replicator) runOneShotReplication(parameters sgreplicate.ReplicationParameters) (sgreplicate.SGReplication, error) {
-
 	replication := sgreplicate.StartOneShotReplication(parameters)
 	r._addReplication(replication, parameters)
 	r.lock.Unlock()
+
+	LogTo("Replicate", "Started one-shot replication: %v", replication)
 
 	if parameters.Async {
 		go func() {
@@ -143,7 +144,6 @@ func (r *Replicator) runOneShotReplication(parameters sgreplicate.ReplicationPar
 }
 
 func (r *Replicator) runContinuousReplication(parameters sgreplicate.ReplicationParameters) (sgreplicate.SGReplication, error) {
-
 	notificationChan := make(chan sgreplicate.ContinuousReplicationNotification)
 
 	factory := func(parameters sgreplicate.ReplicationParameters, notificationChan chan sgreplicate.ReplicationNotification) sgreplicate.Runnable {

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -105,15 +105,15 @@ func (r *Replicator) getReplicationForParams(queryParams sgreplicate.Replication
 
 }
 
-func (r *Replicator) removeReplication(repId string) {
+func (r *Replicator) _removeReplication(repId string) {
 	delete(r.replications, repId)
 	delete(r.replicationParams, repId)
 }
 
-func (r *Replicator) removeReplicationLock(repId string) {
+func (r *Replicator) removeReplication(repId string) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	r.removeReplication(repId)
+	r._removeReplication(repId)
 }
 
 // Starts a replication based on the provided replication config.
@@ -170,7 +170,7 @@ func (r *Replicator) stopReplication(parameters sgreplicate.ReplicationParameter
 
 	taskState := r.populateActiveTaskFromReplication(replication, parameters)
 
-	r.removeReplication(repId)
+	r._removeReplication(repId)
 	return taskState, nil
 }
 
@@ -181,13 +181,13 @@ func (r *Replicator) startOneShotReplication(parameters sgreplicate.ReplicationP
 
 	if parameters.Async {
 		go func() {
-			defer r.removeReplicationLock(parameters.ReplicationId)
+			defer r.removeReplication(parameters.ReplicationId)
 			r.runOneShotReplication(replication, parameters)
 		}()
 		return replication, nil
 	} else {
 		err := r.runOneShotReplication(replication, parameters)
-		r.removeReplication(parameters.ReplicationId)
+		r._removeReplication(parameters.ReplicationId)
 		return replication, err
 	}
 }
@@ -214,7 +214,7 @@ func (r *Replicator) startContinuousReplication(parameters sgreplicate.Replicati
 
 	// Start goroutine to monitor notification channel, to remove the replication if it's terminated internally by sg-replicate
 	go func(rep sgreplicate.SGReplication, notificationChan chan sgreplicate.ContinuousReplicationNotification) {
-		defer r.removeReplicationLock(parameters.ReplicationId)
+		defer r.removeReplication(parameters.ReplicationId)
 
 		for {
 			select {

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -1,0 +1,79 @@
+package base
+
+import (
+	"net/http"
+	"testing"
+
+	assert "github.com/couchbaselabs/go.assert"
+	sgreplicate "github.com/couchbaselabs/sg-replicate"
+)
+
+func TestReplicator(t *testing.T) {
+	r := NewReplicator()
+	assert.Equals(t, len(r.ActiveTasks()), 0)
+
+	params := sgreplicate.ReplicationParameters{
+		SourceDb:  "db1",
+		Lifecycle: sgreplicate.CONTINUOUS,
+	}
+	_, err := r.Replicate(params, false)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(r.ActiveTasks()), 1)
+
+	params = sgreplicate.ReplicationParameters{
+		ReplicationId: "rep1",
+		Lifecycle:     sgreplicate.CONTINUOUS,
+	}
+	_, err = r.Replicate(params, false)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(r.ActiveTasks()), 2)
+
+	// now stop it
+	_, err = r.Replicate(params, true)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(r.ActiveTasks()), 1)
+
+	// stop all
+	err = r.StopReplications()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(r.ActiveTasks()), 0)
+}
+
+func TestReplicatorDuplicateID(t *testing.T) {
+	r := NewReplicator()
+
+	params := sgreplicate.ReplicationParameters{
+		ReplicationId: "rep1",
+		Lifecycle:     sgreplicate.CONTINUOUS,
+	}
+	_, err := r.Replicate(params, false)
+	assert.Equals(t, err, nil)
+
+	// Should get an error because ReplicationIDs are identical.
+	_, err = r.Replicate(params, false)
+	assertHTTPError(t, err, http.StatusConflict)
+}
+
+func TestReplicatorDuplicateParams(t *testing.T) {
+	r := NewReplicator()
+
+	params := sgreplicate.ReplicationParameters{
+		SourceDb:  "db1",
+		Lifecycle: sgreplicate.CONTINUOUS,
+	}
+	_, err := r.Replicate(params, false)
+	assert.Equals(t, err, nil)
+
+	// Should get an error even if ReplicationIDs are different,
+	// as they both share the same parameters.
+	_, err = r.Replicate(params, false)
+	assertHTTPError(t, err, http.StatusConflict)
+}
+
+func assertHTTPError(t *testing.T, err error, status int) {
+	if httpErr, ok := err.(*HTTPError); !ok {
+		assert.Errorf(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
+	} else {
+		assert.Equals(t, httpErr.Status, status)
+	}
+}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -115,7 +115,7 @@ func (sc *ServerContext) startReplicators() {
 
 		// Run single replication, cancel parameter will always be false
 		if _, err := sc.replicator.Replicate(params, false); err != nil {
-			base.Warn("Error starting replication: %v", err)
+			base.Warn("Error starting replication %v: %v", params.ReplicationId, err)
 		}
 
 	}


### PR DESCRIPTION
- Rearranged locks to reduce lock/unlock churn and fix races - Fixes #3229 
- Improved logging
- Reduced number of nested functions/methods and simplified
- Added unit tests `go test -run='(^TestReplicator|Replicate)' -race -count=1 ./...`