### PR TITLE
#3765 Remove documents from channel caches on _purge or _compact

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -528,6 +528,24 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 
 }
 
+// Remove purges the given doc IDs from all channel caches and returns the number of items removed.
+// count will be larger than the input slice if the same document is removed from multiple channel caches.
+func (c *changeCache) Remove(docIDs []string, startTime time.Time) (count int) {
+	// Exit early if there's no work to do
+	if len(docIDs) == 0 {
+		return 0
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for channelName := range c.channelCaches {
+		count += c._getChannelCache(channelName).Remove(docIDs, startTime)
+	}
+
+	return count
+}
+
 func (c *changeCache) unmarshalPrincipal(docJSON []byte, isUser bool) (auth.Principal, error) {
 
 	c.context.BucketLock.RLock()

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -53,6 +53,9 @@ type ChangeIndex interface {
 	// stable=true returns cached value (if available)
 	GetStableClock(stale bool) (clock base.SequenceClock, err error)
 
+	// Remove purges the given doc IDs and returns the number of items removed
+	Remove(docIDs []string, startTime time.Time) (count int)
+
 	// Utility functions for unit testing
 	waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration)
 

--- a/db/database.go
+++ b/db/database.go
@@ -774,12 +774,14 @@ func (db *Database) Compact() (int, error) {
 			}
 			if delErr := db.Bucket.Delete(tombstonesRow.Id); delErr != nil {
 				base.Warnf(base.KeyAll, "Error compacting key %s (delete) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), delErr)
+				continue
 			}
 			count++
 		} else {
 			base.Warnf(base.KeyAll, "Error compacting key %s (purge) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), purgeErr)
 		}
 	}
+
 	return count, nil
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -748,7 +748,8 @@ func (db *Database) Compact() (int, error) {
 
 	// Trigger view compaction for all tombstoned documents older than the purge interval
 	purgeIntervalDuration := time.Duration(-db.PurgeInterval) * time.Hour
-	purgeOlderThan := time.Now().Add(purgeIntervalDuration)
+	startTime := time.Now()
+	purgeOlderThan := startTime.Add(purgeIntervalDuration)
 	results, err := db.QueryTombstones(purgeOlderThan)
 	if err != nil {
 		return 0, err
@@ -756,7 +757,7 @@ func (db *Database) Compact() (int, error) {
 
 	base.Infof(base.KeyAll, "Compacting purged tombstones for %s ...", base.UD(db.Name))
 	purgeBody := Body{"_purged": true}
-	count := 0
+	purgedDocs := make([]string, 0)
 
 	var tombstonesRow QueryIdRow
 	for results.Next(&tombstonesRow) {
@@ -764,7 +765,7 @@ func (db *Database) Compact() (int, error) {
 		// First, attempt to purge.
 		purgeErr := db.Purge(tombstonesRow.Id)
 		if purgeErr == nil {
-			count++
+			purgedDocs = append(purgedDocs, tombstonesRow.Id)
 		} else if base.IsKeyNotFoundError(db.Bucket, purgeErr) {
 			// If key no longer exists, need to add and remove to trigger removal from view
 			_, addErr := db.Bucket.Add(tombstonesRow.Id, 0, purgeBody)
@@ -772,14 +773,23 @@ func (db *Database) Compact() (int, error) {
 				base.Warnf(base.KeyAll, "Error compacting key %s (add) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), addErr)
 				continue
 			}
+
+			// At this point, the doc is not in a usable state for mobile
+			// so mark it to be removed from cache, even if the subsequent delete fails
+			purgedDocs = append(purgedDocs, tombstonesRow.Id)
+
 			if delErr := db.Bucket.Delete(tombstonesRow.Id); delErr != nil {
-				base.Warnf(base.KeyAll, "Error compacting key %s (delete) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), delErr)
-				continue
+				base.Errorf(base.KeyAll, "Error compacting key %s (delete) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), delErr)
 			}
-			count++
 		} else {
 			base.Warnf(base.KeyAll, "Error compacting key %s (purge) - tombstone will not be compacted.  %v", base.UD(tombstonesRow.Id), purgeErr)
 		}
+	}
+
+	// Now purge them from all channel caches
+	count := len(purgedDocs)
+	if count > 0 {
+		db.changeCache.Remove(purgedDocs, startTime)
 	}
 
 	return count, nil

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -19,10 +19,10 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
-	"time"
 )
 
 const (
@@ -188,6 +188,9 @@ func (k *kvChangeIndex) getOldestSkippedSequence() uint64 {
 }
 func (k *kvChangeIndex) getChannelCache(channelName string) *channelCache {
 	return nil
+}
+func (k *kvChangeIndex) Remove(docIDs []string, startTime time.Time) int {
+	return 0
 }
 
 // TODO: refactor waitForSequence to accept either vbNo or clock

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1496,7 +1496,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
 
-	changes, err := rt.WaitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc", "", true)
+	changes, err := rt.WaitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assertNoError(t, err, "Error waiting for changes")
 	assert.Equals(t, changes.Results[0].ID, "doc1")
 	assert.Equals(t, changes.Results[1].ID, "doc2")
@@ -1508,7 +1508,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	json.Unmarshal(resp.Body.Bytes(), &body)
 	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
-	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc", "", true)
+	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assertNoError(t, err, "Error waiting for changes")
 	assert.Equals(t, changes.Results[0].ID, "doc2")
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1487,9 +1487,9 @@ func TestPurgeWithMultipleValidDocs(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"moo":"car"}`), 201)
 }
 
-// TestPurgeWithChanelCache will make sure thant upon calling _purge, the channel caches are also cleaned
+// TestPurgeWithChannelCache will make sure thant upon calling _purge, the channel caches are also cleaned
 // This was fixed in #3765, previously channel caches were not cleaned up
-func TestPurgeWithChanelCache(t *testing.T) {
+func TestPurgeWithChannelCache(t *testing.T) {
 	var rt RestTester
 	defer rt.Close()
 


### PR DESCRIPTION
Fixes #3765 
Fixes #1658 

- Removes documents from channel caches on `_purge` or `_compact`

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/807/
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/808/