### PR TITLE
#3355 Redact configs in sgcollect_info

### DIFF
--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -424,6 +424,36 @@ class TestRemovePasswords(unittest.TestCase):
         assert "foobar" not in with_passwords_removed
 
 
+class TestTagUserData(unittest.TestCase):
+
+    def test_basic(self):
+        json_with_userdata = """
+        {
+          "databases": {
+            "db": {
+              "server": "http://bucket4:foobar@localhost:8091",
+              "bucket":"bucket-1",
+              "username":"bucket-user",
+              "password":"foobar",
+              "users": {
+                "FOO": {
+                  "password": "foobar",
+                  "disabled": false,
+                  "admin_channels": ["uber_secret_channel"]
+                },
+                "bar": { "password": "baz" }
+              }
+            },
+            "db2": { "server": "http://bucket-1:foobar@localhost:8091" }
+          }
+        }
+        """
+        tagged = tag_userdata_in_server_config(json_with_userdata)
+        assert "<ud>uber_secret_channel</ud>" in tagged
+        assert "<ud>foo</ud>" in tagged # everything is lowercased
+        assert "<ud>bucket-user</ud>" in tagged
+
+
 class TestConvertToValidJSON(unittest.TestCase):
 
     def basic_test(self):

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -60,25 +60,6 @@ def tag_userdata_in_server_json(config):
             dbs = config["databases"]
             for db in dbs:
                 tag_userdata_in_db_json(dbs[db])
-            for k, _ in dbs.items():
-                # Tag dict keys that reveal db names.
-                # Can't do this in the same loop, as it modifies
-                # the dict currently being iterated over.
-                dbs[UD(k)] = dbs.pop(k)
-
-        if "replicators" in config:
-            replicators = config["replicators"]
-            for i, _ in enumerate(replicators):
-                r = replicators[i]
-                if "replication_id" in r:
-                    r["replication_id"] = UD(r["replication_id"])
-                if "source" in r:
-                    r["source"] = UD(r["source"])
-                if "target" in r:
-                    r["target"] = UD(r["target"])
-                if "query_params" in r:
-                    for i, _ in enumerate(r["query_params"]):
-                        r["query_params"][i] = UD(r["query_params"][i])
 
 
 def tag_userdata_in_db_config(json_text, log_json_parsing_exceptions=True):
