### PR TITLE
Collate high-volume logs for improved throughput

### DIFF
--- a/base/logger.go
+++ b/base/logger.go
@@ -1,0 +1,36 @@
+package base
+
+import (
+	"log"
+	"strings"
+	"time"
+)
+
+// FlushLogBuffers will cause all log collation buffers to be flushed to the output.
+func FlushLogBuffers() {
+	time.Sleep(loggerCollateFlushDelay)
+}
+
+func logCollationWorker(collateBuffer chan string, logger *log.Logger, bufferSize int) {
+	// This is the temporary buffer we'll store logs in.
+	logBuffer := []string{}
+	for {
+		select {
+		// Add log to buffer and flush to output if it's full.
+		case l := <-collateBuffer:
+			logBuffer = append(logBuffer, l)
+			if len(logBuffer) >= bufferSize {
+				logger.Print(strings.Join(logBuffer, "\n"))
+				// Empty buffer
+				logBuffer = logBuffer[:0]
+			}
+		// Flush the buffer to the output after this time, even if we don't fill it.
+		case <-time.After(loggerCollateFlushTimeout):
+			if len(logBuffer) > 0 {
+				logger.Print(strings.Join(logBuffer, "\n"))
+				// Empty buffer
+				logBuffer = logBuffer[:0]
+			}
+		}
+	}
+}

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -62,13 +62,15 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 					logBuffer = append(logBuffer, l)
 					if len(logBuffer) >= *config.CollationBufferSize {
 						logger.logger.Print(strings.Join(logBuffer, "\n"))
-						logBuffer = []string{}
+						// Empty buffer
+						logBuffer = logBuffer[:0]
 					}
 				// Flush the buffer to the output after this time, even if we don't fill it.
-				case <-time.After(LoggerCollateFlushTimeout):
+				case <-time.After(loggerCollateFlushTimeout):
 					if len(logBuffer) > 0 {
 						logger.logger.Print(strings.Join(logBuffer, "\n"))
-						logBuffer = []string{}
+						// Empty buffer
+						logBuffer = logBuffer[:0]
 					}
 				}
 			}

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/natefinch/lumberjack"
 	"github.com/pkg/errors"
@@ -25,16 +27,19 @@ var (
 type FileLogger struct {
 	Enabled bool
 
-	level  LogLevel
-	output io.Writer
-	logger *log.Logger
+	// collateBuffer is used to store log entries to batch up multiple logs.
+	collateBuffer chan string
+	level         LogLevel
+	output        io.Writer
+	logger        *log.Logger
 }
 
 type FileLoggerConfig struct {
 	Enabled  *bool             `json:"enabled,omitempty"`  // Toggle for this log output
 	Rotation logRotationConfig `json:"rotation,omitempty"` // Log rotation settings
 
-	Output io.Writer `json:"-"` // Logger output. Defaults to os.Stderr. Can be overridden for testing purposes.
+	CollationBufferSize *int      `json:"collation_buffer_size,omitempty"` // The size of the log collation buffer.
+	Output              io.Writer `json:"-"`                               // Logger output. Defaults to os.Stderr. Can be overridden for testing purposes.
 }
 
 type logRotationConfig struct {
@@ -50,12 +55,42 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, logFilePath string, 
 		return nil, err
 	}
 
-	return &FileLogger{
+	logger := &FileLogger{
 		Enabled: *config.Enabled,
 		level:   level,
 		output:  config.Output,
 		logger:  log.New(config.Output, "", 0),
-	}, nil
+	}
+
+	// Only create the collateBuffer channel and worker if required.
+	if *config.CollationBufferSize > 1 {
+		logger.collateBuffer = make(chan string, *config.CollationBufferSize)
+
+		// Start up a single worker to consume messages from the buffer
+		go func() {
+			// This is the temporary buffer we'll store logs in.
+			logBuffer := []string{}
+			for {
+				select {
+				// Add log to buffer and flush to output if it's full.
+				case l := <-logger.collateBuffer:
+					logBuffer = append(logBuffer, l)
+					if len(logBuffer) >= *config.CollationBufferSize {
+						logger.logger.Print(strings.Join(logBuffer, "\n"))
+						logBuffer = []string{}
+					}
+				// Flush the buffer to the output after this time, even if we don't fill it.
+				case <-time.After(LoggerCollateFlushTimeout):
+					if len(logBuffer) > 0 {
+						logger.logger.Print(strings.Join(logBuffer, "\n"))
+						logBuffer = []string{}
+					}
+				}
+			}
+		}()
+	}
+
+	return logger, nil
 }
 
 // Rotate will rotate the active log file.
