### PR TITLE
#3551 Show server pool UUID in GET /{db}

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -232,8 +232,8 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (int, error
 	return purgeIntervalHours, nil
 }
 
-// Get the Server Pool UUID of the bucket
-func (bucket *CouchbaseBucketGoCB) GetServerPoolUUID() (uuid string, err error) {
+// Get the Server UUID of the bucket, this is also known as the Cluster UUID
+func (bucket *CouchbaseBucketGoCB) GetServerUUID() (uuid string, err error) {
 	resp, err := bucket.mgmtRequest(http.MethodGet, "/pools", "application/json", nil)
 	if err != nil {
 		return "", err
@@ -246,14 +246,14 @@ func (bucket *CouchbaseBucketGoCB) GetServerPoolUUID() (uuid string, err error) 
 	}
 
 	var responseJson struct {
-		ServerPoolUUID string `json:"uuid"`
+		ServerUUID string `json:"uuid"`
 	}
 
 	if err := json.Unmarshal(respBytes, &responseJson); err != nil {
 		return "", err
 	}
 
-	return responseJson.ServerPoolUUID, nil
+	return responseJson.ServerUUID, nil
 }
 
 // Gets the bucket max TTL, or 0 if no TTL was set.  Sync gateway should fail to bring the DB online if this is non-zero,

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -269,7 +269,7 @@ func (tbm *TestBucketManager) Close() {
 // See https://forums.couchbase.com/t/is-there-a-way-to-get-the-number-of-items-in-a-bucket/12816/4
 // for GOCB discussion.
 func (tbm *TestBucketManager) BucketItemCount() (itemCount int, err error) {
-	return GoCBBucketItemCount(tbm.Bucket.Bucket, tbm.BucketSpec, tbm.AdministratorUsername, tbm.AdministratorPassword)
+	return tbm.Bucket.BucketItemCount()
 }
 
 func (tbm *TestBucketManager) DropIndexes() error {

--- a/db/database.go
+++ b/db/database.go
@@ -78,7 +78,7 @@ type DatabaseContext struct {
 	ExitChanges        chan struct{}           // Active _changes feeds on the DB will close when this channel is closed
 	OIDCProviders      auth.OIDCProviderMap    // OIDC clients
 	PurgeInterval      int                     // Metadata purge interval, in hours
-	serverPoolUUID     string                  // UUID of the server pool, if available
+	serverUUID         string                  // UUID of the server, if available
 }
 
 type DatabaseContextOptions struct {
@@ -434,27 +434,27 @@ func (context *DatabaseContext) GetStableClock() (clock base.SequenceClock, err 
 	return context.changeCache.GetStableClock(staleOk)
 }
 
-func (context *DatabaseContext) GetServerPoolUUID() string {
+func (context *DatabaseContext) GetServerUUID() string {
 
-	// Lazy load the server pool UUID, if we can get it.
-	if context.serverPoolUUID == "" {
+	// Lazy load the server UUID, if we can get it.
+	if context.serverUUID == "" {
 		b, ok := base.AsGoCBBucket(context.Bucket)
 		if !ok {
-			base.Warnf(base.KeyAll, "Database %v: Unable to get server pool UUID. Bucket was type: %T, not GoCBBucket.", base.MD(context.Name), context.Bucket)
+			base.Warnf(base.KeyAll, "Database %v: Unable to get server UUID. Bucket was type: %T, not GoCBBucket.", base.MD(context.Name), context.Bucket)
 			return ""
 		}
 
-		uuid, err := b.GetServerPoolUUID()
+		uuid, err := b.GetServerUUID()
 		if err != nil {
-			base.Warnf(base.KeyAll, "Database %v: Unable to get server pool UUID: %v", base.MD(context.Name), err)
+			base.Warnf(base.KeyAll, "Database %v: Unable to get server UUID: %v", base.MD(context.Name), err)
 			return ""
 		}
 
-		base.Debugf(base.KeyAll, "Database %v: Got server pool UUID %v", base.MD(context.Name), base.MD(uuid))
-		context.serverPoolUUID = uuid
+		base.Debugf(base.KeyAll, "Database %v: Got server UUID %v", base.MD(context.Name), base.MD(uuid))
+		context.serverUUID = uuid
 	}
 
-	return context.serverPoolUUID
+	return context.serverUUID
 }
 
 // Utility function to support cache testing from outside db package

--- a/db/database.go
+++ b/db/database.go
@@ -435,10 +435,6 @@ func (context *DatabaseContext) GetStableClock() (clock base.SequenceClock, err 
 }
 
 func (context *DatabaseContext) GetServerPoolUUID() *string {
-	if context.BucketSpec.IsWalrusBucket() {
-		// Walrus does not have the concept of a server pool UUID.
-		return nil
-	}
 
 	// Lazy load the server pool UUID, if we can get it.
 	if context.serverPoolUUID == nil {

--- a/rest/api.go
+++ b/rest/api.go
@@ -210,8 +210,12 @@ func (h *handler) handleGetDB() error {
 		"purge_seq":            0,     // TODO: Should track this value
 		"disk_format_version":  0,     // Probably meaningless, but add for compatibility
 		"state":                runState,
-		"server_pool_uuid":     h.db.DatabaseContext.GetServerPoolUUID(),
 	}
+
+	if uuid := h.db.DatabaseContext.GetServerPoolUUID(); uuid != "" {
+		response["server_pool_uuid"] = uuid
+	}
+
 	h.writeJSON(response)
 	return nil
 }

--- a/rest/api.go
+++ b/rest/api.go
@@ -212,8 +212,8 @@ func (h *handler) handleGetDB() error {
 		"state":                runState,
 	}
 
-	if uuid := h.db.DatabaseContext.GetServerPoolUUID(); uuid != "" {
-		response["server_pool_uuid"] = uuid
+	if uuid := h.db.DatabaseContext.GetServerUUID(); uuid != "" {
+		response["server_uuid"] = uuid
 	}
 
 	h.writeJSON(response)

--- a/rest/api.go
+++ b/rest/api.go
@@ -210,6 +210,7 @@ func (h *handler) handleGetDB() error {
 		"purge_seq":            0,     // TODO: Should track this value
 		"disk_format_version":  0,     // Probably meaningless, but add for compatibility
 		"state":                runState,
+		"server_pool_uuid":     h.db.DatabaseContext.GetServerPoolUUID(),
 	}
 	h.writeJSON(response)
 	return nil


### PR DESCRIPTION
Fixes #3551 

- Lazily loads server UUID in `GET /{db}` when using a `GoCBBucket`
- All other bucket types (e.g. Walrus) do not show a `server_uuid` entry in the response
- Copied `mgmtRequest` from GoCB when calling Couchbase Server's REST API

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-master/836/