### PR TITLE
Use wall clock time for sgcollect_info duration

### DIFF
--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -83,6 +83,7 @@ func (sg *sgCollect) Start(zipFilename string, params sgCollectOptions) error {
 	}
 
 	atomic.StoreUint32(sg.status, sgRunning)
+	startTime := time.Now()
 	base.Infof(base.KeyAdmin, "sgcollect_info started with args: %v", base.UD(args))
 
 	// Stream sgcollect_info stderr to warn logs
@@ -112,7 +113,7 @@ func (sg *sgCollect) Start(zipFilename string, params sgCollectOptions) error {
 		err := cmd.Wait()
 
 		atomic.StoreUint32(sg.status, sgStopped)
-		duration := cmd.ProcessState.UserTime()
+		duration := time.Since(startTime)
 
 		if err != nil {
 			if err.Error() == "signal: killed" {


### PR DESCRIPTION
Fixes inaccurate sgcollect_info runtime due to reading CPU time instead of wall clock time.

## Before

<img width="607" alt="screen shot 2018-07-30 at 15 49 48 copy" src="https://user-images.githubusercontent.com/1525809/43405531-f90ee974-9411-11e8-8b9c-c8e5df7c8824.png">

## After

<img width="631" alt="screen shot 2018-07-30 at 15 55 37 copy" src="https://user-images.githubusercontent.com/1525809/43405532-f95f5404-9411-11e8-9b70-b7b31cc34298.png">
