### PR TITLE
Fix ordering in star channel index/queries

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -169,7 +169,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 			len(entries), base.UD(channelName), entries[0].Sequence, entries[len(entries)-1].Sequence)
 	}
 	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
-		base.Infof(base.KeyAll, "changes_view: Query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
+		base.Infof(base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
 			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, options.Limit)
 	}
 	changeCacheExpvars.Add("view_queries", 1)

--- a/db/database.go
+++ b/db/database.go
@@ -837,25 +837,11 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 // Re-runs the sync function on every current document in the database (if doCurrentDocs==true)
 // and/or imports docs in the bucket not known to the gateway (if doImportDocs==true).
 // To be used when the JavaScript sync function changes.
-func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) (int, error) {
+func (db *Database) UpdateAllDocChannels() (int, error) {
 
-	if doCurrentDocs && doImportDocs {
-		return 0, errors.New("UpdateAllDocChannels doesn't support processing both current and imports in one request.")
-	}
+	base.Infof(base.KeyAll, "Recomputing document channels...")
 
-	if !doCurrentDocs && !doImportDocs {
-		return 0, nil
-	}
-
-	if doCurrentDocs {
-		base.Infof(base.KeyAll, "Recomputing document channels...")
-	}
-
-	if doImportDocs {
-		base.Infof(base.KeyAll, "Importing documents...")
-	}
-
-	results, err := db.QueryImport(doCurrentDocs)
+	results, err := db.QueryResync()
 	if err != nil {
 		return 0, err
 	}
@@ -879,19 +865,9 @@ func (db *Database) UpdateAllDocChannels(doCurrentDocs bool, doImportDocs bool) 
 		documentUpdateFunc := func(doc *document) (updatedDoc *document, shouldUpdate bool, updatedExpiry *uint32, err error) {
 			imported := false
 			if !doc.HasValidSyncData(db.writeSequences()) {
-				// This is a document not known to the sync gateway. Ignore or import it:
-				if !doImportDocs {
-					return nil, false, nil, couchbase.UpdateCancel
-				}
-				imported = true
-				if err = db.initializeSyncData(doc); err != nil {
-					return nil, false, nil, err
-				}
-				base.Infof(base.KeyCRUD, "\tImporting document %q --> rev %q", base.UD(docid), doc.CurrentRev)
+				// This is a document not known to the sync gateway. Ignore it:
+				return nil, false, nil, couchbase.UpdateCancel
 			} else {
-				if !doCurrentDocs {
-					return nil, false, nil, couchbase.UpdateCancel
-				}
 				base.Infof(base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
 			}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1225,38 +1225,6 @@ func TestUpdateDesignDoc(t *testing.T) {
 	assertHTTPError(t, err, 403)
 }
 
-func TestLegacyImport(t *testing.T) {
-
-	if base.TestUseXattrs() {
-		t.Skip("This test should not be run in XATTR mode.  Skipping")
-	}
-
-	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
-	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
-
-	// Add docs to the underlying bucket:
-	for i := 1; i <= 20; i++ {
-		db.Bucket.Add(fmt.Sprintf("alreadyHere%d", i), 0, Body{"key1": i, "key2": "hi"})
-	}
-
-	// Make sure they aren't visible thru the gateway:
-	doc, err := db.GetDocument("alreadyHere1", DocUnmarshalAll)
-	assert.Equals(t, doc, (*document)(nil))
-	assert.Equals(t, err.(*base.HTTPError).Status, 404)
-
-	// Import them:
-	count, err := db.UpdateAllDocChannels(false, true)
-	assertNoError(t, err, "ApplySyncFun")
-	assert.Equals(t, count, 20)
-
-	// Now they're visible:
-	doc, err = db.GetDocument("alreadyHere1", DocUnmarshalAll)
-	base.Infof(base.KeyAll, "doc = %+v", doc)
-	assert.True(t, doc != nil)
-	assertNoError(t, err, "can't get doc")
-}
-
 func TestPostWithExistingId(t *testing.T) {
 
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -74,7 +74,7 @@ var (
 		IndexRoleAccess: "ALL (ARRAY (op.name) FOR op IN OBJECT_PAIRS($sync.role_access) END)",
 		IndexChannels: "ALL (ARRAY [op.name, LEAST($sync.sequence,op.val.seq), IFMISSING(op.val.rev,null), IFMISSING(op.val.del,null)] FOR op IN OBJECT_PAIRS($sync.channels) END), " +
 			"$sync.rev, $sync.sequence, $sync.flags",
-		IndexAllDocs:    "META().id, $sync.sequence, $sync.rev, $sync.flags, $sync.deleted",
+		IndexAllDocs:    "$sync.sequence, $sync.rev, $sync.flags, $sync.deleted",
 		IndexTombstones: "$sync.tombstoned_at",
 		IndexSyncDocs:   "META().id",
 	}

--- a/db/query.go
+++ b/db/query.go
@@ -97,7 +97,8 @@ var QueryStarChannel = SGQuery{
 			"META(`%s`).id AS id "+
 			"FROM `%s`"+
 			"WHERE $sync.sequence >= $startSeq AND $sync.sequence < $endSeq "+
-			"AND META().id NOT LIKE '%s'",
+			"AND META().id NOT LIKE '%s'"+
+			"ORDER BY seq",
 		base.BucketQueryToken, base.BucketQueryToken, SyncDocWildcard),
 	adhoc: false,
 }

--- a/db/query.go
+++ b/db/query.go
@@ -153,7 +153,7 @@ var QueryResync = SGQuery{
 		"SELECT META(`%s`).id "+
 			"FROM `%s` "+
 			"WHERE META(`%s`).id NOT LIKE '%s' "+
-			"AND $sync.sequence > 0",
+			"AND $sync.sequence > 0", // Required to use IndexAllDocs
 		base.BucketQueryToken, base.BucketQueryToken, base.BucketQueryToken, SyncDocWildcard),
 	adhoc: false,
 }
@@ -168,7 +168,7 @@ var QueryAllDocs = SGQuery{
 			"$sync.sequence as s, "+
 			"$sync.channels as c "+
 			"FROM `%s` "+
-			"WHERE $sync.sequence > 0 AND "+ // Required to use the
+			"WHERE $sync.sequence > 0 AND "+ // Required to use IndexAllDocs
 			"META(`%s`).id NOT LIKE '%s' "+
 			"AND $sync IS NOT MISSING "+
 			"AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)",

--- a/rest/api.go
+++ b/rest/api.go
@@ -65,7 +65,6 @@ func (h *handler) handleVacuum() error {
 
 func (h *handler) handleFlush() error {
 
-
 	// If it can be flushed, then flush it
 	if _, ok := h.db.Bucket.(sgbucket.FlushableBucket); ok {
 
@@ -151,7 +150,7 @@ func (h *handler) handleResync() error {
 
 	if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBResyncing) {
 
-		docsChanged, err := h.db.UpdateAllDocChannels(true, false)
+		docsChanged, err := h.db.UpdateAllDocChannels()
 		if err != nil {
 			return err
 		}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1685,6 +1685,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	assert.Equals(t, options.HeartbeatMs, uint64(60000))
 }
 
+// Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
 	//restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
 	var rt RestTester
@@ -1904,6 +1905,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
 }
 
+// Test _all_docs API call when using vector sequences (accel), under different security scenarios
 func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	rt := initRestTester(db.ClockSequenceType, `function(doc) {channel(doc.channels);}`)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2342,7 +2342,9 @@ func TestAccessOnTombstone(t *testing.T) {
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
 	assert.Equals(t, err, nil)
 	assert.Equals(t, len(changes.Results), 1)
-	assert.Equals(t, changes.Results[0].ID, "alpha")
+	if len(changes.Results) > 0 {
+		assert.Equals(t, changes.Results[0].ID, "alpha")
+	}
 
 	// Delete the document
 	response = rt.Send(request("DELETE", fmt.Sprintf("/db/alpha?rev=%s", revId), ""))

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -866,7 +866,6 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	spec := base.GetTestBucketSpec(base.DataBucket)
 	username, password, _ := spec.Auth.GetCredentials()
 
-
 	// Add a second database that uses the same underlying bucket.
 	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
 		BucketConfig: BucketConfig{
@@ -875,8 +874,8 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 			Username: username,
 			Password: password,
 		},
-		NumIndexReplicas: rt1.DatabaseConfig.NumIndexReplicas,  // Use the same NumIndexReplicas as original test bucket (0)
-		Name: "db",
+		NumIndexReplicas: rt1.DatabaseConfig.NumIndexReplicas, // Use the same NumIndexReplicas as original test bucket (0)
+		Name:             "db",
 	})
 
 	assertNoError(t, err, "Failed to add database to rest tester")
@@ -1686,20 +1685,230 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	assert.Equals(t, options.HeartbeatMs, uint64(60000))
 }
 
-func TestAccessControl(t *testing.T) {
-	restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
-	defer restTester.Close()
-	testAccessControl(t, restTester)
+func TestAllDocsAccessControl(t *testing.T) {
+	//restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
+	var rt RestTester
+	defer rt.Close()
+	type allDocsRow struct {
+		ID    string `json:"id"`
+		Key   string `json:"key"`
+		Value struct {
+			Rev      string              `json:"rev"`
+			Channels []string            `json:"channels,omitempty"`
+			Access   map[string]base.Set `json:"access,omitempty"` // for admins only
+		} `json:"value"`
+		Doc   db.Body `json:"doc,omitempty"`
+		Error string  `json:"error"`
+	}
+	var allDocsResult struct {
+		TotalRows int          `json:"total_rows"`
+		Offset    int          `json:"offset"`
+		Rows      []allDocsRow `json:"rows"`
+	}
+
+	// Create some docs:
+	a := auth.NewAuthenticator(rt.Bucket(), nil)
+	guest, err := a.GetUser("")
+	assert.Equals(t, err, nil)
+	guest.SetDisabled(false)
+	err = a.Save(guest)
+	assert.Equals(t, err, nil)
+
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["CBS", "Cinemax"]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
+
+	guest.SetDisabled(true)
+	err = a.Save(guest)
+	assert.Equals(t, err, nil)
+
+	// Create a user:
+	alice, err := a.NewUser("alice", "letmein", channels.SetOf("Cinemax"))
+	a.Save(alice)
+
+	// Get a single doc the user has access to:
+	request, _ := http.NewRequest("GET", "/db/doc3", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response := rt.Send(request)
+	assertStatus(t, response, 200)
+
+	// Get a single doc the user doesn't have access to:
+	request, _ = http.NewRequest("GET", "/db/doc2", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 403)
+
+	// Check that _all_docs only returns the docs the user has access to:
+	request, _ = http.NewRequest("GET", "/db/_all_docs?channels=true", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 3)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	assert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
+	assert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"Cinemax"})
+	assert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
+	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+
+	//Check all docs limit option
+	request, _ = http.NewRequest("GET", "/db/_all_docs?limit=1&channels=true", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 1)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+
+	//Check all docs startkey option
+	request, _ = http.NewRequest("GET", "/db/_all_docs?startkey=doc5&channels=true", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 1)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+
+	//Check all docs startkey option with double quote
+	request, _ = http.NewRequest("GET", `/db/_all_docs?startkey="doc5"&channels=true`, nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 1)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+
+	//Check all docs endkey option
+	request, _ = http.NewRequest("GET", "/db/_all_docs?endkey=doc3&channels=true", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 1)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+
+	//Check all docs endkey option
+	request, _ = http.NewRequest("GET", `/db/_all_docs?endkey="doc3"&channels=true`, nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 1)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+
+	// Check _all_docs with include_docs option:
+	request, _ = http.NewRequest("GET", "/db/_all_docs?include_docs=true", nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 3)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	assert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
+	assert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
+
+	// Check POST to _all_docs:
+	body := `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
+	request, _ = http.NewRequest("POST", "/db/_all_docs?channels=true", bytes.NewBufferString(body))
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 4)
+	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	assert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
+	assert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	assert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
+	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	assert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
+	assert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+
+	// Check GET to _all_docs with keys parameter:
+	request, _ = http.NewRequest("GET", `/db/_all_docs?channels=true&keys=%5B%22doc4%22%2C%22doc1%22%2C%22doc3%22%2C%22b0gus%22%5D`, nil)
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 4)
+	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	assert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
+	assert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	assert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
+	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	assert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
+	assert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+
+	// Check POST to _all_docs with limit option:
+	body = `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
+	request, _ = http.NewRequest("POST", "/db/_all_docs?limit=1&channels=true", bytes.NewBufferString(body))
+	request.SetBasicAuth("alice", "letmein")
+	response = rt.Send(request)
+	assertStatus(t, response, 200)
+
+	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 1)
+	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+
+	// Check _all_docs as admin:
+	response = rt.SendAdminRequest("GET", "/db/_all_docs", "")
+	assertStatus(t, response, 200)
+
+	log.Printf("Admin response = %s", response.Body.Bytes())
+	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, len(allDocsResult.Rows), 5)
+	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	assert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
 }
 
-func TestVbSeqAccessControl(t *testing.T) {
+func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
-	restTester := initRestTester(db.ClockSequenceType, `function(doc) {channel(doc.channels);}`)
-	defer restTester.Close()
-	testAccessControl(t, restTester)
-}
+	rt := initRestTester(db.ClockSequenceType, `function(doc) {channel(doc.channels);}`)
+	defer rt.Close()
 
-func testAccessControl(t *testing.T, rt indexTester) {
 	type allDocsRow struct {
 		ID    string `json:"id"`
 		Key   string `json:"key"`
@@ -2061,7 +2270,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	changed, err := database.UpdateSyncFun(`function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.Equals(t, err, nil)
 	assert.True(t, changed)
-	changeCount, err := database.UpdateAllDocChannels(true, false)
+	changeCount, err := database.UpdateAllDocChannels()
 	assert.Equals(t, err, nil)
 	assert.Equals(t, changeCount, 9)
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1715,11 +1715,11 @@ func TestAllDocsAccessControl(t *testing.T) {
 	err = a.Save(guest)
 	assert.Equals(t, err, nil)
 
-	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
-	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
-	assertStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["CBS", "Cinemax"]}`), 201)
-	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["CBS", "Cinemax"]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1446,9 +1446,9 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	a.Save(bernard)
 
 	// Put several documents
-	response = rt.SendAdminRequest("PUT", "/db/doc1", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/doc5", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/doc4", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/doc3", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
@@ -1460,10 +1460,10 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	testDb.FlushChannelCache()
 
 	// Add a few more docs (to increment the channel cache's validFrom)
-	response = rt.SendAdminRequest("PUT", "/db/doc4", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	response = rt.SendAdminRequest("PUT", "/db/doc5", `{"channels":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/doc1", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	testDb.WaitForSequence(5)
@@ -1479,7 +1479,9 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
 	assertNoError(t, err, "Error unmarshalling changes response")
 	assert.Equals(t, len(changes.Results), 5)
-	for _, entry := range changes.Results {
+	for index, entry := range changes.Results {
+		// Expects docs in sequence order from 1-5
+		assert.Equals(t, entry.Seq.Seq, uint64(index+1))
 		log.Printf("Entry:%+v", entry)
 	}
 	queryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
@@ -1491,7 +1493,9 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
 	assertNoError(t, err, "Error unmarshalling changes response")
 	assert.Equals(t, len(changes.Results), 5)
-	for _, entry := range changes.Results {
+	for index, entry := range changes.Results {
+		// Expects docs in sequence order from 1-5
+		assert.Equals(t, entry.Seq.Seq, uint64(index+1))
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there haven't been any more view queries


### PR DESCRIPTION
Fixes #3500 

Star channel queries and _all_docs queries share the same index, to minimize the number/size of indexes that need to be created for Sync Gateway.  Previously this index was incorrectly optimized for _all_docs (ordering by id), and also wasn't doing any subsequent sequence ordering for star channel queries

It's now optimized for star channel queries, since thesemay be used in performance-sensitive functionality (changes worker implementations, sg-replicate, etc), while _all_docs is intended as ad-hoc functionality only.

The existing _all_docs unit test (TestAllDocsAccessControl) wasn't being run as an integration test, because of how the code was reused for accel/non-accel testing.  Split this out to separate tests to allow running against a Couchbase bucket.

Also cleans up some remaining obsolete handling related to legacy import, including removal of the associated N1QL query.