### PR TITLE
#3614 Logging performance optimisations

### DIFF
--- a/base/log_level.go
+++ b/base/log_level.go
@@ -82,3 +82,8 @@ func (l *LogLevel) UnmarshalText(text []byte) error {
 	}
 	return fmt.Errorf("unrecognized log level: %q (valid options: %v)", string(text), logLevelNames)
 }
+
+// logLevelPtr is a convenience function that returns a pointer to the given logKey
+func logLevelPtr(logLevel LogLevel) *LogLevel {
+	return &logLevel
+}

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -83,7 +83,7 @@ func (l *LogLevel) UnmarshalText(text []byte) error {
 	return fmt.Errorf("unrecognized log level: %q (valid options: %v)", string(text), logLevelNames)
 }
 
-// logLevelPtr is a convenience function that returns a pointer to the given logKey
+// logLevelPtr is a convenience function that returns a pointer to the given logLevel
 func logLevelPtr(logLevel LogLevel) *LogLevel {
 	return &logLevel
 }

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -82,8 +82,3 @@ func (l *LogLevel) UnmarshalText(text []byte) error {
 	}
 	return fmt.Errorf("unrecognized log level: %q (valid options: %v)", string(text), logLevelNames)
 }
-
-// logLevelPtr is a convenience function that returns a pointer to the given logLevel
-func logLevelPtr(logLevel LogLevel) *LogLevel {
-	return &logLevel
-}

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -1,0 +1,105 @@
+package base
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	assert "github.com/couchbaselabs/go.assert"
+)
+
+func logLevelPtr(l LogLevel) *LogLevel {
+	return &l
+}
+
+func TestConsoleShouldLog(t *testing.T) {
+	tests := []struct {
+		loggerLevel LogLevel
+		logToLevel  LogLevel
+		loggerKeys  []string
+		logToKey    LogKey
+		expected    bool
+	}{
+		{
+			// Log with matching log level and key
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelInfo,
+			loggerKeys:  []string{"HTTP"},
+			logToKey:    KeyHTTP,
+			expected:    true,
+		},
+		{
+			// Log with higher log level and matching key
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelWarn,
+			loggerKeys:  []string{"HTTP"},
+			logToKey:    KeyHTTP,
+			expected:    true,
+		},
+		{
+			// Log with lower log level and matching key
+			loggerLevel: LevelWarn,
+			logToLevel:  LevelInfo,
+			loggerKeys:  []string{"HTTP"},
+			logToKey:    KeyHTTP,
+			expected:    false,
+		},
+		{
+			// Logger disabled (LevelNone)
+			loggerLevel: LevelNone,
+			logToLevel:  LevelError,
+			loggerKeys:  []string{"HTTP"},
+			logToKey:    KeyHTTP,
+			expected:    false,
+		},
+		{
+			// Logger disabled (No keys)
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelInfo,
+			loggerKeys:  []string{},
+			logToKey:    KeyDCP,
+			expected:    false,
+		},
+		{
+			// Log with matching log level and unmatched key
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelInfo,
+			loggerKeys:  []string{"HTTP"},
+			logToKey:    KeyDCP,
+			expected:    false,
+		},
+		{
+			// Log with matching log level and wildcard key
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelInfo,
+			loggerKeys:  []string{"*"},
+			logToKey:    KeyDCP,
+			expected:    true,
+		},
+		{
+			// Log with lower log level and wildcard key
+			loggerLevel: LevelWarn,
+			logToLevel:  LevelInfo,
+			loggerKeys:  []string{"*"},
+			logToKey:    KeyDCP,
+			expected:    false,
+		},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("logger{%s,%s}.shouldLog(%s,%s)",
+			test.loggerLevel.StringShort(), test.loggerKeys,
+			test.logToLevel.StringShort(), test.logToKey)
+
+		l := newConsoleLoggerOrPanic(&ConsoleLoggerConfig{
+			LogLevel: &test.loggerLevel,
+			LogKeys:  test.loggerKeys,
+			Output:   ioutil.Discard,
+		})
+
+		t.Run(name, func(ts *testing.T) {
+			got := l.shouldLog(test.logToLevel, test.logToKey)
+			assert.Equals(ts, got, test.expected)
+		})
+	}
+}

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -8,10 +8,6 @@ import (
 	assert "github.com/couchbaselabs/go.assert"
 )
 
