### PR TITLE
Use Go 1.10.4 in default/dev product_config and Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@ pipeline {
     agent { label 'sync-gateway-ami-builder' }
 
     environment {
-        GO_VERSION = 'go1.8.5'
+        GO_VERSION = 'go1.10.4'
+        GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/godeps"
         BRANCH = "${BRANCH_NAME}"
@@ -36,7 +37,9 @@ pipeline {
         stage('Setup Tools') {
             steps {
                 echo 'Setting up Go tools..'
-                withEnv(["PATH+=${GO}"]) {
+                // Use gvm to install the required Go version, if not already
+                sh "${GVM} install $GO_VERSION"
+                withEnv(["PATH+=${GO}", "GOPATH=${GOPATH}"]) {
                     sh "go version"
                     sh 'go get -v -u github.com/AlekSi/gocoverutil'
                     sh 'go get -v -u golang.org/x/tools/cmd/cover'

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.8.5",
+            "go_version": "1.10.4",
             "start_build": 1
         },
         "manifest/1.4.0.xml": {
@@ -70,10 +70,9 @@
             "release_name": "Couchbase Sync Gateway Dev",
             "production": true,
             "interval": 30,
-            "go_version": "1.8.5",
+            "go_version": "1.10.4",
             "start_build": 1,
             "do-build": false
         }
     }
 }
-


### PR DESCRIPTION
Closes #3446 
Closes #3175

- Bumped Go version for `default` and `dev` product_config entries
- Bumped Go version in Jenkinsfile, and added `gvm install` automated Go installations