@@ -112,12 +93,8 @@ def tag_userdata_in_db_json(db):
         - Tag any sensitive user-data fields with <ud></ud> tags.
         """
 
-        if "name" in db:
-            db["name"] = UD(db["name"])
         if "username" in db:
             db["username"] = UD(db["username"])
-        if "bucket" in db:
-            db["bucket"] = UD(db["bucket"])
 
         if "users" in db:
             users = db["users"]
@@ -144,27 +121,6 @@ def tag_userdata_in_db_json(db):
                         admin_channels[i] = UD(admin_channels[i])
             for k, _ in roles.items():
                 roles[UD(k)] = roles.pop(k)
-
-        if "oidc" in db:
-            if "default_provider" in db["oidc"]:
-                db["oidc"]["default_provider"] = UD(db["oidc"]["default_provider"])
-            if "providers" in db["oidc"]:
-                providers = db["oidc"]["providers"]
-                for provider in providers:
-                    if "issuer" in provider:
-                        provider["issuer"] = UD(provider["issuer"])
-                    if "discovery_url" in provider:
-                        provider["discovery_url"] = UD(provider["discovery_url"])
-                    if "client_id" in provider:
-                        provider["client_id"] = UD(provider["client_id"])
-                    if "validation_key" in provider:
-                        provider["validation_key"] = UD(provider["validation_key"])
-                    if "callback_url" in provider:
-                        provider["callback_url"] = UD(provider["callback_url"])
-                    if "user_prefix" in provider:
-                        provider["user_prefix"] = UD(provider["user_prefix"])
-                for k, _ in providers.items():
-                    providers[UD(k)] = providers.pop(k)
 
 
 def UD(value):

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -109,8 +109,8 @@ def tag_userdata_in_db_json(db):
                     admin_roles = users[user]["admin_roles"]
                     for i, _ in enumerate(admin_roles):
                         admin_roles[i] = UD(admin_roles[i])
-            for k, _ in users.items():
-                users[UD(k)] = users.pop(k)
+            for i, _ in users.items():
+                users[UD(i)] = users.pop(i)
 
         if "roles" in db:
             roles = db["roles"]
@@ -119,8 +119,8 @@ def tag_userdata_in_db_json(db):
                     admin_channels = roles[role]["admin_channels"]
                     for i, _ in enumerate(admin_channels):
                         admin_channels[i] = UD(admin_channels[i])
-            for k, _ in roles.items():
-                roles[UD(k)] = roles.pop(k)
+            for i, _ in roles.items():
+                roles[UD(i)] = roles.pop(i)
 
 
 def UD(value):

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -43,9 +43,8 @@ def tag_userdata_in_server_config(json_text, log_json_parsing_exceptions=True):
         return formatted_json_string
 
     except Exception as e:
-        msg = "Exception trying to tag config user data in {0}.  Exception: {1}".format(json_text, e)
         if log_json_parsing_exceptions:
-            print(msg)
+            print("Exception trying to tag config user data in {0}.  Exception: {1}".format(json_text, e))
             traceback.print_exc()
         return '{"Error":"Error in sgcollect_info password_remover.py trying to tag config user data.  See logs for details"}'
 
@@ -80,9 +79,8 @@ def tag_userdata_in_db_config(json_text, log_json_parsing_exceptions=True):
         return formatted_json_string
 
     except Exception as e:
-        msg = "Exception trying to tag db config user data in {0}.  Exception: {1}".format(json_text, e)
         if log_json_parsing_exceptions:
-            print(msg)
+            print("Exception trying to tag db config user data in {0}.  Exception: {1}".format(json_text, e))
             traceback.print_exc()
         return '{"Error":"Error in sgcollect_info password_remover.py trying to tag db config user data.  See logs for details"}'
 
@@ -172,9 +170,8 @@ def remove_passwords(json_text, log_json_parsing_exceptions=True):
         return formatted_json_string
 
     except Exception as e:
-        msg = "Exception trying to remove passwords from {0}.  Exception: {1}".format(json_text, e)
         if log_json_parsing_exceptions:
-            print(msg)
+            print("Exception trying to remove passwords from {0}.  Exception: {1}".format(json_text, e))
             traceback.print_exc()
         return '{"Error":"Error in sgcollect_info password_remover.py trying to remove passwords.  See logs for details"}'
 

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -66,6 +66,20 @@ def tag_userdata_in_server_json(config):
                 # the dict currently being iterated over.
                 dbs[UD(k)] = dbs.pop(k)
 
+        if "replicators" in config:
+            replicators = config["replicators"]
+            for i, _ in enumerate(replicators):
+                r = replicators[i]
+                if "replication_id" in r:
+                    r["replication_id"] = UD(r["replication_id"])
+                if "source" in r:
+                    r["source"] = UD(r["source"])
+                if "target" in r:
+                    r["target"] = UD(r["target"])
+                if "query_params" in r:
+                    for i, _ in enumerate(r["query_params"]):
+                        r["query_params"][i] = UD(r["query_params"][i])
+
 
 def tag_userdata_in_db_config(json_text, log_json_parsing_exceptions=True):
     """
@@ -105,27 +119,6 @@ def tag_userdata_in_db_json(db):
         if "bucket" in db:
             db["bucket"] = UD(db["bucket"])
 
-        if "oidc" in db:
-            if "default_provider" in db["oidc"]:
-                db["oidc"]["default_provider"] = UD(db["oidc"]["default_provider"])
-            if "providers" in db["oidc"]:
-                providers = db["oidc"]["providers"]
-                for provider in providers:
-                    if "issuer" in provider:
-                        provider["issuer"] = UD(provider["issuer"])
-                    if "discovery_url" in provider:
-                        provider["discovery_url"] = UD(provider["discovery_url"])
-                    if "client_id" in provider:
-                        provider["client_id"] = UD(provider["client_id"])
-                    if "validation_key" in provider:
-                        provider["validation_key"] = UD(provider["validation_key"])
-                    if "callback_url" in provider:
-                        provider["callback_url"] = UD(provider["callback_url"])
-                    if "user_prefix" in provider:
-                        provider["user_prefix"] = UD(provider["user_prefix"])
-                for k, _ in providers.items():
-                    providers[UD(k)] = providers.pop(k)
-
         if "users" in db:
             users = db["users"]
             for user in users:
