### PR TITLE
#3510 Defer logging-related warnings until after the startup indicator

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -146,7 +146,8 @@ func (keyMask *LogKey) EnabledLogKeys() []string {
 func ToLogKey(keysStr []string) (logKeys LogKey, warnings []DeferredLogFn) {
 
 	for _, key := range keysStr {
-		// Copy the original key, so we can still refer to it after modification.
+		// Take a copy of key, so we can use it in a closure outside the scope
+		// of this loop (the warnings returned are logged asyncronously)
 		originalKey := key
 
 		// Some old log keys (like HTTP+), we want to handle slightly (map to a different key)

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -141,44 +141,41 @@ func (keyMask *LogKey) EnabledLogKeys() []string {
 	return logKeys
 }
 
-// ToLogKey takes a slice of case-sensitive log key names and will return a LogKey bitfield.
-func ToLogKey(keysStr []string) (LogKey, []DeferredLog) {
-	var logKeys LogKey
-	var deferredLogs []DeferredLog
+// ToLogKey takes a slice of case-sensitive log key names and will return a LogKey bitfield
+// and a slice of deferred log functions for any warnings that may occurr.
+func ToLogKey(keysStr []string) (logKeys LogKey, warnings []DeferredLogFn) {
 
-	for _, name := range keysStr {
+	for _, key := range keysStr {
+		// Copy the original key, so we can still refer to it after modification.
+		originalKey := key
 
 		// Some old log keys (like HTTP+), we want to handle slightly (map to a different key)
-		if newLogKey, ok := convertSpecialLogKey(name); ok {
+		if newLogKey, ok := convertSpecialLogKey(key); ok {
 			logKeys.Enable(*newLogKey)
 			continue
 		}
 
 		// Strip a single "+" suffix in log keys and warn (for backwards compatibility)
-		if strings.HasSuffix(name, "+") {
-			newName := strings.TrimSuffix(name, "+")
+		if strings.HasSuffix(key, "+") {
+			newLogKey := strings.TrimSuffix(key, "+")
 
-			// Need to take a copy of name, as the loop will mutate the value
-			nameCpy := name
-			deferredLogs = append(deferredLogs, func() {
-				Warnf(KeyAll, "Deprecated log key: %q found. Changing to: %q.", nameCpy, newName)
+			warnings = append(warnings, func() {
+				Warnf(KeyAll, "Deprecated log key: %q found. Changing to: %q.", originalKey, newLogKey)
 			})
 
-			name = newName
+			key = newLogKey
 		}
 
-		if logKey, ok := logKeyNamesInverse[name]; ok {
+		if logKey, ok := logKeyNamesInverse[key]; ok {
 			logKeys.Enable(logKey)
 		} else {
-			// Need to take a copy of name, as the loop will mutate the value
-			nameCpy := name
-			deferredLogs = append(deferredLogs, func() {
-				Warnf(KeyAll, "Invalid log key: %v", nameCpy)
+			warnings = append(warnings, func() {
+				Warnf(KeyAll, "Invalid log key: %v", originalKey)
 			})
 		}
 	}
 
-	return logKeys, deferredLogs
+	return logKeys, warnings
 }
 
 func inverselogKeyNames(in map[LogKey]string) map[string]LogKey {

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -157,17 +157,23 @@ func ToLogKey(keysStr []string) (LogKey, []DeferredLog) {
 		// Strip a single "+" suffix in log keys and warn (for backwards compatibility)
 		if strings.HasSuffix(name, "+") {
 			newName := strings.TrimSuffix(name, "+")
+
+			// Need to take a copy of name, as the loop will mutate the value
+			nameCpy := name
 			deferredLogs = append(deferredLogs, func() {
-				Warnf(KeyAll, "Deprecated log key: %q found. Changing to: %q.", name, newName)
+				Warnf(KeyAll, "Deprecated log key: %q found. Changing to: %q.", nameCpy, newName)
 			})
+
 			name = newName
 		}
 
 		if logKey, ok := logKeyNamesInverse[name]; ok {
 			logKeys.Enable(logKey)
 		} else {
+			// Need to take a copy of name, as the loop will mutate the value
+			nameCpy := name
 			deferredLogs = append(deferredLogs, func() {
-				Warnf(KeyAll, "Invalid log key: %v", name)
+				Warnf(KeyAll, "Invalid log key: %v", nameCpy)
 			})
 		}
 	}

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -48,34 +48,40 @@ func TestLogKeyNames(t *testing.T) {
 	assert.Equals(t, name, fmt.Sprintf("LogKey(%b)", KeyDCP|KeyReplicate))
 
 	keys := []string{}
-	logKeys, _ := ToLogKey(keys)
+	logKeys, warnings := ToLogKey(keys)
+	assert.Equals(t, len(warnings), 0)
 	assert.Equals(t, logKeys, LogKey(0))
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
 
 	keys = append(keys, "DCP")
-	logKeys, _ = ToLogKey(keys)
+	logKeys, warnings = ToLogKey(keys)
+	assert.Equals(t, len(warnings), 0)
 	assert.Equals(t, logKeys, KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String()})
 
 	keys = append(keys, "Access")
-	logKeys, _ = ToLogKey(keys)
+	logKeys, warnings = ToLogKey(keys)
+	assert.Equals(t, len(warnings), 0)
 	assert.Equals(t, logKeys, KeyAccess|KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAccess.String(), KeyDCP.String()})
 
 	keys = []string{"*", "DCP"}
-	logKeys, _ = ToLogKey(keys)
+	logKeys, warnings = ToLogKey(keys)
+	assert.Equals(t, len(warnings), 0)
 	assert.Equals(t, logKeys, KeyAll|KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
 	// Special handling of log keys
 	keys = []string{"HTTP+"}
-	logKeys, _ = ToLogKey(keys)
+	logKeys, warnings = ToLogKey(keys)
+	assert.Equals(t, len(warnings), 0)
 	assert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String()})
 
 	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
 	keys = []string{"DCP", "WS+", "InvalidLogKey"}
-	logKeys, _ = ToLogKey(keys)
+	logKeys, warnings = ToLogKey(keys)
+	assert.Equals(t, len(warnings), 2)
 	assert.Equals(t, logKeys, KeyDCP|KeyWebSocket)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyWebSocket.String()})
 }

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -48,34 +48,34 @@ func TestLogKeyNames(t *testing.T) {
 	assert.Equals(t, name, fmt.Sprintf("LogKey(%b)", KeyDCP|KeyReplicate))
 
 	keys := []string{}
-	logKeys := ToLogKey(keys)
+	logKeys, _ := ToLogKey(keys)
 	assert.Equals(t, logKeys, LogKey(0))
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
 
 	keys = append(keys, "DCP")
-	logKeys = ToLogKey(keys)
+	logKeys, _ = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String()})
 
 	keys = append(keys, "Access")
-	logKeys = ToLogKey(keys)
+	logKeys, _ = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyAccess|KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAccess.String(), KeyDCP.String()})
 
 	keys = []string{"*", "DCP"}
-	logKeys = ToLogKey(keys)
+	logKeys, _ = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyAll|KeyDCP)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
 	// Special handling of log keys
 	keys = []string{"HTTP+"}
-	logKeys = ToLogKey(keys)
+	logKeys, _ = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String()})
 
 	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
 	keys = []string{"DCP", "WS+", "InvalidLogKey"}
-	logKeys = ToLogKey(keys)
+	logKeys, _ = ToLogKey(keys)
 	assert.Equals(t, logKeys, KeyDCP|KeyWebSocket)
 	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyWebSocket.String()})
 }
