### PR TITLE
#3472 add redaction example and snake_case new logging config options

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -17,9 +17,9 @@ type ConsoleLogger struct {
 }
 
 type ConsoleLoggerConfig struct {
-	LogLevel     *LogLevel `json:",omitempty"` // Log Level for the console output
-	LogKeys      []string  `json:",omitempty"` // Log Keys for the console output
-	ColorEnabled bool      `json:",omitempty"` // Log with color for the console output
+	LogLevel     *LogLevel `json:"log_level,omitempty"`     // Log Level for the console output
+	LogKeys      []string  `json:"log_keys,omitempty"`      // Log Keys for the console output
+	ColorEnabled bool      `json:"color_enabled,omitempty"` // Log with color for the console output
 
 	Output io.Writer `json:"-"` // Logger output. Defaults to os.Stderr. Can be overridden for testing purposes.
 }

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -26,16 +26,16 @@ type FileLogger struct {
 }
 
 type FileLoggerConfig struct {
-	Enabled  *bool             `json:",omitempty"` // Toggle for this log output
-	Rotation logRotationConfig `json:",omitempty"` // Log rotation settings
+	Enabled  *bool             `json:"enabled,omitempty"`  // Toggle for this log output
+	Rotation logRotationConfig `json:"rotation,omitempty"` // Log rotation settings
 
 	Output io.Writer `json:"-"` // Logger output. Defaults to os.Stderr. Can be overridden for testing purposes.
 }
 
 type logRotationConfig struct {
-	MaxSize   *int `json:",omitempty"` // The maximum size in MB of the log file before it gets rotated.
-	MaxAge    *int `json:",omitempty"` // The maximum number of days to retain old log files.
-	LocalTime bool `json:",omitempty"` // If true, it uses the computer's local time to format the backup timestamp.
+	MaxSize   *int `json:"max_size,omitempty"`  // The maximum size in MB of the log file before it gets rotated.
+	MaxAge    *int `json:"max_age,omitempty"`   // The maximum number of days to retain old log files.
+	LocalTime bool `json:"localtime,omitempty"` // If true, it uses the computer's local time to format the backup timestamp.
 }
 
 // NewFileLogger returms a new FileLogger from a config.

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -14,13 +14,13 @@ const (
 )
 
 type LoggingConfig struct {
-	LogFilePath    string              `json:",omitempty"` // Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
-	RedactionLevel RedactionLevel      `json:",omitempty"`
-	Console        ConsoleLoggerConfig `json:",omitempty"` // Console Output
-	Error          FileLoggerConfig    `json:",omitempty"` // Error log file output
-	Warn           FileLoggerConfig    `json:",omitempty"` // Warn log file output
-	Info           FileLoggerConfig    `json:",omitempty"` // Info log file output
-	Debug          FileLoggerConfig    `json:",omitempty"` // Debug log file output
+	LogFilePath    string              `json:"log_file_path,omitempty"`   // Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
+	RedactionLevel RedactionLevel      `json:"redaction_level,omitempty"` // Redaction level to apply to log output.
+	Console        ConsoleLoggerConfig `json:"console,omitempty"`         // Console output
+	Error          FileLoggerConfig    `json:"error,omitempty"`           // Error log file output
+	Warn           FileLoggerConfig    `json:"warn,omitempty"`            // Warn log file output
+	Info           FileLoggerConfig    `json:"info,omitempty"`            // Info log file output
+	Debug          FileLoggerConfig    `json:"debug,omitempty"`           // Debug log file output
 
 	DeprecatedDefaultLog *LogAppenderConfig `json:"default,omitempty"` // Deprecated "default" logging option.
 }

