### PR TITLE
Flush log buffer before exiting when calling Fatalf()

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -386,6 +386,7 @@ func Panicf(logKey LogKey, format string, args ...interface{}) {
 // Fatalf logs the given formatted string and args to the error log level and given log key and then exits.
 func Fatalf(logKey LogKey, format string, args ...interface{}) {
 	logTo(LevelError, logKey, format, args...)
+	FlushLogBuffers()
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Since this isn't a panic, we don't get the automatic handling of buffer flushing. We need to do it manually before exiting in order to ensure we log all fatal errors to console.