### PR TITLE
Add Dockerfile to build Sync Gateway from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.8-stretch
+
+# Stage to build Sync Gateway binary
+FROM golang:1.8-stretch as builder
 
 # Customize this with the commit hash or branch name you want to build
 ENV COMMIT master
@@ -24,5 +26,10 @@ RUN wget https://raw.githubusercontent.com/couchbase/sync_gateway/$COMMIT/bootst
 # Build the Sync Gateway binary
 RUN ./build.sh -v
 
-# Deploy to a directory in the path
-RUN mv godeps/bin/sync_gateway $GOPATH/bin/
+
+# Stage to run the SG binary from the previous stage
+FROM ubuntu:latest as runner
+
+COPY --from=builder /go/godeps/bin/sync_gateway .
+
+ENTRYPOINT ["/sync_gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.8-stretch
+
+# Customize this with the commit hash or branch name you want to build
+ENV COMMIT master
+
+# Refresh apt repository, install git
+RUN apt-get update && apt-get install -y \
+  git
+
+# Without these settings, the repo tool will fail (TODO: cleaner way to do this?)
+RUN git config --global user.email "you@example.com" && \
+    git config --global user.name "Your Name"
+
+# Disable the annoying "color prompt" when running repo that can make this build get stuck
+RUN git config --global color.ui false
+
+# Download and run the bootstrap.sh script which will download and invoke the repo
+# tool to grap all required repositories
+RUN wget https://raw.githubusercontent.com/couchbase/sync_gateway/$COMMIT/bootstrap.sh && \
+    cat bootstrap.sh && \
+    chmod +x bootstrap.sh && \
+    ./bootstrap.sh -c $COMMIT -p sg
+
+# Build the Sync Gateway binary
+RUN ./build.sh -v
+
+# Deploy to a directory in the path
+RUN mv godeps/bin/sync_gateway $GOPATH/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+buildit:
+	./build.sh
+clean:
+	rm -rf bin pkg
+buildclean: clean buildit
+cleanbuild: clean buildit
+test:
+	@./test.sh

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-buildit:
-	./build.sh
-clean:
-	rm -rf bin pkg
-buildclean: clean buildit
-cleanbuild: clean buildit
-test:
-	@./test.sh


### PR DESCRIPTION
I created this during the testing for issue #3558.  I think it would be a good addition to the repo since it enables the easy creation of a docker container based on any Sync Gateway branch, which is not feasible with the official Sync Gateway docker packaging since it consumes binary artifacts.

It could be useful for:
    
 - Testing SG in container-native environments like Kubernetes, OpenShift
 - Certain local docker-based testing (like verifying whether `sgcollect_info` works under docker)
 - It's less resource intensive to run a couchbase cluster in docker containers, and it's much easier if *both* couchbase server and sync gateway are running in the same docker network, and so this would facilitate local testing of Sync Gateway against couchbase clusters.

If this is merged, I can go ahead and setup a dockerhub repo, and so it will be easy to pull a pre-built docker image for the master branch.  With some more effort, it should be possible to have images automatically built for feature branches as well.

To try to reduce pollution in the root of the repo, I removed `Makefile`, which isn't being used AFAIK.  (the last commit on that file is 3 years old: https://github.com/couchbase/sync_gateway/commit/6fbe14bc0803b9bb623da08b1c50705669972c15)

