### PR TITLE
#3448 Add --defaultLogFilePath flag to set fallback logFilePath

### DIFF
--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -37,7 +37,7 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (err error) {
 
 	// If there's nowhere to specified put log files, we'll log an error, but we'll continue anyway.
 	if !hasLogFilePath(&c.LogFilePath, defaultLogFilePath) {
-		Errorf(KeyAll, "No logFilePath configured, and --defaultLogFilePath flag is not set. Unable to write log files!")
+		Errorf(KeyAll, "No logFilePath configured, and --defaultLogFilePath flag is not set. Log files required for product support are not being generated.")
 		return nil
 	}
 

--- a/service/script_templates/com.couchbase.mobile.sync_gateway.plist
+++ b/service/script_templates/com.couchbase.mobile.sync_gateway.plist
@@ -11,6 +11,8 @@
         <key>ProgramArguments</key>
         <array>
             <string>${GATEWAY_TEMPLATE_VAR}</string>
+            <string>--defaultLogFilePath</string>
+            <string>${LOGS_TEMPLATE_VAR}</string>
             <string>${CONFIG_TEMPLATE_VAR}</string>
         </array>
         <key>KeepAlive</key>
@@ -21,4 +23,3 @@
         <string>${LOGS_TEMPLATE_VAR}/${SERVICE_NAME}_error.log</string>
 </dict>
 </plist>
-

--- a/service/script_templates/systemd_debian_sync_gateway.tpl
+++ b/service/script_templates/systemd_debian_sync_gateway.tpl
@@ -17,7 +17,7 @@ ExecStartPre=/bin/mkdir -p ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/mkdir -p ${RUNBASE_TEMPLATE_VAR}/data
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${RUNBASE_TEMPLATE_VAR}/data
-ExecStart=/bin/bash -c '\${GATEWAY} \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
+ExecStart=/bin/bash -c '\${GATEWAY} --defaultLogFilePath \"\${LOGS}\" \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
 Restart=on-failure
 
 # Give a reasonable amount of time for the server to start up/shut down

--- a/service/script_templates/systemd_sync_gateway.tpl
+++ b/service/script_templates/systemd_sync_gateway.tpl
@@ -17,7 +17,7 @@ ExecStartPre=/bin/mkdir -p ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/mkdir -p ${RUNBASE_TEMPLATE_VAR}/data
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${RUNBASE_TEMPLATE_VAR}/data
-ExecStart=/usr/bin/bash -c '\${GATEWAY} \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
+ExecStart=/usr/bin/bash -c '\${GATEWAY} --defaultLogFilePath \"\${LOGS}\" \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
 Restart=on-failure
 
 # Give a reasonable amount of time for the server to start up/shut down

--- a/service/script_templates/sysv_sync_gateway.tpl
+++ b/service/script_templates/sysv_sync_gateway.tpl
@@ -41,7 +41,7 @@ case \"\$1\" in
         else
             echo "Starting $name"
             cd \"\$RUNBASE\"
-            sudo -u \"\$RUNAS\" \$GATEWAY \$CONFIG >> \"\$stdout_log\" 2>> \"\$stderr_log\" &
+            sudo -u \"\$RUNAS\" \$GATEWAY --defaultLogFilePath \"\$LOGS\" \$CONFIG >> \"\$stdout_log\" 2>> \"\$stderr_log\" &
             echo \$! > \"\$PIDFILE\"
             if ! is_running; then
                 echo "Unable to start, see \$stdout_log and \$stderr_log"

--- a/service/script_templates/upstart_redhat_sync_gateway.tpl
+++ b/service/script_templates/upstart_redhat_sync_gateway.tpl
@@ -29,7 +29,7 @@ script
   # Keep a pid around
   echo \$\$ > \$PIDFILE
   cd \$RUNBASE
-  su --session-command \"\$GATEWAY \$CONFIG >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log\" \$RUNAS
+  su --session-command \"\$GATEWAY --defaultLogFilePath \"\$LOGS\" \$CONFIG >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log\" \$RUNAS
 end script
  
 # Remove pid file when we stop the server

--- a/service/script_templates/upstart_ubuntu_sync_gateway.tpl
+++ b/service/script_templates/upstart_ubuntu_sync_gateway.tpl
@@ -24,4 +24,4 @@ pre-start script
   chown -R \${RUNAS}:\${RUNAS} \${RUNBASE}/data
 end script
 
-exec start-stop-daemon --start --chuid \$RUNAS --chdir \$RUNBASE --make-pidfile --pidfile \$PIDFILE --startas \$GATEWAY -- \$CONFIG >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log
+exec start-stop-daemon --start --chuid \$RUNAS --chdir \$RUNBASE --make-pidfile --pidfile \$PIDFILE --startas \$GATEWAY -- --defaultLogFilePath \"\$LOGS\" \$CONFIG >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log

--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -6,9 +6,13 @@ import (
 	"log"
 	"os/exec"
 
-	"github.com/kardianos/service"
 	"os"
+
+	"github.com/kardianos/service"
 )
+
+const installLocation = "C:\\Program Files (x86)\\Couchbase\\"
+const defaultLogFilePath = installLocation + "var\\lib\\couchbase\\logs"
 
 var logger service.Logger
 
@@ -29,12 +33,12 @@ func (p *program) Start(s service.Service) error {
 }
 
 func (p *program) startup() error {
-	logger.Infof("Starting Sync Gateway service using command: `%s %s`", p.ExePath, p.ConfigPath)
+	logger.Infof("Starting Sync Gateway service using command: `%s --defaultLogFilePath %s %s`", p.ExePath, defaultLogFilePath, p.ConfigPath)
 
 	if p.ConfigPath != "" {
-		p.SyncGateway = exec.Command(p.ExePath, p.ConfigPath)
+		p.SyncGateway = exec.Command(p.ExePath, "--defaultLogFilePath", defaultLogFilePath, p.ConfigPath)
 	} else {
-		p.SyncGateway = exec.Command(p.ExePath)
+		p.SyncGateway = exec.Command(p.ExePath, "--defaultLogFilePath", defaultLogFilePath)
 	}
 
 	f, err := os.OpenFile(p.StderrPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
@@ -80,23 +84,23 @@ func main() {
 
 	switch len(os.Args) {
 	case 2:
-		exePath = "C:\\Program Files (x86)\\Couchbase\\sync_gateway.exe" // Uses default binary image path
-		stderrPath = "C:\\Program Files (x86)\\Couchbase\\var\\lib\\couchbase\\logs\\sync_gateway_error.log" // Uses default stderr path
-		svcConfig.Arguments = []string{"start", stderrPath}                          // Uses the default config
+		exePath = installLocation + "sync_gateway.exe"             // Uses default binary image path
+		stderrPath = defaultLogFilePath + "sync_gateway_error.log" // Uses default stderr path
+		svcConfig.Arguments = []string{"start", stderrPath}        // Uses the default config
 	case 3:
-		exePath = "C:\\Program Files (x86)\\Couchbase\\sync_gateway.exe" // Uses default binary image path
-		configPath = os.Args[2]                                          // Uses custom config
-		stderrPath = "C:\\Program Files (x86)\\Couchbase\\var\\lib\\couchbase\\logs\\sync_gateway_error.log" // Uses default stderr path
+		exePath = installLocation + "sync_gateway.exe"             // Uses default binary image path
+		configPath = os.Args[2]                                    // Uses custom config
+		stderrPath = defaultLogFilePath + "sync_gateway_error.log" // Uses default stderr path
 		svcConfig.Arguments = []string{"start", configPath, stderrPath}
 	case 4:
-		exePath = os.Args[2]    // Uses custom binary image path
-		configPath = os.Args[3] // Uses custom config
-		stderrPath = "C:\\Program Files (x86)\\Couchbase\\var\\lib\\couchbase\\logs\\sync_gateway_error.log" // Uses default stderr path
+		exePath = os.Args[2]                                       // Uses custom binary image path
+		configPath = os.Args[3]                                    // Uses custom config
+		stderrPath = defaultLogFilePath + "sync_gateway_error.log" // Uses default stderr path
 		svcConfig.Arguments = []string{"start", exePath, configPath, stderrPath}
 	case 5:
 		exePath = os.Args[2]    // Uses custom binary image path
 		configPath = os.Args[3] // Uses custom config
-		stderrPath = os.Args[4]
+		stderrPath = os.Args[4] // Uses custom stderr path
 		svcConfig.Arguments = []string{"start", exePath, configPath, stderrPath}
 	default:
 		panic("Valid parameters combinations are: COMMAND [none, custom config path, or custom exe path and custom config path].")


### PR DESCRIPTION
Fixes #3448 

Will no longer create a directory structure relative to executable for log files. Instead the value passed in via a `--defaultLogFilePath` command line flag is used (primarily from service scripts)

If neither `--defaultLogFilePath` or a `logFilePath` (from config, etc.) is set, an error is printed in the console and log file outputs are disabled, but startup continues with console logging.

```json
2018-04-18T13:24:24.766+01:00 [ERR] No logFilePath configured, and --defaultLogFilePath flag is not set. Unable to write log files! -- base.(*LoggingConfig).Init() at logging_config.go:40
```

### TODO
Pass `--defaultLogFilePath` in via service scripts:
- [x] Windows (`service/sg-windows/sg-service/sg-service.go`)
- [x] OS X (`service/script_templates/com.couchbase.mobile.sync_gateway.plist`)
- [x] Systemd (`service/script_templates/systemd_sync_gateway.tpl`)
- [x] Systemd Debian (`service/script_templates/systemd_debian_sync_gateway.tpl`)
- [x] sysv (`service/script_templates/sysv_sync_gateway.tpl`)
- [x] Upstart RedHat (`service/script_templates/upstart_redhat_sync_gateway.tpl`)
- [x] Upstart Ubuntu (`service/script_templates/upstart_ubuntu_sync_gateway.tpl`)
- [ ] Docker ([github.com/couchbase/docker: `generate/resources/sync-gateway/scripts/entrypoint.sh`](https://github.com/couchbase/docker))