### PR TITLE
Fix json struct tag on DocAttachment

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -12,6 +12,7 @@ package db
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/base64"
@@ -25,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/couchbase/sync_gateway/base"
-	"crypto/md5"
 )
 
 // Attachments shorter than this will be left in the JSON as base64 rather than being a separate
@@ -50,7 +50,7 @@ type DocAttachment struct {
 	Length      int    `json:"length,omitempty"`
 	Revpos      int    `json:"revpos,omitempty"`
 	Stub        bool   `json:"stub,omitempty"`
-	Data        []byte `json:-` // tell json marshal/unmarshal to ignore this field
+	Data        []byte `json:"-"` // tell json marshal/unmarshal to ignore this field
 }
 
 // Given a CouchDB document body about to be stored in the database, goes through the _attachments


### PR DESCRIPTION
I spotted that the JSON struct tag on DocAttachment was being flagged by `go vet`

```db/attachment.go:54: struct field tag `json:-` not compatible with reflect.StructTag.Get: bad syntax for struct tag value```

`-` should be wrapped in double quotes to be ignored correctly:
https://github.com/golang/go/blob/1e05924cf53c3cfe84114f4bf7a31b8632fdc608/src/encoding/json/encode.go#L93-L94