### PR TITLE
Unmarshal document bodies with decoder.UseNumber()

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -232,6 +232,7 @@ func ReadJSONFromMIME(headers http.Header, input io.Reader, into interface{}) er
 	}
 
 	decoder := json.NewDecoder(input)
+	decoder.UseNumber()
 	if err := decoder.Decode(into); err != nil {
 		base.Warnf(base.KeyAll, "Couldn't parse JSON in HTTP request: %v", err)
 		return base.HTTPErrorf(http.StatusBadRequest, "Bad JSON")

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -649,7 +649,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	assert.Equals(t, len(changes), 3)
 	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
 
-	_, incrErr := db.Bucket.Incr("_sync:seq", 7, 7, 0)
+	_, incrErr := db.Bucket.Incr(SyncSeqKey, 7, 7, 0)
 	assert.True(t, incrErr == nil)
 
 	// Modify user to have access to both channels (sequence 2):

--- a/db/crud.go
+++ b/db/crud.go
@@ -414,7 +414,6 @@ func (db *DatabaseContext) getRevision(doc *document, revid string) (Body, error
 			return nil, err
 		}
 	}
-	body.FixJSONNumbers() // Make sure big ints won't get output in scientific notation
 	body[BodyId] = doc.ID
 	body[BodyRev] = revid
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -173,7 +173,7 @@ func (db *DatabaseContext) OnDemandImportForGet(docid string, rawDoc []byte, raw
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history Body, channels base.Set, err error) {
+func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history Revisions, channels base.Set, err error) {
 	var doc *document
 	if doc, err = context.GetDocument(id.DocID, DocUnmarshalAll); doc == nil {
 		return body, history, channels, err
@@ -183,7 +183,7 @@ func (context *DatabaseContext) revCacheLoader(id IDAndRev) (body Body, history 
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func (context *DatabaseContext) revCacheLoaderForDocument(doc *document, revid string) (body Body, history Body, channels base.Set, err error) {
+func (context *DatabaseContext) revCacheLoaderForDocument(doc *document, revid string) (body Body, history Revisions, channels base.Set, err error) {
 
 	if body, err = context.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether

--- a/db/crud.go
+++ b/db/crud.go
@@ -280,7 +280,7 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 				redactedBody["_removed"] = true
 			}
 			if revisions != nil {
-				redactedBody["_revisions"] = revisions
+				redactedBody[BodyRevisions] = revisions
 			}
 			return redactedBody, nil
 		}
@@ -294,7 +294,7 @@ func (db *Database) GetRevWithHistory(docid, revid string, maxHistory int, histo
 
 	// Add revision metadata:
 	if revisions != nil {
-		body["_revisions"] = revisions
+		body[BodyRevisions] = revisions
 	}
 
 	// If doc is nil (we got the rev from the rev cache)
@@ -488,7 +488,7 @@ func (db *Database) getRevFromDoc(doc *document, revid string, listRevisions boo
 		if getHistoryErr != nil {
 			return nil, getHistoryErr
 		}
-		body["_revisions"] = encodeRevisions(validatedHistory)
+		body[BodyRevisions] = encodeRevisions(validatedHistory)
 	}
 	return body, nil
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -231,9 +231,9 @@ func TestDatabase(t *testing.T) {
 	// Test the _revisions property:
 	log.Printf("Check _revisions...")
 	gotbody, err = db.GetRev("doc1", rev2id, true, nil)
-	revisions := gotbody["_revisions"].(map[string]interface{})
-	assert.Equals(t, revisions["start"], 2)
-	assert.DeepEquals(t, revisions["ids"],
+	revisions := gotbody[BodyRevisions].(map[string]interface{})
+	assert.Equals(t, revisions[RevisionsStart], 2)
+	assert.DeepEquals(t, revisions[RevisionsIds],
 		[]string{"488724414d0ed6b398d6d2aeb228d797",
 			"cb0c9a22be0e5a1b01084ec019defa81"})
 
@@ -293,10 +293,10 @@ func TestGetDeleted(t *testing.T) {
 	body, err = db.GetRev("doc1", rev2id, true, nil)
 	assertNoError(t, err, "GetRev")
 	expectedResult := Body{
-		BodyId:       "doc1",
-		BodyRev:      rev2id,
-		BodyDeleted:  true,
-		"_revisions": map[string]interface{}{"start": 2, "ids": []string{"bc6d97f6e97c0d034a34f8aac2bf8b44", "dfd5e19813767eeddd08270fc5f385cd"}},
+		BodyId:        "doc1",
+		BodyRev:       rev2id,
+		BodyDeleted:   true,
+		BodyRevisions: map[string]interface{}{RevisionsStart: 2, RevisionsIds: []string{"bc6d97f6e97c0d034a34f8aac2bf8b44", "dfd5e19813767eeddd08270fc5f385cd"}},
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
@@ -355,9 +355,9 @@ func TestGetRemovedAsUser(t *testing.T) {
 	expectedResult := Body{
 		"key1":     1234,
 		"channels": []string{"NBC"},
-		"_revisions": map[string]interface{}{
-			"start": 2,
-			"ids":   []string{rev2digest, rev1digest}},
+		BodyRevisions: map[string]interface{}{
+			RevisionsStart: 2,
+			RevisionsIds:   []string{rev2digest, rev1digest}},
 		BodyId:  "doc1",
 		BodyRev: rev2id,
 	}
@@ -386,9 +386,9 @@ func TestGetRemovedAsUser(t *testing.T) {
 		BodyId:     "doc1",
 		BodyRev:    rev2id,
 		"_removed": true,
-		"_revisions": map[string]interface{}{
-			"start": 2,
-			"ids":   []string{rev2digest, rev1digest}},
+		BodyRevisions: map[string]interface{}{
+			RevisionsStart: 2,
+			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
@@ -439,9 +439,9 @@ func TestGetRemoved(t *testing.T) {
 	expectedResult := Body{
 		"key1":     1234,
 		"channels": []string{"NBC"},
-		"_revisions": map[string]interface{}{
-			"start": 2,
-			"ids":   []string{rev2digest, rev1digest}},
+		BodyRevisions: map[string]interface{}{
+			RevisionsStart: 2,
+			RevisionsIds:   []string{rev2digest, rev1digest}},
 		BodyId:  "doc1",
 		BodyRev: rev2id,
 	}
@@ -461,9 +461,9 @@ func TestGetRemoved(t *testing.T) {
 		BodyId:     "doc1",
 		BodyRev:    rev2id,
 		"_removed": true,
-		"_revisions": map[string]interface{}{
-			"start": 2,
-			"ids":   []string{rev2digest, rev1digest}},
+		BodyRevisions: map[string]interface{}{
+			RevisionsStart: 2,
+			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
 	assert.DeepEquals(t, body, expectedResult)
 
@@ -514,9 +514,9 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	expectedResult := Body{
 		"key1":      1234,
 		BodyDeleted: true,
-		"_revisions": map[string]interface{}{
-			"start": 2,
-			"ids":   []string{rev2digest, rev1digest}},
+		BodyRevisions: map[string]interface{}{
+			RevisionsStart: 2,
+			RevisionsIds:   []string{rev2digest, rev1digest}},
 		BodyId:  "doc1",
 		BodyRev: rev2id,
 	}
@@ -537,9 +537,9 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		BodyRev:     rev2id,
 		"_removed":  true,
 		BodyDeleted: true,
-		"_revisions": map[string]interface{}{
-			"start": 2,
-			"ids":   []string{rev2digest, rev1digest}},
+		BodyRevisions: map[string]interface{}{
+			RevisionsStart: 2,
+			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
 	assert.DeepEquals(t, body, expectedResult)
 

--- a/db/document.go
+++ b/db/document.go
@@ -134,7 +134,7 @@ func unmarshalDocument(docid string, data []byte) (*document, error) {
 	if len(data) > 0 {
 		decoder := json.NewDecoder(bytes.NewReader(data))
 		decoder.UseNumber()
-		if err := decoder.Decode(&doc); err != nil {
+		if err := decoder.Decode(doc); err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error unmarshalling doc.")
 		}
 		if doc != nil && doc.Deleted_OLD {

--- a/db/document.go
+++ b/db/document.go
@@ -400,7 +400,7 @@ func (doc *document) getNonWinningRevisionBody(revid string, loader RevLoaderFun
 		return nil
 	}
 
-	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+	if err := body.Unmarshal(bodyBytes); err != nil {
 		base.Warnf(base.KeyAll, "Unexpected error parsing body of rev %q: %v", revid, err)
 		return nil
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -608,7 +608,7 @@ func (doc *document) updateChannels(newChannels base.Set) (changedChannels base.
 
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
-func (doc *document) IsChannelRemoval(revID string) (body Body, history Body, channels base.Set, isRemoval bool, err error) {
+func (doc *document) IsChannelRemoval(revID string) (body Body, history Revisions, channels base.Set, isRemoval bool, err error) {
 
 	channels = make(base.Set)
 

--- a/db/document.go
+++ b/db/document.go
@@ -103,7 +103,7 @@ func newDocument(docid string) *document {
 // Accessors for document properties.  To support lazy unmarshalling of document contents, all access should be done through accessors
 func (doc *document) Body() Body {
 	if doc._body == nil && doc.rawBody != nil {
-		err := json.Unmarshal(doc.rawBody, &doc._body)
+		err := doc._body.Unmarshal(doc.rawBody)
 		if err != nil {
 			base.Warnf(base.KeyAll, "Unable to unmarshal document body from raw body : %s", err)
 			return nil
@@ -132,7 +132,9 @@ func (doc *document) MarshalBody() ([]byte, error) {
 func unmarshalDocument(docid string, data []byte) (*document, error) {
 	doc := newDocument(docid)
 	if len(data) > 0 {
-		if err := json.Unmarshal(data, doc); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.UseNumber()
+		if err := decoder.Decode(&doc); err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error unmarshalling doc.")
 		}
 		if doc != nil && doc.Deleted_OLD {
@@ -702,7 +704,7 @@ func (doc *document) UnmarshalJSON(data []byte) error {
 		doc.syncData = *root.SyncData
 	}
 
-	if err := json.Unmarshal(data, &doc._body); err != nil {
+	if err := doc._body.Unmarshal(data); err != nil {
 		return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalJSON() doc with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
 
@@ -744,7 +746,7 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 		}
 		// Unmarshal body if requested and present
 		if unmarshalLevel == DocUnmarshalAll && len(data) > 0 {
-			return json.Unmarshal(data, &doc._body)
+			return doc._body.Unmarshal(data)
 		} else {
 			doc.rawBody = data
 		}

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -144,10 +144,10 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 		useDecode      bool
 		fixJSONNumbers bool
 	}{
-		{"UnmarshalAndFixNumbers", false, true},
-		{"Unmarshal", false, false},
 		{"Decode", true, false},
 		{"DecodeUseNumber", true, true},
+		{"UnmarshalAndFixNumbers", false, true},
+		{"Unmarshal", false, false},
 	}
 
 	for _, bm := range unmarshalBenchmarks {
@@ -155,10 +155,12 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				doc := newDocument("testDocID")
+				docReader := bytes.NewReader(doc1k_body)
 				b.StartTimer()
 				var err error
 				if bm.useDecode {
-					decoder := json.NewDecoder(bytes.NewBuffer(doc1k_body))
+					//decoder := json.NewDecoder(bytes.NewReader(doc1k_body))
+					decoder := json.NewDecoder(docReader)
 					if bm.fixJSONNumbers {
 						decoder.UseNumber()
 					}

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -121,7 +121,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 		t.Run(fmt.Sprintf("%s", testCase), func(t *testing.T) {
 
 			key := fmt.Sprintf("TestImportDocWithStaleDoc%-s", testCase.name)
-			bodyBytes := rawDocNoMeta()
+			bodyBytes := testCase.docBody
 			body := Body{}
 			err := body.Unmarshal(bodyBytes)
 			assertNoError(t, err, "Error unmarshalling body")

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -88,6 +88,7 @@ func TestMigrateMetadata(t *testing.T) {
 // Scenario 2: import with migration
 //
 // - Same as scenario 1, except that in step 1 it writes a doc with sync metadata, so that it excercises the migration code
+// - Temporarily set expectedGeneration:2, see https://github.com/couchbase/sync_gateway/issues/3804
 //
 func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 
@@ -102,49 +103,52 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	type testcase struct {
-		docBody []byte
-		name    string
+		docBody            []byte
+		name               string
+		expectedGeneration int
 	}
 	testCases := []testcase{
 		{
-			docBody: rawDocNoMeta(),
-			name:    "rawDocNoMeta",
+			docBody:            rawDocNoMeta(),
+			name:               "rawDocNoMeta",
+			expectedGeneration: 1,
 		},
 		{
-			docBody: rawDocWithSyncMeta(),
-			name:    "rawDocWithSyncMeta",
+			docBody:            rawDocWithSyncMeta(),
+			name:               "rawDocWithSyncMeta",
+			expectedGeneration: 2,
 		},
 	}
 
 	for _, testCase := range testCases {
 
-		t.Run(fmt.Sprintf("%s", testCase), func(t *testing.T) {
-
+		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 			key := fmt.Sprintf("TestImportDocWithStaleDoc%-s", testCase.name)
 			bodyBytes := testCase.docBody
 			body := Body{}
 			err := body.Unmarshal(bodyBytes)
 			assertNoError(t, err, "Error unmarshalling body")
 
-			// Create via the SDK with sync metadata intact
-			expirySeconds := time.Second * 30
-			syncMetaExpiry := time.Now().Add(expirySeconds)
+			// Create via the SDK
+			expiryDuration := time.Minute * 30
+			syncMetaExpiry := time.Now().Add(expiryDuration)
 			_, err = testBucket.Bucket.Add(key, uint32(syncMetaExpiry.Unix()), bodyBytes)
 			assertNoError(t, err, "Error writing doc w/ expiry")
 
 			// Get the existing bucket doc
 			_, existingBucketDoc, err := db.GetDocWithXattr(key, DocUnmarshalAll)
+			assertNoError(t, err, fmt.Sprintf("Error retrieving doc w/ xattr: %v", err))
+
 			body = Body{}
 			err = body.Unmarshal(existingBucketDoc.Body)
 			assertNoError(t, err, "Error unmarshalling body")
-			log.Printf("existingBucketDoc: %+v", existingBucketDoc)
 
 			// Set the expiry value
 			existingBucketDoc.Expiry = uint32(syncMetaExpiry.Unix())
 
 			// Perform an SDK update to turn existingBucketDoc into a stale doc
-			laterExpirySeconds := time.Second * 60
-			laterSyncMetaExpiry := time.Now().Add(laterExpirySeconds)
+			laterExpiryDuration := time.Minute * 60
+			laterSyncMetaExpiry := time.Now().Add(laterExpiryDuration)
 			updateCallbackFn := func(current []byte) (updated []byte, expiry *uint32, err error) {
 				// This update function will not be "competing" with other updates, so it doesn't need
 				// to handle being called back multiple times or performing any merging with existing values.
@@ -158,18 +162,16 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 			)
 
 			// Import the doc (will migrate as part of the import since the doc contains sync meta)
-			docOut, errImportDoc := db.importDoc(key, body, false, existingBucketDoc, ImportOnDemand)
-			log.Printf("docOut: %v, errImportDoc: %v", docOut, errImportDoc)
+			_, errImportDoc := db.importDoc(key, body, false, existingBucketDoc, ImportOnDemand)
 			assertNoError(t, errImportDoc, "Unexpected error")
 
 			// Make sure the doc in the bucket has expected XATTR
-			assertXattrSyncMetaRevGeneration(t, testBucket.Bucket, key, 1)
+			assertXattrSyncMetaRevGeneration(t, testBucket.Bucket, key, testCase.expectedGeneration)
 
 			// Verify the expiry has been preserved after the import
 			gocbBucket, _ := base.AsGoCBBucket(testBucket.Bucket)
 			expiry, err := gocbBucket.GetExpiry(key)
 			assertNoError(t, err, "Error calling GetExpiry()")
-			log.Printf("expiry: %v  laterSyncMetaExpiry.Unix(): %v", expiry, laterSyncMetaExpiry.Unix())
 			assert.True(t, expiry == uint32(laterSyncMetaExpiry.Unix()))
 
 		})

--- a/db/revision.go
+++ b/db/revision.go
@@ -28,6 +28,13 @@ const (
 	BodyId      = "_id"
 )
 
+// A revisions property found within a Body.  Expected to be of the form:
+//   Revisions["start"]: int64, starting generation number
+//   Revisions["ids"]: []string, list of digests
+// Used as map[string]interface{} instead of Revisions struct because it's unmarshalled
+// along with Body, and we don't need the overhead of allocating a new object
+type Revisions map[string]interface{}
+
 func (b *Body) Unmarshal(data []byte) error {
 
 	if len(data) == 0 {
@@ -47,6 +54,14 @@ func (b *Body) Unmarshal(data []byte) error {
 func (body Body) ShallowCopy() Body {
 	copied := make(Body, len(body))
 	for key, value := range body {
+		copied[key] = value
+	}
+	return copied
+}
+
+func (revisions Revisions) ShallowCopy() Revisions {
+	copied := make(Revisions, len(revisions))
+	for key, value := range revisions {
 		copied[key] = value
 	}
 	return copied
@@ -212,7 +227,7 @@ func canonicalEncoding(body Body) []byte {
 	return encoded
 }
 
-func GetStringArrayProperty(body Body, property string) ([]string, error) {
+func GetStringArrayProperty(body map[string]interface{}, property string) ([]string, error) {
 	if raw, exists := body[property]; !exists {
 		return nil, nil
 	} else if strings, ok := raw.([]string); ok {

--- a/db/revision.go
+++ b/db/revision.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -44,14 +45,13 @@ const (
 func (b *Body) Unmarshal(data []byte) error {
 
 	if len(data) == 0 {
-		b = &Body{}
-		return nil
+		return errors.New("Unexpected empty JSON input to body.Unmarshal")
 	}
 
 	// Use decoder for unmarshalling to preserve large numbers
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
-	if err := decoder.Decode(&b); err != nil {
+	if err := decoder.Decode(b); err != nil {
 		return err
 	}
 	return nil

--- a/db/revision.go
+++ b/db/revision.go
@@ -23,9 +23,10 @@ import (
 type Body map[string]interface{}
 
 const (
-	BodyDeleted = "_deleted"
-	BodyRev     = "_rev"
-	BodyId      = "_id"
+	BodyDeleted   = "_deleted"
+	BodyRev       = "_rev"
+	BodyId        = "_id"
+	BodyRevisions = "_revisions"
 )
 
 // A revisions property found within a Body.  Expected to be of the form:
@@ -34,6 +35,11 @@ const (
 // Used as map[string]interface{} instead of Revisions struct because it's unmarshalled
 // along with Body, and we don't need the overhead of allocating a new object
 type Revisions map[string]interface{}
+
+const (
+	RevisionsStart = "start"
+	RevisionsIds   = "ids"
+)
 
 func (b *Body) Unmarshal(data []byte) error {
 
@@ -212,7 +218,7 @@ func stripSpecialProperties(body Body) Body {
 
 func containsUserSpecialProperties(body Body) bool {
 	for key := range body {
-		if key != "" && key[0] == '_' && key != BodyId && key != BodyRev && key != BodyDeleted && key != "_attachments" && key != "_revisions" {
+		if key != "" && key[0] == '_' && key != BodyId && key != BodyRev && key != BodyDeleted && key != "_attachments" && key != BodyRevisions {
 			return true
 		}
 	}

--- a/db/revision.go
+++ b/db/revision.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
@@ -28,7 +29,16 @@ const (
 )
 
 func (b *Body) Unmarshal(data []byte) error {
-	if err := json.Unmarshal(data, &b); err != nil {
+
+	if len(data) == 0 {
+		b = &Body{}
+		return nil
+	}
+
+	// Use decoder for unmarshalling to preserve large numbers
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&b); err != nil {
 		return err
 	}
 	return nil

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -19,7 +19,7 @@ func TestRevisionCache(t *testing.T) {
 			BodyId:  ids[i],
 			BodyRev: "x",
 		}
-		history := Revisions{"start": i}
+		history := Revisions{RevisionsStart: i}
 		return body, history, nil
 	}
 	verify := func(body Body, history Revisions, channels base.Set, i int) {
@@ -29,7 +29,7 @@ func TestRevisionCache(t *testing.T) {
 		assert.True(t, body != nil)
 		assert.Equals(t, body[BodyId], ids[i])
 		assert.True(t, history != nil)
-		assert.Equals(t, history["start"], i)
+		assert.Equals(t, history[RevisionsStart], i)
 		assert.DeepEquals(t, channels, base.Set(nil))
 	}
 
@@ -70,7 +70,7 @@ func TestLoaderFunction(t *testing.T) {
 				BodyId:  id.DocID,
 				BodyRev: id.RevID,
 			}
-			history = Revisions{"start": 1}
+			history = Revisions{RevisionsStart: 1}
 			channels = base.SetOf("*")
 		}
 		return
@@ -111,8 +111,8 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	// Invalid _revisions property will be stripped.  Should also not be present in the rev cache.
 	rev1body := Body{
-		"value":      1234,
-		"_revisions": "unexpected data",
+		"value":       1234,
+		BodyRevisions: "unexpected data",
 	}
 	rev1id, err := db.Put("doc1", rev1body)
 	assertNoError(t, err, "Put")
@@ -120,7 +120,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 	// Get the raw document directly from the bucket, validate _revisions property isn't found
 	var bucketBody Body
 	testBucket.Bucket.Get("doc1", &bucketBody)
-	_, ok := bucketBody["_revisions"]
+	_, ok := bucketBody[BodyRevisions]
 	if ok {
 		t.Error("_revisions property still present in document retrieved directly from bucket.")
 	}
@@ -128,7 +128,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 	// Get the doc while still resident in the rev cache w/ history=false, validate _revisions property isn't found
 	body, err := db.GetRev("doc1", rev1id, false, nil)
 	assertNoError(t, err, "GetRev")
-	badRevisions, ok := body["_revisions"]
+	badRevisions, ok := body[BodyRevisions]
 	if ok {
 		t.Errorf("_revisions property still present in document retrieved from rev cache: %s", badRevisions)
 	}
@@ -137,13 +137,13 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 	// properties ("start", "ids")
 	bodyWithHistory, err := db.GetRev("doc1", rev1id, true, nil)
 	assertNoError(t, err, "GetRev")
-	validRevisions, ok := bodyWithHistory["_revisions"]
+	validRevisions, ok := bodyWithHistory[BodyRevisions]
 	if !ok {
 		t.Errorf("Expected _revisions property not found in document retrieved from rev cache: %s", validRevisions)
 	}
 	validRevisionsMap, ok := validRevisions.(map[string]interface{})
-	_, startOk := validRevisionsMap["start"]
+	_, startOk := validRevisionsMap[RevisionsStart]
 	assert.True(t, startOk)
-	_, idsOk := validRevisionsMap["ids"]
+	_, idsOk := validRevisionsMap[RevisionsIds]
 	assert.True(t, idsOk)
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -14,15 +14,15 @@ func TestRevisionCache(t *testing.T) {
 		ids[i] = fmt.Sprintf("%d", i)
 	}
 
-	revForTest := func(i int) (Body, Body, base.Set) {
+	revForTest := func(i int) (Body, Revisions, base.Set) {
 		body := Body{
 			BodyId:  ids[i],
 			BodyRev: "x",
 		}
-		history := Body{"start": i}
+		history := Revisions{"start": i}
 		return body, history, nil
 	}
-	verify := func(body Body, history Body, channels base.Set, i int) {
+	verify := func(body Body, history Revisions, channels base.Set, i int) {
 		if body == nil {
 			t.Fatalf("nil body at #%d", i)
 		}
@@ -61,7 +61,7 @@ func TestRevisionCache(t *testing.T) {
 
 func TestLoaderFunction(t *testing.T) {
 	var callsToLoader = 0
-	loader := func(id IDAndRev) (body Body, history Body, channels base.Set, err error) {
+	loader := func(id IDAndRev) (body Body, history Revisions, channels base.Set, err error) {
 		callsToLoader++
 		if id.DocID[0] != 'J' {
 			err = base.HTTPErrorf(404, "missing")
@@ -70,7 +70,7 @@ func TestLoaderFunction(t *testing.T) {
 				BodyId:  id.DocID,
 				BodyRev: id.RevID,
 			}
-			history = Body{"start": 1}
+			history = Revisions{"start": 1}
 			channels = base.SetOf("*")
 		}
 		return

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -1,8 +1,12 @@
 package db
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
 	"testing"
+
+	"github.com/couchbaselabs/go.assert"
 )
 
 func TestParseRevID(t *testing.T) {
@@ -29,4 +33,39 @@ func TestParseRevID(t *testing.T) {
 	assertTrue(t, generation == 333, "Expected generation")
 	assertTrue(t, digest == "a", "Unexpected digest")
 
+}
+
+func TestBodyUnmarshal(t *testing.T) {
+
+	tests := []struct {
+		name         string
+		inputBytes   []byte
+		expectedBody Body
+	}{
+		{"empty bytes", []byte(""), nil},
+		{"null", []byte("null"), Body(nil)},
+		{"{}", []byte("{}"), Body{}},
+		{"example body", []byte(`{"test":true}`), Body{"test": true}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(ts *testing.T) {
+			var b Body
+			err := b.Unmarshal(test.inputBytes)
+
+			// Unmarshal using json.Unmarshal for comparison below
+			var jsonUnmarshalBody Body
+			unmarshalErr := json.Unmarshal(test.inputBytes, &jsonUnmarshalBody)
+
+			if unmarshalErr != nil {
+				// If json.Unmarshal returns error for input, body.Unmarshal should do the same
+				assertTrue(t, err != nil, fmt.Sprintf("Expected error when unmarshalling %s", test.name))
+			} else {
+				assertNoError(t, err, fmt.Sprintf("Expected no error when unmarshalling %s", test.name))
+				assert.DeepEquals(t, b, test.expectedBody) // Check against expected body
+				assert.DeepEquals(t, b, jsonUnmarshalBody) // Check against json.Unmarshal results
+			}
+
+		})
+	}
 }

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -706,7 +706,7 @@ func (tree RevTree) getHistory(revid string) ([]string, error) {
 // Parses a CouchDB _rev or _revisions property into a list of revision IDs
 func ParseRevisions(body Body) []string {
 	// http://wiki.apache.org/couchdb/HTTP_Document_API#GET
-	revisions, ok := body["_revisions"].(map[string]interface{})
+	revisions, ok := body["_revisions"].(Revisions)
 	if !ok {
 		revid, ok := body[BodyRev].(string)
 		if !ok {
@@ -732,7 +732,7 @@ func ParseRevisions(body Body) []string {
 }
 
 // Splits out the "start" and "ids" properties from encoded revision list
-func splitRevisionList(revisions Body) (int, []string) {
+func splitRevisionList(revisions Revisions) (int, []string) {
 	start, ok := base.ToInt64(revisions["start"])
 	digests, _ := GetStringArrayProperty(revisions, "ids")
 	if ok && len(digests) > 0 && int(start) >= len(digests) {
@@ -744,7 +744,7 @@ func splitRevisionList(revisions Body) (int, []string) {
 
 // Standard CouchDB encoding of a revision list: digests without numeric generation prefixes go in
 // the "ids" property, and the first (largest) generation number in the "start" property.
-func encodeRevisions(revs []string) Body {
+func encodeRevisions(revs []string) Revisions {
 	ids := make([]string, len(revs))
 	var start int
 	for i, revid := range revs {
@@ -756,14 +756,14 @@ func encodeRevisions(revs []string) Body {
 			base.Warnf(base.KeyAll, "encodeRevisions found weird history %v", revs)
 		}
 	}
-	return map[string]interface{}{"start": start, "ids": ids}
+	return Revisions{"start": start, "ids": ids}
 }
 
 // Given a revision history encoded by encodeRevisions() and a list of possible ancestor revIDs,
 // trim the history to stop at the first ancestor revID. If no ancestors are found, trim to
 // length maxUnmatchedLen.
 // TODO: Document/rename what the boolean result return value represents
-func trimEncodedRevisionsToAncestor(revs Body, ancestors []string, maxUnmatchedLen int) (result bool, trimmedRevs Body) {
+func trimEncodedRevisionsToAncestor(revs Revisions, ancestors []string, maxUnmatchedLen int) (result bool, trimmedRevs Revisions) {
 
 	trimmedRevs = revs
 

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -717,7 +717,7 @@ func TestParseRevisions(t *testing.T) {
 
 func TestEncodeRevisions(t *testing.T) {
 	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie"})
-	assert.DeepEquals(t, encoded, Body{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
+	assert.DeepEquals(t, encoded, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
@@ -726,30 +726,30 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 
 	result, trimmedRevs := trimEncodedRevisionsToAncestor(encoded, []string{"3-walter", "17-gretchen", "1-fooey"}, 1000)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey", "louie", "screwy"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie", "screwy"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 2)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 3)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "5-huey"}, 3)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey"}})
 
 	// Check maxLength with no ancestors:
 	encoded = encodeRevisions([]string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(encoded, nil, 6)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey", "louie", "screwy"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie", "screwy"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, nil, 2)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Body{"start": 5, "ids": []string{"huey", "dewey"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey"}})
 }
 
 // Regression test for https://github.com/couchbase/sync_gateway/issues/2847

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -717,7 +717,7 @@ func TestParseRevisions(t *testing.T) {
 
 func TestEncodeRevisions(t *testing.T) {
 	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie"})
-	assert.DeepEquals(t, encoded, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
+	assert.DeepEquals(t, encoded, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
@@ -726,30 +726,30 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 
 	result, trimmedRevs := trimEncodedRevisionsToAncestor(encoded, []string{"3-walter", "17-gretchen", "1-fooey"}, 1000)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie", "screwy"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie", "screwy"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 2)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 3)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "5-huey"}, 3)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey"}})
 
 	// Check maxLength with no ancestors:
 	encoded = encodeRevisions([]string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(encoded, nil, 6)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey", "louie", "screwy"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie", "screwy"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, nil, 2)
 	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{"start": 5, "ids": []string{"huey", "dewey"}})
+	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey"}})
 }
 
 // Regression test for https://github.com/couchbase/sync_gateway/issues/2847

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -10,6 +10,7 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"log"
 )
 
 // Bidirectional sync with an external Couchbase bucket.
@@ -117,8 +118,11 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		// Compare this body to the current revision body to see if it's an echo:
 		parentRev := doc.UpstreamRev
 		newRev := doc.CurrentRev
-		if !reflect.DeepEqual(body, doc.getRevisionBody(newRev, s.context.RevisionBodyLoader)) {
+		docBody := doc.getRevisionBody(newRev, s.context.RevisionBodyLoader)
+		if !reflect.DeepEqual(body, docBody) {
 			// Nope, it's not. Assign it a new rev ID
+			log.Printf("Not equal.  body: %+v  %T", body, body["foo"])
+			log.Printf("Not equal.  docBody: %+v %T", docBody, docBody["foo"])
 			generation, _ := ParseRevID(parentRev)
 			newRev = createRevID(generation+1, parentRev, body)
 		}

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 	"sync/atomic"
 
-	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"log"
 )
 
 // Bidirectional sync with an external Couchbase bucket.
@@ -118,11 +117,8 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		// Compare this body to the current revision body to see if it's an echo:
 		parentRev := doc.UpstreamRev
 		newRev := doc.CurrentRev
-		docBody := doc.getRevisionBody(newRev, s.context.RevisionBodyLoader)
-		if !reflect.DeepEqual(body, docBody) {
+		if !reflect.DeepEqual(body, doc.getRevisionBody(newRev, s.context.RevisionBodyLoader)) {
 			// Nope, it's not. Assign it a new rev ID
-			log.Printf("Not equal.  body: %+v  %T", body, body["foo"])
-			log.Printf("Not equal.  docBody: %+v %T", docBody, docBody["foo"])
 			generation, _ := ParseRevID(parentRev)
 			newRev = createRevID(generation+1, parentRev, body)
 		}

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -143,7 +143,7 @@ func TestShadowerPullWithNotifications(t *testing.T) {
 	})
 
 	// wait for Event Manager queue worker to process
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	channelSize := len(resultChannel)
 

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -65,8 +65,8 @@ func TestShadowerPull(t *testing.T) {
 	})
 	doc1, _ = db.GetDocument("key1", DocUnmarshalAll)
 	doc2, _ = db.GetDocument("key2", DocUnmarshalAll)
-	assert.DeepEquals(t, doc1.Body(), Body{"foo": float64(1)})
-	assert.DeepEquals(t, doc2.Body(), Body{"bar": float64(-1)})
+	assert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
+	assert.DeepEquals(t, doc2.Body(), Body{"bar": json.Number("-1")})
 
 	t.Logf("Deleting remote doc")
 	bucket.Delete("key1")
@@ -331,9 +331,9 @@ func TestShadowerPattern(t *testing.T) {
 	doc2, err := db.GetDocument("key2", DocUnmarshalAll)
 	assertNoError(t, err, fmt.Sprintf("Error getting key2: %v", err))
 
-	assert.DeepEquals(t, doc1.Body(), Body{"foo": float64(1)})
+	assert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
 	assert.True(t, docI == nil)
-	assert.DeepEquals(t, doc2.Body(), Body{"bar": float64(-1)})
+	assert.DeepEquals(t, doc2.Body(), Body{"bar": json.Number("-1")})
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&shadower.pullCount) >= 2

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -65,7 +65,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 			}
 		} else {
 			prevBody := Body{}
-			if err := json.Unmarshal(value, &prevBody); err != nil {
+			if err := prevBody.Unmarshal(value); err != nil {
 				return nil, nil, err
 			}
 			if matchRev != prevBody[BodyRev] {

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -30,7 +30,7 @@ func (db *Database) GetSpecial(doctype string, docid string) (Body, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal(rawDocBytes, &body); err != nil {
+		if err := body.Unmarshal(rawDocBytes); err != nil {
 			return nil, err
 		}
 	} else {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -105,7 +105,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="9769dbb86bba8894283fa9f52f9eb74f5d881c68"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="255290930ae30483b28f3f1b19966f8b3e2ce8e8"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -105,7 +105,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="238f46bf38971b117d90e70cba9bd4682428a8b6"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="9769dbb86bba8894283fa9f52f9eb74f5d881c68"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -279,7 +279,9 @@ func TestDocumentLargeNumbers(t *testing.T) {
 
 	// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(getResponse.Body.Bytes())
-	assert.True(t, strings.Contains(responseString, `"largeInt":9223372036854775807`))
+	if !strings.Contains(responseString, `9223372036854775807`) {
+		t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
+	}
 }
 
 func TestFunkyDocIDs(t *testing.T) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -276,7 +276,6 @@ func TestDocumentLargeNumbers(t *testing.T) {
 	// Get document, validate number value
 	getResponse := rt.SendAdminRequest("GET", "/db/numberDoc", "")
 	assertStatus(t, getResponse, 200)
-	log.Printf("response body: %s", getResponse.Body.Bytes())
 
 	// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(getResponse.Body.Bytes())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1449,7 +1449,7 @@ readerLoop:
 			exp = 1
 		case "doc3":
 			// revs_limit of zero should display no revision object at all
-			assert.Equals(t, partJSON["_revisions"], nil)
+			assert.Equals(t, partJSON[db.BodyRevisions], nil)
 			break readerLoop
 		case "doc4":
 			// revs_limit must be >= 0
@@ -1459,8 +1459,8 @@ readerLoop:
 			t.Error("unrecognised part in response")
 		}
 
-		revisions := partJSON["_revisions"].(map[string]interface{})
-		assert.Equals(t, len(revisions["ids"].([]interface{})), exp)
+		revisions := partJSON[db.BodyRevisions].(map[string]interface{})
+		assert.Equals(t, len(revisions[db.RevisionsIds].([]interface{})), exp)
 	}
 
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -263,25 +263,58 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 	assertStatus(t, response, 400)
 }
 
+// expand to multiple test cases, verifying number values in sync function
 func TestDocumentLargeNumbers(t *testing.T) {
 
-	// Use sync function to ensure no unexpected change to doc.
-	rt := RestTester{SyncFn: `function(doc) {if(doc.largeInt > 1000) { channel("largeNum") }}`}
+	tests := []struct {
+		name            string
+		body            string
+		expectedString  string
+		expectedChannel string
+	}{
+		{"largeInt", `{"number": 9223372036854775807}`, "9223372036854775807", "largeInt"},
+		{"precisionFloat", `{"number": 9223.372036854775807}`, "9223.372036854775807", "precisionFloat"},
+		{"largeInt2", `{"number": 9223372036854775808}`, "9223372036854775808", "largeInt2"},
+	}
+
+	// Use channels to ensure numbers are making it to sync function intact
+	// Note that the sync function is comparing doc.number to string for the large int cases, since javascript
+	// doesn't support 64-bit integers. (https://www.ecma-international.org/ecma-262/5.1/#sec-8.5)
+	syncFn := `function(doc) {` +
+		`if (doc.number == 9223.372036854775807) { channel("precisionFloat")} ` +
+		`if (doc.number == "9223372036854775807") { channel("largeInt")} ` +
+		`if (doc.number == "9223372036854775808") { channel("largeInt2")} ` +
+		`}`
+	rt := RestTester{SyncFn: syncFn}
 	defer rt.Close()
 
-	//Create document
-	response := rt.SendAdminRequest("PUT", "/db/numberDoc", `{"largeInt":9223372036854775807}`)
-	assertStatus(t, response, 201)
+	for _, test := range tests {
+		t.Run(test.name, func(ts *testing.T) {
+			//Create document
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", test.name), test.body)
+			assertStatus(t, response, 201)
 
-	// Get document, validate number value
-	getResponse := rt.SendAdminRequest("GET", "/db/numberDoc", "")
-	assertStatus(t, getResponse, 200)
+			// Get document, validate number value
+			getResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", test.name), "")
+			assertStatus(t, getResponse, 200)
 
-	// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
-	responseString := string(getResponse.Body.Bytes())
-	if !strings.Contains(responseString, `9223372036854775807`) {
-		t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
+			// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
+			responseString := string(getResponse.Body.Bytes())
+			if !strings.Contains(responseString, test.expectedString) {
+				t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
+			}
+
+			// Check channel assignment
+			getRawResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", test.name), "")
+			var rawResponse RawResponse
+			json.Unmarshal(getRawResponse.Body.Bytes(), &rawResponse)
+			log.Printf("raw response: %s", getRawResponse.Body.Bytes())
+			assert.Equals(t, len(rawResponse.Sync.Channels), 1)
+			assertTrue(t, HasActiveChannel(rawResponse.Sync.Channels, test.expectedChannel), fmt.Sprintf("Expected channel %s was not found in document channels", test.expectedChannel))
+
+		})
 	}
+
 }
 
 func TestFunkyDocIDs(t *testing.T) {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -726,7 +726,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 	defer bt.Close()
 
 	// Send non-deleted rev
-	sent, _, resp, err := bt.SendRev("largeNumberRev", "1-abc", []byte(`{"key": "val", "largeNumber": 9223372036854775807, "channels": ["user1"]}`), blip.Properties{})
+	sent, _, resp, err := bt.SendRev("largeNumberRev", "1-abc", []byte(`{"key": "val", "largeNumber":9223372036854775807, "channels": ["user1"]}`), blip.Properties{})
 	assert.True(t, sent)
 	assert.Equals(t, err, nil)
 	assert.Equals(t, resp.Properties["Error-Code"], "")
@@ -735,7 +735,9 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 	response := bt.restTester.SendAdminRequest("GET", "/db/largeNumberRev?rev=1-abc", "")
 	assertStatus(t, response, 200) // Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(response.Body.Bytes())
-	assert.True(t, strings.Contains(responseString, `"largeNumber":9223372036854775807`))
+	if !strings.Contains(responseString, `9223372036854775807`) {
+		t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
+	}
 }
 
 func AssertChangeEquals(t *testing.T, change []interface{}, expectedChange ExpectedChange) {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -706,6 +706,38 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	assert.True(t, deletedValue)
 }
 
+// Test send and retrieval of a doc with a large numeric value.  Ensure proper large number handling.
+//   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
+func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
+	// Setup
+	rt := RestTester{
+		noAdminParty: true,
+	}
+	btSpec := BlipTesterSpec{
+		connectingUsername: "user1",
+		connectingPassword: "1234",
+		restTester:         &rt,
+	}
+	bt, err := NewBlipTesterFromSpec(btSpec)
+	assertNoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+
+	// Send non-deleted rev
+	sent, _, resp, err := bt.SendRev("largeNumberRev", "1-abc", []byte(`{"key": "val", "largeNumber": 9223372036854775807, "channels": ["user1"]}`), blip.Properties{})
+	assert.True(t, sent)
+	assert.Equals(t, err, nil)
+	assert.Equals(t, resp.Properties["Error-Code"], "")
+
+	// Get non-deleted rev
+	response := bt.restTester.SendAdminRequest("GET", "/db/largeNumberRev?rev=1-abc", "")
+	assertStatus(t, response, 200) // Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
+	responseString := string(response.Body.Bytes())
+	assert.True(t, strings.Contains(responseString, `"largeNumber":9223372036854775807`))
+}
+
 func AssertChangeEquals(t *testing.T, change []interface{}, expectedChange ExpectedChange) {
 	if err := expectedChange.Equals(change); err != nil {
 		t.Errorf("Change %+v does not equal expected change: %+v.  Error: %v", change, expectedChange, err)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -223,7 +223,6 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 	response.Properties[getCheckpointResponseRev] = value[db.BodyRev].(string)
 	delete(value, db.BodyRev)
 	delete(value, db.BodyId)
-	value.FixJSONNumbers()
 	response.SetJSONBody(value)
 	return nil
 }

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -2189,7 +2189,6 @@ func TestChangesLargeSequences(t *testing.T) {
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("GET changes response: %s", changesResponse.Body.Bytes())
 	assertNoError(t, err, "Error unmarshalling changes response")
 	assert.Equals(t, len(changes.Results), 1)
 	assert.Equals(t, changes.Results[0].Seq.Seq, uint64(9223372036854775808))
@@ -2198,14 +2197,12 @@ func TestChangesLargeSequences(t *testing.T) {
 	// Validate incoming since value isn't being truncated
 	changesResponse = rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775808", "")
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("GET changes response: %s", changesResponse.Body.Bytes())
 	assertNoError(t, err, "Error unmarshalling changes response")
 	assert.Equals(t, len(changes.Results), 0)
 
 	// Validate incoming since value isn't being truncated
 	changesResponse = rt.SendAdminRequest("POST", "/db/_changes", `{"since":9223372036854775808}`)
 	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-	log.Printf("POST changes response: %s", changesResponse.Body.Bytes())
 	assertNoError(t, err, "Error unmarshalling changes response")
 	assert.Equals(t, len(changes.Results), 0)
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -2161,6 +2161,56 @@ func TestChangesIncludeConflicts(t *testing.T) {
 
 }
 
+// Test _changes handling large sequence values - ensures no truncation of large ints.
+func TestChangesLargeSequences(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("TestChangesLargeSequences doesn't support walrus - needs to customize _sync:seq prior to db creation")
+	}
+
+	initialSeq := uint64(9223372036854775807)
+	rt := RestTester{SyncFn: `function(doc,oldDoc) {
+			 channel(doc.channel)
+		 }`,
+		InitSyncSeq: initialSeq}
+	defer rt.Close()
+
+	// Create document
+	response := rt.SendAdminRequest("PUT", "/db/largeSeqDoc", `{"channel":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+
+	// Get changes
+	rt.ServerContext().Database("db").WaitForPendingChanges()
+
+	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
+	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	log.Printf("GET changes response: %s", changesResponse.Body.Bytes())
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 1)
+	assert.Equals(t, changes.Results[0].Seq.Seq, uint64(9223372036854775808))
+	assert.Equals(t, changes.Last_Seq, "9223372036854775808")
+
+	// Validate incoming since value isn't being truncated
+	changesResponse = rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775808", "")
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	log.Printf("GET changes response: %s", changesResponse.Body.Bytes())
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 0)
+
+	// Validate incoming since value isn't being truncated
+	changesResponse = rt.SendAdminRequest("POST", "/db/_changes", `{"since":9223372036854775808}`)
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	log.Printf("POST changes response: %s", changesResponse.Body.Bytes())
+	assertNoError(t, err, "Error unmarshalling changes response")
+	assert.Equals(t, len(changes.Results), 0)
+
+}
+
 //////// HELPERS:
 
 func assertNoError(t *testing.T, err error, message string) {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -335,7 +335,6 @@ func (h *handler) handleGetLocalDoc() error {
 		return kNotFoundError
 	}
 	value[db.BodyId] = "_local/" + docid
-	value.FixJSONNumbers()
 	h.writeJSON(value)
 	return nil
 }
@@ -345,7 +344,6 @@ func (h *handler) handlePutLocalDoc() error {
 	docid := h.PathVar("docid")
 	body, err := h.readJSON()
 	if err == nil {
-		body.FixJSONNumbers()
 		var revid string
 		revid, err = h.db.PutSpecial("local", docid, body)
 		if err == nil {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -705,7 +705,9 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 	assert.Equals(t, response.Code, 200)
 	// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(response.Body.Bytes())
-	assert.True(t, strings.Contains(responseString, `"largeNumber":9223372036854775807`))
+	if !strings.Contains(responseString, `9223372036854775807`) {
+		t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
+	}
 }
 
 // Structs for manual rev storage validation

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -26,16 +26,16 @@ func SkipImportTestsIfNotEnabled(t *testing.T) {
 	}
 }
 
-type simpleSync struct {
+type SimpleSync struct {
 	Channels map[string]interface{}
 	Rev      string
 }
 
-type rawResponse struct {
-	Sync simpleSync `json:"_sync"`
+type RawResponse struct {
+	Sync SimpleSync `json:"_sync"`
 }
 
-func hasActiveChannel(channelSet map[string]interface{}, channelName string) bool {
+func HasActiveChannel(channelSet map[string]interface{}, channelName string) bool {
 	if channelSet == nil {
 		return false
 	}
@@ -78,12 +78,12 @@ func TestXattrImportOldDoc(t *testing.T) {
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
 	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
 	assert.Equals(t, response.Code, 200)
-	var rawInsertResponse rawResponse
+	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 	assertTrue(t, rawInsertResponse.Sync.Channels != nil, "Expected channels not returned for SDK insert")
 	log.Printf("insert channels: %+v", rawInsertResponse.Sync.Channels)
-	assertTrue(t, hasActiveChannel(rawInsertResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK insert")
+	assertTrue(t, HasActiveChannel(rawInsertResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK insert")
 
 	// 2. Test oldDoc behaviour during SDK update
 
@@ -97,12 +97,12 @@ func TestXattrImportOldDoc(t *testing.T) {
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
 	assert.Equals(t, response.Code, 200)
-	var rawUpdateResponse rawResponse
+	var rawUpdateResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 	assertTrue(t, rawUpdateResponse.Sync.Channels != nil, "Expected channels not returned for SDK update")
 	log.Printf("update channels: %+v", rawUpdateResponse.Sync.Channels)
-	assertTrue(t, hasActiveChannel(rawUpdateResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK update")
+	assertTrue(t, HasActiveChannel(rawUpdateResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK update")
 
 	// 3. Test oldDoc behaviour during SDK delete
 	err = bucket.Delete(key)
@@ -110,12 +110,12 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
 	assert.Equals(t, response.Code, 200)
-	var rawDeleteResponse rawResponse
+	var rawDeleteResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
 	log.Printf("Post-delete: %s", response.Body.Bytes())
 	assertNoError(t, err, "Unable to unmarshal raw response")
-	assertTrue(t, hasActiveChannel(rawDeleteResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK delete")
-	assertTrue(t, hasActiveChannel(rawDeleteResponse.Sync.Channels, "docDeleted"), "doc did not set _deleted:true for SDK delete")
+	assertTrue(t, HasActiveChannel(rawDeleteResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK delete")
+	assertTrue(t, HasActiveChannel(rawDeleteResponse.Sync.Channels, "docDeleted"), "doc did not set _deleted:true for SDK delete")
 
 }
 
@@ -296,7 +296,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	rawPath := fmt.Sprintf("/db/_raw/%s", key)
 	response := rt.SendAdminRequest("GET", rawPath, "")
 	assert.Equals(t, response.Code, 200)
-	var rawInsertResponse rawResponse
+	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 
@@ -306,7 +306,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", rawPath, "")
 	assert.Equals(t, response.Code, 200)
-	var rawDeleteResponse rawResponse
+	var rawDeleteResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
 	log.Printf("Post-delete: %s", response.Body.Bytes())
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -322,7 +322,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	// Attempt to get the document via Sync Gateway, to trigger import.
 	response = rt.SendAdminRequest("GET", rawPath, "")
 	assert.Equals(t, response.Code, 200)
-	var rawUpdateResponse rawResponse
+	var rawUpdateResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 	_, ok := rawUpdateResponse.Sync.Channels["HBO"]

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -700,11 +700,9 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 	_, err := bucket.Add(mobileKey, 0, mobileBody)
 	assertNoError(t, err, "Error writing SDK doc")
 
-	// Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
+	// 2. Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
 	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	assert.Equals(t, response.Code, 200)
-	// Extract rev from response for comparison with second GET below
-	log.Printf("GET returned response: %s", response.Body.Bytes())
 	// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(response.Body.Bytes())
 	assert.True(t, strings.Contains(responseString, `"largeNumber":9223372036854775807`))

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -40,8 +40,9 @@ type RestTester struct {
 	DatabaseConfig          *DbConfig // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
 	AdminHandler            http.Handler
 	PublicHandler           http.Handler
-	EnableNoConflictsMode   bool // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
-	NoFlush                 bool // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
+	EnableNoConflictsMode   bool   // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
+	NoFlush                 bool   // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
+	InitSyncSeq             uint64 // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
 }
 
 func (rt *RestTester) Bucket() base.Bucket {
@@ -57,7 +58,18 @@ func (rt *RestTester) Bucket() base.Bucket {
 		// Initialize the bucket.  For couchbase-backed tests, triggers with creation/flushing of the bucket
 		if !rt.NoFlush {
 			tempBucket := base.GetTestBucketOrPanic() // side effect of creating/flushing bucket
+			if rt.InitSyncSeq > 0 {
+				log.Printf("Initializing Sync Seq to %d", rt.InitSyncSeq)
+				_, incrErr := tempBucket.Incr(db.SyncSeqKey, rt.InitSyncSeq, rt.InitSyncSeq, 0)
+				if incrErr != nil {
+					panic(fmt.Sprintf("Error initializing %s in test bucket: %v", db.SyncSeqKey, incrErr))
+				}
+			}
 			tempBucket.Close()
+		} else {
+			if rt.InitSyncSeq > 0 {
+				panic("RestTester doesn't support NoFlush and InitSyncSeq in same test")
+			}
 		}
 
 		spec := base.GetTestBucketSpec(base.DataBucket)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -59,7 +59,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if !rt.NoFlush {
 			tempBucket := base.GetTestBucketOrPanic() // side effect of creating/flushing bucket
 			if rt.InitSyncSeq > 0 {
-				log.Printf("Initializing Sync Seq to %d", rt.InitSyncSeq)
+				log.Printf("Initializing %s to %d", db.SyncSeqKey, rt.InitSyncSeq)
 				_, incrErr := tempBucket.Incr(db.SyncSeqKey, rt.InitSyncSeq, rt.InitSyncSeq, 0)
 				if incrErr != nil {
 					panic(fmt.Sprintf("Error initializing %s in test bucket: %v", db.SyncSeqKey, incrErr))


### PR DESCRIPTION
Preserve number formatting in document bodies by always unmarshalling via decode with decoder.UseNumber.

Includes the following refactoring/cleanup:
- Only use db.Body when managing actual document bodies.
   - Created a new db.Revisions type for the most common other previous usage of db.Body, and added associated constants
- Always use Body.Unmarshal() to unmarshal document bodies using decoder instead of json.Unmarshal
- Adds unit tests for large number handling during CRUD, blip, import
- Adds tests to validate large number handling for sequences.  Adds ability to set up a test with a non-empty _sync:seq in the bucket

- [ ] Manifest needs updating after https://github.com/couchbase/go-blip/pull/35 is merged

Fixes #3783