### PR TITLE
Include body hash check when identifying SG writes

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -13,9 +13,11 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"expvar"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"math"
 	"net/http"
@@ -842,6 +844,26 @@ func isMinimumVersion(major, minor, minMajor, minMinor uint64) bool {
 	}
 
 	return true
+}
+
+func HexCasToUint64(cas string) uint64 {
+	casBytes, err := hex.DecodeString(strings.TrimPrefix(cas, "0x"))
+	if err != nil || len(casBytes) != 8 {
+		// Invalid cas - return zero
+		return 0
+	}
+
+	return binary.LittleEndian.Uint64(casBytes[0:8])
+}
+
+func Crc32cHash(input []byte) uint32 {
+	// crc32.MakeTable already ensures singleton table creation, so shouldn't need to cache.
+	table := crc32.MakeTable(crc32.Castagnoli)
+	return crc32.Checksum(input, table)
+}
+
+func Crc32cHashString(input []byte) string {
+	return fmt.Sprintf("0x%x", Crc32cHash(input))
 }
 
 var kBackquoteStringRegexp *regexp.Regexp

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -404,7 +404,7 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 	// Import handling.
 	if c.context.UseXattrs() {
 		// If this isn't an SG write, we shouldn't attempt to cache.  Import if this node is configured for import, otherwise ignore.
-		if syncData == nil || !syncData.IsSGWrite(event.Cas) {
+		if syncData == nil || !syncData.IsSGWrite(event.Cas, rawBody) {
 			if c.context.autoImport {
 				// If syncData is nil, or if this was not an SG write, attempt to import
 				isDelete := event.Opcode == sgbucket.FeedOpDeletion

--- a/db/crud.go
+++ b/db/crud.go
@@ -54,8 +54,7 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 			return nil, err
 		}
 		// If existing doc wasn't an SG Write, import the doc.
-		if !doc.IsSGWrite() {
-
+		if !doc.IsSGWrite(rawBucketDoc.Body) {
 			var importErr error
 			doc, importErr = db.OnDemandImportForGet(docid, rawBucketDoc.Body, rawBucketDoc.Xattr, rawBucketDoc.Cas)
 			if importErr != nil {
@@ -125,7 +124,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (syncData, error) {
 		}
 
 		// If existing doc wasn't an SG Write, import the doc.
-		if !doc.IsSGWrite() {
+		if !doc.IsSGWrite(rawDoc) {
 			var importErr error
 
 			doc, importErr = db.OnDemandImportForGet(docid, rawDoc, rawXattr, cas)
@@ -594,7 +593,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		// If the existing doc isn't an SG write, import prior to updating
-		if doc != nil && !doc.IsSGWrite() && db.UseXattrs() {
+		if doc != nil && !doc.IsSGWrite(nil) && db.UseXattrs() {
 			err := db.OnDemandImportForWrite(docid, doc, body)
 			if err != nil {
 				return nil, nil, nil, err
@@ -666,7 +665,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		// If the existing doc isn't an SG write, import prior to updating
-		if doc != nil && !doc.IsSGWrite() && db.UseXattrs() {
+		if doc != nil && !doc.IsSGWrite(nil) && db.UseXattrs() {
 			err := db.OnDemandImportForWrite(docid, doc, body)
 			if err != nil {
 				return nil, nil, nil, err

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -610,7 +610,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
-			ImportDocs: "continuous",
+			AutoImport: "continuous",
 		},
 	}
 	defer rt.Close()

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/gocb"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
@@ -489,6 +490,192 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	assert.Equals(t, response.Code, 201)
 	assertDocProperty(t, response, "id", "TestImportFilterInvalid")
 	assertDocProperty(t, response, "rev", "1-25c26cdf9d7771e07f00be1d13f7fb7c")
+}
+
+// Test scenario where another actor updates a different xattr on a document.  Sync Gateway
+// should detect and not import/create new revision during read-triggered import
+func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+	}
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+
+	// 1. Create doc via the SDK
+	mobileKey := "TestImportMultiActorUpdate"
+	mobileBody := make(map[string]interface{})
+	mobileBody["channels"] = "ABC"
+	_, err := bucket.Add(mobileKey, 0, mobileBody)
+	assertNoError(t, err, "Error writing SDK doc")
+
+	// Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
+	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	assert.Equals(t, response.Code, 200)
+	// Extract rev from response for comparison with second GET below
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	revId, ok := body["_rev"].(string)
+	assertTrue(t, ok, "No rev included in response")
+
+	// Go get the cas for the doc to use for update
+	_, cas, getErr := bucket.GetRaw(mobileKey)
+	assertNoError(t, getErr, "Error retrieving cas for multi-actor document")
+
+	// Modify the document via the SDK to add a new, non-mobile xattr
+	xattrVal := make(map[string]interface{})
+	xattrVal["actor"] = "not mobile"
+	gocbBucket, ok := bucket.(*base.CouchbaseBucketGoCB)
+	assertTrue(t, ok, "Unable to cast bucket to gocb bucket")
+	_, mutateErr := gocbBucket.MutateInEx(mobileKey, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
+		UpsertEx("_nonmobile", xattrVal, gocb.SubdocFlagXattr). // Update the xattr
+		Execute()
+	assertNoError(t, mutateErr, "Error updating non-mobile xattr for multi-actor document")
+
+	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
+	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	assert.Equals(t, response.Code, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	newRevId := body["_rev"].(string)
+	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
+	assert.Equals(t, newRevId, revId)
+}
+
+// Test scenario where another actor updates a different xattr on a document.  Sync Gateway
+// should detect and not import/create new revision during write-triggered import
+func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+	}
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+
+	// 1. Create doc via the SDK
+	mobileKey := "TestImportMultiActorUpdate"
+	mobileBody := make(map[string]interface{})
+	mobileBody["channels"] = "ABC"
+	_, err := bucket.Add(mobileKey, 0, mobileBody)
+	assertNoError(t, err, "Error writing SDK doc")
+
+	// Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
+	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	assert.Equals(t, response.Code, 200)
+	// Extract rev from response for comparison with second GET below
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	revId, ok := body["_rev"].(string)
+	assertTrue(t, ok, "No rev included in response")
+
+	// Go get the cas for the doc to use for update
+	_, cas, getErr := bucket.GetRaw(mobileKey)
+	assertNoError(t, getErr, "Error retrieving cas for multi-actor document")
+
+	// Modify the document via the SDK to add a new, non-mobile xattr
+	xattrVal := make(map[string]interface{})
+	xattrVal["actor"] = "not mobile"
+	gocbBucket, ok := bucket.(*base.CouchbaseBucketGoCB)
+	assertTrue(t, ok, "Unable to cast bucket to gocb bucket")
+	_, mutateErr := gocbBucket.MutateInEx(mobileKey, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
+		UpsertEx("_nonmobile", xattrVal, gocb.SubdocFlagXattr). // Update the xattr
+		Execute()
+	assertNoError(t, mutateErr, "Error updating non-mobile xattr for multi-actor document")
+
+	// Attempt to update the document again via Sync Gateway.  Should not trigger import, PUT should be successful,
+	// rev should have generation 2.
+	putResponse := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", mobileKey, revId), `{"updated":true}`)
+	assert.Equals(t, putResponse.Code, 201)
+	json.Unmarshal(putResponse.Body.Bytes(), &body)
+	log.Printf("Put response details: %s", putResponse.Body.Bytes())
+	newRevId, ok := body["rev"].(string)
+	assertTrue(t, ok, "Unable to cast rev to string")
+	log.Printf("Retrieved via Sync Gateway PUT after non-mobile update, revId:%v", newRevId)
+	assert.Equals(t, newRevId, "2-04bb60e2d65acedb2a846daa0ce882ea")
+}
+
+// Test scenario where another actor updates a different xattr on a document.  Sync Gateway
+// should detect and not import/create new revision during feed-based import
+func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
+
+	SkipImportTestsIfNotEnabled(t)
+
+	rt := RestTester{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			ImportDocs: "continuous",
+		},
+	}
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+
+	// Create doc via the SDK
+	mobileKey := "TestImportMultiActorFeed"
+	mobileBody := make(map[string]interface{})
+	mobileBody["channels"] = "ABC"
+	_, err := bucket.Add(mobileKey, 0, mobileBody)
+	assertNoError(t, err, "Error writing SDK doc")
+
+	// Attempt to get the document via Sync Gateway.  Guarantees initial import is complete
+	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	assert.Equals(t, response.Code, 200)
+	// Extract rev from response for comparison with second GET below
+	var body db.Body
+	json.Unmarshal(response.Body.Bytes(), &body)
+	revId, ok := body["_rev"].(string)
+	assertTrue(t, ok, "No rev included in response")
+
+	// Go get the cas for the doc to use for update
+	_, cas, getErr := bucket.GetRaw(mobileKey)
+	assertNoError(t, getErr, "Error retrieving cas for multi-actor document")
+
+	// Check expvars before update
+	crcMatchesBefore, _ := base.GetExpvarAsInt("syncGateway_import", "crc32c_match_count")
+	crcMismatchesBefore, _ := base.GetExpvarAsInt("syncGateway_import", "crc32c_mismatch_count")
+
+	// Modify the document via the SDK to add a new, non-mobile xattr
+	xattrVal := make(map[string]interface{})
+	xattrVal["actor"] = "not mobile"
+	gocbBucket, ok := bucket.(*base.CouchbaseBucketGoCB)
+	assertTrue(t, ok, "Unable to cast bucket to gocb bucket")
+	_, mutateErr := gocbBucket.MutateInEx(mobileKey, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
+		UpsertEx("_nonmobile", xattrVal, gocb.SubdocFlagXattr). // Update the xattr
+		Execute()
+	assertNoError(t, mutateErr, "Error updating non-mobile xattr for multi-actor document")
+
+	// Wait until crc match count changes
+	var crcMatchesAfter, crcMismatchesAfter int
+	for i := 0; i < 20; i++ {
+		crcMatchesAfter, _ = base.GetExpvarAsInt("syncGateway_import", "crc32c_match_count")
+		crcMismatchesAfter, _ = base.GetExpvarAsInt("syncGateway_import", "crc32c_mismatch_count")
+		// if they changed, import has been processed
+		if crcMatchesAfter > crcMatchesBefore || crcMismatchesAfter > crcMismatchesAfter {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Expect one crcMatch, no mismatches
+	assert.True(t, crcMatchesAfter-crcMatchesBefore == 1)
+	assert.True(t, crcMismatchesAfter-crcMismatchesBefore == 0)
+
+	// Get the doc again, validate rev hasn't changed
+	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
+	assert.Equals(t, response.Code, 200)
+	json.Unmarshal(response.Body.Bytes(), &body)
+	newRevId := body["_rev"].(string)
+	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
+	assert.Equals(t, newRevId, revId)
+
 }
 
 // Structs for manual rev storage validation


### PR DESCRIPTION
When identifying SG writes during import, compare body hash when a cas mismatch is detected, and only import on body hash mismatch.  This will allow SG to avoid repeating import when the document body hasn't changed (such as when another component has written a system xattr).

Uses macro expansion to write the body hash.  KV uses crc32c for that calculation, so we need to use the same when computing it ourselves.  Unit tests include validation that our calculated value matches the server's (using virtual xattr value).

Fixes #3388.

Depends on https://github.com/couchbaselabs/sync-gateway-accel/pull/200