### PR TITLE
Logging: #3365 Add new Log Keys implementation

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -73,7 +73,7 @@ func (keyMask *LogKey) enabled(logKey uint32, checkWildcard bool) bool {
 		flag&logKey != 0
 }
 
-// LogKeyName returns the string representation of a log key.
+// LogKeyName returns the string representation of a single log key.
 func LogKeyName(logKey uint32) string {
 	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
 	return logKeyNames[logKey]

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -5,17 +5,15 @@ import (
 )
 
 // LogKey is a bitfield of log keys.
-type LogKey struct {
-	flag uint32
-}
+type LogKey uint32
 
 // Values for log keys.
 const (
 	// KEY_NONE is shorthand for no log keys.
-	KEY_NONE uint32 = 0
+	KEY_NONE LogKey = 0
 
 	// KEY_ALL is a wildcard for all log keys.
-	KEY_ALL uint32 = 1 << iota
+	KEY_ALL LogKey = 1 << iota
 
 	KEY_ACCESS
 	KEY_ATTACH
@@ -32,61 +30,64 @@ const (
 	KEY_REPLICATE
 )
 
-var logKeyNames = map[uint32]string{
-	KEY_ALL:       "*",
-	KEY_ACCESS:    "Access",
-	KEY_ATTACH:    "Attach",
-	KEY_AUTH:      "Auth",
-	KEY_BUCKET:    "Bucket",
-	KEY_CACHE:     "Cache",
-	KEY_CHANGES:   "Changes",
-	KEY_CRUD:      "CRUD",
-	KEY_DCP:       "DCP",
-	KEY_EVENTS:    "Events",
-	KEY_FEED:      "Feed",
-	KEY_HTTP:      "HTTP",
-	KEY_IMPORT:    "Import",
-	KEY_REPLICATE: "Replicate",
-}
+var (
+	logKeyNames = map[LogKey]string{
+		KEY_ALL:       "*",
+		KEY_ACCESS:    "Access",
+		KEY_ATTACH:    "Attach",
+		KEY_AUTH:      "Auth",
+		KEY_BUCKET:    "Bucket",
+		KEY_CACHE:     "Cache",
+		KEY_CHANGES:   "Changes",
+		KEY_CRUD:      "CRUD",
+		KEY_DCP:       "DCP",
+		KEY_EVENTS:    "Events",
+		KEY_FEED:      "Feed",
+		KEY_HTTP:      "HTTP",
+		KEY_IMPORT:    "Import",
+		KEY_REPLICATE: "Replicate",
+	}
+
+	// Inverse of the map above. Optimisation for string -> LogKey lookups in ToLogKey
+	logKeyNamesInverse = inverselogKeyNames(logKeyNames)
+)
 
 // Enable will enable the given logKey in keyMask.
-func (keyMask *LogKey) Enable(logKey uint32) {
-	val := atomic.LoadUint32(&keyMask.flag)
-	atomic.StoreUint32(&keyMask.flag, val|logKey)
+func (keyMask *LogKey) Enable(logKey LogKey) {
+	val := atomic.LoadUint32((*uint32)(keyMask))
+	atomic.StoreUint32((*uint32)(keyMask), val|uint32(logKey))
 }
 
 // Disable will disable the given logKey in keyMask.
-func (keyMask *LogKey) Disable(logKey uint32) {
-	val := atomic.LoadUint32(&keyMask.flag)
-	atomic.StoreUint32(&keyMask.flag, val & ^logKey)
+func (keyMask *LogKey) Disable(logKey LogKey) {
+	val := atomic.LoadUint32((*uint32)(keyMask))
+	atomic.StoreUint32((*uint32)(keyMask), val & ^uint32(logKey))
 }
 
 // Enabled returns true if the given logKey, or KEY_ALL is enabled in keyMask.
-func (keyMask *LogKey) Enabled(logKey uint32) bool {
+func (keyMask *LogKey) Enabled(logKey LogKey) bool {
 	return keyMask.enabled(logKey, true)
 }
 
 // enabled returns true if the given logKey is enabled in keyMask, with an optional wildcard check.
-func (keyMask *LogKey) enabled(logKey uint32, checkWildcard bool) bool {
-	flag := atomic.LoadUint32(&keyMask.flag)
-	return (checkWildcard && flag&KEY_ALL != 0) ||
-		flag&logKey != 0
+func (keyMask *LogKey) enabled(logKey LogKey, checkWildcard bool) bool {
+	flag := atomic.LoadUint32((*uint32)(keyMask))
+	return (checkWildcard && flag&uint32(KEY_ALL) != 0) ||
+		flag&uint32(logKey) != 0
 }
 
 // LogKeyName returns the string representation of a single log key.
-func LogKeyName(logKey uint32) string {
+func LogKeyName(logKey LogKey) string {
 	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
 	return logKeyNames[logKey]
 }
 
 // ToLogKey takes a slice of case-sensitive log key names and will return a LogKey bitfield.
 func ToLogKey(keysStr []string) LogKey {
-	var logKeys = LogKey{}
+	var logKeys LogKey
 	for _, name := range keysStr {
-		for logKey, logKeyName := range logKeyNames {
-			if logKeyName == name {
-				logKeys.Enable(logKey)
-			}
+		if logKey, ok := logKeyNamesInverse[name]; ok {
+			logKeys.Enable(logKey)
 		}
 	}
 	return logKeys
@@ -96,10 +97,18 @@ func ToLogKey(keysStr []string) LogKey {
 func (keyMask LogKey) EnabledLogKeys() []string {
 	var logKeys = make([]string, 0, len(logKeyNames))
 	for i := 0; i < len(logKeyNames); i++ {
-		logKey := uint32(1) << uint32(i)
+		logKey := LogKey(1) << uint32(i)
 		if keyMask.enabled(logKey, false) {
 			logKeys = append(logKeys, LogKeyName(logKey))
 		}
 	}
 	return logKeys
+}
+
+func inverselogKeyNames(in map[LogKey]string) map[string]LogKey {
+	var out = make(map[string]LogKey, len(in))
+	for k, v := range in {
+		out[v] = k
+	}
+	return out
 }

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -51,22 +51,14 @@ var logKeyNames = map[uint32]string{
 
 // Enable will enable the given logKey in keyMask.
 func (keyMask *LogKey) Enable(logKey uint32) {
-	for {
-		val := atomic.LoadUint32(&keyMask.flag)
-		if atomic.CompareAndSwapUint32(&keyMask.flag, val, val|logKey) {
-			break
-		}
-	}
+	val := atomic.LoadUint32(&keyMask.flag)
+	atomic.StoreUint32(&keyMask.flag, val|logKey)
 }
 
 // Disable will disable the given logKey in keyMask.
 func (keyMask *LogKey) Disable(logKey uint32) {
-	for {
-		val := atomic.LoadUint32(&keyMask.flag)
-		if atomic.CompareAndSwapUint32(&keyMask.flag, val, val & ^logKey) {
-			break
-		}
-	}
+	val := atomic.LoadUint32(&keyMask.flag)
+	atomic.StoreUint32(&keyMask.flag, val & ^logKey)
 }
 
 // Enabled returns true if the given logKey, or KEY_ALL is enabled in keyMask.

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -51,14 +51,22 @@ var logKeyNames = map[uint32]string{
 
 // Enable will enable the given logKey in keyMask.
 func (keyMask *LogKey) Enable(logKey uint32) {
-	val := atomic.LoadUint32(&keyMask.flag)
-	atomic.CompareAndSwapUint32(&keyMask.flag, val, val|logKey)
+	for {
+		val := atomic.LoadUint32(&keyMask.flag)
+		if atomic.CompareAndSwapUint32(&keyMask.flag, val, val|logKey) {
+			break
+		}
+	}
 }
 
 // Disable will disable the given logKey in keyMask.
 func (keyMask *LogKey) Disable(logKey uint32) {
-	val := atomic.LoadUint32(&keyMask.flag)
-	atomic.CompareAndSwapUint32(&keyMask.flag, val, val & ^logKey)
+	for {
+		val := atomic.LoadUint32(&keyMask.flag)
+		if atomic.CompareAndSwapUint32(&keyMask.flag, val, val & ^logKey) {
+			break
+		}
+	}
 }
 
 // Enabled returns true if the given logKey, or KEY_ALL is enabled in keyMask.

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -1,0 +1,90 @@
+package base
+
+// LogKey is a bitfield of log keys.
+type LogKey uint
+
+// Values for log keys.
+const (
+	// KEY_NONE is shorthand for no log keys.
+	KEY_NONE LogKey = 0
+
+	// KEY_ALL is a wildcard for all log keys.
+	KEY_ALL LogKey = 1 << iota
+
+	KEY_ACCESS
+	KEY_ATTACH
+	KEY_AUTH
+	KEY_BUCKET
+	KEY_CACHE
+	KEY_CHANGES
+	KEY_CRUD
+	KEY_DCP
+	KEY_EVENTS
+	KEY_FEED
+	KEY_HTTP
+	KEY_IMPORT
+	KEY_REPLICATE
+)
+
+var logKeyNames = map[LogKey]string{
+	KEY_ALL:       "*",
+	KEY_ACCESS:    "Access",
+	KEY_ATTACH:    "Attach",
+	KEY_AUTH:      "Auth",
+	KEY_BUCKET:    "Bucket",
+	KEY_CACHE:     "Cache",
+	KEY_CHANGES:   "Changes",
+	KEY_CRUD:      "CRUD",
+	KEY_DCP:       "DCP",
+	KEY_EVENTS:    "Events",
+	KEY_FEED:      "Feed",
+	KEY_HTTP:      "HTTP",
+	KEY_IMPORT:    "Import",
+	KEY_REPLICATE: "Replicate",
+}
+
+// Enable will enable the given logKey in keyMask.
+func (keyMask *LogKey) Enable(logKey LogKey) {
+	*keyMask |= logKey
+}
+
+// Disable will disable the given logKey in keyMask.
+func (keyMask *LogKey) Disable(logKey LogKey) {
+	*keyMask &= ^logKey
+}
+
+// Enabled returns true if the given logKey, or KEY_ALL is enabled in keyMask.
+func (keyMask LogKey) Enabled(logKey LogKey) bool {
+	return keyMask.enabled(logKey, true)
+}
+
+// enabled returns true if the given logKey is enabled in keyMask, with an optional wildcard check.
+func (keyMask LogKey) enabled(logKey LogKey, checkWildcard bool) bool {
+	return (checkWildcard && keyMask&KEY_ALL != 0) ||
+		keyMask&logKey != 0
+}
+
+// ToLogKey takes a slice of case-sensitive log key names and will return a LogKey bitfield.
+func ToLogKey(keysStr []string) LogKey {
+	var logKeys = KEY_NONE
+	for _, name := range keysStr {
+		for logKey, logKeyName := range logKeyNames {
+			if logKeyName == name {
+				logKeys.Enable(logKey)
+			}
+		}
+	}
+	return logKeys
+}
+
+// EnabledLogKeys returns a slice of enabled log key names.
+func (keyMask LogKey) EnabledLogKeys() []string {
+	var logKeys = make([]string, 0, len(logKeyNames))
+	for i := 0; i < len(logKeyNames); i++ {
+		logKey := LogKey(1 << uint(i))
+		if keyMask.enabled(logKey, false) {
+			logKeys = append(logKeys, logKeyNames[logKey])
+		}
+	}
+	return logKeys
+}

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -73,6 +73,12 @@ func (keyMask *LogKey) enabled(logKey uint32, checkWildcard bool) bool {
 		flag&logKey != 0
 }
 
+// LogKeyName returns the string representation of a log key.
+func LogKeyName(logKey uint32) string {
+	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
+	return logKeyNames[logKey]
+}
+
 // ToLogKey takes a slice of case-sensitive log key names and will return a LogKey bitfield.
 func ToLogKey(keysStr []string) LogKey {
 	var logKeys = LogKey{}
@@ -92,7 +98,7 @@ func (keyMask LogKey) EnabledLogKeys() []string {
 	for i := 0; i < len(logKeyNames); i++ {
 		logKey := uint32(1) << uint32(i)
 		if keyMask.enabled(logKey, false) {
-			logKeys = append(logKeys, logKeyNames[logKey])
+			logKeys = append(logKeys, LogKeyName(logKey))
 		}
 	}
 	return logKeys

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -2,55 +2,87 @@ package base
 
 import (
 	"testing"
+	"time"
 
 	"github.com/couchbaselabs/go.assert"
 )
 
+func TestLogKeyConcurrency(t *testing.T) {
+	logKey := LogKey{flag: KEY_ACCESS | KEY_HTTP | KEY_REPLICATE}
+
+	stop := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			default:
+				logKey.Enable(KEY_DCP)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			default:
+				logKey.Disable(KEY_ACCESS)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	time.Sleep(time.Millisecond * 100)
+	stop <- struct{}{}
+}
+
 func TestLogKey(t *testing.T) {
-	logKey := KEY_HTTP
+	logKey := LogKey{flag: KEY_HTTP}
 	assert.True(t, logKey.Enabled(KEY_HTTP))
 
 	// Enable more log keys.
 	logKey.Enable(KEY_ACCESS | KEY_REPLICATE)
 	assert.True(t, logKey.Enabled(KEY_ACCESS))
 	assert.True(t, logKey.Enabled(KEY_REPLICATE))
-	assert.Equals(t, logKey, KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
+	assert.Equals(t, logKey.flag, KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
 
 	// Enable wildcard and check unset key is enabled.
 	logKey.Enable(KEY_ALL)
 	assert.True(t, logKey.Enabled(KEY_CACHE))
-	assert.Equals(t, logKey, KEY_ALL|KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
+	assert.Equals(t, logKey.flag, KEY_ALL|KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
 
 	// Disable wildcard and check that existing keys are still set.
 	logKey.Disable(KEY_ALL)
 	assert.False(t, logKey.Enabled(KEY_CACHE))
-	assert.Equals(t, logKey, KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
+	assert.Equals(t, logKey.flag, KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
 }
 
 func TestLogKeyNames(t *testing.T) {
 	keys := []string{}
 	logKeys := ToLogKey(keys)
-	assert.Equals(t, logKeys, KEY_NONE)
+	assert.Equals(t, logKeys.flag, KEY_NONE)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
 
 	keys = append(keys, "DCP")
 	logKeys = ToLogKey(keys)
-	assert.Equals(t, logKeys, KEY_DCP)
+	assert.Equals(t, logKeys.flag, KEY_DCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"DCP"})
 
 	keys = append(keys, "Access")
 	logKeys = ToLogKey(keys)
-	assert.Equals(t, logKeys, KEY_ACCESS|KEY_DCP)
+	assert.Equals(t, logKeys.flag, KEY_ACCESS|KEY_DCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"Access", "DCP"})
 
 	keys = []string{"*", "DCP"}
 	logKeys = ToLogKey(keys)
-	assert.Equals(t, logKeys, KEY_ALL|KEY_DCP)
+	assert.Equals(t, logKeys.flag, KEY_ALL|KEY_DCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"*", "DCP"})
 }
 
 func BenchmarkEnabledLogKeys(b *testing.B) {
-	logKeys := KEY_CRUD | KEY_DCP | KEY_REPLICATE
+	logKeys := LogKey{flag: KEY_CRUD | KEY_DCP | KEY_REPLICATE}
 	for i := 0; i < b.N; i++ {
 		_ = logKeys.EnabledLogKeys()
 	}
@@ -63,13 +95,13 @@ func BenchmarkToLogKey(b *testing.B) {
 }
 
 func BenchmarkLogKeyEnabled(b *testing.B) {
-	logKeys := KEY_CRUD | KEY_DCP | KEY_REPLICATE
+	logKeys := LogKey{flag: KEY_CRUD | KEY_DCP | KEY_REPLICATE}
 	benchmarkLogKeyEnabled(b, "Wildcard", KEY_ALL, logKeys)
 	benchmarkLogKeyEnabled(b, "Hit", KEY_DCP, logKeys)
 	benchmarkLogKeyEnabled(b, "Miss", KEY_CACHE, logKeys)
 }
 
-func benchmarkLogKeyEnabled(b *testing.B, name string, logKey LogKey, logKeys LogKey) {
+func benchmarkLogKeyEnabled(b *testing.B, name string, logKey uint32, logKeys LogKey) {
 	b.Run(name, func(bn *testing.B) {
 		for i := 0; i < bn.N; i++ {
 			logKeys.Enabled(logKey)

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -1,0 +1,78 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/couchbaselabs/go.assert"
+)
+
+func TestLogKey(t *testing.T) {
+	logKey := KEY_HTTP
+	assert.True(t, logKey.Enabled(KEY_HTTP))
+
+	// Enable more log keys.
+	logKey.Enable(KEY_ACCESS | KEY_REPLICATE)
+	assert.True(t, logKey.Enabled(KEY_ACCESS))
+	assert.True(t, logKey.Enabled(KEY_REPLICATE))
+	assert.Equals(t, logKey, KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
+
+	// Enable wildcard and check unset key is enabled.
+	logKey.Enable(KEY_ALL)
+	assert.True(t, logKey.Enabled(KEY_CACHE))
+	assert.Equals(t, logKey, KEY_ALL|KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
+
+	// Disable wildcard and check that existing keys are still set.
+	logKey.Disable(KEY_ALL)
+	assert.False(t, logKey.Enabled(KEY_CACHE))
+	assert.Equals(t, logKey, KEY_ACCESS|KEY_HTTP|KEY_REPLICATE)
+}
+
+func TestLogKeyNames(t *testing.T) {
+	keys := []string{}
+	logKeys := ToLogKey(keys)
+	assert.Equals(t, logKeys, KEY_NONE)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
+
+	keys = append(keys, "DCP")
+	logKeys = ToLogKey(keys)
+	assert.Equals(t, logKeys, KEY_DCP)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"DCP"})
+
+	keys = append(keys, "Access")
+	logKeys = ToLogKey(keys)
+	assert.Equals(t, logKeys, KEY_ACCESS|KEY_DCP)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"Access", "DCP"})
+
+	keys = []string{"*", "DCP"}
+	logKeys = ToLogKey(keys)
+	assert.Equals(t, logKeys, KEY_ALL|KEY_DCP)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"*", "DCP"})
+}
+
+func BenchmarkEnabledLogKeys(b *testing.B) {
+	logKeys := KEY_CRUD | KEY_DCP | KEY_REPLICATE
+	for i := 0; i < b.N; i++ {
+		_ = logKeys.EnabledLogKeys()
+	}
+}
+
+func BenchmarkToLogKey(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = ToLogKey([]string{"CRUD", "DCP", "Replicate"})
+	}
+}
+
+func BenchmarkLogKeyEnabled(b *testing.B) {
+	logKeys := KEY_CRUD | KEY_DCP | KEY_REPLICATE
+	benchmarkLogKeyEnabled(b, "Wildcard", KEY_ALL, logKeys)
+	benchmarkLogKeyEnabled(b, "Hit", KEY_DCP, logKeys)
+	benchmarkLogKeyEnabled(b, "Miss", KEY_CACHE, logKeys)
+}
+
+func benchmarkLogKeyEnabled(b *testing.B, name string, logKey LogKey, logKeys LogKey) {
+	b.Run(name, func(bn *testing.B) {
+		for i := 0; i < bn.N; i++ {
+			logKeys.Enabled(logKey)
+		}
+	})
+}

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestLogKeyConcurrency(t *testing.T) {
-	logKey := LogKey{flag: KEY_ACCESS | KEY_HTTP | KEY_REPLICATE}
-
+	logKey := LogKey{}
 	stop := make(chan struct{})
 
 	go func() {
@@ -27,7 +26,18 @@ func TestLogKeyConcurrency(t *testing.T) {
 		for {
 			select {
 			default:
-				logKey.Disable(KEY_ACCESS)
+				logKey.Disable(KEY_DCP)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			default:
+				logKey.Enabled(KEY_DCP)
 			case <-stop:
 				return
 			}

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -96,7 +96,7 @@ func BenchmarkToLogKey(b *testing.B) {
 
 func BenchmarkLogKeyEnabled(b *testing.B) {
 	logKeys := LogKey{flag: KEY_CRUD | KEY_DCP | KEY_REPLICATE}
-	benchmarkLogKeyEnabled(b, "Wildcard", KEY_ALL, logKeys)
+	benchmarkLogKeyEnabled(b, "Wildcard", KEY_CACHE, LogKey{flag: KEY_ALL})
 	benchmarkLogKeyEnabled(b, "Hit", KEY_DCP, logKeys)
 	benchmarkLogKeyEnabled(b, "Miss", KEY_CACHE, logKeys)
 }

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -78,17 +78,17 @@ func TestLogKeyNames(t *testing.T) {
 	keys = append(keys, "DCP")
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys.flag, KEY_DCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"DCP"})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KEY_DCP)})
 
 	keys = append(keys, "Access")
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys.flag, KEY_ACCESS|KEY_DCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"Access", "DCP"})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KEY_ACCESS), LogKeyName(KEY_DCP)})
 
 	keys = []string{"*", "DCP"}
 	logKeys = ToLogKey(keys)
 	assert.Equals(t, logKeys.flag, KEY_ALL|KEY_DCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{"*", "DCP"})
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{LogKeyName(KEY_ALL), LogKeyName(KEY_DCP)})
 }
 
 func BenchmarkEnabledLogKeys(b *testing.B) {


### PR DESCRIPTION
Adds new Log Keys implementation, to be used in the new logging API (#3365)

### Description

The current Log Keys implementation was managed with a global writeable map, which introduced the requirement for mutexes when reading on each log call.

Using a bitfield will allow concurrent read/write using sync.Atomic and low/zero allocs. Concurrent lock-free name lookups can be achieved too, as long as the maps are not written to. [[1]](https://golang.org/doc/faq#atomic_maps)

### Tests/Benchmark
```
✔ ~/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway [feature/issue_3365_new_logging_api_logkeys|✚ 1⚑ 5]
12:19 $ go test -run='LogKey' -v -race ./base
=== RUN   TestLogKey
--- PASS: TestLogKey (0.00s)
=== RUN   TestLogKeyNames
--- PASS: TestLogKeyNames (0.00s)
=== RUN   TestLogKeyConcurrency
--- PASS: TestLogKeyConcurrency (0.10s)
PASS
ok  	github.com/couchbase/sync_gateway/base	1.144s

✔ ~/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway [feature/issue_3365_new_logging_api_logkeys|✚ 1⚑ 5]
12:20 $ go test -run='xxx' -bench='LogKey' -v -benchmem ./base
goos: darwin
goarch: amd64
pkg: github.com/couchbase/sync_gateway/base
BenchmarkLogKeyEnabled/Wildcard-8         	2000000000	         0.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkLogKeyEnabled/Hit-8              	2000000000	         0.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkLogKeyEnabled/Miss-8             	2000000000	         0.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkToggleLogKeys/Enable-8           	100000000	        11.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkToggleLogKeys/Disable-8          	100000000	        11.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkLogKeyName-8                     	100000000	        13.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkToLogKey-8                       	20000000	        92.8 ns/op	       4 B/op	       1 allocs/op
BenchmarkEnabledLogKeys-8                 	10000000	       180 ns/op	     228 B/op	       2 allocs/op
PASS
ok  	github.com/couchbase/sync_gateway/base	9.801s
```