### PR TITLE
#2516 sgcollect_info REST endpoint

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -17,6 +17,7 @@ const (
 	// KeyAll is a wildcard for all log keys.
 	KeyAll LogKey = 1 << iota
 
+	KeyAdmin
 	KeyAccel
 	KeyAccess
 	KeyAttach
@@ -55,6 +56,7 @@ var (
 	logKeyNames = map[LogKey]string{
 		KeyNone:           "",
 		KeyAll:            "*",
+		KeyAdmin:          "Admin",
 		KeyAccel:          "Accel",
 		KeyAccess:         "Access",
 		KeyAttach:         "Attach",

--- a/base/util.go
+++ b/base/util.go
@@ -816,6 +816,10 @@ func StringSliceContains(set []string, target string) bool {
 	return false
 }
 
+func Uint32Ptr(u uint32) *uint32 {
+	return &u
+}
+
 func BoolPtr(b bool) *bool {
 	return &b
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -400,8 +400,8 @@ func (h *handler) handleSGCollect() error {
 	if sgcollectInstance.Running() {
 		return base.HTTPErrorf(http.StatusTooManyRequests, "sgcollect_info is already running")
 	}
-	sgcollectInstance.Set(true)
-	defer sgcollectInstance.Set(false)
+	sgcollectInstance.SetRunning(true)
+	defer sgcollectInstance.SetRunning(false)
 
 	body, err := h.readBody()
 	if err != nil {
@@ -457,6 +457,9 @@ func streamPipe(resp http.ResponseWriter, pipeReader *io.PipeReader) {
 	for {
 		n, err := pipeReader.Read(buffer)
 		if err != nil {
+			if err != io.EOF {
+				base.Errorf(base.KeyAll, "Unexpected error from pipeReader: %v", err)
+			}
 			pipeReader.Close()
 			break
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -12,9 +12,15 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -392,6 +398,150 @@ func (h *handler) handleSetLogging() error {
 
 	base.UpdateLogKeys(keys, h.rq.Method == "PUT")
 	return nil
+}
+
+// sgcollectRunning is used to reject multiple requests to run sgcollect_info.
+var sgcollectRunning struct {
+	running bool
+	lock    sync.Mutex
+}
+
+func (h *handler) handleSGCollect() error {
+	sgcollectRunning.lock.Lock()
+	if sgcollectRunning.running {
+		sgcollectRunning.lock.Unlock()
+		return base.HTTPErrorf(http.StatusTooManyRequests, "sgcollect_info already running!")
+	}
+	sgcollectRunning.running = true
+	sgcollectRunning.lock.Unlock()
+	defer func() {
+		sgcollectRunning.lock.Lock()
+		sgcollectRunning.running = false
+		sgcollectRunning.lock.Unlock()
+	}()
+
+	body, err := h.readBody()
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to read request body: %v", err)
+	}
+
+	var sgCollectParams struct {
+		RedactLevel     string `json:"redact_level,omitempty"`
+		RedactSalt      string `json:"redact_salt,omitempty"`
+		OutputDirectory string `json:"output_dir,omitempty"`
+		Upload          bool   `json:"upload,omitempty"`
+		UploadProxy     string `json:"upload_proxy,omitempty"`
+		UploadHost      string `json:"upload_host,omitempty"`
+		Customer        string `json:"customer,omitempty"`
+		Ticket          string `json:"ticket,omitempty"`
+	}
+	if err = json.Unmarshal(body, &sgCollectParams); err != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "Unable to parse request body: %v", err)
+	}
+
+	var sgCollectArgs []string
+	if sgCollectParams.RedactLevel != "" {
+		sgCollectArgs = append(sgCollectArgs, "--log-redaction-level", sgCollectParams.RedactLevel)
+	}
+	if sgCollectParams.RedactSalt != "" {
+		sgCollectArgs = append(sgCollectArgs, "--log-redaction-salt", sgCollectParams.RedactSalt)
+	}
+	if sgCollectParams.OutputDirectory != "" {
+		fileInfo, statErr := os.Stat(sgCollectParams.OutputDirectory)
+		if statErr != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, "Invalid output directory specified: %v", statErr)
+		} else if !fileInfo.IsDir() {
+			return base.HTTPErrorf(http.StatusBadRequest, "Invalid output directory specified: not a directory")
+		}
+		sgCollectArgs = append(sgCollectArgs, "-r", sgCollectParams.OutputDirectory)
+	}
+	if sgCollectParams.Upload {
+		if sgCollectParams.UploadHost == "" {
+			return base.HTTPErrorf(http.StatusBadRequest, "Upload host must be set if upload is true.")
+		}
+		sgCollectArgs = append(sgCollectArgs, "--upload-host", sgCollectParams.UploadHost)
+	}
+	if sgCollectParams.UploadProxy != "" {
+		base.Warnf(base.KeyAll, "Unsupported upload_proxy option for sgcollect_info")
+	}
+	if sgCollectParams.Customer != "" {
+		sgCollectArgs = append(sgCollectArgs, "--customer", sgCollectParams.Customer)
+	}
+	if sgCollectParams.Ticket != "" {
+		sgCollectArgs = append(sgCollectArgs, "--ticket", sgCollectParams.Ticket)
+	}
+
+	sgPath, err := os.Executable()
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to get path of SG executable: %v", err)
+	}
+	sgPath, err = filepath.Abs(sgPath)
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to get absolute path of SG executable: %v", err)
+	}
+
+	sgPathDir, err := filepath.Abs(filepath.Dir(sgPath))
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to get directory of SG executable: %v", err)
+	}
+
+	sgcollectBinary := "tools/sgcollect_info"
+	if runtime.GOOS == "windows" {
+		sgcollectBinary += ".exe"
+	}
+
+	sgcollectBinary = filepath.Join(sgPathDir, sgcollectBinary)
+
+	_, err = os.Stat(sgcollectBinary)
+	if err != nil {
+		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to get find SG executable: %v", err)
+	}
+
+	timestamp := time.Now().Format(base.ISO8601Format)
+	sgCollectArgs = append(sgCollectArgs, "--sync-gateway-executable", sgPath, timestamp+".zip")
+
+	base.Debugf(base.KeyHTTP, "Calling sgcollect_info with arguments: %v", sgCollectArgs)
+
+	cmd := exec.CommandContext(h.rq.Context(), sgcollectBinary, sgCollectArgs...)
+
+	pipeReader, pipeWriter := io.Pipe()
+	defer pipeWriter.Close()
+	cmd.Stdout = pipeWriter
+	cmd.Stderr = pipeWriter
+	h.response.WriteHeader(http.StatusAccepted)
+	go streamCmdOutput(h.response, pipeReader)
+
+	if err = cmd.Run(); err != nil {
+		// Already written headers from streamCmdOutput,
+		// can't write an error status back to the response.
+		base.Warnf(base.KeyAll, "sgcollect_info failed: %v", err)
+		return nil
+	}
+
+	return nil
+}
+
+// streamCmdOutput streams output from pipeReader into a the response.
+func streamCmdOutput(res http.ResponseWriter, pipeReader *io.PipeReader) {
+	buffer := make([]byte, 1024) // 1kB buffer
+	for {
+		n, err := pipeReader.Read(buffer)
+		if err != nil {
+			pipeReader.Close()
+			break
+		}
+
+		data := buffer[0:n]
+		res.Write(data)
+		if f, ok := res.(http.Flusher); ok {
+			f.Flush()
+		}
+		//reset buffer
+		for i := 0; i < n; i++ {
+			buffer[i] = 0
+		}
+	}
+
 }
 
 //////// USERS & ROLES:

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -497,10 +497,10 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to get find SG executable: %v", err)
 	}
 
