### PR TITLE
Use constants for blip replication strings, internal doc properties

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -286,7 +286,7 @@ func (db *Database) WriteMultipartDocument(body Body, writer *multipart.Writer, 
 			info.contentType, _ = meta["content_type"].(string)
 			info.data, err = decodeAttachment(meta["data"])
 			if info.data == nil {
-				base.Warnf(base.KeyAll, "Couldn't decode attachment %q of doc %q: %v", base.UD(name), base.UD(body["_id"]), err)
+				base.Warnf(base.KeyAll, "Couldn't decode attachment %q of doc %q: %v", base.UD(name), base.UD(body[BodyId]), err)
 				meta["stub"] = true
 				delete(meta, "data")
 			} else if len(info.data) > kMaxInlineAttachmentSize {
@@ -317,8 +317,8 @@ func (db *Database) WriteMultipartDocument(body Body, writer *multipart.Writer, 
 // The revision will be written as a nested multipart body if it has attachments.
 func (db *Database) WriteRevisionAsPart(revBody Body, isError bool, compressPart bool, writer *multipart.Writer) error {
 	partHeaders := textproto.MIMEHeader{}
-	docID, _ := revBody["_id"].(string)
-	revID, _ := revBody["_rev"].(string)
+	docID, _ := revBody[BodyId].(string)
+	revID, _ := revBody[BodyRev].(string)
 	if len(docID) > 0 {
 		partHeaders.Set("X-Doc-ID", docID)
 		partHeaders.Set("X-Rev-ID", revID)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -66,7 +66,7 @@ func TestAttachments(t *testing.T) {
 	rev2str := `{"_attachments": {"hello.txt": {"stub":true, "revpos":1}, "bye.txt": {"data": "YnllLXlh"}}}`
 	var body2 Body
 	json.Unmarshal([]byte(rev2str), &body2)
-	body2["_rev"] = revid
+	body2[BodyRev] = revid
 	revid, err = db.Put("doc1", body2)
 	assertNoError(t, err, "Couldn't update document")
 	assert.Equals(t, revid, "2-08b42c51334c0469bd060e6d9e6d797b")
@@ -87,7 +87,7 @@ func TestAttachments(t *testing.T) {
 	rev3str := `{"_attachments": {"bye.txt": {"stub":true,"revpos":2}}}`
 	var body3 Body
 	json.Unmarshal([]byte(rev3str), &body3)
-	body3["_rev"] = revid
+	body3[BodyRev] = revid
 	revid, err = db.Put("doc1", body3)
 	assertNoError(t, err, "Couldn't update document")
 	assert.Equals(t, revid, "3-252b9fa1f306930bffc07e7d75b77faf")

--- a/db/changes.go
+++ b/db/changes.go
@@ -849,14 +849,14 @@ func (db *Database) DocIDChangesFeed(userChannels base.Set, explicitDocIds []str
 		}
 
 		changes := make([]ChangeRev, 1)
-		changes[0] = ChangeRev{"rev": body["_rev"].(string)}
+		changes[0] = ChangeRev{"rev": body[BodyRev].(string)}
 		row.Changes = changes
 		row.Seq = SequenceID{Seq: populatedDoc.Sequence}
 		row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 
 		var removedChannels []string
 
-		if deleted, _ := body["_deleted"].(bool); deleted {
+		if deleted, _ := body[BodyDeleted].(bool); deleted {
 			row.Deleted = true
 		}
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -128,7 +128,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Create tombstone 3-b")
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
-	rev3b_body["_deleted"] = true
+	rev3b_body[BodyDeleted] = true
 	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
 
 	// Retrieve tombstone
@@ -180,7 +180,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body := Body{}
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
-	rev3c_body["_deleted"] = true
+	rev3c_body[BodyDeleted] = true
 	assertNoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}, false), "add 3-c (large tombstone)")
 
 	// Validate the tombstone is not stored inline (due to small size)
@@ -295,7 +295,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
-	rev3b_body["_deleted"] = true
+	rev3b_body[BodyDeleted] = true
 	assertNoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
 
 	// Retrieve tombstone

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -177,16 +177,16 @@ func TestDatabase(t *testing.T) {
 	body := Body{"key1": "value1", "key2": 1234}
 	rev1id, err := db.Put("doc1", body)
 	assertNoError(t, err, "Couldn't create document")
-	assert.Equals(t, rev1id, body["_rev"])
+	assert.Equals(t, rev1id, body[BodyRev])
 	assert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
 
 	log.Printf("Create rev 2...")
 	body["key1"] = "new value"
 	body["key2"] = int64(4321)
 	rev2id, err := db.Put("doc1", body)
-	body["_id"] = "doc1"
+	body[BodyId] = "doc1"
 	assertNoError(t, err, "Couldn't update document")
-	assert.Equals(t, rev2id, body["_rev"])
+	assert.Equals(t, rev2id, body[BodyRev])
 	assert.Equals(t, rev2id, "2-488724414d0ed6b398d6d2aeb228d797")
 
 	// Retrieve the document:
@@ -198,7 +198,7 @@ func TestDatabase(t *testing.T) {
 	log.Printf("Retrieve rev 1...")
 	gotbody, err = db.GetRev("doc1", rev1id, false, nil)
 	assertNoError(t, err, "Couldn't get document with rev 1")
-	assert.DeepEquals(t, gotbody, Body{"key1": "value1", "key2": 1234, "_id": "doc1", "_rev": rev1id})
+	assert.DeepEquals(t, gotbody, Body{"key1": "value1", "key2": 1234, BodyId: "doc1", BodyRev: rev1id})
 
 	log.Printf("Retrieve rev 2...")
 	gotbody, err = db.GetRev("doc1", rev2id, false, nil)
@@ -241,7 +241,7 @@ func TestDatabase(t *testing.T) {
 
 	// Test PutExistingRev:
 	log.Printf("Check PutExistingRev...")
-	body["_rev"] = "4-four"
+	body[BodyRev] = "4-four"
 	body["key1"] = "fourth value"
 	body["key2"] = int64(4444)
 	history := []string{"4-four", "3-three", "2-488724414d0ed6b398d6d2aeb228d797",
@@ -274,9 +274,9 @@ func TestGetDeleted(t *testing.T) {
 	body, err = db.GetRev("doc1", rev2id, true, nil)
 	assertNoError(t, err, "GetRev")
 	expectedResult := Body{
-		"_id":        "doc1",
-		"_rev":       rev2id,
-		"_deleted":   true,
+		BodyId:       "doc1",
+		BodyRev:      rev2id,
+		BodyDeleted:  true,
 		"_revisions": map[string]interface{}{"start": 2, "ids": []string{"bc6d97f6e97c0d034a34f8aac2bf8b44", "dfd5e19813767eeddd08270fc5f385cd"}},
 	}
 	assert.DeepEquals(t, body, expectedResult)
@@ -314,7 +314,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	rev2body := Body{
 		"key1":     1234,
 		"channels": []string{"NBC"},
-		"_rev":     rev1id,
+		BodyRev:    rev1id,
 	}
 	rev2id, err := db.Put("doc1", rev2body)
 	assertNoError(t, err, "Put Rev 2")
@@ -323,7 +323,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	rev3body := Body{
 		"key1":     12345,
 		"channels": []string{"NBC"},
-		"_rev":     rev2id,
+		BodyRev:    rev2id,
 	}
 	_, err = db.Put("doc1", rev3body)
 	assertNoError(t, err, "Put Rev 3")
@@ -339,8 +339,8 @@ func TestGetRemovedAsUser(t *testing.T) {
 		"_revisions": map[string]interface{}{
 			"start": 2,
 			"ids":   []string{rev2digest, rev1digest}},
-		"_id":  "doc1",
-		"_rev": rev2id,
+		BodyId:  "doc1",
+		BodyRev: rev2id,
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
@@ -364,8 +364,8 @@ func TestGetRemovedAsUser(t *testing.T) {
 	body, err = db.GetRev("doc1", rev2id, true, nil)
 	assertNoError(t, err, "GetRev")
 	expectedResult = Body{
-		"_id":      "doc1",
-		"_rev":     rev2id,
+		BodyId:     "doc1",
+		BodyRev:    rev2id,
 		"_removed": true,
 		"_revisions": map[string]interface{}{
 			"start": 2,
@@ -398,7 +398,7 @@ func TestGetRemoved(t *testing.T) {
 	rev2body := Body{
 		"key1":     1234,
 		"channels": []string{"NBC"},
-		"_rev":     rev1id,
+		BodyRev:    rev1id,
 	}
 	rev2id, err := db.Put("doc1", rev2body)
 	assertNoError(t, err, "Put Rev 2")
@@ -407,7 +407,7 @@ func TestGetRemoved(t *testing.T) {
 	rev3body := Body{
 		"key1":     12345,
 		"channels": []string{"NBC"},
-		"_rev":     rev2id,
+		BodyRev:    rev2id,
 	}
 	_, err = db.Put("doc1", rev3body)
 	assertNoError(t, err, "Put Rev 3")
@@ -423,8 +423,8 @@ func TestGetRemoved(t *testing.T) {
 		"_revisions": map[string]interface{}{
 			"start": 2,
 			"ids":   []string{rev2digest, rev1digest}},
-		"_id":  "doc1",
-		"_rev": rev2id,
+		BodyId:  "doc1",
+		BodyRev: rev2id,
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
@@ -439,8 +439,8 @@ func TestGetRemoved(t *testing.T) {
 	body, err = db.GetRev("doc1", rev2id, true, nil)
 	assertNoError(t, err, "GetRev")
 	expectedResult = Body{
-		"_id":      "doc1",
-		"_rev":     rev2id,
+		BodyId:     "doc1",
+		BodyRev:    rev2id,
 		"_removed": true,
 		"_revisions": map[string]interface{}{
 			"start": 2,
@@ -471,9 +471,9 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	assertNoError(t, err, "Put")
 
 	rev2body := Body{
-		"key1":     1234,
-		"_deleted": true,
-		"_rev":     rev1id,
+		"key1":      1234,
+		BodyDeleted: true,
+		BodyRev:     rev1id,
 	}
 	rev2id, err := db.Put("doc1", rev2body)
 	assertNoError(t, err, "Put Rev 2")
@@ -482,7 +482,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	rev3body := Body{
 		"key1":     12345,
 		"channels": []string{"NBC"},
-		"_rev":     rev2id,
+		BodyRev:    rev2id,
 	}
 	_, err = db.Put("doc1", rev3body)
 	assertNoError(t, err, "Put Rev 3")
@@ -493,13 +493,13 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	rev2digest := rev2id[2:]
 	rev1digest := rev1id[2:]
 	expectedResult := Body{
-		"key1":     1234,
-		"_deleted": true,
+		"key1":      1234,
+		BodyDeleted: true,
 		"_revisions": map[string]interface{}{
 			"start": 2,
 			"ids":   []string{rev2digest, rev1digest}},
-		"_id":  "doc1",
-		"_rev": rev2id,
+		BodyId:  "doc1",
+		BodyRev: rev2id,
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
@@ -514,10 +514,10 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	body, err = db.GetRev("doc1", rev2id, true, nil)
 	assertNoError(t, err, "GetRev")
 	expectedResult = Body{
-		"_id":      "doc1",
-		"_rev":     rev2id,
-		"_removed": true,
-		"_deleted": true,
+		BodyId:      "doc1",
+		BodyRev:     rev2id,
+		"_removed":  true,
+		BodyDeleted: true,
 		"_revisions": map[string]interface{}{
 			"start": 2,
 			"ids":   []string{rev2digest, rev1digest}},
@@ -703,17 +703,17 @@ func TestRepeatedConflict(t *testing.T) {
 	assertNoError(t, db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false), "add 2-a")
 
 	// Get the _rev that was set in the body by PutExistingRev() and make assertions on it
-	rev, ok := body["_rev"]
+	rev, ok := body[BodyRev]
 	assert.True(t, ok)
 	revGen, _ := ParseRevID(rev.(string))
 	assert.Equals(t, revGen, 2)
 
 	// Remove the _rev key from the body, and call PutExistingRev() again, which should re-add it
-	delete(body, "_rev")
+	delete(body, BodyRev)
 	db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false)
 
 	// The _rev should pass the same assertions as before, since PutExistingRev() should re-add it
-	rev, ok = body["_rev"]
+	rev, ok = body[BodyRev]
 	assert.True(t, ok)
 	revGen, _ = ParseRevID(rev.(string))
 	assert.Equals(t, revGen, 2)
@@ -757,15 +757,15 @@ func TestConflicts(t *testing.T) {
 
 	// Verify the change with the higher revid won:
 	gotBody, err := db.Get("doc")
-	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-b", "n": 2,
+	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-b", "n": 2,
 		"channels": []string{"all", "2b"}})
 
 	// Verify we can still get the other two revisions:
 	gotBody, err = db.GetRev("doc", "1-a", false, nil)
-	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "1-a", "n": 1,
+	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "1-a", "n": 1,
 		"channels": []string{"all", "1"}})
 	gotBody, err = db.GetRev("doc", "2-a", false, nil)
-	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-a", "n": 3,
+	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-a", "n": 3,
 		"channels": []string{"all", "2a"}})
 
 	// Verify the change-log of the "all" channel:
@@ -798,7 +798,7 @@ func TestConflicts(t *testing.T) {
 	log.Printf("post-delete, got raw body: %s", rawBody)
 
 	gotBody, err = db.Get("doc")
-	assert.DeepEquals(t, gotBody, Body{"_id": "doc", "_rev": "2-a", "n": 3,
+	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-a", "n": 3,
 		"channels": []string{"all", "2a"}})
 
 	// Verify channel assignments are correct for channels defined by 2-a:
@@ -852,9 +852,9 @@ func TestNoConflictsMode(t *testing.T) {
 	assertHTTPError(t, err, 409)
 
 	// Create a non-conflict with a longer history, ending in a deletion:
-	body["_deleted"] = true
+	body[BodyDeleted] = true
 	assertNoError(t, db.PutExistingRev("doc", body, []string{"4-a", "3-a", "2-a", "1-a"}, false), "add 4-a")
-	delete(body, "_deleted")
+	delete(body, BodyDeleted)
 
 	// Create a non-conflict with no history (re-creating the document, but with an invalid rev):
 	err = db.PutExistingRev("doc", body, []string{"1-f"}, false)
@@ -862,20 +862,20 @@ func TestNoConflictsMode(t *testing.T) {
 
 	// Resurrect the tombstoned document with a valid history
 	assertNoError(t, db.PutExistingRev("doc", body, []string{"5-f", "4-a"}, false), "add 5-f")
-	delete(body, "_deleted")
+	delete(body, BodyDeleted)
 
 	// Create a new document with a longer history:
 	assertNoError(t, db.PutExistingRev("COD", body, []string{"4-a", "3-a", "2-a", "1-a"}, false), "add COD")
-	delete(body, "_deleted")
+	delete(body, BodyDeleted)
 
 	// Now use Put instead of PutExistingRev:
 
 	// Successfully add a new revision:
-	_, err = db.Put("doc", Body{"_rev": "5-f", "foo": -1})
+	_, err = db.Put("doc", Body{BodyRev: "5-f", "foo": -1})
 	assertNoError(t, err, "Put rev after 1-f")
 
 	// Try to create a conflict:
-	_, err = db.Put("doc", Body{"_rev": "3-a", "foo": 7})
+	_, err = db.Put("doc", Body{BodyRev: "3-a", "foo": 7})
 	assertHTTPError(t, err, 409)
 
 	// Conflict with no ancestry:
@@ -909,14 +909,14 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	// Set AllowConflicts to false
 	db.Options.AllowConflicts = base.BooleanPointer(false)
 	delete(body, "n")
-	body["_deleted"] = true
+	body[BodyDeleted] = true
 
 	// Attempt to tombstone a non-leaf node of a conflicted document
 	err := db.PutExistingRev("doc1", body, []string{"2-c", "1-a"}, false)
 	assertTrue(t, err != nil, "expected error tombstoning non-leaf")
 
 	// Tombstone the non-winning branch of a conflicted document
-	body["_rev"] = "2-a"
+	body[BodyRev] = "2-a"
 	tombstoneRev, putErr := db.Put("doc1", body)
 	assertNoError(t, putErr, "tombstone 2-a")
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
@@ -924,12 +924,12 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	assert.Equals(t, doc.CurrentRev, "2-b")
 
 	// Attempt to add a tombstone rev w/ the previous tombstone as parent
-	body["_rev"] = tombstoneRev
+	body[BodyRev] = tombstoneRev
 	_, putErr = db.Put("doc1", body)
 	assertTrue(t, putErr != nil, "Expect error tombstoning a tombstone")
 
 	// Tombstone the winning branch of a conflicted document
-	body["_rev"] = "2-b"
+	body[BodyRev] = "2-b"
 	_, putErr = db.Put("doc2", body)
 	assertNoError(t, putErr, "tombstone 2-b")
 	doc, err = db.GetDocument("doc2", DocUnmarshalAll)
@@ -938,7 +938,7 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 
 	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
 	db.RevsLimit = uint32(1)
-	body["_rev"] = "2-a"
+	body[BodyRev] = "2-a"
 	_, putErr = db.Put("doc3", body)
 	assertNoError(t, putErr, "tombstone 2-a w/ revslimit=1")
 	doc, err = db.GetDocument("doc3", DocUnmarshalAll)
@@ -975,7 +975,7 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 	// Set AllowConflicts to false
 	db.Options.AllowConflicts = base.BooleanPointer(false)
 	delete(body, "n")
-	body["_deleted"] = true
+	body[BodyDeleted] = true
 
 	// Attempt to tombstone a non-leaf node of a conflicted document
 	err := db.PutExistingRev("doc1", body, []string{"2-c", "1-a"}, false)
@@ -1023,7 +1023,7 @@ func TestSyncFnOnPush(t *testing.T) {
 
 	// Add several revisions at once to a doc, as on a push:
 	log.Printf("Check PutExistingRev...")
-	body["_rev"] = "4-four"
+	body[BodyRev] = "4-four"
 	body["key1"] = "fourth value"
 	body["key2"] = int64(4444)
 	body["channels"] = "clibup"
@@ -1236,7 +1236,7 @@ func TestPostWithExistingId(t *testing.T) {
 	// Test creating a document with existing id property:
 	customDocId := "customIdValue"
 	log.Printf("Create document with existing id...")
-	body := Body{"_id": customDocId, "key1": "value1", "key2": "existing"}
+	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, err := db.Post(body)
 	assert.True(t, rev1id != "")
 	assert.True(t, docid == customDocId)
@@ -1272,7 +1272,7 @@ func TestPutWithUserSpecialProperty(t *testing.T) {
 	// Test creating a document with existing id property:
 	customDocId := "customIdValue"
 	log.Printf("Create document with existing id...")
-	body := Body{"_id": customDocId, "key1": "value1", "_key2": "existing"}
+	body := Body{BodyId: customDocId, "key1": "value1", "_key2": "existing"}
 	docid, rev1id, err := db.Post(body)
 	assert.True(t, rev1id == "")
 	assert.True(t, docid == "")
@@ -1289,7 +1289,7 @@ func TestWithNullPropertyKey(t *testing.T) {
 	// Test creating a document with null property key
 	customDocId := "customIdValue"
 	log.Printf("Create document with empty property key")
-	body := Body{"_id": customDocId, "": "value1"}
+	body := Body{BodyId: customDocId, "": "value1"}
 	docid, rev1id, _ := db.Post(body)
 	assert.True(t, rev1id != "")
 	assert.True(t, docid != "")
@@ -1305,7 +1305,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	// Test creating a document with existing id property:
 	customDocId := "customIdValue"
 	log.Printf("Create document with existing id...")
-	body := Body{"_id": customDocId, "key1": "value1", "key2": "existing"}
+	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, err := db.Post(body)
 	assert.True(t, rev1id != "")
 	assert.True(t, docid == customDocId)
@@ -1319,7 +1319,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	// Test that posting an update with a user special property does not update the
 	//document
 	log.Printf("Update document with existing id...")
-	body = Body{"_id": customDocId, "_rev": rev1id, "_special": "value", "key1": "value1", "key2": "existing"}
+	body = Body{BodyId: customDocId, BodyRev: rev1id, "_special": "value", "key1": "value1", "key2": "existing"}
 	_, err = db.Put(docid, body)
 	assert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
 
@@ -1430,7 +1430,7 @@ func TestChannelView(t *testing.T) {
 	body := Body{"key1": "value1", "key2": 1234}
 	rev1id, err := db.Put("doc1", body)
 	assertNoError(t, err, "Couldn't create document")
-	assert.Equals(t, rev1id, body["_rev"])
+	assert.Equals(t, rev1id, body[BodyRev])
 	assert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
 
 	var entries LogEntries

--- a/db/document.go
+++ b/db/document.go
@@ -627,12 +627,12 @@ func (doc *document) IsChannelRemoval(revID string) (body Body, history Body, ch
 
 	// Construct removal body
 	body = Body{
-		"_id":      doc.ID,
-		"_rev":     revID,
+		BodyId:     doc.ID,
+		BodyRev:    revID,
 		"_removed": true,
 	}
 	if isDelete {
-		body["_deleted"] = true
+		body[BodyDeleted] = true
 	}
 
 	// Build revision history for revID
@@ -785,7 +785,7 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 	// If there's no body, but there is an xattr, set body as {"_deleted":true} to align with non-xattr handling
 	if len(data) == 0 && len(xdata) > 0 {
 		doc._body = Body{}
-		doc._body["_deleted"] = true
+		doc._body[BodyDeleted] = true
 	}
 	return nil
 }
@@ -795,7 +795,7 @@ func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	body := doc._body
 	// If body is non-empty and non-deleted, unmarshal and return
 	if body != nil {
-		deleted, _ := body["_deleted"].(bool)
+		deleted, _ := body[BodyDeleted].(bool)
 		if !deleted {
 			data, err = json.Marshal(body)
 			if err != nil {

--- a/db/event.go
+++ b/db/event.go
@@ -46,7 +46,7 @@ type DocumentChangeEvent struct {
 }
 
 func (dce *DocumentChangeEvent) String() string {
-	return fmt.Sprintf("Document change event for doc id: %s", dce.Doc["_id"])
+	return fmt.Sprintf("Document change event for doc id: %s", dce.Doc[BodyId])
 }
 
 func (dce *DocumentChangeEvent) EventType() EventType {

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -88,7 +88,7 @@ func TestDocumentChangeEvent(t *testing.T) {
 	}
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -165,7 +165,7 @@ func TestSlowExecutionProcessing(t *testing.T) {
 
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -203,7 +203,7 @@ func TestCustomHandler(t *testing.T) {
 
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -242,7 +242,7 @@ func TestUnhandledEvent(t *testing.T) {
 
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -346,7 +346,7 @@ func TestWebhookBasic(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -475,7 +475,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -592,7 +592,7 @@ func TestWebhookTimeout(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set
@@ -693,7 +693,7 @@ func TestUnavailableWebhook(t *testing.T) {
 
 	eventForTest := func(i int) (Body, base.Set) {
 		testBody := Body{
-			"_id":   ids[i],
+			BodyId:  ids[i],
 			"value": i,
 		}
 		var channelSet base.Set

--- a/db/import.go
+++ b/db/import.go
@@ -30,7 +30,7 @@ func (db *Database) ImportDocRaw(docid string, value []byte, xattrValue []byte, 
 
 	var body Body
 	if isDelete {
-		body = Body{"_deleted": true}
+		body = Body{BodyDeleted: true}
 	} else {
 		err := body.Unmarshal(value)
 		if err != nil {
@@ -200,7 +200,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		generation++
 		newRev = createRevID(generation, parentRev, body)
 		base.Infof(base.KeyImport, "Created new rev ID %v", newRev)
-		body["_rev"] = newRev
+		body[BodyRev] = newRev
 		doc.History.addRevision(docid, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete})
 
 		// During import, oldDoc (doc.Body) is nil (since it's no longer available)

--- a/db/revision.go
+++ b/db/revision.go
@@ -21,6 +21,12 @@ import (
 // The body of a CouchDB document/revision as decoded from JSON.
 type Body map[string]interface{}
 
+const (
+	BodyDeleted = "_deleted"
+	BodyRev     = "_rev"
+	BodyId      = "_id"
+)
+
 func (b *Body) Unmarshal(data []byte) error {
 	if err := json.Unmarshal(data, &b); err != nil {
 		return err
@@ -172,7 +178,7 @@ func compareRevIDs(id1, id2 string) int {
 func stripSpecialProperties(body Body) Body {
 	stripped := Body{}
 	for key, value := range body {
-		if key == "" || key[0] != '_' || key == "_attachments" || key == "_deleted" {
+		if key == "" || key[0] != '_' || key == "_attachments" || key == BodyDeleted {
 			stripped[key] = value
 		}
 	}
@@ -181,7 +187,7 @@ func stripSpecialProperties(body Body) Body {
 
 func containsUserSpecialProperties(body Body) bool {
 	for key := range body {
-		if key != "" && key[0] == '_' && key != "_id" && key != "_rev" && key != "_deleted" && key != "_attachments" && key != "_revisions" {
+		if key != "" && key[0] == '_' && key != BodyId && key != BodyRev && key != BodyDeleted && key != "_attachments" && key != "_revisions" {
 			return true
 		}
 	}

--- a/db/revision_cache.go
+++ b/db/revision_cache.go
@@ -175,9 +175,9 @@ func (value *revCacheValue) loadForDoc(doc *document, context *DatabaseContext) 
 func (value *revCacheValue) store(body Body, history Body, channels base.Set) {
 	value.lock.Lock()
 	if value.body == nil {
-		value.body = body.ShallowCopy()     // Don't store a body the caller might later mutate
-		value.body["_id"] = value.key.DocID // Rev cache includes id and rev in the body.  Ensure they are set in case callers aren't passing
-		value.body["_rev"] = value.key.RevID
+		value.body = body.ShallowCopy()      // Don't store a body the caller might later mutate
+		value.body[BodyId] = value.key.DocID // Rev cache includes id and rev in the body.  Ensure they are set in case callers aren't passing
+		value.body[BodyRev] = value.key.RevID
 		value.history = history
 		value.channels = channels
 		value.err = nil

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -16,8 +16,8 @@ func TestRevisionCache(t *testing.T) {
 
 	revForTest := func(i int) (Body, Body, base.Set) {
 		body := Body{
-			"_id":  ids[i],
-			"_rev": "x",
+			BodyId:  ids[i],
+			BodyRev: "x",
 		}
 		history := Body{"start": i}
 		return body, history, nil
@@ -27,7 +27,7 @@ func TestRevisionCache(t *testing.T) {
 			t.Fatalf("nil body at #%d", i)
 		}
 		assert.True(t, body != nil)
-		assert.Equals(t, body["_id"], ids[i])
+		assert.Equals(t, body[BodyId], ids[i])
 		assert.True(t, history != nil)
 		assert.Equals(t, history["start"], i)
 		assert.DeepEquals(t, channels, base.Set(nil))
@@ -36,7 +36,7 @@ func TestRevisionCache(t *testing.T) {
 	cache := NewRevisionCache(10, nil)
 	for i := 0; i < 10; i++ {
 		body, history, channels := revForTest(i)
-		cache.Put(body["_id"].(string), body["_rev"].(string), body, history, channels)
+		cache.Put(body[BodyId].(string), body[BodyRev].(string), body, history, channels)
 	}
 
 	for i := 0; i < 10; i++ {
@@ -46,7 +46,7 @@ func TestRevisionCache(t *testing.T) {
 
 	for i := 10; i < 13; i++ {
 		body, history, channels := revForTest(i)
-		cache.Put(body["_id"].(string), body["_rev"].(string), body, history, channels)
+		cache.Put(body[BodyId].(string), body[BodyRev].(string), body, history, channels)
 	}
 
 	for i := 0; i < 3; i++ {
@@ -67,8 +67,8 @@ func TestLoaderFunction(t *testing.T) {
 			err = base.HTTPErrorf(404, "missing")
 		} else {
 			body = Body{
-				"_id":  id.DocID,
-				"_rev": id.RevID,
+				BodyId:  id.DocID,
+				BodyRev: id.RevID,
 			}
 			history = Body{"start": 1}
 			channels = base.SetOf("*")
@@ -78,7 +78,7 @@ func TestLoaderFunction(t *testing.T) {
 	cache := NewRevisionCache(10, loader)
 
 	body, history, channels, err := cache.Get("Jens", "1")
-	assert.Equals(t, body["_id"], "Jens")
+	assert.Equals(t, body[BodyId], "Jens")
 	assert.True(t, history != nil)
 	assert.True(t, channels != nil)
 	assert.Equals(t, err, error(nil))
@@ -90,7 +90,7 @@ func TestLoaderFunction(t *testing.T) {
 	assert.Equals(t, callsToLoader, 2)
 
 	body, history, channels, err = cache.Get("Jens", "1")
-	assert.Equals(t, body["_id"], "Jens")
+	assert.Equals(t, body[BodyId], "Jens")
 	assert.True(t, history != nil)
 	assert.True(t, channels != nil)
 	assert.Equals(t, err, error(nil))

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -708,7 +708,7 @@ func ParseRevisions(body Body) []string {
 	// http://wiki.apache.org/couchdb/HTTP_Document_API#GET
 	revisions, ok := body["_revisions"].(map[string]interface{})
 	if !ok {
-		revid, ok := body["_rev"].(string)
+		revid, ok := body[BodyRev].(string)
 		if !ok {
 			return nil
 		}

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -93,7 +93,7 @@ func (s *Shadower) readTapFeed() {
 func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas uint64, flags uint32) error {
 	var body Body
 	if isDeletion {
-		body = Body{"_deleted": true}
+		body = Body{BodyDeleted: true}
 	} else {
 		if err := body.Unmarshal(value); err != nil {
 			base.Infof(base.KeyShadow, "Doc %q is not JSON; skipping", base.UD(key))
@@ -124,7 +124,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		}
 		doc.UpstreamRev = newRev
 		doc.UpstreamCAS = &cas
-		body["_rev"] = newRev
+		body[BodyRev] = newRev
 		if doc.History[newRev] == nil {
 			// It's a new rev, so add it to the history:
 			if parentRev != "" && !doc.History.contains(parentRev) {

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -293,9 +293,9 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 
 	//Assert that we can get the two conflicing revisions
 	gotBody, err := db.GetRev("foo", "1-madeup", false, nil)
-	assert.DeepEquals(t, gotBody, Body{"_id": "foo", "a": "b", "_rev": "1-madeup"})
+	assert.DeepEquals(t, gotBody, Body{BodyId: "foo", "a": "b", BodyRev: "1-madeup"})
 	gotBody, err = db.GetRev("foo", "2-edce85747420ad6781bdfccdebf82180", false, nil)
-	assert.DeepEquals(t, gotBody, Body{"_id": "foo", "a": "c", "_rev": "2-edce85747420ad6781bdfccdebf82180"})
+	assert.DeepEquals(t, gotBody, Body{BodyId: "foo", "a": "c", BodyRev: "2-edce85747420ad6781bdfccdebf82180"})
 }
 
 func TestShadowerPattern(t *testing.T) {

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -68,7 +68,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 			if err := json.Unmarshal(value, &prevBody); err != nil {
 				return nil, nil, err
 			}
-			if matchRev != prevBody["_rev"] {
+			if matchRev != prevBody[BodyRev] {
 				return nil, nil, base.HTTPErrorf(http.StatusConflict, "Document update conflict")
 			}
 		}
@@ -80,7 +80,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 				fmt.Sscanf(matchRev, "0-%d", &generation)
 			}
 			revid = fmt.Sprintf("0-%d", generation+1)
-			body["_rev"] = revid
+			body[BodyRev] = revid
 			bodyBytes, marshalErr := json.Marshal(body)
 			return bodyBytes, nil, marshalErr
 		} else {
@@ -93,7 +93,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 }
 
 func (db *Database) PutSpecial(doctype string, docid string, body Body) (string, error) {
-	matchRev, _ := body["_rev"].(string)
+	matchRev, _ := body[BodyRev].(string)
 	body = stripSpecialSpecialProperties(body)
 	return db.putSpecial(doctype, docid, matchRev, body)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -54,7 +54,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	assert.Equals(t, revGeneration, 1)
 
 	// Update doc (normal update, no conflicting revisions added)
-	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", docId), fmt.Sprintf(`{"value":"secondval", "_rev":"%s"}`, revId))
+	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", docId), fmt.Sprintf(`{"value":"secondval", db.BodyRev:"%s"}`, revId))
 	response.DumpBody()
 
 	// Create conflict

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1422,7 +1422,7 @@ readerLoop:
 
 		var exp int
 
-		switch partJSON["_id"] {
+		switch partJSON[db.BodyId] {
 		case "doc1":
 			exp = reqRevsLimit
 		case "doc2":
@@ -3165,7 +3165,7 @@ func TestBulkGetRevPruning(t *testing.T) {
 	// Get latest rev id
 	response = rt.SendRequest("GET", "/db/doc1", "")
 	json.Unmarshal(response.Body.Bytes(), &body)
-	revId = body["_rev"]
+	revId = body[db.BodyRev]
 
 	// Spin up several goroutines to all try to do a _bulk_get on the latest revision.
 	// Since they will be pruning the same shared rev history, it will cause a data race
@@ -3301,7 +3301,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	// Get latest rev id
 	response = rt.SendRequest("GET", resource, "")
 	json.Unmarshal(response.Body.Bytes(), &body)
-	revId := body["_rev"]
+	revId := body[db.BodyRev]
 
 	// Do a bulk_get to get the doc -- this was causing a panic prior to the fix for #2528
 	bulkGetDocs := fmt.Sprintf(`{"docs": [{"id": "%v", "rev": "%v"}, {"id": "%v", "rev": "%v"}]}`, docIdDoc1, revId, docIdDoc2, revidDoc2)
@@ -3379,7 +3379,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 		}
 
 		// Assert expectations for the doc with no attachment errors
-		rawId, ok = partJson["_id"]
+		rawId, ok = partJson[db.BodyId]
 		if ok {
 			_, hasErr := partJson["error"]
 			assertTrue(t, !hasErr, "Did not expect error field for this doc")

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -13,6 +13,57 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
+// Message types
+const (
+	messageSetCheckpoint   = "setCheckpoint"
+	messageGetCheckpoint   = "getCheckpoint"
+	messageSubChanges      = "subChanges"
+	messageChanges         = "changes"
+	messageRev             = "rev"
+	messageGetAttachment   = "getAttachment"
+	messageProposeChanges  = "proposeChanges"
+	messageProveAttachment = "proveAttachment"
+)
+
+// Message properties
+const (
+
+	// Common message properties
+	blipClient   = "client"
+	blipCompress = "compress"
+	blipProfile  = "Profile"
+
+	// setCheckpoint message properties
+	setCheckpointRev = "rev"
+
+	// getCheckpoint message properties
+	getCheckpointResponseRev = "rev"
+
+	// subChanges message properties
+	subChangesActiveOnly = "active_only"
+	subChangesFilter     = "filter"
+	subChangesChannels   = "channels"
+	subChangesSince      = "since"
+	subChangesContinuous = "continuous"
+
+	// rev message properties
+	revMessageId          = "id"
+	revMessageRev         = "rev"
+	revMessageDeleted     = "deleted"
+	revMessageSequence    = "sequence"
+	revMessageHistory     = "history"
+	revMessageNoConflicts = "noconflicts"
+
+	// changes message properties
+	changesResponseMaxHistory = "maxHistory"
+
+	// getAttachment message properties
+	getAttachmentDigest = "digest"
+
+	// proveAttachment
+	proveAttachmentDigest = "digest"
+)
+
 // Function signature for something that parses a sequence id from a string
 type SequenceIDParser func(since string) (db.SequenceID, error)
 
@@ -36,7 +87,7 @@ func newSubChangesParams(rq *blip.Message, logger base.SGLogger, zeroSeq db.Sequ
 
 	// Determine incoming since and docIDs once, since there is some overhead associated with their calculation
 	sinceSequenceId := zeroSeq
-	if sinceStr, found := rq.Properties["since"]; found {
+	if sinceStr, found := rq.Properties[subChangesSince]; found {
 		var err error
 		if sinceSequenceId, err = sequenceIDParser(base.ConvertJSONString(sinceStr)); err != nil {
 			logger.Logf(base.LevelInfo, base.KeySync, "%s: Invalid sequence ID in 'since': %s", rq, sinceStr)
@@ -91,27 +142,27 @@ func (s *subChangesParams) batchSize() int {
 
 func (s *subChangesParams) continuous() bool {
 	continuous := false
-	if val, found := s.rq.Properties["continuous"]; found && val != "false" {
+	if val, found := s.rq.Properties[subChangesContinuous]; found && val != "false" {
 		continuous = true
 	}
 	return continuous
 }
 
 func (s *subChangesParams) activeOnly() bool {
-	return (s.rq.Properties["active_only"] == "true")
+	return (s.rq.Properties[subChangesActiveOnly] == "true")
 }
 
 func (s *subChangesParams) filter() string {
-	return s.rq.Properties["filter"]
+	return s.rq.Properties[subChangesFilter]
 }
 
 func (s *subChangesParams) channels() (channels string, found bool) {
-	channels, found = s.rq.Properties["channels"]
+	channels, found = s.rq.Properties[subChangesChannels]
 	return channels, found
 }
 
 func (s *subChangesParams) channelsExpandedSet() (resultChannels base.Set, err error) {
-	channelsParam, found := s.rq.Properties["channels"]
+	channelsParam, found := s.rq.Properties[subChangesChannels]
 	if !found {
 		return nil, fmt.Errorf("Missing 'channels' filter parameter")
 	}
@@ -156,31 +207,40 @@ func (s *subChangesParams) String() string {
 
 }
 
-type setCheckpointParams struct {
-	rq *blip.Message // The underlying BLIP message
+// setCheckpoint message
+type SetCheckpointMessage struct {
+	*blip.Message
 }
 
-func newSetCheckpointParams(rq *blip.Message) *setCheckpointParams {
-	return &setCheckpointParams{
-		rq: rq,
-	}
+func NewSetCheckpointMessage() *SetCheckpointMessage {
+	scm := &SetCheckpointMessage{blip.NewRequest()}
+	scm.SetProfile(messageSetCheckpoint)
+	return scm
 }
 
-func (s *setCheckpointParams) client() string {
-	return s.rq.Properties["client"]
+func (scm *SetCheckpointMessage) client() string {
+	return scm.Properties[blipClient]
 }
 
-func (s *setCheckpointParams) rev() string {
-	return s.rq.Properties["rev"]
+func (scm *SetCheckpointMessage) setClient(client string) {
+	scm.Properties[blipClient] = client
 }
 
-func (s *setCheckpointParams) String() string {
+func (scm *SetCheckpointMessage) rev() string {
+	return scm.Properties[setCheckpointRev]
+}
+
+func (scm *SetCheckpointMessage) setRev(rev string) {
+	scm.Properties[setCheckpointRev] = rev
+}
+
+func (scm *SetCheckpointMessage) String() string {
 
 	buffer := bytes.NewBufferString("")
 
-	buffer.WriteString(fmt.Sprintf("Client:%v ", s.client()))
+	buffer.WriteString(fmt.Sprintf("Client:%v ", scm.client()))
 
-	rev := s.rev()
+	rev := scm.rev()
 	if len(rev) > 0 {
 		buffer.WriteString(fmt.Sprintf("Rev:%v ", rev))
 	}
@@ -189,40 +249,41 @@ func (s *setCheckpointParams) String() string {
 
 }
 
+type SetCheckpointResponse struct {
+	*blip.Message
+}
+
+func (scr *SetCheckpointResponse) Rev() (rev string) {
+	return scr.Properties[setCheckpointRev]
+}
+
+func (scr *SetCheckpointResponse) setRev(rev string) {
+	scr.Properties[setCheckpointRev] = rev
+}
+
 // Rev message
 type revMessage struct {
 	*blip.Message
 }
 
-// rev message type and properties
-const (
-	messageName_rev = "rev"
-
-	revMessage_id       = "id"
-	revMessage_rev      = "rev"
-	revMessage_deleted  = "deleted"
-	revMessage_sequence = "sequence"
-	revMessage_history  = "history"
-)
-
 func NewRevMessage() *revMessage {
-	rm := &revMessage{}
-	rm.SetProfile(messageName_rev)
+	rm := &revMessage{blip.NewRequest()}
+	rm.SetProfile(messageRev)
 	return rm
 }
 
 func (rm *revMessage) id() (id string, found bool) {
-	id, found = rm.Properties[revMessage_id]
+	id, found = rm.Properties[revMessageId]
 	return id, found
 }
 
 func (rm *revMessage) rev() (rev string, found bool) {
-	rev, found = rm.Properties[revMessage_rev]
+	rev, found = rm.Properties[revMessageRev]
 	return rev, found
 }
 
 func (rm *revMessage) deleted() bool {
-	deleted, found := rm.Properties[revMessage_deleted]
+	deleted, found := rm.Properties[revMessageDeleted]
 	if !found {
 		return false
 	}
@@ -230,36 +291,36 @@ func (rm *revMessage) deleted() bool {
 }
 
 func (rm *revMessage) hasDeletedProperty() bool {
-	_, found := rm.Properties[revMessage_deleted]
+	_, found := rm.Properties[revMessageDeleted]
 	return found
 }
 
 func (rm *revMessage) sequence() (sequence string, found bool) {
-	sequence, found = rm.Properties[revMessage_sequence]
+	sequence, found = rm.Properties[revMessageSequence]
 	return sequence, found
 }
 
 func (rm *revMessage) setId(id string) {
-	rm.Properties[revMessage_id] = id
+	rm.Properties[revMessageId] = id
 }
 
 func (rm *revMessage) setRev(rev string) {
-	rm.Properties[revMessage_rev] = rev
+	rm.Properties[revMessageRev] = rev
 }
 
 func (rm *revMessage) setDeleted(deleted bool) {
 	if deleted {
-		rm.Properties[revMessage_deleted] = "1"
+		rm.Properties[revMessageDeleted] = "1"
 	} else {
-		delete(rm.Properties, revMessage_deleted)
+		delete(rm.Properties, revMessageDeleted)
 	}
 }
 
 func (rm *revMessage) setHistory(history []string) {
 	if len(history) > 0 {
-		rm.Properties[revMessage_history] = strings.Join(history, ",")
+		rm.Properties[revMessageHistory] = strings.Join(history, ",")
 	} else {
-		delete(rm.Properties, revMessage_history)
+		delete(rm.Properties, revMessageHistory)
 	}
 }
 
@@ -268,7 +329,7 @@ func (rm *revMessage) setSequence(seq db.SequenceID) error {
 	if marshalErr != nil {
 		return marshalErr
 	}
-	rm.Properties[revMessage_sequence] = string(seqJSON)
+	rm.Properties[revMessageSequence] = string(seqJSON)
 	return nil
 }
 
@@ -307,7 +368,7 @@ func newGetAttachmentParams(rq *blip.Message) *getAttachmentParams {
 }
 
 func (g *getAttachmentParams) digest() string {
-	return g.rq.Properties["digest"]
+	return g.rq.Properties[getAttachmentDigest]
 }
 
 func (g *getAttachmentParams) String() string {

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -50,8 +50,10 @@ func TestAddRevision(t *testing.T) {
 		if testCase.deletedPropertyValue != "nil" {
 			blipMessage.Properties["deleted"] = testCase.deletedPropertyValue
 		}
-		addRevision := newAddRevisionParams(&blipMessage)
-		assert.Equals(t, addRevision.deleted(), testCase.expectedDeletedVal)
+		revMessage := &revMessage{
+			Message: &blipMessage,
+		}
+		assert.Equals(t, revMessage.deleted(), testCase.expectedDeletedVal)
 	}
 
 }

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -154,7 +154,7 @@ func (h *handler) handleAllDocs() error {
 					row.Status = http.StatusForbidden
 					return row
 				}
-				doc.RevID = body["_rev"].(string)
+				doc.RevID = body[db.BodyRev].(string)
 			}
 			if includeDocs {
 				row.Doc = body
@@ -482,7 +482,7 @@ func (h *handler) handleBulkDocs() error {
 
 		// If ID is present, check whether local doc. (note: if _id is absent or non-string, docid will be
 		// empty string and handled during normal doc processing)
-		docid, _ := doc["_id"].(string)
+		docid, _ := doc[db.BodyId].(string)
 
 		if strings.HasPrefix(docid, "_local/") {
 			localDocs = append(localDocs, doc)
@@ -496,7 +496,7 @@ func (h *handler) handleBulkDocs() error {
 	result := make([]db.Body, 0, len(docs))
 	for _, item := range docs {
 		doc := item.(map[string]interface{})
-		docid, _ := doc["_id"].(string)
+		docid, _ := doc[db.BodyId].(string)
 		var err error
 		var revid string
 		if newEdits {
@@ -540,7 +540,7 @@ func (h *handler) handleBulkDocs() error {
 		var err error
 		var revid string
 		offset := len("_local/")
-		docid, _ := doc["_id"].(string)
+		docid, _ := doc[db.BodyId].(string)
 		idslug := docid[offset:]
 		revid, err = h.db.PutSpecial("local", idslug, doc)
 		status := db.Body{}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -252,7 +252,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	log.Printf("Deletion looks like: %s", response.Body.Bytes())
 	var docBody db.Body
 	json.Unmarshal(response.Body.Bytes(), &docBody)
-	assert.DeepEquals(t, docBody, db.Body{"_id": "alpha", "_rev": rev2, "_deleted": true})
+	assert.DeepEquals(t, docBody, db.Body{db.BodyId: "alpha", db.BodyRev: rev2, db.BodyDeleted: true})
 
 	// Access without deletion revID shouldn't be allowed (since doc is not in Alice's channels):
 	response = rt.Send(requestByUser("GET", "/db/alpha", "", "alice"))
@@ -1062,7 +1062,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	assert.Equals(t, err, nil)
 	assert.Equals(t, len(changes.Results), 4)
 	assert.Equals(t, changes.Results[3].ID, "docD")
-	assert.Equals(t, changes.Results[3].Doc["_id"], "docD")
+	assert.Equals(t, changes.Results[3].Doc[db.BodyId], "docD")
 
 	//test parameter style=all_docs
 	//Create a conflict revision on docC

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -69,7 +69,7 @@ func (h *handler) handleGetDoc() error {
 		if value == nil {
 			return kNotFoundError
 		}
-		h.setHeader("Etag", strconv.Quote(value["_rev"].(string)))
+		h.setHeader("Etag", strconv.Quote(value[db.BodyRev].(string)))
 
 		hasBodies := (attachmentsSince != nil && value["_attachments"] != nil)
 		if h.requestAccepts("multipart/") && (hasBodies || !h.requestAccepts("application/json")) {
@@ -214,11 +214,11 @@ func (h *handler) handlePutAttachment() error {
 		// couchdb creates empty body on attachment PUT
 		// for non-existant doc id
 		body = db.Body{}
-		body["_rev"] = revid
+		body[db.BodyRev] = revid
 	} else if err != nil {
 		return err
 	} else if body != nil {
-		body["_rev"] = revid
+		body[db.BodyRev] = revid
 	}
 
 	// find attachment (if it existed)
@@ -262,9 +262,9 @@ func (h *handler) handlePutDoc() error {
 	if h.getQuery("new_edits") != "false" {
 		// Regular PUT:
 		if oldRev := h.getQuery("rev"); oldRev != "" {
-			body["_rev"] = oldRev
+			body[db.BodyRev] = oldRev
 		} else if ifMatch := h.rq.Header.Get("If-Match"); ifMatch != "" {
-			body["_rev"] = ifMatch
+			body[db.BodyRev] = ifMatch
 		}
 		newRev, err = h.db.Put(docid, body)
 		if err != nil {
@@ -282,7 +282,7 @@ func (h *handler) handlePutDoc() error {
 			return err
 		}
 
-		newRev, ok = body["_rev"].(string)
+		newRev, ok = body[db.BodyRev].(string)
 		if !ok {
 			return base.HTTPErrorf(http.StatusInternalServerError, "Expected revision id in body _rev field")
 		}
@@ -334,7 +334,7 @@ func (h *handler) handleGetLocalDoc() error {
 	if value == nil {
 		return kNotFoundError
 	}
-	value["_id"] = "_local/" + docid
+	value[db.BodyId] = "_local/" + docid
 	value.FixJSONNumbers()
 	h.writeJSON(value)
 	return nil

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -519,7 +519,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	revId, ok := body["_rev"].(string)
+	revId, ok := body[db.BodyRev].(string)
 	assertTrue(t, ok, "No rev included in response")
 
 	// Go get the cas for the doc to use for update
@@ -540,7 +540,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	assert.Equals(t, response.Code, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
-	newRevId := body["_rev"].(string)
+	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	assert.Equals(t, newRevId, revId)
 }
@@ -572,7 +572,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	revId, ok := body["_rev"].(string)
+	revId, ok := body[db.BodyRev].(string)
 	assertTrue(t, ok, "No rev included in response")
 
 	// Go get the cas for the doc to use for update
@@ -631,7 +631,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	revId, ok := body["_rev"].(string)
+	revId, ok := body[db.BodyRev].(string)
 	assertTrue(t, ok, "No rev included in response")
 
 	// Go get the cas for the doc to use for update
@@ -672,7 +672,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	assert.Equals(t, response.Code, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
-	newRevId := body["_rev"].(string)
+	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	assert.Equals(t, newRevId, revId)
 

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -1,11 +1,12 @@
 package rest
 
 import (
-	"testing"
-	"github.com/couchbaselabs/go.assert"
 	"encoding/json"
 	"log"
+	"testing"
+
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbaselabs/go.assert"
 )
 
 func TestDocumentUnmarshal(t *testing.T) {
@@ -50,19 +51,17 @@ func TestDocumentUnmarshal(t *testing.T) {
 
 }
 
-
 func TestAttachmentRoundTrip(t *testing.T) {
-
 
 	doc := RestDocument{}
 	attachmentMap := db.AttachmentMap{
 		"foo": &db.DocAttachment{
 			ContentType: "text",
-			Digest: "whatever",
+			Digest:      "whatever",
 		},
 		"bar": &db.DocAttachment{
 			ContentType: "text",
-			Digest: "whatever",
+			Digest:      "whatever",
 		},
 	}
 
@@ -79,4 +78,3 @@ func TestAttachmentRoundTrip(t *testing.T) {
 	}
 
 }
-


### PR DESCRIPTION
Switch to using constants for blip message names and message properties, as well as the internal doc properties _id, _rev and _deleted.

Includes some refactoring of blip_sync_messages to better support read/write of message properties, and a new test for the SetCheckpoint message.

Fixes #3771 