### PR TITLE
#3609 Validation for FileLogger MaxSize, MaxAge

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -15,7 +15,8 @@ var (
 	ErrInvalidLoggingMaxAge = errors.New("Invalid MaxAge")
 
 	maxAgeLimit             = 9999 // days
-	defaultMaxSize          = 100  // megabytes
+	maxSizeLimit            = 2048 // 2 GB
+	defaultMaxSize          = 100  // 100 MB
 	defaultMaxAgeMultiplier = 2    // e.g. 90 minimum == 180 default maxAge
 )
 
@@ -91,6 +92,8 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 
 	if lfc.Rotation.MaxSize == nil {
 		lfc.Rotation.MaxSize = &defaultMaxSize
+	} else if *lfc.Rotation.MaxSize > maxSizeLimit {
+		return fmt.Errorf("MaxSize for %v was set to %d which is above the maximum of %d", level, *lfc.Rotation.MaxSize, maxSizeLimit)
 	}
 
 	if lfc.Rotation.MaxAge == nil {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -18,6 +18,9 @@ var (
 	maxSizeLimit            = 2048 // 2 GB
 	defaultMaxSize          = 100  // 100 MB
 	defaultMaxAgeMultiplier = 2    // e.g. 90 minimum == 180 default maxAge
+
+	belowMinValueFmt = "%s for %v was set to %d which is below the minimum of %d"
+	aboveMaxValueFmt = "%s for %v was set to %d which is above the maximum of %d"
 )
 
 type FileLogger struct {
@@ -95,9 +98,9 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 	} else if *lfc.Rotation.MaxSize == 0 {
 		// A value of zero disables the log file rotation in Lumberjack.
 	} else if *lfc.Rotation.MaxSize < 0 {
-		return fmt.Errorf("MaxSize for %v was set to %d which is below the minimum of %d", level, *lfc.Rotation.MaxSize, 0)
+		return fmt.Errorf(belowMinValueFmt, "MaxSize", level, *lfc.Rotation.MaxSize, 0)
 	} else if *lfc.Rotation.MaxSize > maxSizeLimit {
-		return fmt.Errorf("MaxSize for %v was set to %d which is above the maximum of %d", level, *lfc.Rotation.MaxSize, maxSizeLimit)
+		return fmt.Errorf(aboveMaxValueFmt, "MaxSize", level, *lfc.Rotation.MaxSize, maxSizeLimit)
 	}
 
 	if lfc.Rotation.MaxAge == nil {
@@ -106,9 +109,9 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 	} else if *lfc.Rotation.MaxAge == 0 {
 		// A value of zero disables the age-based log cleanup in Lumberjack.
 	} else if *lfc.Rotation.MaxAge < minAge {
-		return fmt.Errorf("MaxAge for %v was set to %d which is below the minimum of %d", level, *lfc.Rotation.MaxAge, minAge)
+		return fmt.Errorf(belowMinValueFmt, "MaxAge", level, *lfc.Rotation.MaxAge, minAge)
 	} else if *lfc.Rotation.MaxAge > maxAgeLimit {
-		return fmt.Errorf("MaxAge for %v was set to %d which is above the maximum of %d", level, *lfc.Rotation.MaxAge, maxAgeLimit)
+		return fmt.Errorf(aboveMaxValueFmt, "MaxAge", level, *lfc.Rotation.MaxAge, maxAgeLimit)
 	}
 
 	if lfc.Output == nil {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -15,7 +15,6 @@ var (
 	ErrInvalidLoggingMaxAge = errors.New("Invalid MaxAge")
 
 	maxAgeLimit             = 9999 // days
-	maxSizeLimit            = 2048 // 2 GB
 	defaultMaxSize          = 100  // 100 MB
 	defaultMaxAgeMultiplier = 2    // e.g. 90 minimum == 180 default maxAge
 
@@ -99,8 +98,6 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 		// A value of zero disables the log file rotation in Lumberjack.
 	} else if *lfc.Rotation.MaxSize < 0 {
 		return fmt.Errorf(belowMinValueFmt, "MaxSize", level, *lfc.Rotation.MaxSize, 0)
-	} else if *lfc.Rotation.MaxSize > maxSizeLimit {
-		return fmt.Errorf(aboveMaxValueFmt, "MaxSize", level, *lfc.Rotation.MaxSize, maxSizeLimit)
 	}
 
 	if lfc.Rotation.MaxAge == nil {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -92,6 +92,10 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 
 	if lfc.Rotation.MaxSize == nil {
 		lfc.Rotation.MaxSize = &defaultMaxSize
+	} else if *lfc.Rotation.MaxSize == 0 {
+		// A value of zero disables the log file rotation in Lumberjack.
+	} else if *lfc.Rotation.MaxSize < 0 {
+		return fmt.Errorf("MaxSize for %v was set to %d which is below the minimum of %d", level, *lfc.Rotation.MaxSize, 0)
 	} else if *lfc.Rotation.MaxSize > maxSizeLimit {
 		return fmt.Errorf("MaxSize for %v was set to %d which is above the maximum of %d", level, *lfc.Rotation.MaxSize, maxSizeLimit)
 	}


### PR DESCRIPTION
Fixes #3609 

- Adds a FileLogger MaxSize limit of 2048 MB