### PR TITLE
#3566 Optimise URL sanitization by copying value of URL.Query()

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"runtime"
 	"strings"
@@ -301,20 +302,22 @@ type LoggerWriter struct {
 	LogKey       LogKey        // The log key to log to, eg, KeyHTTP
 	SerialNumber uint64        // The request ID
 	Request      *http.Request // The request
+	QueryValues  url.Values    // A cached copy of the URL query values
 }
 
 // Write() method to satisfy the io.Writer interface
 func (lw *LoggerWriter) Write(p []byte) (n int, err error) {
-	Infof(lw.LogKey, " #%03d: %s %s %s", lw.SerialNumber, lw.Request.Method, SanitizeRequestURL(lw.Request), string(p))
+	Infof(lw.LogKey, " #%03d: %s %s %s", lw.SerialNumber, lw.Request.Method, SanitizeRequestURL(lw.Request, &lw.QueryValues), string(p))
 	return len(p), nil
 }
 
 // Create a new LoggerWriter
-func NewLoggerWriter(logKey LogKey, serialNumber uint64, req *http.Request) *LoggerWriter {
+func NewLoggerWriter(logKey LogKey, serialNumber uint64, req *http.Request, queryValues url.Values) *LoggerWriter {
 	return &LoggerWriter{
 		LogKey:       logKey,
 		SerialNumber: serialNumber,
 		Request:      req,
+		QueryValues:  queryValues,
 	}
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -216,6 +216,7 @@ func (h *handler) invoke(method handlerMethod) error {
 			base.KeyHTTP,
 			h.serialNumber,
 			h.rq,
+			h.getQueryValues(),
 		)
 	}
 
@@ -233,7 +234,8 @@ func (h *handler) logRequestLine() {
 		proto = " HTTP/2"
 	}
 
-	base.Infof(base.KeyHTTP, " #%03d: %s %s%s%s", h.serialNumber, h.rq.Method, base.SanitizeRequestURL(h.rq), proto, h.currentEffectiveUserNameAsUser())
+	queryValues := h.getQueryValues()
+	base.Infof(base.KeyHTTP, " #%03d: %s %s%s%s", h.serialNumber, h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, h.currentEffectiveUserNameAsUser())
 }
 
 func (h *handler) logRequestBody() {
@@ -250,6 +252,7 @@ func (h *handler) logRequestBody() {
 			base.KeyHTTP,
 			h.serialNumber,
 			h.rq,
+			h.getQueryValues(),
 		),
 	)
 


### PR DESCRIPTION
Fixes #3566 

- Optimize URL sanitization by copying the value of URL.Query() to avoid re-parsing the URL on each use.
- Improved tests and coverage for URL sanitization functions.