### PR TITLE
Improve BuildIndex robustness under race conditions

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -431,6 +431,71 @@ func TestDeferredCreateIndex(t *testing.T) {
 
 }
 
+func TestBuildPendingIndexes(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+
+	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		t.Fatalf("Requires gocb bucket")
+	}
+
+	deferredIndexName := "testIndexDeferred"
+	nonDeferredIndexName := "testIndexNonDeferred"
+	assertNoError(t, tearDownTestIndex(bucket, deferredIndexName), "Error in pre-test cleanup")
+	assertNoError(t, tearDownTestIndex(bucket, nonDeferredIndexName), "Error in pre-test cleanup")
+
+	deferN1qlOptions := &N1qlIndexOptions{
+		NumReplica: 0,
+		DeferBuild: true,
+	}
+
+	// Create a deferred and a non-deferred index
+	createExpression := "_sync.sequence"
+	err := bucket.CreateIndex(deferredIndexName, createExpression, "", deferN1qlOptions)
+	if err != nil {
+		t.Errorf("Error creating index: %s", err)
+	}
+
+	createExpression = "_sync.rev"
+	err = bucket.CreateIndex(nonDeferredIndexName, createExpression, "", &N1qlIndexOptions{NumReplica: 0})
+	if err != nil {
+		t.Errorf("Error creating index: %s", err)
+	}
+
+	// Drop the indexes
+	defer func() {
+		err = bucket.DropIndex(deferredIndexName)
+		if err != nil {
+			t.Errorf("Error dropping deferred index: %s", err)
+		}
+	}()
+	defer func() {
+		err = bucket.DropIndex(nonDeferredIndexName)
+		if err != nil {
+			t.Errorf("Error dropping non-deferred index: %s", err)
+		}
+	}()
+
+	buildErr := bucket.BuildPendingIndexes([]string{deferredIndexName, nonDeferredIndexName}, 10)
+	assertNoError(t, buildErr, "Error building indexes")
+
+	readyErr := bucket.WaitForIndexOnline(deferredIndexName)
+	assertNoError(t, readyErr, "Error validating index online")
+	readyErr = bucket.WaitForIndexOnline(nonDeferredIndexName)
+	assertNoError(t, readyErr, "Error validating index online")
+
+	// Ensure no errors from no-op scenarios
+	alreadyBuiltErr := bucket.BuildPendingIndexes([]string{deferredIndexName, nonDeferredIndexName}, 10)
+	assertNoError(t, alreadyBuiltErr, "Error building already built indexes")
+
+	emptySetErr := bucket.BuildPendingIndexes([]string{}, 10)
+	assertNoError(t, emptySetErr, "Error building empty set")
+}
+
 func TestCreateAndDropIndexErrors(t *testing.T) {
 
 	if UnitTestUrlIsWalrus() {

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -423,7 +423,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 		}
 	}()
 
-	buildErr := bucket.BuildIndexes([]string{indexName})
+	buildErr := bucket.buildIndexes([]string{indexName})
 	assertNoError(t, buildErr, "Error building indexes")
 
 	readyErr := bucket.WaitForIndexOnline(indexName)
@@ -431,7 +431,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 
 }
 
-func TestBuildPendingIndexes(t *testing.T) {
+func TestBuildDeferredIndexes(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
@@ -480,7 +480,7 @@ func TestBuildPendingIndexes(t *testing.T) {
 		}
 	}()
 
-	buildErr := bucket.BuildPendingIndexes([]string{deferredIndexName, nonDeferredIndexName}, 10)
+	buildErr := bucket.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
 	assertNoError(t, buildErr, "Error building indexes")
 
 	readyErr := bucket.WaitForIndexOnline(deferredIndexName)
@@ -489,10 +489,10 @@ func TestBuildPendingIndexes(t *testing.T) {
 	assertNoError(t, readyErr, "Error validating index online")
 
 	// Ensure no errors from no-op scenarios
-	alreadyBuiltErr := bucket.BuildPendingIndexes([]string{deferredIndexName, nonDeferredIndexName}, 10)
+	alreadyBuiltErr := bucket.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
 	assertNoError(t, alreadyBuiltErr, "Error building already built indexes")
 
-	emptySetErr := bucket.BuildPendingIndexes([]string{}, 10)
+	emptySetErr := bucket.BuildDeferredIndexes([]string{})
 	assertNoError(t, emptySetErr, "Error building empty set")
 }
 

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -195,7 +195,8 @@ func (i *SGIndex) createIfNeeded(bucket *base.CouchbaseBucketGoCB, useXattrs boo
 			// Two possible scenarios when index already exists in deferred state:
 			//  1. Another SG is in the process of index creation
 			//  2. SG previously crashed between index creation and index build.
-			// GSI doesn't like concurrent build requests, so wait and recheck index state before treating as option 2
+			// GSI doesn't like concurrent build requests, so wait and recheck index state before treating as option 2.
+			// (see known issue documented https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/build-index.html)
 			base.Infof(base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.")
 			time.Sleep(10 * time.Second)
 			exists, indexMeta, metaErr = bucket.GetIndexMeta(indexName)


### PR DESCRIPTION
 - Don't attempt to build index when create fails w/ 'Already exists' error
 - On build failure, analyze current state of indexes, and retry build only for those in deferred/pending state
 - Switch to using gocb's existing struct for SELECT from system:indexes response, and check for both deferred and pending states