### PR TITLE
Feature/issue 3481 2nd testbucket settings

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -769,6 +769,10 @@ func BooleanPointer(booleanValue bool) *bool {
 	return &booleanValue
 }
 
+func StringPointer(value string) *string {
+	return &value
+}
+
 // Convert a Couchbase URI (eg, couchbase://host1,host2) to a list of HTTP URLs with ports (eg, ["http://host1:8091", "http://host2:8091"])
 // Primary use case is for backwards compatibility with go-couchbase, cbdatasource, and CBGT. Supports secure URI's as well (couchbases://).
 // Related CBGT ticket: https://issues.couchbase.com/browse/MB-25522
@@ -1033,4 +1037,23 @@ func ReplaceAll(s, chars, new string) string {
 		s = strings.Replace(s, string(r), new, -1)
 	}
 	return s
+}
+// Make a deep copy from src into dst.
+// Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
+func DeepCopy(dst interface{}, src interface{}) error {
+	if dst == nil {
+		return fmt.Errorf("dst cannot be nil")
+	}
+	if src == nil {
+		return fmt.Errorf("src cannot be nil")
+	}
+	bytes, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal src: %s", err)
+	}
+	err = json.Unmarshal(bytes, dst)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshal into dst: %s", err)
+	}
+	return nil
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1038,22 +1038,3 @@ func ReplaceAll(s, chars, new string) string {
 	}
 	return s
 }
-// Make a deep copy from src into dst.
-// Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
-func DeepCopy(dst interface{}, src interface{}) error {
-	if dst == nil {
-		return fmt.Errorf("dst cannot be nil")
-	}
-	if src == nil {
-		return fmt.Errorf("src cannot be nil")
-	}
-	bytes, err := json.Marshal(src)
-	if err != nil {
-		return fmt.Errorf("Unable to marshal src: %s", err)
-	}
-	err = json.Unmarshal(bytes, dst)
-	if err != nil {
-		return fmt.Errorf("Unable to unmarshal into dst: %s", err)
-	}
-	return nil
-}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbaselabs/go.assert"
+	"reflect"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -491,5 +492,52 @@ func TestReplaceAll(t *testing.T) {
 			output := ReplaceAll(test.input, test.chars, test.new)
 			assert.Equals(ts, output, test.expected)
 		})
+	}
+}
+
+type A struct {
+	String  string
+	Int     int
+	Strings []string
+	Ints    map[string]int
+	As      map[string]*A
+}
+
+// Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
+func TestDeepCopy(t *testing.T) {
+	src := map[string]interface{}{
+		"String":  "Hello World",
+		"Int":     5,
+		"Strings": []string{"A", "B"},
+		"Ints":    map[string]int{"A": 1, "B": 2},
+		"As": map[string]map[string]interface{}{
+			"One": map[string]interface{}{
+				"String": "2",
+			},
+			"Two": map[string]interface{}{
+				"String": "3",
+			},
+		},
+	}
+	dst := &A{
+		Strings: []string{"C"},
+		Ints:    map[string]int{"B": 3, "C": 4},
+		As:      map[string]*A{"One": &A{String: "1", Int: 5}}}
+	expected := &A{
+		String:  "Hello World",
+		Int:     5,
+		Strings: []string{"A", "B"},
+		Ints:    map[string]int{"A": 1, "B": 2, "C": 4},
+		As: map[string]*A{
+			"One": &A{String: "2"},
+			"Two": &A{String: "3"},
+		},
+	}
+	err := DeepCopy(dst, src)
+	if err != nil {
+		t.Errorf("Unable to copy!")
+	}
+	if !reflect.DeepEqual(expected, dst) {
+		t.Errorf("expected and dst differed")
 	}
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -504,7 +504,7 @@ type A struct {
 }
 
 // Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
-func TestDeepCopy(t *testing.T) {
+func TestDeepCopyInefficient(t *testing.T) {
 	src := map[string]interface{}{
 		"String":  "Hello World",
 		"Int":     5,
@@ -533,7 +533,7 @@ func TestDeepCopy(t *testing.T) {
 			"Two": &A{String: "3"},
 		},
 	}
-	err := DeepCopy(dst, src)
+	err := DeepCopyInefficient(dst, src)
 	if err != nil {
 		t.Errorf("Unable to copy!")
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb"
+	"encoding/json"
 )
 
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
@@ -551,4 +552,24 @@ func EnableTestLogKey(logKey string) {
 func ResetTestLogging() {
 	ConsoleLogLevel().Set(LevelInfo)
 	ConsoleLogKey().Set(KeyHTTP)
+}
+
+// Make a deep copy from src into dst.
+// Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
+func DeepCopyInefficient(dst interface{}, src interface{}) error {
+	if dst == nil {
+		return fmt.Errorf("dst cannot be nil")
+	}
+	if src == nil {
+		return fmt.Errorf("src cannot be nil")
+	}
+	bytes, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal src: %s", err)
+	}
+	err = json.Unmarshal(bytes, dst)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshal into dst: %s", err)
+	}
+	return nil
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -862,22 +862,13 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 		AdminInterface: &DefaultAdminInterface,
 	})
 
-	server := base.UnitTestUrl()
-	bucketName := rt1.RestTesterBucket.GetName()
-	spec := base.GetTestBucketSpec(base.DataBucket)
-	username, password, _ := spec.Auth.GetCredentials()
+	// For the second rest tester, create a copy of the original database config and
+	// clear out the sync function.
+	dbConfigCopy := rt1.DatabaseConfig.MustDeepCopy()
+	dbConfigCopy.Sync = base.StringPointer("")
 
 	// Add a second database that uses the same underlying bucket.
-	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   &server,
-			Bucket:   &bucketName,
-			Username: username,
-			Password: password,
-		},
-		NumIndexReplicas: rt1.DatabaseConfig.NumIndexReplicas, // Use the same NumIndexReplicas as original test bucket (0)
-		Name:             "db",
-	})
+	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(dbConfigCopy)
 
 	assertNoError(t, err, "Failed to add database to rest tester")
 
