### PR TITLE
Jenkinsfile: Use Go 1.10's test ./... to do multi-package coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,13 +67,12 @@ pipeline {
                 }
             }
         }
-        stage('Test') {
+        stage('Test with coverage') {
             steps {
                 echo 'Testing with -race and -cover..'
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                    // Test with -race and -cover at the same time (to save running tests several times)
-                    sh 'go test -race -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_sg.out github.com/couchbase/sync_gateway/...'
-                    sh 'go test -race -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_merged.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                    sh 'go test -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_sg.out github.com/couchbase/sync_gateway/...'
+                    sh 'go test -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_merged.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
 
                     // Print total coverage stats
                     sh 'go tool cover -func=cover_sg.out | awk \'END{print "Total SG Coverage:     " $3}\''
@@ -97,6 +96,14 @@ pipeline {
                     // TODO: Requires Cobertura Plugin to be installed on Jenkins first
                     // sh 'gocov convert cover_sg.out | gocov-xml > reports/coverage.xml'
                     // step([$class: 'CoberturaPublisher', coberturaReportFile: 'reports/coverage.xml'])
+                }
+            }
+        }
+        stage('Test with race') {
+            steps {
+                echo 'Testing with -race..'
+                withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
+                    sh './test.sh -race'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
         }
         stage('Test with coverage') {
             steps {
-                echo 'Testing with -race and -cover..'
+                echo 'Testing with -cover..'
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
                     sh 'go test -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_sg.out github.com/couchbase/sync_gateway/...'
                     sh 'go test -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_merged.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,23 +71,24 @@ pipeline {
             steps {
                 echo 'Testing with -cover..'
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh 'go test -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_sg.out github.com/couchbase/sync_gateway/...'
-                    sh 'go test -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_merged.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                    // Build public and private coverprofiles (private containing accel code too)
+                    sh 'go test -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                    sh 'go test -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
 
                     // Print total coverage stats
-                    sh 'go tool cover -func=cover_sg.out | awk \'END{print "Total SG Coverage:     " $3}\''
-                    sh 'go tool cover -func=cover_merged.out | awk \'END{print "Total SG+SGA Coverage: " $3}\''
+                    sh 'go tool cover -func=cover_public.out | awk \'END{print "Total SG Coverage: " $3}\''
+                    sh 'go tool cover -func=cover_private.out | awk \'END{print "Total SG+SGA Coverage: " $3}\''
 
                     // Publish combined HTML coverage report to Jenkins
                     sh 'mkdir reports'
-                    sh 'go tool cover -html=cover_merged.out -o reports/coverage.html'
+                    sh 'go tool cover -html=cover_private.out -o reports/coverage.html'
                     publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, includes: 'coverage.html', keepAll: false, reportDir: 'reports', reportFiles: 'coverage.html', reportName: 'Code Coverage', reportTitles: ''])
                 }
 
                 // Travis-related variables are required as coveralls only officially supports a certain set of CI tools.
                 withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
                     // Replace covermode values with set just for coveralls to reduce the variability in reports.
-                    sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_sg.out > cover_coveralls.out'
+                    sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_public.out > cover_coveralls.out'
 
                     // Send just the SG coverage report to coveralls.io - **NOT** accel! It will expose the private codebase!!!
                     sh "goveralls -coverprofile=cover_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
             steps {
                 echo 'Testing with -race..'
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './test.sh -race'
+                    sh './test.sh -race -count=1'
                 }
             }
         }

--- a/db/database.go
+++ b/db/database.go
@@ -541,6 +541,9 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 }
 
 func (context *DatabaseContext) Authenticator() *auth.Authenticator {
+	context.BucketLock.RLock()
+	defer context.BucketLock.RUnlock()
+
 	// Authenticators are lightweight & stateless, so it's OK to return a new one every time
 	authenticator := auth.NewAuthenticator(context.Bucket, context)
 	if context.Options.SessionCookieName != "" {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -25,7 +25,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="74bf43222348706c6bae5825846cec0b2326d6fd"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="51b0884f0520931001661dee195ea934095577be"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -25,7 +25,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="26ba5c444a15ce22ae7102af85d722ff19716a02"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="74bf43222348706c6bae5825846cec0b2326d6fd"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -25,7 +25,7 @@
 
   
   <!-- Sync Gateway Accel-->
-  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="51b0884f0520931001661dee195ea934095577be"/>
+  <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="26ba5c444a15ce22ae7102af85d722ff19716a02"/>
 
   <!-- Dependencies specific to Sync Gateway Accel-->
   <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>


### PR DESCRIPTION
- Use `go test ./...` rather than `gocoverutil` now we're on >= Go 1.10
- Print total coverage stats in the console output, because why not
- Improved comments describing jenkinsfile steps