### PR TITLE
Logging: #3365 Add new Log Levels implementation

### DIFF
--- a/base/log_level.go
+++ b/base/log_level.go
@@ -50,10 +50,17 @@ func (l *LogLevel) MarshalText() (text []byte, err error) {
 	if l == nil {
 		return nil, errors.New("invalid log level")
 	}
-	return []byte(LogLevelName(*l)), nil
+	name := LogLevelName(*l)
+	if name == "" {
+		return nil, fmt.Errorf("unrecognized log level: %v (valid range: %d-%d)", *l, 0, levelCount-1)
+	}
+	return []byte(name), nil
 }
 
 func (l *LogLevel) UnmarshalText(text []byte) error {
+	if l == nil {
+		return errors.New("invalid log level")
+	}
 	for i, name := range logLevelNames {
 		if name == string(text) {
 			l.Set(LogLevel(i))

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"errors"
+	"fmt"
 	"sync/atomic"
 )
 
@@ -21,18 +22,17 @@ const (
 	LEVEL_DEBUG
 )
 
-var (
-	logLevelNames = []string{"none", "error", "warn", "info", "debug"}
-
-	ErrInvalidLogLevel = errors.New("invalid log level")
-)
+var logLevelNames = []string{"none", "error", "warn", "info", "debug"}
 
 func (l *LogLevel) Set(newLevel LogLevel) {
 	atomic.StoreUint32((*uint32)(l), uint32(newLevel))
 }
 
-// Enabled returns true if the log key is enabled.
+// Enabled returns true if the log level is enabled.
 func (l *LogLevel) Enabled(logLevel LogLevel) bool {
+	if l == nil {
+		return false
+	}
 	return atomic.LoadUint32((*uint32)(l)) >= uint32(logLevel)
 }
 
@@ -44,7 +44,7 @@ func LogLevelName(logLevel LogLevel) string {
 
 func (l *LogLevel) MarshalText() (text []byte, err error) {
 	if l == nil {
-		return nil, ErrInvalidLogLevel
+		return nil, errors.New("invalid log level")
 	}
 	return []byte(LogLevelName(*l)), nil
 }
@@ -56,5 +56,5 @@ func (l *LogLevel) UnmarshalText(text []byte) error {
 			return nil
 		}
 	}
-	return ErrInvalidLogLevel
+	return fmt.Errorf("unrecognized log level: %q (valid options: %v)", string(text), logLevelNames)
 }

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -56,7 +56,7 @@ func (l *LogLevel) MarshalText() (text []byte, err error) {
 func (l *LogLevel) UnmarshalText(text []byte) error {
 	for i, name := range logLevelNames {
 		if name == string(text) {
-			*l = LogLevel(i)
+			l.Set(LogLevel(i))
 			return nil
 		}
 	}

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -24,7 +24,10 @@ const (
 	levelCount
 )
 
-var logLevelNames = []string{"none", "error", "warn", "info", "debug"}
+var (
+	logLevelNames      = []string{"none", "error", "warn", "info", "debug"}
+	logLevelNamesPrint = []string{"NON", "ERR", "WRN", "INF", "DBG"}
+)
 
 func (l *LogLevel) Set(newLevel LogLevel) {
 	atomic.StoreUint32((*uint32)(l), uint32(newLevel))
@@ -38,12 +41,20 @@ func (l *LogLevel) Enabled(logLevel LogLevel) bool {
 	return atomic.LoadUint32((*uint32)(l)) >= uint32(logLevel)
 }
 
-// LogLevelName returns the string representation of a log level.
+// LogLevelName returns the string representation of a log level (e.g. "debug" or "warn")
 func LogLevelName(logLevel LogLevel) string {
 	if int(logLevel) >= len(logLevelNames) {
 		return ""
 	}
 	return logLevelNames[logLevel]
+}
+
+// logLevelNamePrint returns the string value to print for a log level (e.g. "DBG" or "WRN")
+func logLevelNamePrint(logLevel LogLevel) string {
+	if int(logLevel) >= len(logLevelNames) {
+		return ""
+	}
+	return logLevelNamesPrint[logLevel]
 }
 
 func (l *LogLevel) MarshalText() (text []byte, err error) {

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -10,16 +10,16 @@ import (
 type LogLevel uint32
 
 const (
-	// LEVEL_NONE disables all logging
-	LEVEL_NONE LogLevel = iota
-	// LEVEL_ERROR enables only error logging.
-	LEVEL_ERROR
-	// LEVEL_WARN enables warn, and error logging.
-	LEVEL_WARN
-	// LEVEL_INFO enables info, warn, and error logging.
-	LEVEL_INFO
-	// LEVEL_DEBUG enables all logging.
-	LEVEL_DEBUG
+	// LevelNone disables all logging
+	LevelNone LogLevel = iota
+	// LevelError enables only error logging.
+	LevelError
+	// LevelWarn enables warn, and error logging.
+	LevelWarn
+	// LevelInfo enables info, warn, and error logging.
+	LevelInfo
+	// LevelDebug enables all logging.
+	LevelDebug
 )
 
 var logLevelNames = []string{"none", "error", "warn", "info", "debug"}

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -1,0 +1,60 @@
+package base
+
+import (
+	"errors"
+	"sync/atomic"
+)
+
+// LogLevel is used to represent a log level.
+type LogLevel uint32
+
+const (
+	// LEVEL_NONE disables all logging
+	LEVEL_NONE LogLevel = iota
+	// LEVEL_ERROR enables only error logging.
+	LEVEL_ERROR
+	// LEVEL_WARN enables warn, and error logging.
+	LEVEL_WARN
+	// LEVEL_INFO enables info, warn, and error logging.
+	LEVEL_INFO
+	// LEVEL_DEBUG enables all logging.
+	LEVEL_DEBUG
+)
+
+var (
+	logLevelNames = []string{"none", "error", "warn", "info", "debug"}
+
+	ErrInvalidLogLevel = errors.New("invalid log level")
+)
+
+func (l *LogLevel) Set(newLevel LogLevel) {
+	atomic.StoreUint32((*uint32)(l), uint32(newLevel))
+}
+
+// Enabled returns true if the log key is enabled.
+func (l *LogLevel) Enabled(logLevel LogLevel) bool {
+	return atomic.LoadUint32((*uint32)(l)) >= uint32(logLevel)
+}
+
+// LogLevelName returns the string representation of a log level.
+func LogLevelName(logLevel LogLevel) string {
+	// No lock required to read concurrently, as long as nobody writes to logLevelNames.
+	return logLevelNames[logLevel]
+}
+
+func (l *LogLevel) MarshalText() (text []byte, err error) {
+	if l == nil {
+		return nil, ErrInvalidLogLevel
+	}
+	return []byte(LogLevelName(*l)), nil
+}
+
+func (l *LogLevel) UnmarshalText(text []byte) error {
+	for i, name := range logLevelNames {
+		if name == string(text) {
+			*l = LogLevel(i)
+			return nil
+		}
+	}
+	return ErrInvalidLogLevel
+}

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -20,6 +20,8 @@ const (
 	LevelInfo
 	// LevelDebug enables all logging.
 	LevelDebug
+
+	levelCount
 )
 
 var logLevelNames = []string{"none", "error", "warn", "info", "debug"}
@@ -38,7 +40,9 @@ func (l *LogLevel) Enabled(logLevel LogLevel) bool {
 
 // LogLevelName returns the string representation of a log level.
 func LogLevelName(logLevel LogLevel) string {
-	// No lock required to read concurrently, as long as nobody writes to logLevelNames.
+	if int(logLevel) >= len(logLevelNames) {
+		return ""
+	}
 	return logLevelNames[logLevel]
 }
 

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -48,51 +49,36 @@ func TestLogLevelNames(t *testing.T) {
 }
 
 func TestLogLevelText(t *testing.T) {
+	for i := LogLevel(0); i < levelCount; i++ {
+		t.Run(fmt.Sprintf("LogLevel: %v", i), func(ts *testing.T) {
+			text, err := i.MarshalText()
+			assert.Equals(ts, err, nil)
+			assert.Equals(ts, string(text), LogLevelName(i))
+
+			var logLevel LogLevel
+			err = logLevel.UnmarshalText(text)
+			assert.Equals(ts, err, nil)
+			assert.Equals(ts, logLevel, i)
+		})
+	}
+
+	// nil pointer recievers
 	var logLevelPtr *LogLevel
-	text, err := logLevelPtr.MarshalText()
+	_, err := logLevelPtr.MarshalText()
 	assert.Equals(t, err.Error(), "invalid log level")
-	err = logLevelPtr.UnmarshalText(text)
+	err = logLevelPtr.UnmarshalText([]byte("none"))
+	assert.Equals(t, err.Error(), "invalid log level")
+
+	// Invalid values
+	var logLevel = LogLevel(math.MaxUint32)
+	text, err := logLevel.MarshalText()
 	assert.NotEquals(t, err, nil)
+	assert.Equals(t, string(text), "")
 
-	var logLevel LogLevel
-	text, err = logLevel.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "none")
-	err = logLevel.UnmarshalText(text)
-	assert.Equals(t, err, nil)
+	logLevel = LevelNone
+	err = logLevel.UnmarshalText([]byte(""))
+	assert.NotEquals(t, err, nil)
 	assert.Equals(t, logLevel, LevelNone)
-
-	logLevel.Set(LevelDebug)
-	text, err = logLevel.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "debug")
-	err = logLevel.UnmarshalText(text)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LevelDebug)
-
-	logLevel.Set(LevelInfo)
-	text, err = logLevel.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "info")
-	err = logLevel.UnmarshalText(text)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LevelInfo)
-
-	logLevel.Set(LevelWarn)
-	text, err = logLevel.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "warn")
-	err = logLevel.UnmarshalText(text)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LevelWarn)
-
-	logLevel.Set(LevelError)
-	text, err = logLevel.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "error")
-	err = logLevel.UnmarshalText(text)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LevelError)
 }
 
 func TestLogLevelConcurrency(t *testing.T) {

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -143,15 +143,20 @@ func BenchmarkLogLevelName(b *testing.B) {
 }
 
 func BenchmarkLogLevelEnabled(b *testing.B) {
-	logLevel := LevelInfo
-	benchmarkLogLevelEnabled(b, "Hit", LevelError, logLevel)
-	benchmarkLogLevelEnabled(b, "Miss", LevelDebug, logLevel)
-}
+	var tests = []struct {
+		Name         string
+		TestLogLevel LogLevel
+		SetLogLevel  LogLevel
+	}{
+		{"Hit", LevelError, LevelInfo},
+		{"Miss", LevelDebug, LevelInfo},
+	}
 
-func benchmarkLogLevelEnabled(b *testing.B, name string, l LogLevel, logLevel LogLevel) {
-	b.Run(name, func(bn *testing.B) {
-		for i := 0; i < bn.N; i++ {
-			logLevel.Enabled(l)
-		}
-	})
+	for _, t := range tests {
+		b.Run(t.Name, func(bn *testing.B) {
+			for i := 0; i < bn.N; i++ {
+				t.SetLogLevel.Enabled(t.TestLogLevel)
+			}
+		})
+	}
 }

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -8,6 +8,12 @@ import (
 )
 
 func TestLogLevel(t *testing.T) {
+	var logLevelPtr *LogLevel
+	assert.False(t, logLevelPtr.Enabled(LEVEL_DEBUG))
+	assert.False(t, logLevelPtr.Enabled(LEVEL_INFO))
+	assert.False(t, logLevelPtr.Enabled(LEVEL_WARN))
+	assert.False(t, logLevelPtr.Enabled(LEVEL_ERROR))
+
 	logLevel := LEVEL_NONE
 	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
 	assert.False(t, logLevel.Enabled(LEVEL_INFO))
@@ -36,30 +42,51 @@ func TestLogLevelNames(t *testing.T) {
 }
 
 func TestLogLevelText(t *testing.T) {
+	var logLevelPtr *LogLevel
+	text, err := logLevelPtr.MarshalText()
+	assert.Equals(t, err.Error(), "invalid log level")
+	err = logLevelPtr.UnmarshalText(text)
+	assert.NotEquals(t, err, nil)
+
 	var logLevel LogLevel
-	text, err := logLevel.MarshalText()
+	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "none")
+	err = logLevel.UnmarshalText(text)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, logLevel, LEVEL_NONE)
 
 	logLevel.Set(LEVEL_DEBUG)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "debug")
