### PR TITLE
#3579 Add SetUpTestLogging to setup and teardown logging in tests

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1256,8 +1256,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
 	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
+		t.Error("Can't cast to bucket")
 	}
 
 	// Create document with XATTR
@@ -1306,7 +1305,7 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	EnableTestLogKey("CRUD+")
+	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
 
 	testBucket := GetTestBucketOrPanic()
 	defer testBucket.Close()
@@ -1406,7 +1405,7 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	EnableTestLogKey("CRUD+")
+	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
 
 	testBucket := GetTestBucketOrPanic()
 	defer testBucket.Close()

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -117,12 +117,25 @@ func (keyMask *LogKey) enabled(logKey LogKey, checkWildcards bool) bool {
 	return flag&uint64(logKey) != 0
 }
 
-// String returns the string representation of a single log key.
+// String returns the string representation of one or more log keys.
 func (logKey LogKey) String() string {
 	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
 	if str, ok := logKeyNames[logKey]; ok {
 		return str
 	}
+
+	// Try to pretty-print a set of log keys.
+	names := []string{}
+	for k, v := range logKeyNames {
+		if logKey&k != 0 {
+			names = append(names, v)
+		}
+	}
+	if len(names) > 0 {
+		return strings.Join(names, ", ")
+	}
+
+	// Fall back to a binary representation.
 	return fmt.Sprintf("LogKey(%b)", logKey)
 }
 

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -43,9 +42,10 @@ func TestLogKeyNames(t *testing.T) {
 	name := KeyDCP.String()
 	assert.Equals(t, name, "DCP")
 
-	// Combined log keys, or key masks print the binary representation.
+	// Combined log keys, will pretty-print a set of log keys
 	name = LogKey(KeyDCP | KeyReplicate).String()
-	assert.Equals(t, name, fmt.Sprintf("LogKey(%b)", KeyDCP|KeyReplicate))
+	assert.StringContains(t, name, "DCP")
+	assert.StringContains(t, name, "Replicate")
 
 	keys := []string{}
 	logKeys := ToLogKey(keys)

--- a/base/logging.go
+++ b/base/logging.go
@@ -269,7 +269,7 @@ func UpdateLogKeys(keys map[string]bool, replace bool) {
 
 // Returns a string identifying a function on the call stack.
 // Use depth=1 for the caller of the function that calls GetCallersName, etc.
-func GetCallersName(depth int) string {
+func GetCallersName(depth int, includeLine bool) string {
 	pc, file, line, ok := runtime.Caller(depth + 1)
 	if !ok {
 		return "???"
@@ -277,10 +277,14 @@ func GetCallersName(depth int) string {
 
 	fnname := ""
 	if fn := runtime.FuncForPC(pc); fn != nil {
-		fnname = fn.Name()
+		fnname = lastComponent(fn.Name())
 	}
 
-	return fmt.Sprintf("%s() at %s:%d", lastComponent(fnname), lastComponent(file), line)
+	if !includeLine {
+		return fnname
+	}
+
+	return fmt.Sprintf("%s() at %s:%d", fnname, lastComponent(file), line)
 }
 
 // Partial interface for the SGLogger
@@ -426,7 +430,7 @@ func logTo(logLevel LogLevel, logKey LogKey, format string, args ...interface{})
 
 	// Warn and error logs also append caller name/line numbers.
 	if logLevel <= LevelWarn {
-		format += " -- " + GetCallersName(2)
+		format += " -- " + GetCallersName(2, true)
 	}
 
 	// Perform log redaction, if necessary.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -548,8 +548,8 @@ func NumOpenBuckets(bucketName string) int32 {
 // Shorthand style:
 //     defer SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)()
 func SetUpTestLogging(logLevel LogLevel, logKeys LogKey) (teardownFn func()) {
-	Infof(KeyAll, "Test: Set log level: %v", logLevel)
-	Infof(KeyAll, "Test: Set log keys: %v", logKeys)
+	caller := GetCallersName(1, false)
+	Infof(KeyAll, "%s: Log Level: %v - Log Keys: %v", caller, logLevel, logKeys)
 
 	// Set the console logger settings
 	consoleLogger.LogLevel.Set(logLevel)
@@ -560,8 +560,7 @@ func SetUpTestLogging(logLevel LogLevel, logKeys LogKey) (teardownFn func()) {
 		consoleLogger.LogLevel.Set(LevelInfo)
 		consoleLogger.LogKey.Set(KeyHTTP)
 
-		Infof(KeyAll, "Test: Reset log level: %v", LevelInfo)
-		Infof(KeyAll, "Test: Reset log keys: %v", KeyHTTP)
+		Infof(KeyAll, "%v: Reset logging", caller)
 	}
 }
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -549,7 +549,7 @@ func NumOpenBuckets(bucketName string) int32 {
 //     defer SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)()
 func SetUpTestLogging(logLevel LogLevel, logKeys LogKey) (teardownFn func()) {
 	caller := GetCallersName(1, false)
-	Infof(KeyAll, "%s: Log Level: %v - Log Keys: %v", caller, logLevel, logKeys)
+	Infof(KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
 
 	// Set the console logger settings
 	consoleLogger.LogLevel.Set(logLevel)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb"
-	"encoding/json"
 )
 
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
@@ -39,9 +39,6 @@ func (tb TestBucket) Close() {
 	tb.Bucket.Close()
 
 	DecrNumOpenBuckets(tb.Bucket.GetName())
-
-	ResetTestLogging()
-
 }
 
 func GetTestBucketOrPanic() TestBucket {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -535,20 +535,34 @@ func NumOpenBuckets(bucketName string) int32 {
 	return numOpen
 }
 
-// EnableTestLogKey will enable the given log key, if it exists,
-// and also enable debug level logging, if a + log key is provided.
-func EnableTestLogKey(logKey string) {
-	if strings.HasSuffix(logKey, "+") {
-		ConsoleLogLevel().Set(LevelDebug)
-	}
-	newLogKey := ToLogKey([]string{logKey})
-	ConsoleLogKey().Enable(newLogKey)
-}
+// SetUpTestLogging will set the given log level and log keys,
+// and return a function that can be deferred for teardown.
+//
+// To set multiple log keys, use the bitwise OR operator.
+// E.g. KeyCache|KeyDCP|KeySync
+//
+// Usage:
+//     teardownFn := SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)
+//     defer teardownFn()
+//
+// Shorthand style:
+//     defer SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)()
+func SetUpTestLogging(logLevel LogLevel, logKeys LogKey) (teardownFn func()) {
+	Infof(KeyAll, "Test: Set log level: %v", logLevel)
+	Infof(KeyAll, "Test: Set log keys: %v", logKeys)
 
-// ResetTestLogging return logging back to a standard state (Info level and HTTP log key)
-func ResetTestLogging() {
-	ConsoleLogLevel().Set(LevelInfo)
-	ConsoleLogKey().Set(KeyHTTP)
+	// Set the console logger settings
+	consoleLogger.LogLevel.Set(logLevel)
+	consoleLogger.LogKey.Set(logKeys)
+
+	return func() {
+		// Return to default state
+		consoleLogger.LogLevel.Set(LevelInfo)
+		consoleLogger.LogKey.Set(KeyHTTP)
+
+		Infof(KeyAll, "Test: Reset log level: %v", LevelInfo)
+		Infof(KeyAll, "Test: Reset log keys: %v", KeyHTTP)
+	}
 }
 
 // Make a deep copy from src into dst.

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -479,18 +479,11 @@ func TestContinuousChangesBackfill(t *testing.T) {
 // Test low sequence handling of late arriving sequences to a continuous changes feed
 func TestLowSequenceHandling(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyQuery)()
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
-
-	var logKeys = map[string]bool{
-		"Cache":                true,
-		"Changes":              true,
-		"Changes+":             true,
-		base.KeyQuery.String(): true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -552,18 +545,11 @@ func TestLowSequenceHandling(t *testing.T) {
 // user doesn't have visibility to some of the late arriving sequences
 func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyQuery)()
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
-
-	var logKeys = map[string]bool{
-		"Cache":                true,
-		"Changes":              true,
-		"Changes+":             true,
-		base.KeyQuery.String(): true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -613,15 +599,11 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 // user gets added to a new channel with existing entries (and existing backfill)
 func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges|base.KeyQuery)()
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
-
-	var logKeys = map[string]bool{
-		"Sequence":             true,
-		base.KeyQuery.String(): true,
-	}
-	base.UpdateLogKeys(logKeys, true)
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -695,17 +677,11 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	// TODO: Disabled until https://github.com/couchbase/sync_gateway/issues/3056 is fixed.
 	t.Skip("WARNING: TEST DISABLED")
 
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges|base.KeyCache)()
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
-
-	var logKeys = map[string]bool{
-		"Cache":    true,
-		"Changes":  true,
-		"Changes+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -794,15 +770,11 @@ func TestChannelRace(t *testing.T) {
 	// Disabling for now - should be refactored.
 	t.Skip("WARNING: TEST DISABLED")
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges)()
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
-
-	var logKeys = map[string]bool{
-		"Sequences": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -896,12 +868,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	var logKeys = map[string]bool{
-		"Cache":  true,
-		"Cache+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache)()
 
 	// Use leaky bucket to have the tap feed 'lose' document 3
 	leakyConfig := base.LeakyBucketConfig{

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -277,13 +277,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("DCP+")
-
-	defer func() {
-		base.ResetTestLogging()
-	}()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyDCP)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer tearDownTestDB(t, db)
@@ -322,8 +316,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -389,10 +382,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	base.EnableTestLogKey("Sequences")
-	base.EnableTestLogKey("Cache")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("DCP")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyChanges|base.KeyDCP)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -949,8 +939,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 // Test that housekeeping goroutines get terminated when change cache is stopped
 func TestStopChangeCache(t *testing.T) {
 
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("DCP+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges|base.KeyDCP)()
 
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
@@ -996,7 +985,7 @@ func TestChannelCacheSize(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	base.EnableTestLogKey("Cache+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache)()
 
 	channelOptions := ChannelCacheOptions{
 		ChannelCacheMinLength: 600,
@@ -1212,8 +1201,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	}
 
 	// Enable relevant logging
-	base.EnableTestLogKey("Cache")
-	base.EnableTestLogKey("Changes")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyChanges)()
 
 	// Create a test db that uses channel cache
 	channelOptions := ChannelCacheOptions{

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -31,7 +31,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -131,7 +131,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  See https://gist.github.com/tleyden/a41632355fadde54f19e84ba68015512")
 	}
 
-	base.EnableTestLogKey("*")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestDuplicateDocID(t *testing.T) {
 
-	base.EnableTestLogKey("Cache")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	context := testBucketContext()
 	defer context.Close()
@@ -68,7 +68,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 func TestLateArrivingSequence(t *testing.T) {
 
-	base.EnableTestLogKey("Cache")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	context := testBucketContext()
 	defer context.Close()
@@ -101,7 +101,7 @@ func TestLateArrivingSequence(t *testing.T) {
 
 func TestLateSequenceAsFirst(t *testing.T) {
 
-	base.EnableTestLogKey("Cache")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	context := testBucketContext()
 	defer context.Close()
@@ -134,7 +134,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 func TestDuplicateLateArrivingSequence(t *testing.T) {
 
-	base.EnableTestLogKey("Cache")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	context := testBucketContext()
 	defer context.Close()
@@ -208,8 +208,8 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 func TestPrependChanges(t *testing.T) {
 
-	base.EnableTestLogKey("Cache")
-	defer base.ResetTestLogging()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
+
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -430,7 +430,7 @@ func writeEntries(entries []*LogEntry) {
 
 func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -449,7 +449,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -466,7 +466,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -483,7 +483,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -500,7 +500,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -517,9 +517,8 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
-	base.EnableTestLogKey("Cache")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	//base.SetLogLevel(2) // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -536,7 +535,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -650,13 +650,7 @@ func TestAllDocsOnly(t *testing.T) {
 // Unit test for bug #673
 func TestUpdatePrincipal(t *testing.T) {
 
-	var logKeys = map[string]bool{
-		"Cache":    true,
-		"Changes":  true,
-		"Changes+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
@@ -733,16 +727,6 @@ func TestConflicts(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
-
-	/*
-		var logKeys = map[string]bool {
-			"Cache": true,
-			"Changes": true,
-			"Changes+": true,
-		}
-
-		base.UpdateLogKeys(logKeys, true)
-	*/
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
@@ -840,16 +824,6 @@ func TestNoConflictsMode(t *testing.T) {
 	// Strictly speaking, this flag should be set before opening the database, but it only affects
 	// Put operations and replication, so it doesn't make a difference if we do it afterwards.
 	db.Options.AllowConflicts = base.BooleanPointer(false)
-
-	/*
-		var logKeys = map[string]bool {
-			"Cache": true,
-			"Changes": true,
-			"Changes+": true,
-		}
-
-		base.UpdateLogKeys(logKeys, true)
-	*/
 
 	// Create revs 1 and 2 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -90,7 +90,7 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database,
 func testBucket() base.TestBucket {
 
 	// Retry loop in case the GSI indexes don't handle the flush and we need to drop them and retry
-	for i:= 0; i < 2; i++ {
+	for i := 0; i < 2; i++ {
 
 		testBucket := base.GetTestBucketOrPanic()
 		err := installViews(testBucket.Bucket)
@@ -115,8 +115,8 @@ func testBucket() base.TestBucket {
 					log.Fatalf("Unable to drop GSI indexes for test: %v", err)
 					// ^^ effectively panics
 				}
-				testBucket.Close()  // Close the bucket, it will get re-opened on next loop iteration
-				continue  // Goes to top of outer for loop to retry
+				testBucket.Close() // Close the bucket, it will get re-opened on next loop iteration
+				continue           // Goes to top of outer for loop to retry
 			}
 
 		}
@@ -126,7 +126,6 @@ func testBucket() base.TestBucket {
 	}
 
 	panic(fmt.Sprintf("Failed to create a testbucket after multiple attempts"))
-
 
 }
 
@@ -1489,7 +1488,7 @@ func TestConcurrentImport(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	base.EnableTestLogKey("Import")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
 
 	// Add doc to the underlying bucket:
 	db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
@@ -1553,7 +1552,8 @@ func TestViewCustom(t *testing.T) {
 //////// BENCHMARKS
 
 func BenchmarkDatabase(b *testing.B) {
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+
 	for i := 0; i < b.N; i++ {
 		bucket, _ := ConnectToBucket(base.BucketSpec{
 			Server:          base.UnitTestUrl(),

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -153,14 +153,10 @@ func TestDBStateChangeEvent(t *testing.T) {
 // the max concurrent goroutines
 func TestSlowExecutionProcessing(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyEvents)()
+
 	em := NewEventManager()
 	em.Start(0, -1)
-
-	var logKeys = map[string]bool{
-		"Events": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
 
 	ids := make([]string, 20)
 	for i := 0; i < 20; i++ {
@@ -581,16 +577,11 @@ func TestWebhookOldDoc(t *testing.T) {
 }
 
 func TestWebhookTimeout(t *testing.T) {
-
 	if !testLiveHTTP {
 		return
 	}
 
-	var logKeys = map[string]bool{
-		"Events+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyEvents)()
 
 	count, sum, _ := InitWebhookTest()
 	ids := make([]string, 200)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -25,8 +25,7 @@ func TestMigrateMetadata(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
-	base.EnableTestLogKey("Migrate")
-	base.EnableTestLogKey("Import")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate|base.KeyImport)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
@@ -95,8 +94,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
-	base.EnableTestLogKey("Migrate")
-	base.EnableTestLogKey("Import")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate|base.KeyImport)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -181,7 +181,7 @@ func TestDenseBlockGetEntry(t *testing.T) {
 
 func TestDenseBlockMultipleUpdates(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()
@@ -246,7 +246,7 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 
 func TestDenseBlockRemovalByKey(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()
@@ -308,7 +308,7 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 
 func TestDenseBlockRollbackTo(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()
@@ -409,7 +409,7 @@ func TestDenseBlockOverflow(t *testing.T) {
 	// Test passes locally with both Walrus and Couchbase, and with and without -race.
 	t.Skip("WARNING: TEST DISABLED")
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()
@@ -481,7 +481,7 @@ func TestDenseBlockOverflow(t *testing.T) {
 // CAS handling test
 func TestDenseBlockConcurrentUpdates(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()
@@ -613,7 +613,7 @@ func TestDenseBlockIterator(t *testing.T) {
 // --------------------
 func TestDenseBlockList(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	log.Printf("Calling testIndexBucket() to bucket on server: %v", base.UnitTestUrl())
 
@@ -654,7 +654,7 @@ func TestDenseBlockList(t *testing.T) {
 // Artificially set the CAS to an invalid value, to ensure write processing recovers from CAS mismatch
 func TestDenseBlockListBadCas(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	log.Printf("Calling testIndexBucket() to bucket on server: %v", base.UnitTestUrl())
 
@@ -702,7 +702,7 @@ func TestDenseBlockListBadCas(t *testing.T) {
 // Test multiple writers attempting to concurrently initialize a block
 func TestDenseBlockListConcurrentInit(t *testing.T) {
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()
@@ -736,7 +736,7 @@ func TestDenseBlockListRotate(t *testing.T) {
 		MaxListBlockCount = initCount
 	}()
 
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	log.Printf("Calling testIndexBucket() to bucket on server: %v", base.UnitTestUrl())
 
@@ -772,7 +772,7 @@ func TestDenseBlockListRotate(t *testing.T) {
 //----------------------------------------------------------------------------------------------
 
 func TestCalculateChangedPartitions(t *testing.T) {
-	base.EnableTestLogKey("Accel")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
 
 	testIndexBucket := base.GetTestIndexBucketOrPanic()
 	defer testIndexBucket.Close()

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -54,7 +54,7 @@ func TestRepairBucket(t *testing.T) {
 		t.Skip("This test only works against walrus (requires views)")
 	}
 
-	base.EnableTestLogKey("CRUD")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
 	testBucket, numDocs := testBucketWithViewsAndBrokenDoc()
 	defer testBucket.Close()
@@ -86,7 +86,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 		t.Skip("This test only works against walrus (requires views)")
 	}
 
-	base.EnableTestLogKey("CRUD")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
 	testBucket, _ := testBucketWithViewsAndBrokenDoc()
 	defer testBucket.Close()
@@ -136,7 +136,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 		t.Skip("This test only works against walrus (requires views)")
 	}
 
-	base.EnableTestLogKey("CRUD")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
 	testBucket, _ := testBucketWithViewsAndBrokenDoc()
 	defer testBucket.Close()

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -780,7 +780,7 @@ func TestRevsHistoryInfiniteLoop(t *testing.T) {
 // Repair tool for https://github.com/couchbase/sync_gateway/issues/2847
 func TestRepairRevsHistoryWithCycles(t *testing.T) {
 
-	base.EnableTestLogKey("CRUD")
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
 	for i, testdocProblematicRevTree := range testdocProblematicRevTrees {
 

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -160,11 +160,7 @@ func TestShadowerPush(t *testing.T) {
 		t.Skip("BucketShadowing with XATTRS is not a supported configuration")
 	}
 
-	var logKeys = map[string]bool{
-		"Shadow": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyShadow)()
 
 	testBucket := makeExternalBucket()
 	defer testBucket.Close()
@@ -214,12 +210,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 		t.Skip("BucketShadowing with XATTRS is not a supported configuration")
 	}
 
-	var logKeys = map[string]bool{
-		"Shadow":  true,
-		"Shadow+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyShadow)()
 
 	testBucket := makeExternalBucket()
 	defer testBucket.Close()
@@ -253,12 +244,7 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 			"Logs: https://gist.github.com/tleyden/795df447314a521aba5bd1aa6d0ed42e")
 	}
 
-	var logKeys = map[string]bool{
-		"Shadow":  true,
-		"Shadow+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyShadow)()
 
 	testBucket := makeExternalBucket()
 	defer testBucket.Close()

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1563,15 +1563,15 @@ func TestReplicateErrorConditions(t *testing.T) {
 // - Functional tests in mobile-testkit repo
 func TestDocumentChangeReplicate(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate)()
+	base.EnableSgReplicateLogging()
+
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("Skip replication tests during integration tests, since they might be leaving replications running in background")
 	}
 
 	var rt RestTester
 	defer rt.Close() // Close RestTester, which closes ServerContext, which stops all replications
-
-	base.EnableTestLogKey("Replicate")
-	base.EnableSgReplicateLogging()
 
 	//Initiate synchronous one shot replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db", "target":"http://localhost:4985/db"}`), 500)

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -297,7 +297,7 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 }
 
 func initBenchmarkLogging() {
-	base.ConsoleLogLevel().Set(base.LevelNone) // disables logging
+	base.SetUpTestLogging(base.LevelNone, base.KeyNone) // disables logging
 }
 
 func PurgeDoc(rt RestTester, docid string) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1153,11 +1153,7 @@ func TestBulkGetEmptyDocs(t *testing.T) {
 
 func TestBulkDocsChangeToAccess(t *testing.T) {
 
-	var logKeys = map[string]bool{
-		"Access": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccess)()
 
 	rt := RestTester{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`}
 	defer rt.Close()
@@ -1189,12 +1185,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 
-	var logKeys = map[string]bool{
-		"Access":  true,
-		"Access+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess)()
 
 	rt := RestTester{SyncFn: `
 		function(doc) {
@@ -2435,13 +2426,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
-	var logKeys = map[string]bool{
-		"Access":   true,
-		"CRUD":     true,
-		"Changes+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
 
 	rt := RestTester{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	defer rt.Close()
@@ -2486,13 +2471,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 func TestRoleAccessChanges(t *testing.T) {
 
-	var logKeys = map[string]bool{
-		"Access":   true,
-		"CRUD":     true,
-		"Changes+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
 
 	rt := RestTester{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	defer rt.Close()
@@ -2615,12 +2594,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	// Changes feed with since=4 would ordinarily be empty, but zegpold got access to channel
 	// gamma after sequence 4, so the pre-existing docs in that channel are included:
-	var additionalLogKeys = map[string]bool{
-		"Changes": true,
-		"Cache":   true,
-	}
-
-	base.UpdateLogKeys(additionalLogKeys, false)
+	base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyAccess|base.KeyCRUD|base.KeyChanges)
 
 	response = rt.Send(requestByUser("GET", "/db/_changes?since=4", "", "zegpold"))
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
@@ -2816,6 +2790,9 @@ func TestOldDocHandling(t *testing.T) {
 }
 
 func TestStarAccess(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges)()
+
 	type allDocsRow struct {
 		ID    string `json:"id"`
 		Key   string `json:"key"`
@@ -2836,12 +2813,6 @@ func TestStarAccess(t *testing.T) {
 	// Create some docs:
 	var rt RestTester
 	defer rt.Close()
-
-	var logKeys = map[string]bool{
-		"Changes+": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	var changes struct {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2106,10 +2106,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 func TestChannelAccessChanges(t *testing.T) {
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
-	base.EnableTestLogKey("Accel+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD|base.KeyAccel)()
 
 	rt := RestTester{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
 	defer rt.Close()
@@ -2279,10 +2276,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 func TestAccessOnTombstone(t *testing.T) {
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
-	base.EnableTestLogKey("Accel+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD|base.KeyAccel)()
 
 	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 if (doc.owner) {
@@ -2352,9 +2346,7 @@ func TestAccessOnTombstone(t *testing.T) {
 //Test for wrong _changes entries for user joining a populated channel
 func TestUserJoiningPopulatedChannel(t *testing.T) {
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD)()
 
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channels)}`}
 	defer rt.Close()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -31,6 +31,8 @@ import (
 // Replication Spec: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges
 func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -144,6 +146,8 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -250,6 +254,8 @@ func TestContinuousChangesSubscription(t *testing.T) {
 // Start subChanges w/ continuous=false, batchsize=20
 // Validate we get the expected updates and changes ends
 func TestBlipOneShotChangesSubscription(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
@@ -394,6 +400,8 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 
 // Test subChanges w/ docID filter
 func TestBlipSubChangesDocIDFilter(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
@@ -550,6 +558,8 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 // 4. Make sure that the server responds to accept the changes (empty array)
 func TestProposedChangesNoConflictsMode(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
 	})
@@ -586,6 +596,8 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 
 // Connect to public port with authentication
 func TestPublicPortAuthentication(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
 	btUser1, err := NewBlipTesterFromSpec(BlipTesterSpec{
@@ -643,6 +655,8 @@ func TestPublicPortAuthentication(t *testing.T) {
 // Test send and retrieval of a doc.
 //   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetRev(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
 	rt := RestTester{
@@ -726,6 +740,8 @@ func TestNoConflictsModeReplication(t *testing.T) {
 // Reproduces https://github.com/couchbase/sync_gateway/issues/2717
 func TestReloadUser(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	syncFn := `
 		function(doc) {
 			if (doc._id == "access1") {
@@ -780,6 +796,8 @@ func TestReloadUser(t *testing.T) {
 // it shows up in the user's changes feed
 func TestAccessGrantViaSyncFunction(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	// Setup
 	rt := RestTester{
 		SyncFn:       `function(doc) {channel(doc.channels); access(doc.accessUser, doc.accessChannel);}`,
@@ -824,6 +842,8 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 // it shows up in the user's changes feed
 func TestAccessGrantViaAdminApi(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
@@ -860,6 +880,8 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 }
 
 func TestCheckpoint(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
@@ -929,6 +951,8 @@ func TestCheckpoint(t *testing.T) {
 // - Get attachment via REST and verifies it returns the correct content
 func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
@@ -968,6 +992,8 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 }
 
 func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
@@ -1020,6 +1046,8 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 // returns an error code
 func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	syncFn := `
 		function(doc) {
 			requireAccess("PBS");
@@ -1067,6 +1095,8 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
 func TestPutInvalidRevMalformedBody(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:                true,
@@ -1103,6 +1133,8 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 
 func TestPutRevNoConflictsMode(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
@@ -1128,6 +1160,8 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 }
 
 func TestPutRevConflictsMode(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
@@ -1167,6 +1201,8 @@ func TestPutRevConflictsMode(t *testing.T) {
 // - Same as Expected (this test is unable to repro SG #3281, but is being left in as a regression test)
 //
 func TestGetRemovedDoc(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
 	rt := RestTester{
@@ -1254,6 +1290,8 @@ func TestGetRemovedDoc(t *testing.T) {
 // - Open a one-off subChanges request, assert no error
 func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -1307,6 +1345,5 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 	errorCode3 := subChangesResponse3.Properties["Error-Code"]
 	log.Printf("errorCode: %v", errorCode3)
 	assert.True(t, errorCode == "")
-
 
 }

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -636,7 +636,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 			CachePendingSeqMaxNum:  &maxNum,
 			CacheSkippedSeqMaxWait: &skippedMaxWait,
 		},
-		NumIndexReplicas:&numIndexReplicas,
+		NumIndexReplicas: &numIndexReplicas,
 	}
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
 	defer rt.Close()
@@ -706,6 +706,8 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 func TestUnusedSequences(t *testing.T) {
 
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD|base.KeyHTTP)()
+
 	// Only do 10 iterations if running against walrus.  If against a live couchbase server,
 	// just do single iteration.  (Takes approx 30s)
 	numIterations := 10
@@ -722,10 +724,6 @@ func TestUnusedSequences(t *testing.T) {
 }
 
 func _testConcurrentDelete(t *testing.T) {
-
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
 
 	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
@@ -765,10 +763,6 @@ func _testConcurrentDelete(t *testing.T) {
 
 func _testConcurrentPutAsDelete(t *testing.T) {
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
-
 	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
 		 }`}
@@ -806,10 +800,6 @@ func _testConcurrentPutAsDelete(t *testing.T) {
 
 func _testConcurrentUpdate(t *testing.T) {
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
-
 	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
 		 }`}
@@ -846,11 +836,6 @@ func _testConcurrentUpdate(t *testing.T) {
 }
 
 func _testConcurrentNewEditsFalseDelete(t *testing.T) {
-
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
-	base.EnableTestLogKey("HTTP+")
 
 	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
@@ -2135,9 +2120,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 // Test _changes returning conflicts
 func TestChangesIncludeConflicts(t *testing.T) {
 
-	base.EnableTestLogKey("Cache+")
-	base.EnableTestLogKey("Changes+")
-	base.EnableTestLogKey("CRUD+")
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD)()
 
 	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -882,11 +882,7 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 
 func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
-	var logKeys = map[string]bool{
-		"TEST": true,
-	}
-
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
 
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channels)}`}
 	defer rt.Close()
@@ -1081,11 +1077,8 @@ func updateTestDoc(rt RestTester, docid string, revid string, body string) (newR
 
 // Validate retrieval of various document body types using include_docs.
 func TestChangesIncludeDocs(t *testing.T) {
-	var logKeys = map[string]bool{
-		"TEST": true,
-	}
 
-	base.UpdateLogKeys(logKeys, true)
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
 
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channels)}`}
 	testDB := rt.GetDatabase()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -627,14 +627,10 @@ type BlipTester struct {
 
 	// The blip sender that can be used for sending messages over the websocket connection
 	sender *blip.Sender
-
-	// logTeardownFn can be run on Close() when we want to reset the logging to a known state.
-	logTeardownFn func()
 }
 
 // Close the bliptester
 func (bt BlipTester) Close() {
-	defer bt.logTeardownFn()
 	bt.restTester.Close()
 }
 
@@ -648,8 +644,6 @@ func NewBlipTester() (*BlipTester, error) {
 func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 
 	bt := &BlipTester{}
-
-	bt.logTeardownFn = base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)
 
 	if spec.restTester != nil {
 		bt.restTester = spec.restTester

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -255,7 +255,6 @@ func (rt *RestTester) Close() {
 	if rt.RestTesterServerContext != nil {
 		rt.RestTesterServerContext.Close()
 	}
-	base.ResetTestLogging()
 }
 
 func (rt *RestTester) SendRequest(method, resource string, body string) *TestResponse {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -132,7 +132,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 						panic(fmt.Sprintf("Failed to drop bucket indexes: %v", err))
 					}
 
-					continue  // Go to the top of the for loop to retry
+					continue // Go to the top of the for loop to retry
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #3579

Adds a `SetUpTestLogging(LogLevel, LogKey)` function as described in https://github.com/couchbase/sync_gateway/issues/3579#issuecomment-390004874

## Usage
```go
teardownFn := SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)
defer teardownFn()

// Shorthand style
defer SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)()
```

## Example Output
```
$ go test -run='TestPutRev' -v ./rest
=== RUN   TestPutRevNoConflictsMode
2018-06-04T16:32:05.457+01:00 [INF] Test: Set log level: info
2018-06-04T16:32:05.457+01:00 [INF] Test: Set log keys: HTTP, SyncMsg, Sync
2018-06-04T16:32:05.457+01:00 [INF] Opening Walrus database test_data_bucket-c7dce132180e6984495a73cf465ddd52 on <walrus:>
2018-06-04T16:32:05.457+01:00 [INF] Opening db /db as bucket "test_data_bucket-659e5ce1747b97536839a4256d09e43f", pool "default", server <walrus:>
2018-06-04T16:32:05.458+01:00 [INF] Opening Walrus database test_data_bucket-659e5ce1747b97536839a4256d09e43f on <walrus:>
2018-06-04T16:32:05.458+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2018-06-04T16:32:05.458+01:00 [INF] Design docs successfully created for view version 2.1.
2018-06-04T16:32:05.458+01:00 [INF] Verifying view availability for bucket test_data_bucket-659e5ce1747b97536839a4256d09e43f...
2018-06-04T16:32:05.458+01:00 [INF] Views ready for bucket test_data_bucket-659e5ce1747b97536839a4256d09e43f.
2018-06-04T16:32:05.459+01:00 [INF] Initializing changes cache for database db
2018-06-04T16:32:05.459+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "db"
2018-06-04T16:32:05.463+01:00 [INF] HTTP:  #001: GET /db/_blipsync (as GUEST)
2018-06-04T16:32:05.464+01:00 [INF] SyncMsg: [6072f776] #1: Type:rev Id:foo Rev:1-abc Deleted:false  User:GUEST
2018-06-04T16:32:05.465+01:00 [INF] SyncMsg: [6072f776] #2: Type:rev Id:foo Rev:1-def Deleted:false  User:GUEST
2018-06-04T16:32:05.465+01:00 [INF] SyncMsg: [6072f776] #2: Type:rev   --> 409 Document revision conflict Time:143.001µs User:GUEST
2018-06-04T16:32:05.465+01:00 [INF] SyncMsg: [6072f776] #3: Type:rev Id:foo Rev:1-ghi Deleted:false  User:GUEST
2018-06-04T16:32:05.466+01:00 [INF] SyncMsg: [6072f776] #3: Type:rev   --> 409 Document revision conflict Time:120.652µs User:GUEST
2018-06-04T16:32:05.466+01:00 [INF] Test: Reset log level: info
2018-06-04T16:32:05.466+01:00 [INF] Test: Reset log keys: HTTP
--- PASS: TestPutRevNoConflictsMode (0.01s)
=== RUN   TestPutRevConflictsMode
2018-06-04T16:32:05.466+01:00 [INF] Test: Set log level: info
2018-06-04T16:32:05.466+01:00 [INF] Test: Set log keys: HTTP, SyncMsg, Sync
2018-06-04T16:32:05.466+01:00 [INF] Opening Walrus database test_data_bucket-134bc1c00941282fc1a6302c3836e48c on <walrus:>
2018-06-04T16:32:05.466+01:00 [INF] Opening db /db as bucket "test_data_bucket-0e8905865d93e198f13f22f5e9bc7952", pool "default", server <walrus:>
2018-06-04T16:32:05.466+01:00 [INF] Opening Walrus database test_data_bucket-0e8905865d93e198f13f22f5e9bc7952 on <walrus:>
2018-06-04T16:32:05.466+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2018-06-04T16:32:05.466+01:00 [INF] Design docs successfully created for view version 2.1.
2018-06-04T16:32:05.466+01:00 [INF] Verifying view availability for bucket test_data_bucket-0e8905865d93e198f13f22f5e9bc7952...
2018-06-04T16:32:05.466+01:00 [INF] Views ready for bucket test_data_bucket-0e8905865d93e198f13f22f5e9bc7952.
2018-06-04T16:32:05.466+01:00 [INF] Initializing changes cache for database db
2018-06-04T16:32:05.466+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "db"
2018-06-04T16:32:05.470+01:00 [INF] HTTP:  #002: GET /db/_blipsync (as GUEST)
2018-06-04T16:32:05.471+01:00 [INF] SyncMsg: [26737021] #1: Type:rev Id:foo Rev:1-abc Deleted:false  User:GUEST
2018-06-04T16:32:05.471+01:00 [INF] SyncMsg: [26737021] #2: Type:rev Id:foo Rev:1-def Deleted:false  User:GUEST
2018-06-04T16:32:05.471+01:00 [INF] SyncMsg: [26737021] #3: Type:rev Id:foo Rev:1-ghi Deleted:false  User:GUEST
2018-06-04T16:32:05.472+01:00 [INF] SyncMsg: [26737021] #3: Type:rev   --> 409 Document revision conflict Time:148.745µs User:GUEST
2018-06-04T16:32:05.472+01:00 [INF] Test: Reset log level: info
2018-06-04T16:32:05.472+01:00 [INF] Test: Reset log keys: HTTP
--- PASS: TestPutRevConflictsMode (0.01s)
PASS
ok  	github.com/couchbase/sync_gateway/rest	0.038s
```

## Changes
- Adds a `SetUpTestLogging(LogLevel, LogKey)` function as described in https://github.com/couchbase/sync_gateway/issues/3579#issuecomment-390004874 which can be used to initialise logging in unit tests to a known log level and keys. Returns a teardown function that can be deferred for resetting the logging state between tests.

- Migrated usages of `EnableTestLogKey` to use `SetUpTestLogging`

- Migrated usages of `base.UpdateLogKeys` to use `SetUpTestLogging`

- Changes `LogKey.String()` method to return a comma-separated string of combined log keys (old behaviour was to print a binary representation)

- Changes `BlipTester` to handle its own logging setup/teardown
