### PR TITLE
Fix for build index error

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2465,6 +2465,9 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 	case *LoggingBucket:
 		gocbBucket, ok := typedBucket.GetUnderlyingBucket().(*CouchbaseBucketGoCB)
 		return gocbBucket, ok
+	case TestBucket:
+		gocbBucket, ok := typedBucket.Bucket.(*CouchbaseBucketGoCB)
+		return gocbBucket, ok
 	default:
 		return nil, false
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -100,7 +100,7 @@ func testBucket() base.TestBucket {
 
 	err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0, 0)
 	if err != nil {
-		log.Printf("Unable to initialize GSI indexes for test:%v", err)
+		log.Fatalf("Unable to initialize GSI indexes for test:%v", err)
 	}
 	return testBucket
 }


### PR DESCRIPTION
Defer handling was being lost when xattrs=true or num_replicas>0.  Build index error was also not being handled, resulting in silent failiures.

Improved unit test coverage of InitializeIndexes to detect/catch this type of issue.

Fixes #3499 