### PR TITLE
#3548 Fix 2.0 and 2.1 paths in service scripts and sgcollect_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,5 @@
 \#*\#
 /bin
 /pkg
-
-service/sg-windows/sg-windows
-service/sg-windows/sg-accel-service
-service/sg-windows/sgsrv.iml
+*.exe
+*.iml

--- a/service/sg-windows/sg-accel-service/sg-accel-service.go
+++ b/service/sg-windows/sg-accel-service/sg-accel-service.go
@@ -6,16 +6,20 @@ import (
 	"log"
 	"os/exec"
 
-	"github.com/kardianos/service"
 	"os"
+
+	"github.com/kardianos/service"
 )
+
+const installLocation = "C:\\Program Files\\Couchbase\\Sync Gateway Accelerator\\"
+const defaultLogFilePath = installLocation + "var\\lib\\couchbase\\logs"
 
 var logger service.Logger
 
 type program struct {
 	ExePath    string
 	ConfigPath string
-	StderrPath  string
+	StderrPath string
 	SGAccel    *exec.Cmd
 }
 
@@ -29,12 +33,12 @@ func (p *program) Start(s service.Service) error {
 }
 
 func (p *program) startup() error {
-	logger.Infof("Starting the Sync Gateway Accelerator service using command: `%s %s`", p.ExePath, p.ConfigPath)
+	logger.Infof("Starting the Sync Gateway Accelerator service using command: `%s --defaultLogFilePath %s %s`", p.ExePath, defaultLogFilePath, p.ConfigPath)
 
 	if p.ConfigPath != "" {
-		p.SGAccel = exec.Command(p.ExePath, p.ConfigPath)
+		p.SGAccel = exec.Command(p.ExePath, "--defaultLogFilePath", defaultLogFilePath, p.ConfigPath)
 	} else {
-		p.SGAccel = exec.Command(p.ExePath)
+		p.SGAccel = exec.Command(p.ExePath, "--defaultLogFilePath", defaultLogFilePath)
 	}
 
 	f, err := os.OpenFile(p.StderrPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
@@ -80,25 +84,24 @@ func main() {
 
 	switch len(os.Args) {
 	case 2:
-		exePath = "C:\\Program Files (x86)\\Couchbase\\sg_accel.exe" // Uses default binary image path
-		stderrPath = "C:\\Program Files (x86)\\Couchbase\\var\\lib\\couchbase\\logs\\sg_accel_error.log" // Uses default stderr path
-		svcConfig.Arguments = []string{"start", stderrPath}                      // Uses the default config
+		exePath = installLocation + "sg_accel.exe"             // Uses default binary image path
+		stderrPath = defaultLogFilePath + "sg_accel_error.log" // Uses default stderr path
+		svcConfig.Arguments = []string{"start", stderrPath}    // Uses the default config
 	case 3:
-		exePath = "C:\\Program Files (x86)\\Couchbase\\sg_accel.exe" // Uses default binary image path
-		configPath = os.Args[2]                                      // Uses custom config
-		stderrPath = "C:\\Program Files (x86)\\Couchbase\\var\\lib\\couchbase\\logs\\sg_accel_error.log" // Uses default stderr path
+		exePath = installLocation + "sg_accel.exe"             // Uses default binary image path
+		configPath = os.Args[2]                                // Uses custom config
+		stderrPath = defaultLogFilePath + "sg_accel_error.log" // Uses default stderr path
 		svcConfig.Arguments = []string{"start", configPath, stderrPath}
 	case 4:
-		exePath = os.Args[2]    // Uses custom binary image path
-		configPath = os.Args[3] // Uses custom config
-		stderrPath = "C:\\Program Files (x86)\\Couchbase\\var\\lib\\couchbase\\logs\\sg_accel_error.log" // Uses default stderr path
+		exePath = os.Args[2]                                   // Uses custom binary image path
+		configPath = os.Args[3]                                // Uses custom config
+		stderrPath = defaultLogFilePath + "sg_accel_error.log" // Uses default stderr path
 		svcConfig.Arguments = []string{"start", exePath, configPath, stderrPath}
 	case 5:
 		exePath = os.Args[2]    // Uses custom binary image path
 		configPath = os.Args[3] // Uses custom config
-		stderrPath = os.Args[4]
+		stderrPath = os.Args[4] // Uses custom stderr path
 		svcConfig.Arguments = []string{"start", exePath, configPath, stderrPath}
-
 	default:
 		panic("Valid parameters combinations are: COMMAND [none, custom config path, or custom exe path and custom config path].")
 	}

--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kardianos/service"
 )
 
-const installLocation = "C:\\Program Files (x86)\\Couchbase\\"
+const installLocation = "C:\\Program Files\\Couchbase\\Sync Gateway\\"
 const defaultLogFilePath = installLocation + "var\\lib\\couchbase\\logs"
 
 var logger service.Logger

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -449,8 +449,10 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
         "/opt/sg_accel/etc/sg_accel.json",                                  # amazon linux AMI sg accel
         "/Users/sync_gateway/sg_accel.json",                                # OSX sg accel
         "/Users/sync_gateway/sync_gateway.json"                             # OSX sync gateway
-        R'C:\Program Files (x86)\Couchbase\basic_sg_accel_config.json',     # Windows sg accel
-        R'C:\Program Files (x86)\Couchbase\serviceconfig.json'               # Windows sync gateway
+        R'C:\Program Files (x86)\Couchbase\basic_sg_accel_config.json',     # Windows (Pre-2.0) sg accel
+        R'C:\Program Files (x86)\Couchbase\serviceconfig.json'              # Windows (Pre-2.0) sync gateway
+        R'C:\Program Files\Couchbase\Sync Gateway Accelerator\basic_sg_accel_config.json', # Windows (Post-2.0) sg accel
+        R'C:\Program Files\Couchbase\Sync Gateway\serviceconfig.json'       # Windows (Post-2.0) sync gateway
     ]
     sg_config_files = [ x for x in sg_config_files if os.path.exists(x)]
 
@@ -606,10 +608,12 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
 def discover_sg_binary_path(options, sg_url):
 
     sg_bin_dirs = [
-        "/opt/couchbase-sync-gateway/bin/sync_gateway",            # Linux + OSX
-        "/opt/couchbase-sg-accel/bin/sg_accel",                    # Linux + OSX
-        R'C:\Program Files (x86)\Couchbase\sync_gateway.exe',      # Windows
-        R'C:\Program Files (x86)\Couchbase\sg_accel.exe',          # Windows
+        "/opt/couchbase-sync-gateway/bin/sync_gateway",                      # Linux + OSX
+        "/opt/couchbase-sg-accel/bin/sg_accel",                              # Linux + OSX
+        R'C:\Program Files (x86)\Couchbase\sync_gateway.exe',                # Windows (Pre-2.0)
+        R'C:\Program Files (x86)\Couchbase\sg_accel.exe',                    # Windows (Pre-2.0)
+        R'C:\Program Files\Couchbase\Sync Gateway\sync_gateway.exe',         # Windows (Post-2.0)
+        R'C:\Program Files\Couchbase\Sync Gateway Accelerator\sg_accel.exe', # Windows (Post-2.0)
     ]
 
     for sg_binary_path_candidate in sg_bin_dirs:

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -287,9 +287,11 @@ def make_collect_logs_tasks(zip_dir, sg_url):
         "/home/sync_gateway/logs",
         "/var/log/sg_accel",
         "/var/log/sync_gateway",
-        "/Users/sync_gateway/logs",
-        "/Users/sg_accel/logs",
-        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs'
+        "/Users/sync_gateway/logs",                                                     # OSX sync gateway
+        "/Users/sg_accel/logs",                                                         # OSX sg accel
+        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',                     # Windows (Pre-2.1)
+        R'C:\Program Files\Couchbase\Sync Gateway Accelerator\var\lib\couchbase\logs',  # Windows (Post-2.1) sg accel
+        R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'               # Windows (Post-2.1) sync gateway
     ]
     # Try to find user-specified log path
     config_url = "{0}/_config".format(sg_url)
