### PR TITLE
Catch missed teardownFn calls in SetUpTestLogging

### DIFF
--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -39,7 +39,7 @@ type LoggingConfig struct {
 	DeprecatedDefaultLog *LogAppenderConfig `json:"default,omitempty"` // Deprecated "default" logging option.
 }
 
-// Init will initilize loging, return any warnings that need to be logged at a later time.
+// Init will initialize loging, return any warnings that need to be logged at a later time.
 func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogFn, err error) {
 	if c == nil {
 		return warnings, errors.New("nil LoggingConfig")

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -595,15 +595,21 @@ func TestSetUpTestLogging(t *testing.T) {
 	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
 	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
 
+	teardownFn = DisableTestLogging()
+	assert.Equals(t, *consoleLogger.LogLevel, LevelNone)
+	assert.Equals(t, *consoleLogger.LogKey, KeyNone)
+
+	teardownFn()
+	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
+	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+
 	SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
 	assert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
 	assert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
 
 	// Now we should panic because we forgot to call teardown!
 	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic from multiple SetUpTestLogging calls")
-		}
+		assertTrue(t, recover() != nil, "Expected panic from multiple SetUpTestLogging calls")
 	}()
 	SetUpTestLogging(LevelError, KeyAuth|KeyCRUD)
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -581,3 +581,29 @@ func TestRedactBasicAuthURL(t *testing.T) {
 		assert.Equals(t, RedactBasicAuthURL(test.input), test.expected)
 	}
 }
+
+func TestSetUpTestLogging(t *testing.T) {
+	// Check default state of logging is as expected.
+	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
+	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+
+	teardownFn := SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
+	assert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
+	assert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
+
+	teardownFn()
+	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
+	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+
+	SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
+	assert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
+	assert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
+
+	// Now we should panic because we forgot to call teardown!
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic from multiple SetUpTestLogging calls")
+		}
+	}()
+	SetUpTestLogging(LevelError, KeyAuth|KeyCRUD)
+}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -550,6 +550,20 @@ func NumOpenBuckets(bucketName string) int32 {
 // Shorthand style:
 //     defer SetUpTestLogging(LevelDebug, KeyCache|KeyDCP|KeySync)()
 func SetUpTestLogging(logLevel LogLevel, logKeys LogKey) (teardownFn func()) {
+	caller := GetCallersName(1, false)
+	Infof(KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
+	return setTestLogging(logLevel, logKeys, caller)
+}
+
+// DisableTestLogging is an alias for SetUpTestLogging(LevelNone, KeyNone)
+// This function will panic if called multiple times without running the teardownFn.
+func DisableTestLogging() (teardownFn func()) {
+	caller := GetCallersName(1, false)
+	Infof(KeyAll, "%s: Disabling logging", caller)
+	return setTestLogging(LevelNone, KeyNone, caller)
+}
+
+func setTestLogging(logLevel LogLevel, logKeys LogKey, caller string) (teardownFn func()) {
 	initialLogLevel := LevelInfo
 	initialLogKey := KeyHTTP
 
@@ -559,8 +573,6 @@ func SetUpTestLogging(logLevel LogLevel, logKeys LogKey) (teardownFn func()) {
 		panic("Logging is in an unexpected state! Did a previous test forget to call the teardownFn of SetUpTestLogging?")
 	}
 
-	caller := GetCallersName(1, false)
-	Infof(KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
 	consoleLogger.LogLevel.Set(logLevel)
 	consoleLogger.LogKey.Set(logKeys)
 

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -430,7 +430,7 @@ func writeEntries(entries []*LogEntry) {
 
 func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -449,7 +449,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -466,7 +466,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -483,7 +483,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -500,7 +500,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
@@ -535,7 +535,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 	context := testBucketContext()
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1534,7 +1534,7 @@ func TestViewCustom(t *testing.T) {
 //////// BENCHMARKS
 
 func BenchmarkDatabase(b *testing.B) {
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 
 	for i := 0; i < b.N; i++ {
 		bucket, _ := ConnectToBucket(base.BucketSpec{

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="cfb311c6c78b481c057e0b4b3a465e20c43acbc2"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="940f36196a6a129226dfcebbe1cfa9b493dcd734"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="940f36196a6a129226dfcebbe1cfa9b493dcd734"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="be5b4cc097efe306b7ae8224f88152b254fc0ed7"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="ece34eb09fc57a0d27452d0e2c2e01154daaa1e2"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="cfb311c6c78b481c057e0b4b3a465e20c43acbc2"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -57,7 +57,8 @@ var doc_1k_format = `{%s
 
 func BenchmarkReadOps_Get(b *testing.B) {
 
-	initBenchmarkLogging()
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
 
@@ -106,7 +107,8 @@ func BenchmarkReadOps_Get(b *testing.B) {
 // Benchmark 100% rev cache miss scenario
 func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
-	initBenchmarkLogging()
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
 
@@ -171,7 +173,8 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 func BenchmarkReadOps_Changes(b *testing.B) {
 
-	initBenchmarkLogging()
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
 
@@ -242,7 +245,8 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 
 func BenchmarkReadOps_RevsDiff(b *testing.B) {
 
-	initBenchmarkLogging()
+	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
 
@@ -294,10 +298,6 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 		})
 	}
 
-}
-
-func initBenchmarkLogging() {
-	base.SetUpTestLogging(base.LevelNone, base.KeyNone) // disables logging
 }
 
 func PurgeDoc(rt RestTester, docid string) {

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -57,7 +57,7 @@ var doc_1k_format = `{%s
 
 func BenchmarkReadOps_Get(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
@@ -107,7 +107,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 // Benchmark 100% rev cache miss scenario
 func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
@@ -173,7 +173,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 func BenchmarkReadOps_Changes(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")
@@ -245,7 +245,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 
 func BenchmarkReadOps_RevsDiff(b *testing.B) {
 
-	defer base.SetUpTestLogging(base.LevelNone, base.KeyNone)() // disables logging
+	defer base.DisableTestLogging()()
 
 	var rt RestTester
 	defer PurgeDoc(rt, "doc1k")

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbaselabs/go.assert"
@@ -32,11 +33,10 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP|base.KeyAccel)()
+
 	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`)
 	defer it.Close()
-
-	response := it.SendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "DIndex+":true}`)
-	assert.True(t, response != nil)
 
 	// Create user:
 	a := it.ServerContext().Database("db").Authenticator()
@@ -45,7 +45,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	a.Save(bernard)
 
 	// Put several documents in channel PBS
-	response = it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
@@ -87,11 +87,10 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+
 	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	defer it.Close()
-
-	response := it.SendAdminRequest("PUT", "/_logging", `{"Changes":true, "Changes+":true, "HTTP":true, "Wait":true}`)
-	assert.True(t, response != nil)
 
 	// Create user:
 	userResponse := it.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["ABC"]}`)
@@ -110,7 +109,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	*/
 
 	// Put several documents in channel PBS
-	response = it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)


### PR DESCRIPTION
This should make it easier to spot when tests have accidentally skipped resetting the logging in between tests.

- Will make `SetUpTestLogging` panic if a previous test has not called the teardownFn.
- Fixed tests which were not correctly setting up or tearing down logging settings.

## Companion PR:
- [x] https://github.com/couchbaselabs/sync-gateway-accel/pull/213
- [x] Update manifest in SG for the above changes