### PR TITLE
Improve error reporting in CouchbaseBucketGoCB.Query()

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -60,7 +60,7 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params interface{}, c
 
 		// Non-retry error - return
 		if !isIndexerError(queryErr) {
-			Warnf(KeyAll, "Error when querying index using statement: [%s]", UD(bucketStatement))
+			Warnf(KeyAll, "Error when querying index using statement: [%s].  Error: %+v", UD(bucketStatement), pkgerrors.WithStack(queryErr))
 			return queryResults, queryErr
 		}
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -60,8 +60,8 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params interface{}, c
 
 		// Non-retry error - return
 		if !isIndexerError(queryErr) {
-			Warnf(KeyAll, "Error when querying index using statement: [%s].  Error: %+v", UD(bucketStatement), pkgerrors.WithStack(queryErr))
-			return queryResults, queryErr
+			Warnf(KeyAll, "Error when querying index using statement: [%s]", UD(bucketStatement))
+			return queryResults, pkgerrors.WithStack(queryErr)
 		}
 
 		// Indexer error - wait then retry

--- a/base/constants.go
+++ b/base/constants.go
@@ -82,6 +82,10 @@ const (
 	// Keep idle connections around for a maximimum of 90 seconds.  This is the same value used by the Go DefaultTransport.
 	DefaultHttpIdleConnTimeoutMilliseconds = "90000"
 
+	// Set this to true to dump stacktraces (for pkgerrors wrapped errors only) whenever an error is returned to
+	// an API client.  Currently only works with REST API calls.
+	StacktraceOnAPIErrors = false
+
 )
 
 func UnitTestUrl() string {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -335,7 +335,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 					h.writeStatus(http.StatusNoContent, "")
 				}
 			}
-			h.logDuration(true, nil)
+			h.logDuration(true)
 		}
 	})
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -335,7 +335,7 @@ func wrapRouter(sc *ServerContext, privs handlerPrivs, router *mux.Router) http.
 					h.writeStatus(http.StatusNoContent, "")
 				}
 			}
-			h.logDuration(true)
+			h.logDuration(true, nil)
 		}
 	})
 }


### PR DESCRIPTION

This is happening on a feature branch related to https://github.com/couchbase/sync_gateway/issues/3570, so I'm not sure it's a bug per se.  But I think there can be some improvement to the error reporting to make it easier to debug.

I decided to pull this change out into a separate PR to make it easier to review/discuss in isolation.

Before:

```
=== RUN   TestAllDocsChannelsAfterChannelMove
2018-05-18T11:12:39.705-07:00 [INF] Successfully opened bucket
2018-05-18 11:12:39.705419 I | Flushing bucket test_data_bucket
2018-05-18T11:12:48.354-07:00 [INF] GoCBCustomSGTranscoder Opening Couchbase database test_data_bucket on <http://couchbase-server:8091> as user "test_data_bucket"
2018-05-18T11:12:48.381-07:00 [INF] Successfully opened bucket
2018-05-18T11:12:48.409-07:00 [INF] Opening db /db as bucket "test_data_bucket", pool "default", server <http://couchbase-server:8091>
2018-05-18T11:12:48.410-07:00 [INF] GoCBCustomSGTranscoder Opening Couchbase database test_data_bucket on <http://couchbase-server:8091> as user "test_data_bucket"
2018-05-18T11:12:48.436-07:00 [INF] Successfully opened bucket
2018-05-18T11:12:48.436-07:00 [INF] Initializing indexes with numReplicas: 0...
2018-05-18T11:12:49.292-07:00 [INF] Verifying index availability for bucket test_data_bucket...
2018-05-18T11:12:49.307-07:00 [INF] Indexes ready for bucket test_data_bucket.
2018-05-18T11:12:49.308-07:00 [INF] Initializing changes cache for database db with sequence: 0
2018-05-18T11:12:49.376-07:00 [INF] Using metadata purge interval of 3.00 days for tombstone compaction.
2018-05-18T11:12:49.421-07:00 [WRN] QueryAccess called with empty username - returning empty result iterator -- db.(*DatabaseContext).QueryAccess() at query.go:252
2018-05-18T11:12:49.421-07:00 [WRN] QueryRoleAccess called with empty username -- db.(*DatabaseContext).QueryRoleAccess() at query.go:273
2018-05-18T11:12:49.433-07:00 [INF] HTTP:  #001: PUT http://localhost/db/doc1 (as GUEST)
2018-05-18T11:12:49.449-07:00 [INF] HTTP:  #002: GET http://localhost/db/_all_docs?channels=true (as ADMIN)
2018-05-18T11:12:49.462-07:00 [INFO] Using plain authentication for user <ud>test_data_bucket</ud>
2018-05-18T11:12:53.926-07:00 [WRN] Error when querying index using statement: [SELECT META(`test_data_bucket`).id as id, meta(`test_data_bucket`).xattrs._sync.rev as r, meta(`test_data_bucket`).xattrs._sync.sequence as s, meta(`test_data_bucket`).xattrs._sync.channels as c FROM `test_data_bucket` WHERE meta(`test_data_bucket`).xattrs._sync.sequence > 0 AND META(`test_data_bucket`).id NOT LIKE '\\_sync:%' AND meta(`test_data_bucket`).xattrs._sync IS NOT MISSING AND (meta(`test_data_bucket`).xattrs._sync.flags IS MISSING OR BITTEST(meta(`test_data_bucket`).xattrs._sync.flags,1) = false) ORDER BY META(`test_data_bucket`).id] -- base.(*CouchbaseBucketGoCB).Query() at bucket_n1ql.go:64
2018-05-18T11:12:53.927-07:00 [INF] HTTP: #002:     --> 500 Internal error: [5001] Panic: runtime error: index out of range  (4477.4 ms)
2018-05-18 11:12:53.927091 I | Admin response = {"rows":[
{"error":"Internal Server Error","reason":"Internal error: [5001] Panic: runtime error: index out of range"}

	api_test.go:2708
	assert.Equals(t, err, nil)

	expected: <nil>
	     got: &json.SyntaxError{msg:"unexpected end of JSON input", Offset:118}

	api_test.go:2709
	assert.Equals(t, len(allDocsResult.Rows), 1)

	expected: 1
	     got: 0
--- FAIL: TestAllDocsChannelsAfterChannelMove (14.23s)
```

Looking at this error, I don't see an easy way to figure out the cause of the `error: index out of range` error.  

After the logging change, there is a stack trace which makes it easier to trace the cause:

```
=== RUN   TestAllDocsChannelsAfterChannelMove
2018-05-18T11:14:45.341-07:00 [INF] Successfully opened bucket
2018-05-18 11:14:45.341844 I | Flushing bucket test_data_bucket
2018-05-18T11:14:52.567-07:00 [INF] GoCBCustomSGTranscoder Opening Couchbase database test_data_bucket on <http://couchbase-server:8091> as user "test_data_bucket"
2018-05-18T11:14:52.598-07:00 [INF] Successfully opened bucket
2018-05-18T11:14:52.629-07:00 [INF] Opening db /db as bucket "test_data_bucket", pool "default", server <http://couchbase-server:8091>
2018-05-18T11:14:52.629-07:00 [INF] GoCBCustomSGTranscoder Opening Couchbase database test_data_bucket on <http://couchbase-server:8091> as user "test_data_bucket"
2018-05-18T11:14:52.655-07:00 [INF] Successfully opened bucket
2018-05-18T11:14:52.655-07:00 [INF] Initializing indexes with numReplicas: 0...
2018-05-18T11:14:53.476-07:00 [INF] Verifying index availability for bucket test_data_bucket...
2018-05-18T11:14:53.487-07:00 [INF] Indexes ready for bucket test_data_bucket.
2018-05-18T11:14:53.488-07:00 [INF] Initializing changes cache for database db with sequence: 0
2018-05-18T11:14:53.540-07:00 [INF] Using metadata purge interval of 3.00 days for tombstone compaction.
2018-05-18T11:14:53.564-07:00 [WRN] QueryAccess called with empty username - returning empty result iterator -- db.(*DatabaseContext).QueryAccess() at query.go:252
2018-05-18T11:14:53.564-07:00 [WRN] QueryRoleAccess called with empty username -- db.(*DatabaseContext).QueryRoleAccess() at query.go:273
2018-05-18T11:14:53.571-07:00 [INF] HTTP:  #001: PUT http://localhost/db/doc1 (as GUEST)
2018-05-18T11:14:53.577-07:00 [INF] HTTP:  #002: GET http://localhost/db/_all_docs?channels=true (as ADMIN)
2018-05-18T11:14:53.583-07:00 [INFO] Using plain authentication for user <ud>test_data_bucket</ud>
2018-05-18T11:14:58.383-07:00 [WRN] Error when querying index using statement: [SELECT META(`test_data_bucket`).id as id, meta(`test_data_bucket`).xattrs._sync.rev as r, meta(`test_data_bucket`).xattrs._sync.sequence as s, meta(`test_data_bucket`).xattrs._sync.channels as c FROM `test_data_bucket` WHERE meta(`test_data_bucket`).xattrs._sync.sequence > 0 AND META(`test_data_bucket`).id NOT LIKE '\\_sync:%' AND meta(`test_data_bucket`).xattrs._sync IS NOT MISSING AND (meta(`test_data_bucket`).xattrs._sync.flags IS MISSING OR BITTEST(meta(`test_data_bucket`).xattrs._sync.flags,1) = false) ORDER BY META(`test_data_bucket`).id].  Error: [5001] Panic: runtime error: index out of range
github.com/couchbase/sync_gateway/base.(*CouchbaseBucketGoCB).Query
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/base/bucket_n1ql.go:63
github.com/couchbase/sync_gateway/db.(*DatabaseContext).N1QLQueryWithStats
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/db/query.go:218
github.com/couchbase/sync_gateway/db.(*DatabaseContext).QueryAllDocs
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/db/query.go:413
github.com/couchbase/sync_gateway/db.(*Database).ForEachDocID
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/db/database.go:602
github.com/couchbase/sync_gateway/rest.(*handler).handleAllDocs
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/bulk_api.go:223
github.com/couchbase/sync_gateway/rest.(*handler).invoke
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/handler.go:223
github.com/couchbase/sync_gateway/rest.makeHandler.func1
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/handler.go:97
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:1918
github.com/gorilla/mux.(*Router).ServeHTTP
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/gorilla/mux/mux.go:114
github.com/couchbase/sync_gateway/rest.wrapRouter.func1
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/routing.go:311
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:1918
github.com/couchbase/sync_gateway/rest.(*RestTester).SendAdminRequest
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:343
github.com/couchbase/sync_gateway/rest.TestAllDocsChannelsAfterChannelMove
	/Users/tleyden/Development/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/api_test.go:2703
testing.tRunner
	/usr/local/go/src/testing/testing.go:746
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2337 -- base.(*CouchbaseBucketGoCB).Query() at bucket_n1ql.go:63
2018-05-18T11:14:58.384-07:00 [INF] HTTP: #002:     --> 500 Internal error: [5001] Panic: runtime error: index out of range  (4807.0 ms)
2018-05-18 11:14:58.384265 I | Admin response = {"rows":[
{"error":"Internal Server Error","reason":"Internal error: [5001] Panic: runtime error: index out of range"}

	api_test.go:2708
	assert.Equals(t, err, nil)

	expected: <nil>
	     got: &json.SyntaxError{msg:"unexpected end of JSON input", Offset:118}

	api_test.go:2709
	assert.Equals(t, len(allDocsResult.Rows), 1)

	expected: 1
	     got: 0
--- FAIL: TestAllDocsChannelsAfterChannelMove (13.05s)
```

From the stacktrace, it's now immediately apparent that the `index out of range` error happened during the call to:

```
	response = rt.SendAdminRequest("GET", "/db/_all_docs?channels=true", "")

```

whereas in the first case, it would take some additional reasoning to do that, and in the general case there might be room for ambiguity.  

Also, I think `isIndexerError()` might be better renamed as `isRecoverableIndexerError()` or `isTemporaryIndexerError()`, since it's trying to distinguish between retryable / permanent errors.  Should I add that to this PR?