+	err = logLevel.UnmarshalText(text)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, logLevel, LEVEL_DEBUG)
 
 	logLevel.Set(LEVEL_INFO)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "info")
+	err = logLevel.UnmarshalText(text)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, logLevel, LEVEL_INFO)
 
 	logLevel.Set(LEVEL_WARN)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "warn")
+	err = logLevel.UnmarshalText(text)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, logLevel, LEVEL_WARN)
 
 	logLevel.Set(LEVEL_ERROR)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "error")
+	err = logLevel.UnmarshalText(text)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, logLevel, LEVEL_ERROR)
 }
 
 func TestLogLevelConcurrency(t *testing.T) {

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -34,11 +35,16 @@ func TestLogLevel(t *testing.T) {
 }
 
 func TestLogLevelNames(t *testing.T) {
+	// Ensure number of level constants, and names match.
+	assert.Equals(t, len(logLevelNames), int(levelCount))
+
 	assert.Equals(t, LogLevelName(LevelNone), "none")
 	assert.Equals(t, LogLevelName(LevelError), "error")
 	assert.Equals(t, LogLevelName(LevelInfo), "info")
 	assert.Equals(t, LogLevelName(LevelWarn), "warn")
 	assert.Equals(t, LogLevelName(LevelDebug), "debug")
+
+	assert.Equals(t, LogLevelName(math.MaxUint32), "")
 }
 
 func TestLogLevelText(t *testing.T) {

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -9,36 +9,36 @@ import (
 
 func TestLogLevel(t *testing.T) {
 	var logLevelPtr *LogLevel
-	assert.False(t, logLevelPtr.Enabled(LEVEL_DEBUG))
-	assert.False(t, logLevelPtr.Enabled(LEVEL_INFO))
-	assert.False(t, logLevelPtr.Enabled(LEVEL_WARN))
-	assert.False(t, logLevelPtr.Enabled(LEVEL_ERROR))
+	assert.False(t, logLevelPtr.Enabled(LevelDebug))
+	assert.False(t, logLevelPtr.Enabled(LevelInfo))
+	assert.False(t, logLevelPtr.Enabled(LevelWarn))
+	assert.False(t, logLevelPtr.Enabled(LevelError))
 
-	logLevel := LEVEL_NONE
-	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
-	assert.False(t, logLevel.Enabled(LEVEL_INFO))
-	assert.False(t, logLevel.Enabled(LEVEL_WARN))
-	assert.False(t, logLevel.Enabled(LEVEL_ERROR))
+	logLevel := LevelNone
+	assert.False(t, logLevel.Enabled(LevelDebug))
+	assert.False(t, logLevel.Enabled(LevelInfo))
+	assert.False(t, logLevel.Enabled(LevelWarn))
+	assert.False(t, logLevel.Enabled(LevelError))
 
-	logLevel.Set(LEVEL_INFO)
-	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
-	assert.True(t, logLevel.Enabled(LEVEL_INFO))
-	assert.True(t, logLevel.Enabled(LEVEL_WARN))
-	assert.True(t, logLevel.Enabled(LEVEL_ERROR))
+	logLevel.Set(LevelInfo)
+	assert.False(t, logLevel.Enabled(LevelDebug))
+	assert.True(t, logLevel.Enabled(LevelInfo))
+	assert.True(t, logLevel.Enabled(LevelWarn))
+	assert.True(t, logLevel.Enabled(LevelError))
 
-	logLevel.Set(LEVEL_WARN)
-	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
-	assert.False(t, logLevel.Enabled(LEVEL_INFO))
-	assert.True(t, logLevel.Enabled(LEVEL_WARN))
-	assert.True(t, logLevel.Enabled(LEVEL_ERROR))
+	logLevel.Set(LevelWarn)
+	assert.False(t, logLevel.Enabled(LevelDebug))
+	assert.False(t, logLevel.Enabled(LevelInfo))
+	assert.True(t, logLevel.Enabled(LevelWarn))
+	assert.True(t, logLevel.Enabled(LevelError))
 }
 
 func TestLogLevelNames(t *testing.T) {
-	assert.Equals(t, LogLevelName(LEVEL_NONE), "none")
-	assert.Equals(t, LogLevelName(LEVEL_DEBUG), "debug")
-	assert.Equals(t, LogLevelName(LEVEL_INFO), "info")
-	assert.Equals(t, LogLevelName(LEVEL_WARN), "warn")
-	assert.Equals(t, LogLevelName(LEVEL_ERROR), "error")
+	assert.Equals(t, LogLevelName(LevelNone), "none")
+	assert.Equals(t, LogLevelName(LevelError), "error")
+	assert.Equals(t, LogLevelName(LevelInfo), "info")
+	assert.Equals(t, LogLevelName(LevelWarn), "warn")
+	assert.Equals(t, LogLevelName(LevelDebug), "debug")
 }
 
 func TestLogLevelText(t *testing.T) {
@@ -54,50 +54,50 @@ func TestLogLevelText(t *testing.T) {
 	assert.Equals(t, string(text), "none")
 	err = logLevel.UnmarshalText(text)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LEVEL_NONE)
+	assert.Equals(t, logLevel, LevelNone)
 
-	logLevel.Set(LEVEL_DEBUG)
+	logLevel.Set(LevelDebug)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "debug")
 	err = logLevel.UnmarshalText(text)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LEVEL_DEBUG)
+	assert.Equals(t, logLevel, LevelDebug)
 
-	logLevel.Set(LEVEL_INFO)
+	logLevel.Set(LevelInfo)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "info")
 	err = logLevel.UnmarshalText(text)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LEVEL_INFO)
