### PR TITLE
Attempt to make gocb bucket flushable

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2212,13 +2212,6 @@ func (bucket *CouchbaseBucketGoCB) BucketItemCount() (itemCount int, err error) 
 	return GoCBBucketItemCount(bucket.Bucket, bucket.spec, user, pass)
 }
 
-func (bucket *CouchbaseBucketGoCB) goCBHttpClient() *http.Client {
-
-	goCBClient := bucket.Bucket.IoRouter()
-	return goCBClient.HttpClient()
-
-}
-
 func (bucket *CouchbaseBucketGoCB) getExpirySingleAttempt(k string) (expiry uint32, getMetaError error) {
 
 	bucket.singleOps <- struct{}{}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2224,7 +2224,9 @@ func (bucket *CouchbaseBucketGoCB) BucketItemCount() (itemCount int, err error) 
 
 	req.SetBasicAuth(user, pass)
 
-	resp, err := http.DefaultClient.Do(req)
+	goCBClient := bucket.goCBHttpClient()
+
+	resp, err := goCBClient.Do(req)
 	if err != nil {
 		return -1, err
 	}
@@ -2252,6 +2254,13 @@ func (bucket *CouchbaseBucketGoCB) BucketItemCount() (itemCount int, err error) 
 	itemCountFloat := itemCountRaw.(float64)
 
 	return int(itemCountFloat), nil
+
+}
+
+func (bucket *CouchbaseBucketGoCB) goCBHttpClient() *http.Client {
+
+	goCBClient := bucket.Bucket.IoRouter()
+	return goCBClient.HttpClient()
 
 }
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2165,8 +2165,8 @@ func (bucket *CouchbaseBucketGoCB) CloseAndDelete() error {
 		err = bucketManager.Flush()
 		if err != nil {
 			Warn("Error flushing bucket: %v  Will retry.", err)
+			shouldRetry = true
 		}
-		shouldRetry = (err != nil) // retry (until max attempts) if there was an error
 		return shouldRetry, err, nil
 	}
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2455,11 +2455,21 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 
 func GoCBBucketItemCount(bucket *gocb.Bucket, spec BucketSpec, user, pass string) (itemCount int, err error) {
 
-	reqUri := fmt.Sprintf("%s/pools/default/buckets/%s", spec.Server, spec.BucketName)
+	relativeUri := fmt.Sprintf("pools/default/buckets/%s", spec.BucketName)
+
+	mgmtEps := bucket.IoRouter().MgmtEps()
+	if len(mgmtEps) == 0 {
+		return -1, fmt.Errorf("No available Couchbase Server nodes")
+	}
+	bucketEp := mgmtEps[rand.Intn(len(mgmtEps))]
+
+	reqUri := fmt.Sprintf("%s/%s", bucketEp, relativeUri)
+
 	req, err := http.NewRequest("GET", reqUri, nil)
 	if err != nil {
 		return -1, err
 	}
+
 	req.Header.Add("Content-Type", "application/json")
 
 	req.SetBasicAuth(user, pass)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -2151,7 +2150,6 @@ func (bucket *CouchbaseBucketGoCB) Close() {
 	}
 }
 
