### PR TITLE
Add log keys from accel

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -17,6 +17,7 @@ const (
 	// KeyAll is a wildcard for all log keys.
 	KeyAll LogKey = 1 << iota
 
+	KeyAccel
 	KeyAccess
 	KeyAttach
 	KeyAuth
@@ -28,7 +29,6 @@ const (
 	KeyCompact
 	KeyCRUD
 	KeyDCP
-	KeyDIndex
 	KeyEvents
 	KeyFeed
 	KeyGoCB
@@ -55,6 +55,7 @@ var (
 	logKeyNames = map[LogKey]string{
 		KeyNone:           "",
 		KeyAll:            "*",
+		KeyAccel:          "Accel",
 		KeyAccess:         "Access",
 		KeyAttach:         "Attach",
 		KeyAuth:           "Auth",
@@ -66,7 +67,6 @@ var (
 		KeyCompact:        "Compact",
 		KeyCRUD:           "CRUD",
 		KeyDCP:            "DCP",
-		KeyDIndex:         "DIndex",
 		KeyEvents:         "Events",
 		KeyFeed:           "Feed",
 		KeyGoCB:           "gocb",

--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -259,7 +259,7 @@ func (s *ShardedClock) Load() (isChanged bool, err error) {
 	newCounter, err := s.bucket.Incr(s.countKey, 0, 0, 0)
 	if err != nil {
 		Warnf(KeyAll, "Error getting count for %s:%v", s.countKey, err)
-		Debugf(KeyDIndex, "Error getting count:%v", err)
+		Debugf(KeyAccel, "Error getting count:%v", err)
 		return false, err
 	}
 	if newCounter == s.counter {

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -304,7 +304,7 @@ func (k *kvChangeIndexReader) GetChangesForRange(channelName string, sinceClock 
 	}
 	changes, err := reader.GetChanges(sinceClock, toClock, limit, activeOnly)
 	if err != nil {
-		base.Debugf(base.KeyDIndex, "No clock found for channel %s, assuming no entries in index", base.UD(channelName))
+		base.Debugf(base.KeyAccel, "No clock found for channel %s, assuming no entries in index", base.UD(channelName))
 		return nil, nil
 	}
 
@@ -318,10 +318,10 @@ func (k *kvChangeIndexReader) getOrCreateReader(channelName string) (*KvChannelI
 	if index == nil {
 		index, err = k.newChannelReader(channelName)
 		IndexExpvars.Add("getOrCreateReader_create", 1)
-		base.Debugf(base.KeyDIndex, "getOrCreateReader: Created new reader for channel %s", base.UD(channelName))
+		base.Debugf(base.KeyAccel, "getOrCreateReader: Created new reader for channel %s", base.UD(channelName))
 	} else {
 		IndexExpvars.Add("getOrCreateReader_get", 1)
-		base.Debugf(base.KeyDIndex, "getOrCreateReader: Using existing reader for channel %s", base.UD(channelName))
+		base.Debugf(base.KeyAccel, "getOrCreateReader: Using existing reader for channel %s", base.UD(channelName))
 	}
 	return index, err
 }

--- a/db/kv_channel_index.go
+++ b/db/kv_channel_index.go
@@ -77,7 +77,7 @@ func (k *KvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 	if unreadPollCount > kMaxUnreadPollCount {
 		// We've sent a notify, but had (kMaxUnreadPollCount) polls without anyone calling getChanges.
 		// Assume nobody is listening for updates - cancel polling for this channel
-		base.Debugf(base.KeyDIndex, "Cancelling polling for channel %s", base.UD(k.channelName))
+		base.Debugf(base.KeyAccel, "Cancelling polling for channel %s", base.UD(k.channelName))
 		return false, true
 	}
 
@@ -113,7 +113,7 @@ func (k *KvChannelIndex) pollForChanges(stableClock base.SequenceClock, newChann
 	}
 
 	if hasPostStableChanges {
-		base.Debugf(base.KeyDIndex, "Channel %s has changes later than the stable sequence - will be updated in next polling cycle.", base.UD(k.channelName))
+		base.Debugf(base.KeyAccel, "Channel %s has changes later than the stable sequence - will be updated in next polling cycle.", base.UD(k.channelName))
 	}
 	k.lastPolledPostStable = hasPostStableChanges
 
@@ -259,7 +259,7 @@ func (k *KvChannelIndex) loadChannelClock() (base.SequenceClock, error) {
 	key := GetChannelClockKey(k.channelName)
 	value, _, err := k.indexBucket.GetRaw(key)
 	if err != nil {
-		base.Debugf(base.KeyDIndex, "No existing channel clock for key %s:%v.  Using empty channel clock", base.UD(key), err)
+		base.Debugf(base.KeyAccel, "No existing channel clock for key %s:%v.  Using empty channel clock", base.UD(key), err)
 		return chanClock, err
 	}
 	err = chanClock.Unmarshal(value)
@@ -281,7 +281,7 @@ func (k *KvChannelIndex) loadClock() {
 	}
 	data, cas, err := k.indexBucket.GetRaw(GetChannelClockKey(k.channelName))
 	if err != nil {
-		base.Debugf(base.KeyDIndex, "Unable to find existing channel clock for channel %s - treating as new", base.UD(k.channelName))
+		base.Debugf(base.KeyAccel, "Unable to find existing channel clock for channel %s - treating as new", base.UD(k.channelName))
 	}
 	k.clock.Unmarshal(data)
 	k.clock.SetCas(cas)

--- a/db/kv_channel_storage.go
+++ b/db/kv_channel_storage.go
@@ -142,7 +142,7 @@ func (b *BitFlagStorage) AddEntrySet(entries []*LogEntry) (partitionUpdates []*b
 	clockUpdates := base.NewSequenceClockImpl()
 	for _, entry := range entries {
 		// Update the sequence in the appropriate cache block
-		base.Debugf(base.KeyDIndex, "Add to channel index [%s], vbNo=%d, isRemoval:%v", base.UD(b.channelName), entry.VbNo, entry.IsRemoved())
+		base.Debugf(base.KeyAccel, "Add to channel index [%s], vbNo=%d, isRemoval:%v", base.UD(b.channelName), entry.VbNo, entry.IsRemoved())
 		blockKey := GenerateBlockKey(b.channelName, entry.Sequence, b.partitions.VbMap[entry.VbNo])
 		if _, ok := blockSets[blockKey]; !ok {
 			blockSets[blockKey] = make([]*LogEntry, 0)
@@ -699,7 +699,7 @@ func (b *BitFlagBlock) GetEntries(vbNo uint16, fromSeq uint64, toSeq uint64, inc
 
 	// Validate range against block bounds
 	if fromSeq > b.value.MaxSequence() || toSeq < b.value.MinSequence {
-		base.Debugf(base.KeyDIndex, "Invalid Range for block [%s] (from, to): (%d, %d).  MinSeq:%d", base.UD(b.Key()), fromSeq, toSeq, b.value.MinSequence)
+		base.Debugf(base.KeyAccel, "Invalid Range for block [%s] (from, to): (%d, %d).  MinSeq:%d", base.UD(b.Key()), fromSeq, toSeq, b.value.MinSequence)
 		return entries, keySet
 	}
 
@@ -847,7 +847,7 @@ func (b *BitFlagBufferBlock) GetEntries(vbNo uint16, fromSeq uint64, toSeq uint6
 
 	// Validate range against block bounds
 	if fromSeq > b.maxSequence || toSeq < b.minSequence {
-		base.Debugf(base.KeyDIndex, "Invalid Range for block (from, to): (%d, %d).  MinSeq:%d", fromSeq, toSeq, b.minSequence)
+		base.Debugf(base.KeyAccel, "Invalid Range for block (from, to): (%d, %d).  MinSeq:%d", fromSeq, toSeq, b.minSequence)
 		return entries, keySet
 	}
 

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -189,7 +189,7 @@ func (s *sequenceHasher) GetHash(clock base.SequenceClock) (string, error) {
 		}
 		_, err = base.WriteCasRaw(s.bucket, key, initialValue, existingClocks.cas, base.SecondsToCbsExpiry(int(s.hashExpiry)), func(value []byte) (updatedValue []byte, err error) {
 			// Note: The following is invoked upon cas failure - may be called multiple times
-			base.Debugf(base.KeyDIndex, "CAS fail - reapplying changes for hash storage for key: %s", base.UD(key))
+			base.Debugf(base.KeyAccel, "CAS fail - reapplying changes for hash storage for key: %s", base.UD(key))
 			var sClocks storedClocks
 			err = sClocks.Unmarshal(value)
 			if err != nil {
@@ -203,7 +203,7 @@ func (s *sequenceHasher) GetHash(clock base.SequenceClock) (string, error) {
 			}
 			// Not found - add
 			sClocks.Sequences = append(sClocks.Sequences, clockValue)
-			base.Debugf(base.KeyDIndex, "Reattempting stored hash write for key %s:", base.UD(key))
+			base.Debugf(base.KeyAccel, "Reattempting stored hash write for key %s:", base.UD(key))
 			index = len(sClocks.Sequences) - 1
 			return sClocks.Marshal()
 		})

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -36,7 +36,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="6f618c5fc9e9a1f3130839e61e2357153956f369"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="551d6ff8d7b84979133b4d5991f9159e33e8d3ce"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>


### PR DESCRIPTION
- [x] Bump accel revision in manifest after https://github.com/couchbaselabs/sync-gateway-accel/pull/204

- Add log keys from accel
- Change LogKey subtype to uint64 to alleviate const overflows