### PR TITLE
Wrap external logger interfaces so log output is consistent

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 
 	"github.com/couchbase/gocb"
-	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 	"gopkg.in/couchbase/gocbcore.v7"
 )
@@ -71,38 +71,8 @@ type CouchbaseBucketGoCB struct {
 	viewOps      chan struct{} // Manages max concurrent view ops (per kv node)
 }
 
-type GoCBLogger struct{}
-
-func (l GoCBLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
-	switch level {
-	case gocbcore.LogError:
-		Errorf(KeyGoCB, format, v...)
-	case gocbcore.LogWarn:
-		Warnf(KeyGoCB, format, v...)
-	default:
-		Infof(KeyGoCB, format, v...)
-	}
-	return nil
-}
-
-func EnableGoCBLogging() {
-	gocbcore.SetLogger(GoCBLogger{})
-}
-
-func DisableGoCBLogging() {
-	gocbcore.SetLogger(nil)
-}
-
 // Creates a Bucket that talks to a real live Couchbase server.
 func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err error) {
-
-	// Only wrap the gocb logging when the log key is set, to avoid the overhead of a log keys
-	// map lookup for every gocb log call
-
-	logKeys := GetLogKeys()
-	if logKeys["gocb"] {
-		EnableGoCBLogging()
-	}
 
 	// TODO: Push the above down into spec.GetConnString
 	connString, err := spec.GetGoCBConnString()

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -577,6 +577,10 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		dataSourceOptions.IncludeXAttrs = true
 	}
 
+	dataSourceOptions.Logf = func(fmt string, v ...interface{}) {
+		Debugf(KeyDCP, fmt, v...)
+	}
+
 	dataSourceOptions.Name = GenerateDcpStreamName("SG")
 
 	auth := spec.Auth

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -1,0 +1,180 @@
+package base
+
+import (
+	"github.com/couchbase/gocb"
+	"github.com/couchbase/goutils/logging"
+	"gopkg.in/couchbase/gocbcore.v7"
+)
+
+// This file implements wrappers around the loggers of external packages
+// so that all of SG's logging output is consistent
+
+func initExternalLoggers() {
+	gocb.SetLogger(GoCBLogger{})
+	gocbcore.SetLogger(GoCBCoreLogger{})
+	logging.SetLogger(CBGoUtilsLogger{})
+}
+
+// **************************************************
+// Implementation of github.com/couchbase/gocb.Logger
+// **************************************************
+type GoCBLogger struct{}
+
+var _ gocb.Logger = GoCBLogger{}
+
+func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
+	switch level {
+	case gocb.LogError:
+		Errorf(KeyGoCB, format, v...)
+	case gocb.LogWarn:
+		Warnf(KeyGoCB, format, v...)
+	default:
+		Tracef(KeyGoCB, format, v...)
+	}
+	return nil
+}
+
+// ******************************************************
+// Implementation of github.com/couchbase/gocbcore.Logger
+// ******************************************************
+type GoCBCoreLogger struct{}
+
+var _ gocbcore.Logger = GoCBCoreLogger{}
+
+func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
+	switch level {
+	case gocbcore.LogError:
+		Errorf(KeyGoCB, format, v...)
+	case gocbcore.LogWarn:
+		Warnf(KeyGoCB, format, v...)
+	default:
+		Tracef(KeyGoCB, format, v...)
+	}
+	return nil
+}
+
+// **************************************************************
+// Implementation for github.com/couchbase/goutils/logging.Logger
+// **************************************************************
+type CBGoUtilsLogger struct{}
+
+var _ logging.Logger = CBGoUtilsLogger{}
+
+func (CBGoUtilsLogger) SetLevel(l logging.Level) {
+	return // no-op
+}
+
+func (CBGoUtilsLogger) Level() logging.Level {
+	if consoleLogger == nil || consoleLogger.LogLevel == nil {
+		return logging.INFO
+	}
+	return ToDeprecatedLogLevel(*consoleLogger.LogLevel).cgLevel()
+}
+
+func (CBGoUtilsLogger) Fatalf(fmt string, args ...interface{}) {
+	Fatalf(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Severef(fmt string, args ...interface{}) {
+	Errorf(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Errorf(fmt string, args ...interface{}) {
+	Errorf(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Warnf(fmt string, args ...interface{}) {
+	Warnf(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Infof(fmt string, args ...interface{}) {
+	Infof(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Requestf(rlevel logging.Level, fmt string, args ...interface{}) {
+	Tracef(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Tracef(fmt string, args ...interface{}) {
+	Tracef(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Debugf(fmt string, args ...interface{}) {
+	Debugf(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Logf(level logging.Level, fmt string, args ...interface{}) {
+	Infof(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+}
+
+func (CBGoUtilsLogger) Fatalm(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Fatalm not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Fatalp(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Fatalp not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Severem(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Severem not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Severep(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Severep not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Errorm(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Errorm not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Errorp(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Errorp not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Warnm(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Warnm not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Warnp(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Warnp not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Infom(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Infom not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Infop(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Infop not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Requestm(rlevel logging.Level, msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Requestm not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Requestp(rlevel logging.Level, msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Requestp not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Tracem(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Tracem not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Tracep(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Tracep not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Debugm(msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Debugm not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Debugp(msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Debugp not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Logm(level logging.Level, msg string, kv logging.Map) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Logm not implemented! "+msg)
+}
+
+func (CBGoUtilsLogger) Logp(level logging.Level, msg string, kv ...logging.Pair) {
+	Warnf(KeyAll, "CBGoUtilsLogger: Logp not implemented! "+msg)
+}

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -107,6 +107,7 @@ func (CBGoUtilsLogger) Logf(level logging.Level, fmt string, args ...interface{}
 	Infof(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
+// go-couchbase/gomemcached don't use Pair/Map logs, so these are all stubs
 func (CBGoUtilsLogger) Fatalm(msg string, kv logging.Map) {
 	Warnf(KeyAll, "CBGoUtilsLogger: Fatalm not implemented! "+msg)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -375,6 +375,7 @@ func init() {
 	// This maintains consistent formatting (timestamps, levels, etc) in the output,
 	// and allows a single set of logging functions to be used, rather than fmt.Printf()
 	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{})
+	initExternalLoggers()
 }
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -81,6 +81,9 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 		return warnings, err
 	}
 
+	// Initialize external loggers too
+	initExternalLoggers()
+
 	return warnings, nil
 }
 


### PR DESCRIPTION
Added or moved logging wrappers for `gocb`, `gocbcore`, `goutil/logging` (used by `gomemcached`), and `go-couchbase/cbdatasource` packages, so log output from SG is consistent (timestamp formats, log level labels, etc.)

Example before:
![screen shot 2018-07-09 at 16 07 35](https://user-images.githubusercontent.com/1525809/42458726-367f5f5e-8392-11e8-80f5-bef4b8f4340d.png)

after:
![screen shot 2018-07-09 at 16 04 16](https://user-images.githubusercontent.com/1525809/42458701-294fc670-8392-11e8-9bde-d813287443e9.png)