@@ -151,6 +144,27 @@ def tag_userdata_in_db_json(db):
                         admin_channels[i] = UD(admin_channels[i])
             for k, _ in roles.items():
                 roles[UD(k)] = roles.pop(k)
+
+        if "oidc" in db:
+            if "default_provider" in db["oidc"]:
+                db["oidc"]["default_provider"] = UD(db["oidc"]["default_provider"])
+            if "providers" in db["oidc"]:
+                providers = db["oidc"]["providers"]
+                for provider in providers:
+                    if "issuer" in provider:
+                        provider["issuer"] = UD(provider["issuer"])
+                    if "discovery_url" in provider:
+                        provider["discovery_url"] = UD(provider["discovery_url"])
+                    if "client_id" in provider:
+                        provider["client_id"] = UD(provider["client_id"])
+                    if "validation_key" in provider:
+                        provider["validation_key"] = UD(provider["validation_key"])
+                    if "callback_url" in provider:
+                        provider["callback_url"] = UD(provider["callback_url"])
+                    if "user_prefix" in provider:
+                        provider["user_prefix"] = UD(provider["user_prefix"])
+                for k, _ in providers.items():
+                    providers[UD(k)] = providers.pop(k)
 
 
 def UD(value):

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -453,6 +453,9 @@ class TestTagUserData(unittest.TestCase):
         assert "<ud>foo</ud>" in tagged # everything is lowercased
         assert "<ud>bucket-user</ud>" in tagged
 
+        assert "<ud>baz</ud>" not in tagged # passwords shouldn't be tagged, they get removed
+        assert "<ud>bucket-1</ud>" not in tagged # bucket name is acutally metadata
+
 
 class TestConvertToValidJSON(unittest.TestCase):
 

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -96,27 +96,31 @@ def tag_userdata_in_db_json(db):
 
         if "users" in db:
             users = db["users"]
-            for user in users:
-                if "name" in users[user]:
-                    users[user]["name"] = UD(users[user]["name"])
-                if "admin_channels" in users[user]:
-                    admin_channels = users[user]["admin_channels"]
+            for username in users:
+                user = users[username]
+                if "name" in user:
+                    user["name"] = UD(user["name"])
+                if "admin_channels" in user:
+                    admin_channels = user["admin_channels"]
                     for i, _ in enumerate(admin_channels):
                         admin_channels[i] = UD(admin_channels[i])
-                if "admin_roles" in users[user]:
-                    admin_roles = users[user]["admin_roles"]
+                if "admin_roles" in user:
+                    admin_roles = user["admin_roles"]
                     for i, _ in enumerate(admin_roles):
                         admin_roles[i] = UD(admin_roles[i])
+            # Tag dict keys. Can't be done in the above loop.
             for i, _ in users.items():
                 users[UD(i)] = users.pop(i)
 
         if "roles" in db:
             roles = db["roles"]
-            for role in roles:
-                if "admin_channels" in roles[role]:
-                    admin_channels = roles[role]["admin_channels"]
+            for rolename in roles:
+                role = roles[rolename]
+                if "admin_channels" in role:
+                    admin_channels = role["admin_channels"]
                     for i, _ in enumerate(admin_channels):
                         admin_channels[i] = UD(admin_channels[i])
+            # Tag dict keys. Can't be done in the above loop.
             for i, _ in roles.items():
                 roles[UD(i)] = roles.pop(i)
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -396,7 +396,7 @@ def get_db_list(sg_url):
 
 # Get the "status" for the server overall that's available
 # at the server root URL, as well as the status of each database
-def make_status_tasks(sg_url):
+def make_status_tasks(sg_url, should_redact):
 
     tasks = []
 
@@ -429,7 +429,7 @@ def make_status_tasks(sg_url):
 # Running config
 #   Server config
 #   Each DB config
-def make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level):
+def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
 
     collect_config_tasks = []
 
@@ -454,7 +454,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level):
     # Tag user data before redaction, if redact_level is set
     server_config_postprocessors = [password_remover.remove_passwords]
     db_config_postprocessors = [password_remover.remove_passwords]
-    if redact_level != "none":
+    if should_redact:
         server_config_postprocessors.append(password_remover.tag_userdata_in_server_config)
         db_config_postprocessors.append(password_remover.tag_userdata_in_db_config)
 
@@ -544,7 +544,7 @@ def make_download_expvars_task(sg_url):
     )
 
 
