### PR TITLE
Add N1QL Create Index, Drop Index, Query

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -1,0 +1,100 @@
+package base
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/couchbase/gocb"
+)
+
+const BucketQueryToken = "$_bucket" // Token used for bucket name replacement in query statements
+
+func (bucket *CouchbaseBucketGoCB) N1QLQuery(statement string, prepared bool, consistency gocb.ConsistencyMode, params map[string]interface{}) (gocb.QueryResults, error) {
+
+	n1qlQuery := gocb.NewN1qlQuery(statement)
+	n1qlQuery.AdHoc(!prepared)
+	n1qlQuery.Consistency(consistency)
+
+	results, err := bucket.ExecuteN1qlQuery(n1qlQuery, params)
+
+	if isGoCBTimeoutError(err) {
+		return results, ErrViewTimeoutError
+	}
+
+	return results, err
+}
+
+func (bucket *CouchbaseBucketGoCB) CreateIndex(indexName string, expression string, numReplica uint) error {
+
+	createStatement := fmt.Sprintf("CREATE INDEX %s ON %s(%s)", indexName, bucket.GetName(), expression)
+
+	if numReplica > 0 {
+		createStatement = fmt.Sprintf("%s with {num_replica:%d}", createStatement, numReplica)
+	}
+
+	n1qlQuery := gocb.NewN1qlQuery(createStatement)
+	results, err := bucket.ExecuteN1qlQuery(n1qlQuery, nil)
+	if err != nil {
+		return err
+	}
+
+	closeErr := results.Close()
+	if closeErr != nil {
+		return closeErr
+	}
+
+	return nil
+}
+
+func (bucket *CouchbaseBucketGoCB) DropIndex(indexName string) error {
+	statement := fmt.Sprintf("DROP INDEX %s.%s", bucket.GetName(), indexName)
+	n1qlQuery := gocb.NewN1qlQuery(statement)
+
+	results, err := bucket.ExecuteN1qlQuery(n1qlQuery, nil)
+	if err != nil {
+		return err
+	}
+
+	closeErr := results.Close()
+	if closeErr != nil {
+		return closeErr
+	}
+	return err
+}
+
+// Query accepts a parameterized statement,  optional list of params, and an optional flag to force adhoc query execution.
+// Params specified using the $param notation in the statement are intended to be used w/ N1QL prepared statements, and will be
+// passed through as params to n1ql.  e.g.:
+//   SELECT _sync.sequence FROM $_bucket WHERE _sync.sequence > $minSeq
+// https://developer.couchbase.com/documentation/server/current/sdk/go/n1ql-queries-with-sdk.html for additional details.
+// Will additionally replace all instances of BucketQueryToken($_bucket) in the statement
+// with the bucket name.  'bucket' should not be included in params.
+//
+// If adhoc=true, prepared statement handling will be disabled.  Should only be set to true for queries that can't be prepared, e.g.:
+//  SELECT _sync.channels.ABC.seq from $bucket
+func (bucket *CouchbaseBucketGoCB) Query(statement string, params interface{}, adhoc bool) (gocb.QueryResults, error) {
+	bucketStatement := strings.Replace(statement, BucketQueryToken, bucket.GetName(), -1)
+	n1qlQuery := gocb.NewN1qlQuery(bucketStatement)
+	n1qlQuery = n1qlQuery.AdHoc(adhoc)
+	return bucket.ExecuteN1qlQuery(n1qlQuery, params)
+}
+
+func QueryCloseErrors(closeError error) []error {
+
+	if closeError == nil {
+		return nil
+	}
+
+	closeErrors := make([]error, 0)
+	switch v := closeError.(type) {
+	case *gocb.MultiError:
+		for _, multiErr := range v.Errors {
+			closeErrors = append(closeErrors, multiErr)
+		}
+	default:
+		closeErrors = append(closeErrors, v)
+	}
+
+	return closeErrors
+
+}

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -1,0 +1,247 @@
+package base
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/couchbase/gocb"
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestN1qlQuery(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		t.Errorf("Requires gocb bucket")
+	}
+
+	// Write a few docs to the bucket to query
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("doc%d", i)
+		body := fmt.Sprintf(`{"val": %d}`, i)
+		added, err := bucket.AddRaw(key, 0, []byte(body))
+		if err != nil {
+			t.Errorf("Error adding doc for TestN1qlQuery: %v", err)
+		}
+		assertTrue(t, added, "AddRaw returned added=false, expected true")
+	}
+
+	indexExpression := "val"
+	err := bucket.CreateIndex("testIndex_value", indexExpression, 0)
+	if err != nil {
+		t.Errorf("Error creating index: %s", err)
+	}
+
+	// Defer index teardown
+	defer func() {
+		// Drop the index
+		err = bucket.DropIndex("testIndex_value")
+		if err != nil {
+			t.Errorf("Error dropping index: %s", err)
+		}
+	}()
+
+	// Query the index
+	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", BucketQueryToken)
+	params := make(map[string]interface{})
+	params["minvalue"] = 2
+
+	queryResults, queryErr := bucket.Query(queryExpression, params, false)
+	assertNoError(t, queryErr, "Error executing n1ql query")
+
+	// Struct to receive the query response (META().id, val)
+	var queryResult struct {
+		Id  string
+		Val int
+	}
+	var queryCloseErr error
+	var count int
+
+	// Iterate over results - validate values and count to ensure $minvalue is being applied correctly
+	for {
+		ok := queryResults.Next(&queryResult)
+		if !ok {
+			queryCloseErr = queryResults.Close()
+			break
+		}
+		assertTrue(t, queryResult.Val > 2, "Query returned unexpected result")
+		count++
+	}
+
+	// Requery the index, validate empty resultset behaviour
+	params = make(map[string]interface{})
+	params["minvalue"] = 10
+
+	queryResults, queryErr = bucket.Query(queryExpression, params, false)
+	assertNoError(t, queryErr, "Error executing n1ql query")
+
+	count = 0
+	for {
+		ok := queryResults.Next(&queryResult)
+		if !ok {
+			queryCloseErr = queryResults.Close()
+			break
+		}
+		assertTrue(t, queryResult.Val > 10, "Query returned unexpected result")
+		count++
+	}
+
+	assertNoError(t, queryCloseErr, "Unexpected error closing query results")
+	assert.Equals(t, count, 0)
+
+}
+
+// Ensure that n1ql query errors are handled and returned (and don't result in panic etc)
+func TestMalformedN1qlQuery(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		t.Errorf("Requires gocb bucket")
+	}
+
+	// Write a few docs to the bucket to query
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("doc%d", i)
+		body := fmt.Sprintf(`{"val": %d}`, i)
+		added, err := bucket.AddRaw(key, 0, []byte(body))
+		if err != nil {
+			t.Errorf("Error adding doc for TestN1qlQuery: %v", err)
+		}
+		assertTrue(t, added, "AddRaw returned added=false, expected true")
+	}
+
+	indexExpression := "val"
+	err := bucket.CreateIndex("testIndex_value", indexExpression, 0)
+	if err != nil {
+		t.Errorf("Error creating index: %s", err)
+	}
+
+	// Defer index teardown
+	defer func() {
+		// Drop the index
+		err = bucket.DropIndex("testIndex_value")
+		if err != nil {
+			t.Errorf("Error dropping index: %s", err)
+		}
+	}()
+
+	// Query with syntax error
+	queryExpression := "SELECT META().id, val WHERE val > $minvalue"
+	params := make(map[string]interface{})
+	_, queryErr := bucket.Query(queryExpression, params, false)
+	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
+
+	// Query against non-existing bucket
+	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", "badBucket")
+	params = map[string]interface{}{"minvalue": 2}
+	_, queryErr = bucket.Query(queryExpression, params, false)
+	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
+
+	// Specify params for non-parameterized query (no error expected, ensure doesn't break)
+	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > 5", BucketQueryToken)
+	params = map[string]interface{}{"minvalue": 2}
+	_, queryErr = bucket.Query(queryExpression, params, false)
+	assertTrue(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
+
+	// Omit params for parameterized query
+	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", BucketQueryToken)
+	params = make(map[string]interface{})
+	_, queryErr = bucket.Query(queryExpression, params, false)
+	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (missing params)")
+
+}
+
+func TestCreateAndDropIndex(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		t.Errorf("Requires gocb bucket")
+	}
+
+	createExpression := "_sync.sequence"
+	err := bucket.CreateIndex("testIndex_sequence", createExpression, 0)
+	if err != nil {
+		t.Errorf("Error creating index: %s", err)
+	}
+
+	// Drop the index
+	err = bucket.DropIndex("testIndex_sequence")
+	if err != nil {
+		t.Errorf("Error dropping index: %s", err)
+	}
+}
+
+func TestCreateAndDropIndexErrors(t *testing.T) {
+
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		t.Errorf("Requires gocb bucket")
+	}
+
+	// Malformed expression
+	createExpression := "_sync sequence"
+	err := bucket.CreateIndex("testIndex_malformed", createExpression, 0)
+	if err == nil {
+		t.Errorf("Expected error for malformed index expression")
+	}
+
+	// Create index
+	createExpression = "_sync.sequence"
+	err = bucket.CreateIndex("testIndex_sequence", createExpression, 0)
+	if err != nil {
+		t.Errorf("Error creating index: %s", err)
+	}
+
+	// Attempt to recreate duplicate index
+	err = bucket.CreateIndex("testIndex_sequence", createExpression, 0)
+	if err == nil {
+		t.Errorf("Expected error attempting to recreate already existing index")
+	}
+
+	// Drop non-existent index
+	err = bucket.DropIndex("testIndex_not_found")
+	if err == nil {
+		t.Errorf("Expected error attempting to drop non-existent index", err)
+	}
+
+	// Drop the index
+	err = bucket.DropIndex("testIndex_sequence")
+	if err != nil {
+		t.Errorf("Error dropping index: %s", err)
+	}
+
+	// Drop index that's already been dropped
+	err = bucket.DropIndex("testIndex_sequence")
+	if err == nil {
+		t.Errorf("Expected error attempting to drop index twice")
+	}
+}
+
+func queryResultCount(queryResults gocb.QueryResults) (count int, err error) {
+
+	for {
+		bytes := queryResults.NextBytes()
+		if bytes == nil {
+			return count, queryResults.Close()
+		}
+		log.Printf("QueryResults[%d]: %s", count, bytes)
+		count++
+	}
+}

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -53,7 +53,7 @@ func TestN1qlQuery(t *testing.T) {
 	params := make(map[string]interface{})
 	params["minvalue"] = 2
 
-	queryResults, queryErr := bucket.Query(queryExpression, params, false)
+	queryResults, queryErr := bucket.Query(queryExpression, params, gocb.RequestPlus, false)
 	assertNoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
@@ -79,7 +79,7 @@ func TestN1qlQuery(t *testing.T) {
 	params = make(map[string]interface{})
 	params["minvalue"] = 10
 
-	queryResults, queryErr = bucket.Query(queryExpression, params, false)
+	queryResults, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
 	assertNoError(t, queryErr, "Error executing n1ql query")
 
 	count = 0
@@ -139,25 +139,25 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	// Query with syntax error
 	queryExpression := "SELECT META().id, val WHERE val > $minvalue"
 	params := make(map[string]interface{})
-	_, queryErr := bucket.Query(queryExpression, params, false)
+	_, queryErr := bucket.Query(queryExpression, params, gocb.RequestPlus, false)
 	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
 
 	// Query against non-existing bucket
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", "badBucket")
 	params = map[string]interface{}{"minvalue": 2}
-	_, queryErr = bucket.Query(queryExpression, params, false)
+	_, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
 	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
 
 	// Specify params for non-parameterized query (no error expected, ensure doesn't break)
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > 5", BucketQueryToken)
 	params = map[string]interface{}{"minvalue": 2}
-	_, queryErr = bucket.Query(queryExpression, params, false)
+	_, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
 	assertTrue(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
 
 	// Omit params for parameterized query
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", BucketQueryToken)
 	params = make(map[string]interface{})
-	_, queryErr = bucket.Query(queryExpression, params, false)
+	_, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
 	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (missing params)")
 
 }

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -19,7 +19,7 @@ func TestN1qlQuery(t *testing.T) {
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
 	if !ok {
-		t.Errorf("Requires gocb bucket")
+		t.Fatalf("Requires gocb bucket")
 	}
 
 	// Write a few docs to the bucket to query
@@ -107,7 +107,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
 	if !ok {
-		t.Errorf("Requires gocb bucket")
+		t.Fatalf("Requires gocb bucket")
 	}
 
 	// Write a few docs to the bucket to query
@@ -170,7 +170,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
 	if !ok {
-		t.Errorf("Requires gocb bucket")
+		t.Fatalf("Requires gocb bucket")
 	}
 
 	createExpression := "_sync.sequence"
@@ -188,11 +188,14 @@ func TestCreateAndDropIndex(t *testing.T) {
 
 func TestCreateAndDropIndexErrors(t *testing.T) {
 
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
 	testBucket := GetTestBucketOrPanic()
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
 	if !ok {
-		t.Errorf("Requires gocb bucket")
+		t.Fatalf("Requires gocb bucket")
 	}
 
 	// Malformed expression


### PR DESCRIPTION
Since these are specific to gocb and we don't have any (current) plans to support in other bucket implementations, these are implemented without a change to the Bucket API.  Usage (including any bucket type cast checking) will be included in #3351.

Fixes #3350