### PR TITLE
$SG_COLOR env var to determine color output

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -24,7 +24,7 @@ type ConsoleLoggerConfig struct {
 	Output io.Writer `json:"-"` // Logger output. Defaults to os.Stderr. Can be overridden for testing purposes.
 }
 
-// NewConsoleLogger returms a new ConsoleLogger from a config.
+// NewConsoleLogger returns a new ConsoleLogger from a config.
 func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
 	// validate and set defaults
 	if err := config.init(); err != nil {

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -19,7 +19,7 @@ type ConsoleLogger struct {
 type ConsoleLoggerConfig struct {
 	LogLevel     *LogLevel `json:"log_level,omitempty"`     // Log Level for the console output
 	LogKeys      []string  `json:"log_keys,omitempty"`      // Log Keys for the console output
-	ColorEnabled bool      `json:"color_enabled,omitempty"` // Log with color for the console output
+	ColorEnabled *bool     `json:"color_enabled,omitempty"` // Log with color for the console output
 
 	Output io.Writer `json:"-"` // Logger output. Defaults to os.Stderr. Can be overridden for testing purposes.
 }
@@ -36,7 +36,7 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, error) {
 	return &ConsoleLogger{
 		LogLevel:     config.LogLevel,
 		LogKey:       &logKey,
-		ColorEnabled: config.ColorEnabled,
+		ColorEnabled: *config.ColorEnabled,
 		logger:       log.New(config.Output, "", 0),
 	}, nil
 }
@@ -73,6 +73,12 @@ func (lcc *ConsoleLoggerConfig) init() error {
 
 	// Always enable the HTTP log key
 	lcc.LogKeys = append(lcc.LogKeys, logKeyNames[KeyHTTP])
+
+	// If ColorEnabled is not explicitly set, use the value of the default consoleLogger
+	// This is set from the $SG_COLOR env var on startup.
+	if lcc.ColorEnabled == nil {
+		lcc.ColorEnabled = &consoleLogger.ColorEnabled
+	}
 
 	return nil
 }

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 )
 
 type ConsoleLogger struct {
@@ -74,10 +75,11 @@ func (lcc *ConsoleLoggerConfig) init() error {
 	// Always enable the HTTP log key
 	lcc.LogKeys = append(lcc.LogKeys, logKeyNames[KeyHTTP])
 
-	// If ColorEnabled is not explicitly set, use the value of the default consoleLogger
-	// This is set from the $SG_COLOR env var on startup.
+	// If ColorEnabled is not explicitly set, use the value of $SG_COLOR
 	if lcc.ColorEnabled == nil {
-		lcc.ColorEnabled = &consoleLogger.ColorEnabled
+		// Ignore error parsing this value to treat it as false.
+		color, _ := strconv.ParseBool(os.Getenv("SG_COLOR"))
+		lcc.ColorEnabled = &color
 	}
 
 	return nil

--- a/base/logging.go
+++ b/base/logging.go
@@ -371,7 +371,7 @@ func init() {
 	// We'll initilise a default consoleLogger so we can still log stuff before/during parsing logging configs.
 	// This maintains consistent formatting (timestamps, levels, etc) in the output,
 	// and allows a single set of logging functions to be used, rather than fmt.Printf()
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{ColorEnabled: color})
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{ColorEnabled: &color})
 }
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.

--- a/base/logging.go
+++ b/base/logging.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -364,10 +365,13 @@ func RotateLogfiles() map[*FileLogger]error {
 }
 
 func init() {
+	// Ignore error parsing this value to treat it as false.
+	color, _ := strconv.ParseBool(os.Getenv("SG_COLOR"))
+
 	// We'll initilise a default consoleLogger so we can still log stuff before/during parsing logging configs.
 	// This maintains consistent formatting (timestamps, levels, etc) in the output,
 	// and allows a single set of logging functions to be used, rather than fmt.Printf()
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{})
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{ColorEnabled: color})
 }
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.

--- a/base/logging.go
+++ b/base/logging.go
@@ -513,15 +513,17 @@ func color(str string, logLevel LogLevel) string {
 
 	switch logLevel {
 	case LevelError:
-		color = "\033[1;31m"
+		color = "\033[1;31m" // Red
 	case LevelWarn:
-		color = "\033[1;33m"
+		color = "\033[1;33m" // Yellow
 	case LevelInfo:
-		color = "\033[1;34m"
+		color = "\033[1;34m" // Blue
 	case LevelDebug:
-		color = "\033[0;36m"
-	case LevelNone:
-		color = "\033[0;32m"
+		color = "\033[0;36m" // Cyan
+	case LevelTrace:
+		color = "\033[0;37m" // White
+	default:
+		color = "\033[0m" // None
 	}
 
 	return color + str + "\033[0m"

--- a/base/logging.go
+++ b/base/logging.go
@@ -17,7 +17,6 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -365,13 +364,10 @@ func RotateLogfiles() map[*FileLogger]error {
 }
 
 func init() {
-	// Ignore error parsing this value to treat it as false.
-	color, _ := strconv.ParseBool(os.Getenv("SG_COLOR"))
-
 	// We'll initilise a default consoleLogger so we can still log stuff before/during parsing logging configs.
 	// This maintains consistent formatting (timestamps, levels, etc) in the output,
 	// and allows a single set of logging functions to be used, rather than fmt.Printf()
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{ColorEnabled: &color})
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{})
 }
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.


### PR DESCRIPTION
Reads the value of `$SG_COLOR` to determine if console log outputs should have color enabled. This can be useful for having color in logs for unit tests, etc.

This env var is used as a fallback, and any value set in `logging.console.color` will override it. See the truth table below for combinations of the two options. They all default to false (opt-in color).

| `logging.console.color` | `$SG_COLOR` | color enabled? | Description     |
| :---------------------: | :---------: | :------------: | --------------- |
| -                       | -           | ✘              | Env var used (default false) |
| -                       | ✔           | ✔              | Env var used    |
| ✘                       | ~✔~         | ✘              | Env var ignored |
| ✔                       | ~✘~         | ✔              | Env var ignored |