### PR TITLE
Improve "Opening Couchbase database" log message

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -498,7 +498,8 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		if spec.Auth != nil {
 			username, _, _ = spec.Auth.GetCredentials()
 		}
-		LogfR("%v Opening Couchbase database %s on <%s>%s as user %q", spec.CouchbaseDriver, MD(spec.BucketName), SD(spec.Server), UD(username))
+				
+		LogfR("%v Opening Couchbase database %s on <%s>%s as user %q", spec.CouchbaseDriver, MD(spec.BucketName), SD(spec.Server), suffix, UD(username))
 
 		switch spec.CouchbaseDriver {
 		case GoCB, GoCBCustomSGTranscoder:


### PR DESCRIPTION
I noticed this in the logs: `2018-04-11T14:24:07.529-07:00 GoCBCustomSGTranscoder Opening Couchbase database db_no_xattr on <http://couchbase-server:8091>db_no_xattr as user %!q(MISSING)`