### PR TITLE
Remove satori/go.uuid dependency in favour of google/uuid

### DIFF
--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -20,8 +20,8 @@ import (
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
 	"github.com/couchbase/sg-bucket"
+	"github.com/google/uuid"
 	pkgerrors "github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 )
 
 var dcpExpvars *expvar.Map
@@ -638,9 +638,12 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 // version number / commit for debugging purposes
 func GenerateDcpStreamName(product string) string {
 
-	// Use V2 since it takes the timestamp into account (as opposed to V4 which appears that it would
-	// require the random number generator to be seeded), so that it's more likely to be unique across different processes.
-	uuidComponent := uuid.NewV2(uuid.DomainPerson).String()
+	// Create a time-based UUID for uniqueness of DCP Stream Names
+	u, err := uuid.NewUUID()
+	if err != nil {
+		// Current implementation of uuid.NewUUID *never* returns an error.
+		Errorf(KeyAll, "Error generating UUID for DCP Stream Name: %v", err)
+	}
 
 	commitTruncated := StringPrefix(GitCommit, 7)
 
@@ -649,7 +652,7 @@ func GenerateDcpStreamName(product string) string {
 		product,
 		VersionNumber,
 		commitTruncated,
-		uuidComponent,
+		u.String(),
 	)
 
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -7,7 +7,6 @@
 
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
   <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
-  <remote fetch="https://github.com/satori/" name="satori"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
@@ -111,13 +110,11 @@
 
   <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="238f46bf38971b117d90e70cba9bd4682428a8b6"/>
 
-  <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
-
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
   <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
-  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="dec09d789f3dba190787f8b4454c7d3c936fed9e"/>
+  <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
 
   <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -25,7 +25,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b66c08447b48e8e2663a36a2b17d80c2e52e0b49"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="74bf43222348706c6bae5825846cec0b2326d6fd"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -25,7 +25,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="f0a38abfe15d99b4bded9f66d257ec58a23edace"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="b66c08447b48e8e2663a36a2b17d80c2e52e0b49"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>


### PR DESCRIPTION
Fixes #3742 

- Removes `satori/go.uuid` dependency in favour of `google/uuid` mirrored in `couchbasedeps`
- Bumped `google/uuid` version to latest (they've marked the package as API stable now)

`uuid.NewUUID` returns a time-based UUID, similar to `uuid.NewV2` to prevent duplicate UUIDs with an unseeded rand source.

## TODO
- [x] Bump manifest once accel PR is merged: https://github.com/couchbaselabs/sync-gateway-accel/pull/219