### PR TITLE
Improves situation on LiteCore #437

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -300,10 +300,15 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, params *subChangesParams
 		}
 	}()
 
+	// Don't send conflicting rev tree branches, just send the winning rev tree branch leaf revision + history.
+	// Otherwise, Couchbase Lite will non-deterministically choose an arbitrary branch as the winner and
+	// tombstone the other branch.  See LiteCore #437.
+	sendConflicts := false
+
 	bh.LogTo("Sync", "Sending changes since %v. User:%s", params.since(), bh.effectiveUsername)
 	options := db.ChangesOptions{
 		Since:      params.since(),
-		Conflicts:  true,
+		Conflicts:  sendConflicts,
 		Continuous: bh.continuous,
 		ActiveOnly: bh.activeOnly,
 		Terminator: bh.blipSyncContext.terminator,

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -300,9 +300,8 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, params *subChangesParams
 		}
 	}()
 
-	// Don't send conflicting rev tree branches, just send the winning rev tree branch leaf revision + history.
-	// Otherwise, Couchbase Lite will non-deterministically choose an arbitrary branch as the winner and
-	// tombstone the other branch.  See LiteCore #437.
+	// Don't send conflicting rev tree branches, just send the winning revision + history, since
+	// CBL 2.0 (and blip_sync) don't support branched revision trees.  See LiteCore #437.
 	sendConflicts := false
 
 	bh.LogTo("Sync", "Sending changes since %v. User:%s", params.since(), bh.effectiveUsername)


### PR DESCRIPTION
After this Sync Gateway change, the situation for https://github.com/couchbase/couchbase-lite-core/issues/437 incrementally improved as described in: https://github.com/couchbase/couchbase-lite-core/issues/437#issuecomment-370039341 

## Before

1. The rev tree branch that cblite considered a winner was determined as a winner was non-deterministic 
1. In the case where the shorter rev tree branch was chosen as the winning branch by cblite, all subsequent updates to the cblite doc failed to push, as they were rejected by the SG `proposeChanges` endpoint

## After

1. Both of those issues appear to be resolved
1. Still some caveats mentioned in https://github.com/couchbase/couchbase-lite-core/issues/437#issuecomment-370045740 -- this probably requires more discussion to figure out how to handle these cases.