### PR TITLE
#3741 Bump sg-replicate revision and remove go-httpclient dependency

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -6,7 +6,6 @@
   <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
 
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
-  <remote fetch="https://github.com/mreiferson/" name="mreiferson"/>
 
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
@@ -88,11 +87,9 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="b0907c1dc06bfb60354416769e40bb07b4367d88"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="39e5f5f92ee5bf24b8eb1b998b853843ddb41e7f"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
-
-  <project name="go-httpclient" path="godeps/src/github.com/mreiferson/go-httpclient" remote="mreiferson" revision="63fe23f7434723dc904c901043af07931f293c47"/>
 
   <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
 


### PR DESCRIPTION
Fixes #3741 

- Remove third-party go-httpclient dependency from sg-replicate