### PR TITLE
Avoid calling pkgerrors.Wrapf() with nil errors, since it's confusing

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -135,7 +135,10 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 		if changed {
 			// Save the updated doc:
 			updatedBytes, marshalErr := json.Marshal(princ)
-			return updatedBytes, nil, pkgerrors.Wrapf(marshalErr, "Error calling json.Marshal() for doc ID: %s in getPrincipal()", docID)
+			if marshalErr != nil {
+				marshalErr = pkgerrors.Wrapf(marshalErr, "Error calling json.Marshal() for doc ID: %s in getPrincipal()", docID)
+			}
+			return updatedBytes, nil, marshalErr
 		} else {
 			// Principal is valid, so stop the update
 			return nil, nil, couchbase.UpdateCancel


### PR DESCRIPTION
I stumbled across this code:

```
updatedBytes, marshalErr := json.Marshal(princ)
return updatedBytes, nil, pkgerrors.Wrapf(marshalErr, "Error calling json.Marshal() for doc ID: %s in getPrincipal()", docID)
```

and was confused by the fact that it appeared to be returning an error in the success case.  As it turns out, `pkgerrors.Wrapf` will return `nil` when `marshalErr` is nil.

Also, note that this case seems to have snuck past the log redaction changes in https://github.com/couchbase/sync_gateway/pull/3309 for the auth package.

I threw out a quick PR for discussion .. I think that change would at least make it less confusing that the error returned might be nil.  While I think the error wrapping could provide valuable stack trace context, it will need to be redacted somehow, or the doc id should be removed.