### PR TITLE
#3724 Fix resync with xattrs warnings

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
-	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
@@ -108,7 +107,7 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 		// Be careful: this block can be invoked multiple times if there are races!
 		if currentValue == nil {
 			princ = nil
-			return nil, nil, couchbase.UpdateCancel
+			return nil, nil, base.ErrUpdateCancel
 		}
 
 		princ = factory()
@@ -143,11 +142,11 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 			return updatedBytes, nil, marshalErr
 		} else {
 			// Principal is valid, so stop the update
-			return nil, nil, couchbase.UpdateCancel
+			return nil, nil, base.ErrUpdateCancel
 		}
 	})
 
-	if err != nil && err != couchbase.UpdateCancel {
+	if err != nil && err != base.ErrUpdateCancel {
 		return nil, err
 	}
 	return princ, nil
@@ -443,7 +442,7 @@ func (auth *Authenticator) updateVbucketSequences(docID string, factory func() P
 	err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// Be careful: this block can be invoked multiple times if there are races!
 		if currentValue == nil {
-			return nil, nil, couchbase.UpdateCancel
+			return nil, nil, base.ErrUpdateCancel
 		}
 		princ := factory()
 		if err := json.Unmarshal(currentValue, princ); err != nil {
@@ -491,11 +490,11 @@ func (auth *Authenticator) updateVbucketSequences(docID string, factory func() P
 			return updatedBytes, nil, marshalErr
 		} else {
 			// No entries found requiring update, so cancel update.
-			return nil, nil, couchbase.UpdateCancel
+			return nil, nil, base.ErrUpdateCancel
 		}
 	})
 
-	if err != nil && err != couchbase.UpdateCancel {
+	if err != nil && err != base.ErrUpdateCancel {
 		return err
 	}
 	return nil

--- a/base/error.go
+++ b/base/error.go
@@ -23,20 +23,21 @@ import (
 type sgErrorCode uint16
 
 const (
-	alreadyImported       = sgErrorCode(0x00)
-	importCancelled       = sgErrorCode(0x01)
-	importCasFailure      = sgErrorCode(0x02)
-	viewTimeoutError      = sgErrorCode(0x03)
-	revTreeAddRevFailure  = sgErrorCode(0x04)
-	importCancelledFilter = sgErrorCode(0x05)
-	documentMigrated      = sgErrorCode(0x06)
-	fatalBucketConnection = sgErrorCode(0x07)
-	emptyMetadata         = sgErrorCode(0x08)
-	casFailureShouldRetry = sgErrorCode(0x09)
-	errPartialViewErrors  = sgErrorCode(0x10)
-	indexerError          = sgErrorCode(0x11)
-	indexExists           = sgErrorCode(0x12)
-	notFound              = sgErrorCode(0x13)
+	alreadyImported = sgErrorCode(iota)
+	importCancelled
+	importCasFailure
+	viewTimeoutError
+	revTreeAddRevFailure
+	importCancelledFilter
+	documentMigrated
+	fatalBucketConnection
+	emptyMetadata
+	casFailureShouldRetry
+	errPartialViewErrors
+	indexerError
+	indexExists
+	notFound
+	updateCancel
 )
 
 type SGError struct {
@@ -57,6 +58,7 @@ var (
 	ErrIndexerError          = &SGError{indexerError}
 	ErrIndexAlreadyExists    = &SGError{indexExists}
 	ErrNotFound              = &SGError{notFound}
+	ErrUpdateCancel          = &SGError{updateCancel}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
@@ -89,6 +91,8 @@ func (e SGError) Error() string {
 		return "Indexer error"
 	case indexExists:
 		return "Index already exists"
+	case updateCancel:
+		return "Cancel update"
 	case notFound:
 		return "Not Found"
 	default:

--- a/base/error.go
+++ b/base/error.go
@@ -20,84 +20,36 @@ import (
 	pkgerrors "github.com/pkg/errors"
 )
 
-type sgErrorCode uint16
-
-const (
-	alreadyImported = sgErrorCode(iota)
-	importCancelled
-	importCasFailure
-	viewTimeoutError
-	revTreeAddRevFailure
-	importCancelledFilter
-	documentMigrated
-	fatalBucketConnection
-	emptyMetadata
-	casFailureShouldRetry
-	errPartialViewErrors
-	indexerError
-	indexExists
-	notFound
-	updateCancel
-)
-
-type SGError struct {
-	code sgErrorCode
+type sgError struct {
+	message string
 }
 
 var (
-	ErrRevTreeAddRevFailure  = &SGError{revTreeAddRevFailure}
-	ErrImportCancelled       = &SGError{importCancelled}
-	ErrAlreadyImported       = &SGError{alreadyImported}
-	ErrImportCasFailure      = &SGError{importCasFailure}
-	ErrViewTimeoutError      = &SGError{viewTimeoutError}
-	ErrImportCancelledFilter = &SGError{importCancelledFilter}
-	ErrDocumentMigrated      = &SGError{documentMigrated}
-	ErrFatalBucketConnection = &SGError{fatalBucketConnection}
-	ErrEmptyMetadata         = &SGError{emptyMetadata}
-	ErrCasFailureShouldRetry = &SGError{casFailureShouldRetry}
-	ErrIndexerError          = &SGError{indexerError}
-	ErrIndexAlreadyExists    = &SGError{indexExists}
-	ErrNotFound              = &SGError{notFound}
-	ErrUpdateCancel          = &SGError{updateCancel}
+	ErrRevTreeAddRevFailure  = &sgError{"Failure adding Rev to RevTree"}
+	ErrImportCancelled       = &sgError{"Import cancelled"}
+	ErrAlreadyImported       = &sgError{"Document already imported"}
+	ErrImportCasFailure      = &sgError{"CAS failure during import"}
+	ErrViewTimeoutError      = &sgError{"Timeout performing Query"}
+	ErrImportCancelledFilter = &sgError{"Import cancelled based on import filter"}
+	ErrDocumentMigrated      = &sgError{"Document migrated"}
+	ErrFatalBucketConnection = &sgError{"Fatal error connecting to bucket"}
+	ErrEmptyMetadata         = &sgError{"Empty Sync Gateway metadata"}
+	ErrCasFailureShouldRetry = &sgError{"CAS failure should retry"}
+	ErrIndexerError          = &sgError{"Indexer error"}
+	ErrIndexAlreadyExists    = &sgError{"Index already exists"}
+	ErrNotFound              = &sgError{"Not Found"}
+	ErrUpdateCancel          = &sgError{"Cancel update"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
-	ErrPartialViewErrors = &SGError{errPartialViewErrors}
+	ErrPartialViewErrors = &sgError{"Partial errors in view"}
 )
 
-func (e SGError) Error() string {
-	switch e.code {
-	case alreadyImported:
-		return "Document already imported"
-	case importCancelled:
-		return "Import cancelled"
-	case documentMigrated:
-		return "Document migrated"
-	case importCancelledFilter:
-		return "Import cancelled based on import filter"
-	case importCasFailure:
-		return "CAS failure during import"
-	case revTreeAddRevFailure:
-		return "Failure adding Rev to RevTree"
-	case viewTimeoutError:
-		return "Timeout performing Query"
-	case fatalBucketConnection:
-		return "Fatal error connecting to bucket"
-	case emptyMetadata:
-		return "Empty Sync Gateway metadata"
-	case errPartialViewErrors:
-		return "Partial errors in view"
-	case indexerError:
-		return "Indexer error"
-	case indexExists:
-		return "Index already exists"
-	case updateCancel:
-		return "Cancel update"
-	case notFound:
-		return "Not Found"
-	default:
-		return "Unknown error"
+func (e *sgError) Error() string {
+	if e.message != "" {
+		return e.message
 	}
+	return "Unknown error"
 }
 
 // Simple error implementation wrapping an HTTP response status.
@@ -160,7 +112,7 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		}
 	case sgbucket.MissingError:
 		return http.StatusNotFound, "missing"
-	case *SGError:
+	case *sgError:
 		switch unwrappedErr {
 		case ErrNotFound:
 			return http.StatusNotFound, "missing"

--- a/db/crud.go
+++ b/db/crud.go
@@ -700,7 +700,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 		if currentRevIndex == 0 {
 			base.Debugf(base.KeyCRUD, "PutExistingRev(%q): No new revisions to add", base.UD(docid))
 			body["_rev"] = newRev                        // The _rev field is expected by some callers.  If missing, may cause problems for callers.
-			return nil, nil, nil, couchbase.UpdateCancel // No new revisions to add
+			return nil, nil, nil, base.ErrUpdateCancel // No new revisions to add
 		}
 
 		// Conflict-free mode check
@@ -1128,7 +1128,7 @@ func (db *Database) updateAndReturnDoc(
 		}
 	}
 
-	if err == couchbase.UpdateCancel {
+	if err == base.ErrUpdateCancel {
 		return nil, "", nil
 	} else if err == couchbase.ErrOverwritten {
 		// ErrOverwritten is ok; if a later revision got persisted, that's fine too

--- a/db/database.go
+++ b/db/database.go
@@ -916,7 +916,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 				// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 				// so deleteDoc is always returned as false.
 				if currentValue == nil || len(currentValue) == 0 {
-					return nil, nil, deleteDoc, nil, errors.New("Cancel update")
+					return nil, nil, deleteDoc, nil, couchbase.UpdateCancel
 				}
 				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll)
 				if err != nil {
@@ -935,7 +935,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 					raw, rawXattr, err = updatedDoc.MarshalWithXattr()
 					return raw, rawXattr, deleteDoc, updatedExpiry, err
 				} else {
-					return nil, nil, deleteDoc, nil, errors.New("Cancel update")
+					return nil, nil, deleteDoc, nil, couchbase.UpdateCancel
 				}
 			}
 			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, writeUpdateFunc)

--- a/db/database.go
+++ b/db/database.go
@@ -21,7 +21,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/couchbase/go-couchbase"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -831,11 +830,11 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 			bytes, err := json.Marshal(syncData)
 			return bytes, nil, err
 		} else {
-			return nil, nil, couchbase.UpdateCancel // value unchanged, no need to save
+			return nil, nil, base.ErrUpdateCancel // value unchanged, no need to save
 		}
 	})
 
-	if err == couchbase.UpdateCancel {
+	if err == base.ErrUpdateCancel {
 		err = nil
 	}
 	return
@@ -877,7 +876,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 			imported := false
 			if !doc.HasValidSyncData(db.writeSequences()) {
 				// This is a document not known to the sync gateway. Ignore it:
-				return nil, false, nil, couchbase.UpdateCancel
+				return nil, false, nil, base.ErrUpdateCancel
 			} else {
 				base.Debugf(base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
 			}
@@ -916,7 +915,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 				// There's no scenario where a doc should from non-deleted to deleted during UpdateAllDocChannels processing,
 				// so deleteDoc is always returned as false.
 				if currentValue == nil || len(currentValue) == 0 {
-					return nil, nil, deleteDoc, nil, couchbase.UpdateCancel
+					return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
 				}
 				doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll)
 				if err != nil {
@@ -935,7 +934,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 					raw, rawXattr, err = updatedDoc.MarshalWithXattr()
 					return raw, rawXattr, deleteDoc, updatedExpiry, err
 				} else {
-					return nil, nil, deleteDoc, nil, couchbase.UpdateCancel
+					return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
 				}
 			}
 			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, writeUpdateFunc)
@@ -943,7 +942,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 			err = db.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 				// Be careful: this block can be invoked multiple times if there are races!
 				if currentValue == nil {
-					return nil, nil, couchbase.UpdateCancel // someone deleted it?!
+					return nil, nil, base.ErrUpdateCancel // someone deleted it?!
 				}
 				doc, err := unmarshalDocument(docid, currentValue)
 				if err != nil {
@@ -961,13 +960,13 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 					updatedBytes, marshalErr := json.Marshal(updatedDoc)
 					return updatedBytes, updatedExpiry, marshalErr
 				} else {
-					return nil, nil, couchbase.UpdateCancel
+					return nil, nil, base.ErrUpdateCancel
 				}
 			})
 		}
 		if err == nil {
 			changeCount++
-		} else if err != couchbase.UpdateCancel {
+		} else if err != base.ErrUpdateCancel {
 			base.Warnf(base.KeyAll, "Error updating doc %q: %v", base.UD(docid), err)
 		}
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -879,7 +879,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 				// This is a document not known to the sync gateway. Ignore it:
 				return nil, false, nil, couchbase.UpdateCancel
 			} else {
-				base.Infof(base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
+				base.Debugf(base.KeyCRUD, "\tRe-syncing document %q", base.UD(docid))
 			}
 
 			// Run the sync fn over each current/leaf revision, in case there are conflicts:

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/couchbase/go-couchbase"
-
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -112,7 +110,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 	_, err = db.updateDoc(key, false, expiry, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		if doc.UpstreamCAS != nil && *doc.UpstreamCAS == cas {
-			return nil, nil, nil, couchbase.UpdateCancel // we already have this doc revision
+			return nil, nil, nil, base.ErrUpdateCancel // we already have this doc revision
 		}
 		base.Debugf(base.KeyShadow, "Pulling %q, CAS=%x ... have UpstreamRev=%q, UpstreamCAS=%x", base.UD(key), cas, doc.UpstreamRev, doc.UpstreamCAS)
 
@@ -147,7 +145,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		}
 		return body, nil, nil, nil
 	})
-	if err == couchbase.UpdateCancel {
+	if err == base.ErrUpdateCancel {
 		err = nil
 	}
 	return err


### PR DESCRIPTION
Fixes #3724 

- Fix error handling for no-ops when importing docs with xattrs
- Move `Re-syncing document 'x'` log to debug level
- Simplify `SGError` type to remove sgErorCodes for description lookups
- Create new `ErrUpdateCancel` in base, and change all uses of `couchbase.UpdateCancel`