### PR TITLE
2.1.1 Backport: Fixes issue #3558 Initialize cache after DCP start (#3607)

### DIFF
--- a/db/change_index.go
+++ b/db/change_index.go
@@ -27,13 +27,16 @@ import (
 type ChangeIndex interface {
 
 	// Initialize the index
-	Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), cacheOptions *CacheOptions, indexOptions *ChannelIndexOptions) error
+	Init(context *DatabaseContext, notifyChange func(base.Set), cacheOptions *CacheOptions, indexOptions *ChannelIndexOptions) error
 
 	// Stop the index
 	Stop()
 
+	// Start the index
+	Start() error
+
 	// Clear the index
-	Clear()
+	Clear() error
 
 	// Enable/Disable indexing
 	EnableChannelIndexing(enable bool)

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -47,7 +47,7 @@ func init() {
 	IndexExpvars = expvar.NewMap("syncGateway_index")
 }
 
-func (k *kvChangeIndex) Init(context *DatabaseContext, lastSequence SequenceID, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) (err error) {
+func (k *kvChangeIndex) Init(context *DatabaseContext, onChange func(base.Set), options *CacheOptions, indexOptions *ChannelIndexOptions) (err error) {
 
 	k.context = context
 	k.reader = &kvChangeIndexReader{}
@@ -63,8 +63,9 @@ func (k *kvChangeIndex) Prune() {
 	// TODO: currently no pruning of channel indexes
 }
 
-func (k *kvChangeIndex) Clear() {
+func (k *kvChangeIndex) Clear() error {
 	k.reader.Clear()
+	return nil
 }
 
 func (k *kvChangeIndex) Stop() {
@@ -410,6 +411,9 @@ func (k *kvChangeIndex) generatePartitionStats() (PartitionStats, error) {
 	partitionStats.PartitionsMatch = reflect.DeepEqual(partitionStats.PartitionMap, partitionStats.CBGTMap)
 	return partitionStats, nil
 }
+
+// The following are no-ops for kvChangeIndex.
+func (k *kvChangeIndex) Start() (error) { return nil }
 
 func IsNotFoundError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "not found")


### PR DESCRIPTION
* Add experimental dockerfile

* Fix attempt for build err

* Trying to figure out how to get source commit/branch

* Revert "Trying to figure out how to get source commit/branch"

This reverts commit bd5e502876256e301f61b282b29f500a64c3fffb.

* Add artificial delay after getting last seq, but before starting dcp feed

* Reload c.initialSequence in DocChanged() as long as c.initialSequenceLazyLoaded == false

* Notes from call w/ Adam

* Add c.getInitialSequence() + _getNextSequence()

* Fixes

* Add comments

* Notes from call w/ Adam

* Sketch out changes and test

* Change the changeindex iface

* Fix data race

WARNING: DATA RACE
Write at 0x00c4201fa2e0 by goroutine 9:
  github.com/couchbase/sync_gateway/db.(*changeCache)._addToCache()
      /drone/godeps/src/github.com/couchbase/sync_gateway/db/change_cache.go:689 +0x4ff
  github.com/couchbase/sync_gateway/db.(*changeCache).processEntry()
      /drone/godeps/src/github.com/couchbase/sync_gateway/db/change_cache.go:650 +0x1f6
  github.com/couchbase/sync_gateway/db.(*changeCache).DocChangedSynchronous()
      /drone/godeps/src/github.com/couchbase/sync_gateway/db/change_cache.go:549 +0x20a4

Previous read at 0x00c4201fa2e0 by goroutine 42:
  github.com/couchbase/sync_gateway/db.(*changeCache).waitForSequence()
      /drone/godeps/src/github.com/couchbase/sync_gateway/db/util_testing.go:25 +0xbd
  github.com/couchbase/sync_gateway/db.TestDocDeletionFromChannelCoalesced()
      /drone/godeps/src/github.com/couchbase/sync_gateway/db/changes_test.go:233 +0x5fe
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

* Use getNextSequence() in a few more places

* Fix another race

https://gist.github.com/tleyden/dccaa3cf2be85160051a793333c24467

* Remove dockerfile, moved to a separate PR

* Gofmt

* PR cleanup

* PR cleanup

* Remove check that’s leftover from first attempt

* Add comments

* First round of PR feedback

* Address PR feedback about avoiding external locking