### PR TITLE
Fixes #3335 BlipTester concurrency safety issues

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -61,7 +61,7 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params interface{}, c
 		// Non-retry error - return
 		if !isIndexerError(queryErr) {
 			Warnf(KeyAll, "Error when querying index using statement: [%s]", UD(bucketStatement))
-			return queryResults, queryErr
+			return queryResults, pkgerrors.WithStack(queryErr)
 		}
 
 		// Indexer error - wait then retry

--- a/base/constants.go
+++ b/base/constants.go
@@ -84,6 +84,10 @@ const (
 	// Keep idle connections around for a maximimum of 90 seconds.  This is the same value used by the Go DefaultTransport.
 	DefaultHttpIdleConnTimeoutMilliseconds = "90000"
 
+	// Set this to true to dump stacktraces (for pkgerrors wrapped errors only) whenever an error is returned to
+	// an API client.  Currently only works with REST API calls.
+	StacktraceOnAPIErrors = false
+
 )
 
 func UnitTestUrl() string {

--- a/base/constants.go
+++ b/base/constants.go
@@ -66,7 +66,9 @@ const (
 
 	DefaultViewQueryPageSize = 5000 // This must be greater than 1, or the code won't work due to windowing method
 
-	DefaultWaitForSequenceTesting = time.Second * 2
+	// Until the sporadic integration tests failures in SG #3570 are fixed, should be GTE n1ql query timeout
+	// to make it easier to identify root cause of test failures.
+	DefaultWaitForSequenceTesting = time.Second * 30
 
 	// Default the max number of idle connections per host to a relatively high number to avoid
 	// excessive socket churn caused by opening short-lived connections and closing them after, which can cause

--- a/base/util.go
+++ b/base/util.go
@@ -769,6 +769,10 @@ func BooleanPointer(booleanValue bool) *bool {
 	return &booleanValue
 }
 
+func StringPointer(value string) *string {
+	return &value
+}
+
 // Convert a Couchbase URI (eg, couchbase://host1,host2) to a list of HTTP URLs with ports (eg, ["http://host1:8091", "http://host2:8091"])
 // Primary use case is for backwards compatibility with go-couchbase, cbdatasource, and CBGT. Supports secure URI's as well (couchbases://).
 // Related CBGT ticket: https://issues.couchbase.com/browse/MB-25522

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/couchbaselabs/go.assert"
+	"reflect"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -491,5 +492,52 @@ func TestReplaceAll(t *testing.T) {
 			output := ReplaceAll(test.input, test.chars, test.new)
 			assert.Equals(ts, output, test.expected)
 		})
+	}
+}
+
+type A struct {
+	String  string
+	Int     int
+	Strings []string
+	Ints    map[string]int
+	As      map[string]*A
+}
+
+// Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
+func TestDeepCopyInefficient(t *testing.T) {
+	src := map[string]interface{}{
+		"String":  "Hello World",
+		"Int":     5,
+		"Strings": []string{"A", "B"},
+		"Ints":    map[string]int{"A": 1, "B": 2},
+		"As": map[string]map[string]interface{}{
+			"One": map[string]interface{}{
+				"String": "2",
+			},
+			"Two": map[string]interface{}{
+				"String": "3",
+			},
+		},
+	}
+	dst := &A{
+		Strings: []string{"C"},
+		Ints:    map[string]int{"B": 3, "C": 4},
+		As:      map[string]*A{"One": &A{String: "1", Int: 5}}}
+	expected := &A{
+		String:  "Hello World",
+		Int:     5,
+		Strings: []string{"A", "B"},
+		Ints:    map[string]int{"A": 1, "B": 2, "C": 4},
+		As: map[string]*A{
+			"One": &A{String: "2"},
+			"Two": &A{String: "3"},
+		},
+	}
+	err := DeepCopyInefficient(dst, src)
+	if err != nil {
+		t.Errorf("Unable to copy!")
+	}
+	if !reflect.DeepEqual(expected, dst) {
+		t.Errorf("expected and dst differed")
 	}
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb"
+	"encoding/json"
 )
 
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
@@ -551,4 +552,24 @@ func EnableTestLogKey(logKey string) {
 func ResetTestLogging() {
 	ConsoleLogLevel().Set(LevelInfo)
 	ConsoleLogKey().Set(KeyHTTP)
+}
+
+// Make a deep copy from src into dst.
+// Copied from https://github.com/getlantern/deepcopy, commit 7f45deb8130a0acc553242eb0e009e3f6f3d9ce3 (Apache 2 licensed)
+func DeepCopyInefficient(dst interface{}, src interface{}) error {
+	if dst == nil {
+		return fmt.Errorf("dst cannot be nil")
+	}
+	if src == nil {
+		return fmt.Errorf("src cannot be nil")
+	}
+	bytes, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf("Unable to marshal src: %s", err)
+	}
+	err = json.Unmarshal(bytes, dst)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshal into dst: %s", err)
+	}
+	return nil
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -30,6 +30,7 @@ func init() {
 
 type TestBucket struct {
 	Bucket
+	BucketSpec BucketSpec
 }
 
 func (tb TestBucket) Close() {
@@ -137,7 +138,10 @@ func GetBucketOrPanicCommon(bucketType CouchbaseBucketType) TestBucket {
 		panic(fmt.Sprintf("Could not open bucket: %v", err))
 	}
 
-	return TestBucket{Bucket: bucket}
+	return TestBucket{
+		Bucket:     bucket,
+		BucketSpec: spec,
+	}
 
 }
 
@@ -347,7 +351,7 @@ func (tbm *TestBucketManager) FlushBucket() error {
 	// Ignore sporadic errors like:
 	// Error trying to empty bucket. err: {"_":"Flush failed with unexpected error. Check server logs for details."}
 
-	log.Printf("Flushing bucket %s", tbm.Bucket.Name())
+	Infof(KeyAll, "Flushing bucket %s", tbm.Bucket.Name())
 
 	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
 		err = tbm.Bucket.Flush()

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -35,15 +35,22 @@ func init() {
 }
 
 // Manages a cache of the recent change history of all channels.
+//
+// Core responsibilities:
+//
+// - Manage collection of channel caches
+// - Receive DCP changes via callbacks
+//    - Perform sequence buffering to ensure documents are received in sequence order
+//    - Propagating DCP changes down to appropriate channel caches
 type changeCache struct {
 	context         *DatabaseContext
 	logsDisabled    bool                     // If true, ignore incoming tap changes
-	nextSequence    uint64                   // Next consecutive sequence number to add
-	initialSequence uint64                   // DB's current sequence at startup time
+	nextSequence    uint64                   // Next consecutive sequence number to add.  State variable for sequence buffering tracking.  Should use getNextSequence() rather than accessing directly.
+	initialSequence uint64                   // DB's current sequence at startup time. Should use getInitialSequence() rather than accessing directly.
 	receivedSeqs    map[uint64]struct{}      // Set of all sequences received
 	pendingLogs     LogPriorityQueue         // Out-of-sequence entries waiting to be cached
 	channelCaches   map[string]*channelCache // A cache of changes for each channel
-	onChange        func(base.Set)           // Client callback that notifies of channel changes
+	notifyChange    func(base.Set)           // Client callback that notifies of channel changes
 	stopped         bool                     // Set by the Stop method
 	skippedSeqs     SkippedSequenceQueue     // Skipped sequences still pending on the TAP feed
 	skippedSeqLock  sync.RWMutex             // Coordinates access to skippedSeqs queue
@@ -83,12 +90,13 @@ type CacheOptions struct {
 
 // Initializes a new changeCache.
 // lastSequence is the last known database sequence assigned.
-// onChange is an optional function that will be called to notify of channel changes.
-func (c *changeCache) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) error {
+// notifyChange is an optional function that will be called to notify of channel changes.
+// After calling Init(), you must call .Start() to start useing the cache, otherwise it will be in a locked state
+// and callers will block on trying to obtain the lock.
+func (c *changeCache) Init(context *DatabaseContext, notifyChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) error {
 	c.context = context
-	c.initialSequence = lastSequence.Seq
-	c.nextSequence = lastSequence.Seq + 1
-	c.onChange = onChange
+
+	c.notifyChange = notifyChange
 	c.channelCaches = make(map[string]*channelCache, 10)
 	c.receivedSeqs = make(map[uint64]struct{})
 	c.terminator = make(chan bool)
@@ -118,7 +126,7 @@ func (c *changeCache) Init(context *DatabaseContext, lastSequence SequenceID, on
 	base.Infof(base.KeyCache, "Initializing changes cache with options %+v", c.options)
 
 	if context.UseGlobalSequence() {
-		base.Infof(base.KeyAll, "Initializing changes cache for database %s with sequence: %d", base.UD(context.Name), c.initialSequence)
+		base.Infof(base.KeyAll, "Initializing changes cache for database %s", base.UD(context.Name))
 	}
 
 	heap.Init(&c.pendingLogs)
@@ -147,6 +155,24 @@ func (c *changeCache) Init(context *DatabaseContext, lastSequence SequenceID, on
 		}
 	}()
 
+	// Lock the cache -- not usable until .Start() called.  This fixes the DCP startup race condition documented in SG #3558.
+	c.lock.Lock()
+
+	return nil
+}
+
+func (c *changeCache) Start() error {
+
+	// Unlock the cache after this function returns.
+	defer c.lock.Unlock()
+
+	// Find the current global doc sequence and use that for the initial sequence for the change cache
+	lastSequence, err := c.context.LastSequence()
+	if err != nil {
+		return err
+	}
+
+	c._setInitialSequence(lastSequence)
 	return nil
 }
 
@@ -169,14 +195,25 @@ func (c *changeCache) IsStopped() bool {
 	return c.stopped
 }
 
-// Forgets all cached changes for all channels.
-func (c *changeCache) Clear() {
+// Empty out all channel caches.
+func (c *changeCache) Clear() error {
 	c.lock.Lock()
-	c.initialSequence, _ = c.context.LastSequence()
+	defer c.lock.Unlock()
+
+	// Reset initialSequence so that any new channel caches have their validFrom set to the current last sequence
+	// the point at which the change cache was initialized / re-initialized.
+	// No need to touch c.nextSequence here, because we don't want to touch the sequence buffering state.
+	var err error
+	c.initialSequence, err = c.context.LastSequence()
+	if err != nil {
+		return err
+	}
+
 	c.channelCaches = make(map[string]*channelCache, 10)
 	c.pendingLogs = nil
 	heap.Init(&c.pendingLogs)
-	c.lock.Unlock()
+
+	return nil
 }
 
 // If set to false, DocChanged() becomes a no-op.
@@ -193,14 +230,15 @@ func (c *changeCache) EnableChannelIndexing(enable bool) {
 func (c *changeCache) CleanUp() bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+
 	if c.channelCaches == nil {
 		return false
 	}
 
 	// If entries have been pending too long, add them to the cache:
 	changedChannels := c._addPendingLogs()
-	if c.onChange != nil && len(changedChannels) > 0 {
-		c.onChange(changedChannels)
+	if c.notifyChange != nil && len(changedChannels) > 0 {
+		c.notifyChange(changedChannels)
 	}
 
 	// Remove old cache entries:
@@ -275,8 +313,8 @@ func (c *changeCache) CleanSkippedSequenceQueue() bool {
 
 	// Since the calls to processEntry() above may unblock pending sequences, if there were any changed channels we need
 	// to notify any change listeners that are working changes feeds for these channels
-	if c.onChange != nil && len(changedChannelsCombined) > 0 {
-		c.onChange(changedChannelsCombined)
+	if c.notifyChange != nil && len(changedChannelsCombined) > 0 {
+		c.notifyChange(changedChannelsCombined)
 	}
 
 	// Purge pending deletes
@@ -292,76 +330,19 @@ func (c *changeCache) CleanSkippedSequenceQueue() bool {
 	return true
 }
 
-// FOR TESTS ONLY: Blocks until the given sequence has been received.
-func (c *changeCache) waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration) {
-	c.waitForSequence(sequence.Seq, maxWaitTime)
-}
-
-func (c *changeCache) waitForSequence(sequence uint64, maxWaitTime time.Duration) {
-
-	startTime := time.Now()
-
-	for {
-
-		if time.Since(startTime) >= maxWaitTime {
-			panic(fmt.Sprintf("changeCache: Sequence %d did not show up after waiting %v", sequence, time.Since(startTime)))
-		}
-
-		c.lock.RLock()
-		nextSequence := c.nextSequence
-		c.lock.RUnlock()
-		if nextSequence >= sequence+1 {
-			base.Infof(base.KeyAll, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-// FOR TESTS ONLY: Blocks until the given sequence has been received.
-func (c *changeCache) waitForSequenceWithMissing(sequence uint64, maxWaitTime time.Duration) {
-
-	startTime := time.Now()
-
-	for {
-
-		if time.Since(startTime) >= maxWaitTime {
-			panic(fmt.Sprintf("changeCache: Sequence %d did not show up after waiting %v", sequence, time.Since(startTime)))
-		}
-
-		c.lock.RLock()
-		nextSequence := c.nextSequence
-		c.lock.RUnlock()
-		if nextSequence >= sequence+1 {
-			foundInMissing := false
-			c.skippedSeqLock.RLock()
-			for _, skippedSeq := range c.skippedSeqs {
-				if skippedSeq.seq == sequence {
-					foundInMissing = true
-					break
-				}
-			}
-			c.skippedSeqLock.RUnlock()
-			if !foundInMissing {
-				base.Infof(base.KeyAll, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
-				return
-			}
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
 //////// ADDING CHANGES:
 
 // Given a newly changed document (received from the tap feed), adds change entries to channels.
 // The JSON must be the raw document from the bucket, with the metadata and all.
 func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
+
 	if event.Synchronous {
 		c.DocChangedSynchronous(event)
 	} else {
 		go c.DocChangedSynchronous(event)
 	}
 }
+
 
 // Note that DocChangedSynchronous may be executed concurrently for multiple events (in the DCP case, DCP events
 // originating from multiple vbuckets).  Only processEntry is locking - all other functionality needs to support
@@ -452,7 +433,7 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 		}
 	}
 
-	if syncData.Sequence <= c.initialSequence {
+	if syncData.Sequence <= c.getInitialSequence() {
 		return // Tap is sending us an old value from before I started up; ignore it
 	}
 
@@ -483,9 +464,9 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 	}
 
 	if len(syncData.RecentSequences) > 0 {
-		nextSeq := c.getNextSequence()
+
 		for _, seq := range syncData.RecentSequences {
-			if seq >= nextSeq && seq < currentSequence {
+			if seq >= c.getNextSequence() && seq < currentSequence {
 				base.Infof(base.KeyCache, "Received deduplicated #%d for (%q / %q)", seq, base.UD(docID), syncData.CurrentRev)
 				change := &LogEntry{
 					Sequence:     seq,
@@ -522,8 +503,8 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 	changedChannelsCombined = changedChannelsCombined.Union(changedChannels)
 
 	// Notify change listeners for all of the changed channels
-	if c.onChange != nil && len(changedChannelsCombined) > 0 {
-		c.onChange(changedChannelsCombined)
+	if c.notifyChange != nil && len(changedChannelsCombined) > 0 {
+		c.notifyChange(changedChannelsCombined)
 	}
 
 }
@@ -556,8 +537,8 @@ func (c *changeCache) processUnusedSequence(docID string) {
 	// Since processEntry may unblock pending sequences, if there were any changed channels we need
 	// to notify any change listeners that are working changes feeds for these channels
 	changedChannels := c.processEntry(change)
-	if c.onChange != nil && len(changedChannels) > 0 {
-		c.onChange(changedChannels)
+	if c.notifyChange != nil && len(changedChannels) > 0 {
+		c.notifyChange(changedChannels)
 	}
 
 }
@@ -572,10 +553,8 @@ func (c *changeCache) processPrincipalDoc(docID string, docJSON []byte, isUser b
 		return
 	}
 	sequence := princ.Sequence()
-	c.lock.RLock()
-	initialSequence := c.initialSequence
-	c.lock.RUnlock()
-	if sequence <= initialSequence {
+
+	if sequence <= c.getInitialSequence() {
 		return // Tap is sending us an old value from before I started up; ignore it
 	}
 
@@ -593,8 +572,8 @@ func (c *changeCache) processPrincipalDoc(docID string, docJSON []byte, isUser b
 	base.Infof(base.KeyCache, "Received #%d (%q)", change.Sequence, base.UD(change.DocID))
 
 	changedChannels := c.processEntry(change)
-	if c.onChange != nil && len(changedChannels) > 0 {
-		c.onChange(changedChannels)
+	if c.notifyChange != nil && len(changedChannels) > 0 {
+		c.notifyChange(changedChannels)
 	}
 }
 
@@ -607,7 +586,7 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 	}
 
 	sequence := change.Sequence
-	nextSequence := c.nextSequence
+
 	if _, found := c.receivedSeqs[sequence]; found {
 		base.Debugf(base.KeyCache, "  Ignoring duplicate of #%d", sequence)
 		return nil
@@ -616,17 +595,17 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 	// FIX: c.receivedSeqs grows monotonically. Need a way to remove old sequences.
 
 	var changedChannels base.Set
-	if sequence == nextSequence || nextSequence == 0 {
+	if sequence == c.nextSequence || c.nextSequence == 0 {
 		// This is the expected next sequence so we can add it now:
 		changedChannels = c._addToCache(change)
 		// Also add any pending sequences that are now contiguous:
 		changedChannels = changedChannels.Union(c._addPendingLogs())
-	} else if sequence > nextSequence {
+	} else if sequence > c.nextSequence {
 		// There's a missing sequence (or several), so put this one on ice until it arrives:
 		heap.Push(&c.pendingLogs, change)
 		numPending := len(c.pendingLogs)
 		base.Infof(base.KeyCache, "  Deferring #%d (%d now waiting for #%d...#%d)",
-			sequence, numPending, nextSequence, c.pendingLogs[0].Sequence-1)
+			sequence, numPending, c.nextSequence, c.pendingLogs[0].Sequence-1)
 		changeCacheExpvars.Get("maxPending").(*base.IntMax).SetIfMax(int64(numPending))
 		if numPending > c.options.CachePendingSeqMaxNum {
 			// Too many pending; add the oldest one:
@@ -637,9 +616,9 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 		// Remove from skipped sequence queue
 		if !c.WasSkipped(sequence) {
 			// Error removing from skipped sequences
-			base.Infof(base.KeyCache, "  Received unexpected out-of-order change - not in skippedSeqs (seq %d, expecting %d) doc %q / %q", sequence, nextSequence, base.UD(change.DocID), change.RevID)
+			base.Infof(base.KeyCache, "  Received unexpected out-of-order change - not in skippedSeqs (seq %d, expecting %d) doc %q / %q", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
 		} else {
-			base.Infof(base.KeyCache, "  Received previously skipped out-of-order change (seq %d, expecting %d) doc %q / %q ", sequence, nextSequence, base.UD(change.DocID), change.RevID)
+			base.Infof(base.KeyCache, "  Received previously skipped out-of-order change (seq %d, expecting %d) doc %q / %q ", sequence, c.nextSequence, base.UD(change.DocID), change.RevID)
 			change.Skipped = true
 		}
 
@@ -654,6 +633,7 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 // Adds an entry to the appropriate channels' caches, returning the affected channels.  lateSequence
 // flag indicates whether it was a change arriving out of sequence
 func (c *changeCache) _addToCache(change *LogEntry) base.Set {
+
 	if change.Sequence >= c.nextSequence {
 		c.nextSequence = change.Sequence + 1
 	}
@@ -736,17 +716,9 @@ func (c *changeCache) getChannelCache(channelName string) *channelCache {
 	return c._getChannelCache(channelName)
 }
 
-func (c *changeCache) getNextSequence() uint64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return c.nextSequence
-}
-
 func (c *changeCache) GetStableSequence(docID string) SequenceID {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
 	// Stable sequence is independent of docID in changeCache
-	return SequenceID{Seq: c.nextSequence - 1}
+	return SequenceID{Seq: c.LastSequence()}
 }
 
 func (c *changeCache) GetStableClock(stale bool) (clock base.SequenceClock, err error) {
@@ -756,7 +728,11 @@ func (c *changeCache) GetStableClock(stale bool) (clock base.SequenceClock, err 
 func (c *changeCache) _getChannelCache(channelName string) *channelCache {
 	cache := c.channelCaches[channelName]
 	if cache == nil {
-		cache = newChannelCacheWithOptions(c.context, channelName, c.initialSequence+1, c.options)
+
+		// expect to see everything _after_ the sequence at the time of cache init, but not the sequence itself since it not expected to appear on DCP
+		validFrom := c.initialSequence + 1
+
+		cache = newChannelCacheWithOptions(c.context, channelName, validFrom, c.options)
 		c.channelCaches[channelName] = cache
 	}
 	return cache
@@ -778,9 +754,9 @@ func (c *changeCache) GetCachedChanges(channelName string, options ChangesOption
 
 // Returns the sequence number the cache is up-to-date with.
 func (c *changeCache) LastSequence() uint64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return c.nextSequence - 1
+
+	lastSequence := c.getNextSequence() - 1
+	return lastSequence
 }
 
 func (c *changeCache) _allChannels() base.Set {
@@ -802,6 +778,26 @@ func (c *changeCache) getOldestSkippedSequence() uint64 {
 	} else {
 		return uint64(0)
 	}
+}
+
+// Set the initial sequence.  Presumes that change chache is already locked.
+func (c *changeCache) _setInitialSequence(initialSequence uint64) {
+	c.initialSequence = initialSequence
+	c.nextSequence = initialSequence + 1
+}
+
+// Concurrent-safe get value of nextSequence 
+func (c *changeCache) getNextSequence() uint64 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.nextSequence
+}
+
+// Concurrent-safe get value of initialSequence
+func (c *changeCache) getInitialSequence() uint64 {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.initialSequence
 }
 
 //////// LOG PRIORITY QUEUE -- container/heap callbacks that should not be called directly.   Use heap.Init/Push/etc()

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -27,13 +27,16 @@ import (
 type ChangeIndex interface {
 
 	// Initialize the index
-	Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), cacheOptions *CacheOptions, indexOptions *ChannelIndexOptions) error
+	Init(context *DatabaseContext, notifyChange func(base.Set), cacheOptions *CacheOptions, indexOptions *ChannelIndexOptions) error
 
 	// Stop the index
 	Stop()
 
+	// Start the index
+	Start() error
+
 	// Clear the index
-	Clear()
+	Clear() error
 
 	// Enable/Disable indexing
 	EnableChannelIndexing(enable bool)

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -471,7 +471,6 @@ func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint6
 					entriesToPrepend := make(LogEntries, 0, cacheCapacity)
 					for changeIndex := i; changeIndex >= 0; changeIndex-- {
 						change := changes[changeIndex]
-						changesValidFrom = change.Sequence
 
 						// If docid is already in cache, existing revision must be for a later sequence; can ignore this revision.
 						if _, docIdExists := c.cachedDocIDs[change.DocID]; docIdExists {
@@ -483,6 +482,9 @@ func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint6
 						c.cachedDocIDs[change.DocID] = struct{}{}
 
 						if len(entriesToPrepend) >= cacheCapacity {
+							// If we reach capacity before prepending the entire set of changes, set changesValidFrom to the oldest sequence
+							// that's been prepended to the cache
+							changesValidFrom = change.Sequence
 							break
 						}
 					}

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -222,12 +222,12 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended := cache.prependChanges(changesToPrepend, 10, true)
+	numPrepended := cache.prependChanges(changesToPrepend, 5, true)
 	assert.Equals(t, numPrepended, 3)
 
 	// Validate cache
 	validFrom, cachedChanges := cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(10))
+	assert.Equals(t, validFrom, uint64(5))
 	assert.Equals(t, len(cachedChanges), 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
@@ -244,12 +244,12 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 10, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
 	assert.Equals(t, numPrepended, 2)
 
 	// Validate cache
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(10))
+	assert.Equals(t, validFrom, uint64(5))
 	assert.Equals(t, len(cachedChanges), 4)
 	if len(cachedChanges) == 4 {
 		assert.Equals(t, cachedChanges[0].DocID, "doc3")
@@ -265,7 +265,7 @@ func TestPrependChanges(t *testing.T) {
 	// Write a new revision for a prepended doc to the cache, validate that old entry is removed
 	cache.addToCache(e(24, "doc3", "3-a"), false)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(10))
+	assert.Equals(t, validFrom, uint64(5))
 	assert.Equals(t, len(cachedChanges), 4)
 	if len(cachedChanges) == 4 {
 		assert.Equals(t, cachedChanges[0].DocID, "doc5")
@@ -301,7 +301,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 10, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
 	assert.Equals(t, numPrepended, 1)
 
 	// Validate cache
@@ -335,10 +335,10 @@ func TestPrependChanges(t *testing.T) {
 		e(12, "doc4", "2-a"),
 		e(14, "doc1", "2-a"),
 	}
-	numPrepended = cache.prependChanges(changesToPrepend, 10, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
 	assert.Equals(t, numPrepended, 0)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(8))
+	assert.Equals(t, validFrom, uint64(5))
 	assert.Equals(t, len(cachedChanges), 4)
 	if len(cachedChanges) == 5 {
 		assert.Equals(t, cachedChanges[0].DocID, "doc1")
@@ -369,7 +369,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 10, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 6, true)
 	assert.Equals(t, numPrepended, 0)
 
 	// Validate cache

--- a/db/database.go
+++ b/db/database.go
@@ -206,10 +206,6 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	if err != nil {
 		return nil, err
 	}
-	lastSeq, err := context.sequences.lastSequence()
-	if err != nil {
-		return nil, err
-	}
 
 	if options.IndexOptions == nil {
 		// In-memory channel cache
@@ -226,20 +222,19 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	// Callback that is invoked whenever a set of channels is changed in the ChangeCache
-	onChange := func(changedChannels base.Set) {
+	notifyChange := func(changedChannels base.Set) {
 		context.mutationListener.Notify(changedChannels)
 	}
 
-	// Initialize the ChangeCache
+	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
 	context.changeCache.Init(
 		context,
-		SequenceID{Seq: lastSeq},
-		onChange,
+		notifyChange,
 		options.CacheOptions,
 		options.IndexOptions,
 	)
 
-	// Set the DB Context onChange callback to call back the changecache DocChanged callback
+	// Set the DB Context notifyChange callback to call back the changecache DocChanged callback
 	context.SetOnChangeCallback(context.changeCache.DocChanged)
 
 	// Initialize the tap Listener for notify handling
@@ -255,7 +250,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	if options.IndexOptions == nil || options.TrackDocs {
 		base.Infof(base.KeyDCP, "Starting mutation feed on bucket %v due to either channel cache mode or doc tracking (auto-import/bucketshadow)", base.MD(bucket.GetName()))
 
-		if err = context.mutationListener.Start(bucket, options.TrackDocs, feedMode, func(bucket string, err error) {
+		err = context.mutationListener.Start(bucket, options.TrackDocs, feedMode, func(bucket string, err error) {
 
 			msgFormat := "%v dropped Mutation Feed (TAP/DCP) due to error: %v, taking offline"
 			base.Warnf(base.KeyAll, msgFormat, base.UD(bucket), err)
@@ -303,9 +298,20 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 			// TODO: invoke the same callback function from there as well, to pick up the auto-online handling
 
-		}); err != nil {
+		})
+
+		// Check if there is an error starting the DCP feed
+		if err != nil {
+			context.changeCache = nil
 			return nil, err
 		}
+
+		// Unlock change cache
+		err := context.changeCache.Start()
+		if err != nil {
+			return nil, err
+		}
+
 	}
 
 	// Load providers into provider map.  Does basic validation on the provider definition, and identifies the default provider.
@@ -480,9 +486,9 @@ func (context *DatabaseContext) RestartListener() error {
 }
 
 // Cache flush support.  Currently test-only - added for unit test access from rest package
-func (context *DatabaseContext) FlushChannelCache() {
+func (context *DatabaseContext) FlushChannelCache() error {
 	base.Infof(base.KeyCache, "Flushing channel cache")
-	context.changeCache.Clear()
+	return context.changeCache.Clear()
 }
 
 // Removes previous versions of Sync Gateway's design docs found on the server
@@ -851,7 +857,11 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 	// really confuse the changeCache, so turn it off until we're done:
 	db.changeCache.EnableChannelIndexing(false)
 	defer db.changeCache.EnableChannelIndexing(true)
-	db.changeCache.Clear()
+
+	err = db.changeCache.Clear()
+	if err != nil {
+		return 0, err
+	}
 
 	base.Infof(base.KeyAll, "Re-running sync function on all documents...")
 	changeCount := 0

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -89,17 +89,45 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database,
 
 func testBucket() base.TestBucket {
 
-	testBucket := base.GetTestBucketOrPanic()
-	err := installViews(testBucket.Bucket)
-	if err != nil {
-		log.Fatalf("Couldn't connect to bucket: %v", err)
+	// Retry loop in case the GSI indexes don't handle the flush and we need to drop them and retry
+	for i:= 0; i < 2; i++ {
+
+		testBucket := base.GetTestBucketOrPanic()
+		err := installViews(testBucket.Bucket)
+		if err != nil {
+			log.Fatalf("Couldn't connect to bucket: %v", err)
+			// ^^ effectively panics
+		}
+
+		err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0)
+		if err != nil {
+			log.Fatalf("Unable to initialize GSI indexes for test: %v", err)
+			// ^^ effectively panics
+		}
+
+		// Since GetTestBucketOrPanic() always returns an _empty_ bucket, it's safe to wait for the indexes to be empty
+		gocbBucket, isGoCbBucket := base.AsGoCBBucket(testBucket.Bucket)
+		if isGoCbBucket {
+			waitForIndexRollbackErr := WaitForIndexEmpty(gocbBucket, testBucket.BucketSpec.UseXattrs)
+			if waitForIndexRollbackErr != nil {
+				base.Infof(base.KeyAll, "Error WaitForIndexEmpty: %v.  Drop indexes and retry", waitForIndexRollbackErr)
+				if err := base.DropAllBucketIndexes(gocbBucket); err != nil {
+					log.Fatalf("Unable to drop GSI indexes for test: %v", err)
+					// ^^ effectively panics
+				}
+				testBucket.Close()  // Close the bucket, it will get re-opened on next loop iteration
+				continue  // Goes to top of outer for loop to retry
+			}
+
+		}
+
+		return testBucket
+
 	}
 
-	err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0)
-	if err != nil {
-		log.Fatalf("Unable to initialize GSI indexes for test:%v", err)
-	}
-	return testBucket
+	panic(fmt.Sprintf("Failed to create a testbucket after multiple attempts"))
+
+
 }
 
 func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyOptions base.LeakyBucketConfig) *Database {
@@ -1415,6 +1443,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 }
 
 func TestChannelView(t *testing.T) {
+
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -47,7 +47,7 @@ func init() {
 	IndexExpvars = expvar.NewMap("syncGateway_index")
 }
 
-func (k *kvChangeIndex) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) (err error) {
+func (k *kvChangeIndex) Init(context *DatabaseContext, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) (err error) {
 
 	k.context = context
 	k.reader = &kvChangeIndexReader{}
@@ -63,8 +63,9 @@ func (k *kvChangeIndex) Prune() {
 	// TODO: currently no pruning of channel indexes
 }
 
-func (k *kvChangeIndex) Clear() {
+func (k *kvChangeIndex) Clear() error {
 	k.reader.Clear()
+	return nil
 }
 
 func (k *kvChangeIndex) Stop() {
@@ -407,6 +408,9 @@ func (k *kvChangeIndex) generatePartitionStats() (PartitionStats, error) {
 	partitionStats.PartitionsMatch = reflect.DeepEqual(partitionStats.PartitionMap, partitionStats.CBGTMap)
 	return partitionStats, nil
 }
+
+// The following are no-ops for kvChangeIndex.
+func (k *kvChangeIndex) Start() (error) { return nil }
 
 func IsNotFoundError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "not found")

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"math"
+
+	"github.com/couchbase/gocb"
+	"github.com/couchbase/sync_gateway/base"
+	"fmt"
+)
+
+// Workaround SG #3570 by doing a polling loop until the star channel query returns 0 results.
+// Uses the star channel index as a proxy to indicate that _all_ indexes are empty (which might not be true)
+func WaitForIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
+
+	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+
+		var results gocb.QueryResults
+
+		// Create the star channel query
+		statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement)  // append LIMIT 1 since we only care if there are any results or not
+		starChannelQueryStatement := replaceSyncTokensQuery(statement,useXattrs)
+		params := map[string]interface{}{}
+		params[QueryParamStartSeq] = 0
+		params[QueryParamEndSeq] = math.MaxInt64
+
+		// Execute the query
+		results, err = bucket.Query(starChannelQueryStatement, params, gocb.RequestPlus, true)
+
+		// If there was an error, then retry.  Assume it's an "index rollback" error which happens as
+		// the index processes the bucket flush operation
+		if err != nil {
+			base.Infof(base.KeyAll, "Error querying star channel: %v.  Assuming it's a temp error, will retry", err)
+			return true, err, nil
+		}
+
+		// If it's empty, we're done
+		var queryRow AllDocsIndexQueryRow
+		found := results.Next(&queryRow)
+		resultsCloseErr := results.Close()
+		if resultsCloseErr != nil {
+			return false, resultsCloseErr, nil
+		}
+		if !found {
+			base.Infof(base.KeyAll, "WaitForIndexEmpty found 0 results.  GSI index appears to be empty.")
+			return false, nil, nil
+		}
+
+		// Otherwise, retry
+		base.Infof(base.KeyAll, "WaitForIndexEmpty found non-zero results.  Retrying until the GSI index is empty.")
+		return true, nil, nil
+
+	}
+
+	// Kick off the retry loop
+	err, _ := base.RetryLoop(
+		"Wait for index to be empty",
+		retryWorker,
+		base.CreateMaxDoublingSleeperFunc(30, 100, 2000),
+	)
+	return err
+
+}
+
+// Count how many rows are in gocb.QueryResults
+func ResultsEmpty(results gocb.QueryResults) (resultsEmpty bool) {
+
+	var queryRow AllDocsIndexQueryRow
+	found := results.Next(&queryRow)
+	return !found
+
+}
+
+

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -116,7 +116,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="238f46bf38971b117d90e70cba9bd4682428a8b6"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="0b608de1d822b78201f3c5812dce1832f789f0e4"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -862,22 +862,14 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 		AdminInterface: &DefaultAdminInterface,
 	})
 
-	server := base.UnitTestUrl()
-	bucketName := rt1.RestTesterBucket.GetName()
-	spec := base.GetTestBucketSpec(base.DataBucket)
-	username, password, _ := spec.Auth.GetCredentials()
+	// For the second rest tester, create a copy of the original database config and
+	// clear out the sync function.
+	dbConfigCopy, err := rt1.DatabaseConfig.DeepCopy()
+	assertNoError(t, err, "Unexpected error")
+	dbConfigCopy.Sync = base.StringPointer("")
 
 	// Add a second database that uses the same underlying bucket.
-	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   &server,
-			Bucket:   &bucketName,
-			Username: username,
-			Password: password,
-		},
-		NumIndexReplicas: rt1.DatabaseConfig.NumIndexReplicas, // Use the same NumIndexReplicas as original test bucket (0)
-		Name:             "db",
-	})
+	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(dbConfigCopy)
 
 	assertNoError(t, err, "Failed to add database to rest tester")
 
@@ -959,22 +951,14 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 		AdminInterface: &DefaultAdminInterface,
 	})
 
-	server := base.UnitTestUrl()
-	bucketName := rt1.RestTesterBucket.GetName()
-	spec := base.GetTestBucketSpec(base.DataBucket)
-	username, password, _ := spec.Auth.GetCredentials()
+	// For the second rest tester, create a copy of the original database config and
+	// clear out the sync function.
+	dbConfigCopy, err := rt1.DatabaseConfig.DeepCopy()
+	assertNoError(t, err, "Unexpected error calling DeepCopy()")
+	dbConfigCopy.Sync = base.StringPointer("")
 
-	rt1UseXattrs := rt1.GetDatabase().UseXattrs()
-	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   &server,
-			Bucket:   &bucketName,
-			Username: username,
-			Password: password,
-		},
-		Name:         "db",
-		EnableXattrs: &rt1UseXattrs,
-	})
+	// Add a second database that uses the same underlying bucket.
+	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(dbConfigCopy)
 
 	assertNoError(t, err, "Failed to add database to rest tester")
 
@@ -1063,22 +1047,14 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 		AdminInterface: &DefaultAdminInterface,
 	})
 
-	server := base.UnitTestUrl()
-	bucketName := rt1.RestTesterBucket.GetName()
-	spec := base.GetTestBucketSpec(base.DataBucket)
-	username, password, _ := spec.Auth.GetCredentials()
+	// For the second rest tester, create a copy of the original database config and
+	// clear out the sync function.
+	dbConfigCopy, err := rt1.DatabaseConfig.DeepCopy()
+	assertNoError(t, err, "Unexpected error calling DeepCopy()")
+	dbConfigCopy.Sync = base.StringPointer("")
 
-	rt1UseXattrs := rt1.GetDatabase().UseXattrs()
-	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(&DbConfig{
-		BucketConfig: BucketConfig{
-			Server:   &server,
-			Bucket:   &bucketName,
-			Username: username,
-			Password: password,
-		},
-		Name:         "db",
-		EnableXattrs: &rt1UseXattrs,
-	})
+	// Add a second database that uses the same underlying bucket.
+	_, err = rt2.RestTesterServerContext.AddDatabaseFromConfig(dbConfigCopy)
 
 	assertNoError(t, err, "Failed to add database to rest tester")
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -86,7 +86,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	receivedChangesRequestWg := sync.WaitGroup{}
 
 	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+	bt.blipContext.HandlerForProfile.SetHandler("changes", func(request *blip.Message) {
 
 		log.Printf("got changes message: %+v", request)
 		body, err := request.Body()
@@ -118,7 +118,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
 		receivedChangesRequestWg.Done()
 
-	}
+	})
 
 	// Send subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
 	subChangesRequest := blip.NewRequest()
@@ -154,7 +154,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
 	lastReceivedSeq := float64(0)
 	var numbatchesReceived int32
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+	bt.blipContext.HandlerForProfile.SetHandler("changes", func(request *blip.Message) {
 
 		body, err := request.Body()
 
@@ -201,7 +201,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 			response.SetBody(emptyResponseValBytes)
 		}
 
-	}
+	})
 
 	// Increment waitgroup since just the act of subscribing to continuous changes will cause
 	// the callback changes handler to be invoked with an initial change w/ empty body, signaling that
@@ -268,7 +268,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
 	lastReceivedSeq := float64(0)
 	var numbatchesReceived int32
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+	bt.blipContext.HandlerForProfile.SetHandler("changes", func(request *blip.Message) {
 
 		body, err := request.Body()
 
@@ -315,7 +315,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 			response.SetBody(emptyResponseValBytes)
 		}
 
-	}
+	})
 
 	// Increment waitgroup to account for the expected 'caught up' nil changes entry.
 	receivedChangesWg.Add(1)
@@ -420,7 +420,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	// When this test sends subChanges, Sync Gateway will send a changes request that must be handled
 	lastReceivedSeq := float64(0)
 	var numbatchesReceived int32
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+	bt.blipContext.HandlerForProfile.SetHandler("changes", func(request *blip.Message) {
 
 		body, err := request.Body()
 
@@ -477,7 +477,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 			response.SetBody(emptyResponseValBytes)
 		}
 
-	}
+	})
 
 	// Increment waitgroup to account for the expected 'caught up' nil changes entry.
 	receivedChangesWg.Add(1)
@@ -1258,7 +1258,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+	bt.blipContext.HandlerForProfile.SetHandler("changes", func(request *blip.Message) {
 		if !request.NoReply() {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
@@ -1267,7 +1267,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 			assertNoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
-	}
+	})
 
 	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
 	subChangesRequest := blip.NewRequest()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -167,7 +167,7 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 		}
 	}
 
-	ctx.blipContext.HandlerForProfile[profile] = handlerFnWrapper
+	ctx.blipContext.HandlerForProfile.SetHandler(profile, handlerFnWrapper)
 
 }
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -629,12 +629,14 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	maxNum := 50
 	skippedMaxWait := uint32(120000)
 
+	numIndexReplicas := uint(0)
 	shortWaitConfig := &DbConfig{
 		CacheConfig: &CacheConfig{
 			CachePendingSeqMaxWait: &pendingMaxWait,
 			CachePendingSeqMaxNum:  &maxNum,
 			CacheSkippedSeqMaxWait: &skippedMaxWait,
 		},
+		NumIndexReplicas:&numIndexReplicas,
 	}
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
 	defer rt.Close()

--- a/rest/config.go
+++ b/rest/config.go
@@ -472,6 +472,19 @@ func (dbConfig *DbConfig) UseXattrs() bool {
 	return base.DefaultUseXattrs
 }
 
+// Create a deepcopy of this DbConfig, or panic.
+// This will only copy all of the _exported_ fields of the DbConfig.
+func (dbConfig *DbConfig) DeepCopy() (dbConfigCopy *DbConfig, err error) {
+
+	dbConfigDeepCopy := &DbConfig{}
+	err = base.DeepCopyInefficient(&dbConfigDeepCopy, dbConfig)
+	if err != nil {
+		return nil, err
+	}
+	return dbConfigDeepCopy, nil
+
+}
+
 // Implementation of AuthHandler interface for ClusterConfig
 func (clusterConfig *ClusterConfig) GetCredentials() (string, string, string) {
 	return base.TransformBucketCredentials(clusterConfig.Username, clusterConfig.Password, *clusterConfig.Bucket)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -682,6 +682,11 @@ func (h *handler) writeError(err error) {
 		err = auth.OIDCToHTTPError(err) // Map OIDC/OAuth2 errors to HTTP form
 		status, message := base.ErrorAsHTTPStatus(err)
 		h.writeStatus(status, message)
+		format := "%v"
+		if base.StacktraceOnAPIErrors {
+			format = "%+v"
+		}
+		base.Errorf(base.KeyAll, format, err)
 	}
 }
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -46,7 +46,13 @@ type RestTester struct {
 
 func (rt *RestTester) Bucket() base.Bucket {
 
-	if rt.RestTesterBucket == nil {
+	if rt.RestTesterBucket != nil {
+		return rt.RestTesterBucket
+	}
+
+	// Put this in a loop in case certain operations fail, like waiting for GSI indexes to be empty.
+	// Limit number of attempts to 2.
+	for i := 0; i < 2; i++ {
 
 		// Initialize the bucket.  For couchbase-backed tests, triggers with creation/flushing of the bucket
 		if !rt.NoFlush {
@@ -82,7 +88,17 @@ func (rt *RestTester) Bucket() base.Bucket {
 		useXattrs := base.TestUseXattrs()
 
 		if rt.DatabaseConfig == nil {
+
+			// If no db config was passed in, create one
 			rt.DatabaseConfig = &DbConfig{}
+
+			// By default, does NOT use views when running against couchbase server, since should use GSI
+			rt.DatabaseConfig.UseViews = base.TestUseViews()
+
+			// numReplicas set to 0 for test buckets, since it should assume that there is only one node.
+			numReplicas := uint(0)
+			rt.DatabaseConfig.NumIndexReplicas = &numReplicas
+
 		}
 
 		rt.DatabaseConfig.BucketConfig = BucketConfig{
@@ -99,24 +115,37 @@ func (rt *RestTester) Bucket() base.Bucket {
 			rt.DatabaseConfig.AllowConflicts = &boolVal
 		}
 
-		// Set to 0 for test buckets, since it should assume that there is only one node.
-		numReplicas := uint(0)
-
-		rt.DatabaseConfig.UseViews = base.TestUseViews()
-		rt.DatabaseConfig.NumIndexReplicas = &numReplicas
-
 		_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(rt.DatabaseConfig)
 		if err != nil {
 			panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))
 		}
 		rt.RestTesterBucket = rt.RestTesterServerContext.Database("db").Bucket
 
+		// As long as bucket flushing wasn't disabled, wait for index to be empty (if this is a gocb bucket)
+		if !rt.NoFlush {
+			asGoCbBucket, isGoCbBucket := base.AsGoCBBucket(rt.RestTesterBucket)
+			if isGoCbBucket {
+				if err := db.WaitForIndexEmpty(asGoCbBucket, spec.UseXattrs); err != nil {
+					base.Infof(base.KeyAll, "WaitForIndexEmpty returned an error: %v.  Dropping indexes and retrying", err)
+					// if WaitForIndexEmpty returns error, drop the indexes and retry
+					if err := base.DropAllBucketIndexes(asGoCbBucket); err != nil {
+						panic(fmt.Sprintf("Failed to drop bucket indexes: %v", err))
+					}
+
+					continue  // Go to the top of the for loop to retry
+				}
+			}
+		}
+
 		if !rt.noAdminParty {
 			rt.SetAdminParty(true)
 		}
 
+		return rt.RestTesterBucket
 	}
-	return rt.RestTesterBucket
+
+	panic(fmt.Sprintf("Failed to create a RestTesterBucket after multiple attempts"))
+
 }
 
 func (rt *RestTester) BucketAllowEmptyPassword() base.Bucket {
@@ -365,6 +394,14 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 		} else {
 			response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 		}
+
+		// If the view is undefined, it might be a race condition where the view is still being created
+		// See https://github.com/couchbase/sync_gateway/issues/3570#issuecomment-390487982
+		if strings.Contains(response.Body.String(), "view_undefined") {
+			base.Infof(base.KeyAll, "view_undefined error: %v.  Retrying", response.Body.String())
+			return true, nil, nil
+		}
+
 		if response.Code != 200 {
 			return false, fmt.Errorf("Got response code: %d from view call.  Expected 200.", response.Code), sgbucket.ViewResult{}
 		}

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -95,9 +95,10 @@ func TestViewQuery(t *testing.T) {
 
 }
 
-//Tests #1109, where design doc contains multiple views
+//Tests #1109, wh ere design doc contains multiple views
 func TestViewQueryMultipleViews(t *testing.T) {
-	var rt RestTester
+
+	rt := RestTester{}
 	defer rt.Close()
 
 	//Define three views
@@ -126,6 +127,7 @@ func TestViewQueryMultipleViews(t *testing.T) {
 }
 
 func TestViewQueryUserAccess(t *testing.T) {
+
 	var rt RestTester
 	defer rt.Close()
 
@@ -140,12 +142,14 @@ func TestViewQueryUserAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
-	assertNoError(t, err, "Unexpected error")
+	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
 	assert.Equals(t, len(result.Rows), 2)
 	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
+	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
+
 	assert.Equals(t, len(result.Rows), 2)
 	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
@@ -157,7 +161,8 @@ func TestViewQueryUserAccess(t *testing.T) {
 	a.Save(testUser)
 
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
-	assertNoError(t, err, "Unexpected error")
+	assertNoError(t, err, "Unexpected error in WaitForNUserViewResults")
+
 	assert.Equals(t, len(result.Rows), 2)
 	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
@@ -168,6 +173,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	request.SetBasicAuth(testUser.Name(), password)
 	userResponse := rt.Send(request)
 	assertStatus(t, userResponse, 403)
+
 }
 
 func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
@@ -210,6 +216,7 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 }
 
 func TestUserViewQuery(t *testing.T) {
+
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
@@ -525,6 +532,7 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 }
 
 func TestPostInstallCleanup(t *testing.T) {
+
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 

--- a/tools/password_remover.py
+++ b/tools/password_remover.py
@@ -6,8 +6,7 @@ Redacts sensitive data in config files
 
 import unittest
 import json
-import re
-from urlparse import urlparse, urlunparse
+from urlparse import urlparse
 import traceback
 
 
@@ -22,7 +21,7 @@ def is_valid_json(invalid_json):
     except Exception as e:
         pass
 
-    return got_exception == False
+    return got_exception is False
 
 
 def tag_userdata_in_server_config(json_text, log_json_parsing_exceptions=True):
@@ -193,8 +192,8 @@ def strip_password_from_url(url_string):
     """
 
     parsed_url = urlparse(url_string)
-    if parsed_url.username == None and parsed_url.password == None:
-       return url_string
+    if parsed_url.username is None and parsed_url.password is None:
+        return url_string
 
     new_url = "{0}://{1}:*****@{2}:{3}/{4}".format(
         parsed_url.scheme,
@@ -345,7 +344,6 @@ class TestRemovePasswords(unittest.TestCase):
         with_passwords_removed = remove_passwords(json_with_passwords)
         assert "foobar" not in with_passwords_removed
 
-
     def test_alternative_config(self):
 
         sg_config = '{"Interface":":4984","AdminInterface":":4985","Facebook":{"Register":true},"Log":["*"],"Databases":{"todolite":{"server":"http://localhost:8091","pool":"default","bucket":"default","password":"foobar","name":"todolite","sync":"\\nfunction(doc, oldDoc) {\\n  // NOTE this function is the same across the iOS, Android, and PhoneGap versions.\\n  if (doc.type == \\"task\\") {\\n    if (!doc.list_id) {\\n      throw({forbidden : \\"Items must have a list_id.\\"});\\n    }\\n    channel(\\"list-\\"+doc.list_id);\\n  } else if (doc.type == \\"list\\" || (doc._deleted \\u0026\\u0026 oldDoc \\u0026\\u0026 oldDoc.type == \\"list\\")) {\\n    // Make sure that the owner propery exists:\\n    var owner = oldDoc ? oldDoc.owner : doc.owner;\\n    if (!owner) {\\n      throw({forbidden : \\"List must have an owner.\\"});\\n    }\\n\\n    // Make sure that only the owner of the list can update the list:\\n    if (doc.owner \\u0026\\u0026 owner != doc.owner) {\\n      throw({forbidden : \\"Cannot change owner for lists.\\"});\\n    }\\n\\n    var ownerName = owner.substring(owner.indexOf(\\":\\")+1);\\n    requireUser(ownerName);\\n\\n    var ch = \\"list-\\"+doc._id;\\n    if (!doc._deleted) {\\n      channel(ch);\\n    }\\n\\n    // Grant owner access to the channel:\\n    access(ownerName, ch);\\n\\n    // Grant shared members access to the channel:\\n    var members = !doc._deleted ? doc.members : oldDoc.members;\\n    if (Array.isArray(members)) {\\n      var memberNames = [];\\n      for (var i = members.length - 1; i \\u003e= 0; i--) {\\n        memberNames.push(members[i].substring(members[i].indexOf(\\":\\")+1))\\n      };\\n      access(memberNames, ch);\\n    }\\n  } else if (doc.type == \\"profile\\") {\\n    channel(\\"profiles\\");\\n    var user = doc._id.substring(doc._id.indexOf(\\":\\")+1);\\n    if (user !== doc.user_id) {\\n      throw({forbidden : \\"Profile user_id must match docid.\\"});\\n    }\\n    requireUser(user);\\n    access(user, \\"profiles\\");\\n  }\\n}\\n","users":{"GUEST":{"name":"","admin_channels":["*"],"all_channels":null,"disabled":true}}}}}'
@@ -450,11 +448,11 @@ class TestTagUserData(unittest.TestCase):
         """
         tagged = tag_userdata_in_server_config(json_with_userdata)
         assert "<ud>uber_secret_channel</ud>" in tagged
-        assert "<ud>foo</ud>" in tagged # everything is lowercased
+        assert "<ud>foo</ud>" in tagged           # everything is lowercased
         assert "<ud>bucket-user</ud>" in tagged
 
-        assert "<ud>baz</ud>" not in tagged # passwords shouldn't be tagged, they get removed
-        assert "<ud>bucket-1</ud>" not in tagged # bucket name is acutally metadata
+        assert "<ud>baz</ud>" not in tagged       # passwords shouldn't be tagged, they get removed
+        assert "<ud>bucket-1</ud>" not in tagged  # bucket name is acutally metadata
 
 
 class TestConvertToValidJSON(unittest.TestCase):
@@ -496,12 +494,12 @@ class TestConvertToValidJSON(unittest.TestCase):
         got_exception = True
         try:
             parsed_json = json.loads(valid_json)
-            formatted_json_string = json.dumps(parsed_json, indent=4)
+            json.dumps(parsed_json, indent=4)
             got_exception = False
         except Exception as e:
             print("Exception: {0}".format(e))
 
-        assert got_exception == False, "Failed to convert to valid JSON"
+        assert got_exception is False, "Failed to convert to valid JSON"
 
     def basic_test_two_sync_functions(self):
 
@@ -562,12 +560,12 @@ class TestConvertToValidJSON(unittest.TestCase):
         got_exception = True
         try:
             parsed_json = json.loads(valid_json)
-            formatted_json_string = json.dumps(parsed_json, indent=4)
+            json.dumps(parsed_json, indent=4)
             got_exception = False
         except Exception as e:
             print("Exception: {0}".format(e))
 
-        assert got_exception == False, "Failed to convert to valid JSON"
+        assert got_exception is False, "Failed to convert to valid JSON"
 
 
 if __name__ == "__main__":

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -3,24 +3,16 @@
 import os
 import sys
 import tempfile
-import time
 import subprocess
-import string
 import re
 import platform
 import glob
-import socket
-import threading
 import optparse
-import atexit
-import signal
-import urllib
-import urllib2 
+import urllib2
 import shutil
-import urlparse
 import json
-import tempfile
 import uuid
+
 from sys import platform as _platform
 
 from tasks import CbcollectInfoOptions
@@ -28,15 +20,14 @@ from tasks import dump_utilities
 from tasks import generate_upload_url
 from tasks import TaskRunner
 from tasks import make_os_tasks
-from tasks import get_server_guts
 from tasks import log
-from tasks import read_guts
 from tasks import AllOsTask
 from tasks import make_curl_task
 from tasks import flatten
 from tasks import do_upload_and_exit
 from tasks import add_file_task
 from tasks import add_gzip_file_task
+from tasks import setup_stdin_watcher
 
 import password_remover
 
@@ -61,8 +52,8 @@ else:
 # See https://github.com/couchbase/sync_gateway/issues/1640
 #
 # Python version compatibility:
-# 
-# Until the libc / centos6 issues are resolved, this should remain python 2.6 compatible.  
+#
+# Until the libc / centos6 issues are resolved, this should remain python 2.6 compatible.
 # One common incompatibility is the formatting syntax, as discussed here: http://bit.ly/2rIH8wg
 USAGE = """usage: %prog [options] output_file.zip
 
@@ -71,6 +62,7 @@ USAGE = """usage: %prog [options] output_file.zip
     %prog -v output_file.zip"""
 
 mydir = os.path.dirname(sys.argv[0])
+
 
 def create_option_parser():
     parser = optparse.OptionParser(usage=USAGE, option_class=CbcollectInfoOptions)
@@ -115,6 +107,7 @@ def create_option_parser():
     parser.add_option("--sync-gateway-executable", dest="sync_gateway_executable",
                       help="path to Sync Gateway executable.  By default will try to discover via expvars")
     return parser
+
 
 def expvar_url(sg_url):
 
@@ -176,7 +169,7 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
     if sg_binary_path is None:
         sg_binary_path = ""
 
-    #if sg_binary_path does not point to a file, generate a new path by starting with the location of sgcollect_info script
+    # if sg_binary_path does not point to a file, generate a new path by starting with the location of sgcollect_info script
     if not os.path.isfile(sg_binary_path):
         # the filename of the sg_binary without any path information, eg, "sync_gateway"
         sg_binary_filename = os.path.basename(sg_binary_path)
@@ -215,11 +208,13 @@ def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
 
     return pprof_tasks
 
+
 def to_lower_case_keys_dict(original_dict):
     result = {}
-    for k,v in original_dict.items():
-        result[k.lower()] = v 
+    for k, v in original_dict.items():
+        result[k.lower()] = v
     return result
+
 
 def extract_element_from_config(element, config):
     """ The config returned from /_config may not be fully formed json
@@ -234,12 +229,13 @@ def extract_element_from_config(element, config):
         # convert dictionary keys to lower case
         original_dict = json.loads(config)
         lower_case_keys_dict = to_lower_case_keys_dict(original_dict)
-        
-        #lookup key after converting element name to lower case
+
+        # lookup key after converting element name to lower case
         return lower_case_keys_dict[element.lower()]
     except (ValueError, KeyError):
         # If we can't deserialise the json or find the key then return nothing
         return
+
 
 def extract_element_from_default_logging_config(element, config):
     # extracts a property from nested logging object
@@ -256,6 +252,7 @@ def extract_element_from_default_logging_config(element, config):
             # If we can't deserialise the json or find the key then return nothing
             return
 
+
 def extract_element_from_logging_config(element, config):
     # extracts a property from nested logging object
         try:
@@ -268,6 +265,7 @@ def extract_element_from_logging_config(element, config):
         except (ValueError, KeyError):
             # If we can't deserialise the json or find the key then return nothing
             return
+
 
 def make_collect_logs_tasks(zip_dir, sg_url):
 
@@ -328,7 +326,6 @@ def make_collect_logs_tasks(zip_dir, sg_url):
             # Track which log file paths have been added so far
             sg_log_file_paths[sg_log_file_path] = sg_log_file_path
 
-
     # Find log file path from logging.["default"] style config
     guessed_logging_path = extract_element_from_default_logging_config('LogFilePath', config_str)
     if guessed_logging_path:
@@ -345,11 +342,10 @@ def make_collect_logs_tasks(zip_dir, sg_url):
         )
 
         for log_file_item_name in glob.iglob(rotated_logs_pattern):
-            log_file_item_path = os.path.join(log_file_parent_dir,log_file_item_name)
+            log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
             print('Capturing rotated log file {0}'.format(log_file_item_path))
             task = add_file_task(sourcefile_path=log_file_item_path)
             sg_tasks.append(task)
-
 
     # Find log file path from SGW 2.1 style logging config
     guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)
@@ -391,7 +387,6 @@ def get_db_list(sg_url):
 
     # build url to _all_dbs
     all_dbs_url = "{0}/_all_dbs".format(sg_url)
-
     data = []
 
     # get content and parse into json
@@ -418,7 +413,7 @@ def make_status_tasks(sg_url, should_redact):
                           url=sg_url,
                           log_file="server_status.log")
     tasks.append(task)
-        
+
     # Get list of dbs from _all_dbs
     # For each db, get db config
     dbs = get_db_list(sg_url)
@@ -432,7 +427,7 @@ def make_status_tasks(sg_url, should_redact):
         tasks.append(task)
 
     return tasks
-    
+
 
 # Startup config
 #   Commandline args (covered in expvars, IIRC)
@@ -458,7 +453,7 @@ def make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact):
         R'C:\Program Files\Couchbase\Sync Gateway Accelerator\basic_sg_accel_config.json',  # Windows (Post-2.0) sg accel
         R'C:\Program Files\Couchbase\Sync Gateway\serviceconfig.json'    # Windows (Post-2.0) sync gateway
     ]
-    sg_config_files = [ x for x in sg_config_files if os.path.exists(x)]
+    sg_config_files = [x for x in sg_config_files if os.path.exists(x)]
 
     # If a config path was discovered from the expvars, or passed in via the user, add that in the
     # list of files to probe
@@ -512,14 +507,14 @@ def get_config_path_from_cmdline(cmdline_args):
         if ".json" in cmdline_arg and "http" not in cmdline_arg:
             return cmdline_arg
     return None
-    
+
 
 def get_paths_from_expvars(sg_url):
 
     data = None
     sg_binary_path = None
     sg_config_path = None
-    
+
     # get content and parse into json
     try:
         response = urllib2.urlopen(expvar_url(sg_url))
@@ -527,7 +522,7 @@ def get_paths_from_expvars(sg_url):
     except urllib2.URLError as e:
         print("WARNING: Unable to connect to Sync Gateway: {0}".format(e))
 
-    if data is not None and data.has_key("cmdline"):
+    if data is not None and "cmdline" in data:
         cmdline_args = data["cmdline"]
         if len(cmdline_args) == 0:
             return (sg_binary_path, sg_config_path)
@@ -567,14 +562,14 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
 
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(sg_url)
-    print "Discovered from expvars: sg_binary_path={0} sg_config_path={1}".format(sg_binary_path, sg_config_path)
+    print("Discovered from expvars: sg_binary_path={0} sg_config_path={1}".format(sg_binary_path, sg_config_path))
 
     # If user passed in a specific path to the SG binary, then use it
     if sync_gateway_executable_path is not None and len(sync_gateway_executable_path) > 0:
         if not os.path.exists(sync_gateway_executable_path):
             raise Exception("Path to sync gateway executable passed in does not exist: {0}".format(sync_gateway_executable_path))
         sg_binary_path = sync_gateway_executable_path
-    
+
     # Collect logs
     collect_logs_tasks = make_collect_logs_tasks(zip_dir, sg_url)
 
@@ -583,7 +578,7 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
     # If the user passed in a valid config path, then use that rather than what's in the expvars
     if sync_gateway_config_path_option is not None and len(sync_gateway_config_path_option) > 0 and os.path.exists(sync_gateway_config_path_option):
         sg_config_path = sync_gateway_config_path_option
-    
+
     # Add a task to collect pprofs
     go_tool_pprof_tasks = make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url)
 
@@ -591,10 +586,10 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
 
     # Add a task to collect Sync Gateway config
     config_tasks = make_config_tasks(zip_dir, sg_config_path, sg_url, should_redact)
-    
-    # Curl the / endpoint and /db endpoints and save output 
+
+    # Curl the / endpoint and /db endpoints and save output
     status_tasks = make_status_tasks(sg_url, should_redact)
-    
+
     # Compbine all tasks into flattened list
     sg_tasks = flatten(
         [
@@ -606,8 +601,9 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
             status_tasks,
         ]
     )
-    
+
     return sg_tasks
+
 
 def discover_sg_binary_path(options, sg_url):
 
@@ -624,7 +620,6 @@ def discover_sg_binary_path(options, sg_url):
         if os.path.exists(sg_binary_path_candidate):
             return sg_binary_path_candidate
 
-
     sg_binary_path, _ = get_paths_from_expvars(sg_url)
 
     if options.sync_gateway_executable is not None and len(options.sync_gateway_executable) > 0:
@@ -636,6 +631,7 @@ def discover_sg_binary_path(options, sg_url):
     # fallback to whatever was specified in options
     return options.sync_gateway_executable
 
+
 def main():
 
     # ask all tools to use C locale (MB-12050)
@@ -646,7 +642,7 @@ def main():
     if platform.system() == 'Darwin':
         os.environ["COUCHBASE_TOP"] = os.path.abspath(os.path.join(mydir, ".."))
 
-    # Parse command line options 
+    # Parse command line options
     parser = create_option_parser()
     options, args = parser.parse_args()
 
@@ -662,7 +658,7 @@ def main():
     sg_url = options.sync_gateway_url
     if sg_url is None:
         sg_url = "http://127.0.0.1:4985"
-    print "Using Sync Gateway URL: {0}".format(sg_url)
+    print("Using Sync Gateway URL: {0}".format(sg_url))
 
     # Build path to zip directory, make sure it exists
     zip_filename = args[0]
@@ -711,7 +707,7 @@ def main():
 
         os.environ['LD_LIBRARY_PATH'] = ':'.join(library_path)
 
-    # Windows 
+    # Windows
     elif os.name == 'nt':
 
         path = [
@@ -721,7 +717,7 @@ def main():
         os.environ['PATH'] = ';'.join(path)
 
     # If user asked to just upload, then upload and exit
-    if options.just_upload_into != None:
+    if options.just_upload_into is not None:
         do_upload_and_exit(args[0], options.just_upload_into)
 
     # Create a TaskRunner and run all of the OS tasks (collect top, netstat, etc)
@@ -746,7 +742,7 @@ def main():
     if sg_binary_path is not None and sg_binary_path != "" and os.path.exists(sg_binary_path):
         runner.collect_file(sg_binary_path)
     else:
-        print "WARNING: unable to find Sync Gateway executable, omitting from result.  Go pprofs will not be accurate."
+        print("WARNING: unable to find Sync Gateway executable, omitting from result.  Go pprofs will not be accurate.")
 
     # Echo the command line args used to run sgcollect_info
     cmd_line_args_task = AllOsTask(
@@ -785,9 +781,9 @@ def main():
             do_upload_and_exit(zip_filename, upload_url)
 
     if options.redact_level != "none":
-        print "Zipfile built: {0}".format(redact_zip_file)
+        print("Zipfile built: {0}".format(redact_zip_file))
 
-    print "Zipfile built: {0}".format(zip_filename)
+    print("Zipfile built: {0}".format(zip_filename))
 
 
 def ud(value, should_redact=True):


### PR DESCRIPTION
Fixes #3335 

Changes go-blip's `HandlerForProfile` to a struct rather than a raw map, and the struct provides the appropriate locking to protect the map from data races.

- [ ] Companion go-blip PR
- [ ] Integration tests (http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/741/)