### PR TITLE
Move RedactBasicAuthURL into base so it can be used by SG Accel

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -43,6 +43,14 @@ const (
 	kMaxDeltaTtlDuration = 60 * 60 * 24 * 30 * time.Second
 )
 
+// basicAuthURLRegexp is used to match the HTTP basic auth component of a URL
+var basicAuthURLRegexp = regexp.MustCompilePOSIX(`:\/\/[^:/]+:[^@/]+@`)
+
+// RedactBasicAuthURL returns the given string, with a redacted HTTP basic auth component.
+func RedactBasicAuthURL(url string) string {
+	return basicAuthURLRegexp.ReplaceAllLiteralString(url, "://****:****@")
+}
+
 func GenerateRandomSecret() string {
 	randomBytes := make([]byte, 20)
 	n, err := io.ReadFull(rand.Reader, randomBytes)

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -493,3 +493,43 @@ func TestReplaceAll(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactBasicAuthURL(t *testing.T) {
+	tests := []struct {
+		input,
+		expected string
+	}{
+		{
+			input:    "http://hostname",
+			expected: "http://hostname",
+		},
+		{
+			input:    "http://username:password@hostname",
+			expected: "http://****:****@hostname",
+		},
+		{
+			input:    "https://username:password@example.org:8123",
+			expected: "https://****:****@example.org:8123",
+		},
+		{
+			input:    "https://username:password@example.org/path",
+			expected: "https://****:****@example.org/path",
+		},
+		{
+			input:    "https://username:password@example.org:8123/path?key=val&email=me@example.org",
+			expected: "https://****:****@example.org:8123/path?key=val&email=me@example.org",
+		},
+		{
+			input:    "https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar",
+			expected: "https://****:****@example.com:8888/bar",
+		},
+		{
+			input:    "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
+			expected: "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equals(t, RedactBasicAuthURL(test.input), test.expected)
+	}
+}

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -33,9 +32,6 @@ type Webhook struct {
 
 // default HTTP post timeout
 const kDefaultWebhookTimeout = 60
-
-// used to match the HTTP basic auth component of a URL
-var kBasicAuthUrlRegexp = regexp.MustCompilePOSIX(`:\/\/[^:/]+:[^@/]+@`)
 
 // Creates a new webhook handler based on the url and filter function.
 func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, error) {
@@ -148,5 +144,5 @@ func (wh *Webhook) String() string {
 
 func (wh *Webhook) SanitizedUrl() string {
 	// Basic auth credentials may have been included in the URL, in which case obscure them
-	return kBasicAuthUrlRegexp.ReplaceAllLiteralString(wh.url, "://****:****@")
+	return base.RedactBasicAuthURL(wh.url)
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="6c7d8ea54e5aa60a859341dc63ae63d477751acc"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b9e59151693215e85b8fd41339d7e152e55f4dd3"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>


### PR DESCRIPTION
For https://github.com/couchbaselabs/sync-gateway-accel/issues/207

## TODO
- [x] Update manifest for https://github.com/couchbaselabs/sync-gateway-accel/pull/209