### PR TITLE
#3587 #3597 fix default windows output_dir, make validation rules stricter, improve logging

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -434,10 +433,9 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", err)
 	}
 
-	zipPath := filepath.Join(params.OutputDirectory, sgcollectFilename())
-	args := params.Args()
+	zipFilename := sgcollectFilename()
 
-	if err := sgcollectInstance.Start(zipPath, args...); err != nil {
+	if err := sgcollectInstance.Start(zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -22,6 +23,8 @@ var (
 	ErrSGCollectInfoAlreadyRunning = errors.New("already running")
 	// ErrSGCollectInfoNotRunning is returned if sgcollect_info is not running.
 	ErrSGCollectInfoNotRunning = errors.New("not running")
+
+	validateTicketPattern = regexp.MustCompile(`\d{1,7}`)
 
 	sgcollectInstance = sgCollect{status: base.Uint32Ptr(sgStopped)}
 )
@@ -179,6 +182,12 @@ func (c *sgCollectOptions) Validate() error {
 	if c.OutputDirectory != "" {
 		if err := validateOutputDirectory(c.OutputDirectory); err != nil {
 			return err
+		}
+	}
+
+	if c.Ticket != "" {
+		if !validateTicketPattern.MatchString(c.Ticket) {
+			return errors.New("ticket number must be 1 to 7 digits")
 		}
 	}
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -143,6 +143,8 @@ func (c *sgCollectOptions) Validate() error {
 			return err
 		} else if !fileInfo.IsDir() {
 			return errors.New("not a directory")
+		} else if writable := fileInfo.Mode().Perm()&100100100 != 0; !writable {
+			return errors.New("directory not writable")
 		}
 	}
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -155,8 +155,18 @@ func (c *sgCollectOptions) Validate() error {
 		if c.UploadHost == "" {
 			c.UploadHost = defaultSGUploadHost
 		}
-	} else if c.UploadHost != "" {
-		return errors.New("upload must be set to true if an upload_host is specified")
+	} else {
+		// These fields suggest the user actually wanted to upload,
+		// so we'll enforce "upload: true" if any of these are set.
+		if c.UploadHost != "" {
+			return errors.New("upload must be set to true if upload_host is specified")
+		}
+		if c.Customer != "" {
+			return errors.New("upload must be set to true if customer is specified")
+		}
+		if c.Ticket != "" {
+			return errors.New("upload must be set to true if ticket is specified")
+		}
 	}
 
 	return nil

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -143,7 +143,7 @@ func (c *sgCollectOptions) Validate() error {
 			return err
 		} else if !fileInfo.IsDir() {
 			return errors.New("not a directory")
-		} else if writable := fileInfo.Mode().Perm()&100100100 != 0; !writable {
+		} else if writable := fileInfo.Mode().Perm()&100100100 != 0; writable {
 			return errors.New("directory not writable")
 		}
 	}

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -30,8 +30,7 @@ const (
 	sgStopped uint32 = iota
 	sgRunning
 
-	defaultSGUploadHost    = "https://s3.amazonaws.com/cb-customers"
-	defaultOutputDirectory = "" // TODO
+	defaultSGUploadHost = "https://s3.amazonaws.com/cb-customers"
 )
 
 type sgCollect struct {

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -40,6 +40,10 @@ func TestSgcollectOptionsValidate(t *testing.T) {
 			errContains: "",
 		},
 		{
+			options:     &sgCollectOptions{Upload: true, Customer: "alice", Ticket: "abc"},
+			errContains: "ticket number must be",
+		},
+		{
 			options:     &sgCollectOptions{Upload: true, Customer: "alice", UploadHost: "example.org/custom-s3-bucket-url"},
 			errContains: "",
 		},

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -29,50 +29,53 @@ func TestSgcollectOptionsValidate(t *testing.T) {
 
 	tests := []struct {
 		options     *sgCollectOptions
-		hasError    bool
 		errContains string
 	}{
 		{
 			options:     &sgCollectOptions{},
-			hasError:    false,
 			errContains: "",
 		},
 		{
-			options:     &sgCollectOptions{Upload: true},
-			hasError:    true,
-			errContains: "customer must be set",
-		},
-		{
 			options:     &sgCollectOptions{Upload: true, Customer: "alice"},
-			hasError:    false,
 			errContains: "",
 		},
 		{
 			options:     &sgCollectOptions{Upload: true, Customer: "alice", UploadHost: "example.org/custom-s3-bucket-url"},
-			hasError:    false,
 			errContains: "",
 		},
 		{
+			options:     &sgCollectOptions{Upload: true},
+			errContains: "customer must be set",
+		},
+		{
+			options:     &sgCollectOptions{Upload: true, Ticket: "12345"},
+			errContains: "customer must be set",
+		},
+		{
+			options:     &sgCollectOptions{Upload: false, Customer: "alice"},
+			errContains: "upload must be set to true",
+		},
+		{
+			options:     &sgCollectOptions{Upload: false, Ticket: "12345"},
+			errContains: "upload must be set to true",
+		},
+		{
 			options:     &sgCollectOptions{Upload: false, Customer: "alice", UploadHost: "example.org/custom-s3-bucket-url"},
-			hasError:    true,
 			errContains: "upload must be set to true",
 		},
 		{
 			// Directory exists
 			options:     &sgCollectOptions{OutputDirectory: "."},
-			hasError:    false,
 			errContains: "",
 		},
 		{
 			// Directory doesn't exist
 			options:     &sgCollectOptions{OutputDirectory: "/path/to/output/dir"},
-			hasError:    true,
 			errContains: "no such file or directory",
 		},
 		{
 			// Path not a directory
 			options:     &sgCollectOptions{OutputDirectory: binPath},
-			hasError:    true,
 			errContains: "not a directory",
 		},
 	}
@@ -86,7 +89,7 @@ func TestSgcollectOptionsValidate(t *testing.T) {
 				errStr = err.Error()
 			}
 
-			assert.Equals(ts, err != nil, test.hasError)
+			assert.Equals(ts, err != nil, test.errContains != "")
 			assert.StringContains(ts, errStr, test.errContains)
 
 		})


### PR DESCRIPTION
- Use sgCollect's path as a fallback, to prevent logs being put in `Windows\System32` ( fixes #3597 )

- Makes validation rules around much stricter ( fixes #3587 ) 
  - enforce upload:true if any of customer,ticket or upload_host are set
  - Validates ticket number format before running sgcollect_info

- Separates stdout/stderr from sgcollect_info and logs at the appropriate level