-def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway_executable_path, redact_level):
+def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway_executable_path, should_redact):
 
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(sg_url)
@@ -571,10 +571,10 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
     http_client_pprof_tasks = make_http_client_pprof_tasks(sg_url)
 
     # Add a task to collect Sync Gateway config
-    config_tasks = make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level)
+    config_tasks = make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact)
     
     # Curl the / endpoint and /db endpoints and save output 
-    status_tasks = make_status_tasks(sg_url)
+    status_tasks = make_status_tasks(sg_url, should_redact)
     
     # Compbine all tasks into flattened list
     sg_tasks = flatten(
@@ -655,12 +655,10 @@ def main():
     if options.redact_level != "none" and options.redact_level != "partial":
         parser.error("Invalid redaction level. Only 'none' and 'partial' are supported.")
 
-    ud_prefix = ""
-    ud_suffix = ""
     upload_url = ""
+    should_redact = False
     if options.redact_level != "none":
-        ud_prefix = "<ud>"
-        ud_suffix = "</ud>"
+        should_redact = True
 
         # Generate the s3 URL where zip files will be updated
         redact_zip_file = zip_filename[:-4] + "-redacted" + zip_filename[-4:]
@@ -721,7 +719,7 @@ def main():
     sg_binary_path = discover_sg_binary_path(options, sg_url)
 
     # Run SG specific tasks
-    for task in make_sg_tasks(zip_dir, sg_url, options.sync_gateway_config, options.sync_gateway_executable, options.redact_level):
+    for task in make_sg_tasks(zip_dir, sg_url, options.sync_gateway_config, options.sync_gateway_executable, should_redact):
         runner.run(task)
 
     if sg_binary_path is not None and sg_binary_path != "" and os.path.exists(sg_binary_path):
@@ -732,7 +730,7 @@ def main():
     # Echo the command line args used to run sgcollect_info
     cmd_line_args_task = AllOsTask(
         "Echo sgcollect_info cmd line args",
-        "echo options: {0} args: {1}".format({k: "{0}{1}{2}".format(ud_prefix, v, ud_suffix) for k, v in options.__dict__.items()}, args),
+        "echo options: {0} args: {1}".format({k: ud(v, should_redact) for k, v in options.__dict__.items()}, args),
         log_file="sgcollect_info_options.log",
     )
     runner.run(cmd_line_args_task)
@@ -769,6 +767,13 @@ def main():
         print "Zipfile built: {0}".format(redact_zip_file)
 
     print "Zipfile built: {0}".format(zip_filename)
+
+
+def ud(value, should_redact=True):
+    if not should_redact:
+        return value
+    return "<ud>{0}</ud>".format(value)
+
 
 if __name__ == '__main__':
     main()

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -429,7 +429,7 @@ def make_status_tasks(sg_url):
 # Running config
 #   Server config
 #   Each DB config
-def make_config_tasks(zip_dir, sg_config_path, sg_url):
+def make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level):
 
     collect_config_tasks = []
 
@@ -451,21 +451,27 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url):
     if sg_config_path is not None:
         sg_config_files.append(sg_config_path)
 
+    # Always strip passwords from configs
+    postprocessors = [password_remover.remove_passwords]
+
+    # Tag user data before redaction, if redact_level is set
+    if redact_level != "none":
+        postprocessors.append(password_remover.tag_userdata)
+
     # Get static server config
     for sg_config_file in sg_config_files:
-        task = add_file_task(sourcefile_path=sg_config_file, content_postprocessors=[password_remover.remove_passwords])
+        task = add_file_task(sourcefile_path=sg_config_file, content_postprocessors=postprocessors)
         collect_config_tasks.append(task)
 
 
     # Get server config
-    # TODO: Redact sensitive data
     server_config_url = "{0}/_config".format(sg_url)
     config_task = make_curl_task(name="Collect server config",
                                  user="",
                                  password="",
                                  url=server_config_url,
                                  log_file="running_server_config.log",
-                                 content_postprocessors=[password_remover.remove_passwords])
+                                 content_postprocessors=postprocessors)
     collect_config_tasks.append(config_task)
         
     # Get list of dbs from _all_dbs
@@ -478,7 +484,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url):
                                      password="",
                                      url=db_config_url,
                                      log_file="running_db_{0}_config.log".format(db),
