### PR TITLE
#3667 Store attachment metadata in sync data

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -158,8 +158,6 @@ func (db *Database) retrieveAncestorAttachments(doc *document, parentRev string,
 // If minRevpos is > 0, then only attachments that have been changed in a revision of that
 // generation or later are loaded.
 func (db *Database) loadBodyAttachments(body Body, minRevpos int, docid string) (Body, error) {
-
-	body = body.MutableAttachmentsCopy()
 	for attachmentName, value := range BodyAttachments(body) {
 		meta := value.(map[string]interface{})
 		revpos, ok := base.ToInt64(meta["revpos"])

--- a/db/crud.go
+++ b/db/crud.go
@@ -299,6 +299,7 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 
 	// If doc is nil (we got the rev from the rev cache)
 	// look up the doc sync to get attachment metadata and exp
+	// TODO: Issue #3688 - We should enhance the rev cache to include attachment metadata
 	if doc == nil {
 		if doc, err = db.GetDocument(docid, DocUnmarshalSync); doc == nil {
 			return nil, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -104,7 +104,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (syncData, error) {
 	emptySyncData := syncData{}
 	key := realDocID(docid)
 	if key == "" {
-		return syncData{}, base.HTTPErrorf(400, "Invalid doc ID")
+		return emptySyncData, base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
 	if db.UseXattrs() {
@@ -297,19 +297,24 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 		body["_revisions"] = revisions
 	}
 
-	if showExp {
-		// If doc is nil (we got the rev from the rev cache), look up the doc to find the exp on the doc
-		if doc == nil {
-			if doc, err = db.GetDocument(docid, DocUnmarshalSync); doc == nil {
-				return nil, err
-			}
-		}
-		if doc.Expiry != nil && !doc.Expiry.IsZero() {
-			body["_exp"] = doc.Expiry.Format(time.RFC3339)
+	// If doc is nil (we got the rev from the rev cache)
+	// look up the doc sync to get attachment metadata and exp
+	if doc == nil {
+		if doc, err = db.GetDocument(docid, DocUnmarshalSync); doc == nil {
+			return nil, err
 		}
 	}
 
-	// Add attachment bodies:
+	if showExp && doc.Expiry != nil && !doc.Expiry.IsZero() {
+		body["_exp"] = doc.Expiry.Format(time.RFC3339)
+	}
+
+	// Stamp attachment metadata back into the body
+	if doc.Attachments != nil {
+		body["_attachments"] = doc.Attachments
+	}
+
+	// Add attachment bodies if requested:
 	if attachmentsSince != nil && len(BodyAttachments(body)) > 0 {
 		minRevpos := 1
 		if len(attachmentsSince) > 0 {
@@ -330,6 +335,7 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 			return nil, err
 		}
 	}
+
 	return body, nil
 }
 
@@ -394,7 +400,7 @@ func (db *Database) authorizeDoc(doc *document, revid string) error {
 }
 
 // Gets a revision of a document. If it's obsolete it will be loaded from the database if possible.
-// This method adds the magic _id and _rev properties.
+// This method adds the magic _id, _rev and _attachments properties.
 func (db *DatabaseContext) getRevision(doc *document, revid string) (Body, error) {
 	var body Body
 	if body = doc.getRevisionBody(revid, db.RevisionBodyLoader); body == nil {
@@ -410,6 +416,11 @@ func (db *DatabaseContext) getRevision(doc *document, revid string) (Body, error
 	body.FixJSONNumbers() // Make sure big ints won't get output in scientific notation
 	body["_id"] = doc.ID
 	body["_rev"] = revid
+
+	if doc.Attachments != nil {
+		body["_attachments"] = doc.Attachments
+	}
+
 	return body, nil
 }
 
@@ -615,7 +626,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 			return nil, nil, nil, base.HTTPErrorf(http.StatusConflict, "Document revision conflict")
 		}
 
-		// Process the attachments, replacing bodies with digests. This alters 'body' so it has to
+		// Process the attachments, and populate _sync with metadata. This alters 'body' so it has to
 		// be done before calling createRevID (the ID is based on the digest of the body.)
 		newAttachments, err := db.storeAttachments(doc, body, generation, matchRev, nil)
 		if err != nil {
@@ -629,6 +640,10 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 			base.Infof(base.KeyCRUD, "Failed to add revision ID: %s, error: %v", newRev, err)
 			return nil, nil, nil, base.ErrRevTreeAddRevFailure
 		}
+
+		// move _attachment metadata to syncdata of doc after rev-id generation
+		doc.syncData.Attachments = BodyAttachments(body)
+		delete(body, "_attachments")
 
 		return body, newAttachments, nil, nil
 	})

--- a/db/revision.go
+++ b/db/revision.go
@@ -36,32 +36,6 @@ func (body Body) ShallowCopy() Body {
 	return copied
 }
 
-// Creates a mutable copy that does a deep copy of the _attachments property in the body,
-// suitable for modification by the caller
-func (body Body) MutableAttachmentsCopy() Body {
-	if body == nil {
-		return nil
-	}
-	copied := make(Body, len(body))
-	for k1, v1 := range body {
-		if k1 == "_attachments" {
-			atts := v1.(map[string]interface{})
-			attscopy := make(map[string]interface{}, len(atts))
-			for k2, v2 := range atts {
-				attachment := v2.(map[string]interface{})
-				attachmentcopy := make(map[string]interface{}, len(attachment))
-				for k3, v3 := range attachment {
-					attachmentcopy[k3] = v3
-				}
-				attscopy[k2] = attachmentcopy
-			}
-			v1 = attscopy
-		}
-		copied[k1] = v1
-	}
-	return copied
-}
-
 // Returns the expiry as uint32 (using getExpiry), and removes the _exp property from the body
 func (body Body) extractExpiry() (uint32, error) {
 

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -3,9 +3,6 @@ package db
 import (
 	"log"
 	"testing"
-
-	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
 )
 
 func TestParseRevID(t *testing.T) {
@@ -32,41 +29,4 @@ func TestParseRevID(t *testing.T) {
 	assertTrue(t, generation == 333, "Expected generation")
 	assertTrue(t, digest == "a", "Unexpected digest")
 
-}
-
-func TestMutableAttachmentsCopy(t *testing.T) {
-	obj := "obj"
-
-	b := Body{
-		"ABC": "abc",
-		"def": 1234,
-		"xYz": map[string]string{"objData": "abc"},
-		"obj": &obj,
-		"_attachments": map[string]interface{}{
-			"myattachment": map[string]interface{}{
-				"data":   "xyz",
-				"length": 1234,
-			},
-		},
-	}
-
-	// Take a copy and make sure they're the same
-	bCopy := b.MutableAttachmentsCopy()
-	assert.DeepEquals(t, b, bCopy)
-
-	// Mutate the original and check the copy is intact
-	b["ABC"] = "xyz"
-	assert.Equals(t, b["ABC"], "xyz")
-	assert.Equals(t, bCopy["ABC"], "abc")
-
-	// Try with the special _attachments property
-	att := b["_attachments"].(map[string]interface{})["myattachment"].(map[string]interface{})
-	attCopy := bCopy["_attachments"].(map[string]interface{})["myattachment"].(map[string]interface{})
-	att["data"] = "abc"
-	assert.Equals(t, att["data"], "abc")
-	assert.Equals(t, attCopy["data"], "xyz")
-
-	bCopy["obj"] = base.StringPointer("modifiedObj")
-	assert.Equals(t, *b["obj"].(*string), "obj")
-	assert.Equals(t, *bCopy["obj"].(*string), "modifiedObj")
 }

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -3,6 +3,9 @@ package db
 import (
 	"log"
 	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbaselabs/go.assert"
 )
 
 func TestParseRevID(t *testing.T) {
@@ -29,4 +32,41 @@ func TestParseRevID(t *testing.T) {
 	assertTrue(t, generation == 333, "Expected generation")
 	assertTrue(t, digest == "a", "Unexpected digest")
 
+}
+
+func TestMutableAttachmentsCopy(t *testing.T) {
+	obj := "obj"
+
+	b := Body{
+		"ABC": "abc",
+		"def": 1234,
+		"xYz": map[string]string{"objData": "abc"},
+		"obj": &obj,
+		"_attachments": map[string]interface{}{
+			"myattachment": map[string]interface{}{
+				"data":   "xyz",
+				"length": 1234,
+			},
+		},
+	}
+
+	// Take a copy and make sure they're the same
+	bCopy := b.MutableAttachmentsCopy()
+	assert.DeepEquals(t, b, bCopy)
+
+	// Mutate the original and check the copy is intact
+	b["ABC"] = "xyz"
+	assert.Equals(t, b["ABC"], "xyz")
+	assert.Equals(t, bCopy["ABC"], "abc")
+
+	// Try with the special _attachments property
+	att := b["_attachments"].(map[string]interface{})["myattachment"].(map[string]interface{})
+	attCopy := bCopy["_attachments"].(map[string]interface{})["myattachment"].(map[string]interface{})
+	att["data"] = "abc"
+	assert.Equals(t, att["data"], "abc")
+	assert.Equals(t, attCopy["data"], "xyz")
+
+	bCopy["obj"] = base.StringPointer("modifiedObj")
+	assert.Equals(t, *b["obj"].(*string), "obj")
+	assert.Equals(t, *bCopy["obj"].(*string), "modifiedObj")
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -41,6 +41,8 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", docId), `{"value":"initial"}`)
 	response.DumpBody()
 
+	assertStatus(t, response, http.StatusCreated)
+
 	// Discover revision ID
 	// TODO: The schema for SG responses should be defined in our code somewhere to avoid this clunky approach
 	var responseDoc map[string]interface{}


### PR DESCRIPTION
Closes #3667 

- [x] Move attachment metadata into sync when receiving, and stamp back into `_attachments` when sending documents.
- [x] Ensure inline attachments aren't stored in sync
- [x] Remove unnecessary `MutableAttachmentsCopy()` and ensure `TestAttachmentsNoCrossTalk()` still passes.

## Integration tests
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/775/
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/776/