@@ -181,7 +181,7 @@ func BenchmarkLogKeyName(b *testing.B) {
 
 func BenchmarkToLogKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = ToLogKey([]string{"CRUD", "DCP", "Replicate"})
+		_, _ = ToLogKey([]string{"CRUD", "DCP", "Replicate"})
 	}
 }
 

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -26,20 +26,20 @@ type ConsoleLoggerConfig struct {
 }
 
 // NewConsoleLogger returns a new ConsoleLogger from a config.
-func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
+func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLog, error) {
 	// validate and set defaults
 	if err := config.init(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	logKey := ToLogKey(config.LogKeys)
+	logKey, deferredLogs := ToLogKey(config.LogKeys)
 
 	return &ConsoleLogger{
 		LogLevel:     config.LogLevel,
 		LogKey:       &logKey,
 		ColorEnabled: *config.ColorEnabled,
 		logger:       log.New(config.Output, "", 0),
-	}, nil
+	}, deferredLogs, nil
 }
 
 // shouldLog returns true if the given logLevel and logKey should get logged.
@@ -86,7 +86,7 @@ func (lcc *ConsoleLoggerConfig) init() error {
 }
 
 func newConsoleLoggerOrPanic(config *ConsoleLoggerConfig) *ConsoleLogger {
-	logger, err := NewConsoleLogger(config)
+	logger, _, err := NewConsoleLogger(config)
 	if err != nil {
 		panic(err)
 	}

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -32,14 +32,14 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		return nil, nil, err
 	}
 
