### PR TITLE
Rename localhost:4985 to myhost:4985 in TestDocumentChangeReplicate

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1574,31 +1574,31 @@ func TestDocumentChangeReplicate(t *testing.T) {
 	base.EnableSgReplicateLogging()
 
 	//Initiate synchronous one shot replication
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db", "target":"http://localhost:4985/db"}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db", "target":"http://myhost:4985/db"}`), 500)
 
 	//Initiate asyncronous one shot replication
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db", "target":"http://localhost:4985/db", "async":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db", "target":"http://myhost:4985/db", "async":true}`), 200)
 
 	//Initiate continuous replication
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db", "target":"http://localhost:4985/db", "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db", "target":"http://myhost:4985/db", "continuous":true}`), 200)
 
 	//Initiate synchronous one shot replication with channel filter and JSON array of channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db2", "target":"http://localhost:4985/db2", "filter":"sync_gateway/bychannel", "query_params":["A"]}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db2", "target":"http://myhost:4985/db2", "filter":"sync_gateway/bychannel", "query_params":["A"]}`), 500)
 
 	//Initiate synchronous one shot replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db3", "target":"http://localhost:4985/db3", "filter":"sync_gateway/bychannel", "query_params":{"channels":["A"]}}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db3", "target":"http://myhost:4985/db3", "filter":"sync_gateway/bychannel", "query_params":{"channels":["A"]}}`), 500)
 
 	//Initiate synchronous one shot replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names and custom changes_feed_limit
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db4", "target":"http://localhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db4", "target":"http://myhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10}`), 500)
 
 	//Initiate continuous replication with channel filter and JSON array of channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db2", "target":"http://localhost:4985/db2", "filter":"sync_gateway/bychannel", "query_params":["A"], "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db2", "target":"http://myhost:4985/db2", "filter":"sync_gateway/bychannel", "query_params":["A"], "continuous":true}`), 200)
 
 	//Initiate continuous replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db3", "target":"http://localhost:4985/db3", "filter":"sync_gateway/bychannel", "query_params":{"channels":["A"]}, "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db3", "target":"http://myhost:4985/db3", "filter":"sync_gateway/bychannel", "query_params":{"channels":["A"]}, "continuous":true}`), 200)
 
 	//Initiate continuous replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names and custom changes_feed_limit
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://localhost:4985/db4", "target":"http://localhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10, "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db4", "target":"http://myhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10, "continuous":true}`), 200)
 
 	//Send JSON Object containing source and target as absolute URL and a replication_id
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"http://myhost:4985/mytargetdb", "replication_id":"myreplicationid"}`), 500)


### PR DESCRIPTION
This allows the unit tests to run correctly, even when Sync Gateway is running on port 4984/4985.

Previously the tests would fail due to side-effects of tests calling out to a running SG instance.

## Before
```
13:22 $ go test -run='TestDocumentChangeReplicate' -v -count=1 ./rest
=== RUN   TestDocumentChangeReplicate
2018-06-07T13:22:27.294+01:00 [INF] rest.TestDocumentChangeReplicate: Setup logging: level: info - keys: Replicate
2018-06-07T13:22:27.295+01:00 [INF] Opening Walrus database test_data_bucket-5d26bd1f163b68f2d2f645d9cf6e2322 on <walrus:>
2018-06-07T13:22:27.295+01:00 [INF] Opening db /db as bucket "test_data_bucket-cf600425011789034d70bb51a63c7f7d", pool "default", server <walrus:>
2018-06-07T13:22:27.295+01:00 [INF] Opening Walrus database test_data_bucket-cf600425011789034d70bb51a63c7f7d on <walrus:>
2018-06-07T13:22:27.295+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2018-06-07T13:22:27.295+01:00 [INF] Design docs successfully created for view version 2.1.
2018-06-07T13:22:27.295+01:00 [INF] Verifying view availability for bucket test_data_bucket-cf600425011789034d70bb51a63c7f7d...
2018-06-07T13:22:27.296+01:00 [INF] Views ready for bucket test_data_bucket-cf600425011789034d70bb51a63c7f7d.
2018-06-07T13:22:27.296+01:00 [INF] Initializing changes cache for database db
2018-06-07T13:22:27.296+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "db"
2018-06-07T13:22:27.299+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:6df53c2428f8606b8173314901141a68 Source:http://localhost:4985 SourceDb:db Channels:[] Target:http://localhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:22:27.300+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:6df53c2428f8606b8173314901141a68 Source:http://localhost:4985 SourceDb:db Channels:[] Target:http://localhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}} Stats:0xc420472120 EventChan:0xc4203cf5c0 NotificationChan:0xc4203cf560 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] new state: 0x151ec30
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] resp: &{404 Not Found 404 HTTP/1.1 1 1 map[Content-Type:[application/json] Server:[Couchbase Sync Gateway/2.1 branch/master commit/d066de2] Date:[Thu, 07 Jun 2018 12:22:27 GMT] Content-Length:[40]] 0xc4200c0240 40 [] false false map[] 0xc420248000 <nil>}, err: <nil>
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] 404 trying to get checkpoint, continue..
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_SUCCEEDED {0  }}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] call fetchChangesFeed()
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] Transition from stateFnActiveFetchCheckpoint -> stateFnActiveFetchChangesFeed
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] new state: 0x151f450
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] stateFnActiveFetchChangesFeed
2018/06/07 13:22:27 Replicate: sequenceNumberToString called with: 0 type: int
2018/06/07 13:22:27 Replicate: sequence is an int
2018/06/07 13:22:27 Replicate: sequenceNumberToString called with: 0 type: int
2018/06/07 13:22:27 Replicate: sequence is an int
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] changes feed resp: &{200 OK 200 HTTP/1.1 1 1 map[Server:[Couchbase Sync Gateway/2.1 branch/master commit/d066de2] Date:[Thu, 07 Jun 2018 12:22:27 GMT] Cache-Control:[private, max-age=0, no-cache, no-store] Content-Type:[application/json]] 0xc4203521a0 -1 [] false true map[] 0xc42013c000 <nil>}, err: <nil>
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] event: &{FETCH_CHANGES_FEED_SUCCEEDED {[] 0}}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] stateFnActiveFetchChangesFeed got event: {FETCH_CHANGES_FEED_SUCCEEDED {[] 0}}
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] new state: <nil>
2018/06/07 13:22:27 Replicate: [6df53c2428f8606b8173314901141a68] processEvents() is done
goroutine 34 [running]:
runtime/debug.Stack(0xc420430ea0, 0xc42049de90, 0x12dd154)
	/usr/local/Cellar/go/1.10.2/libexec/src/runtime/debug/stack.go:24 +0xa7
