### PR TITLE
Force build infrastructure to reset build numbers on 2.1.0 builds

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,7 +2,7 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "default",
+            "release": "2.1.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,


### PR DESCRIPTION
From @ceejatec via hipchat:

>  It appears that SGW's version of create-build-manifest uses VERSION for the directory name on latestbuilds.
> So "release" is effectively unused, except that the script still uses it to manage build numbers.
> So I think if you change "release" to "2.1.0", everything should work the way you want.