-	timestamp := time.Now().Format(base.ISO8601Format)
-	sgCollectArgs = append(sgCollectArgs, "--sync-gateway-executable", sgPath, timestamp+".zip")
+	filename := time.Now().Format(base.ISO8601Format) + ".zip"
+	sgCollectArgs = append(sgCollectArgs, "--sync-gateway-executable", sgPath, filename)
 
-	base.Debugf(base.KeyHTTP, "Calling sgcollect_info with arguments: %v", sgCollectArgs)
+	base.Debugf(base.KeyHTTP, "#%03d: Calling sgcollect_info with arguments: %v", h.serialNumber, sgCollectArgs)
 
 	cmd := exec.CommandContext(h.rq.Context(), sgcollectBinary, sgCollectArgs...)
 
@@ -514,10 +514,11 @@ func (h *handler) handleSGCollect() error {
 	if err = cmd.Run(); err != nil {
 		// Already written headers from streamCmdOutput,
 		// can't write an error status back to the response.
-		base.Warnf(base.KeyAll, "sgcollect_info failed: %v", err)
+		base.Warnf(base.KeyAll, "#%03d: sgcollect_info failed: %v", h.serialNumber, err)
 		return nil
 	}
 
+	base.Debugf(base.KeyHTTP, "#%03d: sgcollect_info finished: %s", h.serialNumber, filename)
 	return nil
 }
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -410,6 +410,7 @@ func (h *handler) handleSGCollectCancel() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Error stopping sgcollect_info: %v", err)
 	}
 