-	logKey, deferredLogs := ToLogKey(config.LogKeys)
+	logKey, warnings := ToLogKey(config.LogKeys)
 
 	return &ConsoleLogger{
 		LogLevel:     config.LogLevel,
 		LogKey:       &logKey,
 		ColorEnabled: *config.ColorEnabled,
 		logger:       log.New(config.Output, "", 0),
-	}, deferredLogs, nil
+	}, warnings, nil
 }
 
 // shouldLog returns true if the given logLevel and logKey should get logged.

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -26,7 +26,7 @@ type ConsoleLoggerConfig struct {
 }
 
 // NewConsoleLogger returns a new ConsoleLogger from a config.
-func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLog, error) {
+func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLogFn, error) {
 	// validate and set defaults
 	if err := config.init(); err != nil {
 		return nil, nil, err

--- a/base/logging.go
+++ b/base/logging.go
@@ -34,8 +34,8 @@ const (
 
 type Level int32
 
-// DeferredLog is a log function that can be logged at a later date.
-type DeferredLog func()
+// DeferredLogFn is an anonymous function that can be executed at a later date to log something.
+type DeferredLogFn func()
 
 //By setting DebugLevel to -1, if LogLevel is not set in the logging config it
 //will default to the zero value for int32 (0) which will disable debug
@@ -462,24 +462,25 @@ func logTo(logLevel LogLevel, logKey LogKey, format string, args ...interface{})
 	}
 }
 
-// Broadcastf will print the same log to ALL outputs, ignoring logLevel and logKey settings.
-// This can be useful for printing an indicator of app restarts, version numbers, etc. but MUST be used sparingly.
-func Broadcastf(format string, args ...interface{}) {
-	format = addPrefixes(format, LevelNone, KeyNone)
+// LogSyncGatewayVersion will print the startup indicator and version number to all log outputs.
+func LogSyncGatewayVersion() {
+	format := addPrefixes("==== %s ====", LevelNone, KeyNone)
+	msg := fmt.Sprintf(format, LongVersionString)
+
 	if consoleLogger.logger != nil {
-		consoleLogger.logger.Printf(color(format, LevelNone), args...)
+		consoleLogger.logger.Print(color(msg, LevelNone))
 	}
 	if errorLogger.shouldLog() {
-		errorLogger.logger.Printf(format, args...)
+		errorLogger.logger.Print(msg)
 	}
 	if warnLogger.shouldLog() {
-		warnLogger.logger.Printf(format, args...)
+		warnLogger.logger.Print(msg)
 	}
 	if infoLogger.shouldLog() {
-		infoLogger.logger.Printf(format, args...)
+		infoLogger.logger.Print(msg)
 	}
 	if debugLogger.shouldLog() {
-		debugLogger.logger.Printf(format, args...)
+		debugLogger.logger.Print(msg)
 	}
 }
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -34,6 +34,9 @@ const (
 
 type Level int32
 
+// DeferredLog is a log function that can be logged at a later date.
+type DeferredLog func()
+
 //By setting DebugLevel to -1, if LogLevel is not set in the logging config it
 //will default to the zero value for int32 (0) which will disable debug
 //logging, InfoLevel logging will be the default output.

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -13,6 +13,9 @@ const (
 	debugMinAge = 1
 )
 
+// ErrUnsetLogFilePath is returned when no logFilePath, or --defaultLogFilePath fallback can be used.
+var ErrUnsetLogFilePath = errors.New("No logFilePath configured, and --defaultLogFilePath flag is not set. Log files required for product support are not being generated.")
+
 type LoggingConfig struct {
 	LogFilePath    string              `json:"log_file_path,omitempty"`   // Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.
 	RedactionLevel RedactionLevel      `json:"redaction_level,omitempty"` // Redaction level to apply to log output.
@@ -25,48 +28,47 @@ type LoggingConfig struct {
 	DeprecatedDefaultLog *LogAppenderConfig `json:"default,omitempty"` // Deprecated "default" logging option.
 }
 
-func (c *LoggingConfig) Init(defaultLogFilePath string) (err error) {
+func (c *LoggingConfig) Init(defaultLogFilePath string) (deferredLogs []DeferredLog, err error) {
 	if c == nil {
-		return errors.New("nil LoggingConfig")
+		return deferredLogs, errors.New("nil LoggingConfig")
 	}
 
-	consoleLogger, err = NewConsoleLogger(&c.Console)
+	consoleLogger, deferredLogs, err = NewConsoleLogger(&c.Console)
 	if err != nil {
-		return err
+		return
 	}
 
 	// If there's nowhere to specified put log files, we'll log an error, but we'll continue anyway.
 	if !hasLogFilePath(&c.LogFilePath, defaultLogFilePath) {
-		Errorf(KeyAll, "No logFilePath configured, and --defaultLogFilePath flag is not set. Log files required for product support are not being generated.")
-		return nil
+		return deferredLogs, ErrUnsetLogFilePath
 	}
 
 	err = validateLogFilePath(&c.LogFilePath, defaultLogFilePath)
 	if err != nil {
-		return err
+		return
 	}
 
 	errorLogger, err = NewFileLogger(c.Error, LevelError, c.LogFilePath, errorMinAge)
 	if err != nil {
-		return err
+		return
 	}
 
 	warnLogger, err = NewFileLogger(c.Warn, LevelWarn, c.LogFilePath, warnMinAge)
 	if err != nil {
-		return err
+		return
 	}
 
 	infoLogger, err = NewFileLogger(c.Info, LevelInfo, c.LogFilePath, infoMinAge)
 	if err != nil {
-		return err
+		return
 	}
 
 	debugLogger, err = NewFileLogger(c.Debug, LevelDebug, c.LogFilePath, debugMinAge)
 	if err != nil {
-		return err
+		return
 	}
 
-	return nil
+	return deferredLogs, nil
 }
 
 // validateLogFilePath ensures the given path is created and is a directory.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -544,7 +544,7 @@ func EnableTestLogKey(logKey string) {
 	if strings.HasSuffix(logKey, "+") {
 		ConsoleLogLevel().Set(LevelDebug)
 	}
-	newLogKey := ToLogKey([]string{logKey})
+	newLogKey, _ := ToLogKey([]string{logKey})
 	ConsoleLogKey().Enable(newLogKey)
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -34,7 +34,7 @@ var DefaultAdminInterface = "127.0.0.1:4985" // Only accessible on localhost!
 var DefaultServer = "walrus:"
 var DefaultPool = "default"
 
-// defaultLogFilePath is populated by
+// The value of defaultLogFilePath is populated by --defaultLogFilePath in ParseCommandLine()
 var defaultLogFilePath string
 
 var config *ServerConfig


### PR DESCRIPTION
Fixes #3510 

- Defers logging-related warnings/errors until after the startup indicator has been logged
- Removed `Broadcastf` and replaced with `LogSyncGatewayVersion`
- Re-add `--verbose` flag check to enable `HTTP+` log key

## Before/After
![screen shot 2018-05-16 at 15 53 47](https://user-images.githubusercontent.com/1525809/40124862-5d4819e6-5921-11e8-9edd-7a2c4c4aa4dc.png)

