### PR TITLE
#3436 Add support to _logging endpoints for new logging

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -96,6 +96,11 @@ func (keyMask *LogKey) Disable(logKey LogKey) {
 	atomic.StoreUint32((*uint32)(keyMask), val & ^uint32(logKey))
 }
 
+// Set will override the keyMask with the given logKey.
+func (keyMask *LogKey) Set(logKey LogKey) {
+	atomic.StoreUint32((*uint32)(keyMask), uint32(logKey))
+}
+
 // Enabled returns true if the given logKey is enabled in keyMask.
 // Always returns true if KeyAll is enabled in keyMask.
 func (keyMask *LogKey) Enabled(logKey LogKey) bool {

--- a/base/logging.go
+++ b/base/logging.go
@@ -430,16 +430,15 @@ func GetLogKeys() map[string]bool {
 // UpdateLogKeys updates the console's log keys from a map
 func UpdateLogKeys(keys map[string]bool, replace bool) {
 	if replace {
-		none := KeyNone
-		consoleLogger.LogKey = &none
+		ConsoleLogKey().Set(KeyNone)
 	}
 
 	for k, v := range keys {
 		key := strings.Replace(k, "+", "", -1)
 		if v {
-			consoleLogger.LogKey.Enable(logKeyNamesInverse[key])
+			ConsoleLogKey().Enable(logKeyNamesInverse[key])
 		} else {
-			consoleLogger.LogKey.Disable(logKeyNamesInverse[key])
+			ConsoleLogKey().Disable(logKeyNamesInverse[key])
 		}
 	}
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -227,6 +227,16 @@ func init() {
 	logNoTime = false
 }
 
+func GetLogLevel() int {
+	return logLevel
+}
+
+func SetLogLevel(level int) {
+	logLock.Lock()
+	defer logLock.Unlock()
+	logLevel = level
+}
+
 // For transforming a new log level to the old type.
 func ToDeprecatedLogLevel(logLevel LogLevel) *Level {
 	var deprecatedLogLevel Level
@@ -679,7 +689,7 @@ func NewLoggerWriter(logKey LogKey, serialNumber uint64, req *http.Request) *Log
 
 func CreateRollingLogger(logConfig *LogAppenderConfig) {
 	if logConfig != nil {
-		// TODO:// SetLogLevel(logConfig.LogLevel.sgLevel())
+		SetLogLevel(logConfig.LogLevel.sgLevel())
 		ParseLogFlags(logConfig.LogKeys)
 
 		if logConfig.LogFilePath == nil {

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -242,8 +242,7 @@ func writeEntries(entries []*LogEntry) {
 
 func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
-	base.SetLogLevel(2) // disables logging
-	//base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -262,7 +261,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
-	base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -279,8 +278,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
-	//base.LogKeys["Cache+"] = true
-	base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -297,7 +295,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
-	base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -314,7 +312,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
-	base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -349,7 +347,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
-	base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1557,7 +1557,7 @@ func TestViewCustom(t *testing.T) {
 //////// BENCHMARKS
 
 func BenchmarkDatabase(b *testing.B) {
-	base.SetLogLevel(2) // disables logging
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 	for i := 0; i < b.N; i++ {
 		bucket, _ := ConnectToBucket(base.BucketSpec{
 			Server:          base.UnitTestUrl(),

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -434,13 +434,13 @@ func TestLogging(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &logKeys)
 	assert.DeepEquals(t, logKeys, map[string]interface{}{})
 
-	//Set logKeys, Changes+ should also enable Changes (PUT replaces any existing log keys)
+	//Set logKeys, Changes+ should enable Changes (PUT replaces any existing log keys)
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Cache":true, "HTTP":true}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var updatedLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &updatedLogKeys)
-	assert.DeepEquals(t, updatedLogKeys, map[string]interface{}{"Changes+": true, "Changes": true, "Cache": true, "HTTP": true})
+	assert.DeepEquals(t, updatedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
 
 	//Disable Changes logKey which should also disable Changes+
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
@@ -450,13 +450,13 @@ func TestLogging(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &deletedLogKeys)
 	assert.DeepEquals(t, deletedLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
-	//Enable Changes++, which should enable Changes+ and Changes (POST append logKeys)
+	//Enable Changes++, which should enable Changes (POST append logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var appendedLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &appendedLogKeys)
-	assert.DeepEquals(t, appendedLogKeys, map[string]interface{}{"Changes++": true, "Changes+": true, "Changes": true, "Cache": true, "HTTP": true})
+	assert.DeepEquals(t, appendedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
 
 	//Disable Changes++ (POST modifies logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":false}`), 200)
@@ -464,23 +464,23 @@ func TestLogging(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabledLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &disabledLogKeys)
-	assert.DeepEquals(t, disabledLogKeys, map[string]interface{}{"Changes": true, "Changes+": true, "Cache": true, "HTTP": true})
+	assert.DeepEquals(t, disabledLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
-	//Re-Enable Changes++, which should enable Changes+ and Changes (POST append logKeys)
+	//Re-Enable Changes++, which should enable Changes (POST append logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
-	//Disable Changes+ which should also disable Changes++ (POST modifies logKeys)
+	//Disable Changes+ which should disable Changes (POST modifies logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes+":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled2LogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &disabled2LogKeys)
-	assert.DeepEquals(t, disabled2LogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
+	assert.DeepEquals(t, disabled2LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
-	//Re-Enable Changes++, which should enable Changes+ and Changes (POST append logKeys)
+	//Re-Enable Changes++, which should enable Changes (POST append logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
 
-	//Disable Changes which should also disable Changes+ and Changes++ (POST modifies logKeys)
+	//Disable Changes (POST modifies logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/couchbase/goutils/logging"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 )
@@ -288,7 +287,7 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 				}
 				b.StopTimer()
 				if getResponse.Code != 200 {
-					log.Printf("Unexpected response: %s", getResponse)
+					b.Logf("Unexpected response: %v", getResponse)
 				}
 				b.StartTimer()
 			}
@@ -298,8 +297,7 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 }
 
 func initBenchmarkLogging() {
-	base.SetLogLevel(2) // disables logging
-	logging.SetLogger(nil)
+	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
 }
 
 func PurgeDoc(rt RestTester, docid string) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -868,7 +868,7 @@ func RunServer(config *ServerConfig) {
 
 	base.Broadcastf("==== %s ====", base.LongVersionString)
 
-	base.Infof(base.KeyAll, "Console LogKeys: %v", base.ConsoleLogKeys())
+	base.Infof(base.KeyAll, "Console LogKeys: %v", base.ConsoleLogKey().EnabledLogKeys())
 	base.Infof(base.KeyAll, "Console LogLevel: %v", base.ConsoleLogLevel())
 	base.Infof(base.KeyAll, "Log Redaction Level: %s", config.Logging.RedactionLevel)
 


### PR DESCRIPTION
Fixes #3436 

- Updates `_logging` endpoints to support new logging changes (*mostly* backwards compatible, see below)
- Adds some helper functions to access the `consoleLogger`'s `LogLevel`/`LogKey`. Can be used to change log level and log keys in tests, and from other packages, etc.

## Difference in `_logging` endpoint behaviour
Previously, `+` and `++` log keys could be toggled without affecting the non-plus log key. The new behaviour is that all plus symbols are stripped before applying changes, and a warning will be logged.

| Action | Before | After |
| ------ | ------ | ------ |
| Enable `Changes` | `[Changes]` | `[Changes]` |
| Enable `Changes+` | `[Changes, Changes+]` | `[Changes]` - Warning logged  |
| Enable `Changes++` | `[Changes, Changes+, Changes++]` | `[Changes]` - Warning logged  |
| Disable `Changes++` | `[Changes, Changes+]` | `[]` - Warning logged |
| Disable `Changes+` | `[Changes]` | `[]` - Warning logged  |
| Disable `Changes` | `[]` | `[]` |