### PR TITLE
#3693  Disable log collation on init, and use default value when loading logging config

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -374,7 +374,12 @@ func init() {
 	// We'll initilise a default consoleLogger so we can still log stuff before/during parsing logging configs.
 	// This maintains consistent formatting (timestamps, levels, etc) in the output,
 	// and allows a single set of logging functions to be used, rather than fmt.Printf()
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{})
+
+	// initialCollationBufferSize is set to zero for disabling log collation before
+	// initializing a logging config, and when running under a test scenario.
+	initialCollationBufferSize := 0
+
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{CollationBufferSize: &initialCollationBufferSize})
 	initExternalLoggers()
 }
 


### PR DESCRIPTION
Fixes #3693 

By setting the log collation buffer size to zero on init, we effectively disable it, until the logging config is parsed.

This is useful in scenarios like unit tests, where we do not want log collation enabled by default, but we still want to use a non-zero default value in Sync Gateway.