### PR TITLE
#3677 configurable bcrypt cost

### DIFF
--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	assert "github.com/couchbaselabs/go.assert"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// BenchmarkBcryptCostTime will ouput the time it takes to hash a password with each bcrypt cost value
+func BenchmarkBcryptCostTimes(b *testing.B) {
+	// Little value in running this regularly. Might be useful for one-off informational purposes
+	b.Skip("Benchmark disabled")
+
+	minCostToTest := bcrypt.DefaultCost
+	maxCostToTest := bcrypt.DefaultCost + 5
+
+	for i := minCostToTest; i < maxCostToTest; i++ {
+		b.Run(fmt.Sprintf("cost%d", i), func(bn *testing.B) {
+			bn.N = 1
+			_, err := bcrypt.GenerateFromPassword([]byte("hunter2"), i)
+			assert.Equals(bn, err, nil)
+		})
+	}
+}
+
+// TestBcryptDefaultCostTime will ensure that the default bcrypt cost takes at least a 'reasonable' amount of time
+// If this test fails, it suggests maybe we need to think about increasing the default cost...
+func TestBcryptDefaultCostTime(t *testing.T) {
+	// Modest 2.2GHz macbook i7 takes ~80ms at cost 10
+	// Assume server CPUs are ~2x faster
+	minimumDuration := 40 * time.Millisecond
+
+	startTime := time.Now()
+	_, err := bcrypt.GenerateFromPassword([]byte("hunter2"), bcryptDefaultCost)
+	duration := time.Since(startTime)
+
+	t.Logf("bcrypt.GenerateFromPassword with cost %d took: %v", bcryptDefaultCost, duration)
+	assert.Equals(t, err, nil)
+	assert.True(t, minimumDuration < duration)
+}
+
+func TestSetBcryptCost(t *testing.T) {
+	err := SetBcryptCost(bcryptDefaultCost - 1) // below minimum allowed value
+	assert.Equals(t, errors.Cause(err), ErrInvalidBcryptCost)
+	assert.Equals(t, bcryptCost, bcryptDefaultCost)
+	assert.False(t, bcryptCostChanged)
+
+	err = SetBcryptCost(0) // use default value
+	assert.Equals(t, err, nil)
+	assert.Equals(t, bcryptCost, bcryptDefaultCost)
+	assert.False(t, bcryptCostChanged) // Not explicitly changed
+
+	err = SetBcryptCost(bcryptDefaultCost + 1) // use increased value
+	assert.Equals(t, err, nil)
+	assert.Equals(t, bcryptCost, bcryptDefaultCost+1)
+	assert.True(t, bcryptCostChanged)
+
+	err = SetBcryptCost(bcryptDefaultCost) // back to explicit default value, check changed is still true
+	assert.Equals(t, err, nil)
+	assert.Equals(t, bcryptCost, bcryptDefaultCost)
+	assert.True(t, bcryptCostChanged)
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -22,8 +22,6 @@ import (
 	ch "github.com/couchbase/sync_gateway/channels"
 )
 
-const kBcryptCostFactor = bcrypt.DefaultCost
-
 // Actual implementation of User interface
 type userImpl struct {
 	roleImpl // userImpl "inherits from" Role
@@ -209,7 +207,7 @@ func (user *userImpl) SetPassword(password string) {
 	if password == "" {
 		user.PasswordHash_ = nil
 	} else {
-		hash, err := bcrypt.GenerateFromPassword([]byte(password), kBcryptCostFactor)
+		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
 		if err != nil {
 			panic(fmt.Sprintf("Error hashing password: %v", err))
 		}

--- a/auth/user.go
+++ b/auth/user.go
@@ -209,8 +209,9 @@ func (user *userImpl) Authenticate(password string) bool {
 			return false
 		}
 
-		// password was correct, we'll attempt to upgrade the bcrypt hash
-		user.upgradePasswordHash(user.PasswordHash_, password)
+		// password was correct, we'll rehash the password if required
+		// e.g: in the case of bcryptCost changes
+		user.rehashPassword(user.PasswordHash_, password)
 	} else {
 		// no hash, but (incorrect) password provided
 		if password != "" {
@@ -234,17 +235,27 @@ func (user *userImpl) SetPassword(password string) {
 	}
 }
 
-// upgraePasswordHash will check the bcrypt cost of the given hash
-// and will reset the user's password if the configured cost has since increased
+// rehashPassword will check the bcrypt cost of the given hash
+// and will reset the user's password if the configured cost has since changed
 // Callers should make sure password is correct before calling this
-func (user *userImpl) upgradePasswordHash(hash []byte, password string) {
+func (user *userImpl) rehashPassword(hash []byte, password string) {
+	// Exit early if bcryptCost has not been set
+	if !bcryptCostChanged {
+		return
+	}
+
 	hashCost, costErr := bcrypt.Cost(user.PasswordHash_)
-	if costErr == nil && hashCost < bcryptCost {
-		// the cost of the existing hash is less than the configured bcrypt cost.
-		// We'll re-hash the password to upgrade the cost:
-		base.Debugf(base.KeyAuth, "User account %q upgrading password hash cost: %d to %d",
-			base.UD(user.Name_), hashCost, bcryptCost)
+	if costErr == nil && hashCost != bcryptCost {
+		// the cost of the existing hash is different than the configured bcrypt cost.
+		// We'll re-hash the password to adopt the new cost:
 		user.SetPassword(password)
+		err := user.auth.Save(user)
+		if err != nil {
+			base.Warnf(base.KeyAll, "Error saving user: %v", err)
+			return
+		}
+		base.Debugf(base.KeyAuth, "User account %q changed password hash cost from %d to %d",
+			base.UD(user.Name_), hashCost, bcryptCost)
 	}
 	return
 }

--- a/auth/user.go
+++ b/auth/user.go
@@ -251,7 +251,7 @@ func (user *userImpl) rehashPassword(hash []byte, password string) {
 		user.SetPassword(password)
 		err := user.auth.Save(user)
 		if err != nil {
-			base.Warnf(base.KeyAll, "Error saving user: %v", err)
+			base.Warnf(base.KeyAll, "Unable to save user when rehashing password: %v", err)
 			return
 		}
 		base.Debugf(base.KeyAuth, "User account %q changed password hash cost from %d to %d",

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	assert "github.com/couchbaselabs/go.assert"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestUserPasswordHashUpgrade(t *testing.T) {
+	const (
+		username      = "alice"
+		oldPassword   = "hunter2"
+		newPassword   = "correct horse battery staple"
+		newBcryptCost = 12
+	)
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAuth)
+
+	gTestBucket := base.GetTestBucketOrPanic()
+	defer gTestBucket.Close()
+	bucket := gTestBucket.Bucket
+
+	// Reset bcrypt cost after test
+	defer SetBcryptCost(bcrypt.DefaultCost)
+
+	// Create user
+	auth := NewAuthenticator(bucket, nil)
+	u, err := auth.NewUser(username, oldPassword, base.Set{})
+	assert.Equals(t, err, nil)
+	assert.NotEquals(t, u, nil)
+
+	// Now authenticate
+	assert.False(t, u.Authenticate("test"))
+	assert.True(t, u.Authenticate(oldPassword))
+
+	// Make sure their password was hashed with the desired cost
+	user := u.(*userImpl)
+	cost, err := bcrypt.Cost(user.PasswordHash_)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, cost, bcrypt.DefaultCost)
+
+	// Now bump the global bcrypt cost
+	err = SetBcryptCost(newBcryptCost)
+	assert.Equals(t, err, nil)
+
+	// Cost is still default... Password hash was created before change
+	cost, err = bcrypt.Cost(user.PasswordHash_)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, cost, bcrypt.DefaultCost)
+
+	// Make sure the user can still authenticate
+	assert.True(t, u.Authenticate(oldPassword))
+
+	// Reset password
+	u.SetPassword(newPassword)
+	// Make sure old password doesn't work anymore
+	assert.True(t, u.Authenticate(newPassword))
+	assert.False(t, u.Authenticate(oldPassword))
+	// Now check the bcrypt cost was upgraded
+	cost, err = bcrypt.Cost(user.PasswordHash_)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, cost, newBcryptCost)
+}

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -57,7 +57,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	bucket := gTestBucket.Bucket
 
 	// Reset bcrypt cost after test
-	defer SetBcryptCost(bcrypt.DefaultCost)
+	defer SetBcryptCost(bcryptDefaultCost)
 
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
@@ -71,7 +71,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	// Make sure their password was hashed with the desired cost
 	cost, err := bcrypt.Cost(user.PasswordHash_)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, cost, bcrypt.DefaultCost)
+	assert.Equals(t, cost, bcryptDefaultCost)
 
 	// Try to auth with an incorrect password
 	assert.False(t, u.Authenticate("test"))
@@ -90,7 +90,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	// Check the cost is still the old value
 	cost, err = bcrypt.Cost(user.PasswordHash_)
 	assert.Equals(t, err, nil)
-	assert.Equals(t, cost, bcrypt.DefaultCost)
+	assert.Equals(t, cost, bcryptDefaultCost)
 
 	// Now bump the global bcrypt cost
 	err = SetBcryptCost(newBcryptCost)

--- a/rest/config.go
+++ b/rest/config.go
@@ -97,7 +97,7 @@ type ServerConfig struct {
 	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`             // Config for unsupported features
 	RunMode                    SyncGatewayRunMode       `json:"runmode,omitempty"`                 // Whether this is an SG reader or an SG Accelerator
 	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"`  // BLIP data compression level (0-9)
-	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`             // bcrypt cost to use for password hashes - Zero = bcrypt.DefaultCost
+	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`             // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
 }
 
 // Bucket configuration elements - used by db, shadow, index
@@ -934,7 +934,7 @@ func RunServer(config *ServerConfig) {
 	SetMaxFileDescriptors(config.MaxFileDescriptors)
 
 	// Set global bcrypt cost if configured
-	if config.BcryptCost != 0 {
+	if config.BcryptCost > 0 {
 		if err := auth.SetBcryptCost(config.BcryptCost); err != nil {
 			base.Fatalf(base.KeyAll, "Configuration error: %v", err)
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -97,6 +97,7 @@ type ServerConfig struct {
 	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`             // Config for unsupported features
 	RunMode                    SyncGatewayRunMode       `json:"runmode,omitempty"`                 // Whether this is an SG reader or an SG Accelerator
 	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"`  // BLIP data compression level (0-9)
+	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`             // bcrypt cost to use for password hases - zero = bcrypt.DefaultCost
 }
 
 // Bucket configuration elements - used by db, shadow, index
@@ -931,6 +932,13 @@ func RunServer(config *ServerConfig) {
 	}
 
 	SetMaxFileDescriptors(config.MaxFileDescriptors)
+
+	// Set global bcrypt cost if configured
+	if config.BcryptCost != 0 {
+		if err := auth.SetBcryptCost(config.BcryptCost); err != nil {
+			base.Fatalf(base.KeyAll, "Configuration error: %v", err)
+		}
+	}
 
 	sc := NewServerContext(config)
 	for _, dbConfig := range config.Databases {

--- a/rest/config.go
+++ b/rest/config.go
@@ -97,7 +97,7 @@ type ServerConfig struct {
 	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`             // Config for unsupported features
 	RunMode                    SyncGatewayRunMode       `json:"runmode,omitempty"`                 // Whether this is an SG reader or an SG Accelerator
 	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"`  // BLIP data compression level (0-9)
-	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`             // bcrypt cost to use for password hases - zero = bcrypt.DefaultCost
+	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`             // bcrypt cost to use for password hashes - Zero = bcrypt.DefaultCost
 }
 
 // Bucket configuration elements - used by db, shadow, index


### PR DESCRIPTION
Fixes #3677 

- Makes bcrypt cost configurable via config option: `bcrypt_cost`
  - Values of zero or less are treated as `bcrypt.DefaultCost`
  - Values must be in the range of `bcrypt.DefaultCost` and `bcrypt.MaxCost`
  - Upon successful authentication, we see if we can upgrade the existing hash for that user
  - Passwords that are set after the cost change automatically use the new cost
- Unit test added for hash upgrade scenarios (successful auth and password reset)
- Unit test added for disabled user logic