### PR TITLE
Remove num_replicas_housekeeping

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -98,7 +98,7 @@ func testBucket() base.TestBucket {
 		log.Fatalf("Couldn't connect to bucket: %v", err)
 	}
 
-	err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0, 0)
+	err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0)
 	if err != nil {
 		log.Fatalf("Unable to initialize GSI indexes for test:%v", err)
 	}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -240,7 +240,7 @@ func (i *SGIndex) createIfNeeded(bucket *base.CouchbaseBucketGoCB, useXattrs boo
 }
 
 // Initializes Sync Gateway indexes for bucket.  Creates required indexes if not found, then waits for index readiness.
-func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint, numHousekeepingReplicas uint) error {
+func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint) error {
 
 	gocbBucket, ok := base.AsGoCBBucket(bucket)
 	if !ok {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -22,7 +22,7 @@ func TestInitializeIndexes(t *testing.T) {
 	dropErr := dropAllBucketIndexes(testBucket)
 	assertNoError(t, dropErr, "Error dropping all indexes")
 
-	initErr := InitializeIndexes(testBucket, db.UseXattrs(), 0, 0)
+	initErr := InitializeIndexes(testBucket, db.UseXattrs(), 0)
 	assertNoError(t, initErr, "Error initializing all indexes")
 
 	validateErr := validateAllIndexesOnline(testBucket)

--- a/rest/config.go
+++ b/rest/config.go
@@ -117,34 +117,33 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                         string                         `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
-	Sync                         *string                        `json:"sync,omitempty"`                         // Sync function defines which users can see which data
-	Users                        map[string]*db.PrincipalConfig `json:"users,omitempty"`                        // Initial user accounts
-	Roles                        map[string]*db.PrincipalConfig `json:"roles,omitempty"`                        // Initial roles
-	RevsLimit                    *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
-	AutoImport                   interface{}                    `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
-	ImportFilter                 *string                        `json:"import_filter,omitempty"`                // Filter function (import)
-	Shadow                       *ShadowConfig                  `json:"shadow,omitempty"`                       // This is where the ShadowConfig used to be.  If found, it should throw an error
-	EventHandlers                interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
-	FeedType                     string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword           bool                           `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
-	CacheConfig                  *CacheConfig                   `json:"cache,omitempty"`                        // Cache settings
-	ChannelIndex                 *ChannelIndexConfig            `json:"channel_index,omitempty"`                // Channel index settings
-	RevCacheSize                 *uint32                        `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache
-	StartOffline                 bool                           `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
-	Unsupported                  db.UnsupportedOptions          `json:"unsupported,omitempty"`                  // Config for unsupported features
-	Deprecated                   DeprecatedOptions              `json:"deprecated,omitempty"`                   // Config for Deprecated features
-	OIDCConfig                   *auth.OIDCOptions              `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
-	OldRevExpirySeconds          *uint32                        `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs         *uint32                        `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
-	LocalDocExpirySecs           *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
-	EnableXattrs                 *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
-	SessionCookieName            string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
-	AllowConflicts               *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
-	NumIndexReplicas             *uint                          `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
-	NumIndexReplicasHousekeeping *uint                          `json:"num_index_replicas_housekeeping"`        // Number of GSI index replicas used for housekeeping indexes
-	UseViews                     bool                           `json:"use_views"`                              // Force use of views instead of GSI
-	SendWWWAuthenticateHeader    *bool                          `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	Name                      string                         `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
+	Sync                      *string                        `json:"sync,omitempty"`                         // Sync function defines which users can see which data
+	Users                     map[string]*db.PrincipalConfig `json:"users,omitempty"`                        // Initial user accounts
+	Roles                     map[string]*db.PrincipalConfig `json:"roles,omitempty"`                        // Initial roles
+	RevsLimit                 *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
+	AutoImport                interface{}                    `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
+	ImportFilter              *string                        `json:"import_filter,omitempty"`                // Filter function (import)
+	Shadow                    *ShadowConfig                  `json:"shadow,omitempty"`                       // This is where the ShadowConfig used to be.  If found, it should throw an error
+	EventHandlers             interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
+	FeedType                  string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword        bool                           `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
+	CacheConfig               *CacheConfig                   `json:"cache,omitempty"`                        // Cache settings
+	ChannelIndex              *ChannelIndexConfig            `json:"channel_index,omitempty"`                // Channel index settings
+	RevCacheSize              *uint32                        `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache
+	StartOffline              bool                           `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
+	Unsupported               db.UnsupportedOptions          `json:"unsupported,omitempty"`                  // Config for unsupported features
+	Deprecated                DeprecatedOptions              `json:"deprecated,omitempty"`                   // Config for Deprecated features
+	OIDCConfig                *auth.OIDCOptions              `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds       *uint32                        `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs      *uint32                        `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
+	LocalDocExpirySecs        *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
+	EnableXattrs              *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
+	SessionCookieName         string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
+	AllowConflicts            *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
+	NumIndexReplicas          *uint                          `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
+	UseViews                  bool                           `json:"use_views"`                              // Force use of views instead of GSI
+	SendWWWAuthenticateHeader *bool                          `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
 }
 
 type DeprecatedOptions struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -301,7 +301,6 @@ func (sc *ServerContext) getOrAddDatabaseFromConfig(config *DbConfig, useExistin
 	return sc._getOrAddDatabaseFromConfig(config, useExisting)
 }
 
-
 func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 
 	server := "http://localhost:8091"
@@ -338,7 +337,6 @@ func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 		UseXattrs:            config.UseXattrs(),
 		ViewQueryTimeoutSecs: viewQueryTimeoutSecs,
 	}
-
 
 	return spec, nil
 }
@@ -425,8 +423,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	}
 
-
-
 	bucket, err := db.ConnectToBucket(spec, func(bucket string, err error) {
 
 		msgFormatStr := "%v dropped Mutation feed (TAP/DCP) due to error: %v, taking offline"
@@ -496,15 +492,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 
 		numReplicas := DefaultNumIndexReplicas
-		numHousekeepingReplicas := DefaultNumIndexReplicas
 		if config.NumIndexReplicas != nil {
 			numReplicas = *config.NumIndexReplicas
 		}
-		if config.NumIndexReplicasHousekeeping != nil {
-			numHousekeepingReplicas = *config.NumIndexReplicasHousekeeping
-		}
 
-		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas, numHousekeepingReplicas)
+		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
 		if indexErr != nil {
 			return nil, indexErr
 		}


### PR DESCRIPTION
When using GSI, we're not distinguishing between housekeeping and non-housekeeping indexes when setting the number of replicas.  Given the reduced number of housekeeping indexes (compared to views), it's not necessary to differentiate.

Fixes #3479