### PR TITLE
Backport #3594 gsi test fixes

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -66,7 +66,9 @@ const (
 
 	DefaultViewQueryPageSize = 5000 // This must be greater than 1, or the code won't work due to windowing method
 
-	DefaultWaitForSequenceTesting = time.Second * 2
+	// Until the sporadic integration tests failures in SG #3570 are fixed, should be GTE n1ql query timeout
+	// to make it easier to identify root cause of test failures.
+	DefaultWaitForSequenceTesting = time.Second * 30
 
 	// Default the max number of idle connections per host to a relatively high number to avoid
 	// excessive socket churn caused by opening short-lived connections and closing them after, which can cause

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -30,6 +30,7 @@ func init() {
 
 type TestBucket struct {
 	Bucket
+	BucketSpec BucketSpec
 }
 
 func (tb TestBucket) Close() {
@@ -137,7 +138,10 @@ func GetBucketOrPanicCommon(bucketType CouchbaseBucketType) TestBucket {
 		panic(fmt.Sprintf("Could not open bucket: %v", err))
 	}
 
-	return TestBucket{Bucket: bucket}
+	return TestBucket{
+		Bucket:     bucket,
+		BucketSpec: spec,
+	}
 
 }
 
@@ -347,7 +351,7 @@ func (tbm *TestBucketManager) FlushBucket() error {
 	// Ignore sporadic errors like:
 	// Error trying to empty bucket. err: {"_":"Flush failed with unexpected error. Check server logs for details."}
 
-	log.Printf("Flushing bucket %s", tbm.Bucket.Name())
+	Infof(KeyAll, "Flushing bucket %s", tbm.Bucket.Name())
 
 	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
 		err = tbm.Bucket.Flush()

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -89,17 +89,45 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database,
 
 func testBucket() base.TestBucket {
 
-	testBucket := base.GetTestBucketOrPanic()
-	err := installViews(testBucket.Bucket)
-	if err != nil {
-		log.Fatalf("Couldn't connect to bucket: %v", err)
+	// Retry loop in case the GSI indexes don't handle the flush and we need to drop them and retry
+	for i:= 0; i < 2; i++ {
+
+		testBucket := base.GetTestBucketOrPanic()
+		err := installViews(testBucket.Bucket)
+		if err != nil {
+			log.Fatalf("Couldn't connect to bucket: %v", err)
+			// ^^ effectively panics
+		}
+
+		err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0)
+		if err != nil {
+			log.Fatalf("Unable to initialize GSI indexes for test: %v", err)
+			// ^^ effectively panics
+		}
+
+		// Since GetTestBucketOrPanic() always returns an _empty_ bucket, it's safe to wait for the indexes to be empty
+		gocbBucket, isGoCbBucket := base.AsGoCBBucket(testBucket.Bucket)
+		if isGoCbBucket {
+			waitForIndexRollbackErr := WaitForIndexEmpty(gocbBucket, testBucket.BucketSpec.UseXattrs)
+			if waitForIndexRollbackErr != nil {
+				base.Infof(base.KeyAll, "Error WaitForIndexEmpty: %v.  Drop indexes and retry", waitForIndexRollbackErr)
+				if err := base.DropAllBucketIndexes(gocbBucket); err != nil {
+					log.Fatalf("Unable to drop GSI indexes for test: %v", err)
+					// ^^ effectively panics
+				}
+				testBucket.Close()  // Close the bucket, it will get re-opened on next loop iteration
+				continue  // Goes to top of outer for loop to retry
+			}
+
+		}
+
+		return testBucket
+
 	}
 
-	err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0)
-	if err != nil {
-		log.Fatalf("Unable to initialize GSI indexes for test:%v", err)
-	}
-	return testBucket
+	panic(fmt.Sprintf("Failed to create a testbucket after multiple attempts"))
+
+
 }
 
 func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyOptions base.LeakyBucketConfig) *Database {
@@ -1415,6 +1443,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 }
 
 func TestChannelView(t *testing.T) {
+
 	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1,0 +1,73 @@
+package db
+
+import (
+	"math"
+
+	"github.com/couchbase/gocb"
+	"github.com/couchbase/sync_gateway/base"
+	"fmt"
+)
+
+// Workaround SG #3570 by doing a polling loop until the star channel query returns 0 results.
+// Uses the star channel index as a proxy to indicate that _all_ indexes are empty (which might not be true)
+func WaitForIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
+
+	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+
+		var results gocb.QueryResults
+
+		// Create the star channel query
+		statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement)  // append LIMIT 1 since we only care if there are any results or not
+		starChannelQueryStatement := replaceSyncTokensQuery(statement,useXattrs)
+		params := map[string]interface{}{}
+		params[QueryParamStartSeq] = 0
+		params[QueryParamEndSeq] = math.MaxInt64
+
+		// Execute the query
+		results, err = bucket.Query(starChannelQueryStatement, params, gocb.RequestPlus, true)
+
+		// If there was an error, then retry.  Assume it's an "index rollback" error which happens as
+		// the index processes the bucket flush operation
+		if err != nil {
+			base.Infof(base.KeyAll, "Error querying star channel: %v.  Assuming it's a temp error, will retry", err)
+			return true, err, nil
+		}
+
+		// If it's empty, we're done
+		var queryRow AllDocsIndexQueryRow
+		found := results.Next(&queryRow)
+		resultsCloseErr := results.Close()
+		if resultsCloseErr != nil {
+			return false, resultsCloseErr, nil
+		}
+		if !found {
+			base.Infof(base.KeyAll, "WaitForIndexEmpty found 0 results.  GSI index appears to be empty.")
+			return false, nil, nil
+		}
+
+		// Otherwise, retry
+		base.Infof(base.KeyAll, "WaitForIndexEmpty found non-zero results.  Retrying until the GSI index is empty.")
+		return true, nil, nil
+
+	}
+
+	// Kick off the retry loop
+	err, _ := base.RetryLoop(
+		"Wait for index to be empty",
+		retryWorker,
+		base.CreateMaxDoublingSleeperFunc(30, 100, 2000),
+	)
+	return err
+
+}
+
+// Count how many rows are in gocb.QueryResults
+func ResultsEmpty(results gocb.QueryResults) (resultsEmpty bool) {
+
+	var queryRow AllDocsIndexQueryRow
+	found := results.Next(&queryRow)
+	return !found
+
+}
+
+

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -629,12 +629,14 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	maxNum := 50
 	skippedMaxWait := uint32(120000)
 
