### PR TITLE
Feature/issue 3595 random API errors

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -651,7 +651,13 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		bucket, err = walrus.GetBucket(spec.Server, spec.PoolName, spec.BucketName)
 		// If feed type is not specified (defaults to DCP) or isn't TAP, wrap with pseudo-vbucket handling for walrus
 		if spec.FeedType == "" || spec.FeedType != TapFeedType {
-			bucket = &LeakyBucket{bucket: bucket, config: LeakyBucketConfig{TapFeedVbuckets: true}}
+			var leakyBucketConfig LeakyBucketConfig
+			if spec.LeakyBucketConfig != nil {
+				// If a LeakyBucketConfig was passed in the bucketspec, use it. 
+				leakyBucketConfig = *spec.LeakyBucketConfig
+			}
+			leakyBucketConfig.TapFeedVbuckets = true
+			bucket = &LeakyBucket{bucket: bucket, config: leakyBucketConfig}
 		}
 	} else {
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -707,7 +707,11 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 
 	// Possibly wrap the bucket in a LeakyBucket or a LoggingBucket
 	if spec.LeakyBucketConfig != nil {
-		bucket = NewLeakyBucket(bucket, *spec.LeakyBucketConfig)
+		// Make sure it wasn't already wrapped above in the Walrus case handling
+		_, ok := bucket.(*LeakyBucket)
+		if !ok {
+			bucket = NewLeakyBucket(bucket, *spec.LeakyBucketConfig)
+		}
 	} else if LogDebugEnabled(KeyBucket) { // This is in an "else if" in order to avoid "double wrapping" the bucket.  LeakyBucket takes precedence over LoggingBucket.
 		bucket = &LoggingBucket{bucket: bucket}
 	}

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -102,16 +102,16 @@ type BucketSpec struct {
 	Server, PoolName, BucketName, FeedType string
 	Auth                                   AuthHandler
 	CouchbaseDriver                        CouchbaseDriver
-	Certpath, Keypath, CACertPath          string         // X.509 auth parameters
-	KvTLSPort                              int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
-	MaxNumRetries                          int            // max number of retries before giving up
-	InitialRetrySleepTimeMS                int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
-	UseXattrs                              bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
-	ViewQueryTimeoutSecs                   *uint32        // the view query timeout in seconds (default: 75 seconds)
-	BucketOpTimeout                        *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	LeakyBucketConfig *LeakyBucketConfig // LeakyBucket config, if any
+	Certpath, Keypath, CACertPath          string             // X.509 auth parameters
+	KvTLSPort                              int                // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
+	MaxNumRetries                          int                // max number of retries before giving up
+	InitialRetrySleepTimeMS                int                // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
+	UseXattrs                              bool               // Whether to use xattrs to store _sync metadata.  Used during view initialization
+	ViewQueryTimeoutSecs                   *uint32            // the view query timeout in seconds (default: 75 seconds)
+	BucketOpTimeout                        *time.Duration     // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	LeakyBucketConfig                      *LeakyBucketConfig // LeakyBucket config, if any
 
-	}
+}
 
 // Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.
 func (spec BucketSpec) RetrySleeper() RetrySleeper {
@@ -701,8 +701,8 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 
 	// Possibly wrap the bucket in a LeakyBucket or a LoggingBucket
 	if spec.LeakyBucketConfig != nil {
-			bucket, err = NewLeakyBucket(bucket, *spec.LeakyBucketConfig)
-	} else if LogDebugEnabled(KeyBucket) {  // This is in an "else if" in order to avoid "double wrapping" the bucket.  LeakyBucket takes precedence over LoggingBucket.
+		bucket, err = NewLeakyBucket(bucket, *spec.LeakyBucketConfig)
+	} else if LogDebugEnabled(KeyBucket) { // This is in an "else if" in order to avoid "double wrapping" the bucket.  LeakyBucket takes precedence over LoggingBucket.
 		bucket = &LoggingBucket{bucket: bucket}
 	}
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -653,7 +653,7 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		if spec.FeedType == "" || spec.FeedType != TapFeedType {
 			var leakyBucketConfig LeakyBucketConfig
 			if spec.LeakyBucketConfig != nil {
-				// If a LeakyBucketConfig was passed in the bucketspec, use it. 
+				// If a LeakyBucketConfig was passed in the bucketspec, use it.
 				leakyBucketConfig = *spec.LeakyBucketConfig
 			}
 			leakyBucketConfig.TapFeedVbuckets = true
@@ -707,7 +707,7 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 
 	// Possibly wrap the bucket in a LeakyBucket or a LoggingBucket
 	if spec.LeakyBucketConfig != nil {
-		bucket, err = NewLeakyBucket(bucket, *spec.LeakyBucketConfig)
+		bucket = NewLeakyBucket(bucket, *spec.LeakyBucketConfig)
 	} else if LogDebugEnabled(KeyBucket) { // This is in an "else if" in order to avoid "double wrapping" the bucket.  LeakyBucket takes precedence over LoggingBucket.
 		bucket = &LoggingBucket{bucket: bucket}
 	}

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -697,7 +697,15 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 
 	}
 
-	if LogDebugEnabled(KeyBucket) {
+	isLeakyBucket := true  // TODO: get this from the bucketspec
+	if isLeakyBucket {
+		bucket = &LeakyBucket{
+			bucket: bucket,
+			config: LeakyBucketConfig{
+				InjectNthOpBucketOpTemporaryErrors: 5,
+			},
+		}
+	} else if LogDebugEnabled(KeyBucket) {
 		bucket = &LoggingBucket{bucket: bucket}
 	}
 	return

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2577,6 +2577,9 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 	case *LoggingBucket:
 		gocbBucket, ok := typedBucket.GetUnderlyingBucket().(*CouchbaseBucketGoCB)
 		return gocbBucket, ok
+	case *LeakyBucket:
+		gocbBucket, ok := typedBucket.bucket.(*CouchbaseBucketGoCB)
+		return gocbBucket, ok
 	case TestBucket:
 		gocbBucket, ok := typedBucket.Bucket.(*CouchbaseBucketGoCB)
 		return gocbBucket, ok

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -38,7 +38,7 @@ type LeakyBucketConfig struct {
 
 	// Every Nth bucket op will emulate a temporary/recoverable Couchbase Server errors.  0 means no errors.  This should
 	// be set to a number high enough to get past the startup ops.  Currently, that is > 3.
-	InjectNthBucketOpArtificialErrors uint `json:"inject_nth_bucket_op_artificial_errors"`
+	Bucket503InjectedErrorFrequency uint `json:"bucket_503_injected_error_frequency"`
 }
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
@@ -433,16 +433,16 @@ func (b *LeakyBucket) SetPostQueryCallback(callback func(ddoc, viewName string, 
 
 func (b *LeakyBucket) injectTemporaryError() bool {
 
-	// If InjectNthBucketOpArtificialErrors is disabled, no point in checking further
-	if b.config.InjectNthBucketOpArtificialErrors == 0 {
+	// If Bucket503InjectedErrorFrequency is disabled, no point in checking further
+	if b.config.Bucket503InjectedErrorFrequency == 0 {
 		return false
 	}
 
 	// Increment the number of bucket ops, and get the latest value
 	updatedNumBucketOps := atomic.AddUint64(&b.numBucketOps, uint64(1))
 
-	// If the number of bucket ops is a multiple of InjectNthBucketOpArtificialErrors, return true to introduce a temporary error
-	if updatedNumBucketOps%uint64(b.config.InjectNthBucketOpArtificialErrors) == 0 {
+	// If the number of bucket ops is a multiple of Bucket503InjectedErrorFrequency, return true to introduce a temporary error
+	if updatedNumBucketOps%uint64(b.config.Bucket503InjectedErrorFrequency) == 0 {
 		return true
 	}
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -41,25 +41,11 @@ type LeakyBucketConfig struct {
 	InjectNthBucketOpArtificialErrors uint `json:"inject_nth_bucket_op_artificial_errors"`
 }
 
-func (c LeakyBucketConfig) Validate() error {
-	minNthBucketOpTempError := uint(6) // Discovered by trial and error and set to 2x higher than required.  May change as the codebase evolves.
-	if c.InjectNthBucketOpArtificialErrors > 0 && c.InjectNthBucketOpArtificialErrors < minNthBucketOpTempError {
-		// Since SG does certain bucket operations during startup, the "Nth temporary errors" must be set high enough to
-		// get past those.
-		return fmt.Errorf("Invalid config.  Make inject_nth_bucket_op_artificial_errors > %d to avoid returning temporary errors during startup related bucket ops", minNthBucketOpTempError)
-	}
-	return nil
-}
-
-func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) (Bucket, error) {
-	if err := config.Validate(); err != nil {
-		Warnf(KeyAll, "Leaky bucket config validation error: %v", err)
-		return nil, ErrFatalBucketConnection
-	}
+func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
 	return &LeakyBucket{
 		bucket: bucket,
 		config: config,
-	}, nil
+	}
 }
 
 func (b *LeakyBucket) GetName() string {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -33,17 +33,16 @@ type LeakyBucketConfig struct {
 	TapFeedMissingDocs   []string // Emulate entry not appearing on tap feed
 
 	// Returns a partial error the first time ViewCustom is called
-	FirstTimeViewCustomPartialError    bool                                                       `json:"first_time_view_custom_partial_error,omitempty"`
-	PostQueryCallback                  func(ddoc, viewName string, params map[string]interface{}) // Issues callback after issuing query when bucket.ViewQuery is called
+	FirstTimeViewCustomPartialError bool                                                       `json:"first_time_view_custom_partial_error,omitempty"`
+	PostQueryCallback               func(ddoc, viewName string, params map[string]interface{}) // Issues callback after issuing query when bucket.ViewQuery is called
 
 	// Every Nth bucket op will emulate a temporary/recoverable Couchbase Server errors.  0 means no errors.  This should
 	// be set to a number high enough to get past the startup ops.  Currently, that is > 3.
-	InjectNthOpBucketOpTemporaryErrors uint                                                       `json:"inject_nth_op_bucket_op_temporary_errors"`
-
+	InjectNthOpBucketOpTemporaryErrors uint `json:"inject_nth_op_bucket_op_temporary_errors"`
 }
 
 func (c LeakyBucketConfig) Validate() error {
-	minNthBucketOpTempError := uint(6)  // Discovered by trial and error and set to 2x higher than required.  May change as the codebase evolves.
+	minNthBucketOpTempError := uint(6) // Discovered by trial and error and set to 2x higher than required.  May change as the codebase evolves.
 	if c.InjectNthOpBucketOpTemporaryErrors > 0 && c.InjectNthOpBucketOpTemporaryErrors < minNthBucketOpTempError {
 		// Since SG does certain bucket operations during startup, the "Nth temporary errors" must be set high enough to
 		// get past those.
@@ -447,8 +446,7 @@ func (b *LeakyBucket) injectTemporaryError() bool {
 	}
 
 	// Increment the number of bucket ops, and get the latest value
-	delta := uint64(1)
-	updatedNumBucketOps := atomic.AddUint64(&b.numBucketOps, delta)
+	updatedNumBucketOps := atomic.AddUint64(&b.numBucketOps, uint64(1))
 
 	// If the number of bucket ops is a multiple of InjectNthOpBucketOpTemporaryErrors, return true to introduce a temporary error
 	if updatedNumBucketOps%uint64(b.config.InjectNthOpBucketOpTemporaryErrors) == 0 {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -42,6 +42,13 @@ type LeakyBucketConfig struct {
 }
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
+
+
+	_, ok := bucket.(*LeakyBucket)
+	if ok {
+		panic(fmt.Sprintf("Cannot wrap bucket in a LeakyBucket, would be double wrapping: %+v", bucket))
+	}
+
 	return &LeakyBucket{
 		bucket: bucket,
 		config: config,

--- a/db/database.go
+++ b/db/database.go
@@ -118,9 +118,10 @@ type APIEndpoints struct {
 }
 
 type UnsupportedOptions struct {
-	UserViews        UserViewsOptions        `json:"user_views,omitempty"`         // Config settings for user views
-	OidcTestProvider OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
-	APIEndpoints     APIEndpoints            `json:"api_endpoints,omitempty"`      // Config settings for API endpoints
+	UserViews         UserViewsOptions        `json:"user_views,omitempty"`          // Config settings for user views
+	OidcTestProvider  OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`  // Config settings for OIDC Provider
+	APIEndpoints      APIEndpoints            `json:"api_endpoints,omitempty"`       // Config settings for API endpoints
+	LeakyBucketConfig base.LeakyBucketConfig  `json:"leaky_bucket_config,omitempty"` // Config settings for leaky bucket
 }
 
 // Options associated with the import of documents not written by Sync Gateway

--- a/db/database.go
+++ b/db/database.go
@@ -121,7 +121,7 @@ type UnsupportedOptions struct {
 	UserViews         UserViewsOptions        `json:"user_views,omitempty"`          // Config settings for user views
 	OidcTestProvider  OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`  // Config settings for OIDC Provider
 	APIEndpoints      APIEndpoints            `json:"api_endpoints,omitempty"`       // Config settings for API endpoints
-	LeakyBucketConfig base.LeakyBucketConfig  `json:"leaky_bucket_config,omitempty"` // Config settings for leaky bucket
+	LeakyBucketConfig *base.LeakyBucketConfig  `json:"leaky_bucket_config,omitempty"` // Config settings for leaky bucket
 }
 
 // Options associated with the import of documents not written by Sync Gateway

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -47,7 +47,10 @@ func testLeakyBucket(config base.LeakyBucketConfig) base.Bucket {
 	// decrementing counter
 	base.DecrNumOpenBuckets(testBucket.Bucket.GetName())
 
-	leakyBucket := base.NewLeakyBucket(testBucket.Bucket, config)
+	leakyBucket, err := base.NewLeakyBucket(testBucket.Bucket, config)
+	if err != nil {
+		panic(fmt.Sprintf("Error creating leakybucket: %v", err))
+	}
 	return leakyBucket
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1335,6 +1335,11 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 }
 
 func TestIncrRetrySuccess(t *testing.T) {
+
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Test only works against Walrus, due to incrWithRetry being short-circuited in the LeakyBucket + CouchbaseBucketGoCB case")
+	}
+
 	leakyBucketConfig := base.LeakyBucketConfig{
 		IncrTemporaryFailCount: 2,
 	}
@@ -1347,6 +1352,11 @@ func TestIncrRetrySuccess(t *testing.T) {
 }
 
 func TestIncrRetryUnsuccessful(t *testing.T) {
+
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Test only works against Walrus, due to incrWithRetry being short-circuited in the LeakyBucket + CouchbaseBucketGoCB case")
+	}
+
 	leakyBucketConfig := base.LeakyBucketConfig{
 		IncrTemporaryFailCount: 10,
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -47,11 +47,7 @@ func testLeakyBucket(config base.LeakyBucketConfig) base.Bucket {
 	// decrementing counter
 	base.DecrNumOpenBuckets(testBucket.Bucket.GetName())
 
-	leakyBucket, err := base.NewLeakyBucket(testBucket.Bucket, config)
-	if err != nil {
-		panic(fmt.Sprintf("Error creating leakybucket: %v", err))
-	}
-	return leakyBucket
+	return base.NewLeakyBucket(testBucket.Bucket, config)
 }
 
 func setupTestDBForShadowing(t *testing.T) *Database {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -323,6 +323,11 @@ func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 		operationTimeout := time.Millisecond * time.Duration(*config.BucketOpTimeoutMs)
 		spec.BucketOpTimeout = &operationTimeout
 	}
+
+	if config.Unsupported.LeakyBucketConfig != nil {
+		spec.LeakyBucketConfig = config.Unsupported.LeakyBucketConfig
+	}
+
 	return spec, nil
 }
 


### PR DESCRIPTION
Fixes #3595 

## Sample config

```
{
  "databases": {
    "db": {
            .....
	    "unsupported": {
		"leaky_bucket_config": {
			"bucket_503_injected_error_frequency":7
		}
	   }
    }
  }
}

```

## Sample injected failure network traffic

In the first several attempts the expected value is returned, followed by a 503 error:

https://gist.github.com/tleyden/f1a5b564d35bfb1aef5c962bc5cfcb28#file-gistfile1-txt-L155-L164

## Integration test

http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/727/