### PR TITLE
Locked build repo down to release sha for 2.0.0.xml

### DIFF
--- a/manifest/2.0.0.xml
+++ b/manifest/2.0.0.xml
@@ -23,7 +23,7 @@
     <default remote="couchbase" revision="master"/>
 
     <!-- Build Scripts (required on CI servers) -->
-    <project name="build" path="cbbuild" remote="couchbase">
+    <project name="build" path="cbbuild" remote="couchbase" revision="3bc4afccb8de2beed33c2d994b273d312b9a2a64">
         <annotation name="VERSION" value="2.0.0"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
Need to lock down build repo to sha to prevent builds kick-off for 2.0.0