-
 // This flushes the bucket.
 func (bucket *CouchbaseBucketGoCB) Flush() error {
 
@@ -2173,7 +2171,6 @@ func (bucket *CouchbaseBucketGoCB) Flush() error {
 	if err != nil {
 		return err
 	}
-
 
 	// Wait until the bucket item count is 0, since flush is asynchronous
 	worker := func() (shouldRetry bool, err error, value interface{}) {
@@ -2200,7 +2197,6 @@ func (bucket *CouchbaseBucketGoCB) Flush() error {
 	}
 
 	return nil
-
 
 }
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2152,9 +2152,8 @@ func (bucket *CouchbaseBucketGoCB) Close() {
 }
 
 
-// This flushes the bucket but doesn't actually close the bucket, despite the name CloseAndDelete(),
-// which is based on the sgbucket.DeleteableBucket interface.
-func (bucket *CouchbaseBucketGoCB) CloseAndDelete() error {
+// This flushes the bucket.
+func (bucket *CouchbaseBucketGoCB) Flush() error {
 
 	bucketManager, err := bucket.getBucketManager()
 	if err != nil {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -2148,6 +2149,111 @@ func (bucket *CouchbaseBucketGoCB) Close() {
 		Warnf(KeyAll, "Error closing GoCB bucket: %v.", err)
 		return
 	}
+}
+
+
+// This flushes the bucket but doesn't actually close the bucket, despite the name CloseAndDelete(),
+// which is based on the sgbucket.DeleteableBucket interface.
+func (bucket *CouchbaseBucketGoCB) CloseAndDelete() error {
+
+	bucketManager, err := bucket.getBucketManager()
+	if err != nil {
+		return err
+	}
+
+	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
+		err = bucketManager.Flush()
+		if err != nil {
+			Warn("Error flushing bucket: %v  Will retry.", err)
+		}
+		shouldRetry = (err != nil) // retry (until max attempts) if there was an error
+		return shouldRetry, err, nil
+	}
+
+	err, _ = RetryLoop("EmptyTestBucket", workerFlush, CreateDoublingSleeperFunc(12, 10))
+	if err != nil {
+		return err
+	}
+
+	maxTries := 20
+	numTries := 0
+	for {
+
+		itemCount, err := bucket.BucketItemCount()
+		if err != nil {
+			return err
+		}
+
+		if itemCount == 0 {
+			// Bucket flushed, we're done
+			break
+		}
+
+		if numTries > maxTries {
+			return fmt.Errorf("Timed out waiting for bucket to be empty after flush.  ItemCount: %v", itemCount)
+		}
+
+		// Still items left, wait a little bit and try again
+		Warn("TestBucketManager.EmptyBucket(): still %d items in bucket after flush, waiting for no items.  Will retry.", itemCount)
+		time.Sleep(time.Millisecond * 500)
+
+		numTries += 1
+
+	}
+
+	return nil
+
+}
+
+// GOCB doesn't currently offer a way to do this, and so this is a workaround to go directly
+// to Couchbase Server REST API.
+// See https://forums.couchbase.com/t/is-there-a-way-to-get-the-number-of-items-in-a-bucket/12816/4
+// for GOCB discussion.
+// NOTE: unfortunately this code was duplicated with TestBucketManager.BucketItemCount() since TestBucketManager
+// holds a reference to a *gocb.Bucket, but not a CouchbaseBucketGoCB wrapper.  If this code could get
+// pushed down into *gocb.Bucket, then both methods could be removed.
+func (bucket *CouchbaseBucketGoCB) BucketItemCount() (itemCount int, err error) {
+
+	reqUri := fmt.Sprintf("%s/pools/default/buckets/%s", bucket.spec.Server, bucket.spec.BucketName)
+	req, err := http.NewRequest("GET", reqUri, nil)
+	if err != nil {
+		return -1, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	user, pass, _ := bucket.spec.Auth.GetCredentials()
+
+	req.SetBasicAuth(user, pass)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return -1, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		_, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return -1, err
+		}
+		return -1, pkgerrors.Wrapf(err, "Error trying to find number of items in bucket")
+	}
+
+	respJson := map[string]interface{}{}
+
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&respJson); err != nil {
+		return -1, err
+	}
+
+	basicStats := respJson["basicStats"].(map[string]interface{})
+
+	itemCountRaw := basicStats["itemCount"]
+
+	itemCountFloat := itemCountRaw.(float64)
+
+	return int(itemCountFloat), nil
+
 }
 
 func (bucket *CouchbaseBucketGoCB) getExpirySingleAttempt(k string) (expiry uint32, getMetaError error) {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2163,7 +2163,7 @@ func (bucket *CouchbaseBucketGoCB) Flush() error {
 	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
 		err = bucketManager.Flush()
 		if err != nil {
-			Warn("Error flushing bucket: %v  Will retry.", err)
+			Warnf(KeyAll, "Error flushing bucket: %v  Will retry.", err)
 			shouldRetry = true
 		}
 		return shouldRetry, err, nil
@@ -2193,7 +2193,7 @@ func (bucket *CouchbaseBucketGoCB) Flush() error {
 		}
 
 		// Still items left, wait a little bit and try again
-		Warn("TestBucketManager.EmptyBucket(): still %d items in bucket after flush, waiting for no items.  Will retry.", itemCount)
+		Warnf(KeyAll,"TestBucketManager.EmptyBucket(): still %d items in bucket after flush, waiting for no items.  Will retry.", itemCount)
 		time.Sleep(time.Millisecond * 500)
 
 		numTries += 1

--- a/db/database.go
+++ b/db/database.go
@@ -111,6 +111,9 @@ type UserViewsOptions struct {
 }
 
 type APIEndpoints struct {
+
+	// This setting is only needed for testing purposes.  In the Couchbase Lite unit tests that run in "integration mode"
+	// against a running Sync Gateway, the tests need to be able to flush the data in between tests to start with a clean DB.
 	EnableCouchbaseBucketFlush bool `json:"enable_couchbase_bucket_flush,omitempty"` // Whether Couchbase buckets can be flushed via Admin REST API
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -110,9 +110,14 @@ type UserViewsOptions struct {
 	Enabled *bool `json:"enabled,omitempty"` // Whether pass-through view query is supported through public API
 }
 
+type APIEndpoints struct {
+	EnableCouchbaseBucketFlush bool `json:"enable_couchbase_bucket_flush,omitempty"` // Whether Couchbase buckets can be flushed via Admin REST API
+}
+
 type UnsupportedOptions struct {
 	UserViews        UserViewsOptions        `json:"user_views,omitempty"`         // Config settings for user views
 	OidcTestProvider OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
+	APIEndpoints     APIEndpoints            `json:"api_endpoints,omitempty"`      // Config settings for API endpoints
 }
 
 // Options associated with the import of documents not written by Sync Gateway
@@ -1069,6 +1074,10 @@ func (context *DatabaseContext) AllowConflicts() bool {
 		return *context.Options.AllowConflicts
 	}
 	return base.DefaultAllowConflicts
+}
+
+func (context *DatabaseContext) AllowFlushNonCouchbaseBuckets() bool {
+	return context.Options.UnsupportedOptions.APIEndpoints.EnableCouchbaseBucketFlush
 }
 
 //////// SEQUENCE ALLOCATION:

--- a/rest/api.go
+++ b/rest/api.go
@@ -134,7 +134,7 @@ func (h *handler) handleFlush() error {
 
 	}
 
-	return nil 
+	return nil
 
 }
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -72,8 +72,7 @@ func (h *handler) handleFlush() error {
 		// If it's not a walrus bucket, don't allow flush unless the unsupported config is set
 		if !h.db.BucketSpec.IsWalrusBucket() {
 			if !h.db.DatabaseContext.AllowFlushNonCouchbaseBuckets() {
-				msg := "Flush not allowed on Couchbase buckets by default.  You must explicitly enable the ability to flush " +
-					"Couchbase buckets via the Unsupported option: api_endpoints/enable_couchbase_bucket_flush"
+				msg := "Flush not allowed on Couchbase buckets by default."
 				return fmt.Errorf(msg)
 			}
 		}

--- a/rest/api.go
+++ b/rest/api.go
@@ -93,6 +93,7 @@ func (h *handler) handleFlush() error {
 		if err != nil {
 			return err
 		}
+		defer tempBucketForFlush.Close() // Close the temporary connection to the bucket that was just for purposes of flushing it
 
 		// Flush the bucket (assuming it conforms to sgbucket.DeleteableBucket interface
 		if tempBucketForFlush, ok := tempBucketForFlush.(sgbucket.DeleteableBucket); ok {
@@ -105,8 +106,6 @@ func (h *handler) handleFlush() error {
 
 		}
 
-		// Close the temporary connection to the bucket that was just for purposes of flushing it
-		tempBucketForFlush.Close()
 
 		// Re-open database and add to Sync Gateway
 		_, err2 := h.server.AddDatabaseFromConfig(config)

--- a/rest/api.go
+++ b/rest/api.go
@@ -66,7 +66,7 @@ func (h *handler) handleVacuum() error {
 func (h *handler) handleFlush() error {
 
 
-	// Otherwise, if it can be flushed, then flush it
+	// If it can be flushed, then flush it
 	if _, ok := h.db.Bucket.(sgbucket.FlushableBucket); ok {
 
 		// If it's not a walrus bucket, don't allow flush unless the unsupported config is set

--- a/rest/api.go
+++ b/rest/api.go
@@ -134,6 +134,8 @@ func (h *handler) handleFlush() error {
 
 	}
 
+	return nil 
+
 }
 
 func (h *handler) handleResync() error {

--- a/rest/api.go
+++ b/rest/api.go
@@ -11,6 +11,7 @@ package rest
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	httpprof "net/http/pprof"
@@ -18,7 +19,6 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strconv"
-
 	"sync/atomic"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -64,19 +64,61 @@ func (h *handler) handleVacuum() error {
 }
 
 func (h *handler) handleFlush() error {
-	if bucket, ok := h.db.Bucket.(sgbucket.DeleteableBucket); ok {
+
+	if _, ok := h.db.Bucket.(sgbucket.DeleteableBucket); ok {
+
+		// If it's not a walrus bucket, don't allow flush unless the unsupported config is set
+		if !h.db.BucketSpec.IsWalrusBucket() {
+			if !h.db.DatabaseContext.AllowFlushNonCouchbaseBuckets() {
+				msg := "Flush not allowed on Couchbase buckets.  You must explicitly enable the ability to flush " +
+					"Couchbase buckets via the Unsupported option: api_endpoints/enable_couchbase_bucket_flush"
+				return fmt.Errorf(msg)
+			}
+		}
+
 		name := h.db.Name
 		config := h.server.GetDatabaseConfig(name)
+
+		// This needs to first call RemoveDatabase since flushing the bucket under Sync Gateway might cause issues.
 		h.server.RemoveDatabase(name)
-		err := bucket.CloseAndDelete()
-		_, err2 := h.server.AddDatabaseFromConfig(config)
-		if err == nil {
-			err = err2
+
+		// Create a bucket connection spec from the database config
+		spec, err := GetBucketSpec(config)
+		if err != nil {
+			return err
 		}
-		return err
+
+		// Manually re-open a temporary bucket connection just for flushing purposes
+		tempBucketForFlush, err := db.ConnectToBucket(spec, nil)
+		if err != nil {
+			return err
+		}
+
+		// Flush the bucket (assuming it conforms to sgbucket.DeleteableBucket interface
+		if tempBucketForFlush, ok := tempBucketForFlush.(sgbucket.DeleteableBucket); ok {
+
+			// Flush
+			err := tempBucketForFlush.CloseAndDelete()
+			if err != nil {
+				return err
+			}
+
+		}
+
+		// Close the temporary connection to the bucket that was just for purposes of flushing it
+		tempBucketForFlush.Close()
+
+		// Re-open database and add to Sync Gateway
+		_, err2 := h.server.AddDatabaseFromConfig(config)
+		if err2 != nil {
+			return err2
+		}
+
 	} else {
 		return base.HTTPErrorf(http.StatusServiceUnavailable, "Bucket does not support flush")
 	}
+
+	return nil
 }
 
 func (h *handler) handleResync() error {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -301,12 +301,53 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 	return sc._getOrAddDatabaseFromConfig(config, useExisting)
 }
 
+
+func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
+
+	server := "http://localhost:8091"
+	if config.Server != nil {
+		server = *config.Server
+	}
+
+	pool := "default"
+	if config.Pool != nil {
+		pool = *config.Pool
+	}
+
+	bucketName := config.Name
+	if config.Bucket != nil {
+		bucketName = *config.Bucket
+	}
+
+	feedType := strings.ToLower(config.FeedType)
+
+	couchbaseDriver := base.ChooseCouchbaseDriver(base.DataBucket)
+
+	var viewQueryTimeoutSecs *uint32
+	if config.ViewQueryTimeoutSecs != nil {
+		viewQueryTimeoutSecs = config.ViewQueryTimeoutSecs
+	}
+
+	// Connect to the bucket and add the database:
+	spec = base.BucketSpec{
+		Server:               server,
+		PoolName:             pool,
+		BucketName:           bucketName,
+		FeedType:             feedType,
+		Auth:                 config,
+		CouchbaseDriver:      couchbaseDriver,
+		UseXattrs:            config.UseXattrs(),
+		ViewQueryTimeoutSecs: viewQueryTimeoutSecs,
+	}
+
+
+	return spec, nil
+}
+
 // Adds a database to the ServerContext.  Attempts a read after it gets the write
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
 func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisting bool) (*db.DatabaseContext, error) {
-
-	var viewQueryTimeoutSecs *uint32
 
 	server := "http://localhost:8091"
 	pool := "default"
@@ -325,10 +366,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	dbName := config.Name
 	if dbName == "" {
 		dbName = bucketName
-	}
-
-	if config.ViewQueryTimeoutSecs != nil {
-		viewQueryTimeoutSecs = config.ViewQueryTimeoutSecs
 	}
 
 	if config.OldRevExpirySeconds != nil && *config.OldRevExpirySeconds >= 0 {
@@ -366,22 +403,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		importOptions.ImportFilter = db.NewImportFilterFunction(*config.ImportFilter)
 	}
 
-	feedType := strings.ToLower(config.FeedType)
-
-	couchbaseDriver := base.ChooseCouchbaseDriver(base.DataBucket)
-
-	// Connect to the bucket and add the database:
-	spec := base.BucketSpec{
-		Server:               server,
-		PoolName:             pool,
-		BucketName:           bucketName,
-		FeedType:             feedType,
-		Auth:                 config,
-		CouchbaseDriver:      couchbaseDriver,
-		UseXattrs:            config.UseXattrs(),
-		ViewQueryTimeoutSecs: viewQueryTimeoutSecs,
-	}
-
 	// Set cache properties, if present
 	cacheOptions := db.CacheOptions{}
 	if config.CacheConfig != nil {
@@ -409,6 +430,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			cacheOptions.ChannelCacheAge = time.Duration(*config.CacheConfig.ChannelCacheAge) * time.Second
 		}
 
+	}
+
+	// Connect to the bucket and add the database:
+	spec, err := GetBucketSpec(config)
+	if err != nil {
+		return nil, err
 	}
 
 	bucket, err := db.ConnectToBucket(spec, func(bucket string, err error) {


### PR DESCRIPTION
**Not ready for merge** -- will need to first merge the dependent PR in the sg-bucket repo

Fixes https://github.com/couchbase/sync_gateway/issues/3305 (dev branch)

## Changes:

- Add `CloseAndDelete()` (aka "flush") method to `gocb_bucket.go`, as well as `BucketItemCount()` helper method needed by `CloseAndDelete()`
- Update `handleFlush()` to properly handle the flush so it doesn't try to flush a closed bucket.  Manually verified that this still works against Walrus.
- Add unsupported config flag + check in `handleFlush()` to force the user to set a flag if flushing a Couchbase bucket via REST API
- Refactor out a `GetBucketSpec()` method
- [x] Merge the dependent PR in the sg-bucket repo: https://github.com/couchbase/sg-bucket/pull/34

## Post merge

- [ ] Update the LiteCore replication tests to enable couchbase server buckets to be flushed