### PR TITLE
Fix confusing error wrap code

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -91,6 +91,13 @@ func (auth *Authenticator) GetUser(name string) (User, error) {
 		}
 	}
 	princ.(*userImpl).auth = auth
+
+	// Hack to update the expiry value
+	// TODO: it's much more efficient to update the expiry as part of the getPrincipal() call
+	if updateExpiryErr := auth.Save(princ); updateExpiryErr != nil {
+		return princ.(User), updateExpiryErr
+	}
+
 	return princ.(User), err
 }
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -105,6 +105,8 @@ func (auth *Authenticator) GetRole(name string) (Role, error) {
 func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) (Principal, error) {
 	var princ Principal
 
+	// Doing a get as an update because if we do the get and we find that the user has been invalidated
+	// then we need to reload it.
 	err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// Be careful: this block can be invoked multiple times if there are races!
 		if currentValue == nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -227,7 +227,7 @@ func (auth *Authenticator) Save(p Principal) error {
 		return err
 	}
 
-	if err := auth.bucket.Set(p.DocID(), 0, p); err != nil {
+	if err := auth.bucket.Set(p.DocID(), p.GetExpiry(), p); err != nil {
 		return err
 	}
 	if user, ok := p.(User); ok {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -286,12 +286,12 @@ func TestSaveUsersWithExpiry(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf("test"))
-	expiryOffsetSeconds := uint32(1)
-	user.SetExpiry(expiryOffsetSeconds)
+	expiryOffset := time.Second * time.Duration(1)
+	user.SetInactivityExpiryOffset(expiryOffset)
 	err := auth.Save(user)
 	assert.Equals(t, err, nil)
 
-	time.Sleep(time.Second * 2)
+	time.Sleep(expiryOffset * 2)
 
 	// Expect an error trying to get the user, since they should be expired
 	user, err = auth.GetUser("testUser")
@@ -318,8 +318,8 @@ func TestUpdateUsersWithExpiry(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf("test"))
-	expiryOffsetSeconds := uint32(1)
-	user.SetExpiry(expiryOffsetSeconds)
+	expiryOffsetSeconds := time.Second
+	user.SetInactivityExpiryOffset(expiryOffsetSeconds)
 	err := auth.Save(user)
 	assert.Equals(t, err, nil)
 
@@ -357,8 +357,8 @@ func TestGetUsersWithExpiry(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	testUsername := "testUser"
 	user, _ := auth.NewUser(testUsername, "password", ch.SetOf("test"))
-	expiryOffsetSeconds := uint32(1)
-	user.SetExpiry(expiryOffsetSeconds)
+	expiryOffsetSeconds := time.Second
+	user.SetInactivityExpiryOffset(expiryOffsetSeconds)
 	err := auth.Save(user)
 	assert.Equals(t, err, nil)
 
@@ -399,8 +399,8 @@ func TestUserExpiryLargeExpiry(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	testUsername := "testUser"
 	user, _ := auth.NewUser(testUsername, "password", ch.SetOf("test"))
-	expiryOffsetSeconds := uint32(60 * 60 * 24 * 60)  // 60 days
-	user.SetExpiry(expiryOffsetSeconds)
+	expiryOffsetSeconds := time.Second * time.Duration(60 * 60 * 24 * 60)  // 60 days
+	user.SetInactivityExpiryOffset(expiryOffsetSeconds)
 	err := auth.Save(user)
 	assert.Equals(t, err, nil)
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -293,7 +293,7 @@ func TestSaveUsersWithExpiry(t *testing.T) {
 
 	time.Sleep(expiryOffset * 2)
 
-	// Expect an error trying to get the user, since they should be expired
+	// Verify that the user has been deleted since due to idle timeout expiry
 	user, err = auth.GetUser("testUser")
 	log.Printf("user: %+v.  err: %v", user, err)
 	assert.True(t, user == nil)
@@ -324,7 +324,13 @@ func TestUpdateUsersWithExpiry(t *testing.T) {
 	assert.Equals(t, err, nil)
 
 	for i := 0; i < 10; i++ {
+
 		time.Sleep(time.Millisecond * 500)
+
+		user, err = auth.GetUser("testUser")
+		assert.True(t, user != nil)
+		assert.True(t, err == nil)
+
 		// Update user which should extend expiry
 		user.SetPassword(fmt.Sprintf("password-%d", i))
 		err := auth.Save(user)
@@ -363,12 +369,19 @@ func TestGetUsersWithExpiry(t *testing.T) {
 	assert.Equals(t, err, nil)
 
 	for i := 0; i < 10; i++ {
+
 		time.Sleep(time.Millisecond * 500)
+
+		user, err = auth.GetUser("testUser")
+		assert.True(t, user != nil)
+		assert.True(t, err == nil)
+
 		// Update user which should extend expiry
 		getUserResult, getUserErr := auth.GetUser(testUsername)
 		assert.True(t, getUserResult != nil)
 		assert.Equals(t, getUserResult.Name(), user.Name())
 		assert.True(t, getUserErr == nil)
+
 	}
 
 	// Make sure the user hasn't expired, since their expiry should be renewed

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -12,6 +12,7 @@ package auth
 import (
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"time"
 )
 
 // A Principal is an abstract object that can have access to channels.
@@ -63,11 +64,12 @@ type Principal interface {
 	// the guest user, else 403.
 	UnauthError(message string) error
 
-	// Set the expiry of this Principal.  This value interpreted the same way it is for bucket.Set() and other bucket operations
-	SetExpiry(expiry uint32)
+	// Set the inactivity expiry offset of this Principal.  This represents the largest period of inactivity allowed
+	// by this user before it will be automatically deleted via Couchbase Server expiry value on the backing user doc.
+	SetInactivityExpiryOffset(offset time.Duration)
 
-	// Get expiry of this Principal
-	GetExpiry() (expiry uint32)
+	// Get inactivity expiry offset of this Principal.
+	GetInactivityExpiryOffset() (offset time.Duration)
 
 	DocID() string
 	accessViewKey() string

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -63,6 +63,12 @@ type Principal interface {
 	// the guest user, else 403.
 	UnauthError(message string) error
 
+	// Set the expiry of this Principal.  This value interpreted the same way it is for bucket.Set() and other bucket operations
+	SetExpiry(expiry uint32)
+
+	// Get expiry of this Principal
+	GetExpiry() (expiry uint32)
+
 	DocID() string
 	accessViewKey() string
 	validate() error
@@ -135,4 +141,7 @@ type User interface {
 	GetAddedChannels(channels ch.TimedSet) base.Set
 
 	setRolesSince(ch.TimedSet)
+
+
+
 }

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -66,9 +66,11 @@ type Principal interface {
 
 	// Set the inactivity expiry offset of this Principal.  This represents the largest period of inactivity allowed
 	// by this user before it will be automatically deleted via Couchbase Server expiry value on the backing user doc.
+	// If set to 0, then the user will never be deleted due to inactivity.
 	SetInactivityExpiryOffset(offset time.Duration)
 
-	// Get inactivity expiry offset of this Principal.
+	// Get inactivity expiry offset of this Principal.  For users that have an unlimited inactivity (permament users),
+	// this value will be 0.
 	GetInactivityExpiryOffset() (offset time.Duration)
 
 	DocID() string

--- a/auth/role.go
+++ b/auth/role.go
@@ -147,6 +147,15 @@ func (role *roleImpl) validate() error {
 	return role.ExplicitChannels_.Validate()
 }
 
+func (role *roleImpl) SetExpiry(expiry uint32) {
+	base.Warn("SetExpiry() called on role, but is not supported for roles")
+}
+
+func (role *roleImpl) GetExpiry() (expiry uint32) {
+	base.Warn("GetExpiry() called on role, but is not supported for roles.  Return default value of 0")
+	return uint32(0)
+}
+
 //////// CHANNEL AUTHORIZATION:
 
 func (role *roleImpl) UnauthError(message string) error {

--- a/auth/role.go
+++ b/auth/role.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"time"
 )
 
 /** A group that users can belong to, with associated channel permisisons. */
@@ -147,13 +148,13 @@ func (role *roleImpl) validate() error {
 	return role.ExplicitChannels_.Validate()
 }
 
-func (role *roleImpl) SetExpiry(expiry uint32) {
-	base.Warn("SetExpiry() called on role, but is not supported for roles")
+func (role *roleImpl) SetInactivityExpiryOffset(ignored time.Duration) {
+	base.Warn("SetInactivityExpiryOffset() called on role, but is not supported for roles")
 }
 
-func (role *roleImpl) GetExpiry() (expiry uint32) {
-	base.Warn("GetExpiry() called on role, but is not supported for roles.  Return default value of 0")
-	return uint32(0)
+func (role *roleImpl) GetInactivityExpiryOffset() (ignored time.Duration) {
+	base.Warn("GetInactivityExpiryOffset() called on role, but is not supported for roles.  Return default value of 0")
+	return time.Duration(0)
 }
 
 //////// CHANNEL AUTHORIZATION:

--- a/auth/user.go
+++ b/auth/user.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"time"
 )
 
 const kBcryptCostFactor = bcrypt.DefaultCost
@@ -28,9 +29,9 @@ const kBcryptCostFactor = bcrypt.DefaultCost
 type userImpl struct {
 	roleImpl // userImpl "inherits from" Role
 	userImplBody
-	auth   *Authenticator
-	roles  []Role
-	expiry uint32 // The expiry offset in seconds or UTC timestamp when this user will be auto-deleted.
+	auth                   *Authenticator
+	roles                  []Role
+	inactivityExpiryOffset time.Duration // The expiry offset in seconds or UTC timestamp when this user will be auto-deleted.
 }
 
 // Marshalable data is stored in separate struct from userImpl,
@@ -145,12 +146,12 @@ func (user *userImpl) DocID() string {
 	return docIDForUser(user.Name_)
 }
 
-func (user *userImpl) SetExpiry(expiry uint32) {
-	user.expiry = expiry
+func (user *userImpl) SetInactivityExpiryOffset(inactivityExpiryOffset time.Duration) {
+	user.inactivityExpiryOffset = inactivityExpiryOffset
 }
 
-func (user *userImpl) GetExpiry() (expiry uint32) {
-	return user.expiry
+func (user *userImpl) GetInactivityExpiryOffset() (inactivityExpiryOffset time.Duration) {
+	return user.inactivityExpiryOffset
 }
 
 // Key used in 'access' view (not same meaning as doc ID)

--- a/auth/user.go
+++ b/auth/user.go
@@ -28,8 +28,9 @@ const kBcryptCostFactor = bcrypt.DefaultCost
 type userImpl struct {
 	roleImpl // userImpl "inherits from" Role
 	userImplBody
-	auth  *Authenticator
-	roles []Role
+	auth   *Authenticator
+	roles  []Role
+	expiry uint32 // The expiry offset in seconds or UTC timestamp when this user will be auto-deleted.
 }
 
 // Marshalable data is stored in separate struct from userImpl,
@@ -142,6 +143,14 @@ func docIDForUser(username string) string {
 
 func (user *userImpl) DocID() string {
 	return docIDForUser(user.Name_)
+}
+
+func (user *userImpl) SetExpiry(expiry uint32) {
+	user.expiry = expiry
+}
+
+func (user *userImpl) GetExpiry() (expiry uint32) {
+	return user.expiry
 }
 
 // Key used in 'access' view (not same meaning as doc ID)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1373,6 +1373,7 @@ func (bucket CouchbaseBucketGoCB) deleteDocBodyOnly(k string, xattrKey string, c
 
 }
 
+// Update that has the ability to do a retry loop, which can handles retries on CAS failures.
 func (bucket CouchbaseBucketGoCB) Update(k string, exp uint32, callback sgbucket.UpdateFunc) error {
 
 	for {

--- a/db/users.go
+++ b/db/users.go
@@ -162,6 +162,10 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 
 	}
 
+	// Temp hack: set expiry
+	expiryOffsetSeconds := uint32(60)
+	user.SetExpiry(expiryOffsetSeconds)
+
 	// And finally save the Principal:
 	if changed {
 		// Update the persistent sequence number of this principal (only allocate a sequence when needed - issue #673):

--- a/db/users.go
+++ b/db/users.go
@@ -6,6 +6,7 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
+	"time"
 )
 
 // Struct that configures settings of a User/Role, for UpdatePrincipal.
@@ -163,8 +164,8 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 	}
 
 	// Temp hack: set expiry
-	expiryOffsetSeconds := uint32(60)
-	user.SetExpiry(expiryOffsetSeconds)
+	expiryOffsetSeconds := time.Second * time.Duration(60)
+	user.SetInactivityExpiryOffset(expiryOffsetSeconds)
 
 	// And finally save the Principal:
 	if changed {


### PR DESCRIPTION

I stumbled across this code:

```
updatedBytes, marshalErr := json.Marshal(princ)
return updatedBytes, nil, pkgerrors.Wrapf(marshalErr, "Error calling json.Marshal() for doc ID: %s in getPrincipal()", docID)
```

and was confused by the fact that it appeared to be returning an error in the success case.  As it turns out, `pkgerrors.Wrapf` will return `nil` when `marshalErr` is nil.

Also, note that this case seems to have snuck past the log redaction changes in https://github.com/couchbase/sync_gateway/pull/3309 for the auth package.

I threw out a quick PR for discussion .. I think that change would at least make it less confusing that the error returned might be nil.  While I think the error wrapping could provide valuable stack trace context, it will need to be redacted somehow, or the doc id should be removed.