### PR TITLE
Optional old revision body backups during import

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -125,6 +125,7 @@ type UnsupportedOptions struct {
 // Options associated with the import of documents not written by Sync Gateway
 type ImportOptions struct {
 	ImportFilter *ImportFilterFunction // Opt-in filter for document import
+	BackupOldRev bool                  // Create temporary backup of old revision body when available
 }
 
 // Represents a simulated CouchDB database. A new instance is created for each HTTP request,

--- a/db/revision_cache.go
+++ b/db/revision_cache.go
@@ -62,6 +62,20 @@ func (rc *RevisionCache) Get(docid, revid string) (Body, Body, base.Set, error) 
 	return body, history, channels, err
 }
 
+// Looks up a revision from the cache-only.  Will not fall back to loader function if not
+// present in the cache.
+func (rc *RevisionCache) GetCached(docid, revid string) (Body, Body, base.Set, error) {
+	value := rc.getValue(docid, revid, false)
+	if value == nil {
+		return nil, nil, nil, nil
+	}
+	body, history, channels, err := value.load(rc.loaderFunc)
+	if err != nil {
+		rc.removeValue(value) // don't keep failed loads in the cache
+	}
+	return body, history, channels, err
+}
+
 // Attempts to retrieve the active revision for a document from the cache.  Requires retrieval
 // of the document from the bucket to guarantee the current active revision, but does minimal unmarshalling
 // of the retrieved document to get the current rev from _sync metadata.  If active rev is already in the

--- a/rest/config.go
+++ b/rest/config.go
@@ -166,6 +166,7 @@ type DbConfig struct {
 	RevsLimit                 *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
 	AutoImport                interface{}                    `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
 	ImportFilter              *string                        `json:"import_filter,omitempty"`                // Filter function (import)
+	ImportBackupOldRev        bool                           `json:"import_backup_old_rev"`                  // Whether import should attempt to create a temporary backup of the previous revision body, when available.
 	Shadow                    *ShadowConfig                  `json:"shadow,omitempty"`                       // This is where the ShadowConfig used to be.  If found, it should throw an error
 	EventHandlers             interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
 	FeedType                  string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -378,6 +378,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	if config.ImportFilter != nil {
 		importOptions.ImportFilter = db.NewImportFilterFunction(*config.ImportFilter)
 	}
+	importOptions.BackupOldRev = config.ImportBackupOldRev
 
 	// Set cache properties, if present
 	cacheOptions := db.CacheOptions{}


### PR DESCRIPTION
Allow import to persist a temporary backup of the previous revision body, when it's available via the rev cache.

Given the additional import/DCP work involved (an additional rev cache lookup and kv op per imported document), this is an opt-in feature, enabled using import_backup_old_rev config property.