--- a/examples/basic-couchbase-bucket.json
+++ b/examples/basic-couchbase-bucket.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/examples/basic-sync-function.json
+++ b/examples/basic-sync-function.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/examples/basic-walrus-bucket.json
+++ b/examples/basic-walrus-bucket.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/examples/basic-walrus-persisted-bucket.json
+++ b/examples/basic-walrus-persisted-bucket.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/examples/basic_sg_accel_config.json
+++ b/examples/basic_sg_accel_config.json
@@ -1,8 +1,8 @@
 {
   "logging": {
     "console": {
-      "logLevel": "debug",
-      "logKeys": ["HTTP"]
+      "log_level": "debug",
+      "log_keys": ["HTTP"]
     }
   },
   "adminInterface": "127.0.0.1:4985",

--- a/examples/config-dcpshard.json
+++ b/examples/config-dcpshard.json
@@ -3,7 +3,7 @@
     "adminInterface":":4985",
     "logging": {
       "console": {
-        "logKeys": ["*"]
+        "log_keys": ["*"]
       }
     },
     "verbose":"true",

--- a/examples/config-server.json
+++ b/examples/config-server.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "configServer": "http://localhost:8001/",

--- a/examples/cors.json
+++ b/examples/cors.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "CORS": {

--- a/examples/democlusterconfig.json
+++ b/examples/democlusterconfig.json
@@ -1,8 +1,8 @@
 {
   "logging": {
     "console": {
-      "logLevel": "debug",
-      "logKeys": ["REST", "Shadow", "CRUD", "HTTP","Access", "Changes", "Auth", "SSL"]
+      "log_level": "debug",
+      "log_keys": ["REST", "Shadow", "CRUD", "HTTP","Access", "Changes", "Auth", "SSL"]
     }
   },
   "maxFileDescriptors": 50000,

--- a/examples/events_webhook.json
+++ b/examples/events_webhook.json
@@ -1,8 +1,8 @@
 {
   "logging": {
     "console": {
-      "logLevel": "debug",
-      "logKeys": ["CRUD", "Events"]
+      "log_level": "debug",
+      "log_keys": ["CRUD", "Events"]
     }
   },
   "databases": {

--- a/examples/logging-with-redaction.json
+++ b/examples/logging-with-redaction.json
@@ -1,0 +1,14 @@
+{
+  "logging": {
+    "redaction_level": "partial"
+  },
+  "databases": {
+    "db": {
+      "server": "walrus:data",
+      "bucket": "default",
+      "users": {"GUEST": {"disabled": false,"admina_channels": ["*"]}},
+      "allow_conflicts": false,
+      "revs_limit": 20
+    }
+  }
+}

--- a/examples/logging-with-rotation.json
+++ b/examples/logging-with-rotation.json
@@ -1,22 +1,22 @@
 {
   "logging": {
-    "logFilePath": "/var/tmp/sglogs",
+    "log_file_path": "/var/tmp/sglogs",
     "console": {
-    "logLevel": "debug",
-      "logKeys": ["*"]
+      "log_level": "debug",
+      "log_keys": ["*"]
     },
     "error": {
       "enabled": true,
       "rotation": {
-        "maxsize": 20,
-        "maxage": 180
+        "max_size": 20,
+        "max_age": 180
       }
     },
     "warn": {
       "enabled": true,
       "rotation": {
-        "maxsize": 20,
-        "maxage": 90
+        "max_size": 20,
+        "max_age": 90
       }
     },
     "info": {

--- a/examples/openid-connect.json
+++ b/examples/openid-connect.json
@@ -2,7 +2,7 @@
    "interface":":4984",
    "logging": {
      "console": {
-       "logKeys": ["*"]
+       "log_keys": ["*"]
      }
    },
    "databases": {

--- a/examples/read-write-timeouts.json
+++ b/examples/read-write-timeouts.json
@@ -3,7 +3,7 @@
   "ServerWriteTimeout": 200,
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/examples/replications-in-config.json
+++ b/examples/replications-in-config.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/examples/ssl/ssl.json
+++ b/examples/ssl/ssl.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "SSLCert": "examples/ssl/cert.pem",

--- a/examples/sync_gateway_with_accel_config.json
+++ b/examples/sync_gateway_with_accel_config.json
@@ -1,8 +1,8 @@
 {
   "logging": {
     "console": {
-      "logLevel": "debug",
-      "logKeys": ["HTTP"]
+      "log_level": "debug",
+      "log_keys": ["HTTP"]
     }
   },
   "adminInterface": "127.0.0.1:4985",

--- a/examples/users-roles.json
+++ b/examples/users-roles.json
@@ -1,7 +1,7 @@
 {
   "logging": {
     "console": {
-      "logKeys": ["*"]
+      "log_keys": ["*"]
     }
   },
   "databases": {

--- a/rest/config.go
+++ b/rest/config.go
@@ -578,33 +578,33 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback(verbose bool) {
 	if config.Logging.DeprecatedDefaultLog != nil {
 		// Fall back to the old logging.["default"].LogFilePath option
 		if config.Logging.LogFilePath == "" && config.Logging.DeprecatedDefaultLog.LogFilePath != nil {
-			base.Warnf(base.KeyAll, "Using deprecated config option: logging.[\"default\"].LogFilePath. Use logging.logFilePath instead.")
+			base.Warnf(base.KeyAll, "Using deprecated config option: logging.[\"default\"].LogFilePath. Use logging.log_file_path instead.")
 			// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.
 			config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
 		}
 
 		// Fall back to the old logging.["default"].LogKeys option
 		if len(config.Logging.Console.LogKeys) == 0 && len(config.Logging.DeprecatedDefaultLog.LogKeys) > 0 {
-			base.Warnf(base.KeyAll, "Using deprecated config option: logging.[\"default\"].LogKeys. Use logging.console.logKeys instead.")
+			base.Warnf(base.KeyAll, "Using deprecated config option: logging.[\"default\"].LogKeys. Use logging.console.log_keys instead.")
 			config.Logging.Console.LogKeys = config.Logging.DeprecatedDefaultLog.LogKeys
 		}
 
 		// Fall back to the old logging.["default"].LogLevel option
 		if config.Logging.Console.LogLevel == nil && config.Logging.DeprecatedDefaultLog.LogLevel != 0 {
-			base.Warnf(base.KeyAll, "Using deprecated config option: logging.[\"default\"].LogLevel. Use logging.console.logLevel instead.")
+			base.Warnf(base.KeyAll, "Using deprecated config option: logging.[\"default\"].LogLevel. Use logging.console.log_level instead.")
 			config.Logging.Console.LogLevel = base.ToLogLevel(config.Logging.DeprecatedDefaultLog.LogLevel)
 		}
 	}
 
 	// Fall back to the old LogFilePath option
 	if config.Logging.LogFilePath == "" && config.DeprecatedLogFilePath != nil {
-		base.Warnf(base.KeyAll, "Using deprecated config option: logFilePath. Use logging.logFilePath instead.")
+		base.Warnf(base.KeyAll, "Using deprecated config option: logFilePath. Use logging.log_file_path instead.")
 		config.Logging.LogFilePath = *config.DeprecatedLogFilePath
 	}
 
 	// Fall back to the old Log option
 	if config.Logging.Console.LogKeys == nil && len(config.DeprecatedLog) > 0 {
-		base.Warnf(base.KeyAll, "Using deprecated config option: log. Use logging.console.logKeys instead.")
+		base.Warnf(base.KeyAll, "Using deprecated config option: log. Use logging.console.log_keys instead.")
 		config.Logging.Console.LogKeys = config.DeprecatedLog
 	}
 


### PR DESCRIPTION
Fixes #3472 

- Adds example config for log redaction
- Moves all new logging config options to snake_case

### Breaking config change for older 2.1 builds
The config options rename from `camelCase` to `snake_case` will break existing QE configurations/scripts. They will need to update after this is merged.