+	assert.Equals(t, logLevel, LevelInfo)
 
-	logLevel.Set(LEVEL_WARN)
+	logLevel.Set(LevelWarn)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "warn")
 	err = logLevel.UnmarshalText(text)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LEVEL_WARN)
+	assert.Equals(t, logLevel, LevelWarn)
 
-	logLevel.Set(LEVEL_ERROR)
+	logLevel.Set(LevelError)
 	text, err = logLevel.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "error")
 	err = logLevel.UnmarshalText(text)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, logLevel, LEVEL_ERROR)
+	assert.Equals(t, logLevel, LevelError)
 }
 
 func TestLogLevelConcurrency(t *testing.T) {
-	logLevel := LEVEL_WARN
+	logLevel := LevelWarn
 	stop := make(chan struct{})
 
 	go func() {
 		for {
 			select {
 			default:
-				logLevel.Set(LEVEL_ERROR)
+				logLevel.Set(LevelError)
 			case <-stop:
 				return
 			}
@@ -108,7 +108,7 @@ func TestLogLevelConcurrency(t *testing.T) {
 		for {
 			select {
 			default:
-				logLevel.Set(LEVEL_DEBUG)
+				logLevel.Set(LevelDebug)
 			case <-stop:
 				return
 			}
@@ -119,7 +119,7 @@ func TestLogLevelConcurrency(t *testing.T) {
 		for {
 			select {
 			default:
-				_ = logLevel.Enabled(LEVEL_WARN)
+				_ = logLevel.Enabled(LevelWarn)
 			case <-stop:
 				return
 			}
@@ -132,14 +132,14 @@ func TestLogLevelConcurrency(t *testing.T) {
 
 func BenchmarkLogLevelName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = LogLevelName(LEVEL_WARN)
+		_ = LogLevelName(LevelWarn)
 	}
 }
 
 func BenchmarkLogLevelEnabled(b *testing.B) {
-	logLevel := LEVEL_INFO
-	benchmarkLogLevelEnabled(b, "Hit", LEVEL_ERROR, logLevel)
-	benchmarkLogLevelEnabled(b, "Miss", LEVEL_DEBUG, logLevel)
+	logLevel := LevelInfo
+	benchmarkLogLevelEnabled(b, "Hit", LevelError, logLevel)
+	benchmarkLogLevelEnabled(b, "Miss", LevelDebug, logLevel)
 }
 
 func benchmarkLogLevelEnabled(b *testing.B, name string, l LogLevel, logLevel LogLevel) {

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -1,0 +1,124 @@
+package base
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/couchbaselabs/go.assert"
+)
+
+func TestLogLevel(t *testing.T) {
+	logLevel := LEVEL_NONE
+	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
+	assert.False(t, logLevel.Enabled(LEVEL_INFO))
+	assert.False(t, logLevel.Enabled(LEVEL_WARN))
+	assert.False(t, logLevel.Enabled(LEVEL_ERROR))
+
+	logLevel.Set(LEVEL_INFO)
+	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
+	assert.True(t, logLevel.Enabled(LEVEL_INFO))
+	assert.True(t, logLevel.Enabled(LEVEL_WARN))
+	assert.True(t, logLevel.Enabled(LEVEL_ERROR))
+
+	logLevel.Set(LEVEL_WARN)
+	assert.False(t, logLevel.Enabled(LEVEL_DEBUG))
+	assert.False(t, logLevel.Enabled(LEVEL_INFO))
+	assert.True(t, logLevel.Enabled(LEVEL_WARN))
+	assert.True(t, logLevel.Enabled(LEVEL_ERROR))
+}
+
+func TestLogLevelNames(t *testing.T) {
+	assert.Equals(t, LogLevelName(LEVEL_NONE), "none")
+	assert.Equals(t, LogLevelName(LEVEL_DEBUG), "debug")
+	assert.Equals(t, LogLevelName(LEVEL_INFO), "info")
+	assert.Equals(t, LogLevelName(LEVEL_WARN), "warn")
+	assert.Equals(t, LogLevelName(LEVEL_ERROR), "error")
+}
+
+func TestLogLevelText(t *testing.T) {
+	var logLevel LogLevel
+	text, err := logLevel.MarshalText()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, string(text), "none")
+
+	logLevel.Set(LEVEL_DEBUG)
+	text, err = logLevel.MarshalText()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, string(text), "debug")
+
+	logLevel.Set(LEVEL_INFO)
+	text, err = logLevel.MarshalText()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, string(text), "info")
+
+	logLevel.Set(LEVEL_WARN)
+	text, err = logLevel.MarshalText()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, string(text), "warn")
+
+	logLevel.Set(LEVEL_ERROR)
+	text, err = logLevel.MarshalText()
+	assert.Equals(t, err, nil)
+	assert.Equals(t, string(text), "error")
+}
+
+func TestLogLevelConcurrency(t *testing.T) {
+	logLevel := LEVEL_WARN
+	stop := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			default:
+				logLevel.Set(LEVEL_ERROR)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			default:
+				logLevel.Set(LEVEL_DEBUG)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			default:
+				_ = logLevel.Enabled(LEVEL_WARN)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	time.Sleep(time.Millisecond * 100)
+	stop <- struct{}{}
+}
+
+func BenchmarkLogLevelName(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = LogLevelName(LEVEL_WARN)
+	}
+}
+
+func BenchmarkLogLevelEnabled(b *testing.B) {
+	logLevel := LEVEL_INFO
+	benchmarkLogLevelEnabled(b, "Hit", LEVEL_ERROR, logLevel)
+	benchmarkLogLevelEnabled(b, "Miss", LEVEL_DEBUG, logLevel)
+}
+
+func benchmarkLogLevelEnabled(b *testing.B, name string, l LogLevel, logLevel LogLevel) {
+	b.Run(name, func(bn *testing.B) {
+		for i := 0; i < bn.N; i++ {
+			logLevel.Enabled(l)
+		}
+	})
+}

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -9,30 +9,43 @@ import (
 	assert "github.com/couchbaselabs/go.assert"
 )
 
+// Tests the cascading behaviour of log levels.
 func TestLogLevel(t *testing.T) {
 	var logLevelPtr *LogLevel
-	assert.False(t, logLevelPtr.Enabled(LevelDebug))
-	assert.False(t, logLevelPtr.Enabled(LevelInfo))
-	assert.False(t, logLevelPtr.Enabled(LevelWarn))
 	assert.False(t, logLevelPtr.Enabled(LevelError))
+	assert.False(t, logLevelPtr.Enabled(LevelWarn))
+	assert.False(t, logLevelPtr.Enabled(LevelInfo))
+	assert.False(t, logLevelPtr.Enabled(LevelDebug))
 
 	logLevel := LevelNone
-	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelInfo))
-	assert.False(t, logLevel.Enabled(LevelWarn))
 	assert.False(t, logLevel.Enabled(LevelError))
