### PR TITLE
Adds a configuration option to prevent sending of WWW-Authenticate header

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -82,21 +82,22 @@ type DatabaseContext struct {
 }
 
 type DatabaseContextOptions struct {
-	CacheOptions          *CacheOptions
-	IndexOptions          *ChannelIndexOptions
-	SequenceHashOptions   *SequenceHashOptions
-	RevisionCacheCapacity uint32
-	OldRevExpirySeconds   uint32
-	AdminInterface        *string
-	UnsupportedOptions    UnsupportedOptions
-	TrackDocs             bool // Whether doc tracking channel should be created (used for autoImport, shadowing)
-	OIDCOptions           *auth.OIDCOptions
-	DBOnlineCallback      DBOnlineCallback // Callback function to take the DB back online
-	ImportOptions         ImportOptions
-	EnableXattr           bool   // Use xattr for _sync
-	LocalDocExpirySecs    uint32 // The _local doc expiry time in seconds
-	SessionCookieName     string // Pass-through DbConfig.SessionCookieName
-	AllowConflicts        *bool  // False forbids creating conflicts
+	CacheOptions               *CacheOptions
+	IndexOptions               *ChannelIndexOptions
+	SequenceHashOptions        *SequenceHashOptions
+	RevisionCacheCapacity      uint32
+	OldRevExpirySeconds        uint32
+	AdminInterface             *string
+	UnsupportedOptions         UnsupportedOptions
+	TrackDocs                  bool // Whether doc tracking channel should be created (used for autoImport, shadowing)
+	OIDCOptions                *auth.OIDCOptions
+	DBOnlineCallback           DBOnlineCallback // Callback function to take the DB back online
+	ImportOptions              ImportOptions
+	EnableXattr                bool   // Use xattr for _sync
+	LocalDocExpirySecs         uint32 // The _local doc expiry time in seconds
+	SessionCookieName          string // Pass-through DbConfig.SessionCookieName
+	AllowConflicts             *bool  // False forbids creating conflicts
+	SendWWWAuthenticateHeader  *bool  // False disables setting of 'WWW-Authenticate' header
 }
 
 type OidcTestProviderOptions struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -80,6 +80,7 @@ type ServerConfig struct {
 	MaxIncomingConnections         *int                     `json:",omitempty"`            // Max # of incoming HTTP connections to accept
 	MaxFileDescriptors             *uint64                  `json:",omitempty"`            // Max # of open file descriptors (RLIMIT_NOFILE)
 	CompressResponses              *bool                    `json:",omitempty"`            // If false, disables compression of HTTP responses
+	SendWWWAuthenticateHeader      *bool                    `json:",omitempty"`            // If false, disables setting of 'WWW-Authenticate' header in 401 responses
 	Databases                      DbConfigMap              `json:",omitempty"`            // Pre-configured databases, mapped by name
 	Replications                   []*ReplicationConfig     `json:",omitempty"`
 	MaxHeartbeat                   uint64                   `json:",omitempty"`                        // Max heartbeat value for _changes request (seconds)

--- a/rest/config.go
+++ b/rest/config.go
@@ -83,7 +83,6 @@ type ServerConfig struct {
 	MaxIncomingConnections         *int                     `json:",omitempty"`            // Max # of incoming HTTP connections to accept
 	MaxFileDescriptors             *uint64                  `json:",omitempty"`            // Max # of open file descriptors (RLIMIT_NOFILE)
 	CompressResponses              *bool                    `json:",omitempty"`            // If false, disables compression of HTTP responses
-	SendWWWAuthenticateHeader      *bool                    `json:",omitempty"`            // If false, disables setting of 'WWW-Authenticate' header in 401 responses
 	Databases                      DbConfigMap              `json:",omitempty"`            // Pre-configured databases, mapped by name
 	Replications                   []*ReplicationConfig     `json:",omitempty"`
 	MaxHeartbeat                   uint64                   `json:",omitempty"`                        // Max heartbeat value for _changes request (seconds)

--- a/rest/config.go
+++ b/rest/config.go
@@ -114,29 +114,30 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                 string                         `json:"name,omitempty"`                        // Database name in REST API (stored as key in JSON)
-	Sync                 *string                        `json:"sync,omitempty"`                        // Sync function defines which users can see which data
-	Users                map[string]*db.PrincipalConfig `json:"users,omitempty"`                       // Initial user accounts
-	Roles                map[string]*db.PrincipalConfig `json:"roles,omitempty"`                       // Initial roles
-	RevsLimit            *uint32                        `json:"revs_limit,omitempty"`                  // Max depth a document's revision tree can grow to
-	ImportDocs           interface{}                    `json:"import_docs,omitempty"`                 // false, true, or "continuous"
-	ImportFilter         *string                        `json:"import_filter,omitempty"`               // Filter function (import)
-	Shadow               *ShadowConfig                  `json:"shadow,omitempty"`                      // External bucket to shadow
-	EventHandlers        interface{}                    `json:"event_handlers,omitempty"`              // Event handlers (webhook)
-	FeedType             string                         `json:"feed_type,omitempty"`                   // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword   bool                           `json:"allow_empty_password,omitempty"`        // Allow empty passwords?  Defaults to false
-	CacheConfig          *CacheConfig                   `json:"cache,omitempty"`                       // Cache settings
-	ChannelIndex         *ChannelIndexConfig            `json:"channel_index,omitempty"`               // Channel index settings
-	RevCacheSize         *uint32                        `json:"rev_cache_size,omitempty"`              // Maximum number of revisions to store in the revision cache
-	StartOffline         bool                           `json:"offline,omitempty"`                     // start the DB in the offline state, defaults to false
-	Unsupported          db.UnsupportedOptions          `json:"unsupported,omitempty"`                 // Config for unsupported features
-	OIDCConfig           *auth.OIDCOptions              `json:"oidc,omitempty"`                        // Config properties for OpenID Connect authentication
-	OldRevExpirySeconds  *uint32                        `json:"old_rev_expiry_seconds,omitempty"`      // The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs *uint32                        `json:"view_query_timeout_secs,omitempty"`     // The view query timeout in seconds
-	LocalDocExpirySecs   *uint32                        `json:"local_doc_expiry_secs,omitempty"`       // The _local doc expiry time in seconds
-	EnableXattrs         *bool                          `json:"enable_shared_bucket_access,omitempty"` // Whether to use extended attributes to store _sync metadata
-	SessionCookieName    string                         `json:"session_cookie_name"`                   // Custom per-database session cookie name
-	AllowConflicts       *bool                          `json:"allow_conflicts,omitempty"`             // False forbids creating conflicts
+	Name                      string                         `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
+	Sync                      *string                        `json:"sync,omitempty"`                         // Sync function defines which users can see which data
+	Users                     map[string]*db.PrincipalConfig `json:"users,omitempty"`                        // Initial user accounts
+	Roles                     map[string]*db.PrincipalConfig `json:"roles,omitempty"`                        // Initial roles
+	RevsLimit                 *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
+	ImportDocs                interface{}                    `json:"import_docs,omitempty"`                  // false, true, or "continuous"
+	ImportFilter              *string                        `json:"import_filter,omitempty"`                // Filter function (import)
+	Shadow                    *ShadowConfig                  `json:"shadow,omitempty"`                       // External bucket to shadow
+	EventHandlers             interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
+	FeedType                  string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword        bool                           `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
+	CacheConfig               *CacheConfig                   `json:"cache,omitempty"`                        // Cache settings
+	ChannelIndex              *ChannelIndexConfig            `json:"channel_index,omitempty"`                // Channel index settings
+	RevCacheSize              *uint32                        `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache
+	StartOffline              bool                           `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
+	Unsupported               db.UnsupportedOptions          `json:"unsupported,omitempty"`                  // Config for unsupported features
+	OIDCConfig                *auth.OIDCOptions              `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds       *uint32                        `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs      *uint32                        `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
+	LocalDocExpirySecs        *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
+	EnableXattrs              *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
+	SessionCookieName         string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
+	AllowConflicts            *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
+	SendWWWAuthenticateHeader *bool                          `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
 }
 
 type DbConfigMap map[string]*DbConfig

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -331,7 +331,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 		h.user = context.Authenticator().AuthenticateUser(userName, password)
 		if h.user == nil {
 			base.LogfR("HTTP auth failed for username=%q", base.UD(userName))
-			if h.server.config.SendWWWAuthenticateHeader == nil || *h.server.config.SendWWWAuthenticateHeader {
+			if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
 				h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
 			}
 			return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
@@ -352,7 +352,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 		return err
 	}
 	if h.privs == regularPrivs && h.user.Disabled() {
-		if h.server.config.SendWWWAuthenticateHeader == nil || *h.server.config.SendWWWAuthenticateHeader {
+		if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
 			h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
 		}
 		return base.HTTPErrorf(http.StatusUnauthorized, "Login required")

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -331,7 +331,9 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 		h.user = context.Authenticator().AuthenticateUser(userName, password)
 		if h.user == nil {
 			base.LogfR("HTTP auth failed for username=%q", base.UD(userName))
-			h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
+			if h.server.config.SendWWWAuthenticateHeader == nil || *h.server.config.SendWWWAuthenticateHeader {
+				h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
+			}
 			return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 		}
 		return nil
@@ -350,7 +352,9 @@ func (h *handler) checkAuth(context *db.DatabaseContext) error {
 		return err
 	}
 	if h.privs == regularPrivs && h.user.Disabled() {
-		h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
+		if h.server.config.SendWWWAuthenticateHeader == nil || *h.server.config.SendWWWAuthenticateHeader {
+			h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
+		}
 		return base.HTTPErrorf(http.StatusUnauthorized, "Login required")
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -548,21 +548,22 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	contextOptions := db.DatabaseContextOptions{
-		CacheOptions:          &cacheOptions,
-		IndexOptions:          channelIndexOptions,
-		SequenceHashOptions:   sequenceHashOptions,
-		RevisionCacheCapacity: revCacheSize,
-		OldRevExpirySeconds:   oldRevExpirySeconds,
-		LocalDocExpirySecs:    localDocExpirySecs,
-		AdminInterface:        sc.config.AdminInterface,
-		UnsupportedOptions:    config.Unsupported,
-		TrackDocs:             trackDocs,
-		OIDCOptions:           config.OIDCConfig,
-		DBOnlineCallback:      dbOnlineCallback,
-		ImportOptions:         importOptions,
-		EnableXattr:           config.UseXattrs(),
-		SessionCookieName:     config.SessionCookieName,
-		AllowConflicts:        config.ConflictsAllowed(),
+		CacheOptions:              &cacheOptions,
+		IndexOptions:              channelIndexOptions,
+		SequenceHashOptions:       sequenceHashOptions,
+		RevisionCacheCapacity:     revCacheSize,
+		OldRevExpirySeconds:       oldRevExpirySeconds,
+		LocalDocExpirySecs:        localDocExpirySecs,
+		AdminInterface:            sc.config.AdminInterface,
+		UnsupportedOptions:        config.Unsupported,
+		TrackDocs:                 trackDocs,
+		OIDCOptions:               config.OIDCConfig,
+		DBOnlineCallback:          dbOnlineCallback,
+		ImportOptions:             importOptions,
+		EnableXattr:               config.UseXattrs(),
+		SessionCookieName:         config.SessionCookieName,
+		AllowConflicts:            config.ConflictsAllowed(),
+		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
 	}
 
 	// Create the DB Context


### PR DESCRIPTION
Adds an optional configuration flag to optionally omit the inclusion of a WWW-Authenticate header in authentication error cases. The default behaviour is unchanged.

This is made necessary by the fixed behaviour of browsers on encountering WWW-Authenticate (https://stackoverflow.com/a/37919017/504931), which is not compatible with the use of Sync Gateway from a web browser client (auth popup is not something we want on hitting for example an expired session cookie – will want our own clientside logic to handle that case).