+	h.writeTextStatus(http.StatusOK, []byte("sgcollect_info cancelled"))
 	return nil
 }
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -433,7 +433,7 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", err)
 	}
 
-	filename := time.Now().Format(base.ISO8601Format) + ".zip"
+	filename := "sgcollect_info_" + time.Now().Format(base.ISO8601Format) + ".zip"
 	args := params.Args()
 
 	if err := sgcollectInstance.Start(filename, args...); err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -435,8 +435,6 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 
-	base.Infof(base.KeyAll, "#%03d: sgcollect_info started with args: %v", h.serialNumber, base.UD(args))
-
 	h.writeTextStatus(http.StatusOK, []byte("sgcollect_info started"))
 	return nil
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -395,12 +395,14 @@ func (h *handler) handleSetLogging() error {
 }
 
 func (h *handler) handleSGCollectStatus() error {
-	if !sgcollectInstance.IsRunning() {
-		h.writeTextStatus(http.StatusOK, []byte("sgcollect_info not running"))
-		return nil
+	status := "stopped"
+	if sgcollectInstance.IsRunning() {
+		status = "running"
 	}
 
-	h.writeTextStatus(http.StatusOK, []byte("sgcollect_info running"))
+	h.writeJSONStatus(http.StatusOK, map[string]string{
+		"status": status,
+	})
 	return nil
 }
 
@@ -410,7 +412,9 @@ func (h *handler) handleSGCollectCancel() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Error stopping sgcollect_info: %v", err)
 	}
 
-	h.writeTextStatus(http.StatusOK, []byte("sgcollect_info cancelled"))
+	h.writeJSONStatus(http.StatusOK, map[string]string{
+		"status": "cancelled",
+	})
 	return nil
 }
 
@@ -436,7 +440,9 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 
-	h.writeTextStatus(http.StatusOK, []byte("sgcollect_info started"))
+	h.writeJSONStatus(http.StatusOK, map[string]string{
+		"status": "started",
+	})
 	return nil
 }
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -215,7 +215,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleActiveTasks)).Methods("GET")
-	r.Handle("/_sgcollect",
+	r.Handle("/_sgcollect_info",
 		makeHandler(sc, adminPrivs, (*handler).handleSGCollect)).Methods("POST")
 
 	// Debugging handlers

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -215,6 +215,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleActiveTasks)).Methods("GET")
+	r.Handle("/_sgcollect",
+		makeHandler(sc, adminPrivs, (*handler).handleSGCollect)).Methods("POST")
 
 	// Debugging handlers
 	r.Handle("/_debug/pprof/goroutine",

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -215,6 +215,11 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleActiveTasks)).Methods("GET")
+
+	r.Handle("/_sgcollect_info",
+		makeHandler(sc, adminPrivs, (*handler).handleSGCollectStatus)).Methods("GET")
+	r.Handle("/_sgcollect_info",
+		makeHandler(sc, adminPrivs, (*handler).handleSGCollectCancel)).Methods("DELETE")
 	r.Handle("/_sgcollect_info",
 		makeHandler(sc, adminPrivs, (*handler).handleSGCollect)).Methods("POST")
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -73,7 +73,7 @@ func (i *sgCollectInstance) Running() bool {
 	return i.running
 }
 
