### PR TITLE
Reuse dbname variable

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -649,7 +649,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	sc.databases_[dbcontext.Name] = dbcontext
 
 	// Save the config
-	sc.config.Databases[config.Name] = config
+	sc.config.Databases[dbName] = config
 
 	if config.StartOffline {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)


### PR DESCRIPTION
I noticed this while doing SG Mercury prototyping

On this line https://github.com/couchbase/sync_gateway/blob/master/rest/server_context.go#L344 it will set dbname to the bucket name if config.name is missing.  But later, it uses config.name directly (even if missing).
