### PR TITLE
#3559 Fix output_dir in _sgcollect_info endpoint

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -433,9 +434,10 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", err)
 	}
 
+	zipPath := filepath.Join(params.OutputDirectory, sgcollectFilename())
 	args := params.Args()
 
-	if err := sgcollectInstance.Start(sgcollectFilename(), args...); err != nil {
+	if err := sgcollectInstance.Start(zipPath, args...); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -39,7 +39,7 @@ type sgCollect struct {
 }
 
 // Start will attempt to start sgcollect_info, if another is not already running.
-func (sg *sgCollect) Start(filename string, args ...string) error {
+func (sg *sgCollect) Start(zipPath string, args ...string) error {
 	if atomic.LoadUint32(sg.status) == sgRunning {
 		return ErrSGCollectInfoAlreadyRunning
 	}
@@ -49,7 +49,7 @@ func (sg *sgCollect) Start(filename string, args ...string) error {
 		return err
 	}
 
-	args = append(args, "--sync-gateway-executable", sgPath, filename)
+	args = append(args, "--sync-gateway-executable", sgPath, zipPath)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	sg.cancel = cancelFunc
@@ -156,10 +156,6 @@ func (c *sgCollectOptions) Validate() error {
 // Args returns a set of arguments to pass to sgcollect_info.
 func (c *sgCollectOptions) Args() []string {
 	var args = make([]string, 0)
-
-	if c.OutputDirectory != "" {
-		args = append(args, "-r", c.OutputDirectory)
-	}
 
 	if c.Upload {
 		args = append(args, "--upload-host", c.UploadHost)


### PR DESCRIPTION
Fixes #3559

- Removed incorrect `-p` flag from sgcollect args
- Pass in full path to zip file (prefix output_dir)