### PR TITLE
Fix errors caught by Go 1.11's stricter tests/vet tooling

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -76,11 +76,11 @@ type GoCBLogger struct{}
 func (l GoCBLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:
-		Errorf(KeyGoCB, format, v)
+		Errorf(KeyGoCB, format, v...)
 	case gocbcore.LogWarn:
-		Warnf(KeyGoCB, format, v)
+		Warnf(KeyGoCB, format, v...)
 	default:
-		Infof(KeyGoCB, format, v)
+		Infof(KeyGoCB, format, v...)
 	}
 	return nil
 }

--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -342,7 +342,7 @@ func (s *ShardedClock) UpdateAndWrite(updates map[uint16]uint64) (err error) {
 				// Note: The following is invoked upon cas failure - may be called multiple times
 				err = p.Unmarshal(value)
 				if err != nil {
-					Warnf(KeyAll, "Error unmarshalling clock during update", err)
+					Warnf(KeyAll, "Error unmarshalling clock during update: %v", err)
 					return nil, err
 				}
 				// Reapply sequences to partition
@@ -352,7 +352,7 @@ func (s *ShardedClock) UpdateAndWrite(updates map[uint16]uint64) (err error) {
 				return p.Marshal()
 			})
 			if err != nil {
-				Warnf(KeyAll, "Error writing sharded clock partition [%d]:%v", UD(p.Key), err)
+				Warnf(KeyAll, "Error writing sharded clock partition [%v]:%v", UD(p.Key), err)
 				shardedClockExpvars.Add("partition_cas_failures", 1)
 				return
 			}

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -422,7 +422,7 @@ func ReadMultipartDocument(reader *multipart.Reader) (Body, error) {
 		}
 		if ok {
 			if length != int64(len(data)) {
-				return nil, base.HTTPErrorf(http.StatusBadRequest, "Attachment length mismatch for %q: read %d bytes, should be %g", name, len(data), length)
+				return nil, base.HTTPErrorf(http.StatusBadRequest, "Attachment length mismatch for %q: read %d bytes, should be %d", name, len(data), length)
 			}
 		}
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -525,7 +525,7 @@ func (c *changeCache) processUnusedSequence(docID string) {
 	sequenceStr := strings.TrimPrefix(docID, UnusedSequenceKeyPrefix)
 	sequence, err := strconv.ParseUint(sequenceStr, 10, 64)
 	if err != nil {
-		base.Warnf(base.KeyAll, "Unable to identify sequence number for unused sequence notification with key: %s, error:", base.UD(docID), err)
+		base.Warnf(base.KeyAll, "Unable to identify sequence number for unused sequence notification with key: %s, error: %v", base.UD(docID), err)
 		return
 	}
 	change := &LogEntry{

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -277,8 +277,8 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	// the cache, so repeat the above:
 	cacheValidFrom, resultFromCache = c.getCachedChanges(options)
 	if len(resultFromCache) > numFromCache {
-		base.Infof(base.KeyCache, "2nd getCachedChanges(%q, %d) got %d more, valid from #%d!",
-			base.UD(c.channelName), options.Since, len(resultFromCache)-numFromCache, cacheValidFrom)
+		base.Infof(base.KeyCache, "2nd getCachedChanges(%q, %s) got %d more, valid from #%d!",
+			base.UD(c.channelName), options.Since.String(), len(resultFromCache)-numFromCache, cacheValidFrom)
 	}
 	if cacheValidFrom <= startSeq {
 		return resultFromCache, nil

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -125,7 +125,7 @@ func (wh *Webhook) HandleEvent(event Event) {
 		}()
 
 		if err != nil {
-			base.Warnf(base.KeyAll, "Error attempting to post %s to url %s: %s -- %+v", base.UD(event.String()), base.UD(wh.SanitizedUrl()), err)
+			base.Warnf(base.KeyAll, "Error attempting to post %s to url %s: %s", base.UD(event.String()), base.UD(wh.SanitizedUrl()), err)
 			return
 		}
 

--- a/db/import.go
+++ b/db/import.go
@@ -323,7 +323,7 @@ func (i *ImportFilterFunction) EvaluateFunction(doc Body) (bool, error) {
 
 	result, err := i.Call(doc)
 	if err != nil {
-		base.Warnf(base.KeyAll, "Unexpected error invoking import filter for document %s - processing aborted, document will not be imported.  Error: %v", err)
+		base.Warnf(base.KeyAll, "Unexpected error invoking import filter for document %s - processing aborted, document will not be imported.  Error: %v", base.UD(doc), err)
 		return false, err
 	}
 	switch result := result.(type) {

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -197,7 +197,7 @@ func (i *SGIndex) createIfNeeded(bucket *base.CouchbaseBucketGoCB, useXattrs boo
 			//  2. SG previously crashed between index creation and index build.
 			// GSI doesn't like concurrent build requests, so wait and recheck index state before treating as option 2.
 			// (see known issue documented https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/build-index.html)
-			base.Infof(base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.")
+			base.Infof(base.KeyQuery, "Index %s already in deferred state - waiting 10s to re-evaluate before issuing build to avoid concurrent build requests.", indexName)
 			time.Sleep(10 * time.Second)
 			exists, indexMeta, metaErr = bucket.GetIndexMeta(indexName)
 			if metaErr != nil || indexMeta == nil {

--- a/db/sequence_hasher.go
+++ b/db/sequence_hasher.go
@@ -193,7 +193,7 @@ func (s *sequenceHasher) GetHash(clock base.SequenceClock) (string, error) {
 			var sClocks storedClocks
 			err = sClocks.Unmarshal(value)
 			if err != nil {
-				base.Warnf(base.KeyAll, "Error unmarshalling hash storage during update", err)
+				base.Warnf(base.KeyAll, "Error unmarshalling hash storage during update: %v", err)
 				return nil, err
 			}
 			exists, index = sClocks.Contains(clockValue)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -208,7 +208,7 @@ func validateReplicationParameters(requestParams ReplicationConfig, paramsFromCo
 	//cancel parameter is only supported via the REST API
 	if requestParams.Cancel {
 		if paramsFromConfig {
-			err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate cancel is invalid in Sync Gateway configuration", requestParams.Source)
+			err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate cancel is invalid in Sync Gateway configuration")
 			return
 		} else {
 			cancel = true

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -573,7 +573,6 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["foo"]}`)
 	assertStatus(t, response, 201)
 
-	changesClosed := false
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -588,7 +587,6 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 		//  by the client.  This should be fixed more generally (to terminate all active user sessions when the user is deleted, not just
 		//  changes feeds) but that enhancement is too high risk to introduce at this time.  The timeout on changes will terminate the unit
 		//  test.
-		changesClosed = true
 		if changesResponse.Code == 401 {
 			// case 1 - ok
 		} else {

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -95,7 +95,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 				}
 				b.StopTimer()
 				if getResponse.Code != 200 {
-					log.Printf("Unexpected response: %s", getResponse)
+					log.Printf("Unexpected response status code: %d", getResponse.Code)
 				}
 				b.StartTimer()
 			}
@@ -161,7 +161,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 				}
 				b.StopTimer()
 				if getResponse.Code != 200 {
-					log.Printf("Unexpected response: %s", getResponse)
+					log.Printf("Unexpected response status code: %d", getResponse.Code)
 				}
 				b.StartTimer()
 			}
@@ -232,7 +232,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 				}
 				b.StopTimer()
 				if changesResponse.Code != 200 {
-					log.Printf("Unexpected response: %s", changesResponse.Code)
+					log.Printf("Unexpected response status code: %d", changesResponse.Code)
 				}
 				b.StartTimer()
 			}

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -132,6 +132,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &initialChanges)
+	assertNoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
 	assert.Equals(t, lastSeq, "1")
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -713,8 +713,7 @@ func (bh *blipHandler) downloadOrVerifyAttachments(body db.Body, minRevpos int, 
 }
 
 func (ctx *blipSyncContext) incrementSerialNumber() uint64 {
-	ctx.handlerSerialNumber = atomic.AddUint64(&ctx.handlerSerialNumber, 1)
-	return atomic.LoadUint64(&ctx.handlerSerialNumber)
+	return atomic.AddUint64(&ctx.handlerSerialNumber, 1)
 }
 
 func (ctx *blipSyncContext) addAllowedAttachments(atts map[string]interface{}) {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1034,7 +1034,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("%s", testCase), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 
 			rt = RestTester{
 				SyncFn:         `function(doc, oldDoc) { channel(doc.channels) }`,


### PR DESCRIPTION
Running tests under Go 1.11 flags some errors we'd missed as test failures:

- Remove ineffective atomic assignment in `blipSyncContext.incrementSerialNumber`
- Remove unused/ineffective variable in test
- Fix incorrect formatting directives caught by Go 1.11

The test suite still doesn't completely run under Go 1.11 yet, but this is due to #3671 which will hopefully be fixed before Go 1.11 is shipped.