### PR TITLE
#3514 Add test for setting log key and log level via _logging endpoint

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -427,7 +427,7 @@ function(doc, oldDoc) {
 	wg.Wait()
 }
 
-func TestLogging(t *testing.T) {
+func TestLoggingKeys(t *testing.T) {
 	var rt RestTester
 	defer rt.Close()
 
@@ -535,6 +535,27 @@ func TestLoggingLevels(t *testing.T) {
 
 	// Trying to set log level via the body will not work (the endpoint expects a log key map)
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"logLevel": "debug"}`), http.StatusBadRequest)
+}
+
+func TestLoggingCombined(t *testing.T) {
+	var rt RestTester
+	defer rt.Close()
+
+	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
+	rt.SendAdminRequest("PUT", "/_logging?logLevel=info", `{}`)
+
+	// Log keys should be blank
+	response := rt.SendAdminRequest("GET", "/_logging", "")
+	var logKeys map[string]bool
+	json.Unmarshal(response.Body.Bytes(), &logKeys)
+	assert.DeepEquals(t, logKeys, map[string]bool{})
+
+	// Set log keys and log level in a single request
+	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=trace", `{"Changes":true, "Cache":true, "HTTP":true}`), http.StatusOK)
+
+	response = rt.SendAdminRequest("GET", "/_logging", "")
+	json.Unmarshal(response.Body.Bytes(), &logKeys)
+	assert.DeepEquals(t, logKeys, map[string]bool{"Changes": true, "Cache": true, "HTTP": true})
 }
 
 // Test user delete while that user has an active changes feed (see issue 809)


### PR DESCRIPTION
Fixes #3514 

- Add test for setting log keys and log level simultaneously via the `_logging` endpoint