runtime/debug.PrintStack()
	/usr/local/Cellar/go/1.10.2/libexec/src/runtime/debug/stack.go:16 +0x22
github.com/couchbase/sync_gateway/rest.assertStatus(0xc4202600f0, 0xc42020c7e0, 0x1f4)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:533 +0x5f
github.com/couchbase/sync_gateway/rest.TestDocumentChangeReplicate(0xc4202600f0)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/admin_api_test.go:1598 +0x117
testing.tRunner(0xc4202600f0, 0x198acb0)
	/usr/local/Cellar/go/1.10.2/libexec/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/Cellar/go/1.10.2/libexec/src/testing/testing.go:824 +0x2e0
2018-06-07T13:22:27.310+01:00 [INF] rest.TestDocumentChangeReplicate: Reset logging
--- FAIL: TestDocumentChangeReplicate (0.02s)
	utilities_testing.go:534: Response status 200 (expected 500) for POST <http://localhost/_replicate> : {"type":"replication","replication_id":"6df53c2428f8606b8173314901141a68","continuous":false,"source":"http://localhost:4985/db","target":"http://localhost:4985/db","docs_read":0,"docs_written":0,"doc_write_failures":0,"start_last_seq":0,"end_last_seq":"0"}
FAIL
FAIL	github.com/couchbase/sync_gateway/rest	0.039s
```

## After
```
13:21 $ go test -run='TestDocumentChangeReplicate' -v -count=1 ./rest
=== RUN   TestDocumentChangeReplicate
2018-06-07T13:21:56.031+01:00 [INF] rest.TestDocumentChangeReplicate: Setup logging: level: info - keys: Replicate
2018-06-07T13:21:56.032+01:00 [INF] Opening Walrus database test_data_bucket-2d5067287d4f3114f03ac3e358c7892a on <walrus:>
2018-06-07T13:21:56.032+01:00 [INF] Opening db /db as bucket "test_data_bucket-f9520642c0fb3e4558f8d2bec0114742", pool "default", server <walrus:>
2018-06-07T13:21:56.032+01:00 [INF] Opening Walrus database test_data_bucket-f9520642c0fb3e4558f8d2bec0114742 on <walrus:>
2018-06-07T13:21:56.032+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2018-06-07T13:21:56.032+01:00 [INF] Design docs successfully created for view version 2.1.
2018-06-07T13:21:56.032+01:00 [INF] Verifying view availability for bucket test_data_bucket-f9520642c0fb3e4558f8d2bec0114742...
2018-06-07T13:21:56.033+01:00 [INF] Views ready for bucket test_data_bucket-f9520642c0fb3e4558f8d2bec0114742.
2018-06-07T13:21:56.033+01:00 [INF] Initializing changes cache for database db
2018-06-07T13:21:56.033+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "db"
2018-06-07T13:21:56.036+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:46cea79f4d8cd3688df1dc1a097216fc Source:http://myhost:4985 SourceDb:db Channels:[] Target:http://myhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.037+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:46cea79f4d8cd3688df1dc1a097216fc Source:http://myhost:4985 SourceDb:db Channels:[] Target:http://myhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}} Stats:0xc420316030 EventChan:0xc4203f0120 NotificationChan:0xc4203f00c0 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] resp: <nil>, err: Get http://myhost:4985/db/_local/ec39159bf4fc8e7a5073189295a4d6ad40561344: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] Error getting checkpoint: Get http://myhost:4985/db/_local/ec39159bf4fc8e7a5073189295a4d6ad40561344: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] new state: <nil>
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] processEvents() is done
2018/06/07 13:21:56 Replicate: [46cea79f4d8cd3688df1dc1a097216fc] REPLICATION_ABORTED due to error: FETCH_CHECKPOINT_FAILED
2018-06-07T13:21:56.365+01:00 [ERR] Replication Aborted due to error: FETCH_CHECKPOINT_FAILED -- rest.(*handler).writeError() at handler.go:689
2018-06-07T13:21:56.365+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:7c3766fdbee5716c658d6fe98341aacf Source:http://myhost:4985 SourceDb:db Channels:[] Target:http://myhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:true}
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.365+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:7c3766fdbee5716c658d6fe98341aacf Source:http://myhost:4985 SourceDb:db Channels:[] Target:http://myhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:true}} Stats:0xc4200b7cb0 EventChan:0xc420228540 NotificationChan:0xc4202284e0 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] new state: 0x151ec30
2018-06-07T13:21:56.366+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:97e590851c18adc589c0b78908587113 Source:http://myhost:4985 SourceDb:db Channels:[] Target:http://myhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:1 Disabled:false Async:false}
2018-06-07T13:21:56.366+01:00 [INF] Replicate: Started continuous replication: &{LoggingReplication:{Parameters:{ReplicationId:97e590851c18adc589c0b78908587113 Source:http://myhost:4985 SourceDb:db Channels:[] Target:http://myhost:4985 TargetDb:db ChangesFeedLimit:50 Lifecycle:1 Disabled:false Async:false}} ReplicationStats:0xc420316a20 NotificationChan:0xc4203f0360 EventChan:0xc4203f03c0 Factory:0x1580c80 AbortedReplicationRetryTime:500ms LastSequencePushed:<nil>}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] ContinuousReplication.processEvents()
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] continuous repl state: 0x151c7e0
2018-06-07T13:21:56.366+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:c7c6386218c258c5b4aa66d59b279ed5 Source:http://myhost:4985 SourceDb:db2 Channels:[A] Target:http://myhost:4985 TargetDb:db2 ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.366+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:c7c6386218c258c5b4aa66d59b279ed5 Source:http://myhost:4985 SourceDb:db2 Channels:[A] Target:http://myhost:4985 TargetDb:db2 ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}} Stats:0xc420316fc0 EventChan:0xc4203f05a0 NotificationChan:0xc4203f0540 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] Unexpected notification, ignore
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] resp: <nil>, err: Get http://myhost:4985/db2/_local/588aafaef1bb4eed37e1af3ad0ea97539fef3389: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] Error getting checkpoint: Get http://myhost:4985/db2/_local/588aafaef1bb4eed37e1af3ad0ea97539fef3389: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] resp: <nil>, err: Get http://myhost:4985/db/_local/9ee55287e11df28da11f3f4947ae6f1e94531fd7: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] Error getting checkpoint: Get http://myhost:4985/db/_local/9ee55287e11df28da11f3f4947ae6f1e94531fd7: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] new state: <nil>
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] resp: <nil>, err: Get http://myhost:4985/db/_local/cc624c074b7597c925f49a25a9bc583c302ebc22: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] REPLICATION_ABORTED due to error: FETCH_CHECKPOINT_FAILED
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] Error getting checkpoint: Get http://myhost:4985/db/_local/cc624c074b7597c925f49a25a9bc583c302ebc22: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] new state: <nil>
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] processEvents() is done
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] new state: <nil>
2018/06/07 13:21:56 Replicate: [c7c6386218c258c5b4aa66d59b279ed5] processEvents() is done
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] REPLICATION_ABORTED due to error: FETCH_CHECKPOINT_FAILED
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] Replication aborted .. try again
2018-06-07T13:21:56.368+01:00 [ERR] Replication Aborted due to error: FETCH_CHECKPOINT_FAILED -- rest.(*handler).writeError() at handler.go:689
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] continuous repl new state: 0x151d210
2018/06/07 13:21:56 Replicate: [7c3766fdbee5716c658d6fe98341aacf] processEvents() is done
2018-06-07T13:21:56.368+01:00 [WRN] async one-shot replication 7c3766fdbee5716c658d6fe98341aacf failed: Replication Aborted due to error: FETCH_CHECKPOINT_FAILED -- base.(*Replicator).runOneShotReplication.func1() at replicator.go:135
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] continuous repl state: 0x151d210
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] entered stateFnBackoffRertry
2018-06-07T13:21:56.368+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:733b573d8e0b8859df01907a1f2a3c2a Source:http://myhost:4985 SourceDb:db3 Channels:[A] Target:http://myhost:4985 TargetDb:db3 ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.368+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:733b573d8e0b8859df01907a1f2a3c2a Source:http://myhost:4985 SourceDb:db3 Channels:[A] Target:http://myhost:4985 TargetDb:db3 ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}} Stats:0xc420317890 EventChan:0xc4203f09c0 NotificationChan:0xc4203f0960 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] resp: <nil>, err: Get http://myhost:4985/db3/_local/d2f07f28dd62af41065255da6d1230909f110b91: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] Error getting checkpoint: Get http://myhost:4985/db3/_local/d2f07f28dd62af41065255da6d1230909f110b91: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] new state: <nil>
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] processEvents() is done
2018/06/07 13:21:56 Replicate: [733b573d8e0b8859df01907a1f2a3c2a] REPLICATION_ABORTED due to error: FETCH_CHECKPOINT_FAILED
2018-06-07T13:21:56.369+01:00 [ERR] Replication Aborted due to error: FETCH_CHECKPOINT_FAILED -- rest.(*handler).writeError() at handler.go:689
2018-06-07T13:21:56.370+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:03fc1c496744145c788d4ad7c25ecf2e Source:http://myhost:4985 SourceDb:db4 Channels:[B] Target:http://myhost:4985 TargetDb:db4 ChangesFeedLimit:10 Lifecycle:0 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.370+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:03fc1c496744145c788d4ad7c25ecf2e Source:http://myhost:4985 SourceDb:db4 Channels:[B] Target:http://myhost:4985 TargetDb:db4 ChangesFeedLimit:10 Lifecycle:0 Disabled:false Async:false}} Stats:0xc42041b410 EventChan:0xc4202946c0 NotificationChan:0xc420294660 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] resp: <nil>, err: Get http://myhost:4985/db4/_local/adc5aeffa5b534c9c4c81aa4f997a7b497d43cc7: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] Error getting checkpoint: Get http://myhost:4985/db4/_local/adc5aeffa5b534c9c4c81aa4f997a7b497d43cc7: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] new state: <nil>
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] processEvents() is done
2018/06/07 13:21:56 Replicate: [03fc1c496744145c788d4ad7c25ecf2e] REPLICATION_ABORTED due to error: FETCH_CHECKPOINT_FAILED
2018-06-07T13:21:56.371+01:00 [ERR] Replication Aborted due to error: FETCH_CHECKPOINT_FAILED -- rest.(*handler).writeError() at handler.go:689
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:cd3cf20917b2caff5dca9ae066a4cd2c Source:http://myhost:4985 SourceDb:db2 Channels:[A] Target:http://myhost:4985 TargetDb:db2 ChangesFeedLimit:50 Lifecycle:1 Disabled:false Async:false}
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Started continuous replication: &{LoggingReplication:{Parameters:{ReplicationId:cd3cf20917b2caff5dca9ae066a4cd2c Source:http://myhost:4985 SourceDb:db2 Channels:[A] Target:http://myhost:4985 TargetDb:db2 ChangesFeedLimit:50 Lifecycle:1 Disabled:false Async:false}} ReplicationStats:0xc4204625a0 NotificationChan:0xc420294c60 EventChan:0xc420294cc0 Factory:0x1580c80 AbortedReplicationRetryTime:500ms LastSequencePushed:<nil>}
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] ContinuousReplication.processEvents()
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] continuous repl state: 0x151c7e0
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:0c7737a6d23a2304ce12dbf607903bd8 Source:http://myhost:4985 SourceDb:db3 Channels:[A] Target:http://myhost:4985 TargetDb:db3 ChangesFeedLimit:50 Lifecycle:1 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Started continuous replication: &{LoggingReplication:{Parameters:{ReplicationId:0c7737a6d23a2304ce12dbf607903bd8 Source:http://myhost:4985 SourceDb:db3 Channels:[A] Target:http://myhost:4985 TargetDb:db3 ChangesFeedLimit:50 Lifecycle:1 Disabled:false Async:false}} ReplicationStats:0xc420462780 NotificationChan:0xc420294e40 EventChan:0xc420294ea0 Factory:0x1580c80 AbortedReplicationRetryTime:500ms LastSequencePushed:<nil>}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] ContinuousReplication.processEvents()
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] continuous repl state: 0x151c7e0
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] Unexpected notification, ignore
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:871f806a36242f0e445acd392d4d6600 Source:http://myhost:4985 SourceDb:db4 Channels:[B] Target:http://myhost:4985 TargetDb:db4 ChangesFeedLimit:10 Lifecycle:1 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Started continuous replication: &{LoggingReplication:{Parameters:{ReplicationId:871f806a36242f0e445acd392d4d6600 Source:http://myhost:4985 SourceDb:db4 Channels:[B] Target:http://myhost:4985 TargetDb:db4 ChangesFeedLimit:10 Lifecycle:1 Disabled:false Async:false}} ReplicationStats:0xc420462930 NotificationChan:0xc420295020 EventChan:0xc420295080 Factory:0x1580c80 AbortedReplicationRetryTime:500ms LastSequencePushed:<nil>}
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] ContinuousReplication.processEvents()
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] continuous repl state: 0x151c7e0
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] new state: 0x151ec30
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Creating replication with parameters {ReplicationId:myreplicationid Source:http://myhost:4985 SourceDb:mysourcedb Channels:[] Target:http://myhost:4985 TargetDb:mytargetdb ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] Unexpected notification, ignore
2018/06/07 13:21:56 Replicate: [myreplicationid] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [myreplicationid] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] stateFnPreStarted got event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] stateFnPreStarted got START event: {REPLICATION_START <nil>}
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018-06-07T13:21:56.371+01:00 [INF] Replicate: Started one-shot replication: &{LoggingReplication:{Parameters:{ReplicationId:myreplicationid Source:http://myhost:4985 SourceDb:mysourcedb Channels:[] Target:http://myhost:4985 TargetDb:mytargetdb ChangesFeedLimit:50 Lifecycle:0 Disabled:false Async:false}} Stats:0xc4203de4b0 EventChan:0xc4202290e0 NotificationChan:0xc420229080 FetchedTargetCheckpoint:{LastSequence: Revision: Id:} Changes:{Results:[] LastSequence:<nil>} RevsDiff:map[] Documents:[] PushedBulkDocs:[]}
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] Unexpected notification, ignore
2018/06/07 13:21:56 Replicate: [myreplicationid] sent notificication: &{REPLICATION_ACTIVE <nil> <nil>}
2018/06/07 13:21:56 Replicate: [myreplicationid] Transition from stateFnActiveFetchCheckpoint -> stateFnActive
2018/06/07 13:21:56 Replicate: [myreplicationid] new state: 0x151ec30
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] stateFnCatchingUp, waiting for event
2018/06/07 13:21:56 Replicate: [myreplicationid] resp: <nil>, err: Get http://myhost:4985/mytargetdb/_local/2176705c9fd2a0e0e348472012fd3ed201129255: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [myreplicationid] Error getting checkpoint: Get http://myhost:4985/mytargetdb/_local/2176705c9fd2a0e0e348472012fd3ed201129255: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] resp: <nil>, err: Get http://myhost:4985/db3/_local/236b38f04dff4e291952f62bd3b1d16efb4671e5: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] Error getting checkpoint: Get http://myhost:4985/db3/_local/236b38f04dff4e291952f62bd3b1d16efb4671e5: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] resp: <nil>, err: Get http://myhost:4985/db4/_local/f82f964f63da7aec03b792a05646d3aa6dc4e6cf: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [myreplicationid] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] Error getting checkpoint: Get http://myhost:4985/db4/_local/f82f964f63da7aec03b792a05646d3aa6dc4e6cf: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] new state: <nil>
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] processEvents() is done
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] Replication aborted .. try again
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] continuous repl new state: 0x151d210
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] continuous repl state: 0x151d210
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] entered stateFnBackoffRertry
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] new state: <nil>
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] processEvents() is done
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] resp: <nil>, err: Get http://myhost:4985/db2/_local/5b2eca449e918b10bb3be7dd46690d7f1543ea1b: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] Error getting checkpoint: Get http://myhost:4985/db2/_local/5b2eca449e918b10bb3be7dd46690d7f1543ea1b: dial tcp: lookup myhost: no such host
2018/06/07 13:21:56 Replicate: [myreplicationid] new state: <nil>
2018/06/07 13:21:56 Replicate: [myreplicationid] processEvents() is done
2018/06/07 13:21:56 Replicate: [myreplicationid] REPLICATION_ABORTED due to error: FETCH_CHECKPOINT_FAILED
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] Replication aborted .. try again
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] continuous repl new state: 0x151d210
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] continuous repl state: 0x151d210
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] entered stateFnBackoffRertry
2018-06-07T13:21:56.372+01:00 [ERR] Replication Aborted due to error: FETCH_CHECKPOINT_FAILED -- rest.(*handler).writeError() at handler.go:689
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] stateFnActiveFetchCheckpoint got event: {FETCH_CHECKPOINT_FAILED <nil>}
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] new state: <nil>
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] processEvents() is done
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] Replication aborted .. try again
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] continuous repl new state: 0x151d210
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] continuous repl state: 0x151d210
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] entered stateFnBackoffRertry
2018-06-07T13:21:56.373+01:00 [ERR] 404 No replication found matching specified parameters -- rest.(*handler).writeError() at handler.go:689
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopping replication 871f806a36242f0e445acd392d4d6600
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopped replication 871f806a36242f0e445acd392d4d6600
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopping replication cd3cf20917b2caff5dca9ae066a4cd2c
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopped replication cd3cf20917b2caff5dca9ae066a4cd2c
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopping replication 97e590851c18adc589c0b78908587113
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopped replication 97e590851c18adc589c0b78908587113
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] continuous repl new state: <nil>
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] continuous repl new state: <nil>
2018/06/07 13:21:56 Replicate: [cd3cf20917b2caff5dca9ae066a4cd2c] continuous repl processEvents() is done
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopping replication 0c7737a6d23a2304ce12dbf607903bd8
2018/06/07 13:21:56 Replicate: [871f806a36242f0e445acd392d4d6600] continuous repl processEvents() is done
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] continuous repl new state: <nil>
2018/06/07 13:21:56 Replicate: [0c7737a6d23a2304ce12dbf607903bd8] continuous repl processEvents() is done
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Replication cd3cf20917b2caff5dca9ae066a4cd2c was terminated.
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Stopped replication 0c7737a6d23a2304ce12dbf607903bd8
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] continuous repl new state: <nil>
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Replication 871f806a36242f0e445acd392d4d6600 was terminated.
2018-06-07T13:21:56.373+01:00 [INF] Replicate: Replication 0c7737a6d23a2304ce12dbf607903bd8 was terminated.
2018/06/07 13:21:56 Replicate: [97e590851c18adc589c0b78908587113] continuous repl processEvents() is done
2018-06-07T13:21:56.373+01:00 [INF] rest.TestDocumentChangeReplicate: Reset logging
--- PASS: TestDocumentChangeReplicate (0.34s)
PASS
ok  	github.com/couchbase/sync_gateway/rest	0.367s
```