@@ -443,16 +445,17 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
 
     # Here are the "usual suspects" to probe for finding the static config
     sg_config_files = [
-        "/home/sg_accel/sg_accel.json",                                     # linux sg accel
-        "/home/sync_gateway/sync_gateway.json",                             # linux sync gateway
-        "/opt/sync_gateway/etc/sync_gateway.json",                          # amazon linux AMI sync gateway
-        "/opt/sg_accel/etc/sg_accel.json",                                  # amazon linux AMI sg accel
-        "/Users/sync_gateway/sg_accel.json",                                # OSX sg accel
-        "/Users/sync_gateway/sync_gateway.json"                             # OSX sync gateway
-        R'C:\Program Files (x86)\Couchbase\basic_sg_accel_config.json',     # Windows (Pre-2.0) sg accel
-        R'C:\Program Files (x86)\Couchbase\serviceconfig.json'              # Windows (Pre-2.0) sync gateway
-        R'C:\Program Files\Couchbase\Sync Gateway Accelerator\basic_sg_accel_config.json', # Windows (Post-2.0) sg accel
-        R'C:\Program Files\Couchbase\Sync Gateway\serviceconfig.json'       # Windows (Post-2.0) sync gateway
+        "/home/sg_accel/sg_accel.json",                                  # linux sg accel
+        "/home/sync_gateway/sync_gateway.json",                          # linux sync gateway
+        "/opt/sync_gateway/etc/sync_gateway.json",                       # amazon linux AMI sync gateway
+        "/opt/sg_accel/etc/sg_accel.json",                               # amazon linux AMI sg accel
+        "/Users/sync_gateway/sg_accel.json",                             # OSX sg accel old
+        "/Users/sync_gateway/sync_gateway.json"                          # OSX sync gateway
+        "/Users/sg_accel/sg_accel.json",                                 # OSX sg accel
+        R'C:\Program Files (x86)\Couchbase\basic_sg_accel_config.json',  # Windows (Pre-2.0) sg accel
+        R'C:\Program Files (x86)\Couchbase\serviceconfig.json'           # Windows (Pre-2.0) sync gateway
+        R'C:\Program Files\Couchbase\Sync Gateway Accelerator\basic_sg_accel_config.json',  # Windows (Post-2.0) sg accel
+        R'C:\Program Files\Couchbase\Sync Gateway\serviceconfig.json'    # Windows (Post-2.0) sync gateway
     ]
     sg_config_files = [ x for x in sg_config_files if os.path.exists(x)]
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -289,7 +289,8 @@ def make_collect_logs_tasks(zip_dir, sg_url):
         "/var/log/sync_gateway",
         "/Users/sync_gateway/logs",                                                     # OSX sync gateway
         "/Users/sg_accel/logs",                                                         # OSX sg accel
-        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',                     # Windows (Pre-2.1)
+        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',                     # Windows (Pre-2.0)
+        R'C:\Program Files\Couchbase\var\lib\couchbase\logs',                           # Windows (Post-2.0)
         R'C:\Program Files\Couchbase\Sync Gateway Accelerator\var\lib\couchbase\logs',  # Windows (Post-2.1) sg accel
         R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'               # Windows (Post-2.1) sync gateway
     ]


### PR DESCRIPTION
Fixes #3548 

- Moves new 2.1 logs directory to 2.0 install path on Windows.
- Updates Windows service scripts for 2.0 install path.
- Add 2.0 paths to sgcollect_info.
- Add 2.1 paths to sgcollect_info.