### PR TITLE
#3762 Bump sg-replicate manifest to pick up MaxIdleConnsPerHost change

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -87,7 +87,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="c89e5683853da5ed97731b507dcd8cda2b11afaf"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="39e5f5f92ee5bf24b8eb1b998b853843ddb41e7f"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="6231e870020191bd89f9e89aa5a0c3de32ba6303"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 


### PR DESCRIPTION
Fixes #3762 

- Bump sg-replicate manifest to pick up changes from https://github.com/couchbaselabs/sg-replicate/pull/61