### PR TITLE
Remove third-party remotes and use couchbasedeps

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -4,17 +4,10 @@
   <remote fetch="https://github.com/couchbase/" name="couchbase"/>
   <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
   <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
-  <remote fetch="https://github.com/elazarl/" name="elazarl"/>
-  <remote fetch="https://github.com/natefinch/" name="natefinch"/>
-  <remote fetch="https://github.com/rcrowley/" name="rcrowley"/>
-  <remote fetch="https://github.com/samuel/" name="samuel"/>
+
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
   <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
-  <remote fetch="https://github.com/coreos/" name="coreos"/>
-  <remote fetch="https://github.com/jonboulle/" name="jonboulle"/>
   <remote fetch="https://github.com/satori/" name="satori"/>
-  <remote fetch="https://github.com/pkg/" name="pkg"/>
-  <remote fetch="https://github.com/go-sourcemap/" name="go-sourcemap"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
@@ -38,7 +31,7 @@
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>
   
-  <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="rcrowley" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+  <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
 
   <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
   
@@ -72,7 +65,7 @@
 
   <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e774e379a0452bfff199a69e053dc565918d680c"/>
 
-  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="elazarl" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+  <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 
   <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
 
@@ -80,11 +73,11 @@
 
   <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
 
-  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="natefinch" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+  <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
 
   <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
 
-  <project name="go-metrics" path="godeps/src/github.com/samuel/go-metrics" remote="samuel" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+  <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
 
   <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
@@ -106,13 +99,13 @@
 
   <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
 
-  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="coreos" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+  <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
 
-  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="coreos" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+  <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
 
-  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="coreos" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+  <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
 
-  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="jonboulle" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+  <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
@@ -120,9 +113,9 @@
 
   <project name="go.uuid" path="godeps/src/github.com/satori/go.uuid" remote="satori" revision="5bf94b69c6b68ee1b541973bb8e1144db23a194b"/>
 
-  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="pkg" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+  <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
-  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="go-sourcemap" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+  <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
   <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="dec09d789f3dba190787f8b4454c7d3c936fed9e"/>
 


### PR DESCRIPTION
Closes #3728 

- `satori/go.uuid` has been left for #3742 to remove
- `mreiferson/go-httpclient` will be removed from accel by #3741 