### PR TITLE
Use couchbase github remote for snej/go-blip

### DIFF
--- a/manifest/1.5.0.xml
+++ b/manifest/1.5.0.xml
@@ -116,10 +116,8 @@
 
     <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-    <project name="go-blip" path="godeps/src/github.com/snej/go-blip" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+    <project name="go-blip" path="godeps/src/github.com/snej/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
 
     <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
 </manifest>
-
-

--- a/manifest/1.5.1.xml
+++ b/manifest/1.5.1.xml
@@ -116,10 +116,8 @@
 
     <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-    <project name="go-blip" path="godeps/src/github.com/snej/go-blip" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+    <project name="go-blip" path="godeps/src/github.com/snej/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
 
     <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
 </manifest>
-
-

--- a/manifest/dev.xml
+++ b/manifest/dev.xml
@@ -117,7 +117,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/snej/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 

--- a/manifest/dev.xml
+++ b/manifest/dev.xml
@@ -117,10 +117,8 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="5823a0cbaaa9008406021dc5daf80125ea30bba6"/>
 
-  <project name="go-blip" path="godeps/src/github.com/snej/go-blip" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
+  <project name="go-blip" path="godeps/src/github.com/snej/go-blip" remote="couchbase" revision="d91ad03dfa1649aab06b0ce04577a744f97749b0"/>
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
 </manifest>
-
-


### PR DESCRIPTION
`github.com/snej/go-blip` doesn't exist any more (or has been made private), so trying to build 1.5.x no longer works. I checked that the referenced commit exists in the `couchbase/go-blip` mirror, so this should be a transparent change.

This does not fix the error when running `./bootstrap.sh -c release/1.5.0`, as that pulls `default.xml` from the commit specified (which is still `snej/go-blip` on that branch)

---

I think this opens up a broader question of how we manage our dependencies, as we have quite a few third-party deps outside of `couchbasedeps` that could disappear at any time, and we seem to be responsible for keeping on top of including transitive dependencies in our manifest too, which is not ideal.