### PR TITLE
#3561 Improve sgcollect error messages for s3 upload

### DIFF
--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -147,7 +147,11 @@ func (c *sgCollectOptions) Validate() error {
 	}
 
 	if c.Upload && c.Customer == "" {
-		return errors.New("customer must be set if uploading")
+		return errors.New("customer must be set if upload is true")
+	}
+
+	if !c.Upload && c.UploadHost != "" {
+		return errors.New("upload must be set if upload_host is specified")
 	}
 
 	return nil

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -995,9 +995,8 @@ def do_upload_and_exit(path, url):
         if url.getcode() == 200:
             log('Done uploading')
         else:
-            raise Exception('Uploading failed, expected status code 200, got status code: {0}'.format(url.getcode()))
+            raise Exception('Error uploading, expected status code 200, got status code: {0}'.format(url.getcode()))
     except Exception as e:
-        log('Error uploading: {0}'.format(e))
         log(traceback.format_exc())
         exit_code = 1
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -22,6 +22,7 @@ import urllib2
 import base64
 import mmap
 import hashlib
+import traceback
 
 
 class LogRedactor:
@@ -994,9 +995,10 @@ def do_upload_and_exit(path, url):
         if url.getcode() == 200:
             log('Done uploading')
         else:
-            raise Exception('HTTP status code: %s' % url.getcode())
+            raise Exception('Uploading failed, expected status code 200, got status code: {0}'.format(url.getcode()))
     except Exception as e:
-        log('Error uploading: %s' % e)
+        log('Error uploading: {0}'.format(e))
+        log(traceback.format_exc())
         exit_code = 1
 
     filedata.close()

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -987,13 +987,16 @@ def do_upload_and_exit(path, url):
     request = urllib2.Request(url.encode('utf-8'),data=filedata)
     request.add_header(str('Content-Type'), str('application/zip'))
     request.get_method = lambda: str('PUT')
-    url = opener.open(request)
 
     exit_code = 0
-    if url.getcode() == 200:
-        log('Done uploading')
-    else:
-        log('Error uploading.  HTTP status code: %s' % url.getcode())
+    try:
+        url = opener.open(request)
+        if url.getcode() == 200:
+            log('Done uploading')
+        else:
+            raise Exception('HTTP status code: %s' % url.getcode())
+    except Exception as e:
+        log('Error uploading: %s' % e)
         exit_code = 1
 
     filedata.close()


### PR DESCRIPTION
Fixes #3561 

- Require that `upload` is true when supplying `upload_host`
- Improve sgcollect_info error messages for failed s3 uploads