-                                     content_postprocessors=[password_remover.remove_passwords])
+                                     content_postprocessors=postprocessors)
         collect_config_tasks.append(config_task)
 
     return collect_config_tasks
@@ -539,7 +545,7 @@ def make_download_expvars_task(sg_url):
     )
 
 
-def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway_executable_path):
+def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway_executable_path, redact_level):
 
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(sg_url)
@@ -566,7 +572,7 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
     http_client_pprof_tasks = make_http_client_pprof_tasks(sg_url)
 
     # Add a task to collect Sync Gateway config
-    config_tasks = make_config_tasks(zip_dir, sg_config_path, sg_url)
+    config_tasks = make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level)
     
     # Curl the / endpoint and /db endpoints and save output 
     status_tasks = make_status_tasks(sg_url)
@@ -716,7 +722,7 @@ def main():
     sg_binary_path = discover_sg_binary_path(options, sg_url)
 
     # Run SG specific tasks
-    for task in make_sg_tasks(zip_dir, sg_url, options.sync_gateway_config, options.sync_gateway_executable):
+    for task in make_sg_tasks(zip_dir, sg_url, options.sync_gateway_config, options.sync_gateway_executable, options.redact_level):
         runner.run(task)
 
     if sg_binary_path is not None and sg_binary_path != "" and os.path.exists(sg_binary_path):

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -451,18 +451,17 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level):
     if sg_config_path is not None:
         sg_config_files.append(sg_config_path)
 
-    # Always strip passwords from configs
-    postprocessors = [password_remover.remove_passwords]
-
     # Tag user data before redaction, if redact_level is set
+    server_config_postprocessors = [password_remover.remove_passwords]
+    db_config_postprocessors = [password_remover.remove_passwords]
     if redact_level != "none":
-        postprocessors.append(password_remover.tag_userdata)
+        server_config_postprocessors.append(password_remover.tag_userdata_in_server_config)
+        db_config_postprocessors.append(password_remover.tag_userdata_in_db_config)
 
     # Get static server config
     for sg_config_file in sg_config_files:
-        task = add_file_task(sourcefile_path=sg_config_file, content_postprocessors=postprocessors)
+        task = add_file_task(sourcefile_path=sg_config_file, content_postprocessors=server_config_postprocessors)
         collect_config_tasks.append(task)
-
 
     # Get server config
     server_config_url = "{0}/_config".format(sg_url)
@@ -471,9 +470,9 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level):
                                  password="",
                                  url=server_config_url,
                                  log_file="running_server_config.log",
-                                 content_postprocessors=postprocessors)
+                                 content_postprocessors=server_config_postprocessors)
     collect_config_tasks.append(config_task)
-        
+
     # Get list of dbs from _all_dbs
     # For each db, get db config
     dbs = get_db_list(sg_url)
@@ -484,7 +483,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, redact_level):
                                      password="",
                                      url=db_config_url,
                                      log_file="running_db_{0}_config.log".format(db),
-                                     content_postprocessors=postprocessors)
+                                     content_postprocessors=db_config_postprocessors)
         collect_config_tasks.append(config_task)
 
     return collect_config_tasks
@@ -733,7 +732,7 @@ def main():
     # Echo the command line args used to run sgcollect_info
     cmd_line_args_task = AllOsTask(
         "Echo sgcollect_info cmd line args",
-        "echo options: {0} args: {1}".format({k: ud_prefix+'{0}'+ud_suffix.format(v) for k, v in options.__dict__.items()}, args),
+        "echo options: {0} args: {1}".format({k: "{0}{1}{2}".format(ud_prefix, v, ud_suffix) for k, v in options.__dict__.items()}, args),
         log_file="sgcollect_info_options.log",
     )
     runner.run(cmd_line_args_task)


### PR DESCRIPTION
Fixes #3355 - Tags sensitive user data in configs collected by sgcollect_info before being redacted.

Closes #3259 

## Tagged fields:
```
databases.foo_db.username

databases.foo_db.users.foo_user
databases.foo_db.users.foo_user.name
databases.foo_db.users.foo_user.admin_channels.[]
databases.foo_db.users.foo_user.admin_roles.[]

databases.foo_db.roles.foo_role
databases.foo_db.roles.foo_role.admin_channels.[]
```

Using [this config reference](https://developer.couchbase.com/documentation/mobile/current/guides/sync-gateway/config-properties/index.html#configuration-reference)