### PR TITLE
Skip disabled tests for improved visiblity and allow test suite to run offline

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -700,8 +700,9 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	close(options.Terminator)
 }
 
-// Disabled until https://github.com/couchbase/sync_gateway/issues/3056 is fixed.
-func DisableTestLowSequenceHandlingNoDuplicates(t *testing.T) {
+func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
+	// TODO: Disabled until https://github.com/couchbase/sync_gateway/issues/3056 is fixed.
+	t.Skip("WARNING: TEST DISABLED")
 
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
@@ -797,9 +798,10 @@ func DisableTestLowSequenceHandlingNoDuplicates(t *testing.T) {
 // lines at the start of changesFeed() in changes.go to simulate slow processing:
 //	    base.LogTo("Sequences", "Simulate slow processing time for channel %s - sleeping for 100 ms", channel)
 //	    time.Sleep(100 * time.Millisecond)
-
-// Test current fails intermittently on concurrent access to var changes.  Disabling for now - should be refactored.
-func FailingTestChannelRace(t *testing.T) {
+func TestChannelRace(t *testing.T) {
+	// TODO: Test current fails intermittently on concurrent access to var changes.
+	// Disabling for now - should be refactored.
+	t.Skip("WARNING: TEST DISABLED")
 
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1126,7 +1126,12 @@ func TestAccessFunction(t *testing.T) {
 	assert.DeepEquals(t, user.InheritedChannels(), expected)
 }
 
-func CouchbaseTestAccessFunctionWithVbuckets(t *testing.T) {
+func TestAccessFunctionWithVbuckets(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test only works with a Couchbase server")
+	}
+
 	//base.LogKeys["CRUD"] = true
 	//base.LogKeys["Access"] = true
 
@@ -1480,7 +1485,11 @@ func TestChannelView(t *testing.T) {
 
 //////// XATTR specific tests.  These tests current require setting DefaultUseXattrs=true, and must be run against a Couchbase bucket
 
-func CouchbaseTestConcurrentImport(t *testing.T) {
+func TestConcurrentImport(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() || !base.TestUseXattrs() {
+		t.Skip("Test only works with a Couchbase server and XATTRS")
+	}
 
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -102,7 +102,7 @@ func TestDenseBlockMultipleInserts(t *testing.T) {
 	// Make sure we can safely call getEntryCount() on uninitialized DenseBlock
 	assert.Equals(t, block.getEntryCount(), uint16(0))
 
-	// Initialize the block value 
+	// Initialize the block value
 	block.value = make([]byte, DB_HEADER_LEN, 400)
 
 	// Inserts
@@ -404,7 +404,11 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	assert.Equals(t, block.getEntryCount(), uint16(0))
 }
 
-func DisableTestDenseBlockOverflow(t *testing.T) {
+func TestDenseBlockOverflow(t *testing.T) {
+	// TODO: Test disabled in #2227 for unknown reason.
+	// Test passes locally with both Walrus and Couchbase, and with and without -race.
+	t.Skip("WARNING: TEST DISABLED")
+
 	base.EnableLogKey("ChannelStorage")
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3375,7 +3375,9 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 // Reproduces https://github.com/couchbase/sync_gateway/issues/916.  The test-only RestartListener operation used to simulate a
 // SG restart isn't race-safe, so disabling the test for now.  Should be possible to reinstate this as a proper unit test
 // once we add the ability to take a bucket offline/online.
-func DisabledTestLongpollWithWildcard(t *testing.T) {
+func TestLongpollWithWildcard(t *testing.T) {
+	// TODO: Test disabled because it fails with -race
+	t.Skip("WARNING: TEST DISABLED")
 
 	var changes struct {
 		Results  []db.ChangeEntry

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -465,6 +465,13 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 	assertStatus(t, response, 401)
 
 	response = rt.SendRequestWithHeaders("POST", "/db/_facebook", `{"access_token":"true"}`, reqHeaders)
+
+	// Skip test if dial tcp fails with no such host.
+	// This is to allow tests to be run offline/without third-party dependencies.
+	if response.Code == http.StatusInternalServerError && strings.Contains(response.Body.String(), "no such host") {
+		t.Skipf("WARNING: Host could not be reached: %s", response.Body.String())
+	}
+
 	assertStatus(t, response, 401)
 }
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -365,66 +365,6 @@ func TestPostChangesUserTiming(t *testing.T) {
 
 }
 
-// Tests race between waking up the changes feed, and detecting that the user doc has changed
-// This test can sporadically reproduce issue #2068, as reported in #2999#issuecomment-342681828
-// TODO: enhance this test to reproduce the issue more reliably, possibly by writing updates directly to
-// TODO: to the Couchbase bucket and introducing an artifical delay.
-func DisabledTestPostChangesUserTiming(t *testing.T) {
-
-	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`)
-	defer it.Close()
-
-	response := it.SendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "DIndex+":true}`)
-	assert.True(t, response != nil)
-
-	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
-	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("bernard"))
-	assert.True(t, err == nil)
-	a.Save(bernard)
-
-	var wg sync.WaitGroup
-
-	// Put several documents to channel PBS
-	response = it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
-	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
-	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
-	assertStatus(t, response, 201)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		var changes struct {
-			Results  []db.ChangeEntry
-			Last_Seq string
-		}
-		changesJSON := `{"style":"all_docs", "timeout":6000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-		// Validate that the user receives backfill plus the new doc
-		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-		assertNoError(t, err, "Error unmarshalling changes response")
-
-		if len(changes.Results) != 4 {
-			log.Printf("len(changes.Results) != 4, dumping changes response for diagnosis")
-			log.Printf("changes: %+v", changes)
-			log.Printf("changesResponse status code: %v.  Headers: %+v", changesResponse.Code, changesResponse.HeaderMap)
-			log.Printf("changesResponse raw body: %s", changesResponse.Body.String())
-		}
-		assert.Equals(t, len(changes.Results), 4)
-	}()
-
-	// Wait for changes feed to get into wait mode where it is blocked on the longpoll changes feed response
-	time.Sleep(5 * time.Second)
-
-	// Put a doc in channel bernard, that also grants bernard access to channel PBS
-	response = it.SendAdminRequest("PUT", "/db/grant1", `{"value":1, "channel":["bernard"], "accessUser":"bernard", "accessChannel":"PBS"}`)
-	assertStatus(t, response, 201)
-	wg.Wait()
-
-}
-
 func TestPostChangesSinceInteger(t *testing.T) {
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	defer it.Close()

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -161,9 +161,12 @@ func TestXattrSGTombstone(t *testing.T) {
 }
 
 // Test cas failure during WriteUpdate, triggering import of SDK write.
-// Disabled, as test depends on artificial latency in PutDoc to reliably hit the CAS failure on the SG write.  Scenario fully covered
-// by functional test.
-func DisableTestXattrImportOnCasFailure(t *testing.T) {
+func TestXattrImportOnCasFailure(t *testing.T) {
+
+	// TODO: Disabled, as test depends on artificial latency in PutDoc to
+	// reliably hit the CAS failure on the SG write.
+	// Scenario fully covered by functional test.
+	t.Skip("WARNING: TEST DISABLED")
 
 	SkipImportTestsIfNotEnabled(t)
 

--- a/rest/login_test.go
+++ b/rest/login_test.go
@@ -12,10 +12,14 @@ import (
 	"log"
 	"net/http"
 	"testing"
+
+	assert "github.com/couchbaselabs/go.assert"
+	"github.com/tleyden/fakehttp"
 )
 
-/* Commented due to https://github.com/couchbase/sync_gateway/issues/1659
 func TestVerifyFacebook(t *testing.T) {
+	// TODO: Disabled due to https://github.com/couchbase/sync_gateway/issues/1659
+	t.Skip("WARNING: TEST DISABLED")
 
 	testServer := fakehttp.NewHTTPServer()
 	testServer.Start()

--- a/rest/login_test.go
+++ b/rest/login_test.go
@@ -9,8 +9,10 @@
 package rest
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"testing"
 
 	assert "github.com/couchbaselabs/go.assert"
@@ -42,13 +44,18 @@ func TestVerifyFacebook(t *testing.T) {
 	assert.Equals(t, facebookResponse.Email, "alice@dot.com")
 
 }
-*/
 
 // This test exists because there have been problems with builds of Go being unable to make HTTPS
 // connections due to the TLS package missing the Cgo bits needed to load system root certs.
 func TestVerifyHTTPSSupport(t *testing.T) {
-	_, err := http.Get("https://google.com")
+	resp, err := http.Get("https://google.com")
 	if err != nil {
-		log.Panicf("Error making HTTPS connection: %v", err)
+		// Skip test if dial tcp fails with no such host.
+		// This is to allow tests to be run offline/without third-party dependencies.
+		if strings.Contains(err.Error(), "no such host") {
+			t.Skipf("WARNING: Host could not be reached: %s", err)
+		}
+		t.Errorf("Error making HTTPS connection: %v", err)
 	}
+	defer resp.Body.Close()
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -452,6 +453,12 @@ func requestByUser(method, resource, body, username string) *http.Request {
 }
 
 func assertStatus(t *testing.T, response *TestResponse, expectedStatus int) {
+	// Skip test if dial tcp fails with no such host.
+	// This is to allow tests to be run offline/without third-party dependencies.
+	if response.Code == http.StatusInternalServerError && strings.Contains(response.Body.String(), "no such host") {
+		t.Skipf("WARNING: Host could not be reached: %s", response.Body.String())
+	}
+
 	if response.Code != expectedStatus {
 		debug.PrintStack()
 		t.Fatalf("Response status %d (expected %d) for %s <%s> : %s",

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -453,12 +452,6 @@ func requestByUser(method, resource, body, username string) *http.Request {
 }
 
 func assertStatus(t *testing.T, response *TestResponse, expectedStatus int) {
-	// Skip test if dial tcp fails with no such host.
-	// This is to allow tests to be run offline/without third-party dependencies.
-	if response.Code == http.StatusInternalServerError && strings.Contains(response.Body.String(), "no such host") {
-		t.Skipf("WARNING: Host could not be reached: %s", response.Body.String())
-	}
-
 	if response.Code != expectedStatus {
 		debug.PrintStack()
 		t.Fatalf("Response status %d (expected %d) for %s <%s> : %s",

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -170,9 +170,11 @@ func TestViewQueryUserAccess(t *testing.T) {
 	assertStatus(t, userResponse, 403)
 }
 
-//Waiting for a fix for couchbaselabs/Walrus #13
-//Currently fails against walrus bucket as '_sync' property will exist in doc object if it is emmitted in the map function
-func failingTestViewQueryMultipleViews(t *testing.T) {
+func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
+	// TODO: Waiting for a fix for couchbaselabs/Walrus #13
+	// Currently fails against walrus bucket as '_sync' property will exist in doc object if it is emmitted in the map function
+	t.Skip("WARNING: TEST DISABLED")
+
 	var rt RestTester
 	defer rt.Close()
 


### PR DESCRIPTION
It's difficult to see which tests are disabled, and lack of consistency made searching for disabled tests difficult. Skipping them with a warning gives better visibility.

- Re-enabled all disabled tests, and instead use `t.Skip("WARNING: TEST DISABLED")`
- Re-enabled tests that only ran with Couchbase or XATTRS, and skip if Walrus/XATTRS=false
- Remove disabled test that had since been rewritten (`TestPostChangesUserTiming`)
- Skip some tests that rely on a successful DNS lookup (this allows the test suite to be run offline)

E.g:
```
go test -run='^TestDenseBlockOverflow$' -v ./db
=== RUN   TestDenseBlockOverflow
--- SKIP: TestDenseBlockOverflow (0.00s)
	kv_dense_channel_storage_test.go:410: WARNING: TEST DISABLED
PASS
```