### PR TITLE
#3549 Change _sgcollect_info endpoint zip filename format for Windows compatibility

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -20,6 +20,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -895,4 +896,25 @@ func ConvertBackQuotedStrings(data []byte) []byte {
 		bytes[len(bytes)-1] = '"'
 		return bytes
 	})
+}
+
+// FindPrimaryAddr returns the primary outbound IP of this machine.
+// This is the same as find_primary_addr in sgcollect_info.
+func FindPrimaryAddr() (net.IP, error) {
+	conn, err := net.Dial("udp", "8.8.8.8:56")
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP, nil
+}
+
+// ReplaceAll returns a string with all of the given chars replaced by new
+func ReplaceAll(s, chars, new string) string {
+	for _, r := range chars {
+		s = strings.Replace(s, string(r), new, -1)
+	}
+	return s
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -347,3 +347,37 @@ func TestIsMinimumVersion(t *testing.T) {
 	assertTrue(t, !isMinimumVersion(5, 0, 5, 1), "Invalid minimum version check - expected false")
 	assertTrue(t, !isMinimumVersion(0, 0, 1, 0), "Invalid minimum version check - expected false")
 }
+
+func TestFindPrimaryAddr(t *testing.T) {
+	ip, err := FindPrimaryAddr()
+	if err != nil && strings.Contains(err.Error(), "network is unreachable") {
+		// Skip test if dial fails.
+		// This is to allow tests to be run offline/without third-party dependencies.
+		t.Skipf("WARNING: network is unreachable: %s", err)
+	}
+
+	assert.NotEquals(t, ip, nil)
+	assert.NotEquals(t, ip.String(), "")
+	assert.NotEquals(t, ip.String(), "<nil>")
+}
+
+func TestReplaceAll(t *testing.T) {
+	tests := []struct {
+		input,
+		chars,
+		new,
+		expected string
+	}{
+		{"", "", "", ""},
+		{"safe", ":", "", "safe"},
+		{"unsafe?", "?", "", "unsafe"},
+		{"123:456:789", ":", "-", "123-456-789"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.chars, func(ts *testing.T) {
+			output := ReplaceAll(test.input, test.chars, test.new)
+			assert.Equals(ts, output, test.expected)
+		})
+	}
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -433,10 +433,9 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", err)
 	}
 
-	filename := fmt.Sprintf("sgcollect_info-%v.zip", time.Now().UnixNano())
 	args := params.Args()
 
-	if err := sgcollectInstance.Start(filename, args...); err != nil {
+	if err := sgcollectInstance.Start(sgcollectFilename(), args...); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -433,7 +433,7 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", err)
 	}
 
-	filename := "sgcollect_info_" + time.Now().Format(base.ISO8601Format) + ".zip"
+	filename := fmt.Sprintf("sgcollect_info-%v.zip", time.Now().UnixNano())
 	args := params.Args()
 
 	if err := sgcollectInstance.Start(filename, args...); err != nil {

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -4,12 +4,15 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"sync/atomic"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -204,4 +207,28 @@ func sgCollectPaths() (sgPath, sgCollectPath string) {
 	}
 
 	return sgPath, sgCollectPath
+}
+
+// sgcollectFilename returns a Windows-safe filename for sgcollect_info zip files.
+func sgcollectFilename() string {
+	// get current username
+	username := "unknown"
+	user, err := user.Current()
+	if err == nil && user != nil {
+		username = user.Username
+	}
+
+	// get primary IP address
+	ip := base.FindPrimaryAddr().String()
+
+	// get timestamp
+	timestamp := time.Now().UTC().Format("2006-01-02t150405")
+
+	// E.g: sgcollectinfo-2018-05-10t133456-bbrks@203.0.113.123.zip
+	filename := fmt.Sprintf("sgcollectinfo-%s-%s@%s.zip", timestamp, username, ip)
+
+	// Strip illegal Windows filename characters
+	filename = base.ReplaceAll(filename, "\\/:*?\"<>|", "")
+
+	return filename
 }

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"os/user"
@@ -219,7 +220,10 @@ func sgcollectFilename() string {
 	}
 
 	// get primary IP address
-	ip := base.FindPrimaryAddr().String()
+	ip, err := base.FindPrimaryAddr()
+	if err != nil {
+		ip = net.IPv4zero
+	}
 
 	// get timestamp
 	timestamp := time.Now().UTC().Format("2006-01-02t150405")

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -204,7 +203,7 @@ func sgCollectPaths() (sgPath, sgCollectPath string) {
 	// Make sure sgcollect_info exists
 	_, err = os.Stat(sgCollectPath)
 	if err != nil {
-		base.Warnf(base.KeyAll, "Unable to find sgcollect_info executable")
+		base.Warnf(base.KeyAll, "Unable to find sgcollect_info executable. sgcollect_info cannot be run from the admin API.")
 	}
 
 	return sgPath, sgCollectPath
@@ -216,10 +215,16 @@ func sgcollectFilename() string {
 	// get timestamp
 	timestamp := time.Now().UTC().Format("2006-01-02t150405")
 
-	// Use a shortened product name as username
-	name := "sg"
-	if strings.Contains(base.ServerName, "Accel") {
+	// Use a shortened product name as username.
+	// This may change, so the unit test for sgcollectFilename explicitly checks one of these is set.
+	name := "ProductName"
+	switch base.ProductName {
+	case "Couchbase Sync Gateway":
+		name = "sg"
+	case "Couchbase SG Accel":
 		name = "sga"
+	default:
+		base.Warnf(base.KeyAdmin, "Unrecognised ProductName: %v", base.ProductName)
 	}
 
 	// get primary IP address

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -9,9 +9,9 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -212,11 +212,14 @@ func sgCollectPaths() (sgPath, sgCollectPath string) {
 
 // sgcollectFilename returns a Windows-safe filename for sgcollect_info zip files.
 func sgcollectFilename() string {
-	// get current username
-	username := "unknown"
-	user, err := user.Current()
-	if err == nil && user != nil {
-		username = user.Username
+
+	// get timestamp
+	timestamp := time.Now().UTC().Format("2006-01-02t150405")
+
+	// Use a shortened product name as username
+	name := "sg"
+	if strings.Contains(base.ServerName, "Accel") {
+		name = "sga"
 	}
 
 	// get primary IP address
@@ -225,11 +228,8 @@ func sgcollectFilename() string {
 		ip = net.IPv4zero
 	}
 
-	// get timestamp
-	timestamp := time.Now().UTC().Format("2006-01-02t150405")
-
-	// E.g: sgcollectinfo-2018-05-10t133456-bbrks@203.0.113.123.zip
-	filename := fmt.Sprintf("sgcollectinfo-%s-%s@%s.zip", timestamp, username, ip)
+	// E.g: sgcollectinfo-2018-05-10t133456-sg@203.0.113.123.zip
+	filename := fmt.Sprintf("sgcollectinfo-%s-%s@%s.zip", timestamp, name, ip)
 
 	// Strip illegal Windows filename characters
 	filename = base.ReplaceAll(filename, "\\/:*?\"<>|", "")

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -215,16 +215,10 @@ func sgcollectFilename() string {
 	// get timestamp
 	timestamp := time.Now().UTC().Format("2006-01-02t150405")
 
-	// Use a shortened product name as username.
-	// This may change, so the unit test for sgcollectFilename explicitly checks one of these is set.
-	name := "ProductName"
-	switch base.ProductName {
-	case "Couchbase Sync Gateway":
-		name = "sg"
-	case "Couchbase SG Accel":
+	// use a shortened product name
+	name := "sg"
+	if base.ProductName == "Couchbase SG Accel" {
 		name = "sga"
-	default:
-		base.Warnf(base.KeyAdmin, "Unrecognised ProductName: %v", base.ProductName)
 	}
 
 	// get primary IP address

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -1,0 +1,23 @@
+package rest
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	assert "github.com/couchbaselabs/go.assert"
+)
+
+func TestSgcollectFilename(t *testing.T) {
+	filename := sgcollectFilename()
+
+	assert.True(t, strings.HasPrefix(filename, "sgcollectinfo-"))
+	assert.True(t, strings.HasSuffix(filename, ".zip"))
+
+	// Check it doesn't have forbidden chars
+	assert.False(t, strings.ContainsAny(filename, "\\/:*?\"<>|"))
+
+	matched, err := regexp.Match(`^sgcollectinfo\-\d{4}\-\d{2}\-\d{2}t\d{6}\-sga?@(\d{1,3}\.){4}zip$`, []byte(filename))
+	assertNoError(t, err, "unexpected regexp error")
+	assert.True(t, matched)
+}

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -11,6 +11,9 @@ import (
 func TestSgcollectFilename(t *testing.T) {
 	filename := sgcollectFilename()
 
+	// Check the product name has been set
+	assert.False(t, strings.Contains(filename, "ProductName"))
+
 	// Check it doesn't have forbidden chars
 	assert.False(t, strings.ContainsAny(filename, "\\/:*?\"<>|"))
 

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -11,13 +12,11 @@ import (
 func TestSgcollectFilename(t *testing.T) {
 	filename := sgcollectFilename()
 
-	// Check the product name has been set
-	assert.False(t, strings.Contains(filename, "ProductName"))
-
 	// Check it doesn't have forbidden chars
 	assert.False(t, strings.ContainsAny(filename, "\\/:*?\"<>|"))
 
-	matched, err := regexp.Match(`^sgcollectinfo\-\d{4}\-\d{2}\-\d{2}t\d{6}\-sga?@(\d{1,3}\.){4}zip$`, []byte(filename))
+	pattern := `^sgcollectinfo\-\d{4}\-\d{2}\-\d{2}t\d{6}\-sga?@(\d{1,3}\.){4}zip$`
+	matched, err := regexp.Match(pattern, []byte(filename))
 	assertNoError(t, err, "unexpected regexp error")
-	assert.True(t, matched)
+	assertTrue(t, matched, fmt.Sprintf("Filename: %s did not match pattern: %s", filename, pattern))
 }

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -11,9 +11,6 @@ import (
 func TestSgcollectFilename(t *testing.T) {
 	filename := sgcollectFilename()
 
-	assert.True(t, strings.HasPrefix(filename, "sgcollectinfo-"))
-	assert.True(t, strings.HasSuffix(filename, ".zip"))
-
 	// Check it doesn't have forbidden chars
 	assert.False(t, strings.ContainsAny(filename, "\\/:*?\"<>|"))
 


### PR DESCRIPTION
Fixes #3549 

Change filename output of `_sgcollect_info` endpoint for Windows compatibility. Aligns with server's cbcollect_info filename format of `sgcollectinfo-2018-05-10t133456-sg@203.0.113.123.zip`
