### PR TITLE
Log Redaction: Use clog for tagging redacted data types

### DIFF
--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -1,6 +1,13 @@
 package base
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/couchbase/clog"
+)
+
+// RedactMetadata is a global toggle for system data redaction.
+var RedactMetadata = false
 
 // Metadata is a type which implements the Redactor interface for logging purposes of metadata.
 //
@@ -15,10 +22,13 @@ import "fmt"
 // - And other couchbase resource specific meta data
 type Metadata string
 
-// Redact is a stub which will eventaully tag or redact data in logs.
+// Redact tags the string with Metadata tags for post-processing.
 func (md Metadata) Redact() string {
-	// FIXME: Stub (#3370)
-	return string(md)
+	if !RedactMetadata {
+		return string(md)
+	}
+	return clog.Tag(clog.MetaData, string(md)).(string)
+
 }
 
 // Compile-time interface check.

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -1,6 +1,13 @@
 package base
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/couchbase/clog"
+)
+
+// RedactSystemData is a global toggle for system data redaction.
+var RedactSystemData = false
 
 // SystemData is a type which implements the Redactor interface for logging purposes of system data.
 //
@@ -12,10 +19,12 @@ import "fmt"
 // - DNS topology
 type SystemData string
 
-// Redact is a stub which will eventaully tag or redact data in logs.
+// Redact tags the string with SystemData tags for post-processing.
 func (sd SystemData) Redact() string {
-	// FIXME: Stub (#3370)
-	return string(sd)
+	if !RedactSystemData {
+		return string(sd)
+	}
+	return clog.Tag(clog.SystemData, string(sd)).(string)
 }
 
 // Compile-time interface check.

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -1,10 +1,9 @@
 package base
 
-import "fmt"
+import (
+	"fmt"
 
-const (
-	userDataPrefix = "<ud>"
-	userDataSuffix = "</ud>"
+	"github.com/couchbase/clog"
 )
 
 // RedactUserData is a global toggle for user data redaction.
@@ -26,7 +25,7 @@ func (ud UserData) Redact() string {
 	if !RedactUserData {
 		return string(ud)
 	}
-	return userDataPrefix + string(ud) + userDataSuffix
+	return clog.Tag(clog.UserData, string(ud)).(string)
 }
 
 // Compile-time interface check.

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -7,14 +7,19 @@ import (
 	assert "github.com/couchbaselabs/go.assert"
 )
 
+const (
+	// This is intentionally brittle (hardcoded redaction tags)
+	// We'd probably want to know if this got changed by accident...
+	userDataPrefix = "<ud>"
+	userDataSuffix = "</ud>"
+)
+
 func TestUserDataRedact(t *testing.T) {
 	username := "alice"
 	userdata := UserData(username)
 
-	// This is intentionally brittle (hardcoded redaction tags)
-	// We'd probably want to know if this changed by accident...
 	RedactUserData = true
-	assert.Equals(t, userdata.Redact(), "<ud>"+username+"</ud>")
+	assert.Equals(t, userdata.Redact(), userDataPrefix+username+userDataSuffix)
 
 	RedactUserData = false
 	assert.Equals(t, userdata.Redact(), username)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -101,7 +101,7 @@
 
   <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="b0907c1dc06bfb60354416769e40bb07b4367d88"/>
 
-  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="ef844635a21403c0a5115bfdbbfb416cc57dae51"/>
+  <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 
   <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
 


### PR DESCRIPTION
We can rely on clog to do the actual tagging of data, but still retain our existing redaction infrastructure. This should allow for redaction changes to come in via clog, and not require changes in SGW.