### PR TITLE
Log Redaction: Change fallback formatting to %+v

### DIFF
--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -33,6 +33,6 @@ func MD(i interface{}) Metadata {
 		return Metadata(v.String())
 	default:
 		// Fall back to a slower but safe way of getting a string from any type.
-		return Metadata(fmt.Sprintf("%v", v))
+		return Metadata(fmt.Sprintf("%+v", v))
 	}
 }

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -30,6 +30,6 @@ func SD(i interface{}) SystemData {
 		return SystemData(v.String())
 	default:
 		// Fall back to a slower but safe way of getting a string from any type.
-		return SystemData(fmt.Sprintf("%v", v))
+		return SystemData(fmt.Sprintf("%+v", v))
 	}
 }

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -41,6 +41,6 @@ func UD(i interface{}) UserData {
 		return UserData(v.String())
 	default:
 		// Fall back to a slower but safe way of getting a string from any type.
-		return UserData(fmt.Sprintf("%v", v))
+		return UserData(fmt.Sprintf("%+v", v))
 	}
 }


### PR DESCRIPTION
Change fallback formatting to `%+v` so struct field names are included.