### PR TITLE
Benchmark log rotation

### DIFF
--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/couchbaselabs/go.assert"
@@ -123,8 +125,11 @@ func BenchmarkLogRotation(b *testing.B) {
 	}
 
 	for _, test := range tests {
-		b.Run(fmt.Sprintf("rotate:%t-compress:%t-Bytes:%v", test.rotate, test.compress, test.numBytes), func(bm *testing.B) {
-			logger := lumberjack.Logger{Compress: test.compress}
+		b.Run(fmt.Sprintf("rotate:%t-compress:%t-bytes:%v", test.rotate, test.compress, test.numBytes), func(bm *testing.B) {
+			logPath := filepath.Join(os.TempDir(), "benchmark-logrotate")
+			logger := lumberjack.Logger{Filename: filepath.Join(logPath, "output.log"), Compress: test.compress}
+			defer logger.Close()
+			defer os.RemoveAll(logPath)
 
 			data := make([]byte, test.numBytes)
 			_, err := rand.Read(data)

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -11,10 +11,13 @@ package base
 
 import (
 	"bytes"
+	"fmt"
 	"log"
+	"math/rand"
 	"testing"
 
 	"github.com/couchbaselabs/go.assert"
+	"github.com/natefinch/lumberjack"
 )
 
 // asserts that the logs produced by function f contain string s.
@@ -98,4 +101,45 @@ func TestPrependContextID(t *testing.T) {
 	}
 
 	log.Printf("testInputsOutputs: %+v", testInputsOutputs)
+}
+
+// Benchmark the time it takes to write x bytes of data to a logger, and optionally rotate and compress it.
+func BenchmarkLogRotation(b *testing.B) {
+
+	tests := []struct {
+		rotate   bool
+		compress bool
+		numBytes int
+	}{
+		{rotate: false, compress: false, numBytes: 0},
+		{rotate: false, compress: false, numBytes: 1024 * 1000},   // 1MB
+		{rotate: false, compress: false, numBytes: 1024 * 100000}, // 100MB
+		{rotate: true, compress: false, numBytes: 0},
+		{rotate: true, compress: false, numBytes: 1024 * 1000},   // 1MB
+		{rotate: true, compress: false, numBytes: 1024 * 100000}, // 100MB
+		{rotate: true, compress: true, numBytes: 0},
+		{rotate: true, compress: true, numBytes: 1024 * 1000},   // 1MB
+		{rotate: true, compress: true, numBytes: 1024 * 100000}, // 100MB
+	}
+
+	for _, test := range tests {
+		b.Run(fmt.Sprintf("rotate:%t-compress:%t-Bytes:%v", test.rotate, test.compress, test.numBytes), func(bm *testing.B) {
+			logger := lumberjack.Logger{Compress: test.compress}
+
+			data := make([]byte, test.numBytes)
+			_, err := rand.Read(data)
+			if err != nil {
+				bm.Error(err)
+			}
+
+			bm.ResetTimer()
+			for i := 0; i < bm.N; i++ {
+				_, _ = logger.Write(data)
+				if test.rotate {
+					_ = logger.Rotate()
+				}
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Fixes #3485

- Add benchmark for writing x bytes to logger, and then optionally rotating with or without compression.

### Output
```
15:29 $ go test -run='xxx' -bench='BenchmarkLogRotation' ./base
goos: darwin
goarch: amd64
pkg: github.com/couchbase/sync_gateway/base
BenchmarkLogRotation/rotate:false-compress:false-bytes:0-8         	 1000000	      1589 ns/op
BenchmarkLogRotation/rotate:false-compress:false-bytes:1024000-8   	    1000	   1541823 ns/op
BenchmarkLogRotation/rotate:false-compress:false-bytes:102400000-8 	      10	 145060574 ns/op
BenchmarkLogRotation/rotate:true-compress:false-bytes:0-8          	   10000	    205666 ns/op
BenchmarkLogRotation/rotate:true-compress:false-bytes:1024000-8    	    1000	   1605449 ns/op
BenchmarkLogRotation/rotate:true-compress:false-bytes:102400000-8  	      10	 148280816 ns/op
BenchmarkLogRotation/rotate:true-compress:true-bytes:0-8           	    5000	    295687 ns/op
BenchmarkLogRotation/rotate:true-compress:true-bytes:1024000-8     	    1000	   1701116 ns/op
BenchmarkLogRotation/rotate:true-compress:true-bytes:102400000-8   	      10	 165029431 ns/op
PASS
ok  	github.com/couchbase/sync_gateway/base	16.948s
```

Using the top set of tests as a baseline for logging x bytes per iteration, we can see the additional overhead of rotating with and without compression.