+	numIndexReplicas := uint(0)
 	shortWaitConfig := &DbConfig{
 		CacheConfig: &CacheConfig{
 			CachePendingSeqMaxWait: &pendingMaxWait,
 			CachePendingSeqMaxNum:  &maxNum,
 			CacheSkippedSeqMaxWait: &skippedMaxWait,
 		},
+		NumIndexReplicas:&numIndexReplicas,
 	}
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`, DatabaseConfig: shortWaitConfig}
 	defer rt.Close()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -46,7 +46,13 @@ type RestTester struct {
 
 func (rt *RestTester) Bucket() base.Bucket {
 
-	if rt.RestTesterBucket == nil {
+	if rt.RestTesterBucket != nil {
+		return rt.RestTesterBucket
+	}
+
+	// Put this in a loop in case certain operations fail, like waiting for GSI indexes to be empty.
+	// Limit number of attempts to 2.
+	for i := 0; i < 2; i++ {
 
 		// Initialize the bucket.  For couchbase-backed tests, triggers with creation/flushing of the bucket
 		if !rt.NoFlush {
@@ -82,7 +88,17 @@ func (rt *RestTester) Bucket() base.Bucket {
 		useXattrs := base.TestUseXattrs()
 
 		if rt.DatabaseConfig == nil {
+
+			// If no db config was passed in, create one
 			rt.DatabaseConfig = &DbConfig{}
+
+			// By default, does NOT use views when running against couchbase server, since should use GSI
+			rt.DatabaseConfig.UseViews = base.TestUseViews()
+
+			// numReplicas set to 0 for test buckets, since it should assume that there is only one node.
+			numReplicas := uint(0)
+			rt.DatabaseConfig.NumIndexReplicas = &numReplicas
+
 		}
 
 		rt.DatabaseConfig.BucketConfig = BucketConfig{
@@ -99,24 +115,37 @@ func (rt *RestTester) Bucket() base.Bucket {
 			rt.DatabaseConfig.AllowConflicts = &boolVal
 		}
 
-		// Set to 0 for test buckets, since it should assume that there is only one node.
-		numReplicas := uint(0)
-
-		rt.DatabaseConfig.UseViews = base.TestUseViews()
-		rt.DatabaseConfig.NumIndexReplicas = &numReplicas
-
 		_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(rt.DatabaseConfig)
 		if err != nil {
 			panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))
 		}
 		rt.RestTesterBucket = rt.RestTesterServerContext.Database("db").Bucket
 
+		// As long as bucket flushing wasn't disabled, wait for index to be empty (if this is a gocb bucket)
+		if !rt.NoFlush {
+			asGoCbBucket, isGoCbBucket := base.AsGoCBBucket(rt.RestTesterBucket)
+			if isGoCbBucket {
+				if err := db.WaitForIndexEmpty(asGoCbBucket, spec.UseXattrs); err != nil {
+					base.Infof(base.KeyAll, "WaitForIndexEmpty returned an error: %v.  Dropping indexes and retrying", err)
+					// if WaitForIndexEmpty returns error, drop the indexes and retry
+					if err := base.DropAllBucketIndexes(asGoCbBucket); err != nil {
+						panic(fmt.Sprintf("Failed to drop bucket indexes: %v", err))
+					}
+
+					continue  // Go to the top of the for loop to retry
+				}
+			}
+		}
+
 		if !rt.noAdminParty {
 			rt.SetAdminParty(true)
 		}
 
+		return rt.RestTesterBucket
 	}
-	return rt.RestTesterBucket
+
+	panic(fmt.Sprintf("Failed to create a RestTesterBucket after multiple attempts"))
+
 }
 
 func (rt *RestTester) BucketAllowEmptyPassword() base.Bucket {
@@ -365,6 +394,14 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 		} else {
 			response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 		}
+
+		// If the view is undefined, it might be a race condition where the view is still being created
+		// See https://github.com/couchbase/sync_gateway/issues/3570#issuecomment-390487982
+		if strings.Contains(response.Body.String(), "view_undefined") {
+			base.Infof(base.KeyAll, "view_undefined error: %v.  Retrying", response.Body.String())
+			return true, nil, nil
+		}
+
 		if response.Code != 200 {
 			return false, fmt.Errorf("Got response code: %d from view call.  Expected 200.", response.Code), sgbucket.ViewResult{}
 		}

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -95,9 +95,10 @@ func TestViewQuery(t *testing.T) {
 
 }
 
-//Tests #1109, where design doc contains multiple views
+//Tests #1109, wh ere design doc contains multiple views
 func TestViewQueryMultipleViews(t *testing.T) {
-	var rt RestTester
+
+	rt := RestTester{}
 	defer rt.Close()
 
 	//Define three views
@@ -126,6 +127,7 @@ func TestViewQueryMultipleViews(t *testing.T) {
 }
 
 func TestViewQueryUserAccess(t *testing.T) {
+
 	var rt RestTester
 	defer rt.Close()
 
@@ -140,12 +142,14 @@ func TestViewQueryUserAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
-	assertNoError(t, err, "Unexpected error")
+	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
 	assert.Equals(t, len(result.Rows), 2)
 	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
+	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
+
 	assert.Equals(t, len(result.Rows), 2)
 	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
@@ -157,7 +161,8 @@ func TestViewQueryUserAccess(t *testing.T) {
 	a.Save(testUser)
 
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
-	assertNoError(t, err, "Unexpected error")
+	assertNoError(t, err, "Unexpected error in WaitForNUserViewResults")
+
 	assert.Equals(t, len(result.Rows), 2)
 	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
@@ -168,6 +173,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	request.SetBasicAuth(testUser.Name(), password)
 	userResponse := rt.Send(request)
 	assertStatus(t, userResponse, 403)
+
 }
 
 func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
@@ -210,6 +216,7 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 }
 
 func TestUserViewQuery(t *testing.T) {
+
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
@@ -525,6 +532,7 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 }
 
 func TestPostInstallCleanup(t *testing.T) {
+
 	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 


### PR DESCRIPTION
Backport #3594 gsi test fixes so integration tests run well on the `release/2.1.1` branch

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/790/
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/791/