### PR TITLE
Add test-integraiton-init.sh script, and run it from test.sh

### DIFF
--- a/test-integration-init.sh
+++ b/test-integration-init.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+############
+## CONFIG ##
+############
+
+CB_CLI_PATH=""
+
+CB_SERVER_URL="http://localhost:8091"
+if [ "$SG_TEST_COUCHBASE_SERVER_URL" != "" ]; then
+    CB_SERVER_URL=$SG_TEST_COUCHBASE_SERVER_URL
+fi
+
+CB_ADMIN_USERNAME="Administrator"
+CB_ADMIN_PASSWORD="password"
+
+SG_TEST_BUCKETS=("test_data_bucket" "test_shadowbucket" "test_indexbucket")
+SG_TEST_BUCKET_RAMSIZE=1000 # MB
+
+SG_TEST_BUCKET_PASSWORD="password"
+SG_TEST_BUCKET_RBAC_ROLES=() # No bucket-specific roles when we can rely on global admin
+SG_TEST_GLOBAL_RBAC_ROLES=("admin")
+
+################
+## END CONFIG ##
+################
+
+set -e
+
+cb_cli_tool="couchbase-cli"
+
+# Tries to find couchbase-cli in common places so we can use it to initilize the buckets and RBAC users.
+function find_couchbase-cli {
+    set +e
+    paths=("$CB_CLI_PATH" "/opt/couchbase/bin/" "/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/")
+    for path in "${paths[@]}"; do
+        "$path$cb_cli_tool" -h >/dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            echo "couchbase-cli found at: $path"
+            cb_cli_tool="$path$cb_cli_tool"
+        fi
+    done
+    set -e
+}
+
+# Will attempt to remove buckets and rbac users
+function cb_cleanup {
+    set +e
+    for bucket in "${SG_TEST_BUCKETS[@]}"; do
+        "$cb_cli_tool" bucket-delete -c $CB_SERVER_URL --username $CB_ADMIN_USERNAME \
+            --password $CB_ADMIN_PASSWORD --bucket=$bucket
+    done
+    cb_manage_rbac_users delete
+    set -e
+}
+
+# will create the buckets defined at the top of the script
+function cb_create_buckets {
+    for bucket in "${SG_TEST_BUCKETS[@]}"; do
+        "$cb_cli_tool" bucket-create -c $CB_SERVER_URL --username $CB_ADMIN_USERNAME \
+            --password $CB_ADMIN_PASSWORD --bucket=$bucket --bucket-type=couchbase \
+            --bucket-ramsize=$SG_TEST_BUCKET_RAMSIZE --enable-flush=1 \
+            --bucket-replica=0 --enable-index-replica=0 --wait
+    done
+}
+
+# will create or delete rbac users defined at the top of the script based on given parameter
+function cb_manage_rbac_users {
+    for bucket in "${SG_TEST_BUCKETS[@]}"; do
+        if [ "$1" == "delete" ]; then
+            "$cb_cli_tool" user-manage -c $CB_SERVER_URL --username $CB_ADMIN_USERNAME \
+            --password $CB_ADMIN_PASSWORD --delete --rbac-username $bucket --auth-domain local
+        elif [ "$1" == "create" ]; then
+            # Build up a string in the format of "globalrole,bucketrole1[bucketname],bucketrole2[bucketname]"
+            roles=""
+            for role in "${SG_TEST_GLOBAL_RBAC_ROLES[@]}"; do
+                roles="$roles$role,"
+            done
+            for role in "${SG_TEST_BUCKET_RBAC_ROLES[@]}"; do
+                roles="$roles$role[$bucket],"
+            done
+            # Trim the trailing comma
+            roles=${roles%?}
+            
+            "$cb_cli_tool" user-manage -c $CB_SERVER_URL --username $CB_ADMIN_USERNAME \
+                --password $CB_ADMIN_PASSWORD --set --rbac-username $bucket \
+                --rbac-password $SG_TEST_BUCKET_PASSWORD --roles=$roles --auth-domain local
+        else
+            echo "unrecognised cb_manage_rbac_users argument: $1"
+            exit 1
+        fi
+    done
+}
+
+if [ "$SG_TEST_BACKING_STORE_RECREATE" == "true" ]; then
+    echo "SG_TEST_BACKING_STORE_RECREATE set, re-creating buckets and RBAC users"
+    find_couchbase-cli
+    cb_cleanup
+    cb_create_buckets
+    cb_manage_rbac_users create
+else
+    echo "SG_TEST_BACKING_STORE_RECREATE not set, skipping bucket/RBAC user re-creation"
+fi

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,7 @@ fi
 
 EXTRA_FLAGS=""
 if [ "$SG_TEST_BACKING_STORE" == "Couchbase" ] || [ "$SG_TEST_BACKING_STORE" == "couchbase" ]; then
+    ./test-integration-init.sh
     echo "Integration mode: forcing tests to run in serial across packages via -p 1 flag"
     EXTRA_FLAGS="-p 1"  # force this to run in serial, otherwise packages run in parallel and interfere with each other
 fi


### PR DESCRIPTION
When running integration tests (`SG_TEST_BACKING_STORE==Couchbase`), if `SG_TEST_BACKING_STORE_RECREATE==true`, the new script will attempt to find couchbase-cli in the default Couchbase installation locations for Linux and macOS, and then drop and recreate buckets and RBAC users required to run SG integration tests.

Example:
```
20:58 $ SG_TEST_BACKING_STORE_RECREATE=true SG_TEST_BACKING_STORE=Couchbase ./test.sh
Testing code with 'go test' ...
SG_TEST_BACKING_STORE_RECREATE set, re-creating buckets and RBAC users
couchbase-cli found at: /Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/
SUCCESS: Bucket deleted
SUCCESS: Bucket deleted
SUCCESS: Bucket deleted
SUCCESS: RBAC user removed
SUCCESS: RBAC user removed
SUCCESS: RBAC user removed
SUCCESS: Bucket created
SUCCESS: Bucket created
SUCCESS: Bucket created
SUCCESS: RBAC user set
SUCCESS: RBAC user set
SUCCESS: RBAC user set
Integration mode: forcing tests to run in serial across packages via -p 1 flag
var is unset
-p 1 -timeout=20m
Running Sync Gateway unit tests
?   	github.com/couchbase/sync_gateway	[no test files]
ok  	github.com/couchbase/sync_gateway/auth	8.593s
ok  	github.com/couchbase/sync_gateway/base	2.275s
...
```