### PR TITLE
#3572 Fixes sgcollect_info bad request if upload_host is unset

### DIFF
--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -128,17 +128,8 @@ type sgCollectOptions struct {
 	Ticket          string `json:"ticket,omitempty"`
 }
 
-func (c *sgCollectOptions) setDefaults() {
-	// Default to Support's S3 bucket.
-	if c.UploadHost == "" {
-		c.UploadHost = defaultSGUploadHost
-	}
-}
-
 // Validate ensures the options are OK to use in sgcollect_info.
 func (c *sgCollectOptions) Validate() error {
-	c.setDefaults()
-
 	// Validate given output directory exists, and is a directory.
 	// This does not check for write permission, however sgcollect_info
 	// will fail with an error giving that reason, if this is the case.
@@ -150,13 +141,16 @@ func (c *sgCollectOptions) Validate() error {
 		}
 	}
 
-	// Customer number is required if uploading.
-	if c.Upload && c.Customer == "" {
-		return errors.New("customer must be set if upload is true")
-	}
-
-	// If upload is false, and a custom upload_host is provided, ask them to set upload=true.
-	if c.UploadHost != defaultSGUploadHost && !c.Upload {
+	if c.Upload {
+		// Customer number is required if uploading.
+		if c.Customer == "" {
+			return errors.New("customer must be set if upload is true")
+		}
+		// Default uploading to support bucket if upload_host is not specified.
+		if c.UploadHost == "" {
+			c.UploadHost = defaultSGUploadHost
+		}
+	} else if c.UploadHost != "" {
 		return errors.New("upload must be set to true if an upload_host is specified")
 	}
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -129,6 +129,7 @@ type sgCollectOptions struct {
 }
 
 func (c *sgCollectOptions) setDefaults() {
+	// Default to Support's S3 bucket.
 	if c.UploadHost == "" {
 		c.UploadHost = defualtSGUploadHost
 	}
@@ -138,6 +139,9 @@ func (c *sgCollectOptions) setDefaults() {
 func (c *sgCollectOptions) Validate() error {
 	c.setDefaults()
 
+	// Validate given output directory exists, and is a directory.
+	// This does not check for write permission, however sgcollect_info
+	// will fail with an error giving that reason, if this is the case.
 	if c.OutputDirectory != "" {
 		if fileInfo, err := os.Stat(c.OutputDirectory); err != nil {
 			return err
@@ -146,12 +150,14 @@ func (c *sgCollectOptions) Validate() error {
 		}
 	}
 
+	// Customer number is required if uploading.
 	if c.Upload && c.Customer == "" {
 		return errors.New("customer must be set if upload is true")
 	}
 
-	if !c.Upload && c.UploadHost != "" {
-		return errors.New("upload must be set if upload_host is specified")
+	// If upload is false, and a custom upload_host is provided, ask them to set upload=true.
+	if c.UploadHost != defualtSGUploadHost && !c.Upload {
+		return errors.New("upload must be set to true if an upload_host is specified")
 	}
 
 	return nil

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -30,7 +30,7 @@ const (
 	sgStopped uint32 = iota
 	sgRunning
 
-	defualtSGUploadHost = "https://s3.amazonaws.com/cb-customers"
+	defaultSGUploadHost = "https://s3.amazonaws.com/cb-customers"
 )
 
 type sgCollect struct {
@@ -131,7 +131,7 @@ type sgCollectOptions struct {
 func (c *sgCollectOptions) setDefaults() {
 	// Default to Support's S3 bucket.
 	if c.UploadHost == "" {
-		c.UploadHost = defualtSGUploadHost
+		c.UploadHost = defaultSGUploadHost
 	}
 }
 
@@ -156,7 +156,7 @@ func (c *sgCollectOptions) Validate() error {
 	}
 
 	// If upload is false, and a custom upload_host is provided, ask them to set upload=true.
-	if c.UploadHost != defualtSGUploadHost && !c.Upload {
+	if c.UploadHost != defaultSGUploadHost && !c.Upload {
 		return errors.New("upload must be set to true if an upload_host is specified")
 	}
 


### PR DESCRIPTION
Fixes #3572 

- Fixes case where the default value of `upload_host` was being populated before running the validation enforcing `upload=true` when `upload_host` was set.