### PR TITLE
Attempt to find gozip relative to sgcollect_info before falling back to $PATH

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -342,7 +342,13 @@ class TaskRunner(object):
 
     def _zip_helper(self, prefix, filename, files):
         """Write all our logs to a zipfile"""
-        exe = exec_name("gozip")
+
+        # Get absolute path to gozip relative to this file
+        exe = os.path.abspath(os.path.join(os.path.dirname(__file__), exec_name("gozip")))
+
+        # Don't have gozip relative to this file, try and see if there's one elsewhere in $PATH
+        if not os.path.isfile(exe):
+            exe = exec_name("gozip")
 
         fallback = False
 


### PR DESCRIPTION
Try to look for `gozip` relative to the sgcollect_info script, before falling back to looking in `$PATH`.

This avoids the requirement of setting `gozip` to be in your `$PATH` in order for sgcollect_info to use it, and should make #3637 work out of the box.