### PR TITLE
Logging: Restore defaultMaxSize to 100MB

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -15,7 +15,7 @@ var (
 	ErrInvalidLoggingMaxAge = errors.New("Invalid MaxAge")
 
 	maxAgeLimit             = 9999 // days
-	defaultMaxSize          = 200  // megabytes
+	defaultMaxSize          = 100  // megabytes
 	defaultMaxAgeMultiplier = 2    // e.g. 90 minimum == 180 default maxAge
 )
 


### PR DESCRIPTION
QE have a bunch of tests for log rotation at 100MB, and there was no real reason for this to be increased to 200MB anyway. So therefore, I have lowered it back down to the pre-2.1 default of 100MB.