### PR TITLE
Fix caller names for Fatalf and Panicf

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -804,13 +804,13 @@ func init() {
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.
 func Panicf(logKey LogKey, format string, args ...interface{}) {
-	Errorf(logKey, format, args...)
+	logTo(LevelError, logKey, format, args...)
 	panic(fmt.Sprintf(format, args...))
 }
 
 // Fatalf logs the given formatted string and args to the error log level and given log key and then exits.
 func Fatalf(logKey LogKey, format string, args ...interface{}) {
-	Errorf(logKey, format, args...)
+	logTo(LevelError, logKey, format, args...)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Having an extra function hop for these two functions obscured the caller names for Panicf and Fatalf.

### Before
```json
2018-04-18T12:29:29.545+01:00 [ERR] example msg -- base.Fatalf() at logging.go:813
```

### After
```json
2018-04-18T12:30:28.634+01:00 [ERR] example msg -- base.validateLogFilePath() at logging_config.go:69
```