### PR TITLE
#3774 fix panic on import for empty documents

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -43,6 +43,9 @@ var (
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
 	ErrPartialViewErrors = &sgError{"Partial errors in view"}
+
+	// ErrEmptyDocument is returned when trying to insert a document with a null body.
+	ErrEmptyDocument = &sgError{"Document body is empty"}
 )
 
 func (e *sgError) Error() string {
@@ -116,6 +119,8 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		switch unwrappedErr {
 		case ErrNotFound:
 			return http.StatusNotFound, "missing"
+		case ErrEmptyDocument:
+			return http.StatusBadRequest, "Document body is empty"
 		}
 	case *json.SyntaxError, *json.UnmarshalTypeError:
 		return http.StatusBadRequest, fmt.Sprintf("Invalid JSON: \"%v\"", unwrappedErr)

--- a/db/import.go
+++ b/db/import.go
@@ -3,13 +3,13 @@ package db
 import (
 	"errors"
 	"expvar"
+	"fmt"
 	"strconv"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/robertkrimen/otto"
-	"fmt"
 )
 
 var importExpvars *expvar.Map
@@ -97,6 +97,8 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 	if existingDoc == nil {
 		return nil, base.RedactErrorf("No existing doc present when attempting to import %s", base.UD(docid))
+	} else if body == nil {
+		return nil, base.ErrEmptyDocument
 	}
 
 	var newRev string
@@ -110,9 +112,13 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 			if mode == ImportFromFeed {
 				return nil, nil, nil, base.ErrImportCasFailure
 			}
+
 			// If this is an on-demand import, we want to continue to import the current version of the doc.  Re-initialize existing doc based on the latest doc
 			if mode == ImportOnDemand {
 				body = doc.Body()
+				if body == nil {
+					return nil, nil, nil, base.ErrEmptyDocument
+				}
 
 				// Reload the doc expiry
 				gocbBucket, _ := base.AsGoCBBucket(db.Bucket)

--- a/db/import.go
+++ b/db/import.go
@@ -37,6 +37,9 @@ func (db *Database) ImportDocRaw(docid string, value []byte, xattrValue []byte, 
 			base.Infof(base.KeyImport, "Unmarshal error during importDoc %v", err)
 			return nil, err
 		}
+		if body == nil {
+			return nil, base.ErrEmptyDocument
+		}
 	}
 
 	// Get the doc expiry if it wasn't passed in

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -214,7 +214,6 @@ func rawDocWithSyncMeta() []byte {
 // Invokes db.importDoc() with a null document body
 // Reproduces https://github.com/couchbase/sync_gateway/issues/3774
 func TestImportNullDoc(t *testing.T) {
-
 	if !base.TestUseXattrs() || base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works with XATTRS enabled and in integration mode")
 	}
@@ -240,13 +239,20 @@ func TestImportNullDoc(t *testing.T) {
 	importedDoc, err = db.importDoc(key+"2", body, false, existingDoc, ImportOnDemand)
 	assert.Equals(t, err, nil)
 	assertFalse(t, importedDoc == nil, "Expected imported doc")
+}
+
+func TestImportNullDocRaw(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyImport)()
+
+	db, testBucket := setupTestDB(t)
+	defer testBucket.Close()
+	defer tearDownTestDB(t, db)
 
 	// Feed import of null doc
 	exp := uint32(0)
-	importedDoc, err = db.ImportDocRaw(key+"3", rawNull, []byte("{}"), false, 1, &exp, ImportFromFeed)
+	importedDoc, err := db.ImportDocRaw("TestImportNullDoc", []byte("null"), []byte("{}"), false, 1, &exp, ImportFromFeed)
 	assert.Equals(t, err, base.ErrEmptyDocument)
 	assertTrue(t, importedDoc == nil, "Expected no imported doc")
-
 }
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key string, expectedRevGeneration int) {

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -225,19 +225,27 @@ func TestImportNullDoc(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
+	key := "TestImportNullDoc"
 	var body Body
-	existingDoc := &sgbucket.BucketDocument{Body: []byte("null"), Cas: 1}
+	rawNull := []byte("null")
+	existingDoc := &sgbucket.BucketDocument{Body: rawNull, Cas: 1}
 
 	// Import a null document
-	importedDoc, err := db.importDoc("TestImportNullDoc", body, false, existingDoc, ImportOnDemand)
+	importedDoc, err := db.importDoc(key+"1", body, false, existingDoc, ImportOnDemand)
 	assert.Equals(t, err, base.ErrEmptyDocument)
 	assertTrue(t, importedDoc == nil, "Expected no imported doc")
 
 	// Do a valid on-demand import from a null document
 	body = Body{"new": true}
-	importedDoc, err = db.importDoc("TestImportNullDoc", body, false, existingDoc, ImportOnDemand)
+	importedDoc, err = db.importDoc(key+"2", body, false, existingDoc, ImportOnDemand)
 	assert.Equals(t, err, nil)
 	assertFalse(t, importedDoc == nil, "Expected imported doc")
+
+	// Feed import of null doc
+	exp := uint32(0)
+	importedDoc, err = db.ImportDocRaw(key+"3", rawNull, []byte("{}"), false, 1, &exp, ImportFromFeed)
+	assert.Equals(t, err, base.ErrEmptyDocument)
+	assertTrue(t, importedDoc == nil, "Expected no imported doc")
 
 }
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -210,6 +210,53 @@ func rawDocWithSyncMeta() []byte {
 
 }
 
+// Invokes db.importDoc() with a null document body
+// Reproduces https://github.com/couchbase/sync_gateway/issues/3774
+func TestImportNullDoc(t *testing.T) {
+
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works in integration mode")
+	}
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyMigrate|base.KeyImport)()
+
+	db, testBucket := setupTestDB(t)
+	defer testBucket.Close()
+	defer tearDownTestDB(t, db)
+
+	key := "TestImportNullDoc"
+	body := Body{}
+	docBody := []byte("null")
+	err := body.Unmarshal(docBody)
+	assertNoError(t, err, "Error unmarshalling body")
+
+	// Create via the SDK with sync metadata intact
+	syncMetaExpiry := time.Now().Add(time.Second * 30)
+	_, err = testBucket.Bucket.Add(key, uint32(syncMetaExpiry.Unix()), docBody)
+	assertNoError(t, err, "Error writing doc w/ expiry")
+
+	// Get the existing bucket doc
+	_, existingBucketDoc, err := db.GetDocWithXattr(key, DocUnmarshalAll)
+
+	// Perform an SDK update to turn existingBucketDoc into a stale doc
+	updateCallbackFn := func(current []byte) (updated []byte, expiry *uint32, err error) {
+		exp := uint32(0)
+		return docBody, &exp, nil
+	}
+	errUpdateDoc := testBucket.Bucket.Update(key, uint32(0), updateCallbackFn)
+	assertNoError(t, errUpdateDoc, "Unexpected error")
+
+	// Import the doc (will migrate as part of the import since the doc contains sync meta)
+	docOut, errImportDoc := db.importDoc(key, body, false, existingBucketDoc, ImportOnDemand)
+	assert.Equals(t, errImportDoc, base.ErrEmptyDocument)
+	assert.True(t, docOut == nil)
+
+}
+
 func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key string, expectedRevGeneration int) {
 	xattr := map[string]interface{}{}
 	_, err := bucket.GetWithXattr(key, "_sync", nil, &xattr)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -215,8 +215,8 @@ func rawDocWithSyncMeta() []byte {
 // Reproduces https://github.com/couchbase/sync_gateway/issues/3774
 func TestImportNullDoc(t *testing.T) {
 
-	if !base.TestUseXattrs() {
-		t.Skip("This test only works with XATTRS enabled")
+	if !base.TestUseXattrs() || base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works with XATTRS enabled and in integration mode")
 	}
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyImport)()

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -254,7 +254,7 @@ func (h *handler) handlePutDoc() error {
 		return err
 	}
 	if body == nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "Document body is empty")
+		return base.ErrEmptyDocument
 	}
 	var newRev string
 	var ok bool


### PR DESCRIPTION
Fixes #3774 

- `db.importDoc` now returns `ErrEmptyDocument` if the given document is empty (`null`) to match behavior of the REST API for both feed-based import and on-demand imports.
- Added test to repro #3774 

```
2018-10-04T16:23:30.558+01:00 [DBG] Import+: Attempting to import doc "emptydoc"...
2018-10-04T16:23:30.558+01:00 [DBG] Import+: Did not import doc "emptydoc" - external update will not be accessible via Sync Gateway.  Reason: Document body is empty
...
2018-10-04T16:23:42.786+01:00 [INF] HTTP:  #003: PUT /db/breaksg124312 (as ADMIN)
2018-10-04T16:23:42.786+01:00 [ERR] Document body is empty -- rest.(*handler).writeError() at handler.go:689
2018-10-04T16:23:42.786+01:00 [INF] HTTP: #003:     --> 400 Document body is empty  (0.1 ms)
```