### PR TITLE
#3533 Incorrect redaction tags

### DIFF
--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -139,19 +139,19 @@ func (b *LoggingBucket) DeleteDDoc(docname string) error {
 }
 func (b *LoggingBucket) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
 	start := time.Now()
-	defer func() { Tracef(KeyBucket, "View(%q, %q, ...) [%v]", UD(ddoc), UD(name), time.Since(start)) }()
+	defer func() { Tracef(KeyBucket, "View(%q, %q, ...) [%v]", MD(ddoc), UD(name), time.Since(start)) }()
 	return b.bucket.View(ddoc, name, params)
 }
 
 func (b *LoggingBucket) ViewCustom(ddoc, name string, params map[string]interface{}, vres interface{}) error {
 	start := time.Now()
-	defer func() { Tracef(KeyBucket, "ViewCustom(%q, %q, ...) [%v]", UD(ddoc), UD(name), time.Since(start)) }()
+	defer func() { Tracef(KeyBucket, "ViewCustom(%q, %q, ...) [%v]", MD(ddoc), UD(name), time.Since(start)) }()
 	return b.bucket.ViewCustom(ddoc, name, params, vres)
 }
 
 func (b *LoggingBucket) ViewQuery(ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
 	start := time.Now()
-	defer func() { Tracef(KeyBucket, "ViewQuery(%q, %q, ...) [%v]", UD(ddoc), UD(name), time.Since(start)) }()
+	defer func() { Tracef(KeyBucket, "ViewQuery(%q, %q, ...) [%v]", MD(ddoc), UD(name), time.Since(start)) }()
 	return b.bucket.ViewQuery(ddoc, name, params)
 }
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -162,7 +162,7 @@ func (listener *changeListener) Notify(keys base.Set) {
 		listener.keyCounts[key] = listener.counter
 	}
 	base.Debugf(base.KeyChanges, "Notifying that %q changed (keys=%q) count=%d",
-		base.UD(listener.bucketName), base.UD(keys), listener.counter)
+		base.MD(listener.bucketName), base.UD(keys), listener.counter)
 	listener.tapNotifier.Broadcast()
 	listener.tapNotifier.L.Unlock()
 }
