### PR TITLE
Exit sgcollect_info early if SG is not running

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -643,9 +643,9 @@ def main():
         sg_url = "http://127.0.0.1:4985"
     print "Using Sync Gateway URL: {0}".format(sg_url)
 
-    # Check SG is running before continuing
+    # Exit early if SG is not running
     try:
-        response = urllib2.urlopen(sg_url)
+        urllib2.urlopen(sg_url)
     except urllib2.URLError:
         print("Error: Sync Gateway must be running in order to use sgcollect_info")
         sys.exit(1)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -642,7 +642,14 @@ def main():
     if sg_url is None:
         sg_url = "http://127.0.0.1:4985"
     print "Using Sync Gateway URL: {0}".format(sg_url)
-    
+
+    # Check SG is running before continuing
+    try:
+        response = urllib2.urlopen(sg_url)
+    except urllib2.URLError:
+        print("Error: Sync Gateway must be running in order to use sgcollect_info")
+        sys.exit(1)
+
     # Build path to zip directory, make sure it exists
     zip_filename = args[0]
     if zip_filename[-4:] != '.zip':


### PR DESCRIPTION
Fixes #3526 - Improves the error if you try and run sgcollect_info when SG is not running.

### Before
```
Using Sync Gateway URL: http://127.0.0.1:4985
uname (uname -a) - OK
time and TZ (date; date -u) - OK
ntp time (ntpdate -q pool.ntp.org || nc time.nist.gov 13 || netcat time.nist.gov 13) - Exit code 127
ntp peers (ntpq -p) - Exit code 127
raw /etc/sysconfig/clock (cat /etc/sysconfig/clock) - Exit code 1
raw /etc/timezone (cat /etc/timezone) - Exit code 1
System Hardware (lshw -json || lshw) - Exit code 127
Process list snapshot (export TERM=''; top -Hb -n1 || top -H n1) - OK
Process list (ps -AwwL -o user,pid,lwp,ppid,nlwp,pcpu,maj_flt,min_flt,pri,nice,vsize,rss,tty,stat,wchan:12,start,bsdtime,command) - OK
Raw /proc/vmstat (cat /proc/vmstat) - OK
Raw /proc/mounts (cat /proc/mounts) - OK
Raw /proc/partitions (cat /proc/partitions) - OK
Raw /proc/diskstats (cat /proc/diskstats; echo '') - OK
Taking sample 2 after 1.000000 seconds - OK
Taking sample 3 after 1.000000 seconds - OK
Taking sample 4 after 1.000000 seconds - OK
Taking sample 5 after 1.000000 seconds - OK
Taking sample 6 after 1.000000 seconds - OK
Taking sample 7 after 1.000000 seconds - OK
Taking sample 8 after 1.000000 seconds - OK
Taking sample 9 after 1.000000 seconds - OK
Taking sample 10 after 1.000000 seconds - OK
Raw /proc/interrupts (cat /proc/interrupts) - OK
Swap configuration (free -t) - OK
Swap configuration (swapon -s) - OK
Kernel modules (lsmod) - OK
Distro version (cat /etc/redhat-release) - OK
Distro version (lsb_release -a) - Exit code 127
Distro version (cat /etc/SuSE-release) - Exit code 1
Distro version (cat /etc/issue) - OK
Installed software (rpm -qa) - OK
Installed software (COLUMNS=300 dpkg -l) - Exit code 127
Extended iostat (iostat -x -p ALL 1 10 || iostat -x 1 10) - Exit code 127
Core dump settings (find /proc/sys/kernel -type f -name '*core*' -print -exec cat '{}' ';') - OK
sysctl settings (sysctl -a) - OK
Relevant lsof output (echo sync_gateway | xargs -n1 pgrep | xargs -n1 -r -- lsof -n -p) - OK
LVM info (lvdisplay) - OK
LVM info (vgdisplay) - OK
LVM info (pvdisplay) - OK
Network configuration (ifconfig -a) - Exit code 127
Taking sample 2 after 10.000000 seconds - Exit code 127
Network configuration (echo link addr neigh rule route netns | xargs -n1 -- sh -x -c 'ip $1 list' --) - OK
Raw /proc/net/dev (cat /proc/net/dev) - OK
Network link statistics (ip -s link) - OK
Network status (netstat -anp || netstat -an) - Exit code 127
Network routing table (netstat -rn) - Exit code 127
Network socket statistics (ss -an) - OK
Extended socket statistics (ss -an --info --processes) - OK
Arp cache (arp -na) - Exit code 127
Iptables dump (iptables-save) - OK
Raw /etc/hosts (cat /etc/hosts) - OK
Raw /etc/resolv.conf (cat /etc/resolv.conf) - OK
Raw /etc/nsswitch.conf (cat /etc/nsswitch.conf) - OK
Filesystem (df -ha) - OK
System activity reporter (sar 1 10) - Exit code 127
System paging activity (vmstat 1 10) - OK
System uptime (uptime) - OK
couchbase user definition (getent passwd couchbase) - OK
couchbase user limits (su couchbase -c "ulimit -a") - OK
couchbase user limits (su couchbase -c "ulimit -a") - OK
Interrupt status (intrstat 1 10) - Exit code 127
Processor status (mpstat 1 10) - Exit code 127
System log (cat /var/adm/messages) - Exit code 1
Raw /proc/uptime (cat /proc/uptime) - OK
All logs (tar cz /var/log/syslog* /var/log/dmesg /var/log/messages* /var/log/daemon* /var/log/debug* /var/log/kern.log* 2>/dev/null) - Exit code 2
Relevant proc data (echo sync_gateway | xargs -n1 pgrep | xargs -n1 -- sh -c 'echo $1; cat /proc/$1/status; cat /proc/$1/limits; cat /proc/$1/smaps; cat /proc/$1/numa_maps; cat /proc/$1/task/*/sched; echo' --) - OK
Processes' environment (echo sync_gateway | xargs -n1 pgrep | xargs -n1 -- sh -c 'echo $1; ( cat /proc/$1/environ | tr \\0 \\n ); echo' --) - OK
NUMA data (numactl --hardware) - Exit code 127
NUMA data (numactl --show) - Exit code 127
NUMA data (cat /sys/devices/system/node/node*/numastat) - OK
Kernel log buffer (dmesg -H || dmesg) - OK
Transparent Huge Pages data (cat /sys/kernel/mm/transparent_hugepage/enabled) - OK
Transparent Huge Pages data (cat /sys/kernel/mm/transparent_hugepage/defrag) - OK
Transparent Huge Pages data (cat /sys/kernel/mm/redhat_transparent_hugepage/enabled) - Exit code 1
Transparent Huge Pages data (cat /sys/kernel/mm/redhat_transparent_hugepage/defrag) - Exit code 1
Network statistics (netstat -s) - Exit code 127
Full raw netstat (cat /proc/net/netstat) - OK
CPU throttling info (echo /sys/devices/system/cpu/cpu*/thermal_throttle/* | xargs -n1 -- sh -c 'echo $1; cat $1' --) - Exit code 123
Traceback (most recent call last):
  File "<string>", line 769, in <module>
  File "<string>", line 719, in main
  File "<string>", line 545, in make_sg_tasks
  File "<string>", line 504, in get_paths_from_expvars
  File "urllib2.py", line 154, in urlopen
  File "urllib2.py", line 431, in open
  File "urllib2.py", line 449, in _open
  File "urllib2.py", line 409, in _call_chain
  File "urllib2.py", line 1244, in http_open
  File "urllib2.py", line 1214, in do_open
urllib2.URLError: <urlopen error [Errno 111] Connection refused>
sgcollect_info returned -1

```

### After
```
17:50 $ ./tools/sgcollect_info test.zip
Using Sync Gateway URL: http://127.0.0.1:4985
Error: Sync Gateway must be running in order to use sgcollect_info
```