### PR TITLE
Feature/issue 3595 random temp errors

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -271,12 +271,14 @@ func (f *FailureInjection) ServiceUnavailable() bool {
 		return false
 	}
 
+	// Multiply the input probability (eg, 0.49) * 100 to get a number between 0 and 100
 	probability503ServiceUnavailable := *f.Probability503ServiceUnavailable
-
 	probability503ServiceUnavailable *= 100
 
+	// Generate a random number between 0 and 100
 	randNumber := rand.Intn(100)
 
+	// If the randomly generated number is LTE the setting, return true to cause a failure
 	return float32(randNumber) <= probability503ServiceUnavailable
 
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -97,9 +97,12 @@ func makeHandler(server *ServerContext, privs handlerPrivs, method handlerMethod
 		runOffline := false
 		h := newHandler(server, privs, r, rq, runOffline)
 
-		if server.config.Unsupported != nil && server.config.Unsupported.FailureInjection.ServiceUnavailable() {
-			h.writeStatus(http.StatusServiceUnavailable, "ServiceUnavailable (Artificially injected error)")
-			return
+		// Possibly inject artificial failures
+		if privs == regularPrivs {
+			if server.config.Unsupported != nil && server.config.Unsupported.FailureInjection.ServiceUnavailable() {
+				h.writeStatus(http.StatusServiceUnavailable, "ServiceUnavailable (Artificially injected error)")
+				return
+			}
 		}
 
 		err := h.invoke(method)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -92,8 +92,16 @@ type handlerMethod func(*handler) error
 // Creates an http.Handler that will run a handler with the given method
 func makeHandler(server *ServerContext, privs handlerPrivs, method handlerMethod) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
+
+
 		runOffline := false
 		h := newHandler(server, privs, r, rq, runOffline)
+
+		if server.config.Unsupported != nil && server.config.Unsupported.FailureInjection.ServiceUnavailable() {
+			h.writeStatus(http.StatusServiceUnavailable, "ServiceUnavailable (Artificially injected error)")
+			return
+		}
+
 		err := h.invoke(method)
 		h.writeError(err)
 		h.logDuration(true)


### PR DESCRIPTION
Fixes #3595 by adding an unsupported config to inject artificial failures.

I've only made the change for the REST API, since BLIP is a bit trickier -- in the blip handler there is no easy way I can see to get to the Server Config.  