-func (i *sgCollectInstance) Set(b bool) {
+func (i *sgCollectInstance) SetRunning(b bool) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
 	i.running = b
@@ -91,7 +91,7 @@ func sgCollectPaths() (sgPath, sgCollectPath string, err error) {
 		return "", "", err
 	}
 
-	sgCollectPath = "tools/sgcollect_info"
+	sgCollectPath = filepath.Join("tools", "sgcollect_info")
 	if runtime.GOOS == "windows" {
 		sgCollectPath += ".exe"
 	}

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -1,0 +1,108 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+type sgCollectConfig struct {
+	RedactLevel     string `json:"redact_level,omitempty"`
+	RedactSalt      string `json:"redact_salt,omitempty"`
+	OutputDirectory string `json:"output_dir,omitempty"`
+	Upload          bool   `json:"upload,omitempty"`
+	UploadHost      string `json:"upload_host,omitempty"`
+	Customer        string `json:"customer,omitempty"`
+	Ticket          string `json:"ticket,omitempty"`
+}
+
+// Args validates and returns a set of arguments to pass to sgcollect_info from a config.
+func (c *sgCollectConfig) Args() (args []string, err error) {
+	if c.OutputDirectory != "" {
+		if fileInfo, err := os.Stat(c.OutputDirectory); err != nil {
+			return nil, err
+		} else if !fileInfo.IsDir() {
+			return nil, errors.New("not a directory")
+		}
+
+		args = append(args, "-r", c.OutputDirectory)
+	}
+
+	if c.Upload {
+		if c.UploadHost == "" {
+			return nil, base.HTTPErrorf(http.StatusBadRequest, "Upload host must be set if upload is true.")
+		}
+
+		args = append(args, "--upload-host", c.UploadHost)
+	}
+
+	if c.RedactLevel != "" {
+		args = append(args, "--log-redaction-level", c.RedactLevel)
+	}
+
+	if c.RedactSalt != "" {
+		args = append(args, "--log-redaction-salt", c.RedactSalt)
+	}
+
+	if c.Customer != "" {
+		args = append(args, "--customer", c.Customer)
+	}
+
+	if c.Ticket != "" {
+		args = append(args, "--ticket", c.Ticket)
+	}
+
+	return args, nil
+}
+
+var sgcollectInstance sgCollectInstance
+
+type sgCollectInstance struct {
+	running bool
+	lock    sync.Mutex
+}
+
+func (i *sgCollectInstance) Running() bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.running
+}
+
+func (i *sgCollectInstance) Set(b bool) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.running = b
+}
+
+// sgCollectPaths returns the absolute paths to Sync Gateway and to sgcollect_info.
+func sgCollectPaths() (sgPath, sgCollectPath string, err error) {
+	sgPath, err = os.Executable()
+	if err != nil {
+		return "", "", err
+	}
+
+	sgPath, err = filepath.Abs(sgPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	sgCollectPath = "tools/sgcollect_info"
+	if runtime.GOOS == "windows" {
+		sgCollectPath += ".exe"
+	}
+
+	sgCollectPath = filepath.Join(filepath.Dir(sgPath), sgCollectPath)
+
+	// Make sure sgcollect_info exists
+	_, err = os.Stat(sgCollectPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	return sgPath, sgCollectPath, nil
+}

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -67,16 +67,15 @@ type sgCollectInstance struct {
 	lock    sync.Mutex
 }
 
-func (i *sgCollectInstance) Running() bool {
+// SetRunning will mark the sgCollectInstance as running, if b is true, and is not already running.
+func (i *sgCollectInstance) SetRunning(b bool) error {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	return i.running
-}
-
-func (i *sgCollectInstance) SetRunning(b bool) {
-	i.lock.Lock()
-	defer i.lock.Unlock()
+	if i.running && b {
+		return errors.New("sgcollect_info already running")
+	}
 	i.running = b
+	return nil
 }
 
 // sgCollectPaths returns the absolute paths to Sync Gateway and to sgcollect_info.

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -57,14 +57,15 @@ func (sg *sgCollect) Start(filename string, args ...string) error {
 	}
 
 	sg.running = true
+	base.Infof(base.KeyAll, "sgcollect_info started with args: %v", base.UD(args))
 
-	go func(s *sgCollect, c *exec.Cmd) {
-		if err := c.Wait(); err != nil {
+	go func() {
+		if err := cmd.Wait(); err != nil {
 			base.Warnf(base.KeyAll, "sgcollect_info failed: %v", err)
 		}
-		s.running = false
+		sg.running = false
 		base.Infof(base.KeyAll, "sgcollect_info finished")
-	}(sg, cmd)
+	}()
 
 	return nil
 }

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -1,9 +1,10 @@
 package rest
 
 import (
+	"context"
 	"errors"
-	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -11,7 +12,92 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-type sgCollectConfig struct {
+var (
+	defualtSGUploadHost = "https://s3.amazonaws.com/cb-customers"
+
+	// ErrSGCollectInfoAlreadyRunning is returned if sgcollect_info is already running.
+	ErrSGCollectInfoAlreadyRunning = errors.New("already running")
+	// ErrSGCollectInfoNotRunning is returned if sgcollect_info is not running.
+	ErrSGCollectInfoNotRunning = errors.New("not running")
+
+	sgcollectInstance sgCollect
+)
+
+type sgCollect struct {
+	// output  io.Writer
+	cancel  context.CancelFunc
+	running bool
+
+	sync.Mutex
+}
+
+// Start will attempt to start sgcollect_info, if another is not already running.
+func (sg *sgCollect) Start(filename string, args ...string) error {
+	sg.Lock()
+	defer sg.Unlock()
+
+	if sg.running {
+		return ErrSGCollectInfoAlreadyRunning
+	}
+
+	sgPath, sgCollectPath, err := sgCollectPaths()
+	if err != nil {
+		return err
+	}
+
+	args = append(args, "--sync-gateway-executable", sgPath, filename)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	sg.cancel = cancelFunc
+	cmd := exec.CommandContext(ctx, sgCollectPath, args...)
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	sg.running = true
+
+	go func(s *sgCollect, c *exec.Cmd) {
+		if err := c.Wait(); err != nil {
+			base.Warnf(base.KeyAll, "sgcollect_info failed: %v", err)
+		}
+		s.running = false
+		base.Infof(base.KeyAll, "sgcollect_info finished")
+	}(sg, cmd)
+
+	return nil
+}
+
+// Stop will stop sgcollect_info, if running.
+func (sg *sgCollect) Stop() error {
+	sg.Lock()
+	defer sg.Unlock()
+
+	if !sg.running {
+		return ErrSGCollectInfoNotRunning
+	}
+
+	sg.cancel()
+	sg.running = false
+
+	return nil
+}
+
+// _isRunning returns true if sgcollect_info is running
+func (sg *sgCollect) _isRunning() bool {
+	return sg.running
+}
+
+// IsRunning returns true if sgcollect_info is running
+func (sg *sgCollect) IsRunning() bool {
+	sg.Lock()
+	defer sg.Unlock()
+
+	return sg._isRunning()
+}
+
+type sgCollectOptions struct {
 	RedactLevel     string `json:"redact_level,omitempty"`
 	RedactSalt      string `json:"redact_salt,omitempty"`
 	OutputDirectory string `json:"output_dir,omitempty"`
@@ -21,32 +107,41 @@ type sgCollectConfig struct {
 	Ticket          string `json:"ticket,omitempty"`
 }
 
-// Args validates and returns a set of arguments to pass to sgcollect_info from a config.
-func (c *sgCollectConfig) Args() (args []string, err error) {
+func (c *sgCollectOptions) setDefaults() {
+	if c.UploadHost == "" {
+		c.UploadHost = defualtSGUploadHost
+	}
+}
+
+// Validate ensures the options are OK to use in sgcollect_info.
+func (c *sgCollectOptions) Validate() error {
+	c.setDefaults()
+
 	if c.OutputDirectory != "" {
 		if fileInfo, err := os.Stat(c.OutputDirectory); err != nil {
-			return nil, err
+			return err
 		} else if !fileInfo.IsDir() {
-			return nil, errors.New("not a directory")
+			return errors.New("not a directory")
 		}
+	}
 
+	if c.Upload && c.Customer == "" {
+		return errors.New("customer must be set if uploading")
+	}
+
+	return nil
+}
+
+// Args returns a set of arguments to pass to sgcollect_info.
+func (c *sgCollectOptions) Args() []string {
+	var args = make([]string, 0)
+
+	if c.OutputDirectory != "" {
 		args = append(args, "-r", c.OutputDirectory)
 	}
 
 	if c.Upload {
-		if c.UploadHost == "" {
-			return nil, base.HTTPErrorf(http.StatusBadRequest, "Upload host must be set if upload is true.")
-		}
-
 		args = append(args, "--upload-host", c.UploadHost)
-	}
-
-	if c.RedactLevel != "" {
-		args = append(args, "--log-redaction-level", c.RedactLevel)
-	}
-
-	if c.RedactSalt != "" {
-		args = append(args, "--log-redaction-salt", c.RedactSalt)
 	}
 
 	if c.Customer != "" {
@@ -57,25 +152,15 @@ func (c *sgCollectConfig) Args() (args []string, err error) {
 		args = append(args, "--ticket", c.Ticket)
 	}
 
-	return args, nil
-}
-
-var sgcollectInstance sgCollectInstance
-
-type sgCollectInstance struct {
-	running bool
-	lock    sync.Mutex
-}
-
-// SetRunning will mark the sgCollectInstance as running, if b is true, and is not already running.
-func (i *sgCollectInstance) SetRunning(b bool) error {
-	i.lock.Lock()
-	defer i.lock.Unlock()
-	if i.running && b {
-		return errors.New("sgcollect_info already running")
+	if c.RedactLevel != "" {
+		args = append(args, "--log-redaction-level", c.RedactLevel)
 	}
-	i.running = b
-	return nil
+
+	if c.RedactSalt != "" {
+		args = append(args, "--log-redaction-salt", c.RedactSalt)
+	}
+
+	return args
 }
 
 // sgCollectPaths returns the absolute paths to Sync Gateway and to sgcollect_info.
@@ -90,6 +175,7 @@ func sgCollectPaths() (sgPath, sgCollectPath string, err error) {
 		return "", "", err
 	}
 
+	// TODO: Validate this works on Windows
 	sgCollectPath = filepath.Join("tools", "sgcollect_info")
 	if runtime.GOOS == "windows" {
 		sgCollectPath += ".exe"

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -13,16 +13,15 @@ import (
 )
 
 var (
-	defualtSGUploadHost = "https://s3.amazonaws.com/cb-customers"
-
 	// ErrSGCollectInfoAlreadyRunning is returned if sgcollect_info is already running.
 	ErrSGCollectInfoAlreadyRunning = errors.New("already running")
 	// ErrSGCollectInfoNotRunning is returned if sgcollect_info is not running.
 	ErrSGCollectInfoNotRunning = errors.New("not running")
 
-	sgcollectInstance = sgCollect{status: base.Uint32Ptr(sgStopped)}
+	defualtSGUploadHost   = "https://s3.amazonaws.com/cb-customers"
+	sgPath, sgCollectPath = sgCollectPaths()
 
-	sgPath, sgCollectPath, _ = sgCollectPaths()
+	sgcollectInstance = sgCollect{status: base.Uint32Ptr(sgStopped)}
 )
 
 const (
@@ -149,15 +148,15 @@ func (c *sgCollectOptions) Args() []string {
 }
 
 // sgCollectPaths returns the absolute paths to Sync Gateway and to sgcollect_info.
-func sgCollectPaths() (sgPath, sgCollectPath string, err error) {
-	sgPath, err = os.Executable()
+func sgCollectPaths() (sgPath, sgCollectPath string) {
+	sgPath, err := os.Executable()
 	if err != nil {
-		return "", "", err
+		base.Warnf(base.KeyAll, "Unable to get path to SG executable. sgcollect_info may not contain all data nessesary for support.")
 	}
 
 	sgPath, err = filepath.Abs(sgPath)
 	if err != nil {
-		return "", "", err
+		base.Warnf(base.KeyAll, "Unable to get absolute path to SG executable. sgcollect_info may not contain all data nessesary for support.")
 	}
 
 	// TODO: Validate this works on Windows
@@ -171,8 +170,8 @@ func sgCollectPaths() (sgPath, sgCollectPath string, err error) {
 	// Make sure sgcollect_info exists
 	_, err = os.Stat(sgCollectPath)
 	if err != nil {
-		return "", "", err
+		base.Warnf(base.KeyAll, "Unable to find sgcollect_info executable")
 	}
 
-	return sgPath, sgCollectPath, nil
+	return sgPath, sgCollectPath
 }

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -51,14 +51,14 @@ func (sg *sgCollect) Start(filename string, args ...string) error {
 	}
 
 	atomic.StoreUint32(sg.status, sgRunning)
-	base.Infof(base.KeyAll, "sgcollect_info started with args: %v", base.UD(args))
+	base.Infof(base.KeyAdmin, "sgcollect_info started with args: %v", base.UD(args))
 
 	go func() {
 		if err := cmd.Wait(); err != nil {
-			base.Warnf(base.KeyAll, "sgcollect_info failed: %v", err)
+			base.Warnf(base.KeyAdmin, "sgcollect_info failed: %v", err)
 		}
 		atomic.StoreUint32(sg.status, sgStopped)
-		base.Infof(base.KeyAll, "sgcollect_info finished")
+		base.Infof(base.KeyAdmin, "sgcollect_info finished")
 	}()
 
 	return nil


### PR DESCRIPTION
#2516 - Adds a `/_sgcollect_info` endpoint on the admin API which runs sgcollect_info.


Start sgcollect_info
```
21:19 $ curl -X POST http://localhost:4985/_sgcollect_info -H 'Content-Type: application/json' -d '{}'
```

Cancel sgcollect_info
```
21:19 $ curl -X DELETE http://localhost:4985/_sgcollect_info
```

Status of sgcollect_info
```
21:19 $ curl -X GET http://localhost:4985/_sgcollect_info
```