### PR TITLE
Skip long running tests under -short

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -623,6 +623,10 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 // user gets added to a new channel with existing entries (and existing backfill)
 func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
@@ -948,6 +952,10 @@ func TestSkippedViewRetrieval(t *testing.T) {
 
 // Test that housekeeping goroutines get terminated when change cache is stopped
 func TestStopChangeCache(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	base.EnableTestLogKey("Changes+")
 	base.EnableTestLogKey("DCP+")

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -27,6 +27,10 @@ import (
 // Unit test for bug #314
 func TestChangesAfterChannelAdded(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
@@ -126,6 +130,10 @@ func getZeroSequence(db *Database) ChangesOptions {
 }
 
 func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  See https://gist.github.com/tleyden/a41632355fadde54f19e84ba68015512")

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -221,6 +221,10 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	if !base.UnitTestUrlIsWalrus() && base.TestUseXattrs() {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Same error as TestDocDeletionFromChannelCoalescedRemoved")
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -701,6 +701,10 @@ func TestRepeatedConflict(t *testing.T) {
 
 func TestConflicts(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
@@ -1481,6 +1485,10 @@ func TestConcurrentImport(t *testing.T) {
 }
 
 func TestViewCustom(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	if !base.UnitTestUrlIsWalrus() {
 		t.Skip("This test may not pass under non-walrus, if views aren't enabled, as ViewAllDocs won't exist")

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -293,6 +293,10 @@ func TestUserAllowEmptyPassword(t *testing.T) {
 // Test user access grant while that user has an active changes feed.  (see issue #880)
 func TestUserAccessRace(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	// This test only runs against Walrus due to known sporadic failures.
 	// See https://github.com/couchbase/sync_gateway/issues/3006
 	if !base.UnitTestUrlIsWalrus() {
@@ -752,6 +756,10 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
 func TestSessionExtension(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var rt RestTester
 	defer rt.Close()
 
@@ -1081,6 +1089,10 @@ func TestDBGetConfigNames(t *testing.T) {
 //Take DB offline and ensure can post _resync
 func TestDBOfflinePostResync(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
@@ -1242,6 +1254,10 @@ func TestDBOnlineConcurrent(t *testing.T) {
 // Test bring DB online with delay of 1 second
 func TestSingleDBOnlineWithDelay(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
@@ -1282,6 +1298,10 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 // BD should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
@@ -1332,6 +1352,10 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 // BD should should only be brought online once
 // there should be no errors
 func TestDBOnlineWithTwoDelays(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1119,6 +1119,10 @@ func TestDBOfflinePostResync(t *testing.T) {
 // or even that they execute at the same time.  Disabling test
 func TestDBOfflineSingleResync(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	var rt RestTester
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2376,6 +2376,10 @@ func TestAccessOnTombstone(t *testing.T) {
 //Test for wrong _changes entries for user joining a populated channel
 func TestUserJoiningPopulatedChannel(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	base.EnableTestLogKey("Cache+")
 	base.EnableTestLogKey("Changes+")
 	base.EnableTestLogKey("CRUD+")

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -28,6 +28,10 @@ import (
 
 func TestChangesAccessNotifyInteger(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`)
 	defer it.Close()
 
@@ -78,6 +82,10 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 // channels in the filter were being included in the waiter initialization, but not in the subsequent wait.  Resulting difference in count was resulting
 // in longpoll terminating without any changes.
 func TestChangesNotifyChannelFilter(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	defer it.Close()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -251,6 +251,10 @@ func TestContinuousChangesSubscription(t *testing.T) {
 // Validate we get the expected updates and changes ends
 func TestBlipOneShotChangesSubscription(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	bt, err := NewBlipTester()
 	assertNoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -1307,6 +1311,5 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 	errorCode3 := subChangesResponse3.Properties["Error-Code"]
 	log.Printf("errorCode: %v", errorCode3)
 	assert.True(t, errorCode == "")
-
 
 }

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -540,6 +540,11 @@ func postChangesChannelFilter(t *testing.T, it indexTester) {
 }
 
 func TestPostChangesAdminChannelGrantInteger(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	defer it.Close()
 	postChangesAdminChannelGrant(t, it)
@@ -907,6 +912,10 @@ func TestChangesActiveOnlyInteger(t *testing.T) {
 }
 
 func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	var logKeys = map[string]bool{
 		"TEST": true,

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -312,6 +312,10 @@ func postChanges(t *testing.T, it indexTester) {
 // Tests race between waking up the changes feed, and detecting that the user doc has changed
 func TestPostChangesUserTiming(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`)
 	defer it.Close()
 
@@ -367,6 +371,11 @@ func TestPostChangesUserTiming(t *testing.T) {
 }
 
 func TestPostChangesSinceInteger(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	defer it.Close()
 	postChangesSince(t, it)
@@ -703,6 +712,10 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 }
 
 func TestUnusedSequences(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	// Only do 10 iterations if running against walrus.  If against a live couchbase server,
 	// just do single iteration.  (Takes approx 30s)


### PR DESCRIPTION
Skip the top known long-running tests when running with the `-short` flag. These will still be run under normal circumstances, but we have the option to skip them for faster repetitive testing (such as from IDEs).

## Example of `-short`
```
14:42 $ go test -count=1 ./...
?   	github.com/couchbase/sync_gateway	[no test files]
ok  	github.com/couchbase/sync_gateway/auth	2.813s
ok  	github.com/couchbase/sync_gateway/base	0.350s
ok  	github.com/couchbase/sync_gateway/channels	0.077s
ok  	github.com/couchbase/sync_gateway/db	16.253s
ok  	github.com/couchbase/sync_gateway/rest	46.756s
14:43 $ # total: 66.25s

14:43 $ go test -count=1 -short ./...
?   	github.com/couchbase/sync_gateway	[no test files]
ok  	github.com/couchbase/sync_gateway/auth	2.788s
ok  	github.com/couchbase/sync_gateway/base	0.344s
ok  	github.com/couchbase/sync_gateway/channels	0.064s
ok  	github.com/couchbase/sync_gateway/db	5.577s
ok  	github.com/couchbase/sync_gateway/rest	14.045s
14:43 $ # total: 22.76s
```