-func logLevelPtr(l LogLevel) *LogLevel {
-	return &l
-}
-
 func TestConsoleShouldLog(t *testing.T) {
 	tests := []struct {
 		loggerLevel LogLevel

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -78,7 +78,7 @@ func (l *FileLogger) shouldLog(logLevel LogLevel) bool {
 		// Check the log file is enabled
 		l.Enabled &&
 		// Check the log level is enabled
-		l.level.Enabled(logLevel)
+		l.level >= logLevel
 }
 
 func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int) error {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -73,10 +73,12 @@ func (l FileLogger) String() string {
 }
 
 // shouldLog returns true if we can log.
-func (l *FileLogger) shouldLog() bool {
+func (l *FileLogger) shouldLog(logLevel LogLevel) bool {
 	return l != nil && l.logger != nil &&
 		// Check the log file is enabled
-		l.Enabled
+		l.Enabled &&
+		// Check the log level is enabled
+		l.level.Enabled(logLevel)
 }
 
 func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int) error {

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -1,0 +1,75 @@
+package base
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"testing"
+
+	assert "github.com/couchbaselabs/go.assert"
+)
+
+func TestFileShouldLog(t *testing.T) {
+	tests := []struct {
+		enabled     bool
+		loggerLevel LogLevel
+		logToLevel  LogLevel
+		loggerKeys  []string
+		logToKey    LogKey
+		expected    bool
+	}{
+		{
+			// Log with matching log level
+			enabled:     true,
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelInfo,
+			expected:    true,
+		},
+		{
+			// Log with higher log level
+			enabled:     true,
+			loggerLevel: LevelInfo,
+			logToLevel:  LevelWarn,
+			expected:    true,
+		},
+		{
+			// Log with lower log level
+			enabled:     true,
+			loggerLevel: LevelWarn,
+			logToLevel:  LevelInfo,
+			expected:    false,
+		},
+		{
+			// Logger disabled (enabled = false)
+			enabled:     false,
+			loggerLevel: LevelNone,
+			logToLevel:  LevelError,
+			expected:    false,
+		},
+		{
+			// Logger disabled (LevelNone)
+			enabled:     true,
+			loggerLevel: LevelNone,
+			logToLevel:  LevelInfo,
+			expected:    false,
+		},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("logger{%s,%s}.shouldLog(%s,%s)",
+			test.loggerLevel.StringShort(), test.loggerKeys,
+			test.logToLevel.StringShort(), test.logToKey)
+
+		l := FileLogger{
+			Enabled: test.enabled,
+			level:   test.loggerLevel,
+			output:  ioutil.Discard,
+			logger:  log.New(ioutil.Discard, "", 0),
+		}
+
+		t.Run(name, func(ts *testing.T) {
+			got := l.shouldLog(test.logToLevel)
+			assert.Equals(ts, got, test.expected)
+		})
+	}
+}

--- a/base/logging.go
+++ b/base/logging.go
@@ -435,27 +435,17 @@ func logTo(logLevel LogLevel, logKey LogKey, format string, args ...interface{})
 	if shouldLogConsole {
 		consoleLogger.logger.Printf(color(format, logLevel), args...)
 	}
-
-	switch logLevel {
-	case LevelError:
-		if shouldLogError {
-			errorLogger.logger.Printf(format, args...)
-		}
-		fallthrough
-	case LevelWarn:
-		if shouldLogWarn {
-			warnLogger.logger.Printf(format, args...)
-		}
-		fallthrough
-	case LevelInfo:
-		if shouldLogInfo {
-			infoLogger.logger.Printf(format, args...)
-		}
-		fallthrough
-	case LevelDebug:
-		if shouldLogDebug {
-			debugLogger.logger.Printf(format, args...)
-		}
+	if shouldLogError {
+		errorLogger.logger.Printf(format, args...)
+	}
+	if shouldLogWarn {
+		warnLogger.logger.Printf(format, args...)
+	}
+	if shouldLogInfo {
+		infoLogger.logger.Printf(format, args...)
+	}
+	if shouldLogDebug {
+		debugLogger.logger.Printf(format, args...)
 	}
 }
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -409,10 +409,10 @@ func Tracef(logKey LogKey, format string, args ...interface{}) {
 
 func logTo(logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
 	shouldLogConsole := consoleLogger.shouldLog(logLevel, logKey)
-	shouldLogError := errorLogger.shouldLog()
-	shouldLogWarn := warnLogger.shouldLog()
-	shouldLogInfo := infoLogger.shouldLog()
-	shouldLogDebug := debugLogger.shouldLog()
+	shouldLogError := errorLogger.shouldLog(logLevel)
+	shouldLogWarn := warnLogger.shouldLog(logLevel)
+	shouldLogInfo := infoLogger.shouldLog(logLevel)
+	shouldLogDebug := debugLogger.shouldLog(logLevel)
 
 	shouldLog := shouldLogConsole || shouldLogError || shouldLogWarn || shouldLogInfo || shouldLogDebug
 
@@ -466,16 +466,16 @@ func Broadcastf(format string, args ...interface{}) {
 	if consoleLogger.logger != nil {
 		consoleLogger.logger.Printf(color(format, LevelNone), args...)
 	}
-	if errorLogger.shouldLog() {
+	if errorLogger.shouldLog(LevelError) {
 		errorLogger.logger.Printf(format, args...)
 	}
-	if warnLogger.shouldLog() {
+	if warnLogger.shouldLog(LevelWarn) {
 		warnLogger.logger.Printf(format, args...)
 	}
-	if infoLogger.shouldLog() {
+	if infoLogger.shouldLog(LevelInfo) {
 		infoLogger.logger.Printf(format, args...)
 	}
-	if debugLogger.shouldLog() {
+	if debugLogger.shouldLog(LevelDebug) {
 		debugLogger.logger.Printf(format, args...)
 	}
 }
@@ -546,11 +546,11 @@ func ConsoleLogKey() *LogKey {
 // LogInfoEnabled returns true if either the console should log at info level,
 // or if the infoLogger is enabled.
 func LogInfoEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelInfo, logKey) || infoLogger.shouldLog()
+	return consoleLogger.shouldLog(LevelInfo, logKey) || infoLogger.shouldLog(LevelInfo)
 }
 
 // LogDebugEnabled returns true if either the console should log at debug level,
 // or if the debugLogger is enabled.
 func LogDebugEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelDebug, logKey) || debugLogger.shouldLog()
+	return consoleLogger.shouldLog(LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -408,20 +408,23 @@ func Tracef(logKey LogKey, format string, args ...interface{}) {
 }
 
 func logTo(logLevel LogLevel, logKey LogKey, format string, args ...interface{}) {
+	// Defensive bounds-check for log level. All callers of this funcion should be within this range.
+	if logLevel <= LevelNone || logLevel >= levelCount {
+		return
+	}
+
 	shouldLogConsole := consoleLogger.shouldLog(logLevel, logKey)
 	shouldLogError := errorLogger.shouldLog(logLevel)
 	shouldLogWarn := warnLogger.shouldLog(logLevel)
 	shouldLogInfo := infoLogger.shouldLog(logLevel)
 	shouldLogDebug := debugLogger.shouldLog(logLevel)
 
-	shouldLog := shouldLogConsole || shouldLogError || shouldLogWarn || shouldLogInfo || shouldLogDebug
-
-	// exit early if we aren't going to log anything
-	if !shouldLog || logLevel <= LevelNone {
+	// exit early if we aren't going to log anything anywhere.
+	if !(shouldLogConsole || shouldLogError || shouldLogWarn || shouldLogInfo || shouldLogDebug) {
 		return
 	}
 
-	// Prepend timestamp, level, log key
+	// Prepend timestamp, level, log key.
 	format = addPrefixes(format, logLevel, logKey)
 
 	// Warn and error logs also append caller name/line numbers.

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -99,3 +99,17 @@ func TestPrependContextID(t *testing.T) {
 
 	log.Printf("testInputsOutputs: %+v", testInputsOutputs)
 }
+
+func BenchmarkAddPrefixes(b *testing.B) {
+	tests := []struct{}{
+		{},
+	}
+
+	for _, _ = range tests {
+		b.Run("", func(bn *testing.B) {
+			for i := 0; i < bn.N; i++ {
+				addPrefixes("str", LevelInfo, KeyDCP)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3614 

We can reduce the overhead of debug/trace logging by making the 'shouldLog' checks more stringent and exit early, before calling `addPrefixes`, which has an expensive `time.Format` call.

Also added a bunch of unit tests/benchmarks.