### PR TITLE
#3725 Fix panic in AuthenticateUntrustedJWT for nil OIDC client

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -329,7 +329,7 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(token string, providers OIDC
 	// VerifyJWT validates the claims and signature on the JWT
 	client := provider.GetClient(callbackURLFunc)
 	if client == nil {
-		return nil, jose.JWT{}, fmt.Errorf("OIDC client couldn't be created!")
+		return nil, jose.JWT{}, fmt.Errorf("OIDC client was not initialized")
 	}
 
 	err = client.VerifyJWT(jwt)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,6 +11,7 @@ package auth
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
@@ -327,6 +328,10 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(token string, providers OIDC
 
 	// VerifyJWT validates the claims and signature on the JWT
 	client := provider.GetClient(callbackURLFunc)
+	if client == nil {
+		return nil, jose.JWT{}, fmt.Errorf("OIDC client couldn't be created!")
+	}
+
 	err = client.VerifyJWT(jwt)
 	if err != nil {
 		base.Debugf(base.KeyAuth, "Client %v could not verify JWT. Error: %v", base.UD(client), err)

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -132,6 +132,9 @@ func (op *OIDCProvider) InitUserPrefix() error {
 }
 
 func (op *OIDCProvider) InitOIDCClient() error {
+	if op == nil {
+		return fmt.Errorf("nil provider")
+	}
 
 	if op.Issuer == "" {
 		return base.RedactErrorf("Issuer not defined for OpenID Connect provider %+v", base.UD(op))

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -98,7 +98,7 @@ func (op *OIDCProvider) GetClient(buildCallbackURLFunc OIDCCallbackURLFunc) *oid
 			}
 		}
 		if err = op.InitOIDCClient(); err != nil {
-			base.Warnf(base.KeyAll, "Unable to initialize OIDC client: %v", err)
+			base.Errorf(base.KeyAll, "Unable to initialize OIDC client: %v", err)
 		}
 	})
 
@@ -139,7 +139,6 @@ func (op *OIDCProvider) InitOIDCClient() error {
 
 	config, shouldSyncConfig, err := op.DiscoverConfig()
 	if err != nil || config == nil {
-		base.Warnf(base.KeyAll, "Error during OIDC discovery - unable to initialize client: %v", err)
 		return err
 	}
 

--- a/auth/role.go
+++ b/auth/role.go
@@ -29,15 +29,7 @@ type roleImpl struct {
 	vbNo              *uint16
 }
 
-var kValidNameRegexp *regexp.Regexp
-
-func init() {
-	var err error
-	kValidNameRegexp, err = regexp.Compile(`^[-+.@%\w]*$`)
-	if err != nil {
-		panic("Bad kValidNameRegexp")
-	}
-}
+var kValidNameRegexp = regexp.MustCompile(`^[-+.@%\w]*$`)
 
 func (role *roleImpl) initRole(name string, channels base.Set) error {
 	channels = ch.ExpandingStar(channels)


### PR DESCRIPTION
Fixes #3725 

- Log error instead of warning when OIDC client cannot be created properly
- Error out of `AuthenticateUntrustedJWT` when the OIDC client does not exist
- Added unit tests to bump coverage for most things in `oidc.go`