### PR TITLE
#3464 Override log level to debug if we see any + log key

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -151,8 +151,9 @@ func ToLogKey(keysStr []string) LogKey {
 
 		// Strip "+" in log keys and warn (for backwards compatibility)
 		if strings.HasSuffix(name, "+") {
-			Warnf(KeyAll, "Deprecated plus log key: %q found. Removing plus from log key.", name)
-			name = strings.Replace(name, "+", "", -1)
+			newName := strings.Replace(name, "+", "", -1)
+			Warnf(KeyAll, "Deprecated log key: %q found. Changing to: %q.", name, newName)
+			name = newName
 		}
 
 		if logKey, ok := logKeyNamesInverse[name]; ok {

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -148,8 +148,12 @@ func (keyMask *LogKey) EnabledLogKeys() []string {
 func ToLogKey(keysStr []string) LogKey {
 	var logKeys LogKey
 	for _, name := range keysStr {
-		// Ignore "+" in log keys (for backwards compatibility)
-		name := strings.Replace(name, "+", "", -1)
+
+		// Strip "+" in log keys and warn (for backwards compatibility)
+		if strings.HasSuffix(name, "+") {
+			Warnf(KeyAll, "Deprecated plus log key: %q found. Removing plus from log key.", name)
+			name = strings.Replace(name, "+", "", -1)
+		}
 
 		if logKey, ok := logKeyNamesInverse[name]; ok {
 			logKeys.Enable(logKey)

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 )
 
 type ConsoleLogger struct {
@@ -73,6 +74,14 @@ func (lcc *ConsoleLoggerConfig) init() error {
 
 	// Always enable the HTTP log key
 	lcc.LogKeys = append(lcc.LogKeys, logKeyNames[KeyHTTP])
+
+	// Turn on debug level if we see any "+" log keys
+	for _, k := range lcc.LogKeys {
+		if strings.HasSuffix(k, "+") {
+			Infof(KeyAll, "Found \"+\" Log Key. Switching to debug Log Level.")
+			lcc.LogLevel.Set(LevelDebug)
+		}
+	}
 
 	return nil
 }

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -75,10 +75,10 @@ func (lcc *ConsoleLoggerConfig) init() error {
 	// Always enable the HTTP log key
 	lcc.LogKeys = append(lcc.LogKeys, logKeyNames[KeyHTTP])
 
-	// Turn on debug level if we see any "+" log keys
+	// Overriding to debug log level if we see any "+" log keys
 	for _, k := range lcc.LogKeys {
-		if strings.HasSuffix(k, "+") {
-			Infof(KeyAll, "Found \"+\" Log Key. Switching to debug Log Level.")
+		if strings.HasSuffix(k, "+") && !lcc.LogLevel.Enabled(LevelDebug) {
+			Infof(KeyAll, "Found \"+\" Log Key. Overriding to debug log level.")
 			lcc.LogLevel.Set(LevelDebug)
 		}
 	}

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"strings"
 )
 
 type ConsoleLogger struct {
@@ -74,14 +73,6 @@ func (lcc *ConsoleLoggerConfig) init() error {
 
 	// Always enable the HTTP log key
 	lcc.LogKeys = append(lcc.LogKeys, logKeyNames[KeyHTTP])
-
-	// Overriding to debug log level if we see any "+" log keys
-	for _, k := range lcc.LogKeys {
-		if strings.HasSuffix(k, "+") && !lcc.LogLevel.Enabled(LevelDebug) {
-			Infof(KeyAll, "Found \"+\" Log Key. Overriding to debug log level.")
-			lcc.LogLevel.Set(LevelDebug)
-		}
-	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes #3464 

If we see any `+` log keys, we strip the plusses, and display a deprecated log key warning.

```json
"logKeys": ["HTTP+", "DCP", "Bucket", "Changes+"],
```

```json
2018-04-20T15:19:31.147+01:00 [WRN] Deprecated log key: "HTTP+" found. Changing to: "HTTP". -- base.ToLogKey() at log_keys.go:155
2018-04-20T15:19:31.147+01:00 [WRN] Deprecated log key: "Changes+" found. Changing to: "Changes". -- base.ToLogKey() at log_keys.go:155
```