-
-	logLevel.Set(LevelInfo)
+	assert.False(t, logLevel.Enabled(LevelWarn))
+	assert.False(t, logLevel.Enabled(LevelInfo))
 	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.True(t, logLevel.Enabled(LevelInfo))
-	assert.True(t, logLevel.Enabled(LevelWarn))
+
+	logLevel.Set(LevelError)
 	assert.True(t, logLevel.Enabled(LevelError))
+	assert.False(t, logLevel.Enabled(LevelWarn))
+	assert.False(t, logLevel.Enabled(LevelInfo))
+	assert.False(t, logLevel.Enabled(LevelDebug))
 
 	logLevel.Set(LevelWarn)
-	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelInfo))
-	assert.True(t, logLevel.Enabled(LevelWarn))
 	assert.True(t, logLevel.Enabled(LevelError))
+	assert.True(t, logLevel.Enabled(LevelWarn))
+	assert.False(t, logLevel.Enabled(LevelInfo))
+	assert.False(t, logLevel.Enabled(LevelDebug))
+
+	logLevel.Set(LevelInfo)
+	assert.True(t, logLevel.Enabled(LevelError))
+	assert.True(t, logLevel.Enabled(LevelWarn))
+	assert.True(t, logLevel.Enabled(LevelInfo))
+	assert.False(t, logLevel.Enabled(LevelDebug))
+
+	logLevel.Set(LevelDebug)
+	assert.True(t, logLevel.Enabled(LevelError))
+	assert.True(t, logLevel.Enabled(LevelWarn))
+	assert.True(t, logLevel.Enabled(LevelInfo))
+	assert.True(t, logLevel.Enabled(LevelDebug))
 }
 
 func TestLogLevelNames(t *testing.T) {
@@ -45,6 +58,7 @@ func TestLogLevelNames(t *testing.T) {
 	assert.Equals(t, LogLevelName(LevelWarn), "warn")
 	assert.Equals(t, LogLevelName(LevelDebug), "debug")
 
+	// Test out of bounds log level
 	assert.Equals(t, LogLevelName(math.MaxUint32), "")
 }
 
@@ -81,6 +95,7 @@ func TestLogLevelText(t *testing.T) {
 	assert.Equals(t, logLevel, LevelNone)
 }
 
+// This test has no assertions, but will flag any data races when run under `-race`.
 func TestLogLevelConcurrency(t *testing.T) {
 	logLevel := LevelWarn
 	stop := make(chan struct{})

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -51,6 +51,7 @@ func TestLogLevel(t *testing.T) {
 func TestLogLevelNames(t *testing.T) {
 	// Ensure number of level constants, and names match.
 	assert.Equals(t, len(logLevelNames), int(levelCount))
+	assert.Equals(t, len(logLevelNamesPrint), int(levelCount))
 
 	assert.Equals(t, LogLevelName(LevelNone), "none")
 	assert.Equals(t, LogLevelName(LevelError), "error")

--- a/base/logging.go
+++ b/base/logging.go
@@ -227,7 +227,7 @@ func init() {
 	logNoTime = false
 }
 
-func LogLevel() int {
+func GetLogLevel() int {
 	return logLevel
 }
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -346,7 +346,7 @@ func (h *handler) handleSetLogging() error {
 		return nil
 	}
 	if h.getQuery("level") != "" {
-		base.SetLogLevel(int(getRestrictedIntQuery(h.getQueryValues(), "level", uint64(base.LogLevel()), 1, 3, false)))
+		base.SetLogLevel(int(getRestrictedIntQuery(h.getQueryValues(), "level", uint64(base.GetLogLevel()), 1, 3, false)))
 		if len(body) == 0 {
 			return nil // empty body is OK if request is just setting the log level
 		}


### PR DESCRIPTION
Adds new Log Levels implementation with a similar API to Log Keys (#3380), to be used in the new logging API (#3365)