@@ -959,22 +950,13 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 		AdminInterface: &DefaultAdminInterface,
 	})
 
-	server := base.UnitTestUrl()
-	bucketName := rt1.RestTesterBucket.GetName()
-	spec := base.GetTestBucketSpec(base.DataBucket)
-	username, password, _ := spec.Auth.GetCredentials()
+	// For the second rest tester, create a copy of the original database config and
+	// clear out the sync function.
+	dbConfigCopy := rt1.DatabaseConfig.MustDeepCopy()
+	dbConfigCopy.Sync = base.StringPointer("")
 
-	rt1UseXattrs := rt1.GetDatabase().UseXattrs()
-	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   &server,
-			Bucket:   &bucketName,
-			Username: username,
-			Password: password,
-		},
-		Name:         "db",
-		EnableXattrs: &rt1UseXattrs,
-	})
+	// Add a second database that uses the same underlying bucket.
+	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(dbConfigCopy)
 
 	assertNoError(t, err, "Failed to add database to rest tester")
 
@@ -1063,22 +1045,13 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 		AdminInterface: &DefaultAdminInterface,
 	})
 
-	server := base.UnitTestUrl()
-	bucketName := rt1.RestTesterBucket.GetName()
-	spec := base.GetTestBucketSpec(base.DataBucket)
-	username, password, _ := spec.Auth.GetCredentials()
+	// For the second rest tester, create a copy of the original database config and
+	// clear out the sync function.
+	dbConfigCopy := rt1.DatabaseConfig.MustDeepCopy()
+	dbConfigCopy.Sync = base.StringPointer("")
 
-	rt1UseXattrs := rt1.GetDatabase().UseXattrs()
-	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   &server,
-			Bucket:   &bucketName,
-			Username: username,
-			Password: password,
-		},
-		Name:         "db",
-		EnableXattrs: &rt1UseXattrs,
-	})
+	// Add a second database that uses the same underlying bucket.
+	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(dbConfigCopy)
 
 	assertNoError(t, err, "Failed to add database to rest tester")
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -864,7 +864,8 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 
 	// For the second rest tester, create a copy of the original database config and
 	// clear out the sync function.
-	dbConfigCopy := rt1.DatabaseConfig.MustDeepCopy()
+	dbConfigCopy, err := rt1.DatabaseConfig.DeepCopy()
+	assertNoError(t, err, "Unexpected error")
 	dbConfigCopy.Sync = base.StringPointer("")
 
 	// Add a second database that uses the same underlying bucket.
@@ -952,7 +953,8 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 
 	// For the second rest tester, create a copy of the original database config and
 	// clear out the sync function.
-	dbConfigCopy := rt1.DatabaseConfig.MustDeepCopy()
+	dbConfigCopy, err := rt1.DatabaseConfig.DeepCopy()
+	assertNoError(t, err, "Unexpected error calling DeepCopy()")
 	dbConfigCopy.Sync = base.StringPointer("")
 
 	// Add a second database that uses the same underlying bucket.
@@ -1047,7 +1049,8 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 
 	// For the second rest tester, create a copy of the original database config and
 	// clear out the sync function.
-	dbConfigCopy := rt1.DatabaseConfig.MustDeepCopy()
+	dbConfigCopy, err := rt1.DatabaseConfig.DeepCopy()
+	assertNoError(t, err, "Unexpected error calling DeepCopy()")
 	dbConfigCopy.Sync = base.StringPointer("")
 
 	// Add a second database that uses the same underlying bucket.

--- a/rest/config.go
+++ b/rest/config.go
@@ -472,6 +472,29 @@ func (dbConfig *DbConfig) UseXattrs() bool {
 	return base.DefaultUseXattrs
 }
 
+// Create a deepcopy of this DbConfig, or panic.
+// This will only copy all of the _exported_ fields of the DbConfig.
+func (dbConfig *DbConfig) MustDeepCopy() (dbConfigCopy *DbConfig) {
+
+	dbConfigDeepCopy := &DbConfig{}
+	err := base.DeepCopy(&dbConfigDeepCopy, dbConfig)
+	if err != nil {
+		base.Panicf(base.KeyAll, "Error trying to peform deep copy of DbConfig.  Err: %v" , err)
+	}
+	return dbConfigDeepCopy
+
+}
+
+// Implementation of AuthHandler interface for ShadowConfig
+func (shadowConfig *ShadowConfig) GetCredentials() (string, string, string) {
+	return base.TransformBucketCredentials(shadowConfig.Username, shadowConfig.Password, *shadowConfig.Bucket)
+}
+
+// Implementation of AuthHandler interface for ChannelIndexConfig
+func (channelIndexConfig *ChannelIndexConfig) GetCredentials() (string, string, string) {
+	return base.TransformBucketCredentials(channelIndexConfig.Username, channelIndexConfig.Password, *channelIndexConfig.Bucket)
+}
+
 // Implementation of AuthHandler interface for ClusterConfig
 func (clusterConfig *ClusterConfig) GetCredentials() (string, string, string) {
 	return base.TransformBucketCredentials(clusterConfig.Username, clusterConfig.Password, *clusterConfig.Bucket)

--- a/rest/config.go
+++ b/rest/config.go
@@ -474,25 +474,15 @@ func (dbConfig *DbConfig) UseXattrs() bool {
 
 // Create a deepcopy of this DbConfig, or panic.
 // This will only copy all of the _exported_ fields of the DbConfig.
-func (dbConfig *DbConfig) MustDeepCopy() (dbConfigCopy *DbConfig) {
+func (dbConfig *DbConfig) DeepCopy() (dbConfigCopy *DbConfig, err error) {
 
 	dbConfigDeepCopy := &DbConfig{}
-	err := base.DeepCopy(&dbConfigDeepCopy, dbConfig)
+	err = base.DeepCopyInefficient(&dbConfigDeepCopy, dbConfig)
 	if err != nil {
-		base.Panicf(base.KeyAll, "Error trying to peform deep copy of DbConfig.  Err: %v" , err)
+		return nil, err
 	}
-	return dbConfigDeepCopy
+	return dbConfigDeepCopy, nil
 
-}
-
-// Implementation of AuthHandler interface for ShadowConfig
-func (shadowConfig *ShadowConfig) GetCredentials() (string, string, string) {
-	return base.TransformBucketCredentials(shadowConfig.Username, shadowConfig.Password, *shadowConfig.Bucket)
-}
-
-// Implementation of AuthHandler interface for ChannelIndexConfig
-func (channelIndexConfig *ChannelIndexConfig) GetCredentials() (string, string, string) {
-	return base.TransformBucketCredentials(channelIndexConfig.Username, channelIndexConfig.Password, *channelIndexConfig.Bucket)
 }
 
 // Implementation of AuthHandler interface for ClusterConfig


### PR DESCRIPTION
Fixes #3481 by introducing a mechanism to perform a deep copy of `DbConfig` structs, and therefore avoid omitting important parameters like the index replica count when creating a 2nd database that uses the same underlying bucket.