### PR TITLE
Prevent duplicate channel cache entries when prepending from query

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -217,7 +217,6 @@ func (bucket *CouchbaseBucketGoCB) GetMetadataPurgeInterval() (int, error) {
 
 }
 
-
 // Helper function to retrieve a Metadata Purge Interval from server and convert to hours.  Works for any uri
 // that returns 'purgeInterval' as a root-level property (which includes the two server endpoints for
 // bucket and server purge intervals).
@@ -309,7 +308,6 @@ func (bucket *CouchbaseBucketGoCB) GetMaxTTL() (int, error) {
 	return bucketResponseWithMaxTTL.MaxTTLSeconds, nil
 
 }
-
 
 func (bucket *CouchbaseBucketGoCB) GetName() string {
 	return bucket.spec.BucketName

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -234,7 +234,7 @@ func (c *changeCache) CleanSkippedSequenceQueue() bool {
 				//       aren't indexed by the channel view.  This means we can potentially miss channel removals:
 				//       when an older revision is missed by the TAP feed, and a channel is removed in that revision,
 				//       the doc won't be flagged as removed from that channel in the in-memory channel cache.
-				entries, err := c.context.getChangesInChannelFromView("*", endSequence, options)
+				entries, err := c.context.getChangesInChannelFromQuery("*", endSequence, options)
 				if err == nil && len(entries) > 0 {
 					// Found it - store to send to the caches.
 					found = append(found, entries[0])

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -74,7 +74,7 @@ func nextChannelQueryEntry(results sgbucket.QueryResultIterator) (*LogEntry, boo
 }
 
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
-func (dbc *DatabaseContext) getChangesInChannelFromView(
+func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
 	if dbc.Bucket == nil {
 		return nil, errors.New("No bucket available for channel view query")
@@ -157,7 +157,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 			// Otherwise update startkey and re-query
 
 			startSeq = highSeq + 1
-			base.Infof(base.KeyCache, "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, options.Limit)
+			base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, options.Limit)
 		} else {
 			// If not active-only, we only need one iteration of the loop - the limit applied to the view query is sufficient
 			break
@@ -165,7 +165,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 	}
 
 	if len(entries) > 0 {
-		base.Infof(base.KeyCache, "    Got %d rows from view for %q: #%d ... #%d",
+		base.Infof(base.KeyCache, "    Got %d rows from query for %q: #%d ... #%d",
 			len(entries), base.UD(channelName), entries[0].Sequence, entries[len(entries)-1].Sequence)
 	}
 	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
@@ -178,5 +178,5 @@ func (dbc *DatabaseContext) getChangesInChannelFromView(
 
 // Public channel view call - for unit test support
 func (dbc *DatabaseContext) ChannelViewTest(channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
-	return dbc.getChangesInChannelFromView(channelName, endSeq, options)
+	return dbc.getChangesInChannelFromQuery(channelName, endSeq, options)
 }

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -220,7 +220,7 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 
 	// Now query the view. We set the max sequence equal to cacheValidFrom, so we'll get one
 	// overlap, which helps confirm that we've got everything.
-	resultFromView, err := c.context.getChangesInChannelFromView(c.channelName, cacheValidFrom,
+	resultFromView, err := c.context.getChangesInChannelFromQuery(c.channelName, cacheValidFrom,
 		options)
 	if err != nil {
 		return nil, err

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -350,8 +350,7 @@ func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint6
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	log := c.logs
-	if len(log) == 0 {
+	if len(c.logs) == 0 {
 		// If my cache is empty, just copy the new changes:
 		if len(changes) > 0 {
 			if !openEnded && changes[len(changes)-1].Sequence < c.validFrom {
@@ -381,27 +380,48 @@ func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint6
 
 	} else {
 		// Look for an overlap, and prepend everything up to that point:
-		firstSequence := log[0].Sequence
+		firstSequence := c.logs[0].Sequence
 		if changes[0].Sequence <= firstSequence {
+			// Found overlap - iterate backwards over query results from the overlap point, building set
+			// of entries to append.  Ignore docIDs already in the cache.  Stop when we have enough to
+			// fill to ChannelCacheMaxLength (or run out of query results)
 			for i := len(changes) - 1; i >= 0; i-- {
+				// Found overlap, iterate over remaining to build set to prepend
 				if changes[i].Sequence == firstSequence {
-					if excess := i + len(log) - c.options.ChannelCacheMaxLength; excess > 0 {
-						changes = changes[excess:]
-						changesValidFrom = changes[0].Sequence
-						i -= excess
+					cacheCapacity := c.options.ChannelCacheMaxLength - len(c.logs)
+					if cacheCapacity == 0 {
+						return 0
 					}
-					if i > 0 {
-						newLog := make(LogEntries, 0, i+len(log))
-						newLog = append(newLog, changes[0:i]...)
-						newLog = append(newLog, log...)
-						c.logs = newLog
-						base.Infof(base.KeyCache, "  Added %d entries from view (#%d--#%d) to cache of %q",
-							i, changes[0].Sequence, changes[i-1].Sequence, base.UD(c.channelName))
+					// Build the set of entries to prepend by iterating backwards from the overlap point to the beginning of changes[]
+					entriesToPrepend := make(LogEntries, 0, cacheCapacity)
+					for changeIndex := i; changeIndex >= 0; changeIndex-- {
+						change := changes[changeIndex]
+						changesValidFrom = change.Sequence
+
+						// If docid is already in cache, existing revision must be for a later sequence; can ignore this revision.
+						if _, docIdExists := c.cachedDocIDs[change.DocID]; docIdExists {
+							continue
+						}
+						entriesToPrepend = append(entriesToPrepend, nil)
+						copy(entriesToPrepend[1:], entriesToPrepend)
+						entriesToPrepend[0] = change
+						c.cachedDocIDs[change.DocID] = struct{}{}
+
+						if len(entriesToPrepend) >= cacheCapacity {
+							break
+						}
 					}
-					base.Debugf(base.KeyCache, " Backfill cache from view c.validFrom from %v -> %v",
+
+					numToPrepend := len(entriesToPrepend)
+					if numToPrepend > 0 {
+						c.logs = append(entriesToPrepend, c.logs...)
+						base.Infof(base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
+							numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channelName))
+					}
+					base.Debugf(base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",
 						c.validFrom, changesValidFrom)
 					c.validFrom = changesValidFrom
-					return i
+					return numToPrepend
 				}
 			}
 		}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1434,18 +1434,20 @@ func TestChannelView(t *testing.T) {
 	// Query view (retry loop to wait for indexing)
 	for i := 0; i < 10; i++ {
 		var err error
-		entries, err = db.getChangesInChannelFromView("*", 0, ChangesOptions{})
+		entries, err = db.getChangesInChannelFromQuery("*", 0, ChangesOptions{})
 
 		assertNoError(t, err, "Couldn't create document")
 		if len(entries) >= 1 {
-			log.Printf("View query returned entry: %+v", entries[0])
 			break
 		}
 		log.Printf("No entries found - retrying (%d/10)", i+1)
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	assert.True(t, len(entries) == 1)
+	for i, entry := range entries {
+		log.Printf("View Query returned entry (%d): %v", i, entry)
+	}
+	assert.Equals(t, len(entries), 1)
 
 }
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1604,7 +1604,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	// Validate that there haven't been any more view queries
 	updatedQueryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
 	log.Printf("After second changes request, query count is :%s", updatedQueryCount)
-	assert.Equals(t, updatedQueryCount, "1")
+	assert.Equals(t, updatedQueryCount, queryCount)
 
 }
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -40,7 +40,6 @@ type RestTester struct {
 	DatabaseConfig          *DbConfig // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
 	AdminHandler            http.Handler
 	PublicHandler           http.Handler
-	leakyBucketConfig       *base.LeakyBucketConfig
 	EnableNoConflictsMode   bool // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
 	NoFlush                 bool // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
 }
@@ -114,11 +113,6 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		if !rt.noAdminParty {
 			rt.SetAdminParty(true)
-		}
-
-		// If given a leakyBucketConfig we'll return a leaky bucket.
-		if rt.leakyBucketConfig != nil {
-			return base.NewLeakyBucket(rt.RestTesterBucket, *rt.leakyBucketConfig)
 		}
 
 	}


### PR DESCRIPTION
When prepending entries to the channel cache, enforce that prepended docs don't have a later revision already present in the cache.  Can occur when new cache entries are added while the query used to backfill/prepend the cache is running.

Fixes #3475 

Integration tests:
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/624/
http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/625/