### PR TITLE
Update example configs for new logging

### DIFF
--- a/examples/basic-couchbase-bucket.json
+++ b/examples/basic-couchbase-bucket.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "databases": {
     "db": {
       "server": "http://localhost:8091",

--- a/examples/basic-sync-function.json
+++ b/examples/basic-sync-function.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "databases": {
     "db": {
       "server": "walrus:",

--- a/examples/basic-walrus-bucket.json
+++ b/examples/basic-walrus-bucket.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "databases": {
     "db": {
       "server": "walrus:",

--- a/examples/basic-walrus-persisted-bucket.json
+++ b/examples/basic-walrus-persisted-bucket.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "databases": {
     "db": {
       "server": "walrus:.",

--- a/examples/basic_sg_accel_config.json
+++ b/examples/basic_sg_accel_config.json
@@ -1,25 +1,28 @@
 {
-    "log":[
-        "HTTP+"
-    ],
-    "adminInterface":"127.0.0.1:4985",
-    "interface":"0.0.0.0:4984",
-    "databases":{
-        "default":{
-            "server":"http://localhost:8091",
-            "bucket":"default",
-            "channel_index":{
-                "server":"http://localhost:8091",
-                "bucket":"channel_bucket",
-                "writer":true
-            },
-            "allow_conflicts": false,
-            "revs_limit": 20
-        }
-    },
-    "cluster_config":{
-        "server":"http://localhost:8091",
-        "bucket":"default",
-        "data_dir":"."
+  "logging": {
+    "console": {
+      "logLevel": "debug",
+      "logKeys": ["HTTP"]
     }
+  },
+  "adminInterface": "127.0.0.1:4985",
+  "interface": "0.0.0.0:4984",
+  "databases": {
+    "default": {
+      "server": "http://localhost:8091",
+      "bucket": "default",
+      "channel_index": {
+        "server": "http://localhost:8091",
+        "bucket": "channel_bucket",
+        "writer": true
+      },
+      "allow_conflicts": false,
+      "revs_limit": 20
+    }
+  },
+  "cluster_config": {
+    "server": "http://localhost:8091",
+    "bucket": "default",
+    "data_dir": "."
+  }
 }

--- a/examples/config-dcpshard.json
+++ b/examples/config-dcpshard.json
@@ -1,9 +1,11 @@
 {
     "interface":":4984",
     "adminInterface":":4985",
-    "log":[
-        "*"
-    ],
+    "logging": {
+      "console": {
+        "logKeys": ["*"]
+      }
+    },
     "verbose":"true",
     "cluster_config":{
         "server":"http://localhost:8091",

--- a/examples/config-server.json
+++ b/examples/config-server.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "configServer": "http://localhost:8001/",
   "databases": {
     "db": {

--- a/examples/cors.json
+++ b/examples/cors.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "CORS": {
     "Origin":["http://localhost:8000"],
     "LoginOrigin":["http://localhost:8000"],

--- a/examples/democlusterconfig.json
+++ b/examples/democlusterconfig.json
@@ -1,9 +1,14 @@
 {
-    "log":["REST", "Shadow", "CRUD", "CRUD+", "HTTP", "HTTP+", "Access", "Changes", "Changes+","Auth", "SSL"],
-    "maxFileDescriptors": 50000,
-    "facebook" : {
-        "register" : true
-    },
+  "logging": {
+    "console": {
+      "logLevel": "debug",
+      "logKeys": ["REST", "Shadow", "CRUD", "HTTP","Access", "Changes", "Auth", "SSL"]
+    }
+  },
+  "maxFileDescriptors": 50000,
+  "facebook" : {
+    "register" : true
+  },
 	"databases": {
     "gaggle": {
       "server":"http://172.23.121.38:8091",

--- a/examples/events_webhook.json
+++ b/examples/events_webhook.json
@@ -1,8 +1,10 @@
 {
-  "log": [
-    "CRUD+",
-    "Events+"
-  ],
+  "logging": {
+    "console": {
+      "logLevel": "debug",
+      "logKeys": ["CRUD", "Events"]
+    }
+  },
   "databases": {
     "db": {
       "server": "walrus:",

--- a/examples/logging-with-rotation.json
+++ b/examples/logging-with-rotation.json
@@ -1,15 +1,29 @@
 {
   "logging": {
-    "default": {
-      "logFilePath": "/var/tmp/sglogfile.log",
-      "logKeys": ["*"],
-      "logLevel": "debug",
+    "logFilePath": "/var/tmp/sglogs",
+    "console": {
+    "logLevel": "debug",
+      "logKeys": ["*"]
+    },
+    "error": {
+      "enabled": true,
       "rotation": {
-        "maxsize": 1,
-        "maxage": 30,
-        "maxbackups": 2,
-        "localtime": true
+        "maxsize": 20,
+        "maxage": 180
       }
+    },
+    "warn": {
+      "enabled": true,
+      "rotation": {
+        "maxsize": 20,
+        "maxage": 90
+      }
+    },
+    "info": {
+      "enabled": false
+    },
+    "debug": {
+      "enabled": false
     }
   },
   "databases": {

--- a/examples/openid-connect.json
+++ b/examples/openid-connect.json
@@ -1,6 +1,10 @@
 {
    "interface":":4984",
-   "log":["*"],
+   "logging": {
+     "console": {
+       "logKeys": ["*"]
+     }
+   },
    "databases": {
       "default": {
         "server": "http://localhost:8091",

--- a/examples/read-write-timeouts.json
+++ b/examples/read-write-timeouts.json
@@ -1,7 +1,11 @@
 {
   "ServerReadTimeout": 200,
   "ServerWriteTimeout": 200,
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "databases": {
     "db": {
       "server": "walrus:",

--- a/examples/replications-in-config.json
+++ b/examples/replications-in-config.json
@@ -1,75 +1,73 @@
 {
-   "log":[
-      "*"
-   ],
-   "databases":{
-      "db":{
-         "server":"walrus:",
-         "allow_conflicts": false,
-         "revs_limit": 20
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
+  "databases": {
+    "db": {
+      "server": "walrus:",
+      "allow_conflicts": false,
+      "revs_limit": 20
+    },
+    "db2": {
+      "server": "walrus:",
+      "allow_conflicts": false,
+      "revs_limit": 20
+    },
+    "db3": {
+      "server": "walrus:",
+      "allow_conflicts": false,
+      "revs_limit": 20
+    },
+    "db4": {
+      "server": "walrus:",
+      "users": {
+        "GUEST": {
+          "disabled": false,
+          "admin_channels": ["*"]
+        }
       },
-      "db2":{
-         "server":"walrus:",
-         "allow_conflicts": false,
-         "revs_limit": 20
+      "allow_conflicts": false,
+      "revs_limit": 20
+    },
+    "db5": {
+      "server": "walrus:",
+      "users": {
+        "GUEST": {
+          "disabled": false,
+          "admin_channels": ["*"]
+        }
       },
-      "db3":{
-         "server":"walrus:",
-         "allow_conflicts": false,
-         "revs_limit": 20
-      },
-      "db4":{
-         "server":"walrus:",
-         "users":{
-            "GUEST":{
-               "disabled":false,
-               "admin_channels":[
-                  "*"
-               ]
-            }
-         },
-         "allow_conflicts": false,
-         "revs_limit": 20
-      },
-      "db5":{
-         "server":"walrus:",
-         "users":{
-            "GUEST":{
-               "disabled":false,
-               "admin_channels":[
-                  "*"
-               ]
-            }
-         },
-         "allow_conflicts": false,
-         "revs_limit": 20
-      }
-   },
-   "replications":[
-      {
-         "replication_id":"push-to-other-continuous",
-         "source":"http://localhost:4985/db",
-         "target":"http://otherhost.com:4985/db",
-         "continuous":true
-      },
-      {
-         "replication_id":"pull-from-other-continuous",
-         "source":"http://otherhost.com:4985/db",
-         "target":"http://localhost:4985/db",
-         "continuous":true
-      },
-      {
-         "replication_id":"local-to-local-one-shot",
-         "source":"http://localhost:4985/db2",
-         "target":"http://localhost:4985/db3",
-         "continuous":false
-      },
-      {
-         "replication_id":"local-to-local-one-shot-non-admin-async",
-         "source":"http://localhost:4984/db4",
-         "target":"http://localhost:4984/db5",
-         "continuous":false,
-         "async":true
-      }
-   ]
+      "allow_conflicts": false,
+      "revs_limit": 20
+    }
+  },
+  "replications": [
+    {
+      "replication_id": "push-to-other-continuous",
+      "source": "http://localhost:4985/db",
+      "target": "http://otherhost.com:4985/db",
+      "continuous": true
+    },
+    {
+      "replication_id": "pull-from-other-continuous",
+      "source": "http://otherhost.com:4985/db",
+      "target": "http://localhost:4985/db",
+      "continuous": true
+    },
+    {
+      "replication_id": "local-to-local-one-shot",
+      "source": "http://localhost:4985/db2",
+      "target": "http://localhost:4985/db3",
+      "continuous": false
+    },
+    {
+      "replication_id": "local-to-local-one-shot-non-admin-async",
+      "source": "http://localhost:4984/db4",
+      "target": "http://localhost:4984/db5",
+      "continuous": false,
+      "async": true
+    }
+  ]
 }

--- a/examples/serviceconfig.json
+++ b/examples/serviceconfig.json
@@ -1,15 +1,14 @@
 {
-	"log": ["HTTP+"],
-	"adminInterface": "127.0.0.1:4985",
-	"interface": "0.0.0.0:4984",
-	"databases": {
-		"db": {
-			"server": "walrus:data",
-			"users": {
-				"GUEST": {"disabled": false, "admin_channels": ["*"] }
-			},
+  "adminInterface": "127.0.0.1:4985",
+  "interface": "0.0.0.0:4984",
+  "databases": {
+    "db": {
+      "server": "walrus:data",
+      "users": {
+        "GUEST": {"disabled": false, "admin_channels": ["*"] }
+      },
       "allow_conflicts": false,
       "revs_limit": 20
-		}
-	}
+    }
+  }
 }

--- a/examples/ssl/ssl.json
+++ b/examples/ssl/ssl.json
@@ -1,22 +1,22 @@
 {
-   "log":[
-      "*"
-   ],
-   "SSLCert":"examples/ssl/cert.pem",
-   "SSLKey":"examples/ssl/privkey.pem",
-   "databases":{
-      "db":{
-         "server":"walrus:",
-         "users":{
-            "GUEST":{
-               "disabled":false,
-               "admin_channels":[
-                  "*"
-               ]
-            }
-         },
-         "allow_conflicts": false,
-         "revs_limit": 20
-      }
-   }
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
+  "SSLCert": "examples/ssl/cert.pem",
+  "SSLKey": "examples/ssl/privkey.pem",
+  "databases": {
+    "db": {
+      "server": "walrus:",
+      "users": {
+        "GUEST": {
+          "disabled": false,
+          "admin_channels": ["*"]
+        }
+      },
+      "allow_conflicts": false,
+      "revs_limit": 20
+    }
+  }
 }

--- a/examples/sync_gateway_with_accel_config.json
+++ b/examples/sync_gateway_with_accel_config.json
@@ -1,7 +1,10 @@
 {
-  "log":[
-    "HTTP+"
-  ],
+  "logging": {
+    "console": {
+      "logLevel": "debug",
+      "logKeys": ["HTTP"]
+    }
+  },
   "adminInterface": "127.0.0.1:4985",
   "interface":"0.0.0.0:4984",
   "databases":{

--- a/examples/users-roles.json
+++ b/examples/users-roles.json
@@ -1,5 +1,9 @@
 {
-  "log": ["*"],
+  "logging": {
+    "console": {
+      "logKeys": ["*"]
+    }
+  },
   "databases": {
     "db": {
       "server": "walrus:",


### PR DESCRIPTION
Updates all example configs with the new logging options, and fixes some minor whitespace/indentation formatting.

This resolves warnings about using deprecated options when running SG with one of these configs.