### PR TITLE
Go 1.10: Fix formatting directive in bucket_n1ql_test.go

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -221,7 +221,7 @@ func TestCreateAndDropIndexErrors(t *testing.T) {
 	// Drop non-existent index
 	err = bucket.DropIndex("testIndex_not_found")
 	if err == nil {
-		t.Errorf("Expected error attempting to drop non-existent index", err)
+		t.Errorf("Expected error attempting to drop non-existent index")
 	}
 
 	// Drop the index


### PR DESCRIPTION
Fails in Go 1.10

```
12:27 $ go test ./base
# github.com/couchbase/sync_gateway/base
base/bucket_n1ql_test.go:224: Errorf call has arguments but no formatting directives
FAIL	github.com/couchbase/sync_gateway/base [build failed]
```