### PR TITLE
#3470 HTTPResp log key

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -80,7 +80,7 @@ var (
 		KeySync:           "Sync",
 		KeySyncMsg:        "SyncMsg",
 		KeyWebSocket:      "WS",
-		KeyWebSocketFrame: "WS+", // Debugf printed as WS++
+		KeyWebSocketFrame: "WSFrame",
 	}
 
 	// Inverse of the map above. Optimisation for string -> LogKey lookups in ToLogKey
@@ -160,7 +160,7 @@ func ToLogKey(keysStr []string) LogKey {
 	var logKeys LogKey
 	for _, name := range keysStr {
 
-		// Some old log keys (like HTTP+, and WS++), we want to handle slightly differently.
+		// Some old log keys (like HTTP+), we want to handle slightly (map to a different key)
 		if newLogKey, ok := convertSpecialLogKey(name); ok {
 			logKeys.Enable(*newLogKey)
 			continue
@@ -198,9 +198,6 @@ func convertSpecialLogKey(oldLogKey string) (*LogKey, bool) {
 	case "HTTP+":
 		// HTTP+ Should enable both KeyHTTP and KeyHTTPResp
 		logKey = logKeyPtr(KeyHTTP | KeyHTTPResp)
-	case "WS++":
-		// WS++ should enable both KeyWebSocket and KeyWebSocketFrame
-		logKey = logKeyPtr(KeyWebSocket | KeyWebSocketFrame)
 	}
 
 	return logKey, logKey != nil

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -33,6 +33,7 @@ const (
 	KeyGoCB
 	KeyHeartbeat
 	KeyHTTP
+	KeyHTTPResp
 	KeyImport
 	KeyIndex
 	KeyMigrate
@@ -67,6 +68,7 @@ var (
 		KeyGoCB:           "gocb",
 		KeyHeartbeat:      "Heartbeat",
 		KeyHTTP:           "HTTP",
+		KeyHTTPResp:       "HTTP+", // Infof printed as HTTP+
 		KeyImport:         "Import",
 		KeyIndex:          "Index",
 		KeyMigrate:        "Migrate",

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -206,7 +206,7 @@ func convertSpecialLogKey(oldLogKey string) (*LogKey, bool) {
 	return logKey, logKey != nil
 }
 
-// logKeyPtr is a convinience funciton that returns a pointer to the given logKey
+// logKeyPtr is a convenience function that returns a pointer to the given logKey
 func logKeyPtr(logKey LogKey) *LogKey {
 	return &logKey
 }

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -67,11 +67,11 @@ func TestLogKeyNames(t *testing.T) {
 	assert.Equals(t, logKeys, KeyAll|KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
-	// Special handling of these two log keys...
-	keys = []string{"HTTP+", "WS++"}
+	// Special handling of log keys
+	keys = []string{"HTTP+"}
 	logKeys = ToLogKey(keys)
-	assert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp|KeyWebSocket|KeyWebSocketFrame)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String(), KeyWebSocket.String(), KeyWebSocketFrame.String()})
+	assert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String()})
 
 	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
 	keys = []string{"DCP", "WS+", "InvalidLogKey"}
@@ -94,21 +94,6 @@ func TestConvertSpecialLogKey(t *testing.T) {
 		{
 			input:  "HTTP+",
 			output: logKeyPtr(KeyHTTP | KeyHTTPResp),
-			ok:     true,
-		},
-		{
-			input:  "WS",
-			output: nil,
-			ok:     false,
-		},
-		{
-			input:  "WS+",
-			output: nil,
-			ok:     false,
-		},
-		{
-			input:  "WS++",
-			output: logKeyPtr(KeyWebSocket | KeyWebSocketFrame),
 			ok:     true,
 		},
 	}

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -67,11 +67,61 @@ func TestLogKeyNames(t *testing.T) {
 	assert.Equals(t, logKeys, KeyAll|KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
-	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
-	keys = []string{"DCP", "HTTP+", "InvalidLogKey"}
+	// Special handling of these two log keys...
+	keys = []string{"HTTP+", "WS++"}
 	logKeys = ToLogKey(keys)
-	assert.Equals(t, logKeys, KeyDCP|KeyHTTP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyHTTP.String()})
+	assert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp|KeyWebSocket|KeyWebSocketFrame)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String(), KeyWebSocket.String(), KeyWebSocketFrame.String()})
+
+	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
+	keys = []string{"DCP", "WS+", "InvalidLogKey"}
+	logKeys = ToLogKey(keys)
+	assert.Equals(t, logKeys, KeyDCP|KeyWebSocket)
+	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyWebSocket.String()})
+}
+
+func TestConvertSpecialLogKey(t *testing.T) {
+	tests := []struct {
+		input  string
+		output *LogKey
+		ok     bool
+	}{
+		{
+			input:  "HTTP",
+			output: nil,
+			ok:     false,
+		},
+		{
+			input:  "HTTP+",
+			output: logKeyPtr(KeyHTTP | KeyHTTPResp),
+			ok:     true,
+		},
+		{
+			input:  "WS",
+			output: nil,
+			ok:     false,
+		},
+		{
+			input:  "WS+",
+			output: nil,
+			ok:     false,
+		},
+		{
+			input:  "WS++",
+			output: logKeyPtr(KeyWebSocket | KeyWebSocketFrame),
+			ok:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(ts *testing.T) {
+			output, ok := convertSpecialLogKey(test.input)
+			assert.Equals(ts, ok, test.ok)
+			if ok {
+				assert.Equals(ts, *output, *test.output)
+			}
+		})
+	}
 }
 
 // This test has no assertions, but will flag any data races when run under `-race`.

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -266,15 +266,17 @@ func (h *handler) logDuration(realTime bool) {
 		restExpvars.Add(fmt.Sprintf("requests_%04dms", bin), 1)
 	}
 
+	// Log timings/status codes for errors under the HTTP log key
+	// and the HTTPResp log key for everything else.
+	logKey := base.KeyHTTPResp
 	if h.status >= 300 {
-		base.Warnf(base.KeyHTTP, "#%03d:     --> %d %s  (%.1f ms)",
-			h.serialNumber, h.status, h.statusMessage,
-			float64(duration)/float64(time.Millisecond))
-	} else {
-		base.Debugf(base.KeyHTTP, "#%03d:     --> %d %s  (%.1f ms)",
-			h.serialNumber, h.status, h.statusMessage,
-			float64(duration)/float64(time.Millisecond))
+		logKey = base.KeyHTTP
 	}
+
+	base.Infof(logKey, "#%03d:     --> %d %s  (%.1f ms)",
+		h.serialNumber, h.status, h.statusMessage,
+		float64(duration)/float64(time.Millisecond),
+	)
 }
 
 // logStatusWithDuration will log the request status and the duration of the request.


### PR DESCRIPTION
Fixes #3470 

- Adds a `KeyHTTPResp` log key
- Fixes log level for HTTP statuses >= 300
- Adds special handling for HTTP+ and WS++ log keys