### PR TITLE
Fixes #844 Retrieving a non existent design doc returns 500 error

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1770,7 +1770,7 @@ func (bucket *CouchbaseBucketGoCB) GetDDoc(docname string, into interface{}) err
 		// GoCB doesn't provide an easy way to distinguish what the cause of the error was, so
 		// resort to a string pattern match for "not_found" and propagate a 404 error in that case.
 		if strings.Contains(err.Error(), "not_found") {
-			return HTTPErrorf(404, "%v","missing")
+			return ErrNotFound
 		}
 		return err
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1767,6 +1767,11 @@ func (bucket *CouchbaseBucketGoCB) GetDDoc(docname string, into interface{}) err
 	// TODO: Retry here for recoverable gocb errors?
 	designDocPointer, err := bucketManager.GetDesignDocument(docname)
 	if err != nil {
+		// GoCB doesn't provide an easy way to distinguish what the cause of the error was, so
+		// resort to a string pattern match for "not_found" and propagate a 404 error in that case.
+		if strings.Contains(err.Error(), "not_found") {
+			return HTTPErrorf(404, "%v","missing")
+		}
 		return err
 	}
 

--- a/base/error.go
+++ b/base/error.go
@@ -157,8 +157,8 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 	case sgbucket.MissingError:
 		return http.StatusNotFound, "missing"
 	case *SGError:
-		switch unwrappedErr.code {
-		case notFound:
+		switch unwrappedErr {
+		case ErrNotFound:
 			return http.StatusNotFound, "missing"
 		}
 	case *json.SyntaxError, *json.UnmarshalTypeError:

--- a/base/error.go
+++ b/base/error.go
@@ -36,6 +36,7 @@ const (
 	errPartialViewErrors  = sgErrorCode(0x10)
 	indexerError          = sgErrorCode(0x11)
 	indexExists           = sgErrorCode(0x12)
+	notFound              = sgErrorCode(0x13)
 )
 
 type SGError struct {
@@ -55,6 +56,7 @@ var (
 	ErrCasFailureShouldRetry = &SGError{casFailureShouldRetry}
 	ErrIndexerError          = &SGError{indexerError}
 	ErrIndexAlreadyExists    = &SGError{indexExists}
+	ErrNotFound              = &SGError{notFound}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
@@ -87,6 +89,8 @@ func (e SGError) Error() string {
 		return "Indexer error"
 	case indexExists:
 		return "Index already exists"
+	case notFound:
+		return "Not Found"
 	default:
 		return "Unknown error"
 	}
@@ -152,6 +156,11 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		}
 	case sgbucket.MissingError:
 		return http.StatusNotFound, "missing"
+	case *SGError:
+		switch unwrappedErr.code {
+		case notFound:
+			return http.StatusNotFound, "missing"
+		}
 	case *json.SyntaxError, *json.UnmarshalTypeError:
 		return http.StatusBadRequest, fmt.Sprintf("Invalid JSON: \"%v\"", unwrappedErr)
 	}

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"strings"
 )
 
 // HTTP handler for GET _design/$ddoc
@@ -30,11 +29,6 @@ func (h *handler) handleGetDesignDoc() error {
 		result = db.Body{"filters": db.Body{"bychannel": filter}}
 	} else {
 		if err := h.db.GetDesignDoc(ddocID, &result); err != nil {
-			// GoCB doesn't provide an easy way to distinguish what the cause of the error was, so
-			// resort to a string pattern match for "not_found" and propagate a 404 error in that case.
-			if strings.Contains(err.Error(), "not_found") {
-				return base.HTTPErrorf(404, "%v","missing")
-			}
 			return err
 		}
 	}

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"strings"
 )
 
 // HTTP handler for GET _design/$ddoc
@@ -29,6 +30,11 @@ func (h *handler) handleGetDesignDoc() error {
 		result = db.Body{"filters": db.Body{"bychannel": filter}}
 	} else {
 		if err := h.db.GetDesignDoc(ddocID, &result); err != nil {
+			// GoCB doesn't provide an easy way to distinguish what the cause of the error was, so
+			// resort to a string pattern match for "not_found" and propagate a 404 error in that case.
+			if strings.Contains(err.Error(), "not_found") {
+				return base.HTTPErrorf(404, "%v","missing")
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes #844 

After this change, if trying to get a non-existent design doc, it returns a 404 error w/ a json body:

```
{
    "error": "not_found",
    "reason": "missing"
}
```