### PR TITLE
Fix LoggingBucket always using TAP feed type

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -839,6 +839,10 @@ func GetFeedType(bucket Bucket) (feedType string) {
 		}
 	case *LeakyBucket:
 		return GetFeedType(typedBucket.bucket)
+	case *LoggingBucket:
+		return GetFeedType(typedBucket.bucket)
+	case *StatsBucket:
+		return GetFeedType(typedBucket.bucket)
 	default:
 		return TapFeedType
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2206,7 +2206,8 @@ func (bucket *CouchbaseBucketGoCB) StartTapFeed(args sgbucket.FeedArguments) (sg
 
 	callback := func(dcpFeedEvent sgbucket.FeedEvent) bool {
 		eventFeed <- dcpFeedEvent
-		return true
+		// TAP feed should not persist checkpoints
+		return false
 	}
 
 	err := bucket.StartDCPFeed(args, callback)


### PR DESCRIPTION
Fixes #3620

Get the underlying bucket type for `LoggingBucket` and `StatsBuckets` when getting feed type.

## Integration Tests
- [ ] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/742/
- [ ] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/743/