@@ -201,7 +201,7 @@ func (listener *changeListener) Wait(keys []string, counter uint64, terminateChe
 	listener.tapNotifier.L.Lock()
 	defer listener.tapNotifier.L.Unlock()
 	base.Debugf(base.KeyChanges, "No new changes to send to change listener.  Waiting for %q's count to pass %d",
-		base.UD(listener.bucketName), counter)
+		base.MD(listener.bucketName), counter)
 
 	for {
 		curCounter := listener._currentCount(keys)

--- a/db/database.go
+++ b/db/database.go
@@ -253,7 +253,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	// If not using channel index or using channel index and tracking docs, start the tap feed
 	if options.IndexOptions == nil || options.TrackDocs {
-		base.Infof(base.KeyFeed, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import/bucketshadow)", base.UD(bucket.GetName()))
+		base.Infof(base.KeyFeed, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import/bucketshadow)", base.MD(bucket.GetName()))
 
 		if err = context.mutationListener.Start(bucket, options.TrackDocs, feedMode, func(bucket string, err error) {
 

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -285,7 +285,7 @@ func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint) err
 // Issue a consistency=request_plus query against critical indexes to guarantee indexing is complete and indexes are ready.
 func waitForIndexes(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 	var indexesWg sync.WaitGroup
-	base.Infof(base.KeyAll, "Verifying index availability for bucket %s...", base.UD(bucket.GetName()))
+	base.Infof(base.KeyAll, "Verifying index availability for bucket %s...", base.MD(bucket.GetName()))
 	indexErrors := make(chan error, len(sgIndexes))
 
 	for _, sgIndex := range sgIndexes {
@@ -312,7 +312,7 @@ func waitForIndexes(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 		return err
 	}
 
-	base.Infof(base.KeyAll, "Indexes ready for bucket %s.", base.UD(bucket.GetName()))
+	base.Infof(base.KeyAll, "Indexes ready for bucket %s.", base.MD(bucket.GetName()))
 	return nil
 }
 

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -72,7 +72,7 @@ func (k *kvChangeIndexReader) Init(options *CacheOptions, indexOptions *ChannelI
 	k.indexReadBucket, err = base.GetBucket(indexOptions.Spec, nil)
 	if err != nil {
 		base.Infof(base.KeyAll, "Error opening index bucket %q, pool %q, server <%s>",
-			base.UD(indexOptions.Spec.BucketName), base.UD(indexOptions.Spec.PoolName), base.UD(indexOptions.Spec.Server))
+			base.MD(indexOptions.Spec.BucketName), base.SD(indexOptions.Spec.PoolName), base.SD(indexOptions.Spec.Server))
 		// TODO: revert to local index?
 		return err
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -73,7 +73,7 @@ func (h *handler) handleDbOnline() error {
 
 	json.Unmarshal(body, &input)
 
-	base.Infof(base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.UD(h.db.Name), input.Delay)
+	base.Infof(base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 
 	timer := time.NewTimer(time.Duration(input.Delay) * time.Second)
 	go func() {
@@ -90,7 +90,7 @@ func (h *handler) handleDbOffline() error {
 	h.assertAdminOnly()
 	var err error
 	if err = h.db.TakeDbOffline("ADMIN Request"); err != nil {
-		base.Infof(base.KeyCRUD, "Unable to take Database : %v, offline", base.UD(h.db.Name))
+		base.Infof(base.KeyCRUD, "Unable to take Database : %v, offline", base.MD(h.db.Name))
 	}
 
 	return err

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -124,7 +124,7 @@ func (h *handler) handleBLIPSync() error {
 	server := blipContext.WebSocketServer()
 	defaultHandler := server.Handler
 	server.Handler = func(conn *websocket.Conn) {
-		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol. User:%s.", blipContext.ID, h.currentEffectiveUserName()))
+		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol. User:%s.", blipContext.ID, ctx.effectiveUsername))
 		defer func() {
 			conn.Close() // in case it wasn't closed already
 			ctx.Logf(base.LevelDebug, base.KeyHTTP, "#%03d:    --> BLIP+WebSocket connection closed", h.serialNumber)
@@ -157,12 +157,12 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 			if response := rq.Response(); response != nil {
 				response.SetError("HTTP", status, msg)
 			}
-			ctx.Logf(base.LevelInfo, base.KeySyncMsg, "#%d: Type:%s   --> %d %s Time:%v User:%s", handler.serialNumber, profile, status, msg, time.Since(startTime), base.UD(ctx.effectiveUsername))
+			ctx.Logf(base.LevelInfo, base.KeySyncMsg, "#%d: Type:%s   --> %d %s Time:%v User:%s", handler.serialNumber, profile, status, msg, time.Since(startTime), ctx.effectiveUsername)
 		} else {
 
 			// Log the fact that the handler has finished, except for the "subChanges" special case which does it's own termination related logging
 			if profile != "subChanges" {
-				ctx.Logf(base.LevelDebug, base.KeySyncMsg, "#%d: Type:%s   --> OK Time:%v User:%s ", handler.serialNumber, profile, time.Since(startTime), base.UD(ctx.effectiveUsername))
+				ctx.Logf(base.LevelDebug, base.KeySyncMsg, "#%d: Type:%s   --> OK Time:%v User:%s ", handler.serialNumber, profile, time.Since(startTime), ctx.effectiveUsername)
 			}
 		}
 	}
@@ -177,8 +177,8 @@ func (ctx *blipSyncContext) close() {
 
 // Handler for unknown requests
 func (ctx *blipSyncContext) notFound(rq *blip.Message) {
-	ctx.Logf(base.LevelInfo, base.KeySync, "%s Type:%q User:%s", rq, rq.Profile(), base.UD(ctx.effectiveUsername))
-	ctx.Logf(base.LevelInfo, base.KeySync, "%s    --> 404 Unknown profile. User:%s", rq, base.UD(ctx.effectiveUsername))
+	ctx.Logf(base.LevelInfo, base.KeySync, "%s Type:%q User:%s", rq, rq.Profile(), ctx.effectiveUsername)
+	ctx.Logf(base.LevelInfo, base.KeySync, "%s    --> 404 Unknown profile. User:%s", rq, ctx.effectiveUsername)
 	blip.Unhandled(rq)
 }
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -387,13 +387,13 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			case <-heartbeat:
 				_, err = h.response.Write([]byte("\n"))
 				h.flush()
-				base.Infof(base.KeyHeartbeat, "heartbeat written to _changes feed for request received %s", base.UD(h.currentEffectiveUserNameAsUser()))
+				base.Infof(base.KeyHeartbeat, "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserNameAsUser())
 			case <-timeout:
 				message = "OK (timeout)"
 				forceClose = true
 				break loop
 			case <-closeNotify:
-				base.Infof(base.KeyChanges, "Connection lost from client: %v", base.UD(h.currentEffectiveUserNameAsUser()))
+				base.Infof(base.KeyChanges, "Connection lost from client: %v", h.currentEffectiveUserNameAsUser())
 				forceClose = true
 				break loop
 			case <-h.db.ExitChanges:
@@ -572,14 +572,14 @@ loop:
 		case <-heartbeat:
 			err = send(nil)
 			if h != nil {
-				base.Infof(base.KeyHeartbeat, "heartbeat written to _changes feed for request received %s", base.UD(h.currentEffectiveUserNameAsUser()))
+				base.Infof(base.KeyHeartbeat, "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserNameAsUser())
 			}
 		case <-timeout:
 			forceClose = true
 			break loop
 		case <-closeNotify:
 			if h != nil {
-				base.Debugf(base.KeyChanges, "Client connection lost: %v", base.UD(h.currentEffectiveUserNameAsUser()))
+				base.Debugf(base.KeyChanges, "Client connection lost: %v", h.currentEffectiveUserNameAsUser())
 			} else {
 				base.Debugf(base.KeyChanges, "Client connection lost")
 			}

--- a/rest/config.go
+++ b/rest/config.go
@@ -886,7 +886,7 @@ func RunServer(config *ServerConfig) {
 	sc := NewServerContext(config)
 	for _, dbConfig := range config.Databases {
 		if _, err := sc.AddDatabaseFromConfig(dbConfig); err != nil {
-			base.Fatalf(base.KeyAll, "Error opening database %s: %+v", base.UD(dbConfig.Name), err)
+			base.Fatalf(base.KeyAll, "Error opening database %s: %+v", base.MD(dbConfig.Name), err)
 		}
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -382,7 +382,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
-		base.UD(dbName), base.UD(spec.BucketName), base.SD(spec.PoolName), base.SD(spec.Server))
+		base.MD(dbName), base.MD(spec.BucketName), base.SD(spec.PoolName), base.SD(spec.Server))
 
 	if err := db.ValidateDatabaseName(dbName); err != nil {
 		return nil, err
@@ -580,7 +580,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		sequenceHashOptions.Bucket, err = base.GetBucket(sequenceHashBucketSpec, nil)
 		if err != nil {
 			base.Warnf(base.KeyAll, "Error opening sequence hash bucket %q, pool %q, server <%s>",
-				base.UD(sequenceHashBucketSpec.BucketName), sequenceHashBucketSpec.PoolName, base.SD(sequenceHashBucketSpec.Server))
+				base.MD(sequenceHashBucketSpec.BucketName), base.SD(sequenceHashBucketSpec.PoolName), base.SD(sequenceHashBucketSpec.Server))
 			return nil, err
 		}
 
@@ -662,7 +662,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
 
 	if dbcontext.ChannelMapper == nil {
-		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.UD(dbName))
+		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))
 	}
 
 	// Create default users & roles:
@@ -679,7 +679,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	if shadow := config.Deprecated.Shadow; shadow != nil {
 		if err := sc.startShadowing(dbcontext, shadow); err != nil {
 			base.Warnf(base.KeyAll, "Database %q: unable to connect to external bucket for shadowing: %v",
-				base.UD(dbName), err)
+				base.MD(dbName), err)
 		}
 	}
 
@@ -824,7 +824,7 @@ func (sc *ServerContext) applySyncFunction(dbcontext *db.DatabaseContext, syncFn
 		return err
 	}
 	// Sync function has changed:
-	base.Infof(base.KeyAll, "**NOTE:** %q's sync function has changed. The new function may assign different channels to documents, or permissions to users. You may want to re-sync the database to update these.", base.UD(dbcontext.Name))
+	base.Infof(base.KeyAll, "**NOTE:** %q's sync function has changed. The new function may assign different channels to documents, or permissions to users. You may want to re-sync the database to update these.", base.MD(dbcontext.Name))
 	return nil
 }
 
@@ -875,7 +875,7 @@ func (sc *ServerContext) startShadowing(dbcontext *db.DatabaseContext, shadow *S
 	//Remove credentials from server URL before logging
 	url, err := couchbase.ParseURL(spec.Server)
 	if err == nil {
-		base.Infof(base.KeyAll, "Database %q shadowing remote bucket %q, pool %q, server <%s:%s/%s>", base.UD(dbcontext.Name), base.UD(spec.BucketName), spec.PoolName, url.Scheme, base.SD(url.Host), url.Path)
+		base.Infof(base.KeyAll, "Database %q shadowing remote bucket %q, pool %q, server <%s:%s/%s>", base.MD(dbcontext.Name), base.MD(spec.BucketName), base.SD(spec.PoolName), url.Scheme, base.SD(url.Host), url.Path)
 	}
 	return nil
 }
@@ -893,7 +893,7 @@ func (sc *ServerContext) _removeDatabase(dbName string) bool {
 	if context == nil {
 		return false
 	}
-	base.Infof(base.KeyAll, "Closing db /%s (bucket %q)", base.UD(context.Name), base.UD(context.Bucket.GetName()))
+	base.Infof(base.KeyAll, "Closing db /%s (bucket %q)", base.MD(context.Name), base.MD(context.Bucket.GetName()))
 	context.Close()
 	delete(sc.databases_, dbName)
 	return true

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -15,7 +15,7 @@ import (
 // HTTP handler for GET _design/$ddoc
 func (h *handler) handleGetDesignDoc() error {
 	ddocID := h.PathVar("ddoc")
-	base.Debugf(base.KeyAll, "GetDesignDoc %v", base.UD(ddocID))
+	base.Debugf(base.KeyAll, "GetDesignDoc %v", base.MD(ddocID))
 	var result interface{}
 	if ddocID == db.DesignDocSyncGateway() {
 		// we serve this content here so that CouchDB 1.2 has something to
@@ -100,7 +100,7 @@ func (h *handler) handleView() error {
 		}
 	}
 
-	base.Infof(base.KeyHTTP, "JSON view %q/%q - opts %v", base.UD(ddocName), base.UD(viewName), base.UD(opts))
+	base.Infof(base.KeyHTTP, "JSON view %q/%q - opts %v", base.MD(ddocName), base.MD(viewName), base.MD(opts))
 
 	result, err := h.db.QueryDesignDoc(ddocName, viewName, opts)
 	if err != nil {


### PR DESCRIPTION
Related to #3533 

- Fixed tagging categories on bucket and database names
- Fixed empty `(as )` appearing in logs for anonymous requests

This PR does not resolve the issue of URLs being fully redacted. Separate PR coming.