### PR TITLE
Add retry loop to sporadically failing TestChannelView()

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1414,10 +1414,17 @@ func TestRecentSequenceHistory(t *testing.T) {
 
 }
 
-func TestChannelView(t *testing.T) {
+
+func ChannelViewTestRetry(t *testing.T) error {
+
+	base.EnableTestLogKey("*")
+
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
+
+	// Must be _after_ test bucket is setup, due to SG #3579
+	base.ConsoleLogLevel().Set(base.LevelDebug)
 
 	// Create doc
 	log.Printf("Create doc 1...")
@@ -1444,9 +1451,36 @@ func TestChannelView(t *testing.T) {
 	for i, entry := range entries {
 		log.Printf("View Query returned entry (%d): %v", i, entry)
 	}
-	assert.Equals(t, len(entries), 1)
+
+	// Known to fail sporadically -- return an error in order to trigger a retry
+	if len(entries) != 1 {
+		return fmt.Errorf("Expected 1 entry, got: %d", len(entries))
+	}
+
+	return nil
 
 }
+
+func TestChannelView(t *testing.T) {
+
+	num_retries := 5
+	var err error
+
+	for i := 0; i < num_retries; i++ {
+		if err = ChannelViewTestRetry(t); err == nil {
+			// No errors, we're done
+			return
+		}
+
+		log.Printf("TestChannelView got error: %v.  Will retry attempt (%d/%d)", err, i+1, num_retries)
+		time.Sleep(time.Second * 5)
+
+	}
+
+	t.Errorf("TestChannelView (known to sporadically fail) failed after %d retries.  Considering this a real failure.  Last failure error: %v", num_retries, err)
+
+}
+
 
 //////// XATTR specific tests.  These tests current require setting DefaultUseXattrs=true, and must be run against a Couchbase bucket
 


### PR DESCRIPTION
This is an incremental improvement of #3570 which addresses the sporadic failures described in https://github.com/couchbase/sync_gateway/issues/3539#issuecomment-388113268 by doing a retry loop.

With this fix, I can no longer reproduce the test failure with the steps described in https://github.com/couchbase/sync_gateway/issues/3539#issuecomment-388113268

Also, if it passes the first time, it should have no extra hit in terms of test time.

(Related note: using `SG_TEST_DROP_INDEXES` also solves the problem, but doing that across the entire suite causes it to run much more slowly)