### PR TITLE
Log Redaction: Rename constants to be consistent with LogLevel/LogKey constants

### DIFF
--- a/base/redactor.go
+++ b/base/redactor.go
@@ -27,19 +27,19 @@ func redact(args []interface{}) []interface{} {
 type RedactionLevel int
 
 const (
-	RedactNone RedactionLevel = iota
-	RedactPartial
-	RedactFull
+	REDACT_NONE RedactionLevel = iota
+	REDACT_PARTIAL
+	REDACT_FULL
 )
 
 func SetRedaction(redactionLevel RedactionLevel) {
 	Logf("Log redaction level: %s", redactionLevel)
 	switch redactionLevel {
-	case RedactFull:
+	case REDACT_FULL:
 		RedactUserData = true
-	case RedactPartial:
+	case REDACT_PARTIAL:
 		RedactUserData = true
-	case RedactNone:
+	case REDACT_NONE:
 		RedactUserData = false
 	default:
 		RedactUserData = false
@@ -49,11 +49,11 @@ func SetRedaction(redactionLevel RedactionLevel) {
 // String returns a lower-case ASCII representation of the log redaction level.
 func (l RedactionLevel) String() string {
 	switch l {
-	case RedactNone:
+	case REDACT_NONE:
 		return "none"
-	case RedactPartial:
+	case REDACT_PARTIAL:
 		return "partial"
-	case RedactFull:
+	case REDACT_FULL:
 		return "full"
 	default:
 		return fmt.Sprintf("RedactionLevel(%d)", l)
@@ -72,11 +72,11 @@ func (l *RedactionLevel) MarshalText() ([]byte, error) {
 func (l *RedactionLevel) UnmarshalText(text []byte) error {
 	switch strings.ToLower(string(text)) {
 	case "none":
-		*l = RedactNone
+		*l = REDACT_NONE
 	case "partial":
-		*l = RedactPartial
+		*l = REDACT_PARTIAL
 	case "full":
-		*l = RedactFull
+		*l = REDACT_FULL
 	default:
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -45,29 +45,29 @@ func TestSetRedaction(t *testing.T) {
 	SetRedaction(-1)
 	assert.Equals(t, RedactUserData, false)
 
-	SetRedaction(RedactFull)
+	SetRedaction(REDACT_FULL)
 	assert.Equals(t, RedactUserData, true)
 
-	SetRedaction(RedactPartial)
+	SetRedaction(REDACT_PARTIAL)
 	assert.Equals(t, RedactUserData, true)
 
-	SetRedaction(RedactNone)
+	SetRedaction(REDACT_NONE)
 	assert.Equals(t, RedactUserData, false)
 }
 
 func TestRedactionLevelMarshalText(t *testing.T) {
 	var level RedactionLevel
-	level = RedactNone
+	level = REDACT_NONE
 	text, err := level.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "none")
 
-	level = RedactPartial
+	level = REDACT_PARTIAL
 	text, err = level.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "partial")
 
-	level = RedactFull
+	level = REDACT_FULL
 	text, err = level.MarshalText()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, string(text), "full")
@@ -77,15 +77,15 @@ func TestRedactionLevelUnmarshalText(t *testing.T) {
 	var level RedactionLevel
 	err := level.UnmarshalText([]byte("none"))
 	assert.Equals(t, err, nil)
-	assert.Equals(t, level, RedactNone)
+	assert.Equals(t, level, REDACT_NONE)
 
 	err = level.UnmarshalText([]byte("partial"))
 	assert.Equals(t, err, nil)
-	assert.Equals(t, level, RedactPartial)
+	assert.Equals(t, level, REDACT_PARTIAL)
 
 	err = level.UnmarshalText([]byte("full"))
 	assert.Equals(t, err, nil)
-	assert.Equals(t, level, RedactFull)
+	assert.Equals(t, level, REDACT_FULL)
 
 	err = level.UnmarshalText([]byte("asdf"))
 	assert.Equals(t, err.Error(), "unrecognized level: asdf")


### PR DESCRIPTION
Rename redaction constants to be in line with new Log Level (#3409) and Log Key constants (#3380)