### PR TITLE
Only retry a bucket Update/WriteUpdate with a CAS failure

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1521,9 +1521,10 @@ func (bucket *CouchbaseBucketGoCB) Update(k string, exp uint32, callback sgbucke
 			}
 		}
 
-		// If there was no error, we're done
-		if err == nil {
-			return nil
+		if pkgerrors.Cause(err) == gocb.ErrKeyExists {
+			// retry on cas failure
+		} else if err != nil {
+			return err
 		}
 
 	}
@@ -1596,9 +1597,11 @@ func (bucket *CouchbaseBucketGoCB) WriteUpdate(k string, exp uint32, callback sg
 
 			}
 		}
-		// If there was no error, we're done
-		if err == nil {
-			return nil
+
+		if pkgerrors.Cause(err) == gocb.ErrKeyExists {
+			// retry on cas failure
+		} else if err != nil {
+			return err
 		}
 	}
 }

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -11,7 +11,6 @@ package base
 
 import (
 	"encoding/json"
-	"errors"
 	"expvar"
 	"fmt"
 	"sync"
@@ -20,9 +19,9 @@ import (
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
-	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 var dcpExpvars *expvar.Map
@@ -423,7 +422,7 @@ func (r *DCPReceiver) initFeed(backfillType uint64) error {
 
 	statsUuids, highSeqnos, err := r.bucket.GetStatsVbSeqno(r.maxVbNo, false)
 	if err != nil {
-		return errors.New("Error retrieving stats-vbseqno - DCP not supported")
+		return pkgerrors.Wrap(err, "Error retrieving stats-vbseqno - DCP not supported")
 	}
 
 	r.vbuuids = statsUuids


### PR DESCRIPTION
Closes #3690 
Fixes #3689 

- `Update` and `WriteUpdate` used to go into an unlimited retry loop on every error until it succeeded. Now we only retry on an explicit CAS failure.
- Minor improvement to error message in DCP `initFeed`.