### PR TITLE
Read our own error value instead of the OS-specific error

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -142,7 +142,7 @@ func (op *OIDCProvider) InitOIDCClient() error {
 
 	config, shouldSyncConfig, err := op.DiscoverConfig()
 	if err != nil || config == nil {
-		return err
+		return pkgerrors.Wrap(err, "unable to discover config")
 	}
 
 	clientCredentials := oidc.ClientCredentials{

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -221,7 +221,7 @@ func TestOIDCProvider_InitOIDCClient(t *testing.T) {
 			Provider: &OIDCProvider{
 				Issuer: "http://127.0.0.1:12345/auth",
 			},
-			ErrContains: "connection refused",
+			ErrContains: "unable to discover config",
 		},
 		{
 			Name: "valid provider",


### PR DESCRIPTION
Network errors are not consistent cross-platform, so we'll test for our own error value here instead. This should fix the Windows builds.