### PR TITLE
#3667 strongly typed attachment metadata

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -57,7 +57,7 @@ func TestAttachments(t *testing.T) {
 	assertNoError(t, err, "Couldn't create document")
 
 	log.Printf("Retrieve doc...")
-	rev1output := `{"_attachments":{"bye.txt":{"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA==","digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
+	rev1output := `{"_attachments":{"bye.txt":{"digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1,"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"data":"aGVsbG8gd29ybGQ="}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
 	gotbody, err := db.GetRev("doc1", "", false, []string{})
 	assertNoError(t, err, "Couldn't get document")
 	assert.Equals(t, tojson(gotbody), rev1output)
@@ -72,13 +72,13 @@ func TestAttachments(t *testing.T) {
 	assert.Equals(t, revid, "2-08b42c51334c0469bd060e6d9e6d797b")
 
 	log.Printf("Retrieve doc...")
-	rev2output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
+	rev2output := `{"_attachments":{"bye.txt":{"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2,"data":"YnllLXlh"},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"data":"aGVsbG8gd29ybGQ="}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
 	assertNoError(t, err, "Couldn't get document")
 	assert.Equals(t, tojson(gotbody), rev2output)
 
 	log.Printf("Retrieve doc with atts_since...")
-	rev2Aoutput := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
+	rev2Aoutput := `{"_attachments":{"bye.txt":{"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2,"data":"YnllLXlh"},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{"1-54f3a105fb903018c160712ffddb74dc", "1-foo", "993-bar"})
 	assertNoError(t, err, "Couldn't get document")
 	assert.Equals(t, tojson(gotbody), rev2Aoutput)
@@ -93,7 +93,7 @@ func TestAttachments(t *testing.T) {
 	assert.Equals(t, revid, "3-252b9fa1f306930bffc07e7d75b77faf")
 
 	log.Printf("Retrieve doc...")
-	rev3output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2}},"_id":"doc1","_rev":"3-252b9fa1f306930bffc07e7d75b77faf"}`
+	rev3output := `{"_attachments":{"bye.txt":{"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2,"data":"YnllLXlh"}},"_id":"doc1","_rev":"3-252b9fa1f306930bffc07e7d75b77faf"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
 	assertNoError(t, err, "Couldn't get document")
 	assert.Equals(t, tojson(gotbody), rev3output)

--- a/db/crud.go
+++ b/db/crud.go
@@ -104,7 +104,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (syncData, error) {
 	emptySyncData := syncData{}
 	key := realDocID(docid)
 	if key == "" {
-		return syncData{}, base.HTTPErrorf(400, "Invalid doc ID")
+		return emptySyncData, base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
 	if db.UseXattrs() {

--- a/db/document.go
+++ b/db/document.go
@@ -760,7 +760,7 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 		var revOnlyMeta revOnlySyncData
 		unmarshalErr := json.Unmarshal(xdata, &revOnlyMeta)
 		if unmarshalErr != nil {
-			return pkgerrors.WithStack(base.RedactErrorf( "Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
+			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
 		doc.syncData = syncData{
 			CurrentRev: revOnlyMeta.CurrentRev,

--- a/db/revision.go
+++ b/db/revision.go
@@ -45,15 +45,11 @@ func (body Body) MutableAttachmentsCopy() Body {
 	copied := make(Body, len(body))
 	for k1, v1 := range body {
 		if k1 == "_attachments" {
-			atts := v1.(map[string]interface{})
-			attscopy := make(map[string]interface{}, len(atts))
+			atts := v1.(AttachmentMap)
+			attscopy := make(AttachmentMap, len(atts))
 			for k2, v2 := range atts {
-				attachment := v2.(map[string]interface{})
-				attachmentcopy := make(map[string]interface{}, len(attachment))
-				for k3, v3 := range attachment {
-					attachmentcopy[k3] = v3
-				}
-				attscopy[k2] = attachmentcopy
+				copy := *v2
+				attscopy[k2] = &copy
 			}
 			v1 = attscopy
 		}

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"log"
 	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/go.assert"
 )
 
 func TestParseRevID(t *testing.T) {
@@ -29,4 +32,28 @@ func TestParseRevID(t *testing.T) {
 	assertTrue(t, generation == 333, "Expected generation")
 	assertTrue(t, digest == "a", "Unexpected digest")
 
+}
+
+func TestMutableAttachmentsCopy(t *testing.T) {
+	obj := "obj"
+
+	b := Body{
+		"ABC": "abc",
+		"def": 1234,
+		"xYz": map[string]string{"objData": "abc"},
+		"obj": &obj,
+	}
+
+	// Take a copy and make sure they're the same
+	bCopy := b.MutableAttachmentsCopy()
+	assert.DeepEquals(t, b, bCopy)
+
+	// Mutate the original and check the copy is intact
+	b["ABC"] = "xyz"
+	assert.Equals(t, b["ABC"], "xyz")
+	assert.Equals(t, bCopy["ABC"], "abc")
+
+	bCopy["obj"] = base.StringPointer("modifiedObj")
+	assert.Equals(t, *b["obj"].(*string), "obj")
+	assert.Equals(t, *bCopy["obj"].(*string), "modifiedObj")
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -41,6 +41,8 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", docId), `{"value":"initial"}`)
 	response.DumpBody()
 
+	assertStatus(t, response, http.StatusCreated)
+
 	// Discover revision ID
 	// TODO: The schema for SG responses should be defined in our code somewhere to avoid this clunky approach
 	var responseDoc map[string]interface{}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3266,7 +3266,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	*/
 
 	// Modify the doc directly in the bucket to delete the digest field
-	attachments := db.BodyAttachments(couchbaseDoc)
+	attachments := couchbaseDoc["_attachments"].(map[string]interface{})
 	attach1 := attachments[attachmentName].(map[string]interface{})
 	delete(attach1, "digest")
 	delete(attach1, "content_type")


### PR DESCRIPTION
Related to #3667 

Refactor attachment metadata handling to change from generic `interface{}`/`map[string]interface{}` types to the `DocAttachment`/`AttachmentMap` types we already have.

## Integration Tests:
- [ ] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/767/
- [ ] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/768/