### PR TITLE
Include auth when building bucket spec from BucketConfig

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -107,7 +107,7 @@ type BucketConfig struct {
 	KvTLSPort  int     `json:"kv_tls_port,omitempty"` // Memcached TLS port, if not default (11207)
 }
 
-func (bc BucketConfig) MakeBucketSpec() base.BucketSpec {
+func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 
 	server := "http://localhost:8091"
 	pool := "default"
@@ -136,7 +136,13 @@ func (bc BucketConfig) MakeBucketSpec() base.BucketSpec {
 		Certpath:   bc.CertPath,
 		CACertPath: bc.CACertPath,
 		KvTLSPort:  tlsPort,
+		Auth:       bc,
 	}
+}
+
+// Implementation of AuthHandler interface for BucketConfig
+func (bucketConfig *BucketConfig) GetCredentials() (username string, password string, bucketname string) {
+	return base.TransformBucketCredentials(bucketConfig.Username, bucketConfig.Password, *bucketConfig.Bucket)
 }
 
 type ClusterConfig struct {
@@ -464,16 +470,6 @@ func (dbConfig *DbConfig) UseXattrs() bool {
 		return *dbConfig.EnableXattrs
 	}
 	return base.DefaultUseXattrs
-}
-
-// Implementation of AuthHandler interface for ShadowConfig
-func (shadowConfig *ShadowConfig) GetCredentials() (string, string, string) {
-	return base.TransformBucketCredentials(shadowConfig.Username, shadowConfig.Password, *shadowConfig.Bucket)
-}
-
-// Implementation of AuthHandler interface for ChannelIndexConfig
-func (channelIndexConfig *ChannelIndexConfig) GetCredentials() (string, string, string) {
-	return base.TransformBucketCredentials(channelIndexConfig.Username, channelIndexConfig.Password, *channelIndexConfig.Bucket)
 }
 
 // Implementation of AuthHandler interface for ClusterConfig

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -309,7 +309,6 @@ func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 		spec.BucketName = config.Name
 	}
 
-	spec.Auth = config
 	spec.FeedType = strings.ToLower(config.FeedType)
 
 	spec.CouchbaseDriver = base.ChooseCouchbaseDriver(base.DataBucket)


### PR DESCRIPTION
Previously auth was being assigned post-creation (which led to it being missed for channel index bucket).  Initialize in BucketSpec based on BucketConfig, and base GetCredentials on BucketConfig.

Fixes https://github.com/couchbaselabs/sync-gateway-accel/issues/206