@@ -73,6 +108,16 @@ func (l *FileLogger) Rotate() error {
 
 func (l FileLogger) String() string {
 	return "FileLogger(" + l.level.String() + ")"
+}
+
+// logf will put the given message into the collation buffer if it exists,
+// otherwise will log the message directly.
+func (l *FileLogger) logf(format string, args ...interface{}) {
+	if l.collateBuffer != nil {
+		l.collateBuffer <- fmt.Sprintf(format, args...)
+	} else {
+		l.logger.Printf(format, args...)
+	}
 }
 
 // shouldLog returns true if we can log.
@@ -119,6 +164,15 @@ func (lfc *FileLoggerConfig) init(level LogLevel, logFilePath string, minAge int
 			*lfc.Rotation.MaxSize,
 			*lfc.Rotation.MaxAge,
 		)
+	}
+
+	if lfc.CollationBufferSize == nil {
+		bufferSize := 0
+		// Set a default CollationBufferSize for verbose logs.
+		if level >= LevelInfo {
+			bufferSize = defaultFileLoggerCollateBufferSize
+		}
+		lfc.CollationBufferSize = &bufferSize
 	}
 
 	return nil

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"log"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/natefinch/lumberjack"
 	"github.com/pkg/errors"
@@ -67,29 +65,7 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, logFilePath string, 
 		logger.collateBuffer = make(chan string, *config.CollationBufferSize)
 
 		// Start up a single worker to consume messages from the buffer
-		go func() {
-			// This is the temporary buffer we'll store logs in.
-			logBuffer := []string{}
-			for {
-				select {
-				// Add log to buffer and flush to output if it's full.
-				case l := <-logger.collateBuffer:
-					logBuffer = append(logBuffer, l)
-					if len(logBuffer) >= *config.CollationBufferSize {
-						logger.logger.Print(strings.Join(logBuffer, "\n"))
-						// Empty buffer
-						logBuffer = logBuffer[:0]
-					}
-				// Flush the buffer to the output after this time, even if we don't fill it.
-				case <-time.After(loggerCollateFlushTimeout):
-					if len(logBuffer) > 0 {
-						logger.logger.Print(strings.Join(logBuffer, "\n"))
-						// Empty buffer
-						logBuffer = logBuffer[:0]
-					}
-				}
-			}
-		}()
+		go logCollationWorker(logger.collateBuffer, logger.logger, *config.CollationBufferSize)
 	}
 
 	return logger, nil

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -77,13 +77,15 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, logFilePath string, 
 					logBuffer = append(logBuffer, l)
 					if len(logBuffer) >= *config.CollationBufferSize {
 						logger.logger.Print(strings.Join(logBuffer, "\n"))
-						logBuffer = []string{}
+						// Empty buffer
+						logBuffer = logBuffer[:0]
 					}
 				// Flush the buffer to the output after this time, even if we don't fill it.
-				case <-time.After(LoggerCollateFlushTimeout):
+				case <-time.After(loggerCollateFlushTimeout):
 					if len(logBuffer) > 0 {
 						logger.logger.Print(strings.Join(logBuffer, "\n"))
-						logBuffer = []string{}
+						// Empty buffer
+						logBuffer = logBuffer[:0]
 					}
 				}
 			}

--- a/base/logging.go
+++ b/base/logging.go
@@ -443,19 +443,19 @@ func logTo(logLevel LogLevel, logKey LogKey, format string, args ...interface{})
 	args = redact(args)
 
 	if shouldLogConsole {
-		consoleLogger.logger.Printf(color(format, logLevel), args...)
+		consoleLogger.logf(color(format, logLevel), args...)
 	}
 	if shouldLogError {
-		errorLogger.logger.Printf(format, args...)
+		errorLogger.logf(format, args...)
 	}
 	if shouldLogWarn {
-		warnLogger.logger.Printf(format, args...)
+		warnLogger.logf(format, args...)
 	}
 	if shouldLogInfo {
-		infoLogger.logger.Printf(format, args...)
+		infoLogger.logf(format, args...)
 	}
 	if shouldLogDebug {
-		debugLogger.logger.Printf(format, args...)
+		debugLogger.logf(format, args...)
 	}
 }
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -39,11 +39,6 @@ type LoggingConfig struct {
 	DeprecatedDefaultLog *LogAppenderConfig `json:"default,omitempty"` // Deprecated "default" logging option.
 }
 
-// FlushLogBuffers will cause all log collation buffers to be flushed to the output.
-func FlushLogBuffers() {
-	time.Sleep(loggerCollateFlushDelay)
-}
-
 // Init will initilize loging, return any warnings that need to be logged at a later time.
 func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogFn, err error) {
 	if c == nil {

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -11,6 +12,14 @@ const (
 	warnMinAge  = 90
 	infoMinAge  = 3
 	debugMinAge = 1
+
+	// defaultConsoleLoggerCollateBufferSize is the number of console logs we'll
+	// buffer and collate, before flushing the buffer to the output.
+	defaultConsoleLoggerCollateBufferSize = 10
+	defaultFileLoggerCollateBufferSize    = defaultConsoleLoggerCollateBufferSize
+	// LoggerCollateFlushTimeout is the amount of time to wait before
+	// we flush to the output if we don't fill the buffer.
+	LoggerCollateFlushTimeout = 1 * time.Millisecond
 )
 
 // ErrUnsetLogFilePath is returned when no logFilePath, or --defaultLogFilePath fallback can be used.

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -17,9 +17,11 @@ const (
 	// buffer and collate, before flushing the buffer to the output.
 	defaultConsoleLoggerCollateBufferSize = 10
 	defaultFileLoggerCollateBufferSize    = defaultConsoleLoggerCollateBufferSize
-	// LoggerCollateFlushTimeout is the amount of time to wait before
+	// loggerCollateFlushTimeout is the amount of time to wait before
 	// we flush to the output if we don't fill the buffer.
-	LoggerCollateFlushTimeout = 1 * time.Millisecond
+	loggerCollateFlushTimeout = 1 * time.Millisecond
+	// loggerCollateFlushDelay is the duration to wait to allow the log collation buffers to be flushed to outputs.
+	loggerCollateFlushDelay = 1 * time.Second
 )
 
 // ErrUnsetLogFilePath is returned when no logFilePath, or --defaultLogFilePath fallback can be used.
@@ -35,6 +37,11 @@ type LoggingConfig struct {
 	Debug          FileLoggerConfig    `json:"debug,omitempty"`           // Debug log file output
 
 	DeprecatedDefaultLog *LogAppenderConfig `json:"default,omitempty"` // Deprecated "default" logging option.
+}
+
+// FlushLogBuffers will cause all log collation buffers to be flushed to the output.
+func FlushLogBuffers() {
+	time.Sleep(loggerCollateFlushDelay)
 }
 
 // Init will initilize loging, return any warnings that need to be logged at a later time.

--- a/main.go
+++ b/main.go
@@ -11,12 +11,8 @@ package main
 
 import (
 	"math/rand"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/rest"
 )
 
@@ -26,16 +22,5 @@ func init() {
 
 // Simple Sync Gateway launcher tool.
 func main() {
-
-	signalchannel := make(chan os.Signal, 1)
-	signal.Notify(signalchannel, syscall.SIGHUP)
-
-	go func() {
-		for range signalchannel {
-			base.Infof(base.KeyAll, "Handling SIGHUP signal.")
-			rest.HandleSighup()
-		}
-	}()
-
 	rest.ServerMain(rest.SyncGatewayRunModeNormal)
 }


### PR DESCRIPTION
This PR is intended to improve throughput when we have extremely high volumes of logging. The idea is to batch up logs into a buffer before collating them and pushing to the log output in a single action.

We also have a timeout mechanism, so even if the buffer is not filled, after a short time (1ms), we'll flush it to the output anyway. This avoids having logs sat in a buffer for ages.

I've had to add handling for panic recovery and os interrupts in ServerMain, as without these short delays, we'd miss seeing the last of any logs we wrote.

Based on developer testing, we'd expect to see double the write throughput compared to the 2.1 default config, whilst still logging everything, although still slightly short of the 2.0 default (HTTP only) logging.

<img width="1029" alt="screen shot 2018-06-27 at 13 14 35" src="https://user-images.githubusercontent.com/1525809/41973154-12bc2e74-7a0c-11e8-814d-05d2965265ca.png">
