### PR TITLE
#3766 Split age-based and length-based cache pruning housekeeping jobs

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -556,14 +556,16 @@ func allDocIDs(db *Database) (docs []AllDocsEntry, err error) {
 }
 
 func TestAllDocsOnly(t *testing.T) {
-	db, testBucket := setupTestDBWithCacheOptions(t, CacheOptions{})
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyCache)()
+
+	// Lower the log max length so no more than 50 items will be kept.
+	cacheOptions := CacheOptions{}
+	cacheOptions.ChannelCacheMaxLength = 50
+
+	db, testBucket := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
-
-	// Lower the log expiration time to zero so no more than 50 items will be kept.
-	oldChannelCacheAge := DefaultChannelCacheAge
-	DefaultChannelCacheAge = 0
-	defer func() { DefaultChannelCacheAge = oldChannelCacheAge }()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 


### PR DESCRIPTION
Fixes #3766 

- Cache housekeeping tasks are scheduled separately for length-based, and time-based pruning
- Fix unit test not correctly setting cache options
- Refactor of background task goroutines to be of the form:
    ```go
    c.backgroundTask("abc", c.DoABC, time.Second)
    ```

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-master/831/
- [x] http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-master/833/