### PR TITLE
Add go_version for all previous SG releases

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -14,6 +14,7 @@
             "release_name": "Couchbase Sync Gateway 1.4.0.2",
             "production": true,
             "interval": 120,
+            "go_version": "1.7.4",
             "start_build": 1
         },
         "manifest/1.4.1.xml": {
@@ -21,6 +22,7 @@
             "release_name": "Couchbase Sync Gateway 1.4.1.3",
             "production": true,
             "interval": 120,
+            "go_version": "1.7.4",
             "start_build": 1
         },
         "manifest/1.3.1.xml": {
@@ -28,6 +30,7 @@
             "release_name": "Couchbase Sync Gateway 1.3.1.5",
             "production": true,
             "interval": 60,
+            "go_version": "1.7.4",
             "start_build": 1
         },
         "manifest/1.5.0.xml": {
@@ -35,6 +38,7 @@
             "release_name": "Couchbase Sync Gateway 1.5.0.0",
             "production": true,
             "interval": 120,
+            "go_version": "1.7.4",
             "start_build": 587
         },
         "manifest/1.5.1.xml": {
@@ -42,6 +46,7 @@
             "release_name": "Couchbase Sync Gateway 1.5.1.0",
             "production": true,
             "interval": 120,
+            "go_version": "1.7.4",
             "start_build": 1
         },
         "manifest/2.0.0.xml": {
@@ -49,6 +54,7 @@
             "release_name": "Couchbase Sync Gateway 2.0.0.0",
             "production": true,
             "interval": 120,
+            "go_version": "1.8.5",
             "start_build": 838
         },
         "manifest/2.1.0.xml": {
@@ -64,6 +70,7 @@
             "release_name": "Couchbase Sync Gateway Dev",
             "production": true,
             "interval": 30,
+            "go_version": "1.8.5",
             "start_build": 1,
             "do-build": false
         }


### PR DESCRIPTION
Specified Go 1.7.4 for all pre-2.0.0 SG releases, and Go 1.8.4 for all SG 2.0.0 and up.