### PR TITLE
Refactoring for testify/asserts

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func canSeeAllChannels(princ Principal, channels base.Set) bool {
@@ -36,8 +36,8 @@ func TestValidateGuestUser(t *testing.T) {
 	bucket := gTestBucket.Bucket
 	auth := NewAuthenticator(bucket, nil)
 	user, err := auth.NewUser("", "", nil)
-	assert.True(t, user != nil)
-	assert.True(t, err == nil)
+	goassert.True(t, user != nil)
+	goassert.True(t, err == nil)
 }
 
 func TestValidateUser(t *testing.T) {
@@ -46,14 +46,14 @@ func TestValidateUser(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, err := auth.NewUser("invalid:name", "", nil)
-	assert.Equals(t, user, (User)(nil))
-	assert.True(t, err != nil)
+	goassert.Equals(t, user, (User)(nil))
+	goassert.True(t, err != nil)
 	user, err = auth.NewUser("ValidName", "", nil)
-	assert.True(t, user != nil)
-	assert.Equals(t, err, nil)
+	goassert.True(t, user != nil)
+	goassert.Equals(t, err, nil)
 	user, err = auth.NewUser("ValidName", "letmein", nil)
-	assert.True(t, user != nil)
-	assert.Equals(t, err, nil)
+	goassert.True(t, user != nil)
+	goassert.Equals(t, err, nil)
 }
 
 func TestValidateRole(t *testing.T) {
@@ -62,14 +62,14 @@ func TestValidateRole(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	role, err := auth.NewRole("invalid:name", nil)
-	assert.Equals(t, role, (User)(nil))
-	assert.True(t, err != nil)
+	goassert.Equals(t, role, (User)(nil))
+	goassert.True(t, err != nil)
 	role, err = auth.NewRole("ValidName", nil)
-	assert.True(t, role != nil)
-	assert.Equals(t, err, nil)
+	goassert.True(t, role != nil)
+	goassert.Equals(t, err, nil)
 	role, err = auth.NewRole("ValidName", nil)
-	assert.True(t, role != nil)
-	assert.Equals(t, err, nil)
+	goassert.True(t, role != nil)
+	goassert.Equals(t, err, nil)
 }
 
 func TestValidateUserEmail(t *testing.T) {
@@ -79,15 +79,15 @@ func TestValidateUserEmail(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	badEmails := []string{"", "foo", "foo@", "@bar", "foo @bar", "foo@.bar"}
 	for _, e := range badEmails {
-		assert.False(t, IsValidEmail(e))
+		goassert.False(t, IsValidEmail(e))
 	}
 	goodEmails := []string{"foo@bar", "foo.99@bar.com", "f@bar.exampl-3.com."}
 	for _, e := range goodEmails {
-		assert.True(t, IsValidEmail(e))
+		goassert.True(t, IsValidEmail(e))
 	}
 	user, _ := auth.NewUser("ValidName", "letmein", nil)
-	assert.False(t, user.SetEmail("foo") == nil)
-	assert.Equals(t, user.SetEmail("foo@example.com"), nil)
+	goassert.False(t, user.SetEmail("foo") == nil)
+	goassert.Equals(t, user.SetEmail("foo@example.com"), nil)
 }
 
 func TestUserPasswords(t *testing.T) {
@@ -96,20 +96,20 @@ func TestUserPasswords(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("me", "letmein", nil)
-	assert.True(t, user.Authenticate("letmein"))
-	assert.False(t, user.Authenticate("password"))
-	assert.False(t, user.Authenticate(""))
+	goassert.True(t, user.Authenticate("letmein"))
+	goassert.False(t, user.Authenticate("password"))
+	goassert.False(t, user.Authenticate(""))
 
 	guest, _ := auth.NewUser("", "", nil)
-	assert.True(t, guest.Authenticate(""))
-	assert.False(t, guest.Authenticate("123456"))
+	goassert.True(t, guest.Authenticate(""))
+	goassert.False(t, guest.Authenticate("123456"))
 
 	// Create a second user with the same password
 	user2, _ := auth.NewUser("me", "letmein", nil)
-	assert.True(t, user2.Authenticate("letmein"))
-	assert.False(t, user2.Authenticate("password"))
-	assert.True(t, user.Authenticate("letmein"))
-	assert.False(t, user.Authenticate("password"))
+	goassert.True(t, user2.Authenticate("letmein"))
+	goassert.False(t, user2.Authenticate("password"))
+	goassert.True(t, user.Authenticate("letmein"))
+	goassert.False(t, user.Authenticate("password"))
 }
 
 func TestSerializeUser(t *testing.T) {
@@ -120,17 +120,17 @@ func TestSerializeUser(t *testing.T) {
 	user, _ := auth.NewUser("me", "letmein", ch.SetOf("me", "public"))
 	user.SetEmail("foo@example.com")
 	encoded, _ := json.Marshal(user)
-	assert.True(t, encoded != nil)
+	goassert.True(t, encoded != nil)
 	log.Printf("Marshaled User as: %s", encoded)
 
 	resu := &userImpl{}
 	err := json.Unmarshal(encoded, resu)
-	assert.True(t, err == nil)
-	assert.DeepEquals(t, resu.Name(), user.Name())
-	assert.DeepEquals(t, resu.Email(), user.Email())
-	assert.DeepEquals(t, resu.ExplicitChannels(), user.ExplicitChannels())
-	assert.True(t, resu.Authenticate("letmein"))
-	assert.False(t, resu.Authenticate("123456"))
+	goassert.True(t, err == nil)
+	goassert.DeepEquals(t, resu.Name(), user.Name())
+	goassert.DeepEquals(t, resu.Email(), user.Email())
+	goassert.DeepEquals(t, resu.ExplicitChannels(), user.ExplicitChannels())
+	goassert.True(t, resu.Authenticate("letmein"))
+	goassert.False(t, resu.Authenticate("123456"))
 }
 
 func TestSerializeRole(t *testing.T) {
@@ -140,14 +140,14 @@ func TestSerializeRole(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	role, _ := auth.NewRole("froods", ch.SetOf("hoopy", "public"))
 	encoded, _ := json.Marshal(role)
-	assert.True(t, encoded != nil)
+	goassert.True(t, encoded != nil)
 	log.Printf("Marshaled Role as: %s", encoded)
 	elor := &roleImpl{}
 	err := json.Unmarshal(encoded, elor)
 
-	assert.True(t, err == nil)
-	assert.DeepEquals(t, elor.Name(), role.Name())
-	assert.DeepEquals(t, elor.ExplicitChannels(), role.ExplicitChannels())
+	goassert.True(t, err == nil)
+	goassert.DeepEquals(t, elor.Name(), role.Name())
+	goassert.DeepEquals(t, elor.ExplicitChannels(), role.ExplicitChannels())
 }
 
 func TestUserAccess(t *testing.T) {
@@ -157,69 +157,69 @@ func TestUserAccess(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("foo", "password", nil)
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("!"))
-	assert.False(t, user.CanSeeChannel("x"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("*")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf("x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf()) == nil)
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("!"))
+	goassert.False(t, user.CanSeeChannel("x"))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf()))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("x")))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("*")))
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
+	goassert.False(t, user.AuthorizeAnyChannel(ch.SetOf("x", "y")) == nil)
+	goassert.False(t, user.AuthorizeAnyChannel(ch.SetOf()) == nil)
 
 	// User with access to one channel:
 	user.setChannels(ch.AtSequence(ch.SetOf("x"), 1))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf("x", "y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf("y")) == nil)
-	assert.False(t, user.AuthorizeAnyChannel(ch.SetOf()) == nil)
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x"))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf()))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
+	goassert.True(t, user.AuthorizeAnyChannel(ch.SetOf("x", "y")) == nil)
+	goassert.False(t, user.AuthorizeAnyChannel(ch.SetOf("y")) == nil)
+	goassert.False(t, user.AuthorizeAnyChannel(ch.SetOf()) == nil)
 
 	// User with access to one channel and one derived channel:
 	user.setChannels(ch.AtSequence(ch.SetOf("x", "z"), 1))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x", "z"))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("x")), ch.SetOf("x"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x", "z"))
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("x")), ch.SetOf("x"))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf()))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
 
 	// User with access to two channels:
 	user.setChannels(ch.AtSequence(ch.SetOf("x", "z"), 1))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x", "z"))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("x")), ch.SetOf("x"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x", "z"))
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("x")), ch.SetOf("x"))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf()))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
 
 	user.setChannels(ch.AtSequence(ch.SetOf("x", "y"), 1))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x", "y"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
-	assert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y", "z")))
-	assert.True(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
-	assert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("x", "y"))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf()))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
+	goassert.False(t, canSeeAllChannels(user, ch.SetOf("x", "y", "z")))
+	goassert.True(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
+	goassert.False(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
 
 	// User with wildcard access:
 	user.setChannels(ch.AtSequence(ch.SetOf("*", "q"), 1))
-	assert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("*", "q"))
-	assert.True(t, user.CanSeeChannel("*"))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf()))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
-	assert.True(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
-	assert.True(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
-	assert.True(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf("x")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf("*")) == nil)
-	assert.True(t, user.AuthorizeAnyChannel(ch.SetOf()) == nil)
+	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf("*")), ch.SetOf("*", "q"))
+	goassert.True(t, user.CanSeeChannel("*"))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf()))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x")))
+	goassert.True(t, canSeeAllChannels(user, ch.SetOf("x", "y")))
+	goassert.True(t, user.AuthorizeAllChannels(ch.SetOf("x", "y")) == nil)
+	goassert.True(t, user.AuthorizeAllChannels(ch.SetOf("*")) == nil)
+	goassert.True(t, user.AuthorizeAnyChannel(ch.SetOf("x")) == nil)
+	goassert.True(t, user.AuthorizeAnyChannel(ch.SetOf("*")) == nil)
+	goassert.True(t, user.AuthorizeAnyChannel(ch.SetOf()) == nil)
 }
 
 func TestGetMissingUser(t *testing.T) {
@@ -228,11 +228,11 @@ func TestGetMissingUser(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, err := auth.GetUser("noSuchUser")
-	assert.Equals(t, err, nil)
-	assert.True(t, user == nil)
+	goassert.Equals(t, err, nil)
+	goassert.True(t, user == nil)
 	user, err = auth.GetUserByEmail("noreply@example.com")
-	assert.Equals(t, err, nil)
-	assert.True(t, user == nil)
+	goassert.Equals(t, err, nil)
+	goassert.True(t, user == nil)
 }
 
 func TestGetMissingRole(t *testing.T) {
@@ -241,8 +241,8 @@ func TestGetMissingRole(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	role, err := auth.GetRole("noSuchRole")
-	assert.Equals(t, err, nil)
-	assert.True(t, role == nil)
+	goassert.Equals(t, err, nil)
+	goassert.True(t, role == nil)
 }
 
 func TestGetGuestUser(t *testing.T) {
@@ -251,8 +251,8 @@ func TestGetGuestUser(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, err := auth.GetUser("")
-	assert.Equals(t, err, nil)
-	assert.DeepEquals(t, user, auth.defaultGuestUser())
+	goassert.Equals(t, err, nil)
+	goassert.DeepEquals(t, user, auth.defaultGuestUser())
 
 }
 
@@ -263,11 +263,11 @@ func TestSaveUsers(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf("test"))
 	err := auth.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	user2, err := auth.GetUser("testUser")
-	assert.Equals(t, err, nil)
-	assert.DeepEquals(t, user2, user)
+	goassert.Equals(t, err, nil)
+	goassert.DeepEquals(t, user2, user)
 }
 
 func TestSaveRoles(t *testing.T) {
@@ -276,11 +276,11 @@ func TestSaveRoles(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	role, _ := auth.NewRole("testRole", ch.SetOf("test"))
 	err := auth.Save(role)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	role2, err := auth.GetRole("testRole")
-	assert.Equals(t, err, nil)
-	assert.DeepEquals(t, role2, role)
+	goassert.Equals(t, err, nil)
+	goassert.DeepEquals(t, role2, role)
 }
 
 type mockComputer struct {
@@ -318,11 +318,11 @@ func TestRebuildUserChannels(t *testing.T) {
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf("explicit1"))
 	user.setChannels(nil)
 	err := auth.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	user2, err := auth.GetUser("testUser")
-	assert.Equals(t, err, nil)
-	assert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2", "!"), 1))
+	goassert.Equals(t, err, nil)
+	goassert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2", "!"), 1))
 }
 
 func TestRebuildRoleChannels(t *testing.T) {
@@ -333,11 +333,11 @@ func TestRebuildRoleChannels(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
 	role, _ := auth.NewRole("testRole", ch.SetOf("explicit1"))
 	err := auth.InvalidateChannels(role)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	role2, err := auth.GetRole("testRole")
-	assert.Equals(t, err, nil)
-	assert.DeepEquals(t, role2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2", "!"), 1))
+	goassert.Equals(t, err, nil)
+	goassert.DeepEquals(t, role2.Channels(), ch.AtSequence(ch.SetOf("explicit1", "derived1", "derived2", "!"), 1))
 }
 
 func TestRebuildChannelsError(t *testing.T) {
@@ -347,14 +347,14 @@ func TestRebuildChannelsError(t *testing.T) {
 	computer := mockComputer{}
 	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
 	role, err := auth.NewRole("testRole2", ch.SetOf("explicit1"))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, auth.InvalidateChannels(role), nil)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, auth.InvalidateChannels(role), nil)
 
 	computer.err = errors.New("I'm sorry, Dave.")
 
 	role2, err := auth.GetRole("testRole2")
-	assert.Equals(t, role2, nil)
-	assert.DeepEquals(t, err, computer.err)
+	goassert.Equals(t, role2, nil)
+	goassert.DeepEquals(t, err, computer.err)
 }
 
 func TestRebuildUserRoles(t *testing.T) {
@@ -366,13 +366,13 @@ func TestRebuildUserRoles(t *testing.T) {
 	user, _ := auth.NewUser("testUser", "letmein", nil)
 	user.SetExplicitRoles(ch.TimedSet{"role3": ch.NewVbSimpleSequence(1), "role1": ch.NewVbSimpleSequence(1)})
 	err := auth.InvalidateRoles(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	user2, err := auth.GetUser("testUser")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	expected := ch.AtSequence(base.SetOf("role1", "role3"), 1)
 	expected.AddChannel("role2", 3)
-	assert.DeepEquals(t, user2.RoleNames(), expected)
+	goassert.DeepEquals(t, user2.RoleNames(), expected)
 }
 
 func TestRoleInheritance(t *testing.T) {
@@ -381,25 +381,25 @@ func TestRoleInheritance(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	role, _ := auth.NewRole("square", ch.SetOf("dull", "duller", "dullest"))
-	assert.Equals(t, auth.Save(role), nil)
+	goassert.Equals(t, auth.Save(role), nil)
 	role, _ = auth.NewRole("frood", ch.SetOf("hoopy", "hoopier", "hoopiest"))
-	assert.Equals(t, auth.Save(role), nil)
+	goassert.Equals(t, auth.Save(role), nil)
 
 	user, _ := auth.NewUser("arthur", "password", ch.SetOf("britain"))
 	user.(*userImpl).setRolesSince(ch.TimedSet{"square": ch.NewVbSimpleSequence(0x3), "nonexistent": ch.NewVbSimpleSequence(0x42), "frood": ch.NewVbSimpleSequence(0x4)})
-	assert.DeepEquals(t, user.RoleNames(), ch.TimedSet{"square": ch.NewVbSimpleSequence(0x3), "nonexistent": ch.NewVbSimpleSequence(0x42), "frood": ch.NewVbSimpleSequence(0x4)})
+	goassert.DeepEquals(t, user.RoleNames(), ch.TimedSet{"square": ch.NewVbSimpleSequence(0x3), "nonexistent": ch.NewVbSimpleSequence(0x42), "frood": ch.NewVbSimpleSequence(0x4)})
 	auth.Save(user)
 
 	user2, err := auth.GetUser("arthur")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	log.Printf("Channels = %s", user2.Channels())
-	assert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("!", "britain"), 1))
-	assert.DeepEquals(t, user2.InheritedChannels(),
+	goassert.DeepEquals(t, user2.Channels(), ch.AtSequence(ch.SetOf("!", "britain"), 1))
+	goassert.DeepEquals(t, user2.InheritedChannels(),
 		ch.TimedSet{"!": ch.NewVbSimpleSequence(0x1), "britain": ch.NewVbSimpleSequence(0x1), "dull": ch.NewVbSimpleSequence(0x3), "duller": ch.NewVbSimpleSequence(0x3), "dullest": ch.NewVbSimpleSequence(0x3), "hoopy": ch.NewVbSimpleSequence(0x4), "hoopier": ch.NewVbSimpleSequence(0x4), "hoopiest": ch.NewVbSimpleSequence(0x4)})
-	assert.True(t, user2.CanSeeChannel("britain"))
-	assert.True(t, user2.CanSeeChannel("duller"))
-	assert.True(t, user2.CanSeeChannel("hoopy"))
-	assert.Equals(t, user2.AuthorizeAllChannels(ch.SetOf("britain", "dull", "hoopiest")), nil)
+	goassert.True(t, user2.CanSeeChannel("britain"))
+	goassert.True(t, user2.CanSeeChannel("duller"))
+	goassert.True(t, user2.CanSeeChannel("hoopy"))
+	goassert.Equals(t, user2.AuthorizeAllChannels(ch.SetOf("britain", "dull", "hoopiest")), nil)
 }
 
 func TestRegisterUser(t *testing.T) {
@@ -409,48 +409,48 @@ func TestRegisterUser(t *testing.T) {
 	// Register user based on name, email
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, err := auth.RegisterNewUser("ValidName", "foo@example.com")
-	assert.Equals(t, user.Name(), "ValidName")
-	assert.Equals(t, user.Email(), "foo@example.com")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "ValidName")
+	goassert.Equals(t, user.Email(), "foo@example.com")
+	goassert.Equals(t, err, nil)
 
 	// verify retrieval by username
 	user, err = auth.GetUser("ValidName")
-	assert.Equals(t, user.Name(), "ValidName")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "ValidName")
+	goassert.Equals(t, err, nil)
 
 	// verify retrieval by email
 	user, err = auth.GetUserByEmail("foo@example.com")
-	assert.Equals(t, user.Name(), "ValidName")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "ValidName")
+	goassert.Equals(t, err, nil)
 
 	// Register user based on email, retrieve based on username, email
 	user, err = auth.RegisterNewUser("bar@example.com", "bar@example.com")
-	assert.Equals(t, user.Name(), "bar@example.com")
-	assert.Equals(t, user.Email(), "bar@example.com")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "bar@example.com")
+	goassert.Equals(t, user.Email(), "bar@example.com")
+	goassert.Equals(t, err, nil)
 
 	user, err = auth.GetUser("UnknownName")
-	assert.Equals(t, user, nil)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user, nil)
+	goassert.Equals(t, err, nil)
 
 	user, err = auth.GetUserByEmail("bar@example.com")
-	assert.Equals(t, user.Name(), "bar@example.com")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "bar@example.com")
+	goassert.Equals(t, err, nil)
 
 	// Register user without an email address
 	user, err = auth.RegisterNewUser("01234567890", "")
-	assert.Equals(t, user.Name(), "01234567890")
-	assert.Equals(t, user.Email(), "")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "01234567890")
+	goassert.Equals(t, user.Email(), "")
+	goassert.Equals(t, err, nil)
 	// Get above user by username.
 	user, err = auth.GetUser("01234567890")
-	assert.Equals(t, user.Name(), "01234567890")
-	assert.Equals(t, user.Email(), "")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user.Name(), "01234567890")
+	goassert.Equals(t, user.Email(), "")
+	goassert.Equals(t, err, nil)
 	// Make sure we can't retrieve 01234567890 by supplying empty email.
 	user, err = auth.GetUserByEmail("")
-	assert.Equals(t, user, nil)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, user, nil)
+	goassert.Equals(t, err, nil)
 }
 
 // 8 cases
@@ -573,48 +573,48 @@ func TestFilterToAvailableSince(t *testing.T) {
 
 			// Set up roles, user
 			role, _ := auth.NewRole("ROLE_1", nil)
-			assert.Equals(t, auth.Save(role), nil)
+			goassert.Equals(t, auth.Save(role), nil)
 
 			user, _ := auth.NewUser("testUser", "password", ch.SetOf("explicit1"))
 			user.setChannels(nil)
 			err := auth.Save(user)
-			assert.Equals(t, err, nil)
+			goassert.Equals(t, err, nil)
 
 			user2, err := auth.GetUser("testUser")
-			assert.Equals(t, err, nil)
+			goassert.Equals(t, err, nil)
 
 			channelsSinceStar, secondaryTriggersStar := user2.FilterToAvailableChannelsForSince(ch.SetOf("*"), sinceClock)
 			channelA_Star, ok := channelsSinceStar["A"]
 			log.Printf("channelA_Star: %s", channelA_Star)
-			assert.True(t, ok)
-			assert.True(t, channelA_Star.Equals(tc.expectedResult))
+			goassert.True(t, ok)
+			goassert.True(t, channelA_Star.Equals(tc.expectedResult))
 			secondaryTriggerStar, ok := secondaryTriggersStar["A"]
 			log.Printf("secondaryTrigger %v, expected %v", secondaryTriggerStar, tc.expectedSecondaryTrigger)
-			assert.True(t, secondaryTriggerStar.Equals(tc.expectedSecondaryTrigger))
+			goassert.True(t, secondaryTriggerStar.Equals(tc.expectedSecondaryTrigger))
 
 			channelsSince, secondaryTriggersSince := user2.FilterToAvailableChannelsForSince(ch.SetOf("A"), sinceClock)
 			channelA_Single, ok := channelsSince["A"]
 			log.Printf("channelA_Single: %s", channelA_Single)
-			assert.True(t, ok)
-			assert.True(t, channelA_Single.Equals(tc.expectedResult))
+			goassert.True(t, ok)
+			goassert.True(t, channelA_Single.Equals(tc.expectedResult))
 			secondaryTriggerSince, ok := secondaryTriggersSince["A"]
 			log.Printf("secondaryTrigger %v, expected %v", secondaryTriggerSince, tc.expectedSecondaryTrigger)
-			assert.True(t, secondaryTriggerSince.Equals(tc.expectedSecondaryTrigger))
+			goassert.True(t, secondaryTriggerSince.Equals(tc.expectedSecondaryTrigger))
 
 			channelBSince, secondaryTriggersB := user2.FilterToAvailableChannelsForSince(ch.SetOf("B"), sinceClock)
 			log.Printf("channelBSince: %s", channelBSince)
-			assert.True(t, len(channelBSince) == 0)
-			assert.True(t, len(secondaryTriggersB) == 0)
+			goassert.True(t, len(channelBSince) == 0)
+			goassert.True(t, len(secondaryTriggersB) == 0)
 
 			channelsSinceMulti, secondaryTriggersMulti := user2.FilterToAvailableChannelsForSince(ch.SetOf("A", "B"), sinceClock)
 			log.Printf("syncGrant1Multi: %s", channelsSinceMulti)
-			assert.True(t, len(channelsSinceMulti) == 1)
+			goassert.True(t, len(channelsSinceMulti) == 1)
 			channelA_Multi, ok := channelsSinceMulti["A"]
-			assert.True(t, ok)
-			assert.True(t, channelA_Multi.Equals(tc.expectedResult))
+			goassert.True(t, ok)
+			goassert.True(t, channelA_Multi.Equals(tc.expectedResult))
 			secondaryTriggerMulti, ok := secondaryTriggersMulti["A"]
 			log.Printf("secondaryTrigger %v, expected %v", secondaryTriggerMulti, tc.expectedSecondaryTrigger)
-			assert.True(t, secondaryTriggerMulti.Equals(tc.expectedSecondaryTrigger))
+			goassert.True(t, secondaryTriggerMulti.Equals(tc.expectedSecondaryTrigger))
 
 		})
 	}

--- a/auth/auth_time_sensitive_test.go
+++ b/auth/auth_time_sensitive_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // Test that multiple authentications of the same user/password are fast.
@@ -20,11 +20,11 @@ func TestAuthenticationSpeed(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("me", "goIsKewl", nil)
-	assert.True(t, user.Authenticate("goIsKewl"))
+	goassert.True(t, user.Authenticate("goIsKewl"))
 
 	start := time.Now()
 	for i := 0; i < 1000; i++ {
-		assert.True(t, user.Authenticate("goIsKewl"))
+		goassert.True(t, user.Authenticate("goIsKewl"))
 	}
 	durationPerAuth := time.Since(start) / 1000
 	if durationPerAuth > time.Millisecond {

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestOIDCProviderMap_GetDefaultProvider(t *testing.T) {
@@ -86,7 +86,7 @@ func TestOIDCProviderMap_GetDefaultProvider(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(tt *testing.T) {
 			provider := test.ProviderMap.GetDefaultProvider()
-			assert.Equals(tt, provider, test.ExpectedProvider)
+			goassert.Equals(tt, provider, test.ExpectedProvider)
 		})
 	}
 }
@@ -152,7 +152,7 @@ func TestOIDCProviderMap_GetProviderForIssuer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(tt *testing.T) {
 			provider := providerMap.GetProviderForIssuer(test.Issuer, test.Audiences)
-			assert.Equals(tt, provider, test.ExpectedProvider)
+			goassert.Equals(tt, provider, test.ExpectedProvider)
 		})
 	}
 }
@@ -165,33 +165,33 @@ func TestOIDCUsername(t *testing.T) {
 	}
 
 	err := provider.InitUserPrefix()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, provider.UserPrefix, "www.someprovider.com")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, provider.UserPrefix, "www.someprovider.com")
 
 	// test username suffix
 	oidcUsername := GetOIDCUsername(&provider, "bernard")
-	assert.Equals(t, oidcUsername, "www.someprovider.com_bernard")
-	assert.Equals(t, IsValidPrincipalName(oidcUsername), true)
+	goassert.Equals(t, oidcUsername, "www.someprovider.com_bernard")
+	goassert.Equals(t, IsValidPrincipalName(oidcUsername), true)
 
 	// test char escaping
 	oidcUsername = GetOIDCUsername(&provider, "{bernard}")
-	assert.Equals(t, oidcUsername, "www.someprovider.com_%7Bbernard%7D")
-	assert.Equals(t, IsValidPrincipalName(oidcUsername), true)
+	goassert.Equals(t, oidcUsername, "www.someprovider.com_%7Bbernard%7D")
+	goassert.Equals(t, IsValidPrincipalName(oidcUsername), true)
 
 	// test URL with paths
 	provider.UserPrefix = ""
 	provider.Issuer = "http://www.someprovider.com/extra"
 	err = provider.InitUserPrefix()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, provider.UserPrefix, "www.someprovider.com%2Fextra")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, provider.UserPrefix, "www.someprovider.com%2Fextra")
 
 	// test invalid URL
 	provider.UserPrefix = ""
 	provider.Issuer = "http//www.someprovider.com"
 	err = provider.InitUserPrefix()
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	// falls back to provider name:
-	assert.Equals(t, provider.UserPrefix, "Some_Provider")
+	goassert.Equals(t, provider.UserPrefix, "Some_Provider")
 
 }
 
@@ -238,18 +238,18 @@ func TestOIDCProvider_InitOIDCClient(t *testing.T) {
 		t.Run(test.Name, func(tt *testing.T) {
 			err := test.Provider.InitOIDCClient()
 			if test.ErrContains != "" {
-				assert.NotEquals(tt, err, nil)
-				assert.StringContains(tt, err.Error(), test.ErrContains)
+				goassert.NotEquals(tt, err, nil)
+				goassert.StringContains(tt, err.Error(), test.ErrContains)
 			} else {
-				assert.Equals(tt, err, nil)
+				goassert.Equals(tt, err, nil)
 			}
 
 			if test.Provider != nil {
 				client := test.Provider.GetClient(func() string { return "" })
 				if test.ExpectOIDCClient {
-					assert.NotEquals(tt, client, (*oidc.Client)(nil))
+					goassert.NotEquals(tt, client, (*oidc.Client)(nil))
 				} else {
-					assert.Equals(tt, client, (*oidc.Client)(nil))
+					goassert.Equals(tt, client, (*oidc.Client)(nil))
 				}
 			}
 		})
@@ -276,7 +276,7 @@ func TestFetchCustomProviderConfig(t *testing.T) {
 	for _, discoveryUrl := range providerDiscoveryUrls {
 		oidcProvider := OIDCProvider{}
 		_, err := oidcProvider.FetchCustomProviderConfig(discoveryUrl)
-		assert.True(t, err == nil)
+		goassert.True(t, err == nil)
 	}
 
 }

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -22,7 +22,7 @@ func BenchmarkBcryptCostTimes(b *testing.B) {
 		b.Run(fmt.Sprintf("cost%d", i), func(bn *testing.B) {
 			bn.N = 1
 			_, err := bcrypt.GenerateFromPassword([]byte("hunter2"), i)
-			assert.Equals(bn, err, nil)
+			goassert.Equals(bn, err, nil)
 		})
 	}
 }
@@ -39,28 +39,28 @@ func TestBcryptDefaultCostTime(t *testing.T) {
 	duration := time.Since(startTime)
 
 	t.Logf("bcrypt.GenerateFromPassword with cost %d took: %v", bcryptDefaultCost, duration)
-	assert.Equals(t, err, nil)
-	assert.True(t, minimumDuration < duration)
+	goassert.Equals(t, err, nil)
+	goassert.True(t, minimumDuration < duration)
 }
 
 func TestSetBcryptCost(t *testing.T) {
 	err := SetBcryptCost(bcryptDefaultCost - 1) // below minimum allowed value
-	assert.Equals(t, errors.Cause(err), ErrInvalidBcryptCost)
-	assert.Equals(t, bcryptCost, bcryptDefaultCost)
-	assert.False(t, bcryptCostChanged)
+	goassert.Equals(t, errors.Cause(err), ErrInvalidBcryptCost)
+	goassert.Equals(t, bcryptCost, bcryptDefaultCost)
+	goassert.False(t, bcryptCostChanged)
 
 	err = SetBcryptCost(0) // use default value
-	assert.Equals(t, err, nil)
-	assert.Equals(t, bcryptCost, bcryptDefaultCost)
-	assert.False(t, bcryptCostChanged) // Not explicitly changed
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, bcryptCost, bcryptDefaultCost)
+	goassert.False(t, bcryptCostChanged) // Not explicitly changed
 
 	err = SetBcryptCost(bcryptDefaultCost + 1) // use increased value
-	assert.Equals(t, err, nil)
-	assert.Equals(t, bcryptCost, bcryptDefaultCost+1)
-	assert.True(t, bcryptCostChanged)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, bcryptCost, bcryptDefaultCost+1)
+	goassert.True(t, bcryptCostChanged)
 
 	err = SetBcryptCost(bcryptDefaultCost) // back to explicit default value, check changed is still true
-	assert.Equals(t, err, nil)
-	assert.Equals(t, bcryptCost, bcryptDefaultCost)
-	assert.True(t, bcryptCostChanged)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, bcryptCost, bcryptDefaultCost)
+	goassert.True(t, bcryptCostChanged)
 }

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -23,23 +23,23 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
-	assert.Equals(t, err, nil)
-	assert.NotEquals(t, u, nil)
+	goassert.Equals(t, err, nil)
+	goassert.NotEquals(t, u, nil)
 
-	assert.False(t, u.Disabled())
+	goassert.False(t, u.Disabled())
 	// Correct password, activated account
-	assert.True(t, u.Authenticate(oldPassword))
+	goassert.True(t, u.Authenticate(oldPassword))
 	// Incorrect password, activated account
-	assert.False(t, u.Authenticate("test"))
+	goassert.False(t, u.Authenticate("test"))
 
 	// Disable account
 	u.SetDisabled(true)
 
-	assert.True(t, u.Disabled())
+	goassert.True(t, u.Disabled())
 	// Correct password, disabled account
-	assert.False(t, u.Authenticate(oldPassword))
+	goassert.False(t, u.Authenticate(oldPassword))
 	// Incorrect password, disabled account
-	assert.False(t, u.Authenticate("test"))
+	goassert.False(t, u.Authenticate("test"))
 
 }
 
@@ -62,56 +62,56 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
-	assert.Equals(t, err, nil)
-	assert.NotEquals(t, u, nil)
+	goassert.Equals(t, err, nil)
+	goassert.NotEquals(t, u, nil)
 
 	user := u.(*userImpl)
 	oldHash := user.PasswordHash_
 
 	// Make sure their password was hashed with the desired cost
 	cost, err := bcrypt.Cost(user.PasswordHash_)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, cost, bcryptDefaultCost)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, cost, bcryptDefaultCost)
 
 	// Try to auth with an incorrect password
-	assert.False(t, u.Authenticate("test"))
+	goassert.False(t, u.Authenticate("test"))
 
 	// Make sure the hash has not changed
 	newHash := user.PasswordHash_
-	assert.Equals(t, string(newHash), string(oldHash))
+	goassert.Equals(t, string(newHash), string(oldHash))
 
 	// Authenticate correctly
-	assert.True(t, u.Authenticate(oldPassword))
+	goassert.True(t, u.Authenticate(oldPassword))
 
 	// Make sure the hash has still not changed (we've not changed the cost yet)
 	newHash = user.PasswordHash_
-	assert.Equals(t, string(newHash), string(oldHash))
+	goassert.Equals(t, string(newHash), string(oldHash))
 
 	// Check the cost is still the old value
 	cost, err = bcrypt.Cost(user.PasswordHash_)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, cost, bcryptDefaultCost)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, cost, bcryptDefaultCost)
 
 	// Now bump the global bcrypt cost
 	err = SetBcryptCost(newBcryptCost)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Authenticate incorrectly again
-	assert.False(t, u.Authenticate("test"))
+	goassert.False(t, u.Authenticate("test"))
 
 	// Make sure the hash has still not changed (cost has been bumped, but auth was not successful)
 	newHash = user.PasswordHash_
-	assert.Equals(t, string(newHash), string(oldHash))
+	goassert.Equals(t, string(newHash), string(oldHash))
 
 	// Authenticate correctly
-	assert.True(t, u.Authenticate(oldPassword))
+	goassert.True(t, u.Authenticate(oldPassword))
 
 	// Hash should've changed, as the above authenticate was successful
 	newHash = user.PasswordHash_
-	assert.NotEquals(t, string(newHash), string(oldHash))
+	goassert.NotEquals(t, string(newHash), string(oldHash))
 
 	// Cost should now match newBcryptCost
 	cost, err = bcrypt.Cost(user.PasswordHash_)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, cost, newBcryptCost)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, cost, newBcryptCost)
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/couchbase/sg-bucket"
 	goassert "github.com/couchbaselabs/go.assert"
 	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/couchbase/gocbcore.v7"
 )
 
@@ -95,7 +96,7 @@ func TestAddRaw(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error calling AddRaw(): %v", err)
 	}
-	assertTrue(t, added, "AddRaw returned added=false, expected true")
+	assert.True(t, added, "AddRaw returned added=false, expected true")
 
 	rv, _, err := bucket.GetRaw(key)
 	if string(rv) != string(val) {
@@ -107,7 +108,7 @@ func TestAddRaw(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error calling AddRaw(): %v", err)
 	}
-	assertTrue(t, added == false, "AddRaw returned added=true for duplicate, expected false")
+	assert.True(t, added == false, "AddRaw returned added=true for duplicate, expected false")
 
 	err = bucket.Delete(key)
 	if err != nil {
@@ -156,7 +157,7 @@ func TestBulkGetRaw(t *testing.T) {
 	}
 
 	results, err := bucket.GetBulkRaw(keySet)
-	assertNoError(t, err, fmt.Sprintf("Error calling GetBulkRaw(): %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Error calling GetBulkRaw(): %v", err))
 	goassert.True(t, len(results) == 1000)
 
 	// validate results, and prepare new keySet with non-existent keys
@@ -170,7 +171,7 @@ func TestBulkGetRaw(t *testing.T) {
 
 	// Validate bulkGet that include non-existent keys work as expected
 	mixedResults, err := bucket.GetBulkRaw(mixedKeySet)
-	assertNoError(t, err, fmt.Sprintf("Error calling GetBulkRaw(): %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Error calling GetBulkRaw(): %v", err))
 	goassert.True(t, len(results) == 1000)
 
 	for _, key := range keySet {
@@ -184,7 +185,7 @@ func TestBulkGetRaw(t *testing.T) {
 		nonExistentKeySet[index] = fmt.Sprintf("%s_invalid", key)
 	}
 	emptyResults, err := bucket.GetBulkRaw(nonExistentKeySet)
-	assertNoError(t, err, fmt.Sprintf("Unexpected error calling GetBulkRaw(): %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Unexpected error calling GetBulkRaw(): %v", err))
 	goassert.False(t, emptyResults == nil)
 	goassert.True(t, len(emptyResults) == 0)
 
@@ -591,7 +592,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	val["body_field"] = "1234"
 
 	valBytes, marshalErr := json.Marshal(val)
-	assertNoError(t, marshalErr, "Error marshalling document body")
+	assert.NoError(t, marshalErr, "Error marshalling document body")
 
 	xattrVal := make(map[string]interface{})
 	xattrVal["seq"] = float64(123)
@@ -606,7 +607,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	cas := uint64(0)
 	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	assertNoError(t, err, "WriteCasWithXattr error")
+	assert.NoError(t, err, "WriteCasWithXattr error")
 	log.Printf("Post-write, cas is %d", cas)
 
 	var retrievedVal map[string]interface{}
@@ -621,17 +622,17 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
 	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
 	macroCasString, ok := retrievedXattr[xattrMacroCas].(string)
-	assertTrue(t, ok, "Unable to retrieve xattrMacroCas as string")
+	assert.True(t, ok, "Unable to retrieve xattrMacroCas as string")
 	goassert.Equals(t, HexCasToUint64(macroCasString), cas)
 	macroBodyHashString, ok := retrievedXattr[xattrMacroValueCrc32c].(string)
-	assertTrue(t, ok, "Unable to retrieve xattrMacroValueCrc32c as string")
+	assert.True(t, ok, "Unable to retrieve xattrMacroValueCrc32c as string")
 	goassert.Equals(t, macroBodyHashString, Crc32cHashString(valBytes))
 
 	// Validate against $document.value_crc32c
 	var retrievedVxattr map[string]interface{}
 	_, err = bucket.GetWithXattr(key, "$document", retrievedVal, &retrievedVxattr)
 	vxattrCrc32c, ok := retrievedVxattr["value_crc32c"].(string)
-	assertTrue(t, ok, "Unable to retrieve virtual xattr crc32c as string")
+	assert.True(t, ok, "Unable to retrieve virtual xattr crc32c as string")
 
 	goassert.Equals(t, vxattrCrc32c, Crc32cHashString(valBytes))
 	goassert.Equals(t, vxattrCrc32c, macroBodyHashString)
@@ -671,7 +672,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 
 	cas := uint64(0)
 	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	assertNoError(t, err, "WriteCasWithXattr error")
+	assert.NoError(t, err, "WriteCasWithXattr error")
 	log.Printf("Post-write, cas is %d", cas)
 
 	var retrievedVal map[string]interface{}
@@ -693,7 +694,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 	xattrVal2["seq"] = float64(124)
 	xattrVal2["rev"] = "2-5678"
 	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, getCas, val2, xattrVal2)
-	assertNoError(t, err, "WriteCasWithXattr error")
+	assert.NoError(t, err, "WriteCasWithXattr error")
 	log.Printf("Post-write, cas is %d", cas)
 
 	var retrievedVal2 map[string]interface{}
@@ -737,7 +738,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 
 	cas := uint64(0)
 	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	assertNoError(t, err, "WriteCasWithXattr error")
+	assert.NoError(t, err, "WriteCasWithXattr error")
 	log.Printf("Post-write, cas is %d", cas)
 
 	var retrievedVal map[string]interface{}
@@ -1230,14 +1231,14 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	xattrVal["seq"] = 2
 	xattrVal["rev"] = "1-1234"
 	casOut, writeErr := bucket.WriteCasWithXattr(key, xattrName, 0, getCas, nil, xattrVal)
-	assertNoError(t, writeErr, "Error updating xattr post-delete")
+	assert.NoError(t, writeErr, "Error updating xattr post-delete")
 	log.Printf("WriteCasWithXattr cas: %d", casOut)
 
 	// Retrieve the document, validate cas values
 	var postDeleteVal map[string]interface{}
 	var postDeleteXattr map[string]interface{}
 	getCas2, err := bucket.GetWithXattr(key, xattrName, &postDeleteVal, &postDeleteXattr)
-	assertNoError(t, err, "Error getting document post-delete")
+	assert.NoError(t, err, "Error getting document post-delete")
 	goassert.Equals(t, postDeleteXattr["seq"], float64(2))
 	goassert.Equals(t, len(postDeleteVal), 0)
 	log.Printf("Post-delete xattr (2): %s", postDeleteXattr)
@@ -1382,20 +1383,20 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 		log.Printf("Delete testing for key: %v", key)
 		// First attempt to update with a bad cas value, and ensure we're getting the expected error
 		_, errCasMismatch := bucket.UpdateXattr(key, xattrName, 0, uint64(1234), &updatedXattrVal, shouldDeleteBody[i])
-		assertTrue(t, errCasMismatch == gocb.ErrKeyExists, fmt.Sprintf("Expected cas mismatch error, got: %v", err))
+		assert.True(t, errCasMismatch == gocb.ErrKeyExists, fmt.Sprintf("Expected cas mismatch error, got: %v", err))
 
 		_, errDelete := bucket.UpdateXattr(key, xattrName, 0, uint64(casValues[i]), &updatedXattrVal, shouldDeleteBody[i])
 		log.Printf("Delete error: %v", errDelete)
 
-		assertNoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-		assertTrue(t, verifyDocDeletedXattrExists(bucket, key, xattrName), fmt.Sprintf("Expected doc %s to be deleted", key))
+		assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+		assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrName), fmt.Sprintf("Expected doc %s to be deleted", key))
 	}
 
 	// Now attempt to tombstone key4 (NoDocNoXattr), should not return an error (per SG #3307).  Should save xattr metadata.
 	log.Printf("Deleting key: %v", key4)
 	_, errDelete := bucket.UpdateXattr(key4, xattrName, 0, uint64(0), &updatedXattrVal, false)
-	assertNoError(t, errDelete, "Unexpected error tombstoning non-existent doc")
-	assertTrue(t, verifyDocDeletedXattrExists(bucket, key4, xattrName), "Expected doc to be deleted, but xattrs to exist")
+	assert.NoError(t, errDelete, "Unexpected error tombstoning non-existent doc")
+	assert.True(t, verifyDocDeletedXattrExists(bucket, key4, xattrName), "Expected doc to be deleted, but xattrs to exist")
 
 }
 
@@ -1478,15 +1479,15 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 	for _, key := range keys {
 		log.Printf("Deleting key: %v", key)
 		errDelete := bucket.DeleteWithXattr(key, xattrName)
-		assertNoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-		assertTrue(t, verifyDocAndXattrDeleted(bucket, key, xattrName), "Expected doc to be deleted")
+		assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+		assert.True(t, verifyDocAndXattrDeleted(bucket, key, xattrName), "Expected doc to be deleted")
 	}
 
 	// Now attempt to delete key4 (NoDocNoXattr), which is expected to return a Key Not Found error
 	log.Printf("Deleting key: %v", key4)
 	errDelete := bucket.DeleteWithXattr(key4, xattrName)
-	assertTrue(t, bucket.IsKeyNotFoundError(errDelete), "Exepcted keynotfound error")
-	assertTrue(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
+	assert.True(t, bucket.IsKeyNotFoundError(errDelete), "Exepcted keynotfound error")
+	assert.True(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
 
 }
 
@@ -1535,7 +1536,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 
 	deleteErr := bucket.deleteWithXattrInternal(key, xattrName, callback)
 
-	assertTrue(t, deleteErr != nil, "We expected an error here, because deleteWithXattrInternal should have "+
+	assert.True(t, deleteErr != nil, "We expected an error here, because deleteWithXattrInternal should have "+
 		" detected that the doc was resurrected during its execution")
 
 }
@@ -1605,21 +1606,21 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 	var key1DocResult map[string]interface{}
 	var key1XattrResult map[string]interface{}
 	_, key1err := bucket.GetWithXattr(key1, xattrName, &key1DocResult, &key1XattrResult)
-	assertNoError(t, key1err, "Unexpected error retrieving doc w/ xattr")
+	assert.NoError(t, key1err, "Unexpected error retrieving doc w/ xattr")
 	goassert.Equals(t, key1DocResult["type"], key1)
 	goassert.Equals(t, key1XattrResult["rev"], "1-1234")
 
 	var key2DocResult map[string]interface{}
 	var key2XattrResult map[string]interface{}
 	_, key2err := bucket.GetWithXattr(key2, xattrName, &key2DocResult, &key2XattrResult)
-	assertNoError(t, key2err, "Unexpected error retrieving doc w/out xattr")
+	assert.NoError(t, key2err, "Unexpected error retrieving doc w/out xattr")
 	goassert.Equals(t, key2DocResult["type"], key2)
 	goassert.True(t, key2XattrResult == nil)
 
 	var key3DocResult map[string]interface{}
 	var key3XattrResult map[string]interface{}
 	_, key3err := bucket.GetWithXattr(key3, xattrName, &key3DocResult, &key3XattrResult)
-	assertNoError(t, key3err, "Unexpected error retrieving doc w/out xattr")
+	assert.NoError(t, key3err, "Unexpected error retrieving doc w/out xattr")
 	goassert.True(t, key3DocResult == nil)
 	goassert.Equals(t, key3XattrResult["rev"], "1-1234")
 
@@ -1709,7 +1710,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 	exp := uint32(0)
 	updatedVal["type"] = fmt.Sprintf("updated_%s", key1)
 	_, key1err := bucket.WriteCasWithXattr(key1, xattrName, exp, cas1, &updatedVal, &updatedXattrVal)
-	assertNoError(t, key1err, fmt.Sprintf("Unexpected error mutating %s", key1))
+	assert.NoError(t, key1err, fmt.Sprintf("Unexpected error mutating %s", key1))
 	var key1DocResult map[string]interface{}
 	var key1XattrResult map[string]interface{}
 	_, key1err = bucket.GetWithXattr(key1, xattrName, &key1DocResult, &key1XattrResult)
@@ -1718,7 +1719,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 
 	updatedVal["type"] = fmt.Sprintf("updated_%s", key2)
 	_, key2err := bucket.WriteCasWithXattr(key2, xattrName, exp, uint64(cas2), &updatedVal, &updatedXattrVal)
-	assertNoError(t, key2err, fmt.Sprintf("Unexpected error mutating %s", key2))
+	assert.NoError(t, key2err, fmt.Sprintf("Unexpected error mutating %s", key2))
 	var key2DocResult map[string]interface{}
 	var key2XattrResult map[string]interface{}
 	_, key2err = bucket.GetWithXattr(key2, xattrName, &key2DocResult, &key2XattrResult)
@@ -1727,7 +1728,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 
 	updatedVal["type"] = fmt.Sprintf("updated_%s", key3)
 	_, key3err := bucket.WriteCasWithXattr(key3, xattrName, exp, uint64(cas3), &updatedVal, &updatedXattrVal)
-	assertNoError(t, key3err, fmt.Sprintf("Unexpected error mutating %s", key3))
+	assert.NoError(t, key3err, fmt.Sprintf("Unexpected error mutating %s", key3))
 	var key3DocResult map[string]interface{}
 	var key3XattrResult map[string]interface{}
 	_, key3err = bucket.GetWithXattr(key3, xattrName, &key3DocResult, &key3XattrResult)
@@ -1736,7 +1737,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 
 	updatedVal["type"] = fmt.Sprintf("updated_%s", key4)
 	_, key4err := bucket.WriteCasWithXattr(key4, xattrName, exp, uint64(cas4), &updatedVal, &updatedXattrVal)
-	assertNoError(t, key4err, fmt.Sprintf("Unexpected error mutating %s", key4))
+	assert.NoError(t, key4err, fmt.Sprintf("Unexpected error mutating %s", key4))
 	var key4DocResult map[string]interface{}
 	var key4XattrResult map[string]interface{}
 	_, key4err = bucket.GetWithXattr(key4, xattrName, &key4DocResult, &key4XattrResult)
@@ -1967,7 +1968,7 @@ func TestCouchbaseServerMaxTTL(t *testing.T) {
 
 	gocbBucket := bucket.(*CouchbaseBucketGoCB)
 	maxTTL, err := gocbBucket.GetMaxTTL()
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, maxTTL, 0)
 
 }

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/gocb"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 var testN1qlOptions = &N1qlIndexOptions{
@@ -56,8 +56,8 @@ func TestN1qlQuery(t *testing.T) {
 	exists, state, stateErr := bucket.GetIndexMeta("testIndex_value")
 	assertNoError(t, stateErr, "Error validating index state")
 	assertTrue(t, state != nil, "No state returned for index")
-	assert.Equals(t, state.State, "online")
-	assert.Equals(t, exists, true)
+	goassert.Equals(t, state.State, "online")
+	goassert.Equals(t, exists, true)
 
 	// Defer index teardown
 	defer func() {
@@ -117,7 +117,7 @@ func TestN1qlQuery(t *testing.T) {
 	}
 
 	assertNoError(t, queryCloseErr, "Unexpected error closing query results")
-	assert.Equals(t, count, 0)
+	goassert.Equals(t, count, 0)
 
 }
 
@@ -187,10 +187,10 @@ func TestN1qlFilterExpression(t *testing.T) {
 			break
 		}
 		assertTrue(t, queryResult.Val < 3, "Query returned unexpected result")
-		assert.Equals(t, queryResult.Id, "doc1")
+		goassert.Equals(t, queryResult.Id, "doc1")
 		count++
 	}
-	assert.Equals(t, count, 1)
+	goassert.Equals(t, count, 1)
 
 }
 
@@ -209,7 +209,7 @@ func TestIndexMeta(t *testing.T) {
 
 	// Check index state pre-creation
 	exists, meta, err := bucket.GetIndexMeta("testIndex_value")
-	assert.Equals(t, exists, false)
+	goassert.Equals(t, exists, false)
 	assertNoError(t, err, "Error getting meta for non-existent index")
 
 	indexExpression := "val"
@@ -232,8 +232,8 @@ func TestIndexMeta(t *testing.T) {
 
 	// Check index state post-creation
 	exists, meta, err = bucket.GetIndexMeta("testIndex_value")
-	assert.Equals(t, exists, true)
-	assert.Equals(t, meta.State, "online")
+	goassert.Equals(t, exists, true)
+	goassert.Equals(t, meta.State, "online")
 	assertNoError(t, err, "Error retrieving index state")
 }
 
@@ -353,7 +353,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 
 	// Attempt to create duplicate, validate duplicate error
 	duplicateErr := bucket.CreateIndex("testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
-	assert.Equals(t, duplicateErr, ErrIndexAlreadyExists)
+	goassert.Equals(t, duplicateErr, ErrIndexAlreadyExists)
 
 	// Drop the index
 	err = bucket.DropIndex("testIndexDuplicateSequence")

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/couchbase/gocb"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var testN1qlOptions = &N1qlIndexOptions{
@@ -35,7 +36,7 @@ func TestN1qlQuery(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error adding doc for TestN1qlQuery: %v", err)
 		}
-		assertTrue(t, added, "AddRaw returned added=false, expected true")
+		assert.True(t, added, "AddRaw returned added=false, expected true")
 	}
 
 	indexExpression := "val"
@@ -54,8 +55,8 @@ func TestN1qlQuery(t *testing.T) {
 
 	// Check index state
 	exists, state, stateErr := bucket.GetIndexMeta("testIndex_value")
-	assertNoError(t, stateErr, "Error validating index state")
-	assertTrue(t, state != nil, "No state returned for index")
+	assert.NoError(t, stateErr, "Error validating index state")
+	assert.True(t, state != nil, "No state returned for index")
 	goassert.Equals(t, state.State, "online")
 	goassert.Equals(t, exists, true)
 
@@ -69,7 +70,7 @@ func TestN1qlQuery(t *testing.T) {
 	}()
 
 	readyErr := bucket.WaitForIndexOnline("testIndex_value")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Query the index
 	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", BucketQueryToken)
@@ -77,7 +78,7 @@ func TestN1qlQuery(t *testing.T) {
 	params["minvalue"] = 2
 
 	queryResults, queryErr := bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assertNoError(t, queryErr, "Error executing n1ql query")
+	assert.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
 	var queryResult struct {
@@ -94,7 +95,7 @@ func TestN1qlQuery(t *testing.T) {
 			queryCloseErr = queryResults.Close()
 			break
 		}
-		assertTrue(t, queryResult.Val > 2, "Query returned unexpected result")
+		assert.True(t, queryResult.Val > 2, "Query returned unexpected result")
 		count++
 	}
 
@@ -103,7 +104,7 @@ func TestN1qlQuery(t *testing.T) {
 	params["minvalue"] = 10
 
 	queryResults, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assertNoError(t, queryErr, "Error executing n1ql query")
+	assert.NoError(t, queryErr, "Error executing n1ql query")
 
 	count = 0
 	for {
@@ -112,11 +113,11 @@ func TestN1qlQuery(t *testing.T) {
 			queryCloseErr = queryResults.Close()
 			break
 		}
-		assertTrue(t, queryResult.Val > 10, "Query returned unexpected result")
+		assert.True(t, queryResult.Val > 10, "Query returned unexpected result")
 		count++
 	}
 
-	assertNoError(t, queryCloseErr, "Unexpected error closing query results")
+	assert.NoError(t, queryCloseErr, "Unexpected error closing query results")
 	goassert.Equals(t, count, 0)
 
 }
@@ -142,7 +143,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error adding doc for TestIndexFilterExpression: %v", err)
 		}
-		assertTrue(t, added, "AddRaw returned added=false, expected true")
+		assert.True(t, added, "AddRaw returned added=false, expected true")
 	}
 
 	indexExpression := "val"
@@ -154,7 +155,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 	// Wait for index readiness
 	readyErr := bucket.WaitForIndexOnline("testIndex_filtered_value")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
 	defer func() {
@@ -168,7 +169,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 	// Query the index
 	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE %s AND META().id = 'doc1'", BucketQueryToken, filterExpression)
 	queryResults, queryErr := bucket.Query(queryExpression, nil, gocb.RequestPlus, false)
-	assertNoError(t, queryErr, "Error executing n1ql query")
+	assert.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
 	var queryResult struct {
@@ -183,10 +184,10 @@ func TestN1qlFilterExpression(t *testing.T) {
 		ok := queryResults.Next(&queryResult)
 		if !ok {
 			queryCloseErr = queryResults.Close()
-			assertNoError(t, queryCloseErr, "Error closing queryResults")
+			assert.NoError(t, queryCloseErr, "Error closing queryResults")
 			break
 		}
-		assertTrue(t, queryResult.Val < 3, "Query returned unexpected result")
+		assert.True(t, queryResult.Val < 3, "Query returned unexpected result")
 		goassert.Equals(t, queryResult.Id, "doc1")
 		count++
 	}
@@ -210,7 +211,7 @@ func TestIndexMeta(t *testing.T) {
 	// Check index state pre-creation
 	exists, meta, err := bucket.GetIndexMeta("testIndex_value")
 	goassert.Equals(t, exists, false)
-	assertNoError(t, err, "Error getting meta for non-existent index")
+	assert.NoError(t, err, "Error getting meta for non-existent index")
 
 	indexExpression := "val"
 	err = bucket.CreateIndex("testIndex_value", indexExpression, "", testN1qlOptions)
@@ -219,7 +220,7 @@ func TestIndexMeta(t *testing.T) {
 	}
 
 	readyErr := bucket.WaitForIndexOnline("testIndex_value")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
 	defer func() {
@@ -234,7 +235,7 @@ func TestIndexMeta(t *testing.T) {
 	exists, meta, err = bucket.GetIndexMeta("testIndex_value")
 	goassert.Equals(t, exists, true)
 	goassert.Equals(t, meta.State, "online")
-	assertNoError(t, err, "Error retrieving index state")
+	assert.NoError(t, err, "Error retrieving index state")
 }
 
 // Ensure that n1ql query errors are handled and returned (and don't result in panic etc)
@@ -257,7 +258,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error adding doc for TestN1qlQuery: %v", err)
 		}
-		assertTrue(t, added, "AddRaw returned added=false, expected true")
+		assert.True(t, added, "AddRaw returned added=false, expected true")
 	}
 
 	indexExpression := "val"
@@ -267,7 +268,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	}
 
 	readyErr := bucket.WaitForIndexOnline("testIndex_value_malformed")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
 	defer func() {
@@ -282,25 +283,25 @@ func TestMalformedN1qlQuery(t *testing.T) {
 	queryExpression := "SELECT META().id, val WHERE val > $minvalue"
 	params := make(map[string]interface{})
 	_, queryErr := bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
+	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (syntax)")
 
 	// Query against non-existing bucket
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", "badBucket")
 	params = map[string]interface{}{"minvalue": 2}
 	_, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
+	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (no bucket)")
 
 	// Specify params for non-parameterized query (no error expected, ensure doesn't break)
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > 5", BucketQueryToken)
 	params = map[string]interface{}{"minvalue": 2}
 	_, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assertTrue(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
+	assert.True(t, queryErr == nil, "Unexpected error for malformed n1ql query (extra params)")
 
 	// Omit params for parameterized query
 	queryExpression = fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", BucketQueryToken)
 	params = make(map[string]interface{})
 	_, queryErr = bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assertTrue(t, queryErr != nil, "Expected error for malformed n1ql query (missing params)")
+	assert.True(t, queryErr != nil, "Expected error for malformed n1ql query (missing params)")
 
 }
 
@@ -322,7 +323,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 	}
 
 	readyErr := bucket.WaitForIndexOnline("testIndex_sequence")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
 	err = bucket.DropIndex("testIndex_sequence")
@@ -349,7 +350,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 	}
 
 	readyErr := bucket.WaitForIndexOnline("testIndexDuplicateSequence")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Attempt to create duplicate, validate duplicate error
 	duplicateErr := bucket.CreateIndex("testIndexDuplicateSequence", createExpression, "", testN1qlOptions)
@@ -380,7 +381,7 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 	}
 
 	readyErr := bucket.WaitForIndexOnline("testIndex-sequence")
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Drop the index
 	err = bucket.DropIndex("testIndex-sequence")
@@ -402,7 +403,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 	}
 
 	indexName := "testIndexDeferred"
-	assertNoError(t, tearDownTestIndex(bucket, indexName), "Error in pre-test cleanup")
+	assert.NoError(t, tearDownTestIndex(bucket, indexName), "Error in pre-test cleanup")
 
 	deferN1qlOptions := &N1qlIndexOptions{
 		NumReplica: 0,
@@ -424,10 +425,10 @@ func TestDeferredCreateIndex(t *testing.T) {
 	}()
 
 	buildErr := bucket.buildIndexes([]string{indexName})
-	assertNoError(t, buildErr, "Error building indexes")
+	assert.NoError(t, buildErr, "Error building indexes")
 
 	readyErr := bucket.WaitForIndexOnline(indexName)
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 }
 
@@ -445,8 +446,8 @@ func TestBuildDeferredIndexes(t *testing.T) {
 
 	deferredIndexName := "testIndexDeferred"
 	nonDeferredIndexName := "testIndexNonDeferred"
-	assertNoError(t, tearDownTestIndex(bucket, deferredIndexName), "Error in pre-test cleanup")
-	assertNoError(t, tearDownTestIndex(bucket, nonDeferredIndexName), "Error in pre-test cleanup")
+	assert.NoError(t, tearDownTestIndex(bucket, deferredIndexName), "Error in pre-test cleanup")
+	assert.NoError(t, tearDownTestIndex(bucket, nonDeferredIndexName), "Error in pre-test cleanup")
 
 	deferN1qlOptions := &N1qlIndexOptions{
 		NumReplica: 0,
@@ -481,19 +482,19 @@ func TestBuildDeferredIndexes(t *testing.T) {
 	}()
 
 	buildErr := bucket.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
-	assertNoError(t, buildErr, "Error building indexes")
+	assert.NoError(t, buildErr, "Error building indexes")
 
 	readyErr := bucket.WaitForIndexOnline(deferredIndexName)
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 	readyErr = bucket.WaitForIndexOnline(nonDeferredIndexName)
-	assertNoError(t, readyErr, "Error validating index online")
+	assert.NoError(t, readyErr, "Error validating index online")
 
 	// Ensure no errors from no-op scenarios
 	alreadyBuiltErr := bucket.BuildDeferredIndexes([]string{deferredIndexName, nonDeferredIndexName})
-	assertNoError(t, alreadyBuiltErr, "Error building already built indexes")
+	assert.NoError(t, alreadyBuiltErr, "Error building already built indexes")
 
 	emptySetErr := bucket.BuildDeferredIndexes([]string{})
-	assertNoError(t, emptySetErr, "Error building empty set")
+	assert.NoError(t, emptySetErr, "Error building empty set")
 }
 
 func TestCreateAndDropIndexErrors(t *testing.T) {

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -3,7 +3,7 @@ package base
 import (
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestBucketSpec(t *testing.T) {
@@ -17,20 +17,20 @@ func TestBucketSpec(t *testing.T) {
 
 	connStr, err := bucketSpec.GetGoCBConnString()
 	assertNoError(t, err, "Error creating connection string for bucket spec")
-	assert.Equals(t, connStr, "http://localhost:8091?cacertpath=.%2FmyCACertPath&certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath")
+	goassert.Equals(t, connStr, "http://localhost:8091?cacertpath=.%2FmyCACertPath&certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath")
 
 	// CACertPath not required
 	bucketSpec.CACertPath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
 	assertNoError(t, err, "Error creating connection string for bucket spec")
-	assert.Equals(t, connStr, "http://localhost:8091?certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath")
+	goassert.Equals(t, connStr, "http://localhost:8091?certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath")
 
 	// Certpath and keypath must both be defined - if either are missing, they shouldn't be included in connection string
 	bucketSpec.CACertPath = "./myCACertPath"
 	bucketSpec.Certpath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
 	assertNoError(t, err, "Error creating connection string for bucket spec")
-	assert.Equals(t, connStr, "http://localhost:8091?cacertpath=.%2FmyCACertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256")
+	goassert.Equals(t, connStr, "http://localhost:8091?cacertpath=.%2FmyCACertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256")
 
 	// Standard no-cert
 	bucketSpec.CACertPath = ""
@@ -228,9 +228,9 @@ func TestGetStatsVbSeqno(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(ts *testing.T) {
 			actualUUIDs, actualHighSeqnos, err := GetStatsVbSeqno(test.stats, maxVbno, false)
-			assert.Equals(ts, err, nil)
-			assert.DeepEquals(ts, actualUUIDs, test.expectedUUIDs)
-			assert.DeepEquals(ts, actualHighSeqnos, test.expectedHighSeqnos)
+			goassert.Equals(ts, err, nil)
+			goassert.DeepEquals(ts, actualUUIDs, test.expectedUUIDs)
+			goassert.DeepEquals(ts, actualHighSeqnos, test.expectedHighSeqnos)
 		})
 	}
 }

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBucketSpec(t *testing.T) {
@@ -16,20 +17,20 @@ func TestBucketSpec(t *testing.T) {
 	}
 
 	connStr, err := bucketSpec.GetGoCBConnString()
-	assertNoError(t, err, "Error creating connection string for bucket spec")
+	assert.NoError(t, err, "Error creating connection string for bucket spec")
 	goassert.Equals(t, connStr, "http://localhost:8091?cacertpath=.%2FmyCACertPath&certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath")
 
 	// CACertPath not required
 	bucketSpec.CACertPath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
-	assertNoError(t, err, "Error creating connection string for bucket spec")
+	assert.NoError(t, err, "Error creating connection string for bucket spec")
 	goassert.Equals(t, connStr, "http://localhost:8091?certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath")
 
 	// Certpath and keypath must both be defined - if either are missing, they shouldn't be included in connection string
 	bucketSpec.CACertPath = "./myCACertPath"
 	bucketSpec.Certpath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
-	assertNoError(t, err, "Error creating connection string for bucket spec")
+	assert.NoError(t, err, "Error creating connection string for bucket spec")
 	goassert.Equals(t, connStr, "http://localhost:8091?cacertpath=.%2FmyCACertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256")
 
 	// Standard no-cert
@@ -37,7 +38,7 @@ func TestBucketSpec(t *testing.T) {
 	bucketSpec.Certpath = ""
 	bucketSpec.Keypath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
-	assertNoError(t, err, "Error creating connection string for bucket spec")
+	assert.NoError(t, err, "Error creating connection string for bucket spec")
 
 }
 

--- a/base/dcp_feed_test.go
+++ b/base/dcp_feed_test.go
@@ -3,7 +3,7 @@ package base
 import (
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // func TransformBucketCredentials(inputUsername, inputPassword, inputBucketname string) (username, password, bucketname string) {
@@ -19,9 +19,9 @@ func TestTransformBucketCredentials(t *testing.T) {
 		inputPassword,
 		inputBucketName,
 	)
-	assert.Equals(t, username, inputUsername)
-	assert.Equals(t, password, inputPassword)
-	assert.Equals(t, bucketname, inputBucketName)
+	goassert.Equals(t, username, inputUsername)
+	goassert.Equals(t, password, inputPassword)
+	goassert.Equals(t, bucketname, inputBucketName)
 
 	inputUsername2 := ""
 	inputPassword2 := "bar"
@@ -33,8 +33,8 @@ func TestTransformBucketCredentials(t *testing.T) {
 		inputBucketName2,
 	)
 
-	assert.Equals(t, username2, inputBucketName2)
-	assert.Equals(t, password2, inputPassword2)
-	assert.Equals(t, bucketname2, inputBucketName2)
+	goassert.Equals(t, username2, inputBucketName2)
+	goassert.Equals(t, password2, inputPassword2)
+	goassert.Equals(t, bucketname2, inputBucketName2)
 
 }

--- a/base/expvar_test.go
+++ b/base/expvar_test.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestRollingMeanExpvar(t *testing.T) {
@@ -25,18 +25,18 @@ func TestRollingMeanExpvar(t *testing.T) {
 	rollingMean.AddValue(4)
 	rollingMean.AddValue(6)
 	rollingMean.AddValue(8)
-	assert.Equals(t, rollingMean.String(), "5")
+	goassert.Equals(t, rollingMean.String(), "5")
 
 	// Add a few more to exceed capacity
 	rollingMean.AddValue(10)
 	rollingMean.AddValue(22)
-	assert.Equals(t, rollingMean.String(), "10")
+	goassert.Equals(t, rollingMean.String(), "10")
 
 	// Go around the capacity loop a few times to make sure things don't break
 	for i := 0; i < 100; i++ {
 		rollingMean.AddValue(100)
 	}
-	assert.Equals(t, rollingMean.String(), "100")
+	goassert.Equals(t, rollingMean.String(), "100")
 
 }
 

--- a/base/expvar_test.go
+++ b/base/expvar_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRollingMeanExpvar(t *testing.T) {
@@ -41,7 +42,7 @@ func TestRollingMeanExpvar(t *testing.T) {
 }
 
 func assertMapEntry(t *testing.T, e SequenceTimingExpvar, key string) {
-	assertTrue(t, e.timingMap.Get(key) != nil, fmt.Sprintf("Expected map key %s not found", key))
+	assert.True(t, e.timingMap.Get(key) != nil, fmt.Sprintf("Expected map key %s not found", key))
 }
 
 func TestTimingExpvarSequenceOnly(t *testing.T) {

--- a/base/leaky_bucket_test.go
+++ b/base/leaky_bucket_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sgbucket "github.com/couchbase/sg-bucket"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestDedupeTapEventsLaterSeqSameDoc(t *testing.T) {
@@ -27,11 +27,11 @@ func TestDedupeTapEventsLaterSeqSameDoc(t *testing.T) {
 	deduped := dedupeTapEvents(tapEvents)
 
 	// make sure that one was deduped
-	assert.Equals(t, len(deduped), 1)
+	goassert.Equals(t, len(deduped), 1)
 
 	// make sure the earlier event was deduped
 	dedupedEvent := deduped[0]
-	assert.True(t, dedupedEvent.Cas == 2)
+	goassert.True(t, dedupedEvent.Cas == 2)
 
 }
 
@@ -55,6 +55,6 @@ func TestDedupeNoDedupeDifferentDocs(t *testing.T) {
 	deduped := dedupeTapEvents(tapEvents)
 
 	// make sure that nothing was deduped
-	assert.True(t, len(deduped) == 2)
+	goassert.True(t, len(deduped) == 2)
 
 }

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -4,86 +4,86 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestLogKey(t *testing.T) {
 	var logKeysPtr *LogKey
-	assert.False(t, logKeysPtr.Enabled(KeyHTTP))
+	goassert.False(t, logKeysPtr.Enabled(KeyHTTP))
 
 	logKeys := KeyHTTP
-	assert.True(t, logKeys.Enabled(KeyHTTP))
+	goassert.True(t, logKeys.Enabled(KeyHTTP))
 
 	// Enable more log keys.
 	logKeys.Enable(KeyAccess | KeyReplicate)
-	assert.True(t, logKeys.Enabled(KeyAccess))
-	assert.True(t, logKeys.Enabled(KeyReplicate))
-	assert.Equals(t, logKeys, KeyAccess|KeyHTTP|KeyReplicate)
+	goassert.True(t, logKeys.Enabled(KeyAccess))
+	goassert.True(t, logKeys.Enabled(KeyReplicate))
+	goassert.Equals(t, logKeys, KeyAccess|KeyHTTP|KeyReplicate)
 
 	// Enable wildcard and check unset key is enabled.
 	logKeys.Enable(KeyAll)
-	assert.True(t, logKeys.Enabled(KeyCache))
-	assert.Equals(t, logKeys, KeyAll|KeyAccess|KeyHTTP|KeyReplicate)
+	goassert.True(t, logKeys.Enabled(KeyCache))
+	goassert.Equals(t, logKeys, KeyAll|KeyAccess|KeyHTTP|KeyReplicate)
 
 	// Disable wildcard and check that existing keys are still set.
 	logKeys.Disable(KeyAll)
-	assert.True(t, logKeys.Enabled(KeyAccess))
-	assert.False(t, logKeys.Enabled(KeyCache))
-	assert.Equals(t, logKeys, KeyAccess|KeyHTTP|KeyReplicate)
+	goassert.True(t, logKeys.Enabled(KeyAccess))
+	goassert.False(t, logKeys.Enabled(KeyCache))
+	goassert.Equals(t, logKeys, KeyAccess|KeyHTTP|KeyReplicate)
 
 	// Set KeyNone and check keys are disabled.
 	logKeys = KeyNone
-	assert.False(t, logKeys.Enabled(KeyAll))
-	assert.False(t, logKeys.Enabled(KeyCache))
-	assert.Equals(t, logKeys, KeyNone)
+	goassert.False(t, logKeys.Enabled(KeyAll))
+	goassert.False(t, logKeys.Enabled(KeyCache))
+	goassert.Equals(t, logKeys, KeyNone)
 }
 
 func TestLogKeyNames(t *testing.T) {
 	name := KeyDCP.String()
-	assert.Equals(t, name, "DCP")
+	goassert.Equals(t, name, "DCP")
 
 	// Combined log keys, will pretty-print a set of log keys
 	name = LogKey(KeyDCP | KeyReplicate).String()
-	assert.StringContains(t, name, "DCP")
-	assert.StringContains(t, name, "Replicate")
+	goassert.StringContains(t, name, "DCP")
+	goassert.StringContains(t, name, "Replicate")
 
 	keys := []string{}
 	logKeys, warnings := ToLogKey(keys)
-	assert.Equals(t, len(warnings), 0)
-	assert.Equals(t, logKeys, LogKey(0))
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
+	goassert.Equals(t, len(warnings), 0)
+	goassert.Equals(t, logKeys, LogKey(0))
+	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
 
 	keys = append(keys, "DCP")
 	logKeys, warnings = ToLogKey(keys)
-	assert.Equals(t, len(warnings), 0)
-	assert.Equals(t, logKeys, KeyDCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String()})
+	goassert.Equals(t, len(warnings), 0)
+	goassert.Equals(t, logKeys, KeyDCP)
+	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String()})
 
 	keys = append(keys, "Access")
 	logKeys, warnings = ToLogKey(keys)
-	assert.Equals(t, len(warnings), 0)
-	assert.Equals(t, logKeys, KeyAccess|KeyDCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAccess.String(), KeyDCP.String()})
+	goassert.Equals(t, len(warnings), 0)
+	goassert.Equals(t, logKeys, KeyAccess|KeyDCP)
+	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAccess.String(), KeyDCP.String()})
 
 	keys = []string{"*", "DCP"}
 	logKeys, warnings = ToLogKey(keys)
-	assert.Equals(t, len(warnings), 0)
-	assert.Equals(t, logKeys, KeyAll|KeyDCP)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
+	goassert.Equals(t, len(warnings), 0)
+	goassert.Equals(t, logKeys, KeyAll|KeyDCP)
+	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
 	// Special handling of log keys
 	keys = []string{"HTTP+"}
 	logKeys, warnings = ToLogKey(keys)
-	assert.Equals(t, len(warnings), 0)
-	assert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String()})
+	goassert.Equals(t, len(warnings), 0)
+	goassert.Equals(t, logKeys, KeyHTTP|KeyHTTPResp)
+	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String()})
 
 	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
 	keys = []string{"DCP", "WS+", "InvalidLogKey"}
 	logKeys, warnings = ToLogKey(keys)
-	assert.Equals(t, len(warnings), 2)
-	assert.Equals(t, logKeys, KeyDCP|KeyWebSocket)
-	assert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyWebSocket.String()})
+	goassert.Equals(t, len(warnings), 2)
+	goassert.Equals(t, logKeys, KeyDCP|KeyWebSocket)
+	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyWebSocket.String()})
 }
 
 func TestConvertSpecialLogKey(t *testing.T) {
@@ -107,9 +107,9 @@ func TestConvertSpecialLogKey(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.input, func(ts *testing.T) {
 			output, ok := convertSpecialLogKey(test.input)
-			assert.Equals(ts, ok, test.ok)
+			goassert.Equals(ts, ok, test.ok)
 			if ok {
-				assert.Equals(ts, *output, *test.output)
+				goassert.Equals(ts, *output, *test.output)
 			}
 		})
 	}

--- a/base/log_level_test.go
+++ b/base/log_level_test.go
@@ -6,108 +6,108 @@ import (
 	"testing"
 	"time"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // Tests the cascading behaviour of log levels.
 func TestLogLevel(t *testing.T) {
 	var logLevelPtr *LogLevel
-	assert.False(t, logLevelPtr.Enabled(LevelError))
-	assert.False(t, logLevelPtr.Enabled(LevelWarn))
-	assert.False(t, logLevelPtr.Enabled(LevelInfo))
-	assert.False(t, logLevelPtr.Enabled(LevelDebug))
-	assert.False(t, logLevelPtr.Enabled(LevelTrace))
+	goassert.False(t, logLevelPtr.Enabled(LevelError))
+	goassert.False(t, logLevelPtr.Enabled(LevelWarn))
+	goassert.False(t, logLevelPtr.Enabled(LevelInfo))
+	goassert.False(t, logLevelPtr.Enabled(LevelDebug))
+	goassert.False(t, logLevelPtr.Enabled(LevelTrace))
 
 	logLevel := LevelNone
-	assert.False(t, logLevel.Enabled(LevelError))
-	assert.False(t, logLevel.Enabled(LevelWarn))
-	assert.False(t, logLevel.Enabled(LevelInfo))
-	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelTrace))
+	goassert.False(t, logLevel.Enabled(LevelError))
+	goassert.False(t, logLevel.Enabled(LevelWarn))
+	goassert.False(t, logLevel.Enabled(LevelInfo))
+	goassert.False(t, logLevel.Enabled(LevelDebug))
+	goassert.False(t, logLevel.Enabled(LevelTrace))
 
 	logLevel.Set(LevelError)
-	assert.True(t, logLevel.Enabled(LevelError))
-	assert.False(t, logLevel.Enabled(LevelWarn))
-	assert.False(t, logLevel.Enabled(LevelInfo))
-	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelTrace))
+	goassert.True(t, logLevel.Enabled(LevelError))
+	goassert.False(t, logLevel.Enabled(LevelWarn))
+	goassert.False(t, logLevel.Enabled(LevelInfo))
+	goassert.False(t, logLevel.Enabled(LevelDebug))
+	goassert.False(t, logLevel.Enabled(LevelTrace))
 
 	logLevel.Set(LevelWarn)
-	assert.True(t, logLevel.Enabled(LevelError))
-	assert.True(t, logLevel.Enabled(LevelWarn))
-	assert.False(t, logLevel.Enabled(LevelInfo))
-	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelTrace))
+	goassert.True(t, logLevel.Enabled(LevelError))
+	goassert.True(t, logLevel.Enabled(LevelWarn))
+	goassert.False(t, logLevel.Enabled(LevelInfo))
+	goassert.False(t, logLevel.Enabled(LevelDebug))
+	goassert.False(t, logLevel.Enabled(LevelTrace))
 
 	logLevel.Set(LevelInfo)
-	assert.True(t, logLevel.Enabled(LevelError))
-	assert.True(t, logLevel.Enabled(LevelWarn))
-	assert.True(t, logLevel.Enabled(LevelInfo))
-	assert.False(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelTrace))
+	goassert.True(t, logLevel.Enabled(LevelError))
+	goassert.True(t, logLevel.Enabled(LevelWarn))
+	goassert.True(t, logLevel.Enabled(LevelInfo))
+	goassert.False(t, logLevel.Enabled(LevelDebug))
+	goassert.False(t, logLevel.Enabled(LevelTrace))
 
 	logLevel.Set(LevelDebug)
-	assert.True(t, logLevel.Enabled(LevelError))
-	assert.True(t, logLevel.Enabled(LevelWarn))
-	assert.True(t, logLevel.Enabled(LevelInfo))
-	assert.True(t, logLevel.Enabled(LevelDebug))
-	assert.False(t, logLevel.Enabled(LevelTrace))
+	goassert.True(t, logLevel.Enabled(LevelError))
+	goassert.True(t, logLevel.Enabled(LevelWarn))
+	goassert.True(t, logLevel.Enabled(LevelInfo))
+	goassert.True(t, logLevel.Enabled(LevelDebug))
+	goassert.False(t, logLevel.Enabled(LevelTrace))
 
 	logLevel.Set(LevelTrace)
-	assert.True(t, logLevel.Enabled(LevelError))
-	assert.True(t, logLevel.Enabled(LevelWarn))
-	assert.True(t, logLevel.Enabled(LevelInfo))
-	assert.True(t, logLevel.Enabled(LevelDebug))
-	assert.True(t, logLevel.Enabled(LevelTrace))
+	goassert.True(t, logLevel.Enabled(LevelError))
+	goassert.True(t, logLevel.Enabled(LevelWarn))
+	goassert.True(t, logLevel.Enabled(LevelInfo))
+	goassert.True(t, logLevel.Enabled(LevelDebug))
+	goassert.True(t, logLevel.Enabled(LevelTrace))
 }
 
 func TestLogLevelNames(t *testing.T) {
 	// Ensure number of level constants, and names match.
-	assert.Equals(t, len(logLevelNames), int(levelCount))
-	assert.Equals(t, len(logLevelNamesPrint), int(levelCount))
+	goassert.Equals(t, len(logLevelNames), int(levelCount))
+	goassert.Equals(t, len(logLevelNamesPrint), int(levelCount))
 
-	assert.Equals(t, LevelNone.String(), "none")
-	assert.Equals(t, LevelError.String(), "error")
-	assert.Equals(t, LevelInfo.String(), "info")
-	assert.Equals(t, LevelWarn.String(), "warn")
-	assert.Equals(t, LevelDebug.String(), "debug")
-	assert.Equals(t, LevelTrace.String(), "trace")
+	goassert.Equals(t, LevelNone.String(), "none")
+	goassert.Equals(t, LevelError.String(), "error")
+	goassert.Equals(t, LevelInfo.String(), "info")
+	goassert.Equals(t, LevelWarn.String(), "warn")
+	goassert.Equals(t, LevelDebug.String(), "debug")
+	goassert.Equals(t, LevelTrace.String(), "trace")
 
 	// Test out of bounds log level
-	assert.Equals(t, LogLevel(math.MaxUint32).String(), "LogLevel(4294967295)")
+	goassert.Equals(t, LogLevel(math.MaxUint32).String(), "LogLevel(4294967295)")
 }
 
 func TestLogLevelText(t *testing.T) {
 	for i := LogLevel(0); i < levelCount; i++ {
 		t.Run(fmt.Sprintf("LogLevel: %v", i), func(ts *testing.T) {
 			text, err := i.MarshalText()
-			assert.Equals(ts, err, nil)
-			assert.Equals(ts, string(text), i.String())
+			goassert.Equals(ts, err, nil)
+			goassert.Equals(ts, string(text), i.String())
 
 			var logLevel LogLevel
 			err = logLevel.UnmarshalText(text)
-			assert.Equals(ts, err, nil)
-			assert.Equals(ts, logLevel, i)
+			goassert.Equals(ts, err, nil)
+			goassert.Equals(ts, logLevel, i)
 		})
 	}
 
 	// nil pointer recievers
 	var logLevelPtr *LogLevel
 	_, err := logLevelPtr.MarshalText()
-	assert.StringContains(t, err.Error(), "unrecognized log level")
+	goassert.StringContains(t, err.Error(), "unrecognized log level")
 	err = logLevelPtr.UnmarshalText([]byte("none"))
-	assert.Equals(t, err.Error(), "nil log level")
+	goassert.Equals(t, err.Error(), "nil log level")
 
 	// Invalid values
 	var logLevel = LogLevel(math.MaxUint32)
 	text, err := logLevel.MarshalText()
-	assert.NotEquals(t, err, nil)
-	assert.Equals(t, string(text), "")
+	goassert.NotEquals(t, err, nil)
+	goassert.Equals(t, string(text), "")
 
 	logLevel = LevelNone
 	err = logLevel.UnmarshalText([]byte(""))
-	assert.NotEquals(t, err, nil)
-	assert.Equals(t, logLevel, LevelNone)
+	goassert.NotEquals(t, err, nil)
+	goassert.Equals(t, logLevel, LevelNone)
 }
 
 // This test has no assertions, but will flag any data races when run under `-race`.

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestConsoleShouldLog(t *testing.T) {
@@ -95,7 +95,7 @@ func TestConsoleShouldLog(t *testing.T) {
 
 		t.Run(name, func(ts *testing.T) {
 			got := l.shouldLog(test.logToLevel, test.logToKey)
-			assert.Equals(ts, got, test.expected)
+			goassert.Equals(ts, got, test.expected)
 		})
 	}
 }

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestFileShouldLog(t *testing.T) {
@@ -69,7 +69,7 @@ func TestFileShouldLog(t *testing.T) {
 
 		t.Run(name, func(ts *testing.T) {
 			got := l.shouldLog(test.logToLevel)
-			assert.Equals(ts, got, test.expected)
+			goassert.Equals(ts, got, test.expected)
 		})
 	}
 }

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/natefinch/lumberjack"
 )
 
@@ -33,7 +33,7 @@ func assertLogContains(t *testing.T, s string, f func()) {
 	defer func() { consoleLogger = originalLogger }()
 
 	f()
-	assert.StringContains(t, b.String(), s)
+	goassert.StringContains(t, b.String(), s)
 }
 
 func TestRedactedLogFuncs(t *testing.T) {
@@ -94,11 +94,11 @@ func TestPrependContextID(t *testing.T) {
 
 	for _, testInputOutput := range testInputsOutputs {
 		newFormat, newParams := PrependContextID(contextID, testInputOutput.inputFormat, testInputOutput.inputParams...)
-		assert.Equals(t, newFormat, testInputOutput.outputFormat)
+		goassert.Equals(t, newFormat, testInputOutput.outputFormat)
 
-		assert.Equals(t, len(newParams), len(testInputOutput.outputParams))
+		goassert.Equals(t, len(newParams), len(testInputOutput.outputParams))
 		for i, newParam := range newParams {
-			assert.Equals(t, newParam, testInputOutput.outputParams[i])
+			goassert.Equals(t, newParam, testInputOutput.outputParams[i])
 		}
 	}
 

--- a/base/lru_cache_test.go
+++ b/base/lru_cache_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 type testStruct struct {
@@ -24,9 +24,9 @@ func valueForTest(i int) *testStruct {
 }
 
 func verifyValue(t *testing.T, value *testStruct, i int) {
-	assert.True(t, value != nil)
-	assert.Equals(t, value.x, i)
-	assert.Equals(t, value.y, i*i)
+	goassert.True(t, value != nil)
+	goassert.Equals(t, value.x, i)
+	goassert.Equals(t, value.y, i*i)
 }
 
 func TestLRUCache(t *testing.T) {
@@ -36,7 +36,7 @@ func TestLRUCache(t *testing.T) {
 	}
 
 	cache, err := NewLRUCache(10)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	for i := 0; i < 10; i++ {
 		key := keyForTest(i)
 		value := valueForTest(i)
@@ -46,7 +46,7 @@ func TestLRUCache(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		value, _ := cache.Get(keyForTest(i))
 		testValue, ok := value.(*testStruct)
-		assert.True(t, ok)
+		goassert.True(t, ok)
 		verifyValue(t, testValue, i)
 	}
 
@@ -58,12 +58,12 @@ func TestLRUCache(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		value, _ := cache.Get(keyForTest(i))
-		assert.True(t, value == nil)
+		goassert.True(t, value == nil)
 	}
 	for i := 3; i < 13; i++ {
 		value, _ := cache.Get(keyForTest(i))
 		testValue, ok := value.(*testStruct)
-		assert.True(t, ok)
+		goassert.True(t, ok)
 		verifyValue(t, testValue, i)
 	}
 }

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestRedactHelper(t *testing.T) {
@@ -26,69 +26,69 @@ func TestRedactHelper(t *testing.T) {
 
 	// Since redact performs an in-place redaction,
 	// we'd expect the input slice to change too.
-	assert.DeepEquals(t, out, in)
+	goassert.DeepEquals(t, out, in)
 
 	// Check that ptr wasn't redacted outside of the slice... this could be dangerous!
-	assert.Equals(t, string(ptr), "hello")
+	goassert.Equals(t, string(ptr), "hello")
 
 	// Verify that only the types implementing Redactor have changed.
-	assert.Equals(t, out[0], UserData("alice").Redact())
-	assert.Equals(t, out[1], ptr.Redact())
-	assert.Equals(t, out[2], "bob")
-	assert.Equals(t, out[3], 1234)
-	assert.Equals(t, out[4].(*big.Int).String(), big.NewInt(1234).String())
-	assert.Equals(t, out[5], struct{}{})
+	goassert.Equals(t, out[0], UserData("alice").Redact())
+	goassert.Equals(t, out[1], ptr.Redact())
+	goassert.Equals(t, out[2], "bob")
+	goassert.Equals(t, out[3], 1234)
+	goassert.Equals(t, out[4].(*big.Int).String(), big.NewInt(1234).String())
+	goassert.Equals(t, out[5], struct{}{})
 }
 
 func TestSetRedaction(t *testing.T) {
 	// Hits the default case
 	SetRedaction(-1)
-	assert.Equals(t, RedactUserData, false)
+	goassert.Equals(t, RedactUserData, false)
 
 	SetRedaction(RedactFull)
-	assert.Equals(t, RedactUserData, true)
+	goassert.Equals(t, RedactUserData, true)
 
 	SetRedaction(RedactPartial)
-	assert.Equals(t, RedactUserData, true)
+	goassert.Equals(t, RedactUserData, true)
 
 	SetRedaction(RedactNone)
-	assert.Equals(t, RedactUserData, false)
+	goassert.Equals(t, RedactUserData, false)
 }
 
 func TestRedactionLevelMarshalText(t *testing.T) {
 	var level RedactionLevel
 	level = RedactNone
 	text, err := level.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "none")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, string(text), "none")
 
 	level = RedactPartial
 	text, err = level.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "partial")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, string(text), "partial")
 
 	level = RedactFull
 	text, err = level.MarshalText()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, string(text), "full")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, string(text), "full")
 }
 
 func TestRedactionLevelUnmarshalText(t *testing.T) {
 	var level RedactionLevel
 	err := level.UnmarshalText([]byte("none"))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, level, RedactNone)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, level, RedactNone)
 
 	err = level.UnmarshalText([]byte("partial"))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, level, RedactPartial)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, level, RedactPartial)
 
 	err = level.UnmarshalText([]byte("full"))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, level, RedactFull)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, level, RedactFull)
 
 	err = level.UnmarshalText([]byte("asdf"))
-	assert.Equals(t, err.Error(), "unrecognized redaction level: \"asdf\"")
+	goassert.Equals(t, err.Error(), "unrecognized redaction level: \"asdf\"")
 }
 
 func BenchmarkRedactHelper(b *testing.B) {

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 const (
@@ -19,10 +19,10 @@ func TestUserDataRedact(t *testing.T) {
 	userdata := UserData(username)
 
 	RedactUserData = true
-	assert.Equals(t, userdata.Redact(), userDataPrefix+username+userDataSuffix)
+	goassert.Equals(t, userdata.Redact(), userDataPrefix+username+userDataSuffix)
 
 	RedactUserData = false
-	assert.Equals(t, userdata.Redact(), username)
+	goassert.Equals(t, userdata.Redact(), username)
 }
 
 func TestUD(t *testing.T) {
@@ -31,15 +31,15 @@ func TestUD(t *testing.T) {
 
 	// Straight-forward string test.
 	ud := UD("hello world")
-	assert.Equals(t, ud.Redact(), userDataPrefix+"hello world"+userDataSuffix)
+	goassert.Equals(t, ud.Redact(), userDataPrefix+"hello world"+userDataSuffix)
 
 	// big.Int fulfils the Stringer interface, so we should get sensible values.
 	ud = UD(big.NewInt(1234))
-	assert.Equals(t, ud.Redact(), userDataPrefix+"1234"+userDataSuffix)
+	goassert.Equals(t, ud.Redact(), userDataPrefix+"1234"+userDataSuffix)
 
 	// Even plain structs could be redactable.
 	ud = UD(struct{}{})
-	assert.Equals(t, ud.Redact(), userDataPrefix+"{}"+userDataSuffix)
+	goassert.Equals(t, ud.Redact(), userDataPrefix+"{}"+userDataSuffix)
 }
 
 func BenchmarkUserDataRedact(b *testing.B) {

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -4,39 +4,39 @@ import (
 	"net/http"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	sgreplicate "github.com/couchbaselabs/sg-replicate"
 )
 
 func TestReplicator(t *testing.T) {
 	r := NewReplicator()
-	assert.Equals(t, len(r.ActiveTasks()), 0)
+	goassert.Equals(t, len(r.ActiveTasks()), 0)
 
 	params := sgreplicate.ReplicationParameters{
 		SourceDb:  "db1",
 		Lifecycle: sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(r.ActiveTasks()), 1)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(r.ActiveTasks()), 1)
 
 	params = sgreplicate.ReplicationParameters{
 		ReplicationId: "rep1",
 		Lifecycle:     sgreplicate.CONTINUOUS,
 	}
 	_, err = r.Replicate(params, false)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(r.ActiveTasks()), 2)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(r.ActiveTasks()), 2)
 
 	// now stop it
 	_, err = r.Replicate(params, true)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(r.ActiveTasks()), 1)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(r.ActiveTasks()), 1)
 
 	// stop all
 	err = r.StopReplications()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(r.ActiveTasks()), 0)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(r.ActiveTasks()), 0)
 }
 
 func TestReplicatorDuplicateID(t *testing.T) {
@@ -47,7 +47,7 @@ func TestReplicatorDuplicateID(t *testing.T) {
 		Lifecycle:     sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Should get an error because ReplicationIDs are identical.
 	_, err = r.Replicate(params, false)
@@ -62,7 +62,7 @@ func TestReplicatorDuplicateParams(t *testing.T) {
 		Lifecycle: sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Should get an error even if ReplicationIDs are different,
 	// as they both share the same parameters.
@@ -72,8 +72,8 @@ func TestReplicatorDuplicateParams(t *testing.T) {
 
 func assertHTTPError(t *testing.T, err error, status int) {
 	if httpErr, ok := err.(*HTTPError); !ok {
-		assert.Errorf(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
+		goassert.Errorf(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
 	} else {
-		assert.Equals(t, httpErr.Status, status)
+		goassert.Equals(t, httpErr.Status, status)
 	}
 }

--- a/base/rlimit_test.go
+++ b/base/rlimit_test.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestGetSoftFDLimitWithCurrent(t *testing.T) {
@@ -24,7 +24,7 @@ func TestGetSoftFDLimitWithCurrent(t *testing.T) {
 		requestedSoftFDLimit,
 		limit,
 	)
-	assert.False(t, requiresUpdate)
+	goassert.False(t, requiresUpdate)
 
 	limit.Cur = uint64(512)
 
@@ -32,7 +32,7 @@ func TestGetSoftFDLimitWithCurrent(t *testing.T) {
 		requestedSoftFDLimit,
 		limit,
 	)
-	assert.True(t, requiresUpdate)
-	assert.Equals(t, softFDLimit, requestedSoftFDLimit)
+	goassert.True(t, requiresUpdate)
+	goassert.Equals(t, softFDLimit, requestedSoftFDLimit)
 
 }

--- a/base/set_test.go
+++ b/base/set_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
-	"runtime/debug"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetFromArray(t *testing.T) {
@@ -74,17 +74,17 @@ func TestSetMarshal(t *testing.T) {
 		Channels Set
 	}
 	bytes, err := json.Marshal(str)
-	assertNoError(t, err, "Marshal")
+	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = SetOf()
 	bytes, err = json.Marshal(str)
-	assertNoError(t, err, "Marshal")
+	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":[]}`)
 
 	str.Channels = SetOf("a", "b")
 	bytes, err = json.Marshal(str)
-	assertNoError(t, err, "Marshal")
+	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":["a","b"]}`)
 }
 
@@ -93,31 +93,15 @@ func TestSetUnmarshal(t *testing.T) {
 		Channels Set
 	}
 	err := json.Unmarshal([]byte(`{"channels":null}`), &str)
-	assertNoError(t, err, "Unmarshal")
+	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels, Set(nil))
 
 	err = json.Unmarshal([]byte(`{"channels":[]}`), &str)
-	assertNoError(t, err, "Unmarshal")
+	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels, SetOf())
 
 	err = json.Unmarshal([]byte(`{"channels":["foo"]}`), &str)
-	assertNoError(t, err, "Unmarshal")
+	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels.ToArray(), []string{"foo"})
 
-}
-
-//////// HELPERS:
-
-func assertNoError(t *testing.T, err error, message string) {
-	if err != nil {
-		debug.PrintStack()
-		t.Fatalf("%s: %v", message, err)
-	}
-}
-
-func assertTrue(t *testing.T, success bool, message string) {
-	if !success {
-		debug.PrintStack()
-		t.Fatalf("%s", message)
-	}
 }

--- a/base/set_test.go
+++ b/base/set_test.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"runtime/debug"
 )
 
@@ -28,32 +28,32 @@ func TestSetFromArray(t *testing.T) {
 	}
 	for _, cas := range cases {
 		channels := SetFromArray(cas[0])
-		assert.DeepEquals(t, channels, SetOf(cas[1]...))
+		goassert.DeepEquals(t, channels, SetOf(cas[1]...))
 	}
 }
 
 func TestSet(t *testing.T) {
 	set := SetFromArray(nil)
-	assert.Equals(t, len(set), 0)
-	assert.DeepEquals(t, set.ToArray(), []string{})
+	goassert.Equals(t, len(set), 0)
+	goassert.DeepEquals(t, set.ToArray(), []string{})
 
 	set = SetFromArray([]string{})
-	assert.Equals(t, len(set), 0)
+	goassert.Equals(t, len(set), 0)
 
 	set = SetFromArray([]string{"foo"})
-	assert.Equals(t, len(set), 1)
-	assert.True(t, set.Contains("foo"))
-	assert.False(t, set.Contains("bar"))
+	goassert.Equals(t, len(set), 1)
+	goassert.True(t, set.Contains("foo"))
+	goassert.False(t, set.Contains("bar"))
 
 	values := []string{"bar", "foo", "zog"}
 	set = SetFromArray(values)
-	assert.Equals(t, len(set), 3)
+	goassert.Equals(t, len(set), 3)
 	asArray := set.ToArray()
 	sort.Strings(asArray)
-	assert.DeepEquals(t, asArray, values)
+	goassert.DeepEquals(t, asArray, values)
 
 	set2 := set.copy()
-	assert.DeepEquals(t, set2, set)
+	goassert.DeepEquals(t, set2, set)
 }
 
 func TestUnion(t *testing.T) {
@@ -61,12 +61,12 @@ func TestUnion(t *testing.T) {
 	empty := Set{}
 	set1 := SetOf("foo", "bar", "baz")
 	set2 := SetOf("bar", "block", "deny")
-	assert.DeepEquals(t, set1.Union(empty), set1)
-	assert.DeepEquals(t, empty.Union(set1), set1)
-	assert.DeepEquals(t, set1.Union(nilSet), set1)
-	assert.DeepEquals(t, nilSet.Union(set1), set1)
-	assert.DeepEquals(t, nilSet.Union(nilSet), nilSet)
-	assert.Equals(t, set1.Union(set2).String(), "{bar, baz, block, deny, foo}")
+	goassert.DeepEquals(t, set1.Union(empty), set1)
+	goassert.DeepEquals(t, empty.Union(set1), set1)
+	goassert.DeepEquals(t, set1.Union(nilSet), set1)
+	goassert.DeepEquals(t, nilSet.Union(set1), set1)
+	goassert.DeepEquals(t, nilSet.Union(nilSet), nilSet)
+	goassert.Equals(t, set1.Union(set2).String(), "{bar, baz, block, deny, foo}")
 }
 
 func TestSetMarshal(t *testing.T) {
@@ -75,17 +75,17 @@ func TestSetMarshal(t *testing.T) {
 	}
 	bytes, err := json.Marshal(str)
 	assertNoError(t, err, "Marshal")
-	assert.Equals(t, string(bytes), `{"Channels":null}`)
+	goassert.Equals(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = SetOf()
 	bytes, err = json.Marshal(str)
 	assertNoError(t, err, "Marshal")
-	assert.Equals(t, string(bytes), `{"Channels":[]}`)
+	goassert.Equals(t, string(bytes), `{"Channels":[]}`)
 
 	str.Channels = SetOf("a", "b")
 	bytes, err = json.Marshal(str)
 	assertNoError(t, err, "Marshal")
-	assert.Equals(t, string(bytes), `{"Channels":["a","b"]}`)
+	goassert.Equals(t, string(bytes), `{"Channels":["a","b"]}`)
 }
 
 func TestSetUnmarshal(t *testing.T) {
@@ -94,15 +94,15 @@ func TestSetUnmarshal(t *testing.T) {
 	}
 	err := json.Unmarshal([]byte(`{"channels":null}`), &str)
 	assertNoError(t, err, "Unmarshal")
-	assert.DeepEquals(t, str.Channels, Set(nil))
+	goassert.DeepEquals(t, str.Channels, Set(nil))
 
 	err = json.Unmarshal([]byte(`{"channels":[]}`), &str)
 	assertNoError(t, err, "Unmarshal")
-	assert.DeepEquals(t, str.Channels, SetOf())
+	goassert.DeepEquals(t, str.Channels, SetOf())
 
 	err = json.Unmarshal([]byte(`{"channels":["foo"]}`), &str)
 	assertNoError(t, err, "Unmarshal")
-	assert.DeepEquals(t, str.Channels.ToArray(), []string{"foo"})
+	goassert.DeepEquals(t, str.Channels.ToArray(), []string{"foo"})
 
 }
 

--- a/base/sharded_sequence_clock_test.go
+++ b/base/sharded_sequence_clock_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var numShards = uint16(64)
@@ -72,7 +73,7 @@ func TestShardedSequenceClockCasError(t *testing.T) {
 
 	updateClock2 := NewSequenceClockImpl()
 	updateClock2.SetSequence(51, 101)
-	assertNoError(t, shardedClock2.UpdateAndWrite(updateClock2.ValueAsMap()), "Second update failed")
+	assert.NoError(t, shardedClock2.UpdateAndWrite(updateClock2.ValueAsMap()), "Second update failed")
 
 	// Validate sequence
 	postUpdateClock := shardedClock2.AsClock()
@@ -92,7 +93,7 @@ func TestShardedSequenceClockCasError(t *testing.T) {
 	// Check the partition contents directly from the bucket
 	key := "_idx_c:myClock:clock-3"
 	bytes, _, err := bucket.GetRaw(key)
-	assertTrue(t, err == nil, fmt.Sprintf("Error retrieving partition from bucket:%v", err))
+	assert.True(t, err == nil, fmt.Sprintf("Error retrieving partition from bucket:%v", err))
 
 	partition := NewShardedClockPartitionForBytes(key, bytes, indexPartitions)
 	goassert.Equals(t, partition.GetSequence(50), uint64(100))

--- a/base/sharded_sequence_clock_test.go
+++ b/base/sharded_sequence_clock_test.go
@@ -8,7 +8,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 var numShards = uint16(64)
@@ -48,7 +48,7 @@ func TestShardedSequenceClock(t *testing.T) {
 
 	// Validate sequence
 	postUpdateClock := shardedClock.AsClock()
-	assert.Equals(t, postUpdateClock.GetSequence(50), uint64(100))
+	goassert.Equals(t, postUpdateClock.GetSequence(50), uint64(100))
 
 	bucket.Dump()
 
@@ -76,8 +76,8 @@ func TestShardedSequenceClockCasError(t *testing.T) {
 
 	// Validate sequence
 	postUpdateClock := shardedClock2.AsClock()
-	assert.Equals(t, postUpdateClock.GetSequence(50), uint64(100))
-	assert.Equals(t, postUpdateClock.GetSequence(51), uint64(101))
+	goassert.Equals(t, postUpdateClock.GetSequence(50), uint64(100))
+	goassert.Equals(t, postUpdateClock.GetSequence(51), uint64(101))
 
 	// Apply a second uipdate using the first sharded clock (which should now have invalid cas value for the partition)
 	updateClock3 := NewSequenceClockImpl()
@@ -85,8 +85,8 @@ func TestShardedSequenceClockCasError(t *testing.T) {
 	shardedClock1.UpdateAndWrite(updateClock3.ValueAsMap())
 	// Validate sequence
 	postUpdateClock = shardedClock1.AsClock()
-	assert.Equals(t, postUpdateClock.GetSequence(50), uint64(100))
-	assert.Equals(t, postUpdateClock.GetSequence(51), uint64(102))
+	goassert.Equals(t, postUpdateClock.GetSequence(50), uint64(100))
+	goassert.Equals(t, postUpdateClock.GetSequence(51), uint64(102))
 	bucket.Dump()
 
 	// Check the partition contents directly from the bucket
@@ -95,8 +95,8 @@ func TestShardedSequenceClockCasError(t *testing.T) {
 	assertTrue(t, err == nil, fmt.Sprintf("Error retrieving partition from bucket:%v", err))
 
 	partition := NewShardedClockPartitionForBytes(key, bytes, indexPartitions)
-	assert.Equals(t, partition.GetSequence(50), uint64(100))
-	assert.Equals(t, partition.GetSequence(51), uint64(102))
+	goassert.Equals(t, partition.GetSequence(50), uint64(100))
+	goassert.Equals(t, partition.GetSequence(51), uint64(102))
 }
 
 func TestShardedClockSizes(t *testing.T) {
@@ -148,8 +148,8 @@ func TestShardedClockPartitionBasic(t *testing.T) {
 	p := NewShardedClockPartition("testKey", 5, vbNos)
 	p.SetSequence(vbNos[0], 50)
 
-	assert.Equals(t, p.GetSequence(vbNos[0]), uint64(50))
-	assert.Equals(t, p.GetIndex(), uint16(5))
+	goassert.Equals(t, p.GetSequence(vbNos[0]), uint64(50))
+	goassert.Equals(t, p.GetIndex(), uint16(5))
 
 	clock := NewSequenceClockImpl()
 	p.AddToClock(clock)
@@ -169,7 +169,7 @@ func TestShardedClockPartitionResize(t *testing.T) {
 
 	// validate initial retrieval
 	for i := 0; i < 15; i++ {
-		assert.Equals(t, p.GetSequence(vbNos[i]), uint64(i*1000))
+		goassert.Equals(t, p.GetSequence(vbNos[i]), uint64(i*1000))
 	}
 
 	// Set a odd vbnos to higher values, but less than MaxUint32 (4294967295)
@@ -177,20 +177,20 @@ func TestShardedClockPartitionResize(t *testing.T) {
 		p.SetSequence(vbNos[2*i], uint64(2*i*10000000))
 	}
 
-	assert.Equals(t, p.GetSeqSize(), uint8(2))
+	goassert.Equals(t, p.GetSeqSize(), uint8(2))
 	// validate retrieval
 	for i := 0; i < 7; i++ {
-		assert.Equals(t, p.GetSequence(vbNos[2*i]), uint64(2*i*10000000))
-		assert.Equals(t, p.GetSequence(vbNos[2*i+1]), uint64((2*i+1)*1000))
+		goassert.Equals(t, p.GetSequence(vbNos[2*i]), uint64(2*i*10000000))
+		goassert.Equals(t, p.GetSequence(vbNos[2*i+1]), uint64((2*i+1)*1000))
 	}
 
 	// one more resize
 	p.SetSequence(vbNos[6], 6000000000)
-	assert.Equals(t, p.GetSeqSize(), uint8(3))
+	goassert.Equals(t, p.GetSeqSize(), uint8(3))
 	log.Printf("vbNos[4]:%d", p.GetSequence(vbNos[4]))
-	assert.Equals(t, p.GetSequence(vbNos[4]), uint64(40000000))
-	assert.Equals(t, p.GetSequence(vbNos[5]), uint64(5000))
-	assert.Equals(t, p.GetSequence(vbNos[6]), uint64(6000000000))
+	goassert.Equals(t, p.GetSequence(vbNos[4]), uint64(40000000))
+	goassert.Equals(t, p.GetSequence(vbNos[5]), uint64(5000))
+	goassert.Equals(t, p.GetSequence(vbNos[6]), uint64(6000000000))
 
 }
 
@@ -207,7 +207,7 @@ func TestShardedClockPartitionResizeLarge(t *testing.T) {
 
 	// validate initial retrieval
 	for i := 0; i < 15; i++ {
-		assert.Equals(t, p.GetSequence(vbNos[i]), uint64(i*1000))
+		goassert.Equals(t, p.GetSequence(vbNos[i]), uint64(i*1000))
 	}
 
 	// Set a odd vbnos to higher values, greater than MaxUint32 (4294967295)
@@ -215,11 +215,11 @@ func TestShardedClockPartitionResizeLarge(t *testing.T) {
 		p.SetSequence(vbNos[2*i], uint64(i*100000000000000))
 	}
 
-	assert.Equals(t, p.GetSeqSize(), uint8(4))
+	goassert.Equals(t, p.GetSeqSize(), uint8(4))
 	// validate retrieval
 	for i := 0; i < 7; i++ {
-		assert.Equals(t, p.GetSequence(vbNos[2*i]), uint64(i*100000000000000))
-		assert.Equals(t, p.GetSequence(vbNos[2*i+1]), uint64((2*i+1)*1000))
+		goassert.Equals(t, p.GetSequence(vbNos[2*i]), uint64(i*100000000000000))
+		goassert.Equals(t, p.GetSequence(vbNos[2*i+1]), uint64((2*i+1)*1000))
 	}
 
 }
@@ -396,18 +396,18 @@ func (scp *GobShardedClockPartition) AddToClock(clock SequenceClock) error {
 func TestCompareVbAndSequence(t *testing.T) {
 
 	// Vb and Seq equal
-	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 100), CompareEquals)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 10, 100), CompareEquals)
 
 	// Vb equal
-	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 101), CompareLessThan)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 10, 99), CompareGreaterThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 10, 101), CompareLessThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 10, 99), CompareGreaterThan)
 
 	// Vb different
-	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 100), CompareLessThan)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 99), CompareLessThan)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 11, 101), CompareLessThan)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 100), CompareGreaterThan)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 99), CompareGreaterThan)
-	assert.Equals(t, CompareVbAndSequence(10, 100, 9, 101), CompareGreaterThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 11, 100), CompareLessThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 11, 99), CompareLessThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 11, 101), CompareLessThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 9, 100), CompareGreaterThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 9, 99), CompareGreaterThan)
+	goassert.Equals(t, CompareVbAndSequence(10, 100, 9, 101), CompareGreaterThan)
 
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
@@ -243,7 +244,7 @@ func TestHighSeqNosToSequenceClock(t *testing.T) {
 
 	seqClock, err = HighSeqNosToSequenceClock(highSeqs)
 
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 
 	goassert.True(t, seqClock.GetSequence(0) == 568)
 	goassert.True(t, seqClock.GetSequence(1) == 98798)
@@ -282,7 +283,7 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 
 	for _, inputAndExpected := range inputsAndExpected {
 		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input)
-		assertNoError(t, err, "Unexpected error")
+		assert.NoError(t, err, "Unexpected error")
 		goassert.DeepEquals(t, actual, inputAndExpected.expected)
 	}
 
@@ -334,20 +335,20 @@ func TestReflectExpiry(t *testing.T) {
 func TestIsMinimumVersion(t *testing.T) {
 
 	// Expected true
-	assertTrue(t, isMinimumVersion(1, 0, 0, 0), "Invalid minimum version check - expected true")
-	assertTrue(t, isMinimumVersion(1, 0, 1, 0), "Invalid minimum version check - expected true")
-	assertTrue(t, isMinimumVersion(2, 5, 2, 5), "Invalid minimum version check - expected true")
-	assertTrue(t, isMinimumVersion(3, 0, 2, 5), "Invalid minimum version check - expected true")
-	assertTrue(t, isMinimumVersion(3, 5, 3, 4), "Invalid minimum version check - expected true")
-	assertTrue(t, isMinimumVersion(5, 5, 4, 4), "Invalid minimum version check - expected true")
-	assertTrue(t, isMinimumVersion(0, 0, 0, 0), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(1, 0, 0, 0), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(1, 0, 1, 0), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(2, 5, 2, 5), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(3, 0, 2, 5), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(3, 5, 3, 4), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(5, 5, 4, 4), "Invalid minimum version check - expected true")
+	assert.True(t, isMinimumVersion(0, 0, 0, 0), "Invalid minimum version check - expected true")
 
 	// Expected false
-	assertTrue(t, !isMinimumVersion(0, 0, 1, 0), "Invalid minimum version check - expected false")
-	assertTrue(t, !isMinimumVersion(5, 0, 6, 0), "Invalid minimum version check - expected false")
-	assertTrue(t, !isMinimumVersion(4, 5, 5, 0), "Invalid minimum version check - expected false")
-	assertTrue(t, !isMinimumVersion(5, 0, 5, 1), "Invalid minimum version check - expected false")
-	assertTrue(t, !isMinimumVersion(0, 0, 1, 0), "Invalid minimum version check - expected false")
+	assert.True(t, !isMinimumVersion(0, 0, 1, 0), "Invalid minimum version check - expected false")
+	assert.True(t, !isMinimumVersion(5, 0, 6, 0), "Invalid minimum version check - expected false")
+	assert.True(t, !isMinimumVersion(4, 5, 5, 0), "Invalid minimum version check - expected false")
+	assert.True(t, !isMinimumVersion(5, 0, 5, 1), "Invalid minimum version check - expected false")
+	assert.True(t, !isMinimumVersion(0, 0, 1, 0), "Invalid minimum version check - expected false")
 }
 
 func TestSanitizeRequestURL(t *testing.T) {
@@ -389,7 +390,7 @@ func TestSanitizeRequestURL(t *testing.T) {
 
 	for _, test := range tests {
 		req, err := http.NewRequest(http.MethodGet, test.input, nil)
-		assertNoError(t, err, "Unable to create request")
+		assert.NoError(t, err, "Unable to create request")
 		sanitizedURL := SanitizeRequestURL(req, nil)
 		goassert.Equals(t, sanitizedURL, test.output)
 	}
@@ -448,7 +449,7 @@ func TestSanitizeRequestURLRedaction(t *testing.T) {
 
 	for _, test := range tests {
 		req, err := http.NewRequest(http.MethodGet, test.input, nil)
-		assertNoError(t, err, "Unable to create request")
+		assert.NoError(t, err, "Unable to create request")
 
 		SetRedaction(RedactNone)
 		sanitizedURL := SanitizeRequestURL(req, nil)
@@ -609,7 +610,7 @@ func TestSetUpTestLogging(t *testing.T) {
 
 	// Now we should panic because we forgot to call teardown!
 	defer func() {
-		assertTrue(t, recover() != nil, "Expected panic from multiple SetUpTestLogging calls")
+		assert.True(t, recover() != nil, "Expected panic from multiple SetUpTestLogging calls")
 	}()
 	SetUpTestLogging(LevelError, KeyAuth|KeyCRUD)
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -19,56 +19,56 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestFixJSONNumbers(t *testing.T) {
-	assert.DeepEquals(t, FixJSONNumbers(1), 1)
-	assert.DeepEquals(t, FixJSONNumbers(float64(1.23)), float64(1.23))
-	assert.DeepEquals(t, FixJSONNumbers(float64(123456)), int64(123456))
-	assert.DeepEquals(t, FixJSONNumbers(float64(123456789)), int64(123456789))
-	assert.DeepEquals(t, FixJSONNumbers(float64(12345678901234567890)),
+	goassert.DeepEquals(t, FixJSONNumbers(1), 1)
+	goassert.DeepEquals(t, FixJSONNumbers(float64(1.23)), float64(1.23))
+	goassert.DeepEquals(t, FixJSONNumbers(float64(123456)), int64(123456))
+	goassert.DeepEquals(t, FixJSONNumbers(float64(123456789)), int64(123456789))
+	goassert.DeepEquals(t, FixJSONNumbers(float64(12345678901234567890)),
 		float64(12345678901234567890))
-	assert.DeepEquals(t, FixJSONNumbers("foo"), "foo")
-	assert.DeepEquals(t, FixJSONNumbers([]interface{}{1, float64(123456)}),
+	goassert.DeepEquals(t, FixJSONNumbers("foo"), "foo")
+	goassert.DeepEquals(t, FixJSONNumbers([]interface{}{1, float64(123456)}),
 		[]interface{}{1, int64(123456)})
-	assert.DeepEquals(t, FixJSONNumbers(map[string]interface{}{"foo": float64(123456)}),
+	goassert.DeepEquals(t, FixJSONNumbers(map[string]interface{}{"foo": float64(123456)}),
 		map[string]interface{}{"foo": int64(123456)})
 }
 
 func TestConvertJSONString(t *testing.T) {
-	assert.Equals(t, ConvertJSONString(`"blah"`), "blah")
-	assert.Equals(t, ConvertJSONString("blah"), "blah")
+	goassert.Equals(t, ConvertJSONString(`"blah"`), "blah")
+	goassert.Equals(t, ConvertJSONString("blah"), "blah")
 }
 
 func TestBackQuotedStrings(t *testing.T) {
 	input := `{"foo": "bar"}`
 	output := ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), input)
+	goassert.Equals(t, string(output), input)
 
 	input = "{\"foo\": `bar`}"
 	output = ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), `{"foo": "bar"}`)
+	goassert.Equals(t, string(output), `{"foo": "bar"}`)
 
 	input = "{\"foo\": `bar\nbaz\nboo`}"
 	output = ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), `{"foo": "bar\nbaz\nboo"}`)
+	goassert.Equals(t, string(output), `{"foo": "bar\nbaz\nboo"}`)
 
 	input = "{\"foo\": `bar\n\"baz\n\tboo`}"
 	output = ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), `{"foo": "bar\n\"baz\n\tboo"}`)
+	goassert.Equals(t, string(output), `{"foo": "bar\n\"baz\n\tboo"}`)
 
 	input = "{\"foo\": `bar\n`, \"baz\": `howdy`}"
 	output = ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), `{"foo": "bar\n", "baz": "howdy"}`)
+	goassert.Equals(t, string(output), `{"foo": "bar\n", "baz": "howdy"}`)
 
 	input = "{\"foo\": `bar\r\n`, \"baz\": `\r\nhowdy`}"
 	output = ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), `{"foo": "bar\n", "baz": "\nhowdy"}`)
+	goassert.Equals(t, string(output), `{"foo": "bar\n", "baz": "\nhowdy"}`)
 
 	input = "{\"foo\": `bar\\baz`, \"something\": `else\\is\\here`}"
 	output = ConvertBackQuotedStrings([]byte(input))
-	assert.Equals(t, string(output), `{"foo": "bar\\baz", "something": "else\\is\\here"}`)
+	goassert.Equals(t, string(output), `{"foo": "bar\\baz", "something": "else\\is\\here"}`)
 }
 
 func TestCouchbaseUrlWithAuth(t *testing.T) {
@@ -80,8 +80,8 @@ func TestCouchbaseUrlWithAuth(t *testing.T) {
 		"password",
 		"bucket",
 	)
-	assert.True(t, err == nil)
-	assert.Equals(t, result, "http://username:password@127.0.0.1:8091")
+	goassert.True(t, err == nil)
+	goassert.Equals(t, result, "http://username:password@127.0.0.1:8091")
 
 	// default bucket
 	result, err = CouchbaseUrlWithAuth(
@@ -90,8 +90,8 @@ func TestCouchbaseUrlWithAuth(t *testing.T) {
 		"",
 		"default",
 	)
-	assert.True(t, err == nil)
-	assert.Equals(t, result, "http://127.0.0.1:8091")
+	goassert.True(t, err == nil)
+	goassert.Equals(t, result, "http://127.0.0.1:8091")
 
 }
 
@@ -102,15 +102,15 @@ func TestCreateDoublingSleeperFunc(t *testing.T) {
 	sleeper := CreateDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs)
 
 	shouldContinue, timeTosleepMs := sleeper(1)
-	assert.True(t, shouldContinue)
-	assert.Equals(t, timeTosleepMs, initialTimeToSleepMs)
+	goassert.True(t, shouldContinue)
+	goassert.Equals(t, timeTosleepMs, initialTimeToSleepMs)
 
 	shouldContinue, timeTosleepMs = sleeper(2)
-	assert.True(t, shouldContinue)
-	assert.Equals(t, timeTosleepMs, initialTimeToSleepMs*2)
+	goassert.True(t, shouldContinue)
+	goassert.Equals(t, timeTosleepMs, initialTimeToSleepMs*2)
 
 	shouldContinue, _ = sleeper(3)
-	assert.False(t, shouldContinue)
+	goassert.False(t, shouldContinue)
 
 }
 
@@ -141,9 +141,9 @@ func TestRetryLoop(t *testing.T) {
 	err, result := RetryLoop(description, worker, sleeper)
 
 	// We shouldn't get an error, because it will retry a few times and then succeed
-	assert.True(t, err == nil)
-	assert.Equals(t, result, "result")
-	assert.True(t, numTimesInvoked == 4)
+	goassert.True(t, err == nil)
+	goassert.Equals(t, result, "result")
+	goassert.True(t, numTimesInvoked == 4)
 
 }
 
@@ -173,9 +173,9 @@ func TestRetryLoopTimeoutSafe(t *testing.T) {
 	err, result := RetryLoopTimeout(description, worker, sleeper, time.Hour)
 
 	// We shouldn't get an error, because it will retry a few times and then succeed
-	assert.True(t, err == nil)
-	assert.Equals(t, result, "result")
-	assert.True(t, numTimesInvoked == 4)
+	goassert.True(t, err == nil)
+	goassert.Equals(t, result, "result")
+	goassert.True(t, numTimesInvoked == 4)
 
 }
 
@@ -195,37 +195,37 @@ func TestRetryLoopTimeoutEffective(t *testing.T) {
 	err, _ := RetryLoopTimeout(description, worker, sleeper, time.Millisecond*100)
 
 	// We should get a timeout error
-	assert.True(t, err != nil)
-	assert.True(t, strings.Contains(err.Error(), "timeout"))
+	goassert.True(t, err != nil)
+	goassert.True(t, strings.Contains(err.Error(), "timeout"))
 
 }
 
 func TestSyncSourceFromURL(t *testing.T) {
 	u, err := url.Parse("http://www.test.com:4985/mydb")
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	result := SyncSourceFromURL(u)
-	assert.Equals(t, result, "http://www.test.com:4985")
+	goassert.Equals(t, result, "http://www.test.com:4985")
 
 	u, err = url.Parse("http://www.test.com:4984/mydb/some otherinvalidpath?query=yes#fragment")
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	result = SyncSourceFromURL(u)
-	assert.Equals(t, result, "http://www.test.com:4984")
+	goassert.Equals(t, result, "http://www.test.com:4984")
 
 	u, err = url.Parse("MyDB")
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	result = SyncSourceFromURL(u)
-	assert.Equals(t, result, "")
+	goassert.Equals(t, result, "")
 }
 
 func TestValueToStringArray(t *testing.T) {
 	result := ValueToStringArray("foobar")
-	assert.DeepEquals(t, result, []string{"foobar"})
+	goassert.DeepEquals(t, result, []string{"foobar"})
 
 	result = ValueToStringArray([]string{"foobar", "moocar"})
-	assert.DeepEquals(t, result, []string{"foobar", "moocar"})
+	goassert.DeepEquals(t, result, []string{"foobar", "moocar"})
 
 	result = ValueToStringArray([]interface{}{"foobar", 1, true})
-	assert.DeepEquals(t, result, []string{"foobar"})
+	goassert.DeepEquals(t, result, []string{"foobar"})
 }
 
 func TestHighSeqNosToSequenceClock(t *testing.T) {
@@ -245,11 +245,11 @@ func TestHighSeqNosToSequenceClock(t *testing.T) {
 
 	assertNoError(t, err, "Unexpected error")
 
-	assert.True(t, seqClock.GetSequence(0) == 568)
-	assert.True(t, seqClock.GetSequence(1) == 98798)
-	assert.True(t, seqClock.GetSequence(2) == 100)
-	assert.True(t, seqClock.GetSequence(3) == 2)
-	assert.True(t, seqClock.GetSequence(5) == 250)
+	goassert.True(t, seqClock.GetSequence(0) == 568)
+	goassert.True(t, seqClock.GetSequence(1) == 98798)
+	goassert.True(t, seqClock.GetSequence(2) == 100)
+	goassert.True(t, seqClock.GetSequence(3) == 2)
+	goassert.True(t, seqClock.GetSequence(5) == 250)
 
 }
 
@@ -283,14 +283,14 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 	for _, inputAndExpected := range inputsAndExpected {
 		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input)
 		assertNoError(t, err, "Unexpected error")
-		assert.DeepEquals(t, actual, inputAndExpected.expected)
+		goassert.DeepEquals(t, actual, inputAndExpected.expected)
 	}
 
 	// With a nil (or walrus bucket) and a couchbase or couchbases url, expect errors
 	_, err := CouchbaseURIToHttpURL(nil, "couchbases://host1:18191,host2:18191")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	_, err = CouchbaseURIToHttpURL(nil, "couchbase://host1")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 
 }
 
@@ -298,36 +298,36 @@ func TestReflectExpiry(t *testing.T) {
 	exp := time.Now().Add(time.Hour)
 
 	expiry, err := ReflectExpiry(uint(1234))
-	assert.Equals(t, err.Error(), "Unrecognized expiry format")
-	assert.Equals(t, expiry, (*uint32)(nil))
+	goassert.Equals(t, err.Error(), "Unrecognized expiry format")
+	goassert.Equals(t, expiry, (*uint32)(nil))
 
 	expiry, err = ReflectExpiry(true)
-	assert.Equals(t, err.Error(), "Unrecognized expiry format")
-	assert.Equals(t, expiry, (*uint32)(nil))
+	goassert.Equals(t, err.Error(), "Unrecognized expiry format")
+	goassert.Equals(t, expiry, (*uint32)(nil))
 
 	expiry, err = ReflectExpiry(int64(1234))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, *expiry, uint32(1234))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, *expiry, uint32(1234))
 
 	expiry, err = ReflectExpiry(float64(1234))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, *expiry, uint32(1234))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, *expiry, uint32(1234))
 
 	expiry, err = ReflectExpiry("1234")
-	assert.Equals(t, err, nil)
-	assert.Equals(t, *expiry, uint32(1234))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, *expiry, uint32(1234))
 
 	expiry, err = ReflectExpiry(exp.Format(time.RFC3339))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, *expiry, uint32(exp.Unix()))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, *expiry, uint32(exp.Unix()))
 
 	expiry, err = ReflectExpiry("invalid")
-	assert.Equals(t, err.Error(), `Unable to parse expiry invalid as either numeric or date expiry: parsing time "invalid" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid" as "2006"`)
-	assert.Equals(t, expiry, (*uint32)(nil))
+	goassert.Equals(t, err.Error(), `Unable to parse expiry invalid as either numeric or date expiry: parsing time "invalid" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid" as "2006"`)
+	goassert.Equals(t, expiry, (*uint32)(nil))
 
 	expiry, err = ReflectExpiry(nil)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, expiry, (*uint32)(nil))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, expiry, (*uint32)(nil))
 }
 
 // IsMinimumVersion takes (major, minor, minimumMajor, minimumMinor)
@@ -391,7 +391,7 @@ func TestSanitizeRequestURL(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, test.input, nil)
 		assertNoError(t, err, "Unable to create request")
 		sanitizedURL := SanitizeRequestURL(req, nil)
-		assert.Equals(t, sanitizedURL, test.output)
+		goassert.Equals(t, sanitizedURL, test.output)
 	}
 
 }
@@ -452,11 +452,11 @@ func TestSanitizeRequestURLRedaction(t *testing.T) {
 
 		SetRedaction(RedactNone)
 		sanitizedURL := SanitizeRequestURL(req, nil)
-		assert.Equals(t, sanitizedURL, test.output)
+		goassert.Equals(t, sanitizedURL, test.output)
 
 		SetRedaction(RedactPartial)
 		sanitizedURL = SanitizeRequestURL(req, nil)
-		assert.Equals(t, sanitizedURL, test.outputRedacted)
+		goassert.Equals(t, sanitizedURL, test.outputRedacted)
 	}
 
 }
@@ -469,9 +469,9 @@ func TestFindPrimaryAddr(t *testing.T) {
 		t.Skipf("WARNING: network is unreachable: %s", err)
 	}
 
-	assert.NotEquals(t, ip, nil)
-	assert.NotEquals(t, ip.String(), "")
-	assert.NotEquals(t, ip.String(), "<nil>")
+	goassert.NotEquals(t, ip, nil)
+	goassert.NotEquals(t, ip.String(), "")
+	goassert.NotEquals(t, ip.String(), "<nil>")
 }
 
 func TestReplaceAll(t *testing.T) {
@@ -490,7 +490,7 @@ func TestReplaceAll(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.chars, func(ts *testing.T) {
 			output := ReplaceAll(test.input, test.chars, test.new)
-			assert.Equals(ts, output, test.expected)
+			goassert.Equals(ts, output, test.expected)
 		})
 	}
 }
@@ -578,34 +578,34 @@ func TestRedactBasicAuthURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equals(t, RedactBasicAuthURL(test.input), test.expected)
+		goassert.Equals(t, RedactBasicAuthURL(test.input), test.expected)
 	}
 }
 
 func TestSetUpTestLogging(t *testing.T) {
 	// Check default state of logging is as expected.
-	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
-	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+	goassert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
+	goassert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
 
 	teardownFn := SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
-	assert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
-	assert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
+	goassert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
+	goassert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
 
 	teardownFn()
-	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
-	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+	goassert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
+	goassert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
 
 	teardownFn = DisableTestLogging()
-	assert.Equals(t, *consoleLogger.LogLevel, LevelNone)
-	assert.Equals(t, *consoleLogger.LogKey, KeyNone)
+	goassert.Equals(t, *consoleLogger.LogLevel, LevelNone)
+	goassert.Equals(t, *consoleLogger.LogKey, KeyNone)
 
 	teardownFn()
-	assert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
-	assert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+	goassert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
+	goassert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
 
 	SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
-	assert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
-	assert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
+	goassert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
+	goassert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
 
 	// Now we should panic because we forgot to call teardown!
 	defer func() {

--- a/channels/change_log_test.go
+++ b/channels/change_log_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func e(seq uint64, docid string, revid string) *LogEntry {
@@ -21,38 +21,38 @@ func mklog(since uint64, entries ...*LogEntry) ChangeLog {
 
 func TestEmptyLog(t *testing.T) {
 	var cl ChangeLog
-	assert.Equals(t, len(cl.EntriesAfter(1234)), 0)
+	goassert.Equals(t, len(cl.EntriesAfter(1234)), 0)
 
 	cl.Add(*e(1, "foo", "1-a"))
-	assert.Equals(t, cl.Since, uint64(0))
-	assert.DeepEquals(t, cl.EntriesAfter(0), []*LogEntry{e(1, "foo", "1-a")})
-	assert.DeepEquals(t, cl.EntriesAfter(1), []*LogEntry{})
+	goassert.Equals(t, cl.Since, uint64(0))
+	goassert.DeepEquals(t, cl.EntriesAfter(0), []*LogEntry{e(1, "foo", "1-a")})
+	goassert.DeepEquals(t, cl.EntriesAfter(1), []*LogEntry{})
 }
 
 func TestAddInOrder(t *testing.T) {
 	var cl ChangeLog
 	cl.Add(*e(1, "foo", "1-a"))
 	cl.Add(*e(2, "bar", "1-a"))
-	assert.DeepEquals(t, cl.EntriesAfter(0), []*LogEntry{e(1, "foo", "1-a"), e(2, "bar", "1-a")})
-	assert.DeepEquals(t, cl.EntriesAfter(1), []*LogEntry{e(2, "bar", "1-a")})
-	assert.DeepEquals(t, cl.EntriesAfter(2), []*LogEntry{})
+	goassert.DeepEquals(t, cl.EntriesAfter(0), []*LogEntry{e(1, "foo", "1-a"), e(2, "bar", "1-a")})
+	goassert.DeepEquals(t, cl.EntriesAfter(1), []*LogEntry{e(2, "bar", "1-a")})
+	goassert.DeepEquals(t, cl.EntriesAfter(2), []*LogEntry{})
 	cl.Add(*e(3, "zog", "1-a"))
-	assert.DeepEquals(t, cl.EntriesAfter(2), []*LogEntry{e(3, "zog", "1-a")})
-	assert.DeepEquals(t, cl, mklog(0, e(1, "foo", "1-a"), e(2, "bar", "1-a"), e(3, "zog", "1-a")))
+	goassert.DeepEquals(t, cl.EntriesAfter(2), []*LogEntry{e(3, "zog", "1-a")})
+	goassert.DeepEquals(t, cl, mklog(0, e(1, "foo", "1-a"), e(2, "bar", "1-a"), e(3, "zog", "1-a")))
 }
 
 func TestAddOutOfOrder(t *testing.T) {
 	var cl ChangeLog
 	cl.Add(*e(20, "bar", "1-a"))
 	cl.Add(*e(10, "foo", "1-a"))
-	assert.Equals(t, cl.Since, uint64(19))
-	assert.DeepEquals(t, cl.EntriesAfter(0), []*LogEntry(nil))
-	assert.DeepEquals(t, cl.EntriesAfter(20), []*LogEntry{e(10, "foo", "1-a")})
-	assert.DeepEquals(t, cl.EntriesAfter(10), []*LogEntry{})
+	goassert.Equals(t, cl.Since, uint64(19))
+	goassert.DeepEquals(t, cl.EntriesAfter(0), []*LogEntry(nil))
+	goassert.DeepEquals(t, cl.EntriesAfter(20), []*LogEntry{e(10, "foo", "1-a")})
+	goassert.DeepEquals(t, cl.EntriesAfter(10), []*LogEntry{})
 	cl.Add(*e(30, "zog", "1-a"))
-	assert.DeepEquals(t, cl.EntriesAfter(20), []*LogEntry{e(10, "foo", "1-a"), e(30, "zog", "1-a")})
-	assert.DeepEquals(t, cl.EntriesAfter(10), []*LogEntry{e(30, "zog", "1-a")})
-	assert.DeepEquals(t, cl, mklog(19, e(20, "bar", "1-a"), e(10, "foo", "1-a"), e(30, "zog", "1-a")))
+	goassert.DeepEquals(t, cl.EntriesAfter(20), []*LogEntry{e(10, "foo", "1-a"), e(30, "zog", "1-a")})
+	goassert.DeepEquals(t, cl.EntriesAfter(10), []*LogEntry{e(30, "zog", "1-a")})
+	goassert.DeepEquals(t, cl, mklog(19, e(20, "bar", "1-a"), e(10, "foo", "1-a"), e(30, "zog", "1-a")))
 }
 
 func TestTruncate(t *testing.T) {
@@ -62,8 +62,8 @@ func TestTruncate(t *testing.T) {
 		cl.Add(*e(uint64(i), "foo", fmt.Sprintf("%d-x", i)))
 		cl.TruncateTo(maxLogLength)
 	}
-	assert.Equals(t, len(cl.Entries), maxLogLength)
-	assert.Equals(t, int(cl.Since), maxLogLength)
+	goassert.Equals(t, len(cl.Entries), maxLogLength)
+	goassert.Equals(t, int(cl.Since), maxLogLength)
 }
 
 func TestSort(t *testing.T) {
@@ -80,6 +80,6 @@ func TestSort(t *testing.T) {
 
 	expectedSeqs := []uint64{1, 2, 3, 4, 5, 8, 9}
 	for i, entry := range cl.Entries {
-		assert.Equals(t, entry.Sequence, expectedSeqs[i])
+		goassert.Equals(t, entry.Sequence, expectedSeqs[i])
 	}
 }

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/robertkrimen/otto"
 	"github.com/robertkrimen/otto/underscore"
 )
@@ -35,7 +35,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 	// Test for https://github.com/robertkrimen/otto/issues/24
 	value, _ := otto.New().ToValue([]string{"foo", "bar", "baz"})
 	strings := ottoValueToStringArray(value)
-	assert.DeepEquals(t, strings, []string{"foo", "bar", "baz"})
+	goassert.DeepEquals(t, strings, []string{"foo", "bar", "baz"})
 }
 
 // verify that our version of Otto treats JSON parsed arrays like real arrays
@@ -43,7 +43,7 @@ func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, SetOf("abc", "xyz"))
+	goassert.DeepEquals(t, res.Channels, SetOf("abc", "xyz"))
 }
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
@@ -51,7 +51,7 @@ func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, SetOf("foo", "bar", "baz"))
+	goassert.DeepEquals(t, res.Channels, SetOf("foo", "bar", "baz"))
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
@@ -59,7 +59,7 @@ func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{"foo": SetOf("bar", "baz")})
+	goassert.DeepEquals(t, res.Access, AccessMap{"foo": SetOf("bar", "baz")})
 }
 
 // Just verify that the calls to the channel() fn show up in the output channel list.
@@ -67,21 +67,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, SetOf("foo", "bar ok", "baz"))
+	goassert.DeepEquals(t, res.Channels, SetOf("foo", "bar ok", "baz"))
 }
 
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
@@ -89,7 +89,7 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{"bar": SetOf("ginger"), "baz": SetOf("ginger"), "foo": SetOf("ginger")})
+	goassert.DeepEquals(t, res.Access, AccessMap{"bar": SetOf("ginger"), "baz": SetOf("ginger"), "foo": SetOf("ginger")})
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
@@ -97,57 +97,57 @@ func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf("ginger", "earl_grey", "green")})
+	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf("ginger", "earl_grey", "green")})
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access["lee"], SetOf("ginger", "earl_grey", "green"))
-	assert.DeepEquals(t, res.Access["nancy"], SetOf("ginger", "earl_grey", "green"))
+	goassert.DeepEquals(t, res.Access["lee"], SetOf("ginger", "earl_grey", "green"))
+	goassert.DeepEquals(t, res.Access["nancy"], SetOf("ginger", "earl_grey", "green"))
 }
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{})
+	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{})
+	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{})
+	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{})
+	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf("ginger")})
+	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf("ginger")})
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Access, AccessMap{})
+	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 // Just verify that the calls to the role() fn show up in the output. (It shares a common
@@ -156,7 +156,7 @@ func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Roles, AccessMap{"bar": SetOf("froods"), "baz": SetOf("froods"), "foo": SetOf("froods")})
+	goassert.DeepEquals(t, res.Roles, AccessMap{"bar": SetOf("froods"), "baz": SetOf("froods"), "foo": SetOf("froods")})
 }
 
 // Now just make sure the input comes through intact
@@ -164,7 +164,7 @@ func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, SetOf("foo"))
+	goassert.DeepEquals(t, res.Channels, SetOf("foo"))
 }
 
 // A more realistic example
@@ -172,11 +172,11 @@ func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, SetOf("foo", "bar", "baz"))
+	goassert.DeepEquals(t, res.Channels, SetOf("foo", "bar", "baz"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, base.Set{})
+	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
 
 // Empty/no-op channel mapper fn
@@ -184,7 +184,7 @@ func TestEmptyChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, base.Set{})
+	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
 
 // channel mapper fn that uses _ underscore JS library
@@ -194,7 +194,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Channels, SetOf("foo"))
+	goassert.DeepEquals(t, res.Channels, SetOf("foo"))
 }
 
 // Validation by calling reject()
@@ -202,7 +202,7 @@ func TestChannelMapperReject(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
 
 // Rejection by calling throw()
@@ -210,14 +210,14 @@ func TestChannelMapperThrow(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
 
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`)
 	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 }
 
 // Test the public API
@@ -225,7 +225,7 @@ func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, output.Channels, SetOf("foo", "bar", "baz"))
+	goassert.DeepEquals(t, output.Channels, SetOf("foo", "bar", "baz"))
 }
 
 // Test the userCtx name parameter
@@ -236,16 +236,16 @@ func TestCheckUser(t *testing.T) {
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, sally)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, linus)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "wrong user"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "wrong user"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
 // Test the userCtx name parameter with a list
@@ -256,16 +256,16 @@ func TestCheckUserArray(t *testing.T) {
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, sally)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, linus)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "wrong user"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "wrong user"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, nil)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
 // Test the userCtx role parameter
@@ -276,16 +276,16 @@ func TestCheckRole(t *testing.T) {
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, sally)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, linus)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing role"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing role"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
 // Test the userCtx role parameter with a list
@@ -296,16 +296,16 @@ func TestCheckRoleArray(t *testing.T) {
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, sally)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": map[string]int{"boy": 1, "musician": 1}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, linus)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing role"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing role"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
 // Test the userCtx.channels parameter
@@ -316,16 +316,16 @@ func TestCheckAccess(t *testing.T) {
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, sally)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, linus)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing channel access"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing channel access"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, nil)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
 // Test the userCtx.channels parameter with a list
@@ -336,16 +336,16 @@ func TestCheckAccessArray(t *testing.T) {
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, sally)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, linus)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing channel access"))
+	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing channel access"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, nil)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, res.Rejection, nil)
+	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
 // Test changing the function
@@ -358,7 +358,7 @@ func TestSetFunction(t *testing.T) {
 	assertNoError(t, err, "SetFunction failed")
 	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, output.Channels, SetOf("all"))
+	goassert.DeepEquals(t, output.Channels, SetOf("all"))
 }
 
 // Test that expiry function sets the expiry property
@@ -366,98 +366,98 @@ func TestExpiryFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error")
-	assert.DeepEquals(t, *res1.Expiry, uint32(100))
+	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error")
-	assert.DeepEquals(t, *res2.Expiry, uint32(500))
+	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error")
-	assert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
+	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
-	assert.True(t, res3.Expiry == nil)
+	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as array")
-	assert.True(t, res4.Expiry == nil)
+	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
-	assert.True(t, res5.Expiry == nil)
+	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
-	assert.True(t, res6.Expiry == nil)
+	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
-	assert.True(t, resInvalidDate.Expiry == nil)
+	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
-	assert.True(t, res7.Expiry == nil)
+	goassert.True(t, res7.Expiry == nil)
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(100);}`)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error")
-	assert.DeepEquals(t, *res1.Expiry, uint32(100))
+	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("500");}`)
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error")
-	assert.DeepEquals(t, *res2.Expiry, uint32(500))
+	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`)
 	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error")
-	assert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
+	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`)
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
-	assert.True(t, res3.Expiry == nil)
+	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`)
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as array")
-	assert.True(t, res4.Expiry == nil)
+	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`)
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
-	assert.True(t, res5.Expiry == nil)
+	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`)
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
-	assert.True(t, res6.Expiry == nil)
+	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`)
 	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
-	assert.True(t, resInvalidDate.Expiry == nil)
+	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	mapper = NewChannelMapper(`function(doc) {expiry();}`)
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
-	assert.True(t, res7.Expiry == nil)
+	goassert.True(t, res7.Expiry == nil)
 }
 
 // Test that expiry function when invoked more than once by sync function
@@ -465,36 +465,36 @@ func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, *res1.Expiry, uint32(100))
+	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess failed")
-	assert.DeepEquals(t, *res2.Expiry, uint32(500))
+	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
-	assert.True(t, res3.Expiry == nil)
+	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
-	assert.True(t, res4.Expiry == nil)
+	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
-	assert.True(t, res5.Expiry == nil)
+	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
-	assert.True(t, res6.Expiry == nil)
+	goassert.True(t, res6.Expiry == nil)
 
 	// No expiry specified
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, noUser)
 	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
-	assert.True(t, res7.Expiry == nil)
+	goassert.True(t, res7.Expiry == nil)
 }
 
 func TestChangedUsers(t *testing.T) {
@@ -505,7 +505,7 @@ func TestChangedUsers(t *testing.T) {
 	ForChangedUsers(a, b, func(name string) {
 		changes[name] = true
 	})
-	assert.DeepEquals(t, changes, map[string]bool{"alice": true, "claire": true, "diana": true})
+	goassert.DeepEquals(t, changes, map[string]bool{"alice": true, "claire": true, "diana": true})
 }
 
 //////// HELPERS:

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -17,6 +17,7 @@ import (
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/robertkrimen/otto"
 	"github.com/robertkrimen/otto/underscore"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -42,7 +43,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf("abc", "xyz"))
 }
 
@@ -50,7 +51,7 @@ func TestJavaScriptWorks(t *testing.T) {
 func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf("foo", "bar", "baz"))
 }
 
@@ -58,7 +59,7 @@ func TestSyncFunction(t *testing.T) {
 func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"foo": SetOf("bar", "baz")})
 }
 
@@ -66,7 +67,7 @@ func TestAccessFunction(t *testing.T) {
 func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf("foo", "bar ok", "baz"))
 }
 
@@ -88,7 +89,7 @@ func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"bar": SetOf("ginger"), "baz": SetOf("ginger"), "foo": SetOf("ginger")})
 }
 
@@ -96,14 +97,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf("ginger", "earl_grey", "green")})
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access["lee"], SetOf("ginger", "earl_grey", "green"))
 	goassert.DeepEquals(t, res.Access["nancy"], SetOf("ginger", "earl_grey", "green"))
 }
@@ -111,42 +112,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf("ginger")})
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
@@ -155,7 +156,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Roles, AccessMap{"bar": SetOf("froods"), "baz": SetOf("froods"), "foo": SetOf("froods")})
 }
 
@@ -163,7 +164,7 @@ func TestRoleFunction(t *testing.T) {
 func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf("foo"))
 }
 
@@ -171,11 +172,11 @@ func TestInputParse(t *testing.T) {
 func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf("foo", "bar", "baz"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
 
@@ -183,7 +184,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 func TestEmptyChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
 
@@ -193,7 +194,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	defer underscore.Disable()
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf("foo"))
 }
 
@@ -201,7 +202,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 func TestChannelMapperReject(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
 
@@ -209,7 +210,7 @@ func TestChannelMapperReject(t *testing.T) {
 func TestChannelMapperThrow(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`)
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
 
@@ -224,7 +225,7 @@ func TestChannelMapperException(t *testing.T) {
 func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, output.Channels, SetOf("foo", "bar", "baz"))
 }
 
@@ -235,16 +236,16 @@ func TestCheckUser(t *testing.T) {
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, sally)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, linus)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "wrong user"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
@@ -255,16 +256,16 @@ func TestCheckUserArray(t *testing.T) {
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, sally)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, linus)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "wrong user"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, nil)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
@@ -275,16 +276,16 @@ func TestCheckRole(t *testing.T) {
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, sally)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, linus)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing role"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
@@ -295,16 +296,16 @@ func TestCheckRoleArray(t *testing.T) {
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, sally)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": map[string]int{"boy": 1, "musician": 1}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, linus)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing role"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
@@ -315,16 +316,16 @@ func TestCheckAccess(t *testing.T) {
 	}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, sally)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, linus)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing channel access"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, nil)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
@@ -335,16 +336,16 @@ func TestCheckAccessArray(t *testing.T) {
 	}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
 	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, sally)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, linus)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "missing channel access"))
 
 	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, nil)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
 
@@ -352,12 +353,12 @@ func TestCheckAccessArray(t *testing.T) {
 func TestSetFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
 	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
-	assertTrue(t, changed, "SetFunction failed")
-	assertNoError(t, err, "SetFunction failed")
+	assert.True(t, changed, "SetFunction failed")
+	assert.NoError(t, err, "SetFunction failed")
 	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, output.Channels, SetOf("all"))
 }
 
@@ -365,98 +366,98 @@ func TestSetFunction(t *testing.T) {
 func TestExpiryFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error")
+	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error")
+	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error")
+	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as array")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
 	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	goassert.True(t, res7.Expiry == nil)
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(100);}`)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error")
+	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("500");}`)
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error")
+	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`)
 	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error")
+	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`)
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`)
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as array")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`)
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`)
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`)
 	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	mapper = NewChannelMapper(`function(doc) {expiry();}`)
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
+	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	goassert.True(t, res7.Expiry == nil)
 }
 
@@ -464,36 +465,36 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`)
 	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess failed")
+	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
+	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
+	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
+	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
+	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res6.Expiry == nil)
 
 	// No expiry specified
 	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, noUser)
-	assertNoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
+	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res7.Expiry == nil)
 }
 
@@ -506,18 +507,4 @@ func TestChangedUsers(t *testing.T) {
 		changes[name] = true
 	})
 	goassert.DeepEquals(t, changes, map[string]bool{"alice": true, "claire": true, "diana": true})
-}
-
-//////// HELPERS:
-
-func assertNoError(t *testing.T, err error, message string) {
-	if err != nil {
-		t.Fatalf("%s: %v", message, err)
-	}
-}
-
-func assertTrue(t *testing.T, success bool, message string) {
-	if !success {
-		t.Fatalf("%s", message)
-	}
 }

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsValidChannel(t *testing.T) {
@@ -42,7 +43,7 @@ func TestSetFromArray(t *testing.T) {
 	}
 	for _, cas := range cases {
 		channels, err := SetFromArray(cas[0], RemoveStar)
-		assertNoError(t, err, "SetFromArray failed")
+		assert.NoError(t, err, "SetFromArray failed")
 		goassert.DeepEquals(t, channels, SetOf(cas[1]...))
 	}
 }
@@ -59,14 +60,14 @@ func TestSetFromArrayWithStar(t *testing.T) {
 	}
 	for _, cas := range cases {
 		channels, err := SetFromArray(cas[0], ExpandStar)
-		assertNoError(t, err, "SetFromArray failed")
+		assert.NoError(t, err, "SetFromArray failed")
 		goassert.DeepEquals(t, channels, SetOf(cas[1]...))
 	}
 }
 
 func TestSetFromArrayError(t *testing.T) {
 	_, err := SetFromArray([]string{""}, RemoveStar)
-	assertTrue(t, err != nil, "SetFromArray didn't return an error")
+	assert.True(t, err != nil, "SetFromArray didn't return an error")
 	_, err = SetFromArray([]string{"chan1", "chan2", "bogus,name", "chan3"}, RemoveStar)
-	assertTrue(t, err != nil, "SetFromArray didn't return an error")
+	assert.True(t, err != nil, "SetFromArray didn't return an error")
 }

--- a/channels/set_test.go
+++ b/channels/set_test.go
@@ -12,7 +12,7 @@ package channels
 import (
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestIsValidChannel(t *testing.T) {
@@ -43,7 +43,7 @@ func TestSetFromArray(t *testing.T) {
 	for _, cas := range cases {
 		channels, err := SetFromArray(cas[0], RemoveStar)
 		assertNoError(t, err, "SetFromArray failed")
-		assert.DeepEquals(t, channels, SetOf(cas[1]...))
+		goassert.DeepEquals(t, channels, SetOf(cas[1]...))
 	}
 }
 
@@ -60,7 +60,7 @@ func TestSetFromArrayWithStar(t *testing.T) {
 	for _, cas := range cases {
 		channels, err := SetFromArray(cas[0], ExpandStar)
 		assertNoError(t, err, "SetFromArray failed")
-		assert.DeepEquals(t, channels, SetOf(cas[1]...))
+		goassert.DeepEquals(t, channels, SetOf(cas[1]...))
 	}
 }
 

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestRequireUser(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireUser(oldDoc._names) }`
 	runner, err := NewSyncRunner(funcSource)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), parse(`{"name": "alpha"}`))
 	assertNotRejected(t, result)
@@ -23,7 +23,7 @@ func TestRequireUser(t *testing.T) {
 func TestRequireRole(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireRole(oldDoc._roles) }`
 	runner, err := NewSyncRunner(funcSource)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), parse(`{"name": "", "roles": {"alpha":""}}`))
 	assertNotRejected(t, result)
@@ -36,7 +36,7 @@ func TestRequireRole(t *testing.T) {
 func TestRequireAccess(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAccess(oldDoc._access) }`
 	runner, err := NewSyncRunner(funcSource)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), parse(`{"name": "", "channels": ["alpha"]}`))
 	assertNotRejected(t, result)
@@ -49,7 +49,7 @@ func TestRequireAccess(t *testing.T) {
 func TestRequireAdmin(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAdmin() }`
 	runner, err := NewSyncRunner(funcSource)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{}`))
 	assertNotRejected(t, result)
@@ -64,8 +64,8 @@ func TestRequireAdmin(t *testing.T) {
 // Helpers
 func assertRejected(t *testing.T, result interface{}, err *base.HTTPError) {
 	r, ok := result.(*ChannelMapperOutput)
-	assert.True(t, ok)
-	assert.DeepEquals(t, r.Rejection, err)
+	goassert.True(t, ok)
+	goassert.DeepEquals(t, r.Rejection, err)
 }
 
 func assertNotRejected(t *testing.T, result interface{}) {

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestTimedSetMarshal(t *testing.T) {
@@ -24,17 +24,17 @@ func TestTimedSetMarshal(t *testing.T) {
 	}
 	bytes, err := json.Marshal(str)
 	assertNoError(t, err, "Marshal")
-	assert.Equals(t, string(bytes), `{"Channels":null}`)
+	goassert.Equals(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = TimedSet{}
 	bytes, err = json.Marshal(str)
 	assertNoError(t, err, "Marshal")
-	assert.Equals(t, string(bytes), `{"Channels":{}}`)
+	goassert.Equals(t, string(bytes), `{"Channels":{}}`)
 
 	str.Channels = AtSequence(SetOf("a", "b"), 17)
 	bytes, err = json.Marshal(str)
 	assertNoError(t, err, "Marshal")
-	assert.Equals(t, string(bytes), `{"Channels":{"a":17,"b":17}}`)
+	goassert.Equals(t, string(bytes), `{"Channels":{"a":17,"b":17}}`)
 }
 
 func TestTimedSetUnmarshal(t *testing.T) {
@@ -43,64 +43,64 @@ func TestTimedSetUnmarshal(t *testing.T) {
 	}
 	err := json.Unmarshal([]byte(`{"channels":null}`), &str)
 	assertNoError(t, err, "Unmarshal")
-	assert.DeepEquals(t, str.Channels, TimedSet(nil))
+	goassert.DeepEquals(t, str.Channels, TimedSet(nil))
 
 	err = json.Unmarshal([]byte(`{"channels":{}}`), &str)
 	assertNoError(t, err, "Unmarshal empty")
-	assert.DeepEquals(t, str.Channels, TimedSet{})
+	goassert.DeepEquals(t, str.Channels, TimedSet{})
 
 	err = json.Unmarshal([]byte(`{"channels":{"a":17,"b":17}}`), &str)
 	assertNoError(t, err, "Unmarshal sequence only")
-	assert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(17), "b": NewVbSimpleSequence(17)})
+	goassert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(17), "b": NewVbSimpleSequence(17)})
 
 	// Now try unmarshaling the alternative array form:
 	err = json.Unmarshal([]byte(`{"channels":[]}`), &str)
 	assertNoError(t, err, "Unmarshal empty array")
-	assert.DeepEquals(t, str.Channels, TimedSet{})
+	goassert.DeepEquals(t, str.Channels, TimedSet{})
 
 	err = json.Unmarshal([]byte(`{"channels":["a","b"]}`), &str)
 	assertNoError(t, err, "Unmarshal populated array")
-	assert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(0), "b": NewVbSimpleSequence(0)})
+	goassert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(0), "b": NewVbSimpleSequence(0)})
 
 	err = json.Unmarshal([]byte(`{"channels":{"a":{"seq":17, "vb":21},"b":{"seq":23, "vb":25}}}`), &str)
 	assertNoError(t, err, "Unmarshal sequence and vbucket only")
-	assert.Equals(t, fmt.Sprintf("%s", str.Channels), fmt.Sprintf("%s", TimedSet{"a": NewVbSequence(21, 17), "b": NewVbSequence(25, 23)}))
+	goassert.Equals(t, fmt.Sprintf("%s", str.Channels), fmt.Sprintf("%s", TimedSet{"a": NewVbSequence(21, 17), "b": NewVbSequence(25, 23)}))
 }
 
 func TestEncodeSequenceID(t *testing.T) {
 	set := TimedSet{"ABC": NewVbSimpleSequence(17), "CBS": NewVbSimpleSequence(23), "BBC": NewVbSimpleSequence(1)}
 	encoded := set.String()
-	assert.Equals(t, encoded, "ABC:17,BBC:1,CBS:23")
+	goassert.Equals(t, encoded, "ABC:17,BBC:1,CBS:23")
 	decoded := TimedSetFromString(encoded)
-	assert.DeepEquals(t, decoded, set)
+	goassert.DeepEquals(t, decoded, set)
 
-	assert.Equals(t, TimedSet{"ABC": NewVbSimpleSequence(17), "CBS": NewVbSimpleSequence(0)}.String(), "ABC:17")
+	goassert.Equals(t, TimedSet{"ABC": NewVbSimpleSequence(17), "CBS": NewVbSimpleSequence(0)}.String(), "ABC:17")
 
-	assert.DeepEquals(t, TimedSetFromString(""), TimedSet{})
-	assert.DeepEquals(t, TimedSetFromString("ABC:17"), TimedSet{"ABC": NewVbSimpleSequence(17)})
+	goassert.DeepEquals(t, TimedSetFromString(""), TimedSet{})
+	goassert.DeepEquals(t, TimedSetFromString("ABC:17"), TimedSet{"ABC": NewVbSimpleSequence(17)})
 
-	assert.DeepEquals(t, TimedSetFromString(":17"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString("ABC:"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString("ABC:0"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString("ABC:-1"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString("ABC:17,"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString(",ABC:17"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString("ABC:17,,NBC:12"), TimedSet(nil))
-	assert.DeepEquals(t, TimedSetFromString("ABC:17,ABC:12"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString(":17"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString("ABC:"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString("ABC:0"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString("ABC:-1"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString("ABC:17,"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString(",ABC:17"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString("ABC:17,,NBC:12"), TimedSet(nil))
+	goassert.DeepEquals(t, TimedSetFromString("ABC:17,ABC:12"), TimedSet(nil))
 }
 
 func TestEqualsWithEqualSet(t *testing.T) {
 	set1 := TimedSet{"ABC": NewVbSimpleSequence(17), "CBS": NewVbSimpleSequence(23), "BBC": NewVbSimpleSequence(1)}
 	set2 := base.SetFromArray([]string{"ABC", "CBS", "BBC"})
-	assert.True(t, set1.Equals(set2))
+	goassert.True(t, set1.Equals(set2))
 
 }
 
 func TestEqualsWithUnequalSet(t *testing.T) {
 	set1 := TimedSet{"ABC": NewVbSimpleSequence(17), "CBS": NewVbSimpleSequence(23), "BBC": NewVbSimpleSequence(1)}
 	set2 := base.SetFromArray([]string{"ABC", "BBC"})
-	assert.True(t, !set1.Equals(set2))
+	goassert.True(t, !set1.Equals(set2))
 	set3 := base.SetFromArray([]string{"ABC", "BBC", "CBS", "FOO"})
-	assert.True(t, !set1.Equals(set3))
+	goassert.True(t, !set1.Equals(set3))
 
 }

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTimedSetMarshal(t *testing.T) {
@@ -23,17 +24,17 @@ func TestTimedSetMarshal(t *testing.T) {
 		Channels TimedSet
 	}
 	bytes, err := json.Marshal(str)
-	assertNoError(t, err, "Marshal")
+	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = TimedSet{}
 	bytes, err = json.Marshal(str)
-	assertNoError(t, err, "Marshal")
+	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":{}}`)
 
 	str.Channels = AtSequence(SetOf("a", "b"), 17)
 	bytes, err = json.Marshal(str)
-	assertNoError(t, err, "Marshal")
+	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":{"a":17,"b":17}}`)
 }
 
@@ -42,28 +43,28 @@ func TestTimedSetUnmarshal(t *testing.T) {
 		Channels TimedSet
 	}
 	err := json.Unmarshal([]byte(`{"channels":null}`), &str)
-	assertNoError(t, err, "Unmarshal")
+	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels, TimedSet(nil))
 
 	err = json.Unmarshal([]byte(`{"channels":{}}`), &str)
-	assertNoError(t, err, "Unmarshal empty")
+	assert.NoError(t, err, "Unmarshal empty")
 	goassert.DeepEquals(t, str.Channels, TimedSet{})
 
 	err = json.Unmarshal([]byte(`{"channels":{"a":17,"b":17}}`), &str)
-	assertNoError(t, err, "Unmarshal sequence only")
+	assert.NoError(t, err, "Unmarshal sequence only")
 	goassert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(17), "b": NewVbSimpleSequence(17)})
 
 	// Now try unmarshaling the alternative array form:
 	err = json.Unmarshal([]byte(`{"channels":[]}`), &str)
-	assertNoError(t, err, "Unmarshal empty array")
+	assert.NoError(t, err, "Unmarshal empty array")
 	goassert.DeepEquals(t, str.Channels, TimedSet{})
 
 	err = json.Unmarshal([]byte(`{"channels":["a","b"]}`), &str)
-	assertNoError(t, err, "Unmarshal populated array")
+	assert.NoError(t, err, "Unmarshal populated array")
 	goassert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(0), "b": NewVbSimpleSequence(0)})
 
 	err = json.Unmarshal([]byte(`{"channels":{"a":{"seq":17, "vb":21},"b":{"seq":23, "vb":25}}}`), &str)
-	assertNoError(t, err, "Unmarshal sequence and vbucket only")
+	assert.NoError(t, err, "Unmarshal sequence and vbucket only")
 	goassert.Equals(t, fmt.Sprintf("%s", str.Channels), fmt.Sprintf("%s", TimedSet{"a": NewVbSequence(21, 17), "b": NewVbSequence(25, 23)}))
 }
 

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func unjson(j string) Body {
@@ -41,10 +42,10 @@ func TestAttachments(t *testing.T) {
 	bucket := testBucket.Bucket
 
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
-	assertNoError(t, err, "Couldn't create context for database 'db'")
+	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
 	db, err := CreateDatabase(context)
-	assertNoError(t, err, "Couldn't create database 'db'")
+	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Test creating & updating a document:
 	log.Printf("Create rev 1...")
@@ -54,12 +55,12 @@ func TestAttachments(t *testing.T) {
 	json.Unmarshal([]byte(rev1input), &body)
 	revid, err := db.Put("doc1", unjson(rev1input))
 	rev1id := revid
-	assertNoError(t, err, "Couldn't create document")
+	assert.NoError(t, err, "Couldn't create document")
 
 	log.Printf("Retrieve doc...")
 	rev1output := `{"_attachments":{"bye.txt":{"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA==","digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
 	gotbody, err := db.GetRev("doc1", "", false, []string{})
-	assertNoError(t, err, "Couldn't get document")
+	assert.NoError(t, err, "Couldn't get document")
 	goassert.Equals(t, tojson(gotbody), rev1output)
 
 	log.Printf("Create rev 2...")
@@ -68,19 +69,19 @@ func TestAttachments(t *testing.T) {
 	json.Unmarshal([]byte(rev2str), &body2)
 	body2[BodyRev] = revid
 	revid, err = db.Put("doc1", body2)
-	assertNoError(t, err, "Couldn't update document")
+	assert.NoError(t, err, "Couldn't update document")
 	goassert.Equals(t, revid, "2-08b42c51334c0469bd060e6d9e6d797b")
 
 	log.Printf("Retrieve doc...")
 	rev2output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
-	assertNoError(t, err, "Couldn't get document")
+	assert.NoError(t, err, "Couldn't get document")
 	goassert.Equals(t, tojson(gotbody), rev2output)
 
 	log.Printf("Retrieve doc with atts_since...")
 	rev2Aoutput := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{"1-54f3a105fb903018c160712ffddb74dc", "1-foo", "993-bar"})
-	assertNoError(t, err, "Couldn't get document")
+	assert.NoError(t, err, "Couldn't get document")
 	goassert.Equals(t, tojson(gotbody), rev2Aoutput)
 
 	log.Printf("Create rev 3...")
@@ -89,24 +90,24 @@ func TestAttachments(t *testing.T) {
 	json.Unmarshal([]byte(rev3str), &body3)
 	body3[BodyRev] = revid
 	revid, err = db.Put("doc1", body3)
-	assertNoError(t, err, "Couldn't update document")
+	assert.NoError(t, err, "Couldn't update document")
 	goassert.Equals(t, revid, "3-252b9fa1f306930bffc07e7d75b77faf")
 
 	log.Printf("Retrieve doc...")
 	rev3output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2}},"_id":"doc1","_rev":"3-252b9fa1f306930bffc07e7d75b77faf"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
-	assertNoError(t, err, "Couldn't get document")
+	assert.NoError(t, err, "Couldn't get document")
 	goassert.Equals(t, tojson(gotbody), rev3output)
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
 	err = db.Bucket.Delete(oldRevisionKey("doc1", rev1id))
-	assertNoError(t, err, "Couldn't compact old revision")
+	assert.NoError(t, err, "Couldn't compact old revision")
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body
 	err = json.Unmarshal([]byte(rev2Bstr), &body2B)
-	assertNoError(t, err, "bad JSON")
+	assert.NoError(t, err, "bad JSON")
 	err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id}, false)
-	assertNoError(t, err, "Couldn't update document")
+	assert.NoError(t, err, "Couldn't update document")
 }
 
 func TestAttachmentForRejectedDocument(t *testing.T) {
@@ -116,10 +117,10 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 	bucket := testBucket.Bucket
 
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
-	assertNoError(t, err, "Couldn't create context for database 'db'")
+	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
 	db, err := CreateDatabase(context)
-	assertNoError(t, err, "Couldn't create database 'db'")
+	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 		throw({forbidden: "None shall pass!"});
@@ -135,6 +136,6 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 	// Attempt to retrieve the attachment doc
 	_, _, err = db.Bucket.GetRaw("_sync:att:sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
 
-	assertTrue(t, err != nil, "Expect error when attempting to retrieve attachment document after doc is rejected.")
+	assert.True(t, err != nil, "Expect error when attempting to retrieve attachment document after doc is rejected.")
 
 }

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func unjson(j string) Body {
@@ -60,7 +60,7 @@ func TestAttachments(t *testing.T) {
 	rev1output := `{"_attachments":{"bye.txt":{"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA==","digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
 	gotbody, err := db.GetRev("doc1", "", false, []string{})
 	assertNoError(t, err, "Couldn't get document")
-	assert.Equals(t, tojson(gotbody), rev1output)
+	goassert.Equals(t, tojson(gotbody), rev1output)
 
 	log.Printf("Create rev 2...")
 	rev2str := `{"_attachments": {"hello.txt": {"stub":true, "revpos":1}, "bye.txt": {"data": "YnllLXlh"}}}`
@@ -69,19 +69,19 @@ func TestAttachments(t *testing.T) {
 	body2[BodyRev] = revid
 	revid, err = db.Put("doc1", body2)
 	assertNoError(t, err, "Couldn't update document")
-	assert.Equals(t, revid, "2-08b42c51334c0469bd060e6d9e6d797b")
+	goassert.Equals(t, revid, "2-08b42c51334c0469bd060e6d9e6d797b")
 
 	log.Printf("Retrieve doc...")
 	rev2output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
 	assertNoError(t, err, "Couldn't get document")
-	assert.Equals(t, tojson(gotbody), rev2output)
+	goassert.Equals(t, tojson(gotbody), rev2output)
 
 	log.Printf("Retrieve doc with atts_since...")
 	rev2Aoutput := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{"1-54f3a105fb903018c160712ffddb74dc", "1-foo", "993-bar"})
 	assertNoError(t, err, "Couldn't get document")
-	assert.Equals(t, tojson(gotbody), rev2Aoutput)
+	goassert.Equals(t, tojson(gotbody), rev2Aoutput)
 
 	log.Printf("Create rev 3...")
 	rev3str := `{"_attachments": {"bye.txt": {"stub":true,"revpos":2}}}`
@@ -90,13 +90,13 @@ func TestAttachments(t *testing.T) {
 	body3[BodyRev] = revid
 	revid, err = db.Put("doc1", body3)
 	assertNoError(t, err, "Couldn't update document")
-	assert.Equals(t, revid, "3-252b9fa1f306930bffc07e7d75b77faf")
+	goassert.Equals(t, revid, "3-252b9fa1f306930bffc07e7d75b77faf")
 
 	log.Printf("Retrieve doc...")
 	rev3output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2}},"_id":"doc1","_rev":"3-252b9fa1f306930bffc07e7d75b77faf"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
 	assertNoError(t, err, "Couldn't get document")
-	assert.Equals(t, tojson(gotbody), rev3output)
+	goassert.Equals(t, tojson(gotbody), rev3output)
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
 	err = db.Bucket.Delete(oldRevisionKey("doc1", rev1id))

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func e(seq uint64, docid string, revid string) *LogEntry {
@@ -47,42 +47,42 @@ func TestSkippedSequenceQueue(t *testing.T) {
 	skipQueue.Push(&SkippedSequence{8, time.Now()})
 	skipQueue.Push(&SkippedSequence{12, time.Now()})
 	skipQueue.Push(&SkippedSequence{18, time.Now()})
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{4, 7, 8, 12, 18}))
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{4, 7, 8, 12, 18}))
 
 	// Retrieval of low value
 	lowValue := skipQueue[0].seq
-	assert.Equals(t, lowValue, uint64(4))
+	goassert.Equals(t, lowValue, uint64(4))
 
 	// Removal of first value
 	err := skipQueue.Remove(4)
-	assert.True(t, err == nil)
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 8, 12, 18}))
+	goassert.True(t, err == nil)
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 8, 12, 18}))
 
 	// Removal of middle values
 	err = skipQueue.Remove(8)
-	assert.True(t, err == nil)
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 12, 18}))
+	goassert.True(t, err == nil)
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 12, 18}))
 
 	err = skipQueue.Remove(12)
-	assert.True(t, err == nil)
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 18}))
+	goassert.True(t, err == nil)
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 18}))
 
 	// Removal of last value
 	err = skipQueue.Remove(18)
-	assert.True(t, err == nil)
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{7}))
+	goassert.True(t, err == nil)
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{7}))
 
 	// Removal of non-existent returns error
 	err = skipQueue.Remove(25)
-	assert.True(t, err != nil)
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{7}))
+	goassert.True(t, err != nil)
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{7}))
 
 	// Add an out-of-sequence entry (make sure bad sequencing doesn't throw us into an infinite loop)
 	err = skipQueue.Push(&SkippedSequence{6, time.Now()})
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	skipQueue.Push(&SkippedSequence{9, time.Now()})
-	assert.True(t, err != nil)
-	assert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 9}))
+	goassert.True(t, err != nil)
+	goassert.True(t, verifySkippedSequences(skipQueue, []uint64{7, 9}))
 }
 
 func TestLateSequenceHandling(t *testing.T) {
@@ -92,14 +92,14 @@ func TestLateSequenceHandling(t *testing.T) {
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
 
 	cache := newChannelCache(context, "Test1", 0)
-	assert.True(t, cache != nil)
+	goassert.True(t, cache != nil)
 
 	// Empty late sequence cache should return empty set
 	startSequence := cache.InitLateSequenceClient()
 	entries, lastSeq, err := cache.GetLateSequencesSince(startSequence)
-	assert.Equals(t, len(entries), 0)
-	assert.Equals(t, lastSeq, uint64(0))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 0)
+	goassert.Equals(t, lastSeq, uint64(0))
+	goassert.True(t, err == nil)
 
 	cache.AddLateSequence(e(5, "foo", "1-a"))
 	cache.AddLateSequence(e(8, "foo2", "1-a"))
@@ -107,47 +107,47 @@ func TestLateSequenceHandling(t *testing.T) {
 	// Retrieve since 0
 	entries, lastSeq, err = cache.GetLateSequencesSince(0)
 	log.Println("entries:", entries)
-	assert.Equals(t, len(entries), 2)
-	assert.Equals(t, lastSeq, uint64(8))
-	assert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 2)
+	goassert.Equals(t, lastSeq, uint64(8))
+	goassert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
+	goassert.True(t, err == nil)
 
 	// Add Sequences.  Will trigger purge on old sequences without listeners
 	cache.AddLateSequence(e(2, "foo3", "1-a"))
 	cache.AddLateSequence(e(7, "foo4", "1-a"))
-	assert.Equals(t, len(cache.lateLogs), 3)
-	assert.Equals(t, cache.lateLogs[0].logEntry.Sequence, uint64(8))
-	assert.Equals(t, cache.lateLogs[1].logEntry.Sequence, uint64(2))
-	assert.Equals(t, cache.lateLogs[2].logEntry.Sequence, uint64(7))
-	assert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
+	goassert.Equals(t, len(cache.lateLogs), 3)
+	goassert.Equals(t, cache.lateLogs[0].logEntry.Sequence, uint64(8))
+	goassert.Equals(t, cache.lateLogs[1].logEntry.Sequence, uint64(2))
+	goassert.Equals(t, cache.lateLogs[2].logEntry.Sequence, uint64(7))
+	goassert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
 
 	// Retrieve since previous
 	entries, lastSeq, err = cache.GetLateSequencesSince(lastSeq)
 	log.Println("entries:", entries)
-	assert.Equals(t, len(entries), 2)
-	assert.Equals(t, lastSeq, uint64(7))
-	assert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(0))
-	assert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
+	goassert.Equals(t, len(entries), 2)
+	goassert.Equals(t, lastSeq, uint64(7))
+	goassert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(0))
+	goassert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
 	log.Println("cache.lateLogs:", cache.lateLogs)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	// Purge.  We have a listener sitting at seq=7, so purge should only clear previous
 	cache.AddLateSequence(e(15, "foo5", "1-a"))
 	cache.AddLateSequence(e(11, "foo6", "1-a"))
 	log.Println("cache.lateLogs:", cache.lateLogs)
 	cache.purgeLateLogEntries()
-	assert.Equals(t, len(cache.lateLogs), 3)
-	assert.Equals(t, cache.lateLogs[0].logEntry.Sequence, uint64(7))
-	assert.Equals(t, cache.lateLogs[1].logEntry.Sequence, uint64(15))
-	assert.Equals(t, cache.lateLogs[2].logEntry.Sequence, uint64(11))
+	goassert.Equals(t, len(cache.lateLogs), 3)
+	goassert.Equals(t, cache.lateLogs[0].logEntry.Sequence, uint64(7))
+	goassert.Equals(t, cache.lateLogs[1].logEntry.Sequence, uint64(15))
+	goassert.Equals(t, cache.lateLogs[2].logEntry.Sequence, uint64(11))
 	log.Println("cache.lateLogs:", cache.lateLogs)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	// Release the listener, and purge again
 	cache.ReleaseLateSequenceClient(uint64(7))
 	cache.purgeLateLogEntries()
-	assert.Equals(t, len(cache.lateLogs), 1)
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(cache.lateLogs), 1)
+	goassert.True(t, err == nil)
 
 }
 
@@ -158,14 +158,14 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
 
 	cache := newChannelCache(context, "Test1", 0)
-	assert.True(t, cache != nil)
+	goassert.True(t, cache != nil)
 
 	// Add Listener before late entries arrive
 	startSequence := cache.InitLateSequenceClient()
 	entries, lastSeq1, err := cache.GetLateSequencesSince(startSequence)
-	assert.Equals(t, len(entries), 0)
-	assert.Equals(t, lastSeq1, uint64(0))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 0)
+	goassert.Equals(t, lastSeq1, uint64(0))
+	goassert.True(t, err == nil)
 
 	// Add two entries
 	cache.AddLateSequence(e(5, "foo", "1-a"))
@@ -174,33 +174,33 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	// Add a second client.  Expect the first listener at [0], and the new one at [2]
 	startSequence = cache.InitLateSequenceClient()
 	entries, lastSeq2, err := cache.GetLateSequencesSince(startSequence)
-	assert.Equals(t, startSequence, uint64(8))
-	assert.Equals(t, lastSeq2, uint64(8))
+	goassert.Equals(t, startSequence, uint64(8))
+	goassert.Equals(t, lastSeq2, uint64(8))
 
-	assert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
-	assert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
+	goassert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
+	goassert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
 
 	cache.AddLateSequence(e(3, "foo3", "1-a"))
 	// First client requests again.  Expect first client at latest (3), second still at (8).
 	entries, lastSeq1, err = cache.GetLateSequencesSince(lastSeq1)
-	assert.Equals(t, lastSeq1, uint64(3))
-	assert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
-	assert.Equals(t, cache.lateLogs[3].getListenerCount(), uint64(1))
+	goassert.Equals(t, lastSeq1, uint64(3))
+	goassert.Equals(t, cache.lateLogs[2].getListenerCount(), uint64(1))
+	goassert.Equals(t, cache.lateLogs[3].getListenerCount(), uint64(1))
 
 	// Add another sequence, which triggers a purge.  Ensure we don't lose our listeners
 	cache.AddLateSequence(e(12, "foo4", "1-a"))
-	assert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
-	assert.Equals(t, cache.lateLogs[1].getListenerCount(), uint64(1))
+	goassert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
+	goassert.Equals(t, cache.lateLogs[1].getListenerCount(), uint64(1))
 
 	// Release the first listener - ensure we maintain the second
 	cache.ReleaseLateSequenceClient(lastSeq1)
-	assert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
-	assert.Equals(t, cache.lateLogs[1].getListenerCount(), uint64(0))
+	goassert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(1))
+	goassert.Equals(t, cache.lateLogs[1].getListenerCount(), uint64(0))
 
 	// Release the second listener
 	cache.ReleaseLateSequenceClient(lastSeq2)
-	assert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(0))
-	assert.Equals(t, cache.lateLogs[1].getListenerCount(), uint64(0))
+	goassert.Equals(t, cache.lateLogs[0].getListenerCount(), uint64(0))
+	goassert.Equals(t, cache.lateLogs[1].getListenerCount(), uint64(0))
 
 }
 
@@ -338,8 +338,8 @@ func TestChannelCacheBackfill(t *testing.T) {
 	db.user, _ = authenticator.GetUser("naomi")
 	changes, err := db.GetChanges(base.SetOf("*"), ChangesOptions{Since: SequenceID{Seq: 0}})
 	assertNoError(t, err, "Couldn't GetChanges")
-	assert.Equals(t, len(changes), 4)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 4)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:      "doc-1",
 		Changes: []ChangeRev{{"rev": "1-a"}}})
@@ -352,22 +352,22 @@ func TestChannelCacheBackfill(t *testing.T) {
 	db.changeCache.waitForSequenceID(SequenceID{Seq: 7}, base.DefaultWaitForSequenceTesting)
 	// verify insert at start (PBS)
 	pbsCache := db.changeCache.getChannelCache("PBS")
-	assert.True(t, verifyCacheSequences(pbsCache, []uint64{3, 5, 6}))
+	goassert.True(t, verifyCacheSequences(pbsCache, []uint64{3, 5, 6}))
 	// verify insert at middle (ABC)
 	abcCache := db.changeCache.getChannelCache("ABC")
-	assert.True(t, verifyCacheSequences(abcCache, []uint64{1, 2, 3, 5, 6}))
+	goassert.True(t, verifyCacheSequences(abcCache, []uint64{1, 2, 3, 5, 6}))
 	// verify insert at end (NBC)
 	nbcCache := db.changeCache.getChannelCache("NBC")
-	assert.True(t, verifyCacheSequences(nbcCache, []uint64{1, 3}))
+	goassert.True(t, verifyCacheSequences(nbcCache, []uint64{1, 3}))
 	// verify insert to empty cache (TBS)
 	tbsCache := db.changeCache.getChannelCache("TBS")
-	assert.True(t, verifyCacheSequences(tbsCache, []uint64{3}))
+	goassert.True(t, verifyCacheSequences(tbsCache, []uint64{3}))
 
 	// verify changes has three entries (needs to resend all since previous LowSeq, which
 	// will be the late arriver (3) along with 5, 6)
 	changes, err = db.GetChanges(base.SetOf("*"), ChangesOptions{Since: lastSeq})
-	assert.Equals(t, len(changes), 3)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 3)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 3, LowSeq: 3},
 		ID:      "doc-3",
 		Changes: []ChangeRev{{"rev": "1-a"}}})
@@ -411,7 +411,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	defer close(options.Terminator)
 
 	feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -472,7 +472,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 		log.Printf("Received %d unexpected docs", len(expectedDocs))
 	}
 
-	assert.Equals(t, len(expectedDocs), 0)
+	goassert.Equals(t, len(expectedDocs), 0)
 }
 
 // Test low sequence handling of late arriving sequences to a continuous changes feed
@@ -515,12 +515,12 @@ func TestLowSequenceHandling(t *testing.T) {
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	changes, err := verifySequencesInFeed(feed, []uint64{1, 2, 5, 6})
-	assert.True(t, err == nil)
-	assert.Equals(t, len(changes), 4)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.True(t, err == nil)
+	goassert.Equals(t, len(changes), 4)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:      "doc-1",
 		Changes: []ChangeRev{{"rev": "1-a"}}})
@@ -530,13 +530,13 @@ func TestLowSequenceHandling(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "PBS"}, 4)
 
 	_, err = verifySequencesInFeed(feed, []uint64{3, 4})
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	WriteDirect(db, []string{"ABC"}, 7)
 	WriteDirect(db, []string{"ABC", "NBC"}, 8)
 	WriteDirect(db, []string{"ABC", "PBS"}, 9)
 	_, err = verifySequencesInFeed(feed, []uint64{7, 8, 9})
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 }
 
@@ -579,17 +579,17 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	_, err = verifySequencesInFeed(feed, []uint64{1, 2, 6})
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	// Test backfill of sequence the user doesn't have visibility to
 	WriteDirect(db, []string{"PBS"}, 3)
 	WriteDirect(db, []string{"ABC"}, 9)
 
 	_, err = verifySequencesInFeed(feed, []uint64{9})
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	close(options.Terminator)
 }
@@ -636,7 +636,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	// Go-routine to work the feed channel and write to an array for use by assertions
 	var changes = make([]*ChangeEntry, 0, 50)
@@ -645,16 +645,16 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	// Validate the initial sequences arrive as expected
 	err = appendFromFeed(&changes, feed, 3, base.DefaultWaitForSequenceTesting)
-	assert.True(t, err == nil)
-	assert.Equals(t, len(changes), 3)
-	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
+	goassert.True(t, err == nil)
+	goassert.Equals(t, len(changes), 3)
+	goassert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
 
 	_, incrErr := db.Bucket.Incr(SyncSeqKey, 7, 7, 0)
-	assert.True(t, incrErr == nil)
+	goassert.True(t, incrErr == nil)
 
 	// Modify user to have access to both channels (sequence 2):
 	userInfo, err := db.GetPrincipal("naomi", true)
-	assert.True(t, userInfo != nil)
+	goassert.True(t, userInfo != nil)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
 	_, err = db.UpdatePrincipal(*userInfo, true, true)
 	assertNoError(t, err, "UpdatePrincipal failed")
@@ -666,8 +666,8 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequenceTesting)
 	assertNoError(t, err, "Expected more changes to be sent on feed, but never received")
-	assert.Equals(t, len(changes), 7)
-	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6", "2:8:5", "2:8:6", "2::8", "2::9"}))
+	goassert.Equals(t, len(changes), 7)
+	goassert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6", "2:8:5", "2:8:6", "2::8", "2::9"}))
 	// Notes:
 	// 1. 2::8 is the user sequence
 	// 2. The duplicate send of sequence '6' is the standard behaviour when a channel is added - we don't know
@@ -717,7 +717,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	// Array to read changes from feed to support assertions
 	var changes = make([]*ChangeEntry, 0, 50)
@@ -725,9 +725,9 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequenceTesting)
 
 	// Validate the initial sequences arrive as expected
-	assert.True(t, err == nil)
-	assert.Equals(t, len(changes), 4)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.True(t, err == nil)
+	goassert.Equals(t, len(changes), 4)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:      "doc-1",
 		Changes: []ChangeRev{{"rev": "1-a"}}})
@@ -739,16 +739,16 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	db.changeCache.waitForSequenceWithMissing(4, base.DefaultWaitForSequenceTesting)
 
 	err = appendFromFeed(&changes, feed, 2, base.DefaultWaitForSequenceTesting)
-	assert.True(t, err == nil)
-	assert.Equals(t, len(changes), 6)
-	assert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4}))
+	goassert.True(t, err == nil)
+	goassert.Equals(t, len(changes), 6)
+	goassert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4}))
 
 	WriteDirect(db, []string{"ABC"}, 7)
 	WriteDirect(db, []string{"ABC", "NBC"}, 8)
 	WriteDirect(db, []string{"ABC", "PBS"}, 9)
 	db.changeCache.waitForSequence(9, base.DefaultWaitForSequenceTesting)
 	appendFromFeed(&changes, feed, 5, base.DefaultWaitForSequenceTesting)
-	assert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4, 7, 8, 9}))
+	goassert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4, 7, 8, 9}))
 
 }
 
@@ -806,7 +806,7 @@ func TestChannelRace(t *testing.T) {
 	options.Continuous = true
 	options.Wait = true
 	feed, err := db.MultiChangesFeed(base.SetOf("Even", "Odd"), options)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	feedClosed := false
 
 	// Go-routine to work the feed channel and write to an array for use by assertions
@@ -832,7 +832,7 @@ func TestChannelRace(t *testing.T) {
 	// Wait for processing of two channels (100 ms each)
 	time.Sleep(250 * time.Millisecond)
 	// Validate the initial sequences arrive as expected
-	assert.Equals(t, len(changes), 3)
+	goassert.Equals(t, len(changes), 3)
 
 	// Send update to trigger the start of the next changes iteration
 	WriteDirect(db, []string{"Even"}, 4)
@@ -850,8 +850,8 @@ func TestChannelRace(t *testing.T) {
 	WriteDirect(db, []string{"Even"}, 8)
 	WriteDirect(db, []string{"Odd"}, 9)
 	time.Sleep(750 * time.Millisecond)
-	assert.Equals(t, len(changes), 9)
-	assert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}))
+	goassert.Equals(t, len(changes), 9)
+	goassert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}))
 	changesString := ""
 	for _, change := range changes {
 		changesString = fmt.Sprintf("%s%d, ", changesString, change.Seq.Seq)
@@ -901,8 +901,8 @@ func TestSkippedViewRetrieval(t *testing.T) {
 	db.changeCache.waitForSequenceID(SequenceID{Seq: 3}, base.DefaultWaitForSequenceTesting)
 	entries, err := db.changeCache.GetChanges("ABC", ChangesOptions{Since: SequenceID{Seq: 2}})
 	assertNoError(t, err, "Get Changes returned error")
-	assert.Equals(t, len(entries), 1)
-	assert.Equals(t, entries[0].DocID, "doc-3")
+	goassert.Equals(t, len(entries), 1)
+	goassert.Equals(t, entries[0].DocID, "doc-3")
 
 }
 
@@ -991,13 +991,13 @@ func TestChannelCacheSize(t *testing.T) {
 	db.user, _ = authenticator.GetUser("naomi")
 	changes, err := db.GetChanges(base.SetOf("ABC"), ChangesOptions{Since: SequenceID{Seq: 0}})
 	assertNoError(t, err, "Couldn't GetChanges")
-	assert.Equals(t, len(changes), 750)
+	goassert.Equals(t, len(changes), 750)
 
 	// Validate that cache stores the expected number of values
 	changeCache, ok := db.changeCache.(*changeCache)
 	assertTrue(t, ok, "Testing skipped sequences without a change cache")
 	abcCache := changeCache.channelCaches["ABC"]
-	assert.Equals(t, len(abcCache.logs), 600)
+	goassert.Equals(t, len(abcCache.logs), 600)
 }
 
 func shortWaitCache() CacheOptions {
@@ -1200,7 +1200,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	changeCacheImpl.notifyChange = func(channels base.Set) {
 		// defer waitForOnChangeCallback.Done()
 		log.Printf("channelsChanged: %v", channels)
-		// assert.True(t, channels.Contains("ABC"))
+		// goassert.True(t, channels.Contains("ABC"))
 		if channels.Contains("ABC") {
 			waitForOnChangeCallback.Done()
 		}

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -10,18 +10,17 @@
 package db
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"testing"
 	"time"
 
-	goassert "github.com/couchbaselabs/go.assert"
-
-	"bytes"
-	"fmt"
-
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // Unit test for bug #314
@@ -54,7 +53,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	goassert.True(t, userInfo != nil)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
 	_, err = db.UpdatePrincipal(*userInfo, true, true)
-	assertNoError(t, err, "UpdatePrincipal failed")
+	assert.NoError(t, err, "UpdatePrincipal failed")
 
 	// Check the _changes feed:
 	db.changeCache.waitForSequence(1, base.DefaultWaitForSequenceTesting)
@@ -65,7 +64,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	}
 	db.user, _ = authenticator.GetUser("naomi")
 	changes, err := db.GetChanges(base.SetOf("*"), getZeroSequence(db))
-	assertNoError(t, err, "Couldn't GetChanges")
+	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	time.Sleep(1000 * time.Millisecond)
 	goassert.Equals(t, len(changes), 3)
@@ -93,7 +92,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	db.changeCache.waitForSequence(3, base.DefaultWaitForSequenceTesting)
 	changes, err = db.GetChanges(base.SetOf("*"), ChangesOptions{Since: lastSeq})
 
-	assertNoError(t, err, "Couldn't GetChanges (2nd)")
+	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
 	goassert.Equals(t, len(changes), 1)
 	goassert.DeepEquals(t, changes[0], &ChangeEntry{
@@ -103,7 +102,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	// validate from zero
 	changes, err = db.GetChanges(base.SetOf("*"), getZeroSequence(db))
-	assertNoError(t, err, "Couldn't GetChanges")
+	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 
 }
@@ -162,7 +161,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	}
 	db.user, _ = authenticator.GetUser("alice")
 	changes, err := db.GetChanges(base.SetOf("*"), getZeroSequence(db))
-	assertNoError(t, err, "Couldn't GetChanges")
+	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	time.Sleep(1000 * time.Millisecond)
 	goassert.Equals(t, len(changes), 1)
@@ -206,7 +205,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	db.changeCache.waitForSequence(3, base.DefaultWaitForSequenceTesting)
 	changes, err = db.GetChanges(base.SetOf("*"), ChangesOptions{Since: lastSeq})
 
-	assertNoError(t, err, "Couldn't GetChanges (2nd)")
+	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
 	goassert.Equals(t, len(changes), 1)
 	goassert.DeepEquals(t, changes[0], &ChangeEntry{
@@ -250,7 +249,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	}
 	db.user, _ = authenticator.GetUser("alice")
 	changes, err := db.GetChanges(base.SetOf("*"), getZeroSequence(db))
-	assertNoError(t, err, "Couldn't GetChanges")
+	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	time.Sleep(1000 * time.Millisecond)
 
@@ -293,7 +292,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	changes, err = db.GetChanges(base.SetOf("*"), ChangesOptions{Since: lastSeq})
 
-	assertNoError(t, err, "Couldn't GetChanges (2nd)")
+	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
 	goassert.Equals(t, len(changes), 1)
 	goassert.DeepEquals(t, changes[0], &ChangeEntry{

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 
 	"bytes"
 	"fmt"
@@ -51,7 +51,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	// Modify user to have access to both channels (sequence 2):
 	userInfo, err := db.GetPrincipal("naomi", true)
-	assert.True(t, userInfo != nil)
+	goassert.True(t, userInfo != nil)
 	userInfo.ExplicitChannels = base.SetOf("ABC", "PBS")
 	_, err = db.UpdatePrincipal(*userInfo, true, true)
 	assertNoError(t, err, "UpdatePrincipal failed")
@@ -68,16 +68,16 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	assertNoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	time.Sleep(1000 * time.Millisecond)
-	assert.Equals(t, len(changes), 3)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{ // Seq 1, from ABC
+	goassert.Equals(t, len(changes), 3)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{ // Seq 1, from ABC
 		Seq:     SequenceID{Seq: 1},
 		ID:      "doc1",
 		Changes: []ChangeRev{{"rev": revid}}})
-	assert.DeepEquals(t, changes[1], &ChangeEntry{ // Seq 1, from PBS backfill
+	goassert.DeepEquals(t, changes[1], &ChangeEntry{ // Seq 1, from PBS backfill
 		Seq:     SequenceID{Seq: 1, TriggeredBy: 2},
 		ID:      "doc1",
 		Changes: []ChangeRev{{"rev": revid}}})
-	assert.DeepEquals(t, changes[2], &ChangeEntry{ // Seq 2, from ABC and PBS
+	goassert.DeepEquals(t, changes[2], &ChangeEntry{ // Seq 2, from ABC and PBS
 		Seq:       SequenceID{Seq: 2},
 		ID:        "_user/naomi",
 		Changes:   []ChangeRev{},
@@ -95,8 +95,8 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	assertNoError(t, err, "Couldn't GetChanges (2nd)")
 
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 3},
 		ID:      "doc2",
 		Changes: []ChangeRev{{"rev": revid}}})
@@ -165,8 +165,8 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	assertNoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
 	time.Sleep(1000 * time.Millisecond)
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{ // Seq 1, from A
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{ // Seq 1, from A
 		Seq:     SequenceID{Seq: 1},
 		ID:      "alpha",
 		Changes: []ChangeRev{{"rev": revid}}})
@@ -179,7 +179,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	//Unmarshall into nested maps
 	var x map[string]interface{}
 	json.Unmarshal(rv, &x)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	sync := x["_sync"].(map[string]interface{})
 	sync["sequence"] = 3
@@ -208,8 +208,8 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	assertNoError(t, err, "Couldn't GetChanges (2nd)")
 
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:        SequenceID{Seq: 2},
 		ID:         "alpha",
 		Removed:    base.SetOf("A"),
@@ -254,8 +254,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	printChanges(changes)
 	time.Sleep(1000 * time.Millisecond)
 
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{ // Seq 1, from A
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{ // Seq 1, from A
 		Seq:     SequenceID{Seq: 1},
 		ID:      "alpha",
 		Changes: []ChangeRev{{"rev": revid}}})
@@ -269,7 +269,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	var x map[string]interface{}
 	json.Unmarshal(rv, &x)
 
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	sync := x["_sync"].(map[string]interface{})
 	sync["sequence"] = 3
@@ -295,8 +295,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	assertNoError(t, err, "Couldn't GetChanges (2nd)")
 
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 3},
 		ID:      "alpha",
 		Changes: []ChangeRev{{"rev": "3-e99405a23fa102238fa8c3fd499b15bc"}}})

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestDuplicateDocID(t *testing.T) {
@@ -36,34 +36,34 @@ func TestDuplicateDocID(t *testing.T) {
 	cache.addToCache(e(3, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
+	goassert.True(t, err == nil)
 
 	// Add a new revision matching mid-list
 	cache.addToCache(e(4, "doc3", "3-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc5", "doc3"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc5", "doc3"}))
+	goassert.True(t, err == nil)
 
 	// Add a new revision matching first
 	cache.addToCache(e(5, "doc1", "1-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
+	goassert.True(t, err == nil)
 
 	// Add a new revision matching last
 	cache.addToCache(e(6, "doc1", "1-c"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
+	goassert.True(t, err == nil)
 
 }
 
@@ -83,20 +83,20 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache.addToCache(e(5, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 5}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 5}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
+	goassert.True(t, err == nil)
 
 	// Add a late-arriving sequence
 	cache.AddLateSequence(e(2, "doc2", "2-a"))
 	cache.addToCache(e(2, "doc2", "2-a"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3, 5}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc5"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3, 5}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc5"}))
+	goassert.True(t, err == nil)
 
 }
 
@@ -116,20 +116,20 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache.addToCache(e(15, "doc3", "3-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{5, 10, 15}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{5, 10, 15}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3"}))
+	goassert.True(t, err == nil)
 
 	// Add a late-arriving sequence
 	cache.AddLateSequence(e(3, "doc0", "0-a"))
 	cache.addToCache(e(3, "doc0", "0-a"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{3, 5, 10, 15}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc0", "doc1", "doc2", "doc3"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{3, 5, 10, 15}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc0", "doc1", "doc2", "doc3"}))
+	goassert.True(t, err == nil)
 
 }
 
@@ -150,60 +150,60 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.addToCache(e(40, "doc4", "4-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
-	assert.True(t, verifyChannelSequences(entries, []uint64{10, 20, 30, 40}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc4"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 4)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{10, 20, 30, 40}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc4"}))
+	goassert.True(t, err == nil)
 
 	// Add a late-arriving sequence that should replace earlier sequence
 	cache.AddLateSequence(e(25, "doc1", "1-c"))
 	cache.addToCache(e(25, "doc1", "1-c"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
+	goassert.True(t, err == nil)
 
 	// Add a late-arriving sequence that should be ignored (later sequence exists for that docID)
 	cache.AddLateSequence(e(15, "doc1", "1-b"))
 	cache.addToCache(e(15, "doc1", "1-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
+	goassert.True(t, err == nil)
 
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(e(27, "doc1", "1-d"))
 	cache.addToCache(e(27, "doc1", "1-d"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 40}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 40}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
+	goassert.True(t, err == nil)
 
 	// Add a late-arriving sequence adjacent to same ID (cache inserts differently)
 	cache.AddLateSequence(e(41, "doc4", "4-b"))
 	cache.addToCache(e(41, "doc4", "4-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 41}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 41}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
+	goassert.True(t, err == nil)
 
 	// Add late arriving that's duplicate of oldest in cache
 	cache.AddLateSequence(e(45, "doc2", "2-b"))
 	cache.addToCache(e(45, "doc2", "2-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 4)
+	goassert.Equals(t, len(entries), 4)
 	writeEntries(entries)
-	assert.True(t, verifyChannelSequences(entries, []uint64{27, 30, 41, 45}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc4", "doc2"}))
-	assert.True(t, err == nil)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{27, 30, 41, 45}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc4", "doc2"}))
+	goassert.True(t, err == nil)
 
 }
 
@@ -224,12 +224,12 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	numPrepended := cache.prependChanges(changesToPrepend, 5, true)
-	assert.Equals(t, numPrepended, 3)
+	goassert.Equals(t, numPrepended, 3)
 
 	// Validate cache
 	validFrom, cachedChanges := cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(5))
-	assert.Equals(t, len(cachedChanges), 3)
+	goassert.Equals(t, validFrom, uint64(5))
+	goassert.Equals(t, len(cachedChanges), 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	cache = newChannelCache(context, "PrependPopulatedCache", 0)
@@ -246,44 +246,44 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
-	assert.Equals(t, numPrepended, 2)
+	goassert.Equals(t, numPrepended, 2)
 
 	// Validate cache
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(5))
-	assert.Equals(t, len(cachedChanges), 4)
+	goassert.Equals(t, validFrom, uint64(5))
+	goassert.Equals(t, len(cachedChanges), 4)
 	if len(cachedChanges) == 4 {
-		assert.Equals(t, cachedChanges[0].DocID, "doc3")
-		assert.Equals(t, cachedChanges[0].RevID, "2-a")
-		assert.Equals(t, cachedChanges[1].DocID, "doc5")
-		assert.Equals(t, cachedChanges[1].RevID, "2-a")
-		assert.Equals(t, cachedChanges[2].DocID, "doc1")
-		assert.Equals(t, cachedChanges[2].RevID, "2-a")
-		assert.Equals(t, cachedChanges[3].DocID, "doc2")
-		assert.Equals(t, cachedChanges[3].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[0].DocID, "doc3")
+		goassert.Equals(t, cachedChanges[0].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[1].DocID, "doc5")
+		goassert.Equals(t, cachedChanges[1].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[2].DocID, "doc1")
+		goassert.Equals(t, cachedChanges[2].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[3].DocID, "doc2")
+		goassert.Equals(t, cachedChanges[3].RevID, "3-a")
 	}
 
 	// Write a new revision for a prepended doc to the cache, validate that old entry is removed
 	cache.addToCache(e(24, "doc3", "3-a"), false)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(5))
-	assert.Equals(t, len(cachedChanges), 4)
+	goassert.Equals(t, validFrom, uint64(5))
+	goassert.Equals(t, len(cachedChanges), 4)
 	if len(cachedChanges) == 4 {
-		assert.Equals(t, cachedChanges[0].DocID, "doc5")
-		assert.Equals(t, cachedChanges[0].RevID, "2-a")
-		assert.Equals(t, cachedChanges[1].DocID, "doc1")
-		assert.Equals(t, cachedChanges[1].RevID, "2-a")
-		assert.Equals(t, cachedChanges[2].DocID, "doc2")
-		assert.Equals(t, cachedChanges[2].RevID, "3-a")
-		assert.Equals(t, cachedChanges[3].DocID, "doc3")
-		assert.Equals(t, cachedChanges[3].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[0].DocID, "doc5")
+		goassert.Equals(t, cachedChanges[0].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[1].DocID, "doc1")
+		goassert.Equals(t, cachedChanges[1].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[2].DocID, "doc2")
+		goassert.Equals(t, cachedChanges[2].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[3].DocID, "doc3")
+		goassert.Equals(t, cachedChanges[3].RevID, "3-a")
 	}
 
 	// Prepend empty set, validate validFrom update
 	cache.prependChanges(LogEntries{}, 5, true)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(5))
-	assert.Equals(t, len(cachedChanges), 4)
+	goassert.Equals(t, validFrom, uint64(5))
+	goassert.Equals(t, len(cachedChanges), 4)
 
 	// 3. Test prepend that exceeds cache capacity
 	cache = newChannelCache(context, "PrependToFillCache", 0)
@@ -303,23 +303,23 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
-	assert.Equals(t, numPrepended, 1)
+	goassert.Equals(t, numPrepended, 1)
 
 	// Validate cache
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(10))
-	assert.Equals(t, len(cachedChanges), 5)
+	goassert.Equals(t, validFrom, uint64(10))
+	goassert.Equals(t, len(cachedChanges), 5)
 	if len(cachedChanges) == 5 {
-		assert.Equals(t, cachedChanges[0].DocID, "doc6")
-		assert.Equals(t, cachedChanges[0].RevID, "2-a")
-		assert.Equals(t, cachedChanges[1].DocID, "doc1")
-		assert.Equals(t, cachedChanges[1].RevID, "2-a")
-		assert.Equals(t, cachedChanges[2].DocID, "doc2")
-		assert.Equals(t, cachedChanges[2].RevID, "3-a")
-		assert.Equals(t, cachedChanges[3].DocID, "doc3")
-		assert.Equals(t, cachedChanges[3].RevID, "3-a")
-		assert.Equals(t, cachedChanges[4].DocID, "doc4")
-		assert.Equals(t, cachedChanges[4].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[0].DocID, "doc6")
+		goassert.Equals(t, cachedChanges[0].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[1].DocID, "doc1")
+		goassert.Equals(t, cachedChanges[1].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[2].DocID, "doc2")
+		goassert.Equals(t, cachedChanges[2].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[3].DocID, "doc3")
+		goassert.Equals(t, cachedChanges[3].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[4].DocID, "doc4")
+		goassert.Equals(t, cachedChanges[4].RevID, "3-a")
 	}
 
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
@@ -337,19 +337,19 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
-	assert.Equals(t, numPrepended, 0)
+	goassert.Equals(t, numPrepended, 0)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(5))
-	assert.Equals(t, len(cachedChanges), 4)
+	goassert.Equals(t, validFrom, uint64(5))
+	goassert.Equals(t, len(cachedChanges), 4)
 	if len(cachedChanges) == 5 {
-		assert.Equals(t, cachedChanges[0].DocID, "doc1")
-		assert.Equals(t, cachedChanges[0].RevID, "2-a")
-		assert.Equals(t, cachedChanges[1].DocID, "doc2")
-		assert.Equals(t, cachedChanges[1].RevID, "3-a")
-		assert.Equals(t, cachedChanges[2].DocID, "doc3")
-		assert.Equals(t, cachedChanges[2].RevID, "3-a")
-		assert.Equals(t, cachedChanges[3].DocID, "doc4")
-		assert.Equals(t, cachedChanges[3].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[0].DocID, "doc1")
+		goassert.Equals(t, cachedChanges[0].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[1].DocID, "doc2")
+		goassert.Equals(t, cachedChanges[1].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[2].DocID, "doc3")
+		goassert.Equals(t, cachedChanges[2].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[3].DocID, "doc4")
+		goassert.Equals(t, cachedChanges[3].RevID, "3-a")
 	}
 
 	// 5. Test prepend for an already full cache
@@ -371,23 +371,23 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	numPrepended = cache.prependChanges(changesToPrepend, 6, true)
-	assert.Equals(t, numPrepended, 0)
+	goassert.Equals(t, numPrepended, 0)
 
 	// Validate cache
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
-	assert.Equals(t, validFrom, uint64(13))
-	assert.Equals(t, len(cachedChanges), 5)
+	goassert.Equals(t, validFrom, uint64(13))
+	goassert.Equals(t, len(cachedChanges), 5)
 	if len(cachedChanges) == 5 {
-		assert.Equals(t, cachedChanges[0].DocID, "doc1")
-		assert.Equals(t, cachedChanges[0].RevID, "2-a")
-		assert.Equals(t, cachedChanges[1].DocID, "doc2")
-		assert.Equals(t, cachedChanges[1].RevID, "3-a")
-		assert.Equals(t, cachedChanges[2].DocID, "doc3")
-		assert.Equals(t, cachedChanges[2].RevID, "3-a")
-		assert.Equals(t, cachedChanges[3].DocID, "doc4")
-		assert.Equals(t, cachedChanges[3].RevID, "3-a")
-		assert.Equals(t, cachedChanges[4].DocID, "doc5")
-		assert.Equals(t, cachedChanges[4].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[0].DocID, "doc1")
+		goassert.Equals(t, cachedChanges[0].RevID, "2-a")
+		goassert.Equals(t, cachedChanges[1].DocID, "doc2")
+		goassert.Equals(t, cachedChanges[1].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[2].DocID, "doc3")
+		goassert.Equals(t, cachedChanges[2].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[3].DocID, "doc4")
+		goassert.Equals(t, cachedChanges[3].RevID, "3-a")
+		goassert.Equals(t, cachedChanges[4].DocID, "doc5")
+		goassert.Equals(t, cachedChanges[4].RevID, "3-a")
 	}
 }
 
@@ -407,28 +407,28 @@ func TestChannelCacheRemove(t *testing.T) {
 	cache.addToCache(e(3, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 3)
-	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 3)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
+	goassert.True(t, err == nil)
 
 	// Now remove doc1
 	cache.Remove([]string{"doc1"}, time.Now())
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 2)
-	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 2)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
+	goassert.True(t, err == nil)
 
 	// Try to remove doc5 with a startTime before it was added to ensure it's not removed
 	// This will print a debug level log:
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
 	cache.Remove([]string{"doc5"}, time.Now().Add(-time.Second*5))
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equals(t, len(entries), 2)
-	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
-	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
-	assert.True(t, err == nil)
+	goassert.Equals(t, len(entries), 2)
+	goassert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
+	goassert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
+	goassert.True(t, err == nil)
 }
 
 func verifyChannelSequences(entries []*LogEntry, sequences []uint64) bool {

--- a/db/channel_index_test.go
+++ b/db/channel_index_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
 )
 
 type channelIndexTest struct {
@@ -593,17 +594,17 @@ func TestChannelVbucketMappings(t *testing.T) {
 	defer index.indexBucket.Close()
 
 	err := verifyVBMapping(index.indexBucket, "foo")
-	assertTrue(t, err == nil, "inconsistent hash")
+	assert.True(t, err == nil, "inconsistent hash")
 
 	err = verifyVBMapping(index.indexBucket, "SomeVeryLongChannelNameInCaseLengthIsSomehowAFactor")
-	assertTrue(t, err == nil, "inconsistent hash")
+	assert.True(t, err == nil, "inconsistent hash")
 	err = verifyVBMapping(index.indexBucket, "Punc-tu-@-tio-n")
-	assertTrue(t, err == nil, "inconsistent hash")
+	assert.True(t, err == nil, "inconsistent hash")
 	err = verifyVBMapping(index.indexBucket, "more::punc::tu::a::tion")
-	assertTrue(t, err == nil, "inconsistent hash")
+	assert.True(t, err == nil, "inconsistent hash")
 
 	err = verifyVBMapping(index.indexBucket, "1")
-	assertTrue(t, err == nil, "inconsistent hash")
+	assert.True(t, err == nil, "inconsistent hash")
 
 	log.Printf("checks out")
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 type treeDoc struct {
@@ -78,7 +78,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Retrieve doc 2-a...")
 	gotbody, err := db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Create rev 2-b
 	//    1-a
@@ -94,14 +94,14 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-b")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2b_body)
+	goassert.DeepEquals(t, gotbody, rev2b_body)
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err := getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equals(t, len(revTree.BodyMap), 0)
-	assert.Equals(t, len(revTree.BodyKeyMap), 1)
+	goassert.Equals(t, len(revTree.BodyMap), 0)
+	goassert.Equals(t, len(revTree.BodyKeyMap), 1)
 
 	// Retrieve the raw revision body backup of 2-a, and verify it's intact
 	log.Printf("Verify document storage of 2-a")
@@ -109,14 +109,14 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rawRevision, _, err := db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assertNoError(t, err, "Couldn't get raw backup revision")
 	json.Unmarshal(rawRevision, &revisionBody)
-	assert.Equals(t, revisionBody["version"], rev2a_body["version"])
-	assert.Equals(t, revisionBody["value"], rev2a_body["value"])
+	goassert.Equals(t, revisionBody["version"], rev2a_body["version"])
+	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 
 	// Retrieve the non-inline revision
 	db.FlushRevisionCache()
 	rev2aGet, err := db.GetRev("doc1", "2-a", false, nil)
 	assertNoError(t, err, "Couldn't get rev 2-a")
-	assert.DeepEquals(t, rev2aGet, rev2a_body)
+	goassert.DeepEquals(t, rev2aGet, rev2a_body)
 
 	// Tombstone 2-b (with rev 3-b, minimal tombstone)
 	//    1-a
@@ -134,13 +134,13 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Retrieve tombstone
 	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
 	assertNoError(t, err, "Couldn't get rev 3-b")
-	assert.DeepEquals(t, rev3bGet, rev3b_body)
+	goassert.DeepEquals(t, rev3bGet, rev3b_body)
 
 	// Retrieve the document, validate that we get 2-a
 	log.Printf("Retrieve doc, expect 2-a")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Ensure previous revision body backup has been removed
 	_, _, err = db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
@@ -149,8 +149,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Validate the tombstone is stored inline (due to small size)
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equals(t, len(revTree.BodyMap), 1)
-	assert.Equals(t, len(revTree.BodyKeyMap), 0)
+	goassert.Equals(t, len(revTree.BodyMap), 1)
+	goassert.Equals(t, len(revTree.BodyKeyMap), 0)
 
 	// Create another conflict (2-c)
 	//      1-a
@@ -168,7 +168,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-c")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2c_body)
+	goassert.DeepEquals(t, gotbody, rev2c_body)
 
 	// Tombstone with a large tombstone
 	//      1-a
@@ -187,19 +187,19 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
 	newRevTree, err := getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equals(t, len(newRevTree.BodyMap), 1)    // tombstone 3-b
-	assert.Equals(t, len(newRevTree.BodyKeyMap), 1) // tombstone 3-c
+	goassert.Equals(t, len(newRevTree.BodyMap), 1)    // tombstone 3-b
+	goassert.Equals(t, len(newRevTree.BodyKeyMap), 1) // tombstone 3-c
 
 	// Retrieve the non-inline tombstone revision
 	db.FlushRevisionCache()
 	rev3cGet, err := db.GetRev("doc1", "3-c", false, nil)
 	assertNoError(t, err, "Couldn't get rev 3-c")
-	assert.DeepEquals(t, rev3cGet, rev3c_body)
+	goassert.DeepEquals(t, rev3cGet, rev3c_body)
 
 	log.Printf("Retrieve doc, verify active rev is 2-a")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Add active revision, ensure all revisions remain intact
 	log.Printf("Create rev 3-a with a large body")
@@ -210,8 +210,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equals(t, len(revTree.BodyMap), 1)    // tombstone 3-b
-	assert.Equals(t, len(revTree.BodyKeyMap), 1) // tombstone 3-c
+	goassert.Equals(t, len(revTree.BodyMap), 1)    // tombstone 3-b
+	goassert.Equals(t, len(revTree.BodyKeyMap), 1) // tombstone 3-c
 }
 
 // TestRevisionStoragePruneTombstone - tests cleanup of external tombstone bodies when pruned.
@@ -244,7 +244,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	log.Printf("Retrieve doc 2-a...")
 	gotbody, err := db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Create rev 2-b
 	//    1-a
@@ -260,14 +260,14 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	log.Printf("Retrieve doc, verify rev 2-b")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2b_body)
+	goassert.DeepEquals(t, gotbody, rev2b_body)
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err := getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equals(t, len(revTree.BodyMap), 0)
-	assert.Equals(t, len(revTree.BodyKeyMap), 1)
+	goassert.Equals(t, len(revTree.BodyMap), 0)
+	goassert.Equals(t, len(revTree.BodyKeyMap), 1)
 
 	// Retrieve the raw revision body backup of 2-a, and verify it's intact
 	log.Printf("Verify document storage of 2-a")
@@ -275,14 +275,14 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rawRevision, _, err := db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assertNoError(t, err, "Couldn't get raw backup revision")
 	json.Unmarshal(rawRevision, &revisionBody)
-	assert.Equals(t, revisionBody["version"], rev2a_body["version"])
-	assert.Equals(t, revisionBody["value"], rev2a_body["value"])
+	goassert.Equals(t, revisionBody["version"], rev2a_body["version"])
+	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 
 	// Retrieve the non-inline revision
 	db.FlushRevisionCache()
 	rev2aGet, err := db.GetRev("doc1", "2-a", false, nil)
 	assertNoError(t, err, "Couldn't get rev 2-a")
-	assert.DeepEquals(t, rev2aGet, rev2a_body)
+	goassert.DeepEquals(t, rev2aGet, rev2a_body)
 
 	// Tombstone 2-b (with rev 3-b, large tombstone)
 	//    1-a
@@ -302,20 +302,20 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	db.FlushRevisionCache()
 	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
 	assertNoError(t, err, "Couldn't get rev 3-b")
-	assert.DeepEquals(t, rev3bGet, rev3b_body)
+	goassert.DeepEquals(t, rev3bGet, rev3b_body)
 
 	// Retrieve the document, validate that we get 2-a
 	log.Printf("Retrieve doc, expect 2-a")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Retrieve the raw document, and verify 2-a isn't stored inline
 	log.Printf("Retrieve doc, verify rev 2-a not inline")
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assertNoError(t, err, "Couldn't get revtree for raw document")
-	assert.Equals(t, len(revTree.BodyMap), 0)
-	assert.Equals(t, len(revTree.BodyKeyMap), 1)
+	goassert.Equals(t, len(revTree.BodyMap), 0)
+	goassert.Equals(t, len(revTree.BodyKeyMap), 1)
 	log.Printf("revTree.BodyKeyMap:%v", revTree.BodyKeyMap)
 
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
@@ -345,7 +345,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	log.Printf("Attempt to retrieve 3-b, expect pruned")
 	db.FlushRevisionCache()
 	rev3bGet, err = db.GetRev("doc1", "3-b", false, nil)
-	assert.Equals(t, err.Error(), "404 missing")
+	goassert.Equals(t, err.Error(), "404 missing")
 
 	// Ensure previous tombstone body backup has been removed
 	log.Printf("Verify revision body doc has been removed from bucket")
@@ -380,7 +380,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	log.Printf("Retrieve doc 2-a...")
 	gotbody, err := db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Create rev 3-a
 
@@ -397,7 +397,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	log.Printf("Retrieve doc 3-a...")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev3a_body)
+	goassert.DeepEquals(t, gotbody, rev3a_body)
 
 	// Create rev 2-b
 	//    1-a
@@ -413,7 +413,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	log.Printf("Retrieve doc, verify still rev 3-a")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev3a_body)
+	goassert.DeepEquals(t, gotbody, rev3a_body)
 
 	// Create rev that hops a few generations
 	//    1-a
@@ -435,7 +435,7 @@ func TestOldRevisionStorage(t *testing.T) {
 	log.Printf("Retrieve doc 6-a...")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev6a_body)
+	goassert.DeepEquals(t, gotbody, rev6a_body)
 
 	// Add child to non-winning revision w/ inline body
 	//    1-a
@@ -526,7 +526,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	log.Printf("Retrieve doc 2-a...")
 	gotbody, err := db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev2a_body)
+	goassert.DeepEquals(t, gotbody, rev2a_body)
 
 	// Create rev 3-a, should re-attempt to write old revision body for 2-a
 	// 1-a
@@ -552,7 +552,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	log.Printf("Retrieve doc, verify still rev 3-a")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev3a_body)
+	goassert.DeepEquals(t, gotbody, rev3a_body)
 
 	// Create rev that hops a few generations
 	//    1-a
@@ -574,7 +574,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	log.Printf("Retrieve doc 6-a...")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, rev6a_body)
+	goassert.DeepEquals(t, gotbody, rev6a_body)
 
 	// Add child to non-winning revision w/ inline body
 	// Creation of 3-b will trigger leaky bucket handling when obsolete body of rev 2-b is persisted
@@ -629,7 +629,7 @@ func TestLargeSequence(t *testing.T) {
 
 	syncData, err := db.GetDocSyncData("largeSeqDoc")
 	assertNoError(t, err, "Error retrieving document sync data")
-	assert.Equals(t, syncData.Sequence, uint64(9223372036854775808))
+	goassert.Equals(t, syncData.Sequence, uint64(9223372036854775808))
 }
 
 const rawDocMalformedRevisionStorage = `
@@ -678,7 +678,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Add doc1 w/ malformed body for rev 2-b included in revision tree")
 	ok, addErr := db.Bucket.AddRaw("doc1", 0, []byte(rawDocMalformedRevisionStorage))
-	assert.True(t, ok)
+	goassert.True(t, ok)
 	assertNoError(t, addErr, "Error writing raw document")
 
 	// Increment _sync:seq to match sequences allocated by raw doc

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/robertkrimen/otto/underscore"
 
 	"strings"
@@ -179,9 +179,9 @@ func tearDownTestDB(t testing.TB, db *Database) {
 func assertHTTPError(t *testing.T, err error, status int) {
 	httpErr, ok := err.(*base.HTTPError)
 	if !ok {
-		assert.Errorf(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
+		goassert.Errorf(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
 	} else {
-		assert.Equals(t, httpErr.Status, status)
+		goassert.Equals(t, httpErr.Status, status)
 	}
 }
 
@@ -196,8 +196,8 @@ func TestDatabase(t *testing.T) {
 	body := Body{"key1": "value1", "key2": 1234}
 	rev1id, err := db.Put("doc1", body)
 	assertNoError(t, err, "Couldn't create document")
-	assert.Equals(t, rev1id, body[BodyRev])
-	assert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
+	goassert.Equals(t, rev1id, body[BodyRev])
+	goassert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
 
 	log.Printf("Create rev 2...")
 	body["key1"] = "new value"
@@ -205,35 +205,35 @@ func TestDatabase(t *testing.T) {
 	rev2id, err := db.Put("doc1", body)
 	body[BodyId] = "doc1"
 	assertNoError(t, err, "Couldn't update document")
-	assert.Equals(t, rev2id, body[BodyRev])
-	assert.Equals(t, rev2id, "2-488724414d0ed6b398d6d2aeb228d797")
+	goassert.Equals(t, rev2id, body[BodyRev])
+	goassert.Equals(t, rev2id, "2-488724414d0ed6b398d6d2aeb228d797")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc...")
 	gotbody, err := db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, body)
+	goassert.DeepEquals(t, gotbody, body)
 
 	log.Printf("Retrieve rev 1...")
 	gotbody, err = db.GetRev("doc1", rev1id, false, nil)
 	assertNoError(t, err, "Couldn't get document with rev 1")
-	assert.DeepEquals(t, gotbody, Body{"key1": "value1", "key2": 1234, BodyId: "doc1", BodyRev: rev1id})
+	goassert.DeepEquals(t, gotbody, Body{"key1": "value1", "key2": 1234, BodyId: "doc1", BodyRev: rev1id})
 
 	log.Printf("Retrieve rev 2...")
 	gotbody, err = db.GetRev("doc1", rev2id, false, nil)
 	assertNoError(t, err, "Couldn't get document with rev")
-	assert.DeepEquals(t, gotbody, body)
+	goassert.DeepEquals(t, gotbody, body)
 
 	gotbody, err = db.GetRev("doc1", "bogusrev", false, nil)
 	status, _ := base.ErrorAsHTTPStatus(err)
-	assert.Equals(t, status, 404)
+	goassert.Equals(t, status, 404)
 
 	// Test the _revisions property:
 	log.Printf("Check _revisions...")
 	gotbody, err = db.GetRev("doc1", rev2id, true, nil)
 	revisions := gotbody[BodyRevisions].(map[string]interface{})
-	assert.Equals(t, revisions[RevisionsStart], 2)
-	assert.DeepEquals(t, revisions[RevisionsIds],
+	goassert.Equals(t, revisions[RevisionsStart], 2)
+	goassert.DeepEquals(t, revisions[RevisionsIds],
 		[]string{"488724414d0ed6b398d6d2aeb228d797",
 			"cb0c9a22be0e5a1b01084ec019defa81"})
 
@@ -242,21 +242,21 @@ func TestDatabase(t *testing.T) {
 	missing, possible := db.RevDiff("doc1",
 		[]string{"1-cb0c9a22be0e5a1b01084ec019defa81",
 			"2-488724414d0ed6b398d6d2aeb228d797"})
-	assert.True(t, missing == nil)
-	assert.True(t, possible == nil)
+	goassert.True(t, missing == nil)
+	goassert.True(t, possible == nil)
 
 	missing, possible = db.RevDiff("doc1",
 		[]string{"1-cb0c9a22be0e5a1b01084ec019defa81",
 			"3-foo"})
-	assert.DeepEquals(t, missing, []string{"3-foo"})
-	assert.DeepEquals(t, possible, []string{"2-488724414d0ed6b398d6d2aeb228d797"})
+	goassert.DeepEquals(t, missing, []string{"3-foo"})
+	goassert.DeepEquals(t, possible, []string{"2-488724414d0ed6b398d6d2aeb228d797"})
 
 	missing, possible = db.RevDiff("nosuchdoc",
 		[]string{"1-cb0c9a22be0e5a1b01084ec019defa81",
 			"3-foo"})
-	assert.DeepEquals(t, missing, []string{"1-cb0c9a22be0e5a1b01084ec019defa81",
+	goassert.DeepEquals(t, missing, []string{"1-cb0c9a22be0e5a1b01084ec019defa81",
 		"3-foo"})
-	assert.True(t, possible == nil)
+	goassert.True(t, possible == nil)
 
 	// Test PutExistingRev:
 	log.Printf("Check PutExistingRev...")
@@ -272,7 +272,7 @@ func TestDatabase(t *testing.T) {
 	log.Printf("Check Get...")
 	gotbody, err = db.Get("doc1")
 	assertNoError(t, err, "Couldn't get document")
-	assert.DeepEquals(t, gotbody, body)
+	goassert.DeepEquals(t, gotbody, body)
 
 }
 
@@ -298,12 +298,12 @@ func TestGetDeleted(t *testing.T) {
 		BodyDeleted:   true,
 		BodyRevisions: map[string]interface{}{RevisionsStart: 2, RevisionsIds: []string{"bc6d97f6e97c0d034a34f8aac2bf8b44", "dfd5e19813767eeddd08270fc5f385cd"}},
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Get the raw doc and make sure the sync data has the current revision
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assertNoError(t, err, "Err getting doc")
-	assert.Equals(t, doc.syncData.CurrentRev, rev2id)
+	goassert.Equals(t, doc.syncData.CurrentRev, rev2id)
 
 	// Try again but with a user who doesn't have access to this revision (see #179)
 	authenticator := auth.NewAuthenticator(db.Bucket, db)
@@ -313,7 +313,7 @@ func TestGetDeleted(t *testing.T) {
 
 	body, err = db.GetRev("doc1", rev2id, true, nil)
 	assertNoError(t, err, "GetRev")
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 }
 
 // Test retrieval of a channel removal revision, when the revision is not otherwise available
@@ -361,7 +361,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 		BodyId:  "doc1",
 		BodyRev: rev2id,
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
@@ -390,7 +390,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
 	err = db.purgeOldRevisionJSON("doc1", rev1id)
@@ -445,7 +445,7 @@ func TestGetRemoved(t *testing.T) {
 		BodyId:  "doc1",
 		BodyRev: rev2id,
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
@@ -465,7 +465,7 @@ func TestGetRemoved(t *testing.T) {
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
 	err = db.purgeOldRevisionJSON("doc1", rev1id)
@@ -520,7 +520,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		BodyId:  "doc1",
 		BodyRev: rev2id,
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
@@ -541,7 +541,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
-	assert.DeepEquals(t, body, expectedResult)
+	goassert.DeepEquals(t, body, expectedResult)
 
 	// Ensure revision is unavailable for a non-leaf revision that isn't available via the rev cache, and wasn't a channel removal
 	err = db.purgeOldRevisionJSON("doc1", rev1id)
@@ -605,9 +605,9 @@ func TestAllDocsOnly(t *testing.T) {
 
 	alldocs, err := allDocIDs(db)
 	assertNoError(t, err, "AllDocIDs failed")
-	assert.Equals(t, len(alldocs), 100)
+	goassert.Equals(t, len(alldocs), 100)
 	for i, entry := range alldocs {
-		assert.True(t, entry.Equal(ids[i]))
+		goassert.True(t, entry.Equal(ids[i]))
 	}
 
 	// Now delete one document and try again:
@@ -616,21 +616,21 @@ func TestAllDocsOnly(t *testing.T) {
 
 	alldocs, err = allDocIDs(db)
 	assertNoError(t, err, "AllDocIDs failed")
-	assert.Equals(t, len(alldocs), 99)
+	goassert.Equals(t, len(alldocs), 99)
 	for i, entry := range alldocs {
 		j := i
 		if i >= 23 {
 			j++
 		}
-		assert.True(t, entry.Equal(ids[j]))
+		goassert.True(t, entry.Equal(ids[j]))
 	}
 
 	// Inspect the channel log to confirm that it's only got the last 50 sequences.
 	// There are 101 sequences overall, so the 1st one it has should be #52.
 	db.changeCache.waitForSequence(101, base.DefaultWaitForSequenceTesting)
 	changeLog := db.GetChangeLog("all", 0)
-	assert.Equals(t, len(changeLog), 50)
-	assert.Equals(t, int(changeLog[0].Sequence), 52)
+	goassert.Equals(t, len(changeLog), 50)
+	goassert.Equals(t, int(changeLog[0].Sequence), 52)
 
 	// Now check the changes feed:
 	var options ChangesOptions
@@ -638,33 +638,33 @@ func TestAllDocsOnly(t *testing.T) {
 	defer close(options.Terminator)
 	changes, err := db.GetChanges(channels.SetOf("all"), options)
 	assertNoError(t, err, "Couldn't GetChanges")
-	assert.Equals(t, len(changes), 100)
+	goassert.Equals(t, len(changes), 100)
 	for i, change := range changes {
 		seq := i + 1
 		if i >= 23 {
 			seq++
 		}
-		assert.Equals(t, change.Seq, SequenceID{Seq: uint64(seq)})
-		assert.Equals(t, change.Deleted, i == 99)
+		goassert.Equals(t, change.Seq, SequenceID{Seq: uint64(seq)})
+		goassert.Equals(t, change.Deleted, i == 99)
 		var removed base.Set
 		if i == 99 {
 			removed = channels.SetOf("all")
 		}
-		assert.DeepEquals(t, change.Removed, removed)
+		goassert.DeepEquals(t, change.Removed, removed)
 	}
 
 	options.IncludeDocs = true
 	changes, err = db.GetChanges(channels.SetOf("KFJC"), options)
 	assertNoError(t, err, "Couldn't GetChanges")
-	assert.Equals(t, len(changes), 10)
+	goassert.Equals(t, len(changes), 10)
 	for i, change := range changes {
-		assert.Equals(t, change.Seq, SequenceID{Seq: uint64(10*i + 1)})
-		assert.Equals(t, change.ID, ids[10*i].DocID)
-		assert.Equals(t, change.Deleted, false)
-		assert.DeepEquals(t, change.Removed, base.Set(nil))
+		goassert.Equals(t, change.Seq, SequenceID{Seq: uint64(10*i + 1)})
+		goassert.Equals(t, change.ID, ids[10*i].DocID)
+		goassert.Equals(t, change.Deleted, false)
+		goassert.DeepEquals(t, change.Removed, base.Set(nil))
 		// Note: When changes uses the rev cache, this test doesn't trigger FixJSONNumbers (since it writes docs as Body, not raw JSON,
 		//       and doesn't require a read from DB)
-		assert.Equals(t, change.Doc["serialnumber"], int64(10*i))
+		goassert.Equals(t, change.Doc["serialnumber"], int64(10*i))
 	}
 }
 
@@ -691,7 +691,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	assertNoError(t, err, "Unable to update principal")
 
 	nextSeq, err := db.sequences.nextSequence()
-	assert.Equals(t, nextSeq, uint64(1))
+	goassert.Equals(t, nextSeq, uint64(1))
 
 	// Validate that a call to UpdatePrincipals with changes to the user does allocate a sequence
 	userInfo, err = db.GetPrincipal("naomi", true)
@@ -700,7 +700,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	assertNoError(t, err, "Unable to update principal")
 
 	nextSeq, err = db.sequences.nextSequence()
-	assert.Equals(t, nextSeq, uint64(3))
+	goassert.Equals(t, nextSeq, uint64(3))
 }
 
 // Re-apply one of the conflicting changes to make sure that PutExistingRev() treats it as a no-op (SG Issue #3048)
@@ -725,9 +725,9 @@ func TestRepeatedConflict(t *testing.T) {
 
 	// Get the _rev that was set in the body by PutExistingRev() and make assertions on it
 	rev, ok := body[BodyRev]
-	assert.True(t, ok)
+	goassert.True(t, ok)
 	revGen, _ := ParseRevID(rev.(string))
-	assert.Equals(t, revGen, 2)
+	goassert.Equals(t, revGen, 2)
 
 	// Remove the _rev key from the body, and call PutExistingRev() again, which should re-add it
 	delete(body, BodyRev)
@@ -735,9 +735,9 @@ func TestRepeatedConflict(t *testing.T) {
 
 	// The _rev should pass the same assertions as before, since PutExistingRev() should re-add it
 	rev, ok = body[BodyRev]
-	assert.True(t, ok)
+	goassert.True(t, ok)
 	revGen, _ = ParseRevID(rev.(string))
-	assert.Equals(t, revGen, 2)
+	goassert.Equals(t, revGen, 2)
 
 }
 
@@ -760,7 +760,7 @@ func TestConflicts(t *testing.T) {
 	time.Sleep(time.Second) // Wait for tap feed to catch up
 
 	changeLog := db.GetChangeLog("all", 0)
-	assert.Equals(t, len(changeLog), 1)
+	goassert.Equals(t, len(changeLog), 1)
 
 	// Create two conflicting changes:
 	body["n"] = 2
@@ -778,25 +778,25 @@ func TestConflicts(t *testing.T) {
 
 	// Verify the change with the higher revid won:
 	gotBody, err := db.Get("doc")
-	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-b", "n": 2,
+	goassert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-b", "n": 2,
 		"channels": []string{"all", "2b"}})
 
 	// Verify we can still get the other two revisions:
 	gotBody, err = db.GetRev("doc", "1-a", false, nil)
-	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "1-a", "n": 1,
+	goassert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "1-a", "n": 1,
 		"channels": []string{"all", "1"}})
 	gotBody, err = db.GetRev("doc", "2-a", false, nil)
-	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-a", "n": 3,
+	goassert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-a", "n": 3,
 		"channels": []string{"all", "2a"}})
 
 	// Verify the change-log of the "all" channel:
 	db.changeCache.waitForSequence(3, base.DefaultWaitForSequenceTesting)
 	changeLog = db.GetChangeLog("all", 0)
-	assert.Equals(t, len(changeLog), 1)
-	assert.Equals(t, changeLog[0].Sequence, uint64(3))
-	assert.Equals(t, changeLog[0].DocID, "doc")
-	assert.Equals(t, changeLog[0].RevID, "2-b")
-	assert.Equals(t, changeLog[0].Flags, uint8(channels.Hidden|channels.Branched|channels.Conflict))
+	goassert.Equals(t, len(changeLog), 1)
+	goassert.Equals(t, changeLog[0].Sequence, uint64(3))
+	goassert.Equals(t, changeLog[0].DocID, "doc")
+	goassert.Equals(t, changeLog[0].RevID, "2-b")
+	goassert.Equals(t, changeLog[0].Flags, uint8(channels.Hidden|channels.Branched|channels.Conflict))
 
 	// Verify the _changes feed:
 	options := ChangesOptions{
@@ -804,8 +804,8 @@ func TestConflicts(t *testing.T) {
 	}
 	changes, err := db.GetChanges(channels.SetOf("all"), options)
 	assertNoError(t, err, "Couldn't GetChanges")
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:      SequenceID{Seq: 3},
 		ID:       "doc",
 		Changes:  []ChangeRev{{"rev": "2-b"}, {"rev": "2-a"}},
@@ -819,22 +819,22 @@ func TestConflicts(t *testing.T) {
 	log.Printf("post-delete, got raw body: %s", rawBody)
 
 	gotBody, err = db.Get("doc")
-	assert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-a", "n": 3,
+	goassert.DeepEquals(t, gotBody, Body{BodyId: "doc", BodyRev: "2-a", "n": 3,
 		"channels": []string{"all", "2a"}})
 
 	// Verify channel assignments are correct for channels defined by 2-a:
 	doc, _ := db.GetDocument("doc", DocUnmarshalAll)
 	chan2a, found := doc.Channels["2a"]
-	assert.True(t, found)
-	assert.True(t, chan2a == nil)             // currently in 2a
-	assert.True(t, doc.Channels["2b"] != nil) // has been removed from 2b
+	goassert.True(t, found)
+	goassert.True(t, chan2a == nil)             // currently in 2a
+	goassert.True(t, doc.Channels["2b"] != nil) // has been removed from 2b
 
 	// Verify the _changes feed:
 	db.changeCache.waitForSequence(4, base.DefaultWaitForSequenceTesting)
 	changes, err = db.GetChanges(channels.SetOf("all"), options)
 	assertNoError(t, err, "Couldn't GetChanges")
-	assert.Equals(t, len(changes), 1)
-	assert.DeepEquals(t, changes[0], &ChangeEntry{
+	goassert.Equals(t, len(changes), 1)
+	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:      SequenceID{Seq: 4},
 		ID:       "doc",
 		Changes:  []ChangeRev{{"rev": "2-a"}, {"rev": rev3}},
@@ -942,7 +942,7 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	assertNoError(t, putErr, "tombstone 2-a")
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assertNoError(t, err, "Retrieve doc post-tombstone")
-	assert.Equals(t, doc.CurrentRev, "2-b")
+	goassert.Equals(t, doc.CurrentRev, "2-b")
 
 	// Attempt to add a tombstone rev w/ the previous tombstone as parent
 	body[BodyRev] = tombstoneRev
@@ -955,7 +955,7 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	assertNoError(t, putErr, "tombstone 2-b")
 	doc, err = db.GetDocument("doc2", DocUnmarshalAll)
 	assertNoError(t, err, "Retrieve doc post-tombstone")
-	assert.Equals(t, doc.CurrentRev, "2-a")
+	goassert.Equals(t, doc.CurrentRev, "2-a")
 
 	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
 	db.RevsLimit = uint32(1)
@@ -964,7 +964,7 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	assertNoError(t, putErr, "tombstone 2-a w/ revslimit=1")
 	doc, err = db.GetDocument("doc3", DocUnmarshalAll)
 	assertNoError(t, err, "Retrieve doc post-tombstone")
-	assert.Equals(t, doc.CurrentRev, "2-b")
+	goassert.Equals(t, doc.CurrentRev, "2-b")
 
 	log.Printf("tombstoned conflicts: %+v", doc)
 
@@ -1006,20 +1006,20 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 	assertNoError(t, db.PutExistingRev("doc1", body, []string{"3-a", "2-a"}, false), "add 3-a (tombstone)")
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assertNoError(t, err, "Retrieve doc post-tombstone")
-	assert.Equals(t, doc.CurrentRev, "2-b")
+	goassert.Equals(t, doc.CurrentRev, "2-b")
 
 	// Tombstone the winning branch of a conflicted document
 	assertNoError(t, db.PutExistingRev("doc2", body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
 	doc, err = db.GetDocument("doc2", DocUnmarshalAll)
 	assertNoError(t, err, "Retrieve doc post-tombstone")
-	assert.Equals(t, doc.CurrentRev, "2-a")
+	goassert.Equals(t, doc.CurrentRev, "2-a")
 
 	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
 	db.RevsLimit = uint32(1)
 	assertNoError(t, db.PutExistingRev("doc3", body, []string{"3-a", "2-a"}, false), "add 3-a (tombstone)")
 	doc, err = db.GetDocument("doc3", DocUnmarshalAll)
 	assertNoError(t, err, "Retrieve doc post-tombstone")
-	assert.Equals(t, doc.CurrentRev, "2-b")
+	goassert.Equals(t, doc.CurrentRev, "2-b")
 
 	log.Printf("tombstoned conflicts: %+v", doc)
 }
@@ -1055,11 +1055,11 @@ func TestSyncFnOnPush(t *testing.T) {
 
 	// Check that the doc has the correct channel (test for issue #300)
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
-	assert.DeepEquals(t, doc.Channels, channels.ChannelMap{
+	goassert.DeepEquals(t, doc.Channels, channels.ChannelMap{
 		"clibup": nil, // i.e. it is currently in this channel (no removal)
 		"public": &channels.ChannelRemoval{Seq: 2, RevID: "4-four"},
 	})
-	assert.DeepEquals(t, doc.History["4-four"].Channels, base.SetOf("clibup"))
+	goassert.DeepEquals(t, doc.History["4-four"].Channels, base.SetOf("clibup"))
 }
 
 func TestInvalidChannel(t *testing.T) {
@@ -1140,10 +1140,10 @@ func TestAccessFunctionDb(t *testing.T) {
 	user, err = authenticator.GetUser("naomi")
 	assertNoError(t, err, "GetUser")
 	expected := channels.AtSequence(channels.SetOf("Hulu", "Netflix", "!"), 1)
-	assert.DeepEquals(t, user.Channels(), expected)
+	goassert.DeepEquals(t, user.Channels(), expected)
 
 	expected.AddChannel("CrunchyRoll", 2)
-	assert.DeepEquals(t, user.InheritedChannels(), expected)
+	goassert.DeepEquals(t, user.InheritedChannels(), expected)
 }
 
 // Disabled until https://github.com/couchbase/sync_gateway/issues/3413 is fixed
@@ -1178,7 +1178,7 @@ func TestAccessFunctionWithVbuckets(t *testing.T) {
 	user, err = authenticator.GetUser("bernard")
 	assertNoError(t, err, "GetUser")
 	expected := channels.TimedSetFromString(fmt.Sprintf("ABC:%d.1,Netflix:1,!:1", testBucket.VBHash("doc1")))
-	assert.DeepEquals(t, user.Channels(), expected)
+	goassert.DeepEquals(t, user.Channels(), expected)
 
 	body = Body{"users": []string{"bernard"}, "userChannels": []string{"NBC"}}
 	_, err = db.Put("doc2", body)
@@ -1188,7 +1188,7 @@ func TestAccessFunctionWithVbuckets(t *testing.T) {
 	user, err = authenticator.GetUser("bernard")
 	assertNoError(t, err, "GetUser")
 	expected = channels.TimedSetFromString(fmt.Sprintf("ABC:%d.1,NBC:%d.1,Netflix:1,!:1", testBucket.VBHash("doc1"), testBucket.VBHash("doc2")))
-	assert.DeepEquals(t, user.Channels(), expected)
+	goassert.DeepEquals(t, user.Channels(), expected)
 
 	// Have another doc assign a new channel, and one of the previously present channels
 	body = Body{"users": []string{"bernard"}, "userChannels": []string{"ABC", "PBS"}}
@@ -1199,17 +1199,17 @@ func TestAccessFunctionWithVbuckets(t *testing.T) {
 	user, err = authenticator.GetUser("bernard")
 	assertNoError(t, err, "GetUser")
 	expected = channels.TimedSetFromString(fmt.Sprintf("ABC:%d.1,NBC:%d.1,PBS:%d.1,Netflix:1,!:1", testBucket.VBHash("doc1"), testBucket.VBHash("doc2"), testBucket.VBHash("doc3")))
-	assert.DeepEquals(t, user.Channels(), expected)
+	goassert.DeepEquals(t, user.Channels(), expected)
 
 }
 
 func TestDocIDs(t *testing.T) {
-	assert.Equals(t, realDocID(""), "")
-	assert.Equals(t, realDocID("_"), "")
-	assert.Equals(t, realDocID("_foo"), "")
-	assert.Equals(t, realDocID("foo"), "foo")
-	assert.Equals(t, realDocID("_design/foo"), "")
-	assert.Equals(t, realDocID("_sync:rev:x"), "")
+	goassert.Equals(t, realDocID(""), "")
+	goassert.Equals(t, realDocID("_"), "")
+	goassert.Equals(t, realDocID("_foo"), "")
+	goassert.Equals(t, realDocID("foo"), "foo")
+	goassert.Equals(t, realDocID("_design/foo"), "")
+	goassert.Equals(t, realDocID("_sync:rev:x"), "")
 }
 
 func TestUpdateDesignDoc(t *testing.T) {
@@ -1238,9 +1238,9 @@ func TestUpdateDesignDoc(t *testing.T) {
 
 	assertNoError(t, err, "retrieve design doc as admin")
 	retrievedView, ok := result.Views["TestView"]
-	assert.True(t, ok)
-	assert.True(t, strings.Contains(retrievedView.Map, "emit()"))
-	assert.NotEquals(t, retrievedView.Map, mapFunction) // SG should wrap the map function, so they shouldn't be equal
+	goassert.True(t, ok)
+	goassert.True(t, strings.Contains(retrievedView.Map, "emit()"))
+	goassert.NotEquals(t, retrievedView.Map, mapFunction) // SG should wrap the map function, so they shouldn't be equal
 
 	authenticator := auth.NewAuthenticator(db.Bucket, db)
 	db.user, _ = authenticator.NewUser("naomi", "letmein", channels.SetOf("Netflix"))
@@ -1259,26 +1259,26 @@ func TestPostWithExistingId(t *testing.T) {
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, err := db.Post(body)
-	assert.True(t, rev1id != "")
-	assert.True(t, docid == customDocId)
+	goassert.True(t, rev1id != "")
+	goassert.True(t, docid == customDocId)
 	assertNoError(t, err, "Couldn't create document")
 
 	// Test retrieval
 	doc, err := db.GetDocument(customDocId, DocUnmarshalAll)
-	assert.True(t, doc != nil)
+	goassert.True(t, doc != nil)
 	assertNoError(t, err, "Unable to retrieve doc using custom id")
 
 	// Test that standard UUID creation still works:
 	log.Printf("Create document with existing id...")
 	body = Body{"notAnId": customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, err = db.Post(body)
-	assert.True(t, rev1id != "")
-	assert.True(t, docid != customDocId)
+	goassert.True(t, rev1id != "")
+	goassert.True(t, docid != customDocId)
 	assertNoError(t, err, "Couldn't create document")
 
 	// Test retrieval
 	doc, err = db.GetDocument(docid, DocUnmarshalAll)
-	assert.True(t, doc != nil)
+	goassert.True(t, doc != nil)
 	assertNoError(t, err, "Unable to retrieve doc using generated uuid")
 
 }
@@ -1295,9 +1295,9 @@ func TestPutWithUserSpecialProperty(t *testing.T) {
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "_key2": "existing"}
 	docid, rev1id, err := db.Post(body)
-	assert.True(t, rev1id == "")
-	assert.True(t, docid == "")
-	assert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
+	goassert.True(t, rev1id == "")
+	goassert.True(t, docid == "")
+	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
 }
 
 // Unit test for issue #976
@@ -1312,8 +1312,8 @@ func TestWithNullPropertyKey(t *testing.T) {
 	log.Printf("Create document with empty property key")
 	body := Body{BodyId: customDocId, "": "value1"}
 	docid, rev1id, _ := db.Post(body)
-	assert.True(t, rev1id != "")
-	assert.True(t, docid != "")
+	goassert.True(t, rev1id != "")
+	goassert.True(t, docid != "")
 }
 
 // Unit test for issue #507
@@ -1328,13 +1328,13 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
 	docid, rev1id, err := db.Post(body)
-	assert.True(t, rev1id != "")
-	assert.True(t, docid == customDocId)
+	goassert.True(t, rev1id != "")
+	goassert.True(t, docid == customDocId)
 	assertNoError(t, err, "Couldn't create document")
 
 	// Test retrieval
 	doc, err := db.GetDocument(customDocId, DocUnmarshalAll)
-	assert.True(t, doc != nil)
+	goassert.True(t, doc != nil)
 	assertNoError(t, err, "Unable to retrieve doc using custom id")
 
 	// Test that posting an update with a user special property does not update the
@@ -1342,12 +1342,12 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	log.Printf("Update document with existing id...")
 	body = Body{BodyId: customDocId, BodyRev: rev1id, "_special": "value", "key1": "value1", "key2": "existing"}
 	_, err = db.Put(docid, body)
-	assert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
+	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
 
 	// Test retrieval gets rev1
 	doc, err = db.GetDocument(docid, DocUnmarshalAll)
-	assert.True(t, doc != nil)
-	assert.True(t, doc.CurrentRev == rev1id)
+	goassert.True(t, doc != nil)
+	goassert.True(t, doc.CurrentRev == rev1id)
 	assertNoError(t, err, "Unable to retrieve doc using generated uuid")
 
 }
@@ -1360,7 +1360,7 @@ func TestIncrRetrySuccess(t *testing.T) {
 	defer leakyBucket.Close()
 	seqAllocator, _ := newSequenceAllocator(leakyBucket)
 	err := seqAllocator.reserveSequences(1)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 }
 
@@ -1373,7 +1373,7 @@ func TestIncrRetryUnsuccessful(t *testing.T) {
 	seqAllocator, _ := newSequenceAllocator(leakyBucket)
 	err := seqAllocator.reserveSequences(1)
 	log.Printf("Got error: %v", err)
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 
 }
 
@@ -1391,11 +1391,11 @@ func TestRecentSequenceHistory(t *testing.T) {
 	seqTracker++
 
 	expectedRecent := make([]uint64, 0)
-	assert.True(t, revid != "")
+	goassert.True(t, revid != "")
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	expectedRecent = append(expectedRecent, seqTracker)
-	assert.True(t, err == nil)
-	assert.DeepEquals(t, doc.RecentSequences, expectedRecent)
+	goassert.True(t, err == nil)
+	goassert.DeepEquals(t, doc.RecentSequences, expectedRecent)
 
 	// Add up to kMaxRecentSequences revisions - validate they are retained when total is less than max
 	for i := 1; i < kMaxRecentSequences; i++ {
@@ -1405,8 +1405,8 @@ func TestRecentSequenceHistory(t *testing.T) {
 	}
 
 	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
-	assert.True(t, err == nil)
-	assert.DeepEquals(t, doc.RecentSequences, expectedRecent)
+	goassert.True(t, err == nil)
+	goassert.DeepEquals(t, doc.RecentSequences, expectedRecent)
 
 	// Recent sequence pruning only prunes entries older than what's been seen over DCP
 	// (to ensure it's not pruning something that may still be coalesced).  Because of this, test waits
@@ -1417,9 +1417,9 @@ func TestRecentSequenceHistory(t *testing.T) {
 	revid, err = db.Put("doc1", body)
 	seqTracker++
 	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	log.Printf("recent:%d, max:%d", len(doc.RecentSequences), kMaxRecentSequences)
-	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
+	goassert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
 
 	// Ensure pruning works when sequences aren't sequential
 	doc2Body := Body{"val": "two"}
@@ -1434,9 +1434,9 @@ func TestRecentSequenceHistory(t *testing.T) {
 	revid, err = db.Put("doc1", body)
 	seqTracker++
 	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	log.Printf("Recent sequences: %v (shouldn't exceed %v)", len(doc.RecentSequences), kMaxRecentSequences)
-	assert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
+	goassert.True(t, len(doc.RecentSequences) <= kMaxRecentSequences)
 
 }
 
@@ -1451,8 +1451,8 @@ func TestChannelView(t *testing.T) {
 	body := Body{"key1": "value1", "key2": 1234}
 	rev1id, err := db.Put("doc1", body)
 	assertNoError(t, err, "Couldn't create document")
-	assert.Equals(t, rev1id, body[BodyRev])
-	assert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
+	goassert.Equals(t, rev1id, body[BodyRev])
+	goassert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
 
 	var entries LogEntries
 	// Query view (retry loop to wait for indexing)
@@ -1471,7 +1471,7 @@ func TestChannelView(t *testing.T) {
 	for i, entry := range entries {
 		log.Printf("View Query returned entry (%d): %v", i, entry)
 	}
-	assert.Equals(t, len(entries), 1)
+	goassert.Equals(t, len(entries), 1)
 
 }
 
@@ -1499,9 +1499,9 @@ func TestConcurrentImport(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			doc, err := db.GetDocument("directWrite", DocUnmarshalAll)
-			assert.True(t, doc != nil)
+			goassert.True(t, doc != nil)
 			assertNoError(t, err, "Document retrieval error")
-			assert.Equals(t, doc.syncData.CurrentRev, "1-36fa688dc2a2c39a952ddce46ab53d12")
+			goassert.Equals(t, doc.syncData.CurrentRev, "1-36fa688dc2a2c39a952ddce46ab53d12")
 		}()
 	}
 	wg.Wait()
@@ -1527,7 +1527,7 @@ func TestViewCustom(t *testing.T) {
 	if err != nil {
 		log.Printf("error putting doc: %v", err)
 	}
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	// Workaround race condition where queryAllDocs doesn't return the doc we just added
 	// TODO: stale=false will guarantee no race when using a couchbase bucket, but this test
@@ -1539,7 +1539,7 @@ func TestViewCustom(t *testing.T) {
 	opts := Body{"stale": false, "reduce": false}
 	viewResult := sgbucket.ViewResult{}
 	errViewCustom := db.Bucket.ViewCustom(DesignDocSyncHousekeeping(), ViewAllDocs, opts, &viewResult)
-	assert.True(t, errViewCustom == nil)
+	goassert.True(t, errViewCustom == nil)
 
 	// assert that the doc added earlier is in the results
 	foundDoc := false
@@ -1548,7 +1548,7 @@ func TestViewCustom(t *testing.T) {
 			foundDoc = true
 		}
 	}
-	assert.True(t, foundDoc)
+	goassert.True(t, foundDoc)
 
 }
 

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoveObsoleteDesignDocs(t *testing.T) {
@@ -21,14 +22,14 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 			"channels": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
-	assertNoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
+	assert.NoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
 
 	err = bucket.PutDDoc(DesignDocSyncHousekeepingPrefix, sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			"all_docs": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
-	assertNoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
+	assert.NoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
 
 	// Add some user design docs that shouldn't be removed
 	err = bucket.PutDDoc("sync_gateway_user_ddoc", sgbucket.DesignDoc{
@@ -36,36 +37,36 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 			"channels_custom": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
-	assertNoError(t, err, "Unable to create design doc (sync_gateway_user_created)")
+	assert.NoError(t, err, "Unable to create design doc (sync_gateway_user_created)")
 
 	// Verify creation was successful
-	assertTrue(t, designDocExists(bucket, DesignDocSyncGatewayPrefix), "Design doc doesn't exist")
-	assertTrue(t, designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Design doc doesn't exist")
-	assertTrue(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc doesn't exist")
+	assert.True(t, designDocExists(bucket, DesignDocSyncGatewayPrefix), "Design doc doesn't exist")
+	assert.True(t, designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Design doc doesn't exist")
+	assert.True(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc doesn't exist")
 
 	// Invoke removal in preview mode
 	removedDDocs, removeErr := removeObsoleteDesignDocs(bucket, true)
-	assertNoError(t, removeErr, "Error removing previous design docs")
+	assert.NoError(t, removeErr, "Error removing previous design docs")
 	goassert.Equals(t, len(removedDDocs), 2)
-	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
-	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
+	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
+	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
 
 	// Re-verify ddocs still exist (preview)
-	assertTrue(t, designDocExists(bucket, DesignDocSyncGatewayPrefix), "Design doc doesn't exist")
-	assertTrue(t, designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Design doc doesn't exist")
-	assertTrue(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc should exist")
+	assert.True(t, designDocExists(bucket, DesignDocSyncGatewayPrefix), "Design doc doesn't exist")
+	assert.True(t, designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Design doc doesn't exist")
+	assert.True(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc should exist")
 
 	// Invoke removal in non-preview mode
 	removedDDocs, removeErr = removeObsoleteDesignDocs(bucket, false)
-	assertNoError(t, removeErr, "Error removing previous design docs")
+	assert.NoError(t, removeErr, "Error removing previous design docs")
 	goassert.Equals(t, len(removedDDocs), 2)
-	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
-	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
+	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
+	assert.True(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
 
 	// Verify ddocs are in expected state
-	assertTrue(t, !designDocExists(bucket, DesignDocSyncGatewayPrefix), "Removed design doc still exists")
-	assertTrue(t, !designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Removed design doc still exists")
-	assertTrue(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc should exist")
+	assert.True(t, !designDocExists(bucket, DesignDocSyncGatewayPrefix), "Removed design doc still exists")
+	assert.True(t, !designDocExists(bucket, DesignDocSyncHousekeepingPrefix), "Removed design doc still exists")
+	assert.True(t, designDocExists(bucket, "sync_gateway_user_ddoc"), "Design doc should exist")
 
 }
 

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestRemoveObsoleteDesignDocs(t *testing.T) {
@@ -46,7 +46,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 	// Invoke removal in preview mode
 	removedDDocs, removeErr := removeObsoleteDesignDocs(bucket, true)
 	assertNoError(t, removeErr, "Error removing previous design docs")
-	assert.Equals(t, len(removedDDocs), 2)
+	goassert.Equals(t, len(removedDDocs), 2)
 	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
 	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
 
@@ -58,7 +58,7 @@ func TestRemoveObsoleteDesignDocs(t *testing.T) {
 	// Invoke removal in non-preview mode
 	removedDDocs, removeErr = removeObsoleteDesignDocs(bucket, false)
 	assertNoError(t, removeErr, "Error removing previous design docs")
-	assert.Equals(t, len(removedDDocs), 2)
+	goassert.Equals(t, len(removedDDocs), 2)
 	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncGatewayPrefix), "Missing design doc from removed set")
 	assertTrue(t, base.StringSliceContains(removedDDocs, DesignDocSyncHousekeepingPrefix), "Missing design doc from removed set")
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // TODO: Could consider checking this in as a file and include it into the compiled test binary using something like https://github.com/jteeuwen/go-bindata
@@ -206,18 +206,18 @@ func TestParseXattr(t *testing.T) {
 
 	resultBody, resultXattr, err := parseXattrStreamData("_sync", dcpBody)
 	assertNoError(t, err, "Unexpected error parsing dcp body")
-	assert.Equals(t, string(resultBody), string(body))
-	assert.Equals(t, string(resultXattr), string(xattrValue))
+	goassert.Equals(t, string(resultBody), string(body))
+	goassert.Equals(t, string(resultXattr), string(xattrValue))
 
 	// Attempt to retrieve non-existent xattr
 	resultBody, resultXattr, err = parseXattrStreamData("nonexistent", dcpBody)
 	assertNoError(t, err, "Unexpected error parsing dcp body")
-	assert.Equals(t, string(resultBody), string(body))
-	assert.Equals(t, string(resultXattr), "")
+	goassert.Equals(t, string(resultBody), string(body))
+	goassert.Equals(t, string(resultXattr), "")
 
 	// Attempt to retrieve xattr from empty dcp body
 	emptyBody, emptyXattr, emptyErr := parseXattrStreamData("_sync", []byte{})
-	assert.Equals(t, emptyErr, base.ErrEmptyMetadata)
+	goassert.Equals(t, emptyErr, base.ErrEmptyMetadata)
 	assertTrue(t, emptyBody == nil, "Nil body expected")
 	assertTrue(t, emptyXattr == nil, "Nil xattr expected")
 }
@@ -228,5 +228,5 @@ func TestParseDocumentCas(t *testing.T) {
 
 	casInt := syncData.GetSyncCas()
 
-	assert.Equals(t, casInt, uint64(1492749160563736576))
+	goassert.Equals(t, casInt, uint64(1492749160563736576))
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // TODO: Could consider checking this in as a file and include it into the compiled test binary using something like https://github.com/jteeuwen/go-bindata
@@ -205,21 +206,21 @@ func TestParseXattr(t *testing.T) {
 	dcpBody = append(dcpBody, body...)
 
 	resultBody, resultXattr, err := parseXattrStreamData("_sync", dcpBody)
-	assertNoError(t, err, "Unexpected error parsing dcp body")
+	assert.NoError(t, err, "Unexpected error parsing dcp body")
 	goassert.Equals(t, string(resultBody), string(body))
 	goassert.Equals(t, string(resultXattr), string(xattrValue))
 
 	// Attempt to retrieve non-existent xattr
 	resultBody, resultXattr, err = parseXattrStreamData("nonexistent", dcpBody)
-	assertNoError(t, err, "Unexpected error parsing dcp body")
+	assert.NoError(t, err, "Unexpected error parsing dcp body")
 	goassert.Equals(t, string(resultBody), string(body))
 	goassert.Equals(t, string(resultXattr), "")
 
 	// Attempt to retrieve xattr from empty dcp body
 	emptyBody, emptyXattr, emptyErr := parseXattrStreamData("_sync", []byte{})
 	goassert.Equals(t, emptyErr, base.ErrEmptyMetadata)
-	assertTrue(t, emptyBody == nil, "Nil body expected")
-	assertTrue(t, emptyXattr == nil, "Nil xattr expected")
+	assert.True(t, emptyBody == nil, "Nil body expected")
+	assert.True(t, emptyXattr == nil, "Nil xattr expected")
 }
 
 func TestParseDocumentCas(t *testing.T) {

--- a/db/event_handler_test.go
+++ b/db/event_handler_test.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"testing"
 )
 
@@ -11,12 +11,12 @@ func TestWebhookString(t *testing.T) {
 	wh = &Webhook{
 		url: "http://username:password@example.com/foo",
 	}
-	assert.Equals(t, wh.String(), "Webhook handler [http://****:****@example.com/foo]")
+	goassert.Equals(t, wh.String(), "Webhook handler [http://****:****@example.com/foo]")
 
 	wh = &Webhook{
 		url: "http://example.com:9000/baz",
 	}
-	assert.Equals(t, wh.String(), "Webhook handler [http://example.com:9000/baz]")
+	goassert.Equals(t, wh.String(), "Webhook handler [http://example.com:9000/baz]")
 }
 
 func TestSanitizedUrl(t *testing.T) {
@@ -25,10 +25,10 @@ func TestSanitizedUrl(t *testing.T) {
 	wh = &Webhook{
 		url: "https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar",
 	}
-	assert.Equals(t, wh.SanitizedUrl(), "https://****:****@example.com:8888/bar")
+	goassert.Equals(t, wh.SanitizedUrl(), "https://****:****@example.com:8888/bar")
 
 	wh = &Webhook{
 		url: "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
 	}
-	assert.Equals(t, wh.SanitizedUrl(), "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux")
+	goassert.Equals(t, wh.SanitizedUrl(), "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux")
 }

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // Webhook tests use an HTTP listener.  Use of this listener is disabled by default, to avoid
@@ -42,26 +42,26 @@ func (th *TestingHandler) HandleEvent(event Event) {
 
 		doc := dsceEvent.Doc
 
-		assert.Equals(th.t, len(doc), 5)
+		goassert.Equals(th.t, len(doc), 5)
 
 		state := doc["state"]
 
 		//state must be online or offline
-		assert.True(th.t, state != nil && (state == "online" || state == "offline"))
+		goassert.True(th.t, state != nil && (state == "online" || state == "offline"))
 
 		//admin interface must resolve to a a valis tcp address
 		adminInterface := (doc["admininterface"]).(string)
 
 		_, err := net.ResolveTCPAddr("tcp", adminInterface)
 
-		assert.Equals(th.t, err, nil)
+		goassert.Equals(th.t, err, nil)
 
 		//localtime must parse from an ISO8601 Format string
 		localtime := (doc["localtime"]).(string)
 
 		_, err = time.Parse(base.ISO8601Format, localtime)
 
-		assert.Equals(th.t, err, nil)
+		goassert.Equals(th.t, err, nil)
 
 		th.ResultChannel <- dsceEvent.Doc
 	}
@@ -368,7 +368,7 @@ func TestWebhookBasic(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, "", channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 10)
+	goassert.Equals(t, *count, 10)
 
 	// Test webhook filter function
 	log.Println("Test filter function")
@@ -389,7 +389,7 @@ func TestWebhookBasic(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, "", channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 4)
+	goassert.Equals(t, *count, 4)
 
 	// Validate payload
 	*count, *sum, *payloads = 0, 0.0, nil
@@ -402,8 +402,8 @@ func TestWebhookBasic(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	receivedPayload := string((*payloads)[0])
 	fmt.Println("payload:", receivedPayload)
-	assert.Equals(t, string((*payloads)[0]), `{"_id":"0","value":0}`)
-	assert.Equals(t, *count, 1)
+	goassert.Equals(t, string((*payloads)[0]), `{"_id":"0","value":0}`)
+	goassert.Equals(t, *count, 1)
 
 	// Test fast fill, fast webhook
 	*count, *sum = 0, 0.0
@@ -417,7 +417,7 @@ func TestWebhookBasic(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, "", channels)
 	}
 	time.Sleep(500 * time.Millisecond)
-	assert.Equals(t, *count, 100)
+	goassert.Equals(t, *count, 100)
 
 	// Test queue full, slow webhook.  Drops events
 	log.Println("Test queue full, slow webhook")
@@ -438,8 +438,8 @@ func TestWebhookBasic(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	// Expect 21 to complete.  5 get goroutines immediately, 15 get queued, and one is blocked waiting
 	// for a goroutine.  The rest get discarded because the queue is full.
-	assert.Equals(t, *count, 21)
-	assert.Equals(t, errCount, 79)
+	goassert.Equals(t, *count, 21)
+	goassert.Equals(t, errCount, 79)
 
 	// Test queue full, slow webhook, long wait time.  Throttles events
 	log.Println("Test queue full, slow webhook, long wait")
@@ -453,7 +453,7 @@ func TestWebhookBasic(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, "", channels)
 	}
 	time.Sleep(5 * time.Second)
-	assert.Equals(t, *count, 100)
+	goassert.Equals(t, *count, 100)
 
 }
 
@@ -499,7 +499,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 10)
+	goassert.Equals(t, *count, 10)
 
 	// Test webhook where an old doc is passed and is not used by the filter
 	log.Println("Test filter function with old doc which is not referenced")
@@ -522,7 +522,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 4)
+	goassert.Equals(t, *count, 4)
 
 	// Test webhook where an old doc is passed and is validated by the filter
 	log.Println("Test filter function with old doc")
@@ -545,7 +545,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 4)
+	goassert.Equals(t, *count, 4)
 
 	// Test webhook where an old doc is not passed but is referenced in the filter function args
 	log.Println("Test filter function with old doc")
@@ -572,7 +572,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 10)
+	goassert.Equals(t, *count, 10)
 
 }
 
@@ -616,7 +616,7 @@ func TestWebhookTimeout(t *testing.T) {
 		em.RaiseDocumentChangeEvent(body, "", channels)
 	}
 	time.Sleep(50 * time.Millisecond)
-	assert.Equals(t, *count, 10)
+	goassert.Equals(t, *count, 10)
 
 	// Test slow webhook, short timeout, numProcess=1, waitForProcess > timeout.  All events should get processed.
 	log.Println("Test slow webhook, short timeout")
@@ -637,7 +637,7 @@ func TestWebhookTimeout(t *testing.T) {
 	}
 	time.Sleep(15 * time.Second)
 	// Even though we timed out waiting for response on the SG side, POST still completed on target side.
-	assert.Equals(t, *count, 10)
+	goassert.Equals(t, *count, 10)
 
 	// Test slow webhook, short timeout, numProcess=1, waitForProcess << timeout.  Events that don't fit in queues
 	// should get dropped (1 immediately processed, 1 in normal queue, 3 in overflow queue, 5 dropped)
@@ -659,7 +659,7 @@ func TestWebhookTimeout(t *testing.T) {
 	}
 	// wait for slow webhook to finish processing
 	time.Sleep(25 * time.Second)
-	assert.Equals(t, *count, 5)
+	goassert.Equals(t, *count, 5)
 
 	// Test slow webhook, no timeout, numProcess=1, waitForProcess=1s.  All events should complete.
 	log.Println("Test slow webhook, no timeout, wait for process ")
@@ -680,7 +680,7 @@ func TestWebhookTimeout(t *testing.T) {
 	}
 	// wait for slow webhook to finish processing
 	time.Sleep(15 * time.Second)
-	assert.Equals(t, *count, 10)
+	goassert.Equals(t, *count, 10)
 
 }
 
@@ -726,7 +726,7 @@ func assertChannelLengthWithTimeout(t *testing.T, c chan Body, expectedLength in
 			// Make sure there are no additional items on the channel after a short wait.
 			// This avoids relying on the longer timeout value for the final check.
 			time.Sleep(timeout / 100)
-			assert.Equals(t, count+len(c), expectedLength)
+			goassert.Equals(t, count+len(c), expectedLength)
 			return
 		}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -8,7 +8,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // There are additional tests that exercise the import functionality in rest/import_test.go
@@ -71,8 +71,8 @@ func TestMigrateMetadata(t *testing.T) {
 		body,
 		existingBucketDoc,
 	)
-	assert.True(t, err != nil)
-	assert.True(t, err == base.ErrCasFailureShouldRetry)
+	goassert.True(t, err != nil)
+	goassert.True(t, err == base.ErrCasFailureShouldRetry)
 
 }
 
@@ -172,7 +172,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 			gocbBucket, _ := base.AsGoCBBucket(testBucket.Bucket)
 			expiry, err := gocbBucket.GetExpiry(key)
 			assertNoError(t, err, "Error calling GetExpiry()")
-			assert.True(t, expiry == uint32(laterSyncMetaExpiry.Unix()))
+			goassert.True(t, expiry == uint32(laterSyncMetaExpiry.Unix()))
 
 		})
 	}
@@ -233,13 +233,13 @@ func TestImportNullDoc(t *testing.T) {
 
 	// Import a null document
 	importedDoc, err := db.importDoc(key+"1", body, false, existingDoc, ImportOnDemand)
-	assert.Equals(t, err, base.ErrEmptyDocument)
+	goassert.Equals(t, err, base.ErrEmptyDocument)
 	assertTrue(t, importedDoc == nil, "Expected no imported doc")
 
 	// Do a valid on-demand import from a null document
 	body = Body{"new": true}
 	importedDoc, err = db.importDoc(key+"2", body, false, existingDoc, ImportOnDemand)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	assertFalse(t, importedDoc == nil, "Expected imported doc")
 }
 
@@ -253,7 +253,7 @@ func TestImportNullDocRaw(t *testing.T) {
 	// Feed import of null doc
 	exp := uint32(0)
 	importedDoc, err := db.ImportDocRaw("TestImportNullDoc", []byte("null"), []byte("{}"), false, 1, &exp, ImportFromFeed)
-	assert.Equals(t, err, base.ErrEmptyDocument)
+	goassert.Equals(t, err, base.ErrEmptyDocument)
 	assertTrue(t, importedDoc == nil, "Expected no imported doc")
 }
 
@@ -262,8 +262,8 @@ func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key stri
 	_, err := bucket.GetWithXattr(key, "_sync", nil, &xattr)
 	assertNoError(t, err, "Error Getting Xattr")
 	revision, ok := xattr["rev"]
-	assert.True(t, ok)
+	goassert.True(t, ok)
 	generation, _ := ParseRevID(revision.(string))
 	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, revision)
-	assert.True(t, generation == expectedRevGeneration)
+	goassert.True(t, generation == expectedRevGeneration)
 }

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/couchbase/gocb"
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInitializeIndexes(t *testing.T) {
@@ -23,13 +24,13 @@ func TestInitializeIndexes(t *testing.T) {
 	goassert.True(t, isGoCBBucket)
 
 	dropErr := base.DropAllBucketIndexes(goCbBucket)
-	assertNoError(t, dropErr, "Error dropping all indexes")
+	assert.NoError(t, dropErr, "Error dropping all indexes")
 
 	initErr := InitializeIndexes(testBucket, db.UseXattrs(), 0)
-	assertNoError(t, initErr, "Error initializing all indexes")
+	assert.NoError(t, initErr, "Error initializing all indexes")
 
 	validateErr := validateAllIndexesOnline(testBucket)
-	assertNoError(t, validateErr, "Error validating indexes online")
+	assert.NoError(t, validateErr, "Error validating indexes online")
 
 }
 
@@ -85,22 +86,22 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	// an initial cleanup to remove existing obsolete indexes
 	removedIndexes, removeErr := removeObsoleteIndexes(testBucket.Bucket, false, db.UseXattrs())
 	log.Printf("removedIndexes: %+v", removedIndexes)
-	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
+	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, true, !db.UseXattrs())
 	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
-	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
+	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
 
 	// Running again w/ preview=false to perform cleanup
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, false, !db.UseXattrs())
 	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
-	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
+	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
 
 	// One more time to make sure they are actually gone
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, false, !db.UseXattrs())
 	goassert.Equals(t, len(removedIndexes), 0)
-	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
+	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 }
 
@@ -118,7 +119,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	removedIndexes, removeErr := removeObsoleteIndexes(testBucket.Bucket, true, db.UseXattrs())
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 0)
-	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
+	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
 
 	// Hack sgIndexes to simulate new version of indexes
 	accessIndex := sgIndexes[IndexAccess]
@@ -135,5 +136,5 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, true, db.UseXattrs())
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 1)
-	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
+	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 }

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/couchbase/gocb"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestInitializeIndexes(t *testing.T) {
@@ -20,7 +20,7 @@ func TestInitializeIndexes(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	goCbBucket, isGoCBBucket := base.AsGoCBBucket(testBucket)
-	assert.True(t, isGoCBBucket)
+	goassert.True(t, isGoCBBucket)
 
 	dropErr := base.DropAllBucketIndexes(goCbBucket)
 	assertNoError(t, dropErr, "Error dropping all indexes")
@@ -89,17 +89,17 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, true, !db.UseXattrs())
-	assert.Equals(t, len(removedIndexes), int(expectedIndexes))
+	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
 	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
 
 	// Running again w/ preview=false to perform cleanup
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, false, !db.UseXattrs())
-	assert.Equals(t, len(removedIndexes), int(expectedIndexes))
+	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
 	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
 
 	// One more time to make sure they are actually gone
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, false, !db.UseXattrs())
-	assert.Equals(t, len(removedIndexes), 0)
+	goassert.Equals(t, len(removedIndexes), 0)
 	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 }
@@ -117,7 +117,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	// Validate that removeObsoleteIndexes is a no-op for the default case
 	removedIndexes, removeErr := removeObsoleteIndexes(testBucket.Bucket, true, db.UseXattrs())
 	log.Printf("removedIndexes: %+v", removedIndexes)
-	assert.Equals(t, len(removedIndexes), 0)
+	goassert.Equals(t, len(removedIndexes), 0)
 	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
 
 	// Hack sgIndexes to simulate new version of indexes
@@ -134,6 +134,6 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	// Validate that removeObsoleteIndexes now triggers removal of one index
 	removedIndexes, removeErr = removeObsoleteIndexes(testBucket.Bucket, true, db.UseXattrs())
 	log.Printf("removedIndexes: %+v", removedIndexes)
-	assert.Equals(t, len(removedIndexes), 1)
+	goassert.Equals(t, len(removedIndexes), 1)
 	assertNoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 }

--- a/db/kv_channel_index_test.go
+++ b/db/kv_channel_index_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func testPartitionMap() *base.IndexPartitions {
@@ -87,9 +87,9 @@ func TestIndexBlockCreation(t *testing.T) {
 	defer testStorage.bucket.Close()
 	entry := makeEntry(1, 1, false)
 	block := testStorage.getIndexBlockForEntry(entry)
-	assert.Equals(t, testStorage.indexBlockCache.Count(), 1)
+	goassert.Equals(t, testStorage.indexBlockCache.Count(), 1)
 	blockEntries := block.GetAllEntries()
-	assert.Equals(t, len(blockEntries), 0)
+	goassert.Equals(t, len(blockEntries), 0)
 
 }
 
@@ -109,7 +109,7 @@ func TestIndexBlockStorage(t *testing.T) {
 
 	// validate in-memory storage
 	storedEntries := block.GetAllEntries()
-	assert.Equals(t, 5, len(storedEntries))
+	goassert.Equals(t, 5, len(storedEntries))
 	log.Printf("Stored: %+v", storedEntries)
 
 	marshalledBlock, err := block.Marshal()
@@ -119,7 +119,7 @@ func TestIndexBlockStorage(t *testing.T) {
 	newBlock := newBitFlagBufferBlock("ABC", 0, 0, testStorage.partitions.VbPositionMaps[0])
 	assertNoError(t, newBlock.Unmarshal(marshalledBlock), "Unmarshal block")
 	loadedEntries := newBlock.GetAllEntries()
-	assert.Equals(t, 5, len(loadedEntries))
+	goassert.Equals(t, 5, len(loadedEntries))
 	log.Printf("Unmarshalled: %+v", loadedEntries)
 
 }
@@ -143,7 +143,7 @@ func TestAddPartitionSet(t *testing.T) {
 	assertNoError(t, channelIndex.addPartitionSet(channelIndex.partitionMap[5], entrySet), "Add partition set")
 
 	block := channelIndex.getIndexBlockForEntry(makeEntry(5, 100, false))
-	assert.Equals(t, len(block.GetAllEntries()), 5)
+	goassert.Equals(t, len(block.GetAllEntries()), 5)
 
 	// Validate error when sending updates for multiple partitions
 
@@ -174,11 +174,11 @@ func TestAddPartitionSetMultiBlock(t *testing.T) {
 	assertNoError(t, channelIndex.addPartitionSet(channelIndex.partitionMap[5], entrySet), "Add partition set")
 
 	block := channelIndex.getIndexBlockForEntry(makeEntry(5, 100, false))
-	assert.Equals(t, len(block.GetAllEntries()), 3) // 5_100, 7_100, 9_100
+	goassert.Equals(t, len(block.GetAllEntries()), 3) // 5_100, 7_100, 9_100
 	block = channelIndex.getIndexBlockForEntry(makeEntry(5, 15000, false))
-	assert.Equals(t, len(block.GetAllEntries()), 1) // 5_15000
+	goassert.Equals(t, len(block.GetAllEntries()), 1) // 5_15000
 	block = channelIndex.getIndexBlockForEntry(makeEntry(9, 25000, false))
-	assert.Equals(t, len(block.GetAllEntries()), 1) // 9_25000
+	goassert.Equals(t, len(block.GetAllEntries()), 1) // 9_25000
 
 }
 */
@@ -197,29 +197,29 @@ func TestVbCache(t *testing.T) {
 	assertNoError(t, vbCache.appendEntries(entries, uint64(5), uint64(25)), "Error appending entries")
 
 	from, to, results := vbCache.getEntries(uint64(10), uint64(20))
-	assert.Equals(t, from, uint64(10))
-	assert.Equals(t, to, uint64(20))
-	assert.Equals(t, len(results), 2)
-	assert.Equals(t, results[0].DocID, "doc1")
-	assert.Equals(t, results[0].Sequence, uint64(15))
-	assert.Equals(t, results[1].DocID, "doc2")
-	assert.Equals(t, results[1].Sequence, uint64(17))
+	goassert.Equals(t, from, uint64(10))
+	goassert.Equals(t, to, uint64(20))
+	goassert.Equals(t, len(results), 2)
+	goassert.Equals(t, results[0].DocID, "doc1")
+	goassert.Equals(t, results[0].Sequence, uint64(15))
+	goassert.Equals(t, results[1].DocID, "doc2")
+	goassert.Equals(t, results[1].Sequence, uint64(17))
 
 	// Request for a range earlier than the cache is valid
 	from, to, results = vbCache.getEntries(uint64(0), uint64(15))
-	assert.Equals(t, from, uint64(5))
-	assert.Equals(t, to, uint64(15))
-	assert.Equals(t, len(results), 1)
-	assert.Equals(t, results[0].DocID, "doc1")
-	assert.Equals(t, results[0].Sequence, uint64(15))
+	goassert.Equals(t, from, uint64(5))
+	goassert.Equals(t, to, uint64(15))
+	goassert.Equals(t, len(results), 1)
+	goassert.Equals(t, results[0].DocID, "doc1")
+	goassert.Equals(t, results[0].Sequence, uint64(15))
 
 	// Request for a range later than the cache is valid
 	from, to, results = vbCache.getEntries(uint64(20), uint64(30))
-	assert.Equals(t, from, uint64(20))
-	assert.Equals(t, to, uint64(25))
-	assert.Equals(t, len(results), 1)
-	assert.Equals(t, results[0].DocID, "doc3")
-	assert.Equals(t, results[0].Sequence, uint64(23))
+	goassert.Equals(t, from, uint64(20))
+	goassert.Equals(t, to, uint64(25))
+	goassert.Equals(t, len(results), 1)
+	goassert.Equals(t, results[0].DocID, "doc3")
+	goassert.Equals(t, results[0].Sequence, uint64(23))
 
 	// Prepend older entries, including one duplicate doc id
 	olderEntries := []*LogEntry{
@@ -229,13 +229,13 @@ func TestVbCache(t *testing.T) {
 	assertNoError(t, vbCache.prependEntries(olderEntries, uint64(3), uint64(4)), "Error prepending entries")
 
 	from, to, results = vbCache.getEntries(uint64(0), uint64(50))
-	assert.Equals(t, from, uint64(3))
-	assert.Equals(t, to, uint64(25))
-	assert.Equals(t, len(results), 4)
-	assert.Equals(t, results[0].DocID, "doc4")
-	assert.Equals(t, results[1].DocID, "doc1")
-	assert.Equals(t, results[2].DocID, "doc2")
-	assert.Equals(t, results[3].DocID, "doc3")
+	goassert.Equals(t, from, uint64(3))
+	goassert.Equals(t, to, uint64(25))
+	goassert.Equals(t, len(results), 4)
+	goassert.Equals(t, results[0].DocID, "doc4")
+	goassert.Equals(t, results[1].DocID, "doc1")
+	goassert.Equals(t, results[2].DocID, "doc2")
+	goassert.Equals(t, results[3].DocID, "doc3")
 
 	// Append newer entries, including two duplicate doc ids
 	newerEntries := []*LogEntry{
@@ -246,14 +246,14 @@ func TestVbCache(t *testing.T) {
 	assertNoError(t, vbCache.appendEntries(newerEntries, uint64(25), uint64(35)), "Error appending entries")
 
 	from, to, results = vbCache.getEntries(uint64(0), uint64(50))
-	assert.Equals(t, from, uint64(3))
-	assert.Equals(t, to, uint64(35))
-	assert.Equals(t, len(results), 5)
-	assert.Equals(t, results[0].DocID, "doc4")
-	assert.Equals(t, results[1].DocID, "doc2")
-	assert.Equals(t, results[2].DocID, "doc1")
-	assert.Equals(t, results[3].DocID, "doc5")
-	assert.Equals(t, results[4].DocID, "doc3")
+	goassert.Equals(t, from, uint64(3))
+	goassert.Equals(t, to, uint64(35))
+	goassert.Equals(t, len(results), 5)
+	goassert.Equals(t, results[0].DocID, "doc4")
+	goassert.Equals(t, results[1].DocID, "doc2")
+	goassert.Equals(t, results[2].DocID, "doc1")
+	goassert.Equals(t, results[3].DocID, "doc5")
+	goassert.Equals(t, results[4].DocID, "doc3")
 
 	// Attempt to add out-of-order entries
 	newerEntries = []*LogEntry{
@@ -264,7 +264,7 @@ func TestVbCache(t *testing.T) {
 	err := vbCache.appendEntries(newerEntries, uint64(35), uint64(43))
 	assertTrue(t, err != nil, "Adding out-of-sequence entries should return error")
 	from, to, results = vbCache.getEntries(uint64(0), uint64(50))
-	assert.Equals(t, len(results), 5)
+	goassert.Equals(t, len(results), 5)
 
 	// Attempt to append entries with gaps
 	newerEntries = []*LogEntry{

--- a/db/kv_channel_index_test.go
+++ b/db/kv_channel_index_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func testPartitionMap() *base.IndexPartitions {
@@ -101,11 +102,11 @@ func TestIndexBlockStorage(t *testing.T) {
 	// Add entries
 	block := testStorage.getIndexBlockForEntry(makeEntry(5, 100, false))
 
-	assertNoError(t, block.AddEntry(makeEntry(5, 100, false)), "Add entry 5_100")
-	assertNoError(t, block.AddEntry(makeEntry(5, 105, true)), "Add entry 5_105")
-	assertNoError(t, block.AddEntry(makeEntry(7, 100, true)), "Add entry 7_100")
-	assertNoError(t, block.AddEntry(makeEntry(9, 100, true)), "Add entry 9_100")
-	assertNoError(t, block.AddEntry(makeEntry(9, 101, true)), "Add entry 9_101")
+	assert.NoError(t, block.AddEntry(makeEntry(5, 100, false)), "Add entry 5_100")
+	assert.NoError(t, block.AddEntry(makeEntry(5, 105, true)), "Add entry 5_105")
+	assert.NoError(t, block.AddEntry(makeEntry(7, 100, true)), "Add entry 7_100")
+	assert.NoError(t, block.AddEntry(makeEntry(9, 100, true)), "Add entry 9_100")
+	assert.NoError(t, block.AddEntry(makeEntry(9, 101, true)), "Add entry 9_101")
 
 	// validate in-memory storage
 	storedEntries := block.GetAllEntries()
@@ -113,11 +114,11 @@ func TestIndexBlockStorage(t *testing.T) {
 	log.Printf("Stored: %+v", storedEntries)
 
 	marshalledBlock, err := block.Marshal()
-	assertNoError(t, err, "Marshal block")
+	assert.NoError(t, err, "Marshal block")
 	log.Printf("Marshalled size: %d", len(marshalledBlock))
 
 	newBlock := newBitFlagBufferBlock("ABC", 0, 0, testStorage.partitions.VbPositionMaps[0])
-	assertNoError(t, newBlock.Unmarshal(marshalledBlock), "Unmarshal block")
+	assert.NoError(t, newBlock.Unmarshal(marshalledBlock), "Unmarshal block")
 	loadedEntries := newBlock.GetAllEntries()
 	goassert.Equals(t, 5, len(loadedEntries))
 	log.Printf("Unmarshalled: %+v", loadedEntries)
@@ -140,7 +141,7 @@ func TestAddPartitionSet(t *testing.T) {
 		makeEntry(9, 1001, false),
 	}
 	// Add entries
-	assertNoError(t, channelIndex.addPartitionSet(channelIndex.partitionMap[5], entrySet), "Add partition set")
+	assert.NoError(t, channelIndex.addPartitionSet(channelIndex.partitionMap[5], entrySet), "Add partition set")
 
 	block := channelIndex.getIndexBlockForEntry(makeEntry(5, 100, false))
 	goassert.Equals(t, len(block.GetAllEntries()), 5)
@@ -153,7 +154,7 @@ func TestAddPartitionSet(t *testing.T) {
 	}
 	err := channelIndex.addPartitionSet(channelIndex.partitionMap[25], entrySet)
 	log.Printf("error adding set? %v", err)
-	assertTrue(t, err != nil, "Adding mixed-partition set should fail.")
+	assert.True(t, err != nil, "Adding mixed-partition set should fail.")
 }
 
 func TestAddPartitionSetMultiBlock(t *testing.T) {
@@ -171,7 +172,7 @@ func TestAddPartitionSetMultiBlock(t *testing.T) {
 		makeEntry(9, 25000, false),
 	}
 	// Add entries
-	assertNoError(t, channelIndex.addPartitionSet(channelIndex.partitionMap[5], entrySet), "Add partition set")
+	assert.NoError(t, channelIndex.addPartitionSet(channelIndex.partitionMap[5], entrySet), "Add partition set")
 
 	block := channelIndex.getIndexBlockForEntry(makeEntry(5, 100, false))
 	goassert.Equals(t, len(block.GetAllEntries()), 3) // 5_100, 7_100, 9_100
@@ -194,7 +195,7 @@ func TestVbCache(t *testing.T) {
 		makeLogEntry(17, "doc2"),
 		makeLogEntry(23, "doc3"),
 	}
-	assertNoError(t, vbCache.appendEntries(entries, uint64(5), uint64(25)), "Error appending entries")
+	assert.NoError(t, vbCache.appendEntries(entries, uint64(5), uint64(25)), "Error appending entries")
 
 	from, to, results := vbCache.getEntries(uint64(10), uint64(20))
 	goassert.Equals(t, from, uint64(10))
@@ -226,7 +227,7 @@ func TestVbCache(t *testing.T) {
 		makeLogEntry(3, "doc1"),
 		makeLogEntry(4, "doc4"),
 	}
-	assertNoError(t, vbCache.prependEntries(olderEntries, uint64(3), uint64(4)), "Error prepending entries")
+	assert.NoError(t, vbCache.prependEntries(olderEntries, uint64(3), uint64(4)), "Error prepending entries")
 
 	from, to, results = vbCache.getEntries(uint64(0), uint64(50))
 	goassert.Equals(t, from, uint64(3))
@@ -243,7 +244,7 @@ func TestVbCache(t *testing.T) {
 		makeLogEntry(31, "doc5"),
 		makeLogEntry(35, "doc3"),
 	}
-	assertNoError(t, vbCache.appendEntries(newerEntries, uint64(25), uint64(35)), "Error appending entries")
+	assert.NoError(t, vbCache.appendEntries(newerEntries, uint64(25), uint64(35)), "Error appending entries")
 
 	from, to, results = vbCache.getEntries(uint64(0), uint64(50))
 	goassert.Equals(t, from, uint64(3))
@@ -262,7 +263,7 @@ func TestVbCache(t *testing.T) {
 		makeLogEntry(43, "doc3"),
 	}
 	err := vbCache.appendEntries(newerEntries, uint64(35), uint64(43))
-	assertTrue(t, err != nil, "Adding out-of-sequence entries should return error")
+	assert.True(t, err != nil, "Adding out-of-sequence entries should return error")
 	from, to, results = vbCache.getEntries(uint64(0), uint64(50))
 	goassert.Equals(t, len(results), 5)
 
@@ -271,14 +272,14 @@ func TestVbCache(t *testing.T) {
 		makeLogEntry(40, "doc1"),
 	}
 	err = vbCache.appendEntries(newerEntries, uint64(40), uint64(45))
-	assertTrue(t, err != nil, "Appending with gap should return error")
+	assert.True(t, err != nil, "Appending with gap should return error")
 
 	// Attempt to prepend entries with gaps
 	newerEntries = []*LogEntry{
 		makeLogEntry(1, "doc1"),
 	}
 	err = vbCache.prependEntries(newerEntries, uint64(0), uint64(1))
-	assertTrue(t, err != nil, "Prepending with gap should return error")
+	assert.True(t, err != nil, "Prepending with gap should return error")
 
 }
 */

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 const (
@@ -54,12 +54,12 @@ func TestDenseBlockSingleDoc(t *testing.T) {
 
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, updateClock.GetSequence(50), uint64(1))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, updateClock.GetSequence(50), uint64(1))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 1)
+	goassert.Equals(t, len(foundEntries), 1)
 	assertLogEntry(t, foundEntries[0], "doc1", "1-abc", 50, 1)
 
 	// Update within the same partition block, deduplicate by id
@@ -67,12 +67,12 @@ func TestDenseBlockSingleDoc(t *testing.T) {
 
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, updateClock.GetSequence(50), uint64(3))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, updateClock.GetSequence(50), uint64(3))
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 1)
+	goassert.Equals(t, len(foundEntries), 1)
 	assertLogEntry(t, foundEntries[0], "doc1", "2-abc", 50, 3)
 
 	// Update within the same partition block, deduplicate by sequence
@@ -81,12 +81,12 @@ func TestDenseBlockSingleDoc(t *testing.T) {
 
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, updateClock.GetSequence(50), uint64(5))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, updateClock.GetSequence(50), uint64(5))
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 1)
+	goassert.Equals(t, len(foundEntries), 1)
 	assertLogEntry(t, foundEntries[0], "doc1", "3-abc", 50, 5)
 }
 
@@ -100,7 +100,7 @@ func TestDenseBlockMultipleInserts(t *testing.T) {
 	block.Key = "block1"
 
 	// Make sure we can safely call getEntryCount() on uninitialized DenseBlock
-	assert.Equals(t, block.getEntryCount(), uint16(0))
+	goassert.Equals(t, block.getEntryCount(), uint16(0))
 
 	// Initialize the block value
 	block.value = make([]byte, DB_HEADER_LEN, 400)
@@ -112,15 +112,15 @@ func TestDenseBlockMultipleInserts(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 10)
+	goassert.Equals(t, len(foundEntries), 10)
 	for i := 0; i < 10; i++ {
 		assertLogEntry(t, foundEntries[i], fmt.Sprintf("doc%d", i), "1-abc", i*10, i+1)
-		assert.Equals(t, updateClock.GetSequence(uint16(i*10)), uint64(i+1))
+		goassert.Equals(t, updateClock.GetSequence(uint16(i*10)), uint64(i+1))
 	}
 
 }
@@ -140,16 +140,16 @@ func TestDenseBlockGetIndexEntry(t *testing.T) {
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	entry := block.GetIndexEntry(0)
-	assert.NotEquals(t, entry, nil)
+	goassert.NotEquals(t, entry, nil)
 
 	entry2 := block.GetIndexEntry(1300)
-	assert.Equals(t, len(entry2), 0)
-	assert.Equals(t, cap(entry2), 0)
+	goassert.Equals(t, len(entry2), 0)
+	goassert.Equals(t, cap(entry2), 0)
 }
 
 func TestDenseBlockGetEntry(t *testing.T) {
@@ -167,16 +167,16 @@ func TestDenseBlockGetEntry(t *testing.T) {
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	entry := block.GetIndexEntry(0)
-	assert.NotEquals(t, entry, nil)
+	goassert.NotEquals(t, entry, nil)
 
 	entry2 := block.GetIndexEntry(1300)
-	assert.Equals(t, len(entry2), 0)
-	assert.Equals(t, cap(entry2), 0)
+	goassert.Equals(t, len(entry2), 0)
+	goassert.Equals(t, cap(entry2), 0)
 }
 
 func TestDenseBlockMultipleUpdates(t *testing.T) {
@@ -198,17 +198,17 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 10)
+	goassert.Equals(t, len(foundEntries), 10)
 	for i := 0; i < 10; i++ {
 		vbno := 10*i + 1
 		sequence := i + 1
 		assertLogEntry(t, foundEntries[i], fmt.Sprintf("doc%d", i), "1-abc", vbno, sequence)
-		assert.Equals(t, updateClock.GetSequence(uint16(i*10+1)), uint64(i+1))
+		goassert.Equals(t, updateClock.GetSequence(uint16(i*10+1)), uint64(i+1))
 
 	}
 
@@ -222,15 +222,15 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, int(block.getEntryCount()), 10)
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, int(block.getEntryCount()), 10)
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 10)
+	goassert.Equals(t, len(foundEntries), 10)
 	for i := 0; i < 10; i++ {
 		assertLogEntry(t, foundEntries[i], fmt.Sprintf("doc%d", i), "2-abc", 10*i+1, 21+i)
-		assert.Equals(t, updateClock.GetSequence(uint16(i*10+1)), uint64(i+21))
+		goassert.Equals(t, updateClock.GetSequence(uint16(i*10+1)), uint64(i+21))
 	}
 
 	// Validate pending removal by adding an entry where the previous revision isn't in the block
@@ -238,9 +238,9 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 	entries[0] = makeBlockEntry("doc_not_in_block", "2-abc", 11, 65, IsNotRemoval, IsNotAdded)
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 1)
-	assert.Equals(t, int(block.getEntryCount()), 11)
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 1)
+	goassert.Equals(t, int(block.getEntryCount()), 11)
 
 }
 
@@ -263,17 +263,17 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 10)
+	goassert.Equals(t, len(foundEntries), 10)
 	for i := 0; i < 10; i++ {
 		sequence := i + 1
 		assertLogEntry(t, foundEntries[i], fmt.Sprintf("doc%d", i), "1-abc", vbno, sequence)
 	}
-	assert.Equals(t, updateClock.GetSequence(uint16(50)), uint64(10))
+	goassert.Equals(t, updateClock.GetSequence(uint16(50)), uint64(10))
 
 	// Updates with removal by key
 	entries = make([]*LogEntry, 10)
@@ -284,25 +284,25 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, int(block.getEntryCount()), 10)
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, int(block.getEntryCount()), 10)
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 10)
+	goassert.Equals(t, len(foundEntries), 10)
 	for i := 0; i < 10; i++ {
 		assertLogEntry(t, foundEntries[i], fmt.Sprintf("doc%d", i), "2-abc", 50, 21+i)
 	}
-	assert.Equals(t, updateClock.GetSequence(uint16(50)), uint64(30))
+	goassert.Equals(t, updateClock.GetSequence(uint16(50)), uint64(30))
 
 	// Validate pending removal by adding an entry where the previous revision isn't in the block
 	entries = make([]*LogEntry, 1)
 	entries[0] = makeBlockEntry("doc_not_in_block", "2-abc", 50, 65, IsNotRemoval, IsNotAdded)
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 1)
-	assert.Equals(t, int(block.getEntryCount()), 11)
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 1)
+	goassert.Equals(t, int(block.getEntryCount()), 11)
 
 }
 
@@ -326,12 +326,12 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 10)
+	goassert.Equals(t, len(foundEntries), 10)
 	assertLogEntry(t, foundEntries[0], "doc0", "1-abc", 0, 1)
 	assertLogEntry(t, foundEntries[1], "doc1", "1-abc", 1, 2)
 	assertLogEntry(t, foundEntries[2], "doc2", "1-abc", 2, 3)
@@ -346,11 +346,11 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	// Rollback should complete in this block
 	rollbackComplete, err := block.RollbackTo(2, 5, indexBucket)
 	assertNoError(t, err, "Error rolling back")
-	assert.Equals(t, rollbackComplete, true)
-	assert.Equals(t, block.getEntryCount(), uint16(8))
+	goassert.Equals(t, rollbackComplete, true)
+	goassert.Equals(t, block.getEntryCount(), uint16(8))
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 8)
+	goassert.Equals(t, len(foundEntries), 8)
 	assertLogEntry(t, foundEntries[0], "doc0", "1-abc", 0, 1)
 	assertLogEntry(t, foundEntries[1], "doc1", "1-abc", 1, 2)
 	assertLogEntry(t, foundEntries[2], "doc2", "1-abc", 2, 3)
@@ -364,11 +364,11 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	// rollback value in this block (haven't seen a sequence earlier than 1 in vb 1)
 	rollbackComplete, err = block.RollbackTo(1, 1, indexBucket)
 	assertNoError(t, err, "Error rolling back")
-	assert.Equals(t, rollbackComplete, false)
-	assert.Equals(t, block.getEntryCount(), uint16(5))
+	goassert.Equals(t, rollbackComplete, false)
+	goassert.Equals(t, block.getEntryCount(), uint16(5))
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 5)
+	goassert.Equals(t, len(foundEntries), 5)
 	assertLogEntry(t, foundEntries[0], "doc0", "1-abc", 0, 1)
 	assertLogEntry(t, foundEntries[1], "doc2", "1-abc", 2, 3)
 	assertLogEntry(t, foundEntries[2], "doc3", "1-abc", 0, 4)
@@ -378,11 +378,11 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	// Remove the first entry, make sure nothing breaks
 	rollbackComplete, err = block.RollbackTo(0, 0, indexBucket)
 	assertNoError(t, err, "Error rolling back")
-	assert.Equals(t, rollbackComplete, false)
-	assert.Equals(t, block.getEntryCount(), uint16(1))
+	goassert.Equals(t, rollbackComplete, false)
+	goassert.Equals(t, block.getEntryCount(), uint16(1))
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 1)
+	goassert.Equals(t, len(foundEntries), 1)
 	assertLogEntry(t, foundEntries[0], "doc2", "1-abc", 2, 3)
 
 	// Attempt to rollback on an empty block
@@ -393,15 +393,15 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 
 	overflow, pendingRemoval, _, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding empty entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(0))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(0))
 
 	// Rollback should complete in this empty block
 	rollbackComplete, err = block.RollbackTo(1, 1, indexBucket)
 	assertNoError(t, err, "Error rolling back")
-	assert.Equals(t, rollbackComplete, true)
-	assert.Equals(t, block.getEntryCount(), uint16(0))
+	goassert.Equals(t, rollbackComplete, true)
+	goassert.Equals(t, block.getEntryCount(), uint16(0))
 }
 
 func TestDenseBlockOverflow(t *testing.T) {
@@ -426,13 +426,13 @@ func TestDenseBlockOverflow(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, int(block.getEntryCount()), 100)
-	assert.Equals(t, updateClock.GetSequence(100), uint64(100))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, int(block.getEntryCount()), 100)
+	goassert.Equals(t, updateClock.GetSequence(100), uint64(100))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 100)
+	goassert.Equals(t, len(foundEntries), 100)
 	for i := 0; i < 100; i++ {
 		assertLogEntriesEqual(t, foundEntries[i], entries[i])
 	}
@@ -447,11 +447,11 @@ func TestDenseBlockOverflow(t *testing.T) {
 	}
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 12)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, int(block.getEntryCount()), 188)
-	assert.Equals(t, len(block.value), 10046)
-	assert.Equals(t, updateClock.GetSequence(100), uint64(188))
+	goassert.Equals(t, len(overflow), 12)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, int(block.getEntryCount()), 188)
+	goassert.Equals(t, len(block.value), 10046)
+	goassert.Equals(t, updateClock.GetSequence(100), uint64(188))
 
 	// Validate overflow contents (last 12 entries)
 	for i := 0; i < 12; i++ {
@@ -459,7 +459,7 @@ func TestDenseBlockOverflow(t *testing.T) {
 	}
 
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 188)
+	goassert.Equals(t, len(foundEntries), 188)
 	for i := 0; i < 188; i++ {
 		vbno := 100
 		sequence := i + 1
@@ -470,11 +470,11 @@ func TestDenseBlockOverflow(t *testing.T) {
 	var newOverflow []*LogEntry
 	newOverflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(overflow, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(newOverflow), 12)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, int(block.getEntryCount()), 188)
-	assert.Equals(t, len(block.value), 10046)
-	assert.Equals(t, len(updateClock), 0)
+	goassert.Equals(t, len(newOverflow), 12)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, int(block.getEntryCount()), 188)
+	goassert.Equals(t, len(block.value), 10046)
+	goassert.Equals(t, len(updateClock), 0)
 
 }
 
@@ -495,12 +495,12 @@ func TestDenseBlockConcurrentUpdates(t *testing.T) {
 
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, updateClock.GetSequence(50), uint64(1))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, updateClock.GetSequence(50), uint64(1))
 
 	foundEntries := block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 1)
+	goassert.Equals(t, len(foundEntries), 1)
 	assertLogEntry(t, foundEntries[0], "doc1", "1-abc", 50, 1)
 	log.Println("Wrote doc as block1")
 
@@ -511,39 +511,39 @@ func TestDenseBlockConcurrentUpdates(t *testing.T) {
 	entries2[0] = makeBlockEntry("doc2", "1-abc", 50, 3, IsNotRemoval, IsAdded)
 	overflow2, pendingRemoval2, updateClock2, casFail, err := block2.AddEntrySet(entries2, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, casFail, true)
-	assert.Equals(t, len(overflow2), 1)
-	assert.Equals(t, len(pendingRemoval2), 0)
-	assert.Equals(t, updateClock2.GetSequence(50), uint64(0))
+	goassert.Equals(t, casFail, true)
+	goassert.Equals(t, len(overflow2), 1)
+	goassert.Equals(t, len(pendingRemoval2), 0)
+	goassert.Equals(t, updateClock2.GetSequence(50), uint64(0))
 
 	block2.loadBlock(indexBucket)
 	overflow2, pendingRemoval2, updateClock2, casFail, err = block2.AddEntrySet(entries2, indexBucket)
-	assert.Equals(t, casFail, false)
-	assert.Equals(t, len(overflow2), 0)
-	assert.Equals(t, len(pendingRemoval2), 0)
-	assert.Equals(t, updateClock2.GetSequence(50), uint64(3))
+	goassert.Equals(t, casFail, false)
+	goassert.Equals(t, len(overflow2), 0)
+	goassert.Equals(t, len(pendingRemoval2), 0)
+	goassert.Equals(t, updateClock2.GetSequence(50), uint64(3))
 
 	log.Println("Wrote doc as block2")
 	foundEntries2 := block2.GetAllEntries()
-	assert.Equals(t, len(foundEntries2), 2)
+	goassert.Equals(t, len(foundEntries2), 2)
 	assertLogEntry(t, foundEntries2[0], "doc1", "1-abc", 50, 1)
 	assertLogEntry(t, foundEntries2[1], "doc2", "1-abc", 50, 3)
 
 	// Attempt to write the same entry with the first block/writer
 	overflow, pendingRemoval, updateClock, casFail, err = block.AddEntrySet(entries2, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 1)
-	assert.Equals(t, casFail, true)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, updateClock.GetSequence(50), uint64(0))
+	goassert.Equals(t, len(overflow), 1)
+	goassert.Equals(t, casFail, true)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, updateClock.GetSequence(50), uint64(0))
 	log.Println("Wrote doc as block1")
 
 	block.loadBlock(indexBucket)
 	foundEntries = block.GetAllEntries()
-	assert.Equals(t, len(foundEntries), 2)
+	goassert.Equals(t, len(foundEntries), 2)
 	assertLogEntry(t, foundEntries[0], "doc1", "1-abc", 50, 1)
 	assertLogEntry(t, foundEntries[1], "doc2", "1-abc", 50, 3)
-	assert.Equals(t, int(block.getEntryCount()), 2)
+	goassert.Equals(t, int(block.getEntryCount()), 2)
 }
 
 // ------------------------
@@ -566,9 +566,9 @@ func TestDenseBlockIterator(t *testing.T) {
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
 	assertNoError(t, err, "Error adding entry set")
-	assert.Equals(t, len(overflow), 0)
-	assert.Equals(t, len(pendingRemoval), 0)
-	assert.Equals(t, block.getEntryCount(), uint16(10))
+	goassert.Equals(t, len(overflow), 0)
+	goassert.Equals(t, len(pendingRemoval), 0)
+	goassert.Equals(t, block.getEntryCount(), uint16(10))
 
 	reader := NewDenseBlockIterator(block)
 	i := 0
@@ -578,7 +578,7 @@ func TestDenseBlockIterator(t *testing.T) {
 		i++
 		logEntry = reader.next()
 	}
-	assert.Equals(t, i, 10)
+	goassert.Equals(t, i, 10)
 
 	reverseReader := NewDenseBlockIterator(block)
 	reverseReader.end()
@@ -589,7 +589,7 @@ func TestDenseBlockIterator(t *testing.T) {
 		i--
 		logEntry = reader.previous()
 	}
-	assert.Equals(t, i, -1)
+	goassert.Equals(t, i, -1)
 
 	bidiReader := NewDenseBlockIterator(block)
 	logEntry = bidiReader.next()
@@ -597,12 +597,12 @@ func TestDenseBlockIterator(t *testing.T) {
 	logEntry = bidiReader.previous()
 	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc0"), "1-abc", 1, 1)
 	logEntry = bidiReader.previous()
-	assert.Equals(t, logEntry == nil, true)
+	goassert.Equals(t, logEntry == nil, true)
 	logEntry = bidiReader.next()
 	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc0"), "1-abc", 1, 1)
 	bidiReader.end()
 	logEntry = bidiReader.next()
-	assert.Equals(t, logEntry == nil, true)
+	goassert.Equals(t, logEntry == nil, true)
 	logEntry = bidiReader.previous()
 	assertLogEntry(t, logEntry.MakeLogEntry(), fmt.Sprintf("doc9"), "1-abc", 91, 10)
 
@@ -632,22 +632,22 @@ func TestDenseBlockList(t *testing.T) {
 
 	// Create a new instance of the same block list, validate contents
 	newList := NewDenseBlockList("ABC", 1, indexBucket)
-	assert.Equals(t, len(newList.blocks), 2)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, len(newList.blocks), 2)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
 
 	// Add a few more blocks to the new list
 	_, err = newList.AddBlock()
 	assertNoError(t, err, "Error adding block2 to blocklist")
-	assert.Equals(t, len(newList.blocks), 3)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
-	assert.Equals(t, newList.blocks[1].BlockIndex, 1)
+	goassert.Equals(t, len(newList.blocks), 3)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, newList.blocks[1].BlockIndex, 1)
 
 	// Attempt to add a block via original list.  Should be cancelled due to cas
 	// mismatch, and reload the current state (i.e. newList)
 	list.AddBlock()
-	assert.Equals(t, len(list.blocks), 3)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
-	assert.Equals(t, newList.blocks[1].BlockIndex, 1)
+	goassert.Equals(t, len(list.blocks), 3)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, newList.blocks[1].BlockIndex, 1)
 
 }
 
@@ -680,22 +680,22 @@ func TestDenseBlockListBadCas(t *testing.T) {
 
 	// Create a new instance of the same block list, validate contents
 	newList := NewDenseBlockList("ABC", 1, indexBucket)
-	assert.Equals(t, len(newList.blocks), 2)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, len(newList.blocks), 2)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
 
 	// Add a few more blocks to the new list
 	_, err = newList.AddBlock()
 	assertNoError(t, err, "Error adding block2 to blocklist")
-	assert.Equals(t, len(newList.blocks), 3)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
-	assert.Equals(t, newList.blocks[1].BlockIndex, 1)
+	goassert.Equals(t, len(newList.blocks), 3)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, newList.blocks[1].BlockIndex, 1)
 
 	// Attempt to add a block via original list.  Should be cancelled due to cas
 	// mismatch, and reload the current state (i.e. newList)
 	list.AddBlock()
-	assert.Equals(t, len(list.blocks), 3)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
-	assert.Equals(t, newList.blocks[1].BlockIndex, 1)
+	goassert.Equals(t, len(list.blocks), 3)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, newList.blocks[1].BlockIndex, 1)
 
 }
 
@@ -723,8 +723,8 @@ func TestDenseBlockListConcurrentInit(t *testing.T) {
 
 	// Create a new instance of the same block list, validate contents
 	newList := NewDenseBlockList("ABC", 1, indexBucket)
-	assert.Equals(t, len(newList.blocks), 1)
-	assert.Equals(t, newList.blocks[0].BlockIndex, 0)
+	goassert.Equals(t, len(newList.blocks), 1)
+	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
 
 }
 
@@ -757,11 +757,11 @@ func TestDenseBlockListRotate(t *testing.T) {
 
 	// Create a new instance of the same block list, validate contents
 	newList := NewDenseBlockList("ABC", 1, indexBucket)
-	assert.Equals(t, len(newList.blocks), 10)
+	goassert.Equals(t, len(newList.blocks), 10)
 
 	err := newList.LoadPrevious()
 	assertNoError(t, err, "Error loading previous")
-	assert.Equals(t, len(newList.blocks), 21)
+	goassert.Equals(t, len(newList.blocks), 21)
 
 }
 
@@ -792,10 +792,10 @@ func TestCalculateChangedPartitions(t *testing.T) {
 	})
 
 	changedVbs, changedPartitions := reader.calculateChanged(startClock, endClock)
-	assert.Equals(t, len(changedVbs), 3)
-	assert.Equals(t, changedVbs[0], uint16(0))   // Partition 0
-	assert.Equals(t, changedVbs[1], uint16(100)) // Partition 6
-	assert.Equals(t, changedVbs[2], uint16(200)) // Partition 12
+	goassert.Equals(t, len(changedVbs), 3)
+	goassert.Equals(t, changedVbs[0], uint16(0))   // Partition 0
+	goassert.Equals(t, changedVbs[1], uint16(100)) // Partition 6
+	goassert.Equals(t, changedVbs[2], uint16(200)) // Partition 12
 
 	changedPartitionCount := 0
 	for partition, partitionRange := range changedPartitions {
@@ -804,13 +804,13 @@ func TestCalculateChangedPartitions(t *testing.T) {
 			assertTrue(t, partition == 0 || partition == 6 || partition == 12, "Unexpected changed partition")
 		}
 	}
-	assert.Equals(t, changedPartitions[0].GetSequenceRange(0).Since, uint64(0))
-	assert.Equals(t, changedPartitions[6].GetSequenceRange(100).Since, uint64(0))
-	assert.Equals(t, changedPartitions[12].GetSequenceRange(200).Since, uint64(0))
-	assert.Equals(t, changedPartitions[0].GetSequenceRange(0).To, uint64(5))
-	assert.Equals(t, changedPartitions[6].GetSequenceRange(100).To, uint64(10))
-	assert.Equals(t, changedPartitions[12].GetSequenceRange(200).To, uint64(15))
-	assert.Equals(t, changedPartitionCount, 3)
+	goassert.Equals(t, changedPartitions[0].GetSequenceRange(0).Since, uint64(0))
+	goassert.Equals(t, changedPartitions[6].GetSequenceRange(100).Since, uint64(0))
+	goassert.Equals(t, changedPartitions[12].GetSequenceRange(200).Since, uint64(0))
+	goassert.Equals(t, changedPartitions[0].GetSequenceRange(0).To, uint64(5))
+	goassert.Equals(t, changedPartitions[6].GetSequenceRange(100).To, uint64(10))
+	goassert.Equals(t, changedPartitions[12].GetSequenceRange(200).To, uint64(15))
+	goassert.Equals(t, changedPartitionCount, 3)
 
 }
 

--- a/db/kv_dense_channel_storage_test.go
+++ b/db/kv_dense_channel_storage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -27,10 +28,10 @@ func makeBlockEntry(docId string, revId string, vbNo int, sequence int, removal 
 }
 
 func assertLogEntry(t *testing.T, entry *LogEntry, docId string, revId string, vbNo int, sequence int) {
-	assertTrue(t, entry.DocID == docId, fmt.Sprintf("Doc ID mismatch.  Expected [%s] Actual [%s]", docId, entry.DocID))
-	assertTrue(t, entry.RevID == revId, fmt.Sprintf("Rev ID mismatch.  Expected [%s] Actual [%s]", revId, entry.RevID))
-	assertTrue(t, entry.VbNo == uint16(vbNo), fmt.Sprintf("VbNo mismatch.  Expected [%d] Actual [%d]", vbNo, entry.VbNo))
-	assertTrue(t, entry.Sequence == uint64(sequence), fmt.Sprintf("Sequence mismatch.  Expected [%d] Actual [%d]", sequence, entry.Sequence))
+	assert.True(t, entry.DocID == docId, fmt.Sprintf("Doc ID mismatch.  Expected [%s] Actual [%s]", docId, entry.DocID))
+	assert.True(t, entry.RevID == revId, fmt.Sprintf("Rev ID mismatch.  Expected [%s] Actual [%s]", revId, entry.RevID))
+	assert.True(t, entry.VbNo == uint16(vbNo), fmt.Sprintf("VbNo mismatch.  Expected [%d] Actual [%d]", vbNo, entry.VbNo))
+	assert.True(t, entry.Sequence == uint64(sequence), fmt.Sprintf("Sequence mismatch.  Expected [%d] Actual [%d]", sequence, entry.Sequence))
 }
 
 func assertLogEntriesEqual(t *testing.T, actualEntry *LogEntry, expectedEntry *LogEntry) {
@@ -53,7 +54,7 @@ func TestDenseBlockSingleDoc(t *testing.T) {
 	entries[0] = makeBlockEntry("doc1", "1-abc", 50, 1, IsNotRemoval, IsAdded)
 
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, updateClock.GetSequence(50), uint64(1))
@@ -66,7 +67,7 @@ func TestDenseBlockSingleDoc(t *testing.T) {
 	entries[0] = makeBlockEntry("doc1", "2-abc", 50, 3, IsNotRemoval, IsNotAdded)
 
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, updateClock.GetSequence(50), uint64(3))
@@ -80,7 +81,7 @@ func TestDenseBlockSingleDoc(t *testing.T) {
 	entries[0].PrevSequence = uint64(3)
 
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, updateClock.GetSequence(50), uint64(5))
@@ -111,7 +112,7 @@ func TestDenseBlockMultipleInserts(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", i*10, i+1, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -139,7 +140,7 @@ func TestDenseBlockGetIndexEntry(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", i*10, i+1, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -166,7 +167,7 @@ func TestDenseBlockGetEntry(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", i*10, i+1, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -197,7 +198,7 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", vbno, sequence, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -221,7 +222,7 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 		entries[i].PrevSequence = uint64(i + 1)
 	}
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, int(block.getEntryCount()), 10)
@@ -237,7 +238,7 @@ func TestDenseBlockMultipleUpdates(t *testing.T) {
 	entries = make([]*LogEntry, 1)
 	entries[0] = makeBlockEntry("doc_not_in_block", "2-abc", 11, 65, IsNotRemoval, IsNotAdded)
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 1)
 	goassert.Equals(t, int(block.getEntryCount()), 11)
@@ -262,7 +263,7 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", vbno, sequence, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -283,7 +284,7 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "2-abc", vbno, sequence, IsNotRemoval, IsNotAdded)
 	}
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, int(block.getEntryCount()), 10)
@@ -299,7 +300,7 @@ func TestDenseBlockRemovalByKey(t *testing.T) {
 	entries = make([]*LogEntry, 1)
 	entries[0] = makeBlockEntry("doc_not_in_block", "2-abc", 50, 65, IsNotRemoval, IsNotAdded)
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 1)
 	goassert.Equals(t, int(block.getEntryCount()), 11)
@@ -325,7 +326,7 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", vbNo, sequence, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -345,7 +346,7 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 
 	// Rollback should complete in this block
 	rollbackComplete, err := block.RollbackTo(2, 5, indexBucket)
-	assertNoError(t, err, "Error rolling back")
+	assert.NoError(t, err, "Error rolling back")
 	goassert.Equals(t, rollbackComplete, true)
 	goassert.Equals(t, block.getEntryCount(), uint16(8))
 
@@ -363,7 +364,7 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	// Rollback should NOT complete in this block, because we don't see a sequence value earlier than
 	// rollback value in this block (haven't seen a sequence earlier than 1 in vb 1)
 	rollbackComplete, err = block.RollbackTo(1, 1, indexBucket)
-	assertNoError(t, err, "Error rolling back")
+	assert.NoError(t, err, "Error rolling back")
 	goassert.Equals(t, rollbackComplete, false)
 	goassert.Equals(t, block.getEntryCount(), uint16(5))
 
@@ -377,7 +378,7 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 
 	// Remove the first entry, make sure nothing breaks
 	rollbackComplete, err = block.RollbackTo(0, 0, indexBucket)
-	assertNoError(t, err, "Error rolling back")
+	assert.NoError(t, err, "Error rolling back")
 	goassert.Equals(t, rollbackComplete, false)
 	goassert.Equals(t, block.getEntryCount(), uint16(1))
 
@@ -392,14 +393,14 @@ func TestDenseBlockRollbackTo(t *testing.T) {
 	entries = make([]*LogEntry, 0)
 
 	overflow, pendingRemoval, _, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding empty entry set")
+	assert.NoError(t, err, "Error adding empty entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(0))
 
 	// Rollback should complete in this empty block
 	rollbackComplete, err = block.RollbackTo(1, 1, indexBucket)
-	assertNoError(t, err, "Error rolling back")
+	assert.NoError(t, err, "Error rolling back")
 	goassert.Equals(t, rollbackComplete, true)
 	goassert.Equals(t, block.getEntryCount(), uint16(0))
 }
@@ -425,7 +426,7 @@ func TestDenseBlockOverflow(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("longerDocumentID-%d", sequence), "1-abcdef01234567890", vbno, sequence, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, int(block.getEntryCount()), 100)
@@ -446,7 +447,7 @@ func TestDenseBlockOverflow(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("longerDocumentID-%d", sequence), "1-abcdef01234567890", vbno, sequence, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 12)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, int(block.getEntryCount()), 188)
@@ -469,7 +470,7 @@ func TestDenseBlockOverflow(t *testing.T) {
 	// Retry the 12 entries, all should overflow
 	var newOverflow []*LogEntry
 	newOverflow, pendingRemoval, updateClock, _, err = block.AddEntrySet(overflow, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(newOverflow), 12)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, int(block.getEntryCount()), 188)
@@ -494,7 +495,7 @@ func TestDenseBlockConcurrentUpdates(t *testing.T) {
 	entries[0] = makeBlockEntry("doc1", "1-abc", 50, 1, IsNotRemoval, IsAdded)
 
 	overflow, pendingRemoval, updateClock, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, updateClock.GetSequence(50), uint64(1))
@@ -510,7 +511,7 @@ func TestDenseBlockConcurrentUpdates(t *testing.T) {
 	entries2 := make([]*LogEntry, 1)
 	entries2[0] = makeBlockEntry("doc2", "1-abc", 50, 3, IsNotRemoval, IsAdded)
 	overflow2, pendingRemoval2, updateClock2, casFail, err := block2.AddEntrySet(entries2, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, casFail, true)
 	goassert.Equals(t, len(overflow2), 1)
 	goassert.Equals(t, len(pendingRemoval2), 0)
@@ -531,7 +532,7 @@ func TestDenseBlockConcurrentUpdates(t *testing.T) {
 
 	// Attempt to write the same entry with the first block/writer
 	overflow, pendingRemoval, updateClock, casFail, err = block.AddEntrySet(entries2, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 1)
 	goassert.Equals(t, casFail, true)
 	goassert.Equals(t, len(pendingRemoval), 0)
@@ -565,7 +566,7 @@ func TestDenseBlockIterator(t *testing.T) {
 		entries[i] = makeBlockEntry(fmt.Sprintf("doc%d", i), "1-abc", vbno, sequence, IsNotRemoval, IsAdded)
 	}
 	overflow, pendingRemoval, _, _, err := block.AddEntrySet(entries, indexBucket)
-	assertNoError(t, err, "Error adding entry set")
+	assert.NoError(t, err, "Error adding entry set")
 	goassert.Equals(t, len(overflow), 0)
 	goassert.Equals(t, len(pendingRemoval), 0)
 	goassert.Equals(t, block.getEntryCount(), uint16(10))
@@ -626,7 +627,7 @@ func TestDenseBlockList(t *testing.T) {
 
 	// Simple insert
 	_, err := list.AddBlock()
-	assertNoError(t, err, "Error adding block to blocklist")
+	assert.NoError(t, err, "Error adding block to blocklist")
 
 	indexBucket.Dump()
 
@@ -637,7 +638,7 @@ func TestDenseBlockList(t *testing.T) {
 
 	// Add a few more blocks to the new list
 	_, err = newList.AddBlock()
-	assertNoError(t, err, "Error adding block2 to blocklist")
+	assert.NoError(t, err, "Error adding block2 to blocklist")
 	goassert.Equals(t, len(newList.blocks), 3)
 	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
 	goassert.Equals(t, newList.blocks[1].BlockIndex, 1)
@@ -674,7 +675,7 @@ func TestDenseBlockListBadCas(t *testing.T) {
 
 	// Simple insert
 	_, err := list.AddBlock()
-	assertNoError(t, err, "Error adding block to blocklist")
+	assert.NoError(t, err, "Error adding block to blocklist")
 
 	indexBucket.Dump()
 
@@ -685,7 +686,7 @@ func TestDenseBlockListBadCas(t *testing.T) {
 
 	// Add a few more blocks to the new list
 	_, err = newList.AddBlock()
-	assertNoError(t, err, "Error adding block2 to blocklist")
+	assert.NoError(t, err, "Error adding block2 to blocklist")
 	goassert.Equals(t, len(newList.blocks), 3)
 	goassert.Equals(t, newList.blocks[0].BlockIndex, 0)
 	goassert.Equals(t, newList.blocks[1].BlockIndex, 1)
@@ -716,7 +717,7 @@ func TestDenseBlockListConcurrentInit(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			list := NewDenseBlockList("ABC", 1, indexBucket)
-			assertTrue(t, list != nil, "Error creating block list")
+			assert.True(t, list != nil, "Error creating block list")
 		}()
 	}
 	wg.Wait()
@@ -750,7 +751,7 @@ func TestDenseBlockListRotate(t *testing.T) {
 	// Add more than max blocks to block list
 	for i := 1; i <= MaxListBlockCount+10; i++ {
 		_, err := list.AddBlock()
-		assertNoError(t, err, "Error adding block to blocklist")
+		assert.NoError(t, err, "Error adding block to blocklist")
 	}
 
 	indexBucket.Dump()
@@ -760,7 +761,7 @@ func TestDenseBlockListRotate(t *testing.T) {
 	goassert.Equals(t, len(newList.blocks), 10)
 
 	err := newList.LoadPrevious()
-	assertNoError(t, err, "Error loading previous")
+	assert.NoError(t, err, "Error loading previous")
 	goassert.Equals(t, len(newList.blocks), 21)
 
 }
@@ -801,7 +802,7 @@ func TestCalculateChangedPartitions(t *testing.T) {
 	for partition, partitionRange := range changedPartitions {
 		if partitionRange != nil {
 			changedPartitionCount++
-			assertTrue(t, partition == 0 || partition == 6 || partition == 12, "Unexpected changed partition")
+			assert.True(t, partition == 0 || partition == 6 || partition == 12, "Unexpected changed partition")
 		}
 	}
 	goassert.Equals(t, changedPartitions[0].GetSequenceRange(0).Since, uint64(0))

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -7,6 +7,7 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // Validate stats for view query
@@ -21,11 +22,11 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	_, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
-	assertNoError(t, err, "Put queryDoc1")
+	assert.NoError(t, err, "Put queryDoc1")
 	_, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
-	assertNoError(t, err, "Put queryDoc2")
+	assert.NoError(t, err, "Put queryDoc2")
 	_, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
-	assertNoError(t, err, "Put queryDoc3")
+	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
 	queryCountExpvar := fmt.Sprintf(viewQueryCountExpvarFormat, DesignDocSyncGateway(), ViewChannels)
@@ -36,12 +37,12 @@ func TestQueryChannelsStatsView(t *testing.T) {
 
 	// Issue channels query
 	results, queryErr := db.QueryChannels("ABC", 0, 10, 100)
-	assertNoError(t, queryErr, "Query error")
+	assert.NoError(t, queryErr, "Query error")
 
 	goassert.Equals(t, countQueryResults(results), 3)
 
 	closeErr := results.Close()
-	assertNoError(t, closeErr, "Close error")
+	assert.NoError(t, closeErr, "Close error")
 
 	channelQueryCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", queryCountExpvar)
 	channelQueryErrorCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", errorCountExpvar)
@@ -63,11 +64,11 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	_, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
-	assertNoError(t, err, "Put queryDoc1")
+	assert.NoError(t, err, "Put queryDoc1")
 	_, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
-	assertNoError(t, err, "Put queryDoc2")
+	assert.NoError(t, err, "Put queryDoc2")
 	_, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
-	assertNoError(t, err, "Put queryDoc3")
+	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
 	queryCountExpvar := fmt.Sprintf(n1qlQueryCountExpvarFormat, QueryTypeChannels)
@@ -78,12 +79,12 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 
 	// Issue channels query
 	results, queryErr := db.QueryChannels("ABC", 0, 10, 100)
-	assertNoError(t, queryErr, "Query error")
+	assert.NoError(t, queryErr, "Query error")
 
 	goassert.Equals(t, countQueryResults(results), 3)
 
 	closeErr := results.Close()
-	assertNoError(t, closeErr, "Close error")
+	assert.NoError(t, closeErr, "Close error")
 
 	channelQueryCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", queryCountExpvar)
 	channelQueryErrorCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", errorCountExpvar)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -6,7 +6,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // Validate stats for view query
@@ -38,7 +38,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	results, queryErr := db.QueryChannels("ABC", 0, 10, 100)
 	assertNoError(t, queryErr, "Query error")
 
-	assert.Equals(t, countQueryResults(results), 3)
+	goassert.Equals(t, countQueryResults(results), 3)
 
 	closeErr := results.Close()
 	assertNoError(t, closeErr, "Close error")
@@ -46,8 +46,8 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	channelQueryCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", queryCountExpvar)
 	channelQueryErrorCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", errorCountExpvar)
 
-	assert.Equals(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	assert.Equals(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
+	goassert.Equals(t, channelQueryCountBefore+1, channelQueryCountAfter)
+	goassert.Equals(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }
 
@@ -80,7 +80,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	results, queryErr := db.QueryChannels("ABC", 0, 10, 100)
 	assertNoError(t, queryErr, "Query error")
 
-	assert.Equals(t, countQueryResults(results), 3)
+	goassert.Equals(t, countQueryResults(results), 3)
 
 	closeErr := results.Close()
 	assertNoError(t, closeErr, "Close error")
@@ -88,8 +88,8 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	channelQueryCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", queryCountExpvar)
 	channelQueryErrorCountAfter, _ := base.GetExpvarAsInt("syncGateway_query", errorCountExpvar)
 
-	assert.Equals(t, channelQueryCountBefore+1, channelQueryCountAfter)
-	assert.Equals(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
+	goassert.Equals(t, channelQueryCountBefore+1, channelQueryCountAfter)
+	goassert.Equals(t, channelQueryErrorCountBefore, channelQueryErrorCountAfter)
 
 }
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -70,7 +71,7 @@ func TestRepairBucket(t *testing.T) {
 
 	repairedDocs, err := repairBucket.RepairBucket()
 
-	assertNoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
 
 	// All docs will be repaired due to the repairJob function that indiscriminately repairs all docs
 	goassert.True(t, len(repairedDocs) == numDocs)
@@ -105,25 +106,25 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	repairedDocs, err := repairBucket.RepairBucket()
 
-	assertNoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
 	goassert.True(t, len(repairedDocs) == 2)
 
 	// Now get the doc from the bucket
 	rawVal, _, errGetDoc := bucket.GetRaw(docIdProblematicRevTree)
-	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting doc: %v", errGetDoc))
+	assert.NoError(t, errGetDoc, fmt.Sprintf("Error getting doc: %v", errGetDoc))
 
 	repairedDoc, errUnmarshal := unmarshalDocument(docIdProblematicRevTree, rawVal)
-	assertNoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
+	assert.NoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
 
 	// Since doc was repaired, should contain no cycles
 	goassert.False(t, repairedDoc.History.ContainsCycles())
 
 	// There should be a backup doc in the bucket with ID _sync:repair:backup:docIdProblematicRevTree
 	rawVal, _, errGetDoc = bucket.GetRaw("_sync:repair:backup:docIdProblematicRevTree")
-	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
+	assert.NoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
 
 	backupDoc, errUnmarshalBackup := unmarshalDocument(docIdProblematicRevTree, rawVal)
-	assertNoError(t, errUnmarshalBackup, fmt.Sprintf("Error umarshalling backup doc: %v", errUnmarshalBackup))
+	assert.NoError(t, errUnmarshalBackup, fmt.Sprintf("Error umarshalling backup doc: %v", errUnmarshalBackup))
 
 	// The backup doc should contain revtree cycles
 	goassert.True(t, backupDoc.History.ContainsCycles())
@@ -155,24 +156,24 @@ func TestRepairBucketDryRun(t *testing.T) {
 
 	repairedDocs, err := repairBucket.RepairBucket()
 
-	assertNoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
 	goassert.True(t, len(repairedDocs) == 2)
 
 	// Now get the doc from the bucket
 	rawVal, _, errGetDoc := bucket.GetRaw(docIdProblematicRevTree2)
-	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting doc: %v", errGetDoc))
+	assert.NoError(t, errGetDoc, fmt.Sprintf("Error getting doc: %v", errGetDoc))
 
 	repairedDoc, errUnmarshal := unmarshalDocument(docIdProblematicRevTree2, rawVal)
-	assertNoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
+	assert.NoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
 
 	// Since doc was not repaired due to dry, should still contain cycles
 	goassert.True(t, repairedDoc.History.ContainsCycles())
 
 	rawVal, _, errGetDoc = bucket.GetRaw("_sync:repair:dryrun:docIdProblematicRevTree2")
-	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
+	assert.NoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
 
 	backupDoc, errUnmarshalBackup := unmarshalDocument(docIdProblematicRevTree2, rawVal)
-	assertNoError(t, errUnmarshalBackup, fmt.Sprintf("Error umarshalling backup doc: %v", errUnmarshalBackup))
+	assert.NoError(t, errUnmarshalBackup, fmt.Sprintf("Error umarshalling backup doc: %v", errUnmarshalBackup))
 
 	// The dry run fixed doc should not contain revtree cycles
 	goassert.False(t, backupDoc.History.ContainsCycles())

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 const (
@@ -73,7 +73,7 @@ func TestRepairBucket(t *testing.T) {
 	assertNoError(t, err, fmt.Sprintf("Unexpected error: %v", err))
 
 	// All docs will be repaired due to the repairJob function that indiscriminately repairs all docs
-	assert.True(t, len(repairedDocs) == numDocs)
+	goassert.True(t, len(repairedDocs) == numDocs)
 
 }
 
@@ -106,7 +106,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	repairedDocs, err := repairBucket.RepairBucket()
 
 	assertNoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
-	assert.True(t, len(repairedDocs) == 2)
+	goassert.True(t, len(repairedDocs) == 2)
 
 	// Now get the doc from the bucket
 	rawVal, _, errGetDoc := bucket.GetRaw(docIdProblematicRevTree)
@@ -116,7 +116,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	assertNoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
 
 	// Since doc was repaired, should contain no cycles
-	assert.False(t, repairedDoc.History.ContainsCycles())
+	goassert.False(t, repairedDoc.History.ContainsCycles())
 
 	// There should be a backup doc in the bucket with ID _sync:repair:backup:docIdProblematicRevTree
 	rawVal, _, errGetDoc = bucket.GetRaw("_sync:repair:backup:docIdProblematicRevTree")
@@ -126,7 +126,7 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 	assertNoError(t, errUnmarshalBackup, fmt.Sprintf("Error umarshalling backup doc: %v", errUnmarshalBackup))
 
 	// The backup doc should contain revtree cycles
-	assert.True(t, backupDoc.History.ContainsCycles())
+	goassert.True(t, backupDoc.History.ContainsCycles())
 
 }
 
@@ -156,7 +156,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 	repairedDocs, err := repairBucket.RepairBucket()
 
 	assertNoError(t, err, fmt.Sprintf("Error repairing bucket: %v", err))
-	assert.True(t, len(repairedDocs) == 2)
+	goassert.True(t, len(repairedDocs) == 2)
 
 	// Now get the doc from the bucket
 	rawVal, _, errGetDoc := bucket.GetRaw(docIdProblematicRevTree2)
@@ -166,7 +166,7 @@ func TestRepairBucketDryRun(t *testing.T) {
 	assertNoError(t, errUnmarshal, fmt.Sprintf("Error unmarshalling doc: %v", errUnmarshal))
 
 	// Since doc was not repaired due to dry, should still contain cycles
-	assert.True(t, repairedDoc.History.ContainsCycles())
+	goassert.True(t, repairedDoc.History.ContainsCycles())
 
 	rawVal, _, errGetDoc = bucket.GetRaw("_sync:repair:dryrun:docIdProblematicRevTree2")
 	assertNoError(t, errGetDoc, fmt.Sprintf("Error getting backup doc: %v", errGetDoc))
@@ -175,6 +175,6 @@ func TestRepairBucketDryRun(t *testing.T) {
 	assertNoError(t, errUnmarshalBackup, fmt.Sprintf("Error umarshalling backup doc: %v", errUnmarshalBackup))
 
 	// The dry run fixed doc should not contain revtree cycles
-	assert.False(t, backupDoc.History.ContainsCycles())
+	goassert.False(t, backupDoc.History.ContainsCycles())
 
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestRevisionCache(t *testing.T) {
@@ -26,11 +26,11 @@ func TestRevisionCache(t *testing.T) {
 		if body == nil {
 			t.Fatalf("nil body at #%d", i)
 		}
-		assert.True(t, body != nil)
-		assert.Equals(t, body[BodyId], ids[i])
-		assert.True(t, history != nil)
-		assert.Equals(t, history[RevisionsStart], i)
-		assert.DeepEquals(t, channels, base.Set(nil))
+		goassert.True(t, body != nil)
+		goassert.Equals(t, body[BodyId], ids[i])
+		goassert.True(t, history != nil)
+		goassert.Equals(t, history[RevisionsStart], i)
+		goassert.DeepEquals(t, channels, base.Set(nil))
 	}
 
 	cache := NewRevisionCache(10, nil)
@@ -51,7 +51,7 @@ func TestRevisionCache(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		body, _, _, _ := cache.Get(ids[i], "x")
-		assert.True(t, body == nil)
+		goassert.True(t, body == nil)
 	}
 	for i := 3; i < 13; i++ {
 		body, history, channels, _ := cache.Get(ids[i], "x")
@@ -78,28 +78,28 @@ func TestLoaderFunction(t *testing.T) {
 	cache := NewRevisionCache(10, loader)
 
 	body, history, channels, err := cache.Get("Jens", "1")
-	assert.Equals(t, body[BodyId], "Jens")
-	assert.True(t, history != nil)
-	assert.True(t, channels != nil)
-	assert.Equals(t, err, error(nil))
-	assert.Equals(t, callsToLoader, 1)
+	goassert.Equals(t, body[BodyId], "Jens")
+	goassert.True(t, history != nil)
+	goassert.True(t, channels != nil)
+	goassert.Equals(t, err, error(nil))
+	goassert.Equals(t, callsToLoader, 1)
 
 	body, history, channels, err = cache.Get("Peter", "1")
-	assert.DeepEquals(t, body, Body(nil))
-	assert.DeepEquals(t, err, base.HTTPErrorf(404, "missing"))
-	assert.Equals(t, callsToLoader, 2)
+	goassert.DeepEquals(t, body, Body(nil))
+	goassert.DeepEquals(t, err, base.HTTPErrorf(404, "missing"))
+	goassert.Equals(t, callsToLoader, 2)
 
 	body, history, channels, err = cache.Get("Jens", "1")
-	assert.Equals(t, body[BodyId], "Jens")
-	assert.True(t, history != nil)
-	assert.True(t, channels != nil)
-	assert.Equals(t, err, error(nil))
-	assert.Equals(t, callsToLoader, 2)
+	goassert.Equals(t, body[BodyId], "Jens")
+	goassert.True(t, history != nil)
+	goassert.True(t, channels != nil)
+	goassert.Equals(t, err, error(nil))
+	goassert.Equals(t, callsToLoader, 2)
 
 	body, history, channels, err = cache.Get("Peter", "1")
-	assert.DeepEquals(t, body, Body(nil))
-	assert.DeepEquals(t, err, base.HTTPErrorf(404, "missing"))
-	assert.Equals(t, callsToLoader, 3)
+	goassert.DeepEquals(t, body, Body(nil))
+	goassert.DeepEquals(t, err, base.HTTPErrorf(404, "missing"))
+	goassert.Equals(t, callsToLoader, 3)
 }
 
 // Ensure internal properties aren't being incorrectly stored in revision cache
@@ -143,7 +143,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 	}
 	validRevisionsMap, ok := validRevisions.(map[string]interface{})
 	_, startOk := validRevisionsMap[RevisionsStart]
-	assert.True(t, startOk)
+	goassert.True(t, startOk)
 	_, idsOk := validRevisionsMap[RevisionsIds]
-	assert.True(t, idsOk)
+	goassert.True(t, idsOk)
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRevisionCache(t *testing.T) {
@@ -115,7 +116,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 		BodyRevisions: "unexpected data",
 	}
 	rev1id, err := db.Put("doc1", rev1body)
-	assertNoError(t, err, "Put")
+	assert.NoError(t, err, "Put")
 
 	// Get the raw document directly from the bucket, validate _revisions property isn't found
 	var bucketBody Body
@@ -127,7 +128,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	// Get the doc while still resident in the rev cache w/ history=false, validate _revisions property isn't found
 	body, err := db.GetRev("doc1", rev1id, false, nil)
-	assertNoError(t, err, "GetRev")
+	assert.NoError(t, err, "GetRev")
 	badRevisions, ok := body[BodyRevisions]
 	if ok {
 		t.Errorf("_revisions property still present in document retrieved from rev cache: %s", badRevisions)
@@ -136,7 +137,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 	// Get the doc while still resident in the rev cache w/ history=true, validate _revisions property is returned with expected
 	// properties ("start", "ids")
 	bodyWithHistory, err := db.GetRev("doc1", rev1id, true, nil)
-	assertNoError(t, err, "GetRev")
+	assert.NoError(t, err, "GetRev")
 	validRevisions, ok := bodyWithHistory[BodyRevisions]
 	if !ok {
 		t.Errorf("Expected _revisions property not found in document retrieved from rev cache: %s", validRevisions)

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestParseRevID(t *testing.T) {
@@ -62,8 +62,8 @@ func TestBodyUnmarshal(t *testing.T) {
 				assertTrue(t, err != nil, fmt.Sprintf("Expected error when unmarshalling %s", test.name))
 			} else {
 				assertNoError(t, err, fmt.Sprintf("Expected no error when unmarshalling %s", test.name))
-				assert.DeepEquals(t, b, test.expectedBody) // Check against expected body
-				assert.DeepEquals(t, b, jsonUnmarshalBody) // Check against json.Unmarshal results
+				goassert.DeepEquals(t, b, test.expectedBody) // Check against expected body
+				goassert.DeepEquals(t, b, jsonUnmarshalBody) // Check against json.Unmarshal results
 			}
 
 		})

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseRevID(t *testing.T) {
@@ -16,22 +17,22 @@ func TestParseRevID(t *testing.T) {
 
 	generation, _ = ParseRevID("ljlkjl")
 	log.Printf("generation: %v", generation)
-	assertTrue(t, generation == -1, "Expected -1 generation for invalid rev id")
+	assert.True(t, generation == -1, "Expected -1 generation for invalid rev id")
 
 	generation, digest = ParseRevID("1-ljlkjl")
 	log.Printf("generation: %v, digest: %v", generation, digest)
-	assertTrue(t, generation == 1, "Expected 1 generation")
-	assertTrue(t, digest == "ljlkjl", "Unexpected digest")
+	assert.True(t, generation == 1, "Expected 1 generation")
+	assert.True(t, digest == "ljlkjl", "Unexpected digest")
 
 	generation, digest = ParseRevID("2222-")
 	log.Printf("generation: %v, digest: %v", generation, digest)
-	assertTrue(t, generation == 2222, "Expected invalid generation")
-	assertTrue(t, digest == "", "Unexpected digest")
+	assert.True(t, generation == 2222, "Expected invalid generation")
+	assert.True(t, digest == "", "Unexpected digest")
 
 	generation, digest = ParseRevID("333-a")
 	log.Printf("generation: %v, digest: %v", generation, digest)
-	assertTrue(t, generation == 333, "Expected generation")
-	assertTrue(t, digest == "a", "Unexpected digest")
+	assert.True(t, generation == 333, "Expected generation")
+	assert.True(t, digest == "a", "Unexpected digest")
 
 }
 
@@ -59,9 +60,9 @@ func TestBodyUnmarshal(t *testing.T) {
 
 			if unmarshalErr != nil {
 				// If json.Unmarshal returns error for input, body.Unmarshal should do the same
-				assertTrue(t, err != nil, fmt.Sprintf("Expected error when unmarshalling %s", test.name))
+				assert.True(t, err != nil, fmt.Sprintf("Expected error when unmarshalling %s", test.name))
 			} else {
-				assertNoError(t, err, fmt.Sprintf("Expected no error when unmarshalling %s", test.name))
+				assert.NoError(t, err, fmt.Sprintf("Expected no error when unmarshalling %s", test.name))
 				goassert.DeepEquals(t, b, test.expectedBody) // Check against expected body
 				goassert.DeepEquals(t, b, jsonUnmarshalBody) // Check against json.Unmarshal results
 			}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // 1-one -- 2-two -- 3-three
@@ -173,7 +173,7 @@ func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs 
 func testUnmarshal(t *testing.T, jsonString string) RevTree {
 	gotmap := RevTree{}
 	assertNoError(t, json.Unmarshal([]byte(jsonString), &gotmap), "Couldn't parse RevTree from JSON")
-	assert.DeepEquals(t, gotmap, testmap)
+	goassert.DeepEquals(t, gotmap, testmap)
 	return gotmap
 }
 
@@ -196,7 +196,7 @@ func TestGetMultiBranchTestRevtree(t *testing.T) {
 	revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
 	leaves := revTree.GetLeaves()
 	sort.Strings(leaves)
-	assert.DeepEquals(t, leaves, []string{"110-left", "150-winning", "76-right"})
+	goassert.DeepEquals(t, leaves, []string{"110-left", "150-winning", "76-right"})
 
 }
 
@@ -216,7 +216,7 @@ func TestRevTreeUnmarshalRevChannelCountMismatch(t *testing.T) {
 	const testJSON = `{"revs": ["3-three", "2-two", "1-one"], "parents": [1, 2, -1], "bodymap": {"0":"{}"}, "channels": [null, ["ABC", "CBS"]]}`
 	gotmap := RevTree{}
 	err := json.Unmarshal([]byte(testJSON), &gotmap)
-	assert.Equals(t, err.Error(), "revtreelist data is invalid, revs/parents/channels counts are inconsistent")
+	goassert.Equals(t, err.Error(), "revtreelist data is invalid, revs/parents/channels counts are inconsistent")
 }
 
 func TestRevTreeMarshal(t *testing.T) {
@@ -234,23 +234,23 @@ func TestRevTreeAccess(t *testing.T) {
 
 func TestRevTreeParentAccess(t *testing.T) {
 	parent := testmap.getParent("3-three")
-	assert.Equals(t, parent, "2-two")
+	goassert.Equals(t, parent, "2-two")
 	parent = testmap.getParent("1-one")
-	assert.Equals(t, parent, "")
+	goassert.Equals(t, parent, "")
 }
 
 func TestRevTreeGetHistory(t *testing.T) {
 	history, err := testmap.getHistory("3-three")
-	assert.True(t, err == nil)
-	assert.DeepEquals(t, history, []string{"3-three", "2-two", "1-one"})
+	goassert.True(t, err == nil)
+	goassert.DeepEquals(t, history, []string{"3-three", "2-two", "1-one"})
 }
 
 func TestRevTreeGetLeaves(t *testing.T) {
 	leaves := testmap.GetLeaves()
-	assert.DeepEquals(t, leaves, []string{"3-three"})
+	goassert.DeepEquals(t, leaves, []string{"3-three"})
 	leaves = branchymap.GetLeaves()
 	sort.Strings(leaves)
-	assert.DeepEquals(t, leaves, []string{"3-drei", "3-three"})
+	goassert.DeepEquals(t, leaves, []string{"3-drei", "3-three"})
 }
 
 func TestRevTreeForEachLeaf(t *testing.T) {
@@ -259,47 +259,47 @@ func TestRevTreeForEachLeaf(t *testing.T) {
 		leaves = append(leaves, rev.ID)
 	})
 	sort.Strings(leaves)
-	assert.DeepEquals(t, leaves, []string{"3-drei", "3-three"})
+	goassert.DeepEquals(t, leaves, []string{"3-drei", "3-three"})
 }
 
 func TestRevTreeAddRevision(t *testing.T) {
 	tempmap := testmap.copy()
-	assert.DeepEquals(t, tempmap, testmap)
+	goassert.DeepEquals(t, tempmap, testmap)
 
 	tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
-	assert.Equals(t, tempmap.getParent("4-four"), "3-three")
+	goassert.Equals(t, tempmap.getParent("4-four"), "3-three")
 }
 
 func TestRevTreeAddRevisionWithEmptyID(t *testing.T) {
 	tempmap := testmap.copy()
-	assert.DeepEquals(t, tempmap, testmap)
+	goassert.DeepEquals(t, tempmap, testmap)
 
 	err := tempmap.addRevision("testdoc", RevInfo{Parent: "3-three"})
-	assert.Equals(t, err.Error(), fmt.Sprintf("doc: %v, RevTree addRevision, empty revid is illegal", "testdoc"))
+	goassert.Equals(t, err.Error(), fmt.Sprintf("doc: %v, RevTree addRevision, empty revid is illegal", "testdoc"))
 }
 
 func TestRevTreeAddDuplicateRevID(t *testing.T) {
 	tempmap := testmap.copy()
-	assert.DeepEquals(t, tempmap, testmap)
+	goassert.DeepEquals(t, tempmap, testmap)
 
 	err := tempmap.addRevision("testdoc", RevInfo{ID: "2-two", Parent: "1-one"})
-	assert.Equals(t, err.Error(), fmt.Sprintf("doc: %v, RevTree addRevision, already contains rev %q", "testdoc", "2-two"))
+	goassert.Equals(t, err.Error(), fmt.Sprintf("doc: %v, RevTree addRevision, already contains rev %q", "testdoc", "2-two"))
 }
 
 func TestRevTreeAddRevisionWithMissingParent(t *testing.T) {
 	tempmap := testmap.copy()
-	assert.DeepEquals(t, tempmap, testmap)
+	goassert.DeepEquals(t, tempmap, testmap)
 
 	err := tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four"})
-	assert.Equals(t, err.Error(), fmt.Sprintf("doc: %v, RevTree addRevision, parent id %q is missing", "testdoc", "4-four"))
+	goassert.Equals(t, err.Error(), fmt.Sprintf("doc: %v, RevTree addRevision, parent id %q is missing", "testdoc", "4-four"))
 }
 
 func TestRevTreeCompareRevIDs(t *testing.T) {
-	assert.Equals(t, compareRevIDs("1-aaa", "1-aaa"), 0)
-	assert.Equals(t, compareRevIDs("1-aaa", "5-aaa"), -1)
-	assert.Equals(t, compareRevIDs("10-aaa", "5-aaa"), 1)
-	assert.Equals(t, compareRevIDs("1-bbb", "1-aaa"), 1)
-	assert.Equals(t, compareRevIDs("5-bbb", "1-zzz"), 1)
+	goassert.Equals(t, compareRevIDs("1-aaa", "1-aaa"), 0)
+	goassert.Equals(t, compareRevIDs("1-aaa", "5-aaa"), -1)
+	goassert.Equals(t, compareRevIDs("10-aaa", "5-aaa"), 1)
+	goassert.Equals(t, compareRevIDs("1-bbb", "1-aaa"), 1)
+	goassert.Equals(t, compareRevIDs("5-bbb", "1-zzz"), 1)
 }
 
 func TestRevTreeIsLeaf(t *testing.T) {
@@ -313,63 +313,63 @@ func TestRevTreeIsLeaf(t *testing.T) {
 func TestRevTreeWinningRev(t *testing.T) {
 	tempmap := branchymap.copy()
 	winner, branched, conflict := tempmap.winningRevision()
-	assert.Equals(t, winner, "3-three")
-	assert.True(t, branched)
-	assert.True(t, conflict)
+	goassert.Equals(t, winner, "3-three")
+	goassert.True(t, branched)
+	goassert.True(t, conflict)
 	tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
 	winner, branched, conflict = tempmap.winningRevision()
-	assert.Equals(t, winner, "4-four")
-	assert.True(t, branched)
-	assert.True(t, conflict)
+	goassert.Equals(t, winner, "4-four")
+	goassert.True(t, branched)
+	goassert.True(t, conflict)
 	tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four", Deleted: true})
 	winner, branched, conflict = tempmap.winningRevision()
-	assert.Equals(t, winner, "3-drei")
-	assert.True(t, branched)
-	assert.False(t, conflict)
+	goassert.Equals(t, winner, "3-drei")
+	goassert.True(t, branched)
+	goassert.False(t, conflict)
 }
 
 func TestPruneRevisions(t *testing.T) {
 
 	tempmap := testmap.copy()
 	tempmap.computeDepthsAndFindLeaves()
-	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
-	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
-	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
+	goassert.Equals(t, tempmap["3-three"].depth, uint32(1))
+	goassert.Equals(t, tempmap["2-two"].depth, uint32(2))
+	goassert.Equals(t, tempmap["1-one"].depth, uint32(3))
 
 	tempmap = branchymap.copy()
 	tempmap.computeDepthsAndFindLeaves()
-	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
-	assert.Equals(t, tempmap["3-drei"].depth, uint32(1))
-	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
-	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
+	goassert.Equals(t, tempmap["3-three"].depth, uint32(1))
+	goassert.Equals(t, tempmap["3-drei"].depth, uint32(1))
+	goassert.Equals(t, tempmap["2-two"].depth, uint32(2))
+	goassert.Equals(t, tempmap["1-one"].depth, uint32(3))
 
 	tempmap["4-vier"] = &RevInfo{ID: "4-vier", Parent: "3-drei"}
 	tempmap.computeDepthsAndFindLeaves()
-	assert.Equals(t, tempmap["4-vier"].depth, uint32(1))
-	assert.Equals(t, tempmap["3-drei"].depth, uint32(2))
-	assert.Equals(t, tempmap["3-three"].depth, uint32(1))
-	assert.Equals(t, tempmap["2-two"].depth, uint32(2))
-	assert.Equals(t, tempmap["1-one"].depth, uint32(3))
+	goassert.Equals(t, tempmap["4-vier"].depth, uint32(1))
+	goassert.Equals(t, tempmap["3-drei"].depth, uint32(2))
+	goassert.Equals(t, tempmap["3-three"].depth, uint32(1))
+	goassert.Equals(t, tempmap["2-two"].depth, uint32(2))
+	goassert.Equals(t, tempmap["1-one"].depth, uint32(3))
 
 	// Prune:
 	pruned, _ := tempmap.pruneRevisions(1000, "")
-	assert.Equals(t, pruned, 0)
+	goassert.Equals(t, pruned, 0)
 	pruned, _ = tempmap.pruneRevisions(3, "")
-	assert.Equals(t, pruned, 0)
+	goassert.Equals(t, pruned, 0)
 	pruned, _ = tempmap.pruneRevisions(2, "")
-	assert.Equals(t, pruned, 1)
-	assert.Equals(t, len(tempmap), 4)
-	assert.Equals(t, tempmap["1-one"], (*RevInfo)(nil))
-	assert.Equals(t, tempmap["2-two"].Parent, "")
+	goassert.Equals(t, pruned, 1)
+	goassert.Equals(t, len(tempmap), 4)
+	goassert.Equals(t, tempmap["1-one"], (*RevInfo)(nil))
+	goassert.Equals(t, tempmap["2-two"].Parent, "")
 
 	// Make sure leaves are never pruned:
 	pruned, _ = tempmap.pruneRevisions(1, "")
-	assert.Equals(t, pruned, 2)
-	assert.Equals(t, len(tempmap), 2)
-	assert.True(t, tempmap["3-three"] != nil)
-	assert.Equals(t, tempmap["3-three"].Parent, "")
-	assert.True(t, tempmap["4-vier"] != nil)
-	assert.Equals(t, tempmap["4-vier"].Parent, "")
+	goassert.Equals(t, pruned, 2)
+	goassert.Equals(t, len(tempmap), 2)
+	goassert.True(t, tempmap["3-three"] != nil)
+	goassert.Equals(t, tempmap["3-three"].Parent, "")
+	goassert.True(t, tempmap["4-vier"] != nil)
+	goassert.Equals(t, tempmap["4-vier"].Parent, "")
 
 }
 
@@ -383,7 +383,7 @@ func TestPruneRevsSingleBranch(t *testing.T) {
 	expectedNumPruned := numRevs - int(maxDepth)
 
 	numPruned, _ := revTree.pruneRevisions(maxDepth, "")
-	assert.Equals(t, numPruned, expectedNumPruned)
+	goassert.Equals(t, numPruned, expectedNumPruned)
 
 }
 
@@ -406,7 +406,7 @@ func TestPruneRevsOneWinningOneNonwinningBranch(t *testing.T) {
 
 	revTree.pruneRevisions(maxDepth, "")
 
-	assert.Equals(t, revTree.LongestBranch(), int(maxDepth))
+	goassert.Equals(t, revTree.LongestBranch(), int(maxDepth))
 
 }
 
@@ -429,11 +429,11 @@ func TestPruneRevsOneWinningOneOldTombstonedBranch(t *testing.T) {
 
 	revTree.pruneRevisions(maxDepth, "")
 
-	assert.True(t, revTree.LongestBranch() == int(maxDepth))
+	goassert.True(t, revTree.LongestBranch() == int(maxDepth))
 
 	// we shouldn't have any tombstoned branches, since the tombstoned branch was so old
 	// it should have been pruned away
-	assert.Equals(t, revTree.FindLongestTombstonedBranch(), 0)
+	goassert.Equals(t, revTree.FindLongestTombstonedBranch(), 0)
 
 }
 
@@ -461,16 +461,16 @@ func TestPruneRevsOneWinningOneOldAndOneRecentTombstonedBranch(t *testing.T) {
 
 	revTree.pruneRevisions(maxDepth, "")
 
-	assert.True(t, revTree.LongestBranch() == int(maxDepth))
+	goassert.True(t, revTree.LongestBranch() == int(maxDepth))
 
 	// the "non-winning high-gen tombstoned" branch should still be around, but pruned to maxDepth
 	tombstonedLeaves := revTree.GetTombstonedLeaves()
-	assert.Equals(t, len(tombstonedLeaves), 1)
+	goassert.Equals(t, len(tombstonedLeaves), 1)
 	tombstonedLeaf := tombstonedLeaves[0]
 
 	tombstonedBranch, err := revTree.getHistory(tombstonedLeaf)
-	assert.True(t, err == nil)
-	assert.Equals(t, len(tombstonedBranch), int(maxDepth))
+	goassert.True(t, err == nil)
+	goassert.Equals(t, len(tombstonedBranch), int(maxDepth))
 
 	// The generation of the longest deleted branch is 97:
 	// 1 unconflictedBranchNumRevs
@@ -479,7 +479,7 @@ func TestPruneRevsOneWinningOneOldAndOneRecentTombstonedBranch(t *testing.T) {
 	// +
 	// 1 extra rev in branchspec since LastRevisionIsTombstone (that variable name is misleading)
 	expectedGenLongestTSd := 6
-	assert.Equals(t, revTree.FindLongestTombstonedBranch(), expectedGenLongestTSd)
+	goassert.Equals(t, revTree.FindLongestTombstonedBranch(), expectedGenLongestTSd)
 
 }
 
@@ -510,7 +510,7 @@ func TestGenerationShortestNonTombstonedBranch(t *testing.T) {
 	// Also, the winning branch has more revisions (10 total), and so will be ignored too
 	expectedGenerationShortestNonTombstonedBranch := 7
 
-	assert.Equals(t, generationShortestNonTombstonedBranch, expectedGenerationShortestNonTombstonedBranch)
+	goassert.Equals(t, generationShortestNonTombstonedBranch, expectedGenerationShortestNonTombstonedBranch)
 
 }
 
@@ -545,7 +545,7 @@ func TestGenerationLongestTombstonedBranch(t *testing.T) {
 	// 1 extra rev in branchspec since LastRevisionIsTombstone (that variable name is misleading)
 	expectedGenerationLongestTombstonedBranch := 3 + 100 + 1
 
-	assert.Equals(t, generationLongestTombstonedBranch, expectedGenerationLongestTombstonedBranch)
+	goassert.Equals(t, generationLongestTombstonedBranch, expectedGenerationLongestTombstonedBranch)
 
 }
 
@@ -572,7 +572,7 @@ func TestPruneRevisionsPostIssue2651ThreeBranches(t *testing.T) {
 	fmt.Printf("numPruned: %v", numPruned)
 	fmt.Printf("LongestBranch: %v", revTree.LongestBranch())
 
-	assert.True(t, uint32(revTree.LongestBranch()) == maxDepth)
+	goassert.True(t, uint32(revTree.LongestBranch()) == maxDepth)
 
 }
 
@@ -601,7 +601,7 @@ func TestPruneRevsSingleTombstonedBranch(t *testing.T) {
 
 	log.Printf("RevTreeAfter pruning: %v", revTree.RenderGraphvizDot())
 
-	assert.Equals(t, numPruned, expectedNumPruned)
+	goassert.Equals(t, numPruned, expectedNumPruned)
 
 }
 
@@ -621,13 +621,13 @@ func TestLongestBranch1(t *testing.T) {
 	}
 	revTree := getMultiBranchTestRevtree1(50, 100, branchSpecs)
 
-	assert.True(t, revTree.LongestBranch() == 150)
+	goassert.True(t, revTree.LongestBranch() == 150)
 
 }
 
 func TestLongestBranch2(t *testing.T) {
 
-	assert.True(t, multiroot.LongestBranch() == 3)
+	goassert.True(t, multiroot.LongestBranch() == 3)
 
 }
 
@@ -681,7 +681,7 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	}
 
 	// Make sure the winning branch is pruned down to maxDepth, even with the disconnected rev tree
-	assert.True(t, revTree.LongestBranch() == 7)
+	goassert.True(t, revTree.LongestBranch() == 7)
 
 }
 
@@ -711,13 +711,13 @@ func TestParseRevisions(t *testing.T) {
 		var body Body
 		assertNoError(t, json.Unmarshal([]byte(c.json), &body), "base JSON in test case")
 		ids := ParseRevisions(body)
-		assert.DeepEquals(t, ids, c.ids)
+		goassert.DeepEquals(t, ids, c.ids)
 	}
 }
 
 func TestEncodeRevisions(t *testing.T) {
 	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie"})
-	assert.DeepEquals(t, encoded, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
+	goassert.DeepEquals(t, encoded, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
@@ -725,31 +725,31 @@ func TestTrimEncodedRevisionsToAncestor(t *testing.T) {
 	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs := trimEncodedRevisionsToAncestor(encoded, []string{"3-walter", "17-gretchen", "1-fooey"}, 1000)
-	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie", "screwy"}})
+	goassert.True(t, result)
+	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie", "screwy"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 2)
-	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
+	goassert.True(t, result)
+	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "1-fooey"}, 3)
-	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
+	goassert.True(t, result)
+	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, []string{"3-walter", "3-louie", "5-huey"}, 3)
-	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey"}})
+	goassert.True(t, result)
+	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey"}})
 
 	// Check maxLength with no ancestors:
 	encoded = encodeRevisions([]string{"5-huey", "4-dewey", "3-louie", "2-screwy"})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(encoded, nil, 6)
-	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie", "screwy"}})
+	goassert.True(t, result)
+	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie", "screwy"}})
 
 	result, trimmedRevs = trimEncodedRevisionsToAncestor(trimmedRevs, nil, 2)
-	assert.True(t, result)
-	assert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey"}})
+	goassert.True(t, result)
+	goassert.DeepEquals(t, trimmedRevs, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey"}})
 }
 
 // Regression test for https://github.com/couchbase/sync_gateway/issues/2847
@@ -770,10 +770,10 @@ func TestRevsHistoryInfiniteLoop(t *testing.T) {
 	)
 
 	// This should return an error, since the history has cycles
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 
 	// The error should *not* be a timeout error
-	assert.False(t, strings.Contains(err.Error(), "Timeout"))
+	goassert.False(t, strings.Contains(err.Error(), "Timeout"))
 
 }
 

--- a/db/sequence_id_test.go
+++ b/db/sequence_id_test.go
@@ -4,55 +4,55 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestParseSequenceID(t *testing.T) {
 	s, err := parseIntegerSequenceID("1234")
 	assertNoError(t, err, "parseIntegerSequenceID")
-	assert.Equals(t, s, SequenceID{Seq: 1234, SeqType: 1})
+	goassert.Equals(t, s, SequenceID{Seq: 1234, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("5678:1234")
 	assertNoError(t, err, "parseIntegerSequenceID")
-	assert.Equals(t, s, SequenceID{Seq: 1234, TriggeredBy: 5678, SeqType: 1})
+	goassert.Equals(t, s, SequenceID{Seq: 1234, TriggeredBy: 5678, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("")
 	assertNoError(t, err, "parseIntegerSequenceID")
-	assert.Equals(t, s, SequenceID{Seq: 0, TriggeredBy: 0})
+	goassert.Equals(t, s, SequenceID{Seq: 0, TriggeredBy: 0})
 
 	s, err = parseIntegerSequenceID("123:456:789")
 	assertNoError(t, err, "parseIntegerSequenceID")
-	assert.Equals(t, s, SequenceID{Seq: 789, TriggeredBy: 456, LowSeq: 123, SeqType: 1})
+	goassert.Equals(t, s, SequenceID{Seq: 789, TriggeredBy: 456, LowSeq: 123, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("123::789")
 	assertNoError(t, err, "parseIntegerSequenceID")
-	assert.Equals(t, s, SequenceID{Seq: 789, TriggeredBy: 0, LowSeq: 123, SeqType: 1})
+	goassert.Equals(t, s, SequenceID{Seq: 789, TriggeredBy: 0, LowSeq: 123, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("foo")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	s, err = parseIntegerSequenceID(":")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	s, err = parseIntegerSequenceID(":1")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	s, err = parseIntegerSequenceID("::1")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	s, err = parseIntegerSequenceID("10:11:12:13")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 	s, err = parseIntegerSequenceID("123:ggg")
-	assert.True(t, err != nil)
+	goassert.True(t, err != nil)
 }
 
 func TestMarshalSequenceID(t *testing.T) {
 	s := SequenceID{Seq: 1234, SeqType: IntSequenceType}
-	assert.Equals(t, s.String(), "1234")
+	goassert.Equals(t, s.String(), "1234")
 	asJson, err := json.Marshal(s)
 	assertNoError(t, err, "Marshal failed")
-	assert.Equals(t, string(asJson), "1234")
+	goassert.Equals(t, string(asJson), "1234")
 
 	var s2 SequenceID
 	err = json.Unmarshal(asJson, &s2)
 	assertNoError(t, err, "Unmarshal failed")
-	assert.Equals(t, s2, s)
+	goassert.Equals(t, s2, s)
 }
 
 func TestSequenceIDUnmarshalJSON(t *testing.T) {
@@ -61,50 +61,50 @@ func TestSequenceIDUnmarshalJSON(t *testing.T) {
 	s := SequenceID{}
 	err := s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
-	assert.Equals(t, s, SequenceID{Seq: 123, SeqType: IntSequenceType})
+	goassert.Equals(t, s, SequenceID{Seq: 123, SeqType: IntSequenceType})
 
 	str = "456:123"
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
-	assert.Equals(t, s, SequenceID{TriggeredBy: 456, Seq: 123, SeqType: IntSequenceType})
+	goassert.Equals(t, s, SequenceID{TriggeredBy: 456, Seq: 123, SeqType: IntSequenceType})
 
 	str = "220::222"
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
-	assert.Equals(t, s, SequenceID{LowSeq: 220, TriggeredBy: 0, Seq: 222, SeqType: IntSequenceType})
+	goassert.Equals(t, s, SequenceID{LowSeq: 220, TriggeredBy: 0, Seq: 222, SeqType: IntSequenceType})
 
 	str = "\"234\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
-	assert.Equals(t, s, SequenceID{Seq: 234, SeqType: IntSequenceType})
+	goassert.Equals(t, s, SequenceID{Seq: 234, SeqType: IntSequenceType})
 
 	str = "\"567:234\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
-	assert.Equals(t, s, SequenceID{TriggeredBy: 567, Seq: 234, SeqType: IntSequenceType})
+	goassert.Equals(t, s, SequenceID{TriggeredBy: 567, Seq: 234, SeqType: IntSequenceType})
 
 	str = "\"220::222\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
 	assertNoError(t, err, "UnmarshalJSON failed")
-	assert.Equals(t, s, SequenceID{LowSeq: 220, TriggeredBy: 0, Seq: 222, SeqType: IntSequenceType})
+	goassert.Equals(t, s, SequenceID{LowSeq: 220, TriggeredBy: 0, Seq: 222, SeqType: IntSequenceType})
 }
 
 func TestMarshalTriggeredSequenceID(t *testing.T) {
 	s := SequenceID{TriggeredBy: 5678, Seq: 1234, SeqType: 1}
-	assert.Equals(t, s.String(), "5678:1234")
+	goassert.Equals(t, s.String(), "5678:1234")
 	asJson, err := json.Marshal(s)
 	assertNoError(t, err, "Marshal failed")
-	assert.Equals(t, string(asJson), "\"5678:1234\"")
+	goassert.Equals(t, string(asJson), "\"5678:1234\"")
 
 	var s2 SequenceID
 	err = json.Unmarshal(asJson, &s2)
 	assertNoError(t, err, "Unmarshal failed")
-	assert.Equals(t, s2, s)
+	goassert.Equals(t, s2, s)
 }
 
 func TestCompareSequenceIDs(t *testing.T) {
@@ -120,7 +120,7 @@ func TestCompareSequenceIDs(t *testing.T) {
 
 	for i := 0; i < len(orderedSeqs); i++ {
 		for j := 0; j < len(orderedSeqs); j++ {
-			assert.Equals(t, orderedSeqs[i].Before(orderedSeqs[j]), i < j)
+			goassert.Equals(t, orderedSeqs[i].Before(orderedSeqs[j]), i < j)
 		}
 	}
 }

--- a/db/sequence_id_test.go
+++ b/db/sequence_id_test.go
@@ -5,27 +5,28 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseSequenceID(t *testing.T) {
 	s, err := parseIntegerSequenceID("1234")
-	assertNoError(t, err, "parseIntegerSequenceID")
+	assert.NoError(t, err, "parseIntegerSequenceID")
 	goassert.Equals(t, s, SequenceID{Seq: 1234, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("5678:1234")
-	assertNoError(t, err, "parseIntegerSequenceID")
+	assert.NoError(t, err, "parseIntegerSequenceID")
 	goassert.Equals(t, s, SequenceID{Seq: 1234, TriggeredBy: 5678, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("")
-	assertNoError(t, err, "parseIntegerSequenceID")
+	assert.NoError(t, err, "parseIntegerSequenceID")
 	goassert.Equals(t, s, SequenceID{Seq: 0, TriggeredBy: 0})
 
 	s, err = parseIntegerSequenceID("123:456:789")
-	assertNoError(t, err, "parseIntegerSequenceID")
+	assert.NoError(t, err, "parseIntegerSequenceID")
 	goassert.Equals(t, s, SequenceID{Seq: 789, TriggeredBy: 456, LowSeq: 123, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("123::789")
-	assertNoError(t, err, "parseIntegerSequenceID")
+	assert.NoError(t, err, "parseIntegerSequenceID")
 	goassert.Equals(t, s, SequenceID{Seq: 789, TriggeredBy: 0, LowSeq: 123, SeqType: 1})
 
 	s, err = parseIntegerSequenceID("foo")
@@ -46,12 +47,12 @@ func TestMarshalSequenceID(t *testing.T) {
 	s := SequenceID{Seq: 1234, SeqType: IntSequenceType}
 	goassert.Equals(t, s.String(), "1234")
 	asJson, err := json.Marshal(s)
-	assertNoError(t, err, "Marshal failed")
+	assert.NoError(t, err, "Marshal failed")
 	goassert.Equals(t, string(asJson), "1234")
 
 	var s2 SequenceID
 	err = json.Unmarshal(asJson, &s2)
-	assertNoError(t, err, "Unmarshal failed")
+	assert.NoError(t, err, "Unmarshal failed")
 	goassert.Equals(t, s2, s)
 }
 
@@ -60,37 +61,37 @@ func TestSequenceIDUnmarshalJSON(t *testing.T) {
 	str := "123"
 	s := SequenceID{}
 	err := s.UnmarshalJSON([]byte(str))
-	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.NoError(t, err, "UnmarshalJSON failed")
 	goassert.Equals(t, s, SequenceID{Seq: 123, SeqType: IntSequenceType})
 
 	str = "456:123"
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
-	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.NoError(t, err, "UnmarshalJSON failed")
 	goassert.Equals(t, s, SequenceID{TriggeredBy: 456, Seq: 123, SeqType: IntSequenceType})
 
 	str = "220::222"
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
-	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.NoError(t, err, "UnmarshalJSON failed")
 	goassert.Equals(t, s, SequenceID{LowSeq: 220, TriggeredBy: 0, Seq: 222, SeqType: IntSequenceType})
 
 	str = "\"234\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
-	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.NoError(t, err, "UnmarshalJSON failed")
 	goassert.Equals(t, s, SequenceID{Seq: 234, SeqType: IntSequenceType})
 
 	str = "\"567:234\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
-	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.NoError(t, err, "UnmarshalJSON failed")
 	goassert.Equals(t, s, SequenceID{TriggeredBy: 567, Seq: 234, SeqType: IntSequenceType})
 
 	str = "\"220::222\""
 	s = SequenceID{}
 	err = s.UnmarshalJSON([]byte(str))
-	assertNoError(t, err, "UnmarshalJSON failed")
+	assert.NoError(t, err, "UnmarshalJSON failed")
 	goassert.Equals(t, s, SequenceID{LowSeq: 220, TriggeredBy: 0, Seq: 222, SeqType: IntSequenceType})
 }
 
@@ -98,12 +99,12 @@ func TestMarshalTriggeredSequenceID(t *testing.T) {
 	s := SequenceID{TriggeredBy: 5678, Seq: 1234, SeqType: 1}
 	goassert.Equals(t, s.String(), "5678:1234")
 	asJson, err := json.Marshal(s)
-	assertNoError(t, err, "Marshal failed")
+	assert.NoError(t, err, "Marshal failed")
 	goassert.Equals(t, string(asJson), "\"5678:1234\"")
 
 	var s2 SequenceID
 	err = json.Unmarshal(asJson, &s2)
-	assertNoError(t, err, "Unmarshal failed")
+	assert.NoError(t, err, "Unmarshal failed")
 	goassert.Equals(t, s2, s)
 }
 

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func makeExternalBucket() base.TestBucket {
@@ -65,8 +65,8 @@ func TestShadowerPull(t *testing.T) {
 	})
 	doc1, _ = db.GetDocument("key1", DocUnmarshalAll)
 	doc2, _ = db.GetDocument("key2", DocUnmarshalAll)
-	assert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
-	assert.DeepEquals(t, doc2.Body(), Body{"bar": json.Number("-1")})
+	goassert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
+	goassert.DeepEquals(t, doc2.Body(), Body{"bar": json.Number("-1")})
 
 	t.Logf("Deleting remote doc")
 	bucket.Delete("key1")
@@ -77,9 +77,9 @@ func TestShadowerPull(t *testing.T) {
 	})
 
 	doc1, _ = db.GetDocument("key1", DocUnmarshalAll)
-	assert.True(t, doc1.hasFlag(channels.Deleted))
+	goassert.True(t, doc1.hasFlag(channels.Deleted))
 	_, err = db.Get("key1")
-	assert.DeepEquals(t, err, &base.HTTPError{Status: 404, Message: "deleted"})
+	goassert.DeepEquals(t, err, &base.HTTPError{Status: 404, Message: "deleted"})
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&shadower.pullCount) >= 4
@@ -147,7 +147,7 @@ func TestShadowerPullWithNotifications(t *testing.T) {
 
 	channelSize := len(resultChannel)
 
-	assert.True(t, channelSize == 3)
+	goassert.True(t, channelSize == 3)
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&shadower.pullCount) >= 4
@@ -185,8 +185,8 @@ func TestShadowerPush(t *testing.T) {
 		_, err2 := bucket.Get("key2", &doc2)
 		return err1 == nil && err2 == nil
 	})
-	assert.DeepEquals(t, doc1, Body{"aaa": "bbb"})
-	assert.DeepEquals(t, doc2, Body{"ccc": "ddd"})
+	goassert.DeepEquals(t, doc1, Body{"aaa": "bbb"})
+	goassert.DeepEquals(t, doc2, Body{"ccc": "ddd"})
 
 	t.Logf("Deleting local doc")
 	db.DeleteDoc("key1", key1rev1)
@@ -195,7 +195,7 @@ func TestShadowerPush(t *testing.T) {
 		_, err = bucket.Get("key1", &doc1)
 		return err != nil
 	})
-	assert.True(t, base.IsDocNotFoundError(err))
+	goassert.True(t, base.IsDocNotFoundError(err))
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&db.Shadower.pullCount) >= 3
@@ -231,7 +231,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 
 	// Make sure the echoed pull didn't create a new revision:
 	doc, _ := db.GetDocument("foo", DocUnmarshalAll)
-	assert.Equals(t, len(doc.History), 1)
+	goassert.Equals(t, len(doc.History), 1)
 }
 
 // Ensure that a new rev pushed from a shadow bucket update, wehre the UpstreamRev does not exist as a parent func init() {
@@ -285,7 +285,7 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 	//validate that upstream_rev was changed in DB
 	raw, _, _ = db.Bucket.GetRaw("foo")
 	json.Unmarshal(raw, &docObj)
-	assert.Equals(t, docObj["upstream_rev"], "1-notexist")
+	goassert.Equals(t, docObj["upstream_rev"], "1-notexist")
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&db.Shadower.pullCount) >= 2
@@ -293,9 +293,9 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 
 	//Assert that we can get the two conflicing revisions
 	gotBody, err := db.GetRev("foo", "1-madeup", false, nil)
-	assert.DeepEquals(t, gotBody, Body{BodyId: "foo", "a": "b", BodyRev: "1-madeup"})
+	goassert.DeepEquals(t, gotBody, Body{BodyId: "foo", "a": "b", BodyRev: "1-madeup"})
 	gotBody, err = db.GetRev("foo", "2-edce85747420ad6781bdfccdebf82180", false, nil)
-	assert.DeepEquals(t, gotBody, Body{BodyId: "foo", "a": "c", BodyRev: "2-edce85747420ad6781bdfccdebf82180"})
+	goassert.DeepEquals(t, gotBody, Body{BodyId: "foo", "a": "c", BodyRev: "2-edce85747420ad6781bdfccdebf82180"})
 }
 
 func TestShadowerPattern(t *testing.T) {
@@ -331,9 +331,9 @@ func TestShadowerPattern(t *testing.T) {
 	doc2, err := db.GetDocument("key2", DocUnmarshalAll)
 	assertNoError(t, err, fmt.Sprintf("Error getting key2: %v", err))
 
-	assert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
-	assert.True(t, docI == nil)
-	assert.DeepEquals(t, doc2.Body(), Body{"bar": json.Number("-1")})
+	goassert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
+	goassert.True(t, docI == nil)
+	goassert.DeepEquals(t, doc2.Body(), Body{"bar": json.Number("-1")})
 
 	waitFor(t, func() bool {
 		return atomic.LoadUint64(&shadower.pullCount) >= 2

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func makeExternalBucket() base.TestBucket {
@@ -28,7 +29,7 @@ func waitFor(t *testing.T, condition func() bool) bool {
 	var start = time.Now()
 	for !condition() {
 		if time.Since(start) >= 15*time.Second {
-			assertFailed(t, "Timeout!")
+			t.Fatal("Timeout!")
 			return false
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -54,7 +55,7 @@ func TestShadowerPull(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	shadower, err := NewShadower(db.DatabaseContext, bucket, nil)
-	assertNoError(t, err, "NewShadower")
+	assert.NoError(t, err, "NewShadower")
 	defer shadower.Stop()
 
 	t.Logf("Waiting for shadower to catch up...")
@@ -115,7 +116,7 @@ func TestShadowerPullWithNotifications(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	shadower, err := NewShadower(db.DatabaseContext, bucket, nil)
-	assertNoError(t, err, "NewShadower")
+	assert.NoError(t, err, "NewShadower")
 	defer shadower.Stop()
 
 	t.Logf("Waiting for shadower to catch up...")
@@ -171,12 +172,12 @@ func TestShadowerPush(t *testing.T) {
 
 	var err error
 	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
-	assertNoError(t, err, "NewShadower")
+	assert.NoError(t, err, "NewShadower")
 
 	key1rev1, err := db.Put("key1", Body{"aaa": "bbb"})
-	assertNoError(t, err, "Put")
+	assert.NoError(t, err, "Put")
 	_, err = db.Put("key2", Body{"ccc": "ddd"})
-	assertNoError(t, err, "Put")
+	assert.NoError(t, err, "Put")
 
 	t.Log("Waiting for shadower to catch up...")
 	var doc1, doc2 Body
@@ -221,7 +222,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 
 	var err error
 	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
-	assertNoError(t, err, "NewShadower")
+	assert.NoError(t, err, "NewShadower")
 
 	// Push an existing doc revision (the way a client's push replicator would)
 	db.PutExistingRev("foo", Body{"a": "b"}, []string{"1-madeup"}, false)
@@ -255,7 +256,7 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 
 	var err error
 	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
-	assertNoError(t, err, "NewShadower")
+	assert.NoError(t, err, "NewShadower")
 
 	// Push an existing doc revision (the way a client's push replicator would)
 	db.PutExistingRev("foo", Body{"a": "b"}, []string{"1-madeup"}, false)
@@ -317,7 +318,7 @@ func TestShadowerPattern(t *testing.T) {
 
 	pattern, _ := regexp.Compile(`key\d+`)
 	shadower, err := NewShadower(db.DatabaseContext, bucket, pattern)
-	assertNoError(t, err, "NewShadower")
+	assert.NoError(t, err, "NewShadower")
 	defer shadower.Stop()
 
 	t.Logf("Waiting for shadower to catch up...")
@@ -326,10 +327,10 @@ func TestShadowerPattern(t *testing.T) {
 		return seq >= 2
 	})
 	doc1, err := db.GetDocument("key1", DocUnmarshalAll)
-	assertNoError(t, err, fmt.Sprintf("Error getting key1: %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Error getting key1: %v", err))
 	docI, _ := db.GetDocument("ignorekey", DocUnmarshalAll)
 	doc2, err := db.GetDocument("key2", DocUnmarshalAll)
-	assertNoError(t, err, fmt.Sprintf("Error getting key2: %v", err))
+	assert.NoError(t, err, fmt.Sprintf("Error getting key2: %v", err))
 
 	goassert.DeepEquals(t, doc1.Body(), Body{"foo": json.Number("1")})
 	goassert.True(t, docI == nil)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -115,7 +115,7 @@
 
   <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
-  <project name="testify" patch="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+  <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
   <!-- gozip tools -->
   <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -115,6 +115,8 @@
 
   <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
 
+  <project name="testify" patch="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+
   <!-- gozip tools -->
   <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // Reproduces #3048 Panic when attempting to make invalid update to a conflicting document
@@ -51,7 +51,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	}
 	revId := responseDoc["rev"].(string)
 	revGeneration, revIdHash := db.ParseRevID(revId)
-	assert.Equals(t, revGeneration, 1)
+	goassert.Equals(t, revGeneration, 1)
 
 	// Update doc (normal update, no conflicting revisions added)
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", docId), fmt.Sprintf(`{"value":"secondval", db.BodyRev:"%s"}`, revId))
@@ -69,7 +69,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	}
 	revId = responseDoc["rev"].(string)
 	revGeneration, _ = db.ParseRevID(revId)
-	assert.Equals(t, revGeneration, 2)
+	goassert.Equals(t, revGeneration, 2)
 
 	// Create conflict again, should be a no-op and return the same response as previous attempt
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?new_edits=false", docId), input)
@@ -79,7 +79,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 	}
 	revId = responseDoc["rev"].(string)
 	revGeneration, _ = db.ParseRevID(revId)
-	assert.Equals(t, revGeneration, 2)
+	goassert.Equals(t, revGeneration, 2)
 
 }
 
@@ -98,30 +98,30 @@ func TestUserAPI(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "snej")
-	assert.Equals(t, body["email"], "jens@couchbase.com")
-	assert.DeepEquals(t, body["admin_channels"], []interface{}{"bar", "foo"})
-	assert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "foo"})
-	assert.Equals(t, body["password"], nil)
+	goassert.Equals(t, body["name"], "snej")
+	goassert.Equals(t, body["email"], "jens@couchbase.com")
+	goassert.DeepEquals(t, body["admin_channels"], []interface{}{"bar", "foo"})
+	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "foo"})
+	goassert.Equals(t, body["password"], nil)
 
 	// Check the list of all users:
 	response = rt.SendAdminRequest("GET", "/db/_user/", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), `["snej"]`)
+	goassert.Equals(t, string(response.Body.Bytes()), `["snej"]`)
 
 	// Check that the actual User object is correct:
 	user, _ := rt.ServerContext().Database("db").Authenticator().GetUser("snej")
-	assert.Equals(t, user.Name(), "snej")
-	assert.Equals(t, user.Email(), "jens@couchbase.com")
-	assert.DeepEquals(t, user.ExplicitChannels(), channels.TimedSet{"bar": channels.NewVbSimpleSequence(0x1), "foo": channels.NewVbSimpleSequence(0x1)})
-	assert.True(t, user.Authenticate("letmein"))
+	goassert.Equals(t, user.Name(), "snej")
+	goassert.Equals(t, user.Email(), "jens@couchbase.com")
+	goassert.DeepEquals(t, user.ExplicitChannels(), channels.TimedSet{"bar": channels.NewVbSimpleSequence(0x1), "foo": channels.NewVbSimpleSequence(0x1)})
+	goassert.True(t, user.Authenticate("letmein"))
 
 	// Change the password and verify it:
 	response = rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"123", "admin_channels":["foo", "bar"]}`)
 	assertStatus(t, response, 200)
 
 	user, _ = rt.ServerContext().Database("db").Authenticator().GetUser("snej")
-	assert.True(t, user.Authenticate("123"))
+	goassert.True(t, user.Authenticate("123"))
 
 	// DELETE the user
 	assertStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
@@ -136,7 +136,7 @@ func TestUserAPI(t *testing.T) {
 	assertStatus(t, response, 200)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "snej")
+	goassert.Equals(t, body["name"], "snej")
 
 	// Create a role
 	assertStatus(t, rt.SendAdminRequest("GET", "/db/_role/hipster", ""), 404)
@@ -152,8 +152,8 @@ func TestUserAPI(t *testing.T) {
 	assertStatus(t, response, 200)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
-	assert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "fedoras", "fixies", "foo"})
+	goassert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
+	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "fedoras", "fixies", "foo"})
 
 	// DELETE the user
 	assertStatus(t, rt.SendAdminRequest("DELETE", "/db/_user/snej", ""), 200)
@@ -380,7 +380,7 @@ function(doc, oldDoc) {
 			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard"))
 
 			changes, err := readContinuousChanges(changesResponse)
-			assert.Equals(t, err, nil)
+			goassert.Equals(t, err, nil)
 
 			changesAccumulated = append(changesAccumulated, changes...)
 
@@ -441,7 +441,7 @@ func TestLoggingKeys(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &logKeys)
-	assert.DeepEquals(t, logKeys, map[string]interface{}{})
+	goassert.DeepEquals(t, logKeys, map[string]interface{}{})
 
 	//Set logKeys, Changes+ should enable Changes (PUT replaces any existing log keys)
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{"Changes+":true, "Cache":true, "HTTP":true}`), 200)
@@ -449,7 +449,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var updatedLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &updatedLogKeys)
-	assert.DeepEquals(t, updatedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, updatedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
 
 	//Disable Changes logKey which should also disable Changes+
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes":false}`), 200)
@@ -457,7 +457,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var deletedLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &deletedLogKeys)
-	assert.DeepEquals(t, deletedLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, deletedLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Enable Changes++, which should enable Changes (POST append logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
@@ -465,7 +465,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var appendedLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &appendedLogKeys)
-	assert.DeepEquals(t, appendedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, appendedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
 
 	//Disable Changes++ (POST modifies logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":false}`), 200)
@@ -473,7 +473,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabledLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &disabledLogKeys)
-	assert.DeepEquals(t, disabledLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, disabledLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Re-Enable Changes++, which should enable Changes (POST append logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
@@ -484,7 +484,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled2LogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &disabled2LogKeys)
-	assert.DeepEquals(t, disabled2LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, disabled2LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Re-Enable Changes++, which should enable Changes (POST append logKeys)
 	assertStatus(t, rt.SendAdminRequest("POST", "/_logging", `{"Changes++":true}`), 200)
@@ -495,7 +495,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled3LogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &disabled3LogKeys)
-	assert.DeepEquals(t, disabled3LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, disabled3LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Disable all logKeys by using PUT with an empty channel list
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging", `{}`), 200)
@@ -503,7 +503,7 @@ func TestLoggingKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var noLogKeys map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &noLogKeys)
-	assert.DeepEquals(t, noLogKeys, map[string]interface{}{})
+	goassert.DeepEquals(t, noLogKeys, map[string]interface{}{})
 }
 
 func TestLoggingLevels(t *testing.T) {
@@ -517,7 +517,7 @@ func TestLoggingLevels(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]bool
 	json.Unmarshal(response.Body.Bytes(), &logKeys)
-	assert.DeepEquals(t, logKeys, map[string]bool{})
+	goassert.DeepEquals(t, logKeys, map[string]bool{})
 
 	// Set log level via logLevel query parameter
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=error", ``), http.StatusOK)
@@ -551,14 +551,14 @@ func TestLoggingCombined(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]bool
 	json.Unmarshal(response.Body.Bytes(), &logKeys)
-	assert.DeepEquals(t, logKeys, map[string]bool{})
+	goassert.DeepEquals(t, logKeys, map[string]bool{})
 
 	// Set log keys and log level in a single request
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=trace", `{"Changes":true, "Cache":true, "HTTP":true}`), http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	json.Unmarshal(response.Body.Bytes(), &logKeys)
-	assert.DeepEquals(t, logKeys, map[string]bool{"Changes": true, "Cache": true, "HTTP": true})
+	goassert.DeepEquals(t, logKeys, map[string]bool{"Changes": true, "Cache": true, "HTTP": true})
 }
 
 // Test user delete while that user has an active changes feed (see issue 809)
@@ -592,7 +592,7 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 			// case 2 - ensure no error processing the changes response.  The number of entries may vary, depending
 			// on whether the changes loop performed an additional iteration before catching the deleted user.
 			_, err := readContinuousChanges(changesResponse)
-			assert.Equals(t, err, nil)
+			goassert.Equals(t, err, nil)
 		}
 	}()
 
@@ -656,13 +656,13 @@ func TestRoleAPI(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "hipster")
-	assert.DeepEquals(t, body["admin_channels"], []interface{}{"fedoras", "fixies"})
-	assert.Equals(t, body["password"], nil)
+	goassert.Equals(t, body["name"], "hipster")
+	goassert.DeepEquals(t, body["admin_channels"], []interface{}{"fedoras", "fixies"})
+	goassert.Equals(t, body["password"], nil)
 
 	response = rt.SendAdminRequest("GET", "/db/_role/", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), `["hipster"]`)
+	goassert.Equals(t, string(response.Body.Bytes()), `["hipster"]`)
 
 	// DELETE the role
 	assertStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
@@ -677,7 +677,7 @@ func TestRoleAPI(t *testing.T) {
 	assertStatus(t, response, 200)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "hipster")
+	goassert.Equals(t, body["name"], "hipster")
 	assertStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
 }
 
@@ -692,9 +692,9 @@ func TestGuestUser(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], base.GuestUsername)
+	goassert.Equals(t, body["name"], base.GuestUsername)
 	// This ain't no admin-party, this ain't no nightclub, this ain't no fooling around:
-	assert.DeepEquals(t, body["admin_channels"], nil)
+	goassert.DeepEquals(t, body["admin_channels"], nil)
 
 	// Disable the guest user:
 	response = rt.SendAdminRequest(http.MethodPut, guestUserEndpoint, `{"disabled":true}`)
@@ -704,14 +704,14 @@ func TestGuestUser(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, guestUserEndpoint, "")
 	assertStatus(t, response, http.StatusOK)
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], base.GuestUsername)
-	assert.DeepEquals(t, body["disabled"], true)
+	goassert.Equals(t, body["name"], base.GuestUsername)
+	goassert.DeepEquals(t, body["disabled"], true)
 
 	// Check that the actual User object is correct:
 	user, _ := rt.ServerContext().Database("db").Authenticator().GetUser("")
-	assert.Equals(t, user.Name(), "")
-	assert.DeepEquals(t, user.ExplicitChannels(), channels.TimedSet{})
-	assert.Equals(t, user.Disabled(), true)
+	goassert.Equals(t, user.Name(), "")
+	goassert.DeepEquals(t, user.ExplicitChannels(), channels.TimedSet{})
+	goassert.Equals(t, user.Disabled(), true)
 
 	// We can't delete the guest user, but we should get a reasonable error back.
 	response = rt.SendAdminRequest(http.MethodDelete, guestUserEndpoint, "")
@@ -727,14 +727,14 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	user, err = a.GetUser("")
-	assert.Equals(t, err, nil)
-	assert.True(t, user.Disabled())
+	goassert.Equals(t, err, nil)
+	goassert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
 	assertStatus(t, response, 401)
@@ -753,7 +753,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
 	log.Printf("expires %s", body["expires"].(string))
 	expires, err := time.Parse(layout, body["expires"].(string)[:19])
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	//create a session with a ttl value one second greater thatn the max offset ttl 2592001 seconds
 	response = rt.SendAdminRequest("POST", "/db/_session", `{"name":"pupshaw", "ttl":2592001}`)
@@ -763,13 +763,13 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	log.Printf("expires2 %s", body["expires"].(string))
 	expires2, err := time.Parse(layout, body["expires"].(string)[:19])
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	//Allow a ten second drift between the expires dates, to pass test on slow servers
 	acceptableTimeDelta := time.Duration(10) * time.Second
 
 	//The difference between the two expires dates should be less than the acceptable time delta
-	assert.True(t, expires2.Sub(expires) < acceptableTimeDelta)
+	goassert.True(t, expires2.Sub(expires) < acceptableTimeDelta)
 }
 
 func TestSessionExtension(t *testing.T) {
@@ -783,14 +783,14 @@ func TestSessionExtension(t *testing.T) {
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	user, err = a.GetUser("")
-	assert.Equals(t, err, nil)
-	assert.True(t, user.Disabled())
+	goassert.Equals(t, err, nil)
+	goassert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
 	assertStatus(t, response, 401)
@@ -807,9 +807,9 @@ func TestSessionExtension(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	sessionId := body["session_id"].(string)
 	sessionExpiration := body["expires"].(string)
-	assert.True(t, sessionId != "")
-	assert.True(t, sessionExpiration != "")
-	assert.True(t, body["cookie_name"].(string) == "SyncGatewaySession")
+	goassert.True(t, sessionId != "")
+	goassert.True(t, sessionExpiration != "")
+	goassert.True(t, body["cookie_name"].(string) == "SyncGatewaySession")
 
 	reqHeaders := map[string]string{
 		"Cookie": "SyncGatewaySession=" + body["session_id"].(string),
@@ -817,7 +817,7 @@ func TestSessionExtension(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1", `{"hi": "there"}`, reqHeaders)
 	assertStatus(t, response, 201)
 
-	assert.True(t, response.Header().Get("Set-Cookie") == "")
+	goassert.True(t, response.Header().Get("Set-Cookie") == "")
 
 	//Sleep for 2 seconds, this will ensure 10% of the 100 seconds session ttl has elapsed and
 	//should cause a new Cookie to be sent by the server with the same session ID and an extended expiration date
@@ -825,7 +825,7 @@ func TestSessionExtension(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc2", `{"hi": "there"}`, reqHeaders)
 	assertStatus(t, response, 201)
 
-	assert.True(t, response.Header().Get("Set-Cookie") != "")
+	goassert.True(t, response.Header().Get("Set-Cookie") != "")
 }
 
 func TestSessionAPI(t *testing.T) {
@@ -951,14 +951,14 @@ func TestDBOfflineSingle(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 }
 
 //Make two concurrent calls to take DB offline
@@ -974,7 +974,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	//Take DB offline concurrently using two goroutines
 	//Both should return success and DB should be offline
@@ -1002,7 +1002,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 }
 
@@ -1016,14 +1016,14 @@ func TestStartDBOffline(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 }
 
 //Take DB offline and ensure that normal REST calls
@@ -1038,7 +1038,7 @@ func TestDBOffline503Response(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1046,7 +1046,7 @@ func TestDBOffline503Response(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	assertStatus(t, rt.SendRequest("GET", "/db/doc1", ""), 503)
 }
@@ -1062,7 +1062,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1070,7 +1070,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/_config", ""), 404)
 }
@@ -1096,10 +1096,10 @@ func TestDBGetConfigNames(t *testing.T) {
 	var body DbConfig
 	json.Unmarshal(response.Body.Bytes(), &body)
 
-	assert.Equals(t, len(body.Users), len(rt.DatabaseConfig.Users))
+	goassert.Equals(t, len(body.Users), len(rt.DatabaseConfig.Users))
 
 	for k, v := range body.Users {
-		assert.Equals(t, *v.Name, k)
+		goassert.Equals(t, *v.Name, k)
 	}
 
 }
@@ -1119,7 +1119,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1127,7 +1127,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	assertStatus(t, rt.SendAdminRequest("POST", "/db/_resync", ""), 200)
 }
@@ -1153,7 +1153,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1161,7 +1161,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	input := bytes.NewBufferString("")
 	request, _ := http.NewRequest("POST", "http://localhost/db/_resync", input)
@@ -1187,7 +1187,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 
 	// Extract the recorded result and make sure it was a 200 response
 	recordedResponseInitialResync := recorder.Result()
-	assert.Equals(t, recordedResponseInitialResync.StatusCode, 200)
+	goassert.Equals(t, recordedResponseInitialResync.StatusCode, 200)
 
 }
 
@@ -1202,7 +1202,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1210,7 +1210,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	rt.SendAdminRequest("POST", "/db/_online", "")
 	assertStatus(t, response, 200)
@@ -1220,7 +1220,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 }
 
 //Take DB online concurrently using two goroutines
@@ -1236,7 +1236,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1244,7 +1244,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -1288,7 +1288,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1296,7 +1296,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
 	assertStatus(t, response, 200)
@@ -1304,7 +1304,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
 	time.Sleep(1500 * time.Millisecond)
@@ -1333,7 +1333,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1341,7 +1341,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	//Bring DB online with delay of two seconds
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":2}")
@@ -1358,7 +1358,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	// Wait until after the 2 second delay, since the online request explicitly asked for a delay
 	time.Sleep(2500 * time.Millisecond)
@@ -1387,7 +1387,7 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
@@ -1395,7 +1395,7 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	//Bring DB online with delay of one seconds
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
@@ -1408,21 +1408,21 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Offline")
+	goassert.True(t, body["state"].(string) == "Offline")
 
 	time.Sleep(1500 * time.Millisecond)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 
 	time.Sleep(600 * time.Millisecond)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.True(t, body["state"].(string) == "Online")
+	goassert.True(t, body["state"].(string) == "Online")
 }
 
 func (rt *RestTester) createSession(t *testing.T, username string) string {
@@ -1456,7 +1456,7 @@ func TestPurgeWithNonArrayRevisionList(t *testing.T) {
 
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
 func TestPurgeWithEmptyRevisionList(t *testing.T) {
@@ -1469,7 +1469,7 @@ func TestPurgeWithEmptyRevisionList(t *testing.T) {
 
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
 func TestPurgeWithGreaterThanOneRevision(t *testing.T) {
@@ -1482,7 +1482,7 @@ func TestPurgeWithGreaterThanOneRevision(t *testing.T) {
 
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
 func TestPurgeWithNonStarRevision(t *testing.T) {
@@ -1495,7 +1495,7 @@ func TestPurgeWithNonStarRevision(t *testing.T) {
 
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
 func TestPurgeWithStarRevision(t *testing.T) {
@@ -1508,7 +1508,7 @@ func TestPurgeWithStarRevision(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	//Create new versions of the doc1 without conflicts
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
@@ -1526,7 +1526,7 @@ func TestPurgeWithMultipleValidDocs(t *testing.T) {
 
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}, "doc2": []interface{}{"*"}}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}, "doc2": []interface{}{"*"}}})
 
 	//Create new versions of the docs without conflicts
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
@@ -1544,19 +1544,19 @@ func TestPurgeWithChannelCache(t *testing.T) {
 
 	changes, err := rt.WaitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assertNoError(t, err, "Error waiting for changes")
-	assert.Equals(t, changes.Results[0].ID, "doc1")
-	assert.Equals(t, changes.Results[1].ID, "doc2")
+	goassert.Equals(t, changes.Results[0].ID, "doc1")
+	goassert.Equals(t, changes.Results[1].ID, "doc2")
 
 	// Purge "doc1"
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"]}`)
 	assertStatus(t, resp, http.StatusOK)
 	var body map[string]interface{}
 	json.Unmarshal(resp.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
 	assertNoError(t, err, "Error waiting for changes")
-	assert.Equals(t, changes.Results[0].ID, "doc2")
+	goassert.Equals(t, changes.Results[0].ID, "doc2")
 
 }
 
@@ -1571,7 +1571,7 @@ func TestPurgeWithSomeInvalidDocs(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body map[string]interface{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
+	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	//Create new versions of the doc1 without conflicts
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // Reproduces #3048 Panic when attempting to make invalid update to a conflicting document
@@ -997,7 +998,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 	}()
 
 	err := WaitWithTimeout(&wg, time.Second*30)
-	assertNoError(t, err, "Error waiting for waitgroup")
+	assert.NoError(t, err, "Error waiting for waitgroup")
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1269,7 +1270,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 
 	// Wait for DB to come online (retry loop)
 	errDbOnline := rt.WaitForDBOnline()
-	assertNoError(t, errDbOnline, "Error waiting for db to come online")
+	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
 
 }
 
@@ -1311,7 +1312,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 
 	// Wait for DB to come online (retry loop)
 	errDbOnline := rt.WaitForDBOnline()
-	assertNoError(t, errDbOnline, "Error waiting for db to come online")
+	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
 
 }
 
@@ -1353,7 +1354,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 
 	// Wait for DB to come online (retry loop)
 	errDbOnline := rt.WaitForDBOnline()
-	assertNoError(t, errDbOnline, "Error waiting for db to come online")
+	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
@@ -1365,7 +1366,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 
 	// Wait for DB to come online (retry loop)
 	errDbOnline = rt.WaitForDBOnline()
-	assertNoError(t, errDbOnline, "Error waiting for db to come online")
+	assert.NoError(t, errDbOnline, "Error waiting for db to come online")
 
 }
 
@@ -1543,7 +1544,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"moo":"car", "channels": ["abc"]}`), http.StatusCreated)
 
 	changes, err := rt.WaitForChanges(2, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
-	assertNoError(t, err, "Error waiting for changes")
+	assert.NoError(t, err, "Error waiting for changes")
 	goassert.Equals(t, changes.Results[0].ID, "doc1")
 	goassert.Equals(t, changes.Results[1].ID, "doc2")
 
@@ -1555,7 +1556,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
-	assertNoError(t, err, "Error waiting for changes")
+	assert.NoError(t, err, "Error waiting for changes")
 	goassert.Equals(t, changes.Results[0].ID, "doc2")
 
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/robertkrimen/otto/underscore"
 )
 
@@ -52,16 +52,16 @@ func TestRoot(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["couchdb"], "Welcome")
+	goassert.Equals(t, body["couchdb"], "Welcome")
 
 	response = rt.SendRequest("HEAD", "/", "")
 	assertStatus(t, response, 200)
 	response = rt.SendRequest("OPTIONS", "/", "")
 	assertStatus(t, response, 204)
-	assert.Equals(t, response.Header().Get("Allow"), "GET, HEAD")
+	goassert.Equals(t, response.Header().Get("Allow"), "GET, HEAD")
 	response = rt.SendRequest("PUT", "/", "")
 	assertStatus(t, response, 405)
-	assert.Equals(t, response.Header().Get("Allow"), "GET, HEAD")
+	goassert.Equals(t, response.Header().Get("Allow"), "GET, HEAD")
 }
 
 func (rt *RestTester) createDoc(t *testing.T, docid string) string {
@@ -69,7 +69,7 @@ func (rt *RestTester) createDoc(t *testing.T, docid string) string {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revid := body["rev"].(string)
 	if revid == "" {
 		t.Fatalf("No revid in response for PUT doc")
@@ -82,7 +82,7 @@ func TestDocLifecycle(t *testing.T) {
 	defer rt.Close()
 
 	revid := rt.createDoc(t, "doc")
-	assert.Equals(t, revid, "1-45ca73d819d5b1c9b8eea95290e79004")
+	goassert.Equals(t, revid, "1-45ca73d819d5b1c9b8eea95290e79004")
 
 	response := rt.SendRequest("DELETE", "/db/doc?rev="+revid, "")
 	assertStatus(t, response, 200)
@@ -97,32 +97,32 @@ func TestDocEtag(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revid := body["rev"].(string)
 	if revid == "" {
 		t.Fatalf("No revid in response for PUT doc")
 	}
 
 	//Validate Etag returned on doc creation
-	assert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
+	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
 
 	response = rt.SendRequest("GET", "/db/doc", "")
 	assertStatus(t, response, 200)
 
 	//Validate Etag returned when retrieving doc
-	assert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
+	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
 
 	//Validate Etag returned when updating doc
 	response = rt.SendRequest("PUT", "/db/doc?rev="+revid, `{"prop":false}`)
 	revid = body["rev"].(string)
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revid = body["rev"].(string)
 	if revid == "" {
 		t.Fatalf("No revid in response for PUT doc")
 	}
 
-	assert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
+	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revid))
 
 	//Test Attachments
 	attachmentBody := "this is the body of attachment"
@@ -136,25 +136,25 @@ func TestDocEtag(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
 		t.Fatalf("No revid in response for PUT attachment")
 	}
-	assert.True(t, revIdAfterAttachment != revid)
+	goassert.True(t, revIdAfterAttachment != revid)
 
 	//validate Etag returned from adding an attachment
-	assert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revIdAfterAttachment))
+	goassert.Equals(t, response.Header().Get("Etag"), strconv.Quote(revIdAfterAttachment))
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc/attach1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.Equals(t, response.Header().Get("Content-Disposition"), "")
-	assert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.Equals(t, response.Header().Get("Content-Disposition"), "")
+	goassert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
 
 	//Validate Etag returned from retrieving an attachment
-	assert.Equals(t, response.Header().Get("Etag"), "\"sha1-nq0xWBV2IEkkpY3ng+PEtFnCcVY=\"")
+	goassert.Equals(t, response.Header().Get("Etag"), "\"sha1-nq0xWBV2IEkkpY3ng+PEtFnCcVY=\"")
 
 }
 
@@ -182,20 +182,20 @@ func TestDocAttachment(t *testing.T) {
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc/attach1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.Equals(t, response.Header().Get("Accept-Ranges"), "bytes")
-	assert.Equals(t, response.Header().Get("Content-Disposition"), "")
-	assert.Equals(t, response.Header().Get("Content-Length"), "30")
-	assert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.Equals(t, response.Header().Get("Accept-Ranges"), "bytes")
+	goassert.Equals(t, response.Header().Get("Content-Disposition"), "")
+	goassert.Equals(t, response.Header().Get("Content-Length"), "30")
+	goassert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
 
 	// retrieve subrange
 	response = rt.SendRequestWithHeaders("GET", "/db/doc/attach1", "", map[string]string{"Range": "bytes=5-6"})
 	assertStatus(t, response, 206)
-	assert.Equals(t, string(response.Body.Bytes()), "is")
-	assert.Equals(t, response.Header().Get("Accept-Ranges"), "bytes")
-	assert.Equals(t, response.Header().Get("Content-Length"), "2")
-	assert.Equals(t, response.Header().Get("Content-Range"), "bytes 5-6/30")
-	assert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), "is")
+	goassert.Equals(t, response.Header().Get("Accept-Ranges"), "bytes")
+	goassert.Equals(t, response.Header().Get("Content-Length"), "2")
+	goassert.Equals(t, response.Header().Get("Content-Range"), "bytes 5-6/30")
+	goassert.Equals(t, response.Header().Get("Content-Type"), attachmentContentType)
 }
 
 // Add an attachment to a document that has been removed from the users channels
@@ -205,10 +205,10 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf("foo"))
@@ -243,10 +243,10 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf("foo"))
@@ -309,7 +309,7 @@ func TestDocumentLargeNumbers(t *testing.T) {
 			var rawResponse RawResponse
 			json.Unmarshal(getRawResponse.Body.Bytes(), &rawResponse)
 			log.Printf("raw response: %s", getRawResponse.Body.Bytes())
-			assert.Equals(t, len(rawResponse.Sync.Channels), 1)
+			goassert.Equals(t, len(rawResponse.Sync.Channels), 1)
 			assertTrue(t, HasActiveChannel(rawResponse.Sync.Channels, test.expectedChannel), fmt.Sprintf("Expected channel %s was not found in document channels", test.expectedChannel))
 
 		})
@@ -377,15 +377,15 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attachpath%2Fattachment.txt", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// add attachment with two embedded '/' (%2F HEX)
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attachpath%2Fattachpath2%2Fattachment.txt?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
@@ -394,9 +394,9 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attachpath%2Fattachpath2%2Fattachment.txt", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	//Create Doc with embedded '/' (%2F HEX) in name
 	doc1revId = rt.createDoc(t, "AC%2FDC")
@@ -409,15 +409,15 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment = body["rev"].(string)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/AC%2FDC/attachpath%2Fattachment.txt", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// add attachment with two embedded '/' (%2F HEX)
 	response = rt.SendRequestWithHeaders("PUT", "/db/AC%2FDC/attachpath%2Fattachpath2%2Fattachment.txt?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
@@ -426,9 +426,9 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/AC%2FDC/attachpath%2Fattachpath2%2Fattachment.txt", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	//Create Doc with embedded '+' (%2B HEX) in name
 	doc1revId = rt.createDoc(t, "AC%2BDC%2BGC2")
@@ -441,15 +441,15 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment = body["rev"].(string)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/AC%2BDC%2BGC2/attachpath%2Fattachment.txt", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// add attachment with two embedded '/' (%2F HEX)
 	response = rt.SendRequestWithHeaders("PUT", "/db/AC%2BDC%2BGC2/attachpath%2Fattachpath2%2Fattachment.txt?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
@@ -458,9 +458,9 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/AC%2BDC%2BGC2/attachpath%2Fattachpath2%2Fattachment.txt", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 }
 
 func TestCORSOrigin(t *testing.T) {
@@ -472,7 +472,7 @@ func TestCORSOrigin(t *testing.T) {
 		"Origin": "http://example.com",
 	}
 	response := rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	assert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "http://example.com")
+	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "http://example.com")
 
 	// now test a non-listed origin
 	// b/c * is in config we get *
@@ -480,21 +480,21 @@ func TestCORSOrigin(t *testing.T) {
 		"Origin": "http://hack0r.com",
 	}
 	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	assert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "*")
+	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "*")
 
 	// now test another origin in config
 	reqHeaders = map[string]string{
 		"Origin": "http://staging.example.com",
 	}
 	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	assert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "http://staging.example.com")
+	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "http://staging.example.com")
 
 	// test no header on _admin apis
 	reqHeaders = map[string]string{
 		"Origin": "http://example.com",
 	}
 	response = rt.SendAdminRequestWithHeaders("GET", "/db/_all_docs", "", reqHeaders)
-	assert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "")
+	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "")
 
 	// test with a config without * should reject non-matches
 	sc := rt.ServerContext()
@@ -505,7 +505,7 @@ func TestCORSOrigin(t *testing.T) {
 		"Origin": "http://hack0r.com",
 	}
 	response = rt.SendRequestWithHeaders("GET", "/db/", "", reqHeaders)
-	assert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "")
+	goassert.Equals(t, response.Header().Get("Access-Control-Allow-Origin"), "")
 }
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
@@ -575,7 +575,7 @@ func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
 
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["reason"], "no session")
+	goassert.Equals(t, body["reason"], "no session")
 }
 
 func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
@@ -595,7 +595,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["reason"], "No CORS")
+	goassert.Equals(t, body["reason"], "No CORS")
 }
 
 func TestNoCORSOriginOnSessionDelete(t *testing.T) {
@@ -611,7 +611,7 @@ func TestNoCORSOriginOnSessionDelete(t *testing.T) {
 
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["reason"], "No CORS")
+	goassert.Equals(t, body["reason"], "No CORS")
 }
 
 func TestManualAttachment(t *testing.T) {
@@ -644,27 +644,27 @@ func TestManualAttachment(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
 		t.Fatalf("No revid in response for PUT attachment")
 	}
-	assert.True(t, revIdAfterAttachment != doc1revId)
+	goassert.True(t, revIdAfterAttachment != doc1revId)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attach1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == "")
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == "")
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// retrieve attachment as admin should have
 	// Content-disposition: attachment
 	response = rt.SendAdminRequest("GET", "/db/doc1/attach1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Disposition") == `attachment; filename="attach1"`)
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Disposition") == `attachment; filename="attach1"`)
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// try to overwrite that attachment
 	attachmentBody = "updated content"
@@ -672,12 +672,12 @@ func TestManualAttachment(t *testing.T) {
 	assertStatus(t, response, 201)
 	body = db.Body{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterUpdateAttachment := body["rev"].(string)
 	if revIdAfterUpdateAttachment == "" {
 		t.Fatalf("No revid in response for PUT attachment")
 	}
-	assert.True(t, revIdAfterUpdateAttachment != revIdAfterAttachment)
+	goassert.True(t, revIdAfterUpdateAttachment != revIdAfterAttachment)
 
 	// try to overwrite that attachment again, this time using If-Match header
 	attachmentBody = "updated content again"
@@ -686,19 +686,19 @@ func TestManualAttachment(t *testing.T) {
 	assertStatus(t, response, 201)
 	body = db.Body{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterUpdateAttachmentAgain := body["rev"].(string)
 	if revIdAfterUpdateAttachmentAgain == "" {
 		t.Fatalf("No revid in response for PUT attachment")
 	}
-	assert.True(t, revIdAfterUpdateAttachmentAgain != revIdAfterUpdateAttachment)
+	goassert.True(t, revIdAfterUpdateAttachmentAgain != revIdAfterUpdateAttachment)
 	delete(reqHeaders, "If-Match")
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attach1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// add another attachment to the document
 	// also no explicit Content-Type header on this one
@@ -708,18 +708,18 @@ func TestManualAttachment(t *testing.T) {
 	assertStatus(t, response, 201)
 	body = db.Body{}
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterSecondAttachment := body["rev"].(string)
 	if revIdAfterSecondAttachment == "" {
 		t.Fatalf("No revid in response for PUT attachment")
 	}
-	assert.True(t, revIdAfterSecondAttachment != revIdAfterUpdateAttachment)
+	goassert.True(t, revIdAfterSecondAttachment != revIdAfterUpdateAttachment)
 
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/doc1/attach2", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Type") == "application/octet-stream")
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Type") == "application/octet-stream")
 
 	// now check the attachments index on the document
 	response = rt.SendRequest("GET", "/db/doc1", "")
@@ -730,7 +730,7 @@ func TestManualAttachment(t *testing.T) {
 	if !ok {
 		t.Errorf("Attachments must be map")
 	} else {
-		assert.Equals(t, len(bodyAttachments), 2)
+		goassert.Equals(t, len(bodyAttachments), 2)
 	}
 	// make sure original document property has remained
 	prop, ok := body["prop"]
@@ -764,7 +764,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
 		t.Fatalf("No revid in response for PUT attachment")
@@ -773,8 +773,8 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	// retrieve attachment
 	response = rt.SendRequest("GET", "/db/notexistyet/attach1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	assert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
+	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
+	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// now check the document
 	body = db.Body{}
@@ -782,7 +782,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	// body should only have 3 top-level entries _id, _rev, _attachments
-	assert.True(t, len(body) == 3)
+	goassert.True(t, len(body) == 3)
 }
 
 func TestBulkDocs(t *testing.T) {
@@ -794,29 +794,29 @@ func TestBulkDocs(t *testing.T) {
 	assertStatus(t, response, 201)
 	var docs []interface{}
 	json.Unmarshal(response.Body.Bytes(), &docs)
-	assert.Equals(t, len(docs), 3)
-	assert.DeepEquals(t, docs[0],
+	goassert.Equals(t, len(docs), 3)
+	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-50133ddd8e49efad34ad9ecae4cb9907", "id": "bulk1"})
 	response = rt.SendRequest("GET", "/db/bulk1", "")
-	assert.Equals(t, response.Body.String(), `{"_id":"bulk1","_rev":"1-50133ddd8e49efad34ad9ecae4cb9907","n":1}`)
-	assert.DeepEquals(t, docs[1],
+	goassert.Equals(t, response.Body.String(), `{"_id":"bulk1","_rev":"1-50133ddd8e49efad34ad9ecae4cb9907","n":1}`)
+	goassert.DeepEquals(t, docs[1],
 		map[string]interface{}{"rev": "1-035168c88bd4b80fb098a8da72f881ce", "id": "bulk2"})
-	assert.DeepEquals(t, docs[2],
+	goassert.DeepEquals(t, docs[2],
 		map[string]interface{}{"rev": "0-1", "id": "_local/bulk3"})
 	response = rt.SendRequest("GET", "/db/_local/bulk3", "")
-	assert.Equals(t, response.Body.String(), `{"_id":"_local/bulk3","_rev":"0-1","n":3}`)
+	goassert.Equals(t, response.Body.String(), `{"_id":"_local/bulk3","_rev":"0-1","n":3}`)
 	assertStatus(t, response, 200)
 
 	// update all documents
 	input = `{"docs": [{"_id": "bulk1", "_rev" : "1-50133ddd8e49efad34ad9ecae4cb9907", "n": 10}, {"_id": "bulk2", "_rev":"1-035168c88bd4b80fb098a8da72f881ce", "n": 20}, {"_id": "_local/bulk3","_rev":"0-1","n": 30}]}`
 	response = rt.SendRequest("POST", "/db/_bulk_docs", input)
 	json.Unmarshal(response.Body.Bytes(), &docs)
-	assert.Equals(t, len(docs), 3)
-	assert.DeepEquals(t, docs[0],
+	goassert.Equals(t, len(docs), 3)
+	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "2-7e384b16e63ee3218349ee568f156d6f", "id": "bulk1"})
 
 	response = rt.SendRequest("GET", "/db/_local/bulk3", "")
-	assert.Equals(t, response.Body.String(), `{"_id":"_local/bulk3","_rev":"0-2","n":30}`)
+	goassert.Equals(t, response.Body.String(), `{"_id":"_local/bulk3","_rev":"0-2","n":30}`)
 	assertStatus(t, response, 200)
 }
 
@@ -831,11 +831,11 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &docs)
 	log.Printf("response: %s", response.Body.Bytes())
 	assertStatus(t, response, 201)
-	assert.Equals(t, len(docs), 2)
-	assert.Equals(t, docs[0]["rev"], "1-50133ddd8e49efad34ad9ecae4cb9907")
-	assert.True(t, docs[0]["id"] != "")
-	assert.Equals(t, docs[1]["rev"], "1-035168c88bd4b80fb098a8da72f881ce")
-	assert.True(t, docs[1]["id"] != "")
+	goassert.Equals(t, len(docs), 2)
+	goassert.Equals(t, docs[0]["rev"], "1-50133ddd8e49efad34ad9ecae4cb9907")
+	goassert.True(t, docs[0]["id"] != "")
+	goassert.Equals(t, docs[1]["rev"], "1-035168c88bd4b80fb098a8da72f881ce")
+	goassert.True(t, docs[1]["id"] != "")
 }
 
 func TestBulkDocsUnusedSequences(t *testing.T) {
@@ -850,16 +850,16 @@ func TestBulkDocsUnusedSequences(t *testing.T) {
 
 	doc1Rev, err := rt.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev.Sequence, uint64(1))
+	goassert.Equals(t, doc1Rev.Sequence, uint64(1))
 
 	doc3Rev, err := rt.GetDatabase().GetDocSyncData("bulk3")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc3Rev.Sequence, uint64(2))
+	goassert.Equals(t, doc3Rev.Sequence, uint64(2))
 
 	//Get current sequence number, this will be 3, as SG allocates enough sequences to process all bulk docs
 	lastSequence, err := rt.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(3))
+	goassert.Equals(t, lastSequence, uint64(3))
 
 	//send another _bulk_docs and validate the sequences used
 	input = `{"docs": [{"_id": "bulk21", "n": 21}, {"_id": "bulk22", "n": 22}, {"_id": "bulk23", "n": 23}]}`
@@ -869,20 +869,20 @@ func TestBulkDocsUnusedSequences(t *testing.T) {
 	//Sequence 3 get used here
 	doc21Rev, err := rt.GetDatabase().GetDocSyncData("bulk21")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc21Rev.Sequence, uint64(3))
+	goassert.Equals(t, doc21Rev.Sequence, uint64(3))
 
 	doc22Rev, err := rt.GetDatabase().GetDocSyncData("bulk22")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc22Rev.Sequence, uint64(4))
+	goassert.Equals(t, doc22Rev.Sequence, uint64(4))
 
 	doc23Rev, err := rt.GetDatabase().GetDocSyncData("bulk23")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc23Rev.Sequence, uint64(5))
+	goassert.Equals(t, doc23Rev.Sequence, uint64(5))
 
 	//Get current sequence number
 	lastSequence, err = rt.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(5))
+	goassert.Equals(t, lastSequence, uint64(5))
 }
 
 func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
@@ -897,16 +897,16 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 
 	doc1Rev, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev.Sequence, uint64(1))
+	goassert.Equals(t, doc1Rev.Sequence, uint64(1))
 
 	doc3Rev, err := rt1.GetDatabase().GetDocSyncData("bulk3")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc3Rev.Sequence, uint64(2))
+	goassert.Equals(t, doc3Rev.Sequence, uint64(2))
 
 	//Get current sequence number, this will be 3, as SG allocates enough sequences to process all bulk docs
 	lastSequence, err := rt1.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(3))
+	goassert.Equals(t, lastSequence, uint64(3))
 
 	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt2.Close()
@@ -935,20 +935,20 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	//Sequence 3 does not get used here as its using a different sequence allocator
 	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc21Rev.Sequence, uint64(4))
+	goassert.Equals(t, doc21Rev.Sequence, uint64(4))
 
 	doc22Rev, err := rt2.GetDatabase().GetDocSyncData("bulk22")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc22Rev.Sequence, uint64(5))
+	goassert.Equals(t, doc22Rev.Sequence, uint64(5))
 
 	doc23Rev, err := rt2.GetDatabase().GetDocSyncData("bulk23")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc23Rev.Sequence, uint64(6))
+	goassert.Equals(t, doc23Rev.Sequence, uint64(6))
 
 	//Get current sequence number
 	lastSequence, err = rt2.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(6))
+	goassert.Equals(t, lastSequence, uint64(6))
 
 	//Now send a bulk_doc to rt1 and see if it uses sequence 3
 	input = `{"docs": [{"_id": "bulk31", "n": 31}, {"_id": "bulk32", "n": 32}, {"_id": "bulk33", "n": 33}]}`
@@ -958,15 +958,15 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	//Sequence 3 get used here as its using first sequence allocator
 	doc31Rev, err := rt1.GetDatabase().GetDocSyncData("bulk31")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc31Rev.Sequence, uint64(3))
+	goassert.Equals(t, doc31Rev.Sequence, uint64(3))
 
 	doc32Rev, err := rt1.GetDatabase().GetDocSyncData("bulk32")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc32Rev.Sequence, uint64(7))
+	goassert.Equals(t, doc32Rev.Sequence, uint64(7))
 
 	doc33Rev, err := rt1.GetDatabase().GetDocSyncData("bulk33")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc33Rev.Sequence, uint64(8))
+	goassert.Equals(t, doc33Rev.Sequence, uint64(8))
 
 }
 
@@ -983,19 +983,19 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 
 	doc1Rev, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev.Sequence, uint64(1))
+	goassert.Equals(t, doc1Rev.Sequence, uint64(1))
 
 	//Get the revID for doc "bulk1"
 	doc1RevID := doc1Rev.CurrentRev
 
 	doc3Rev, err := rt1.GetDatabase().GetDocSyncData("bulk3")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc3Rev.Sequence, uint64(2))
+	goassert.Equals(t, doc3Rev.Sequence, uint64(2))
 
 	//Get current sequence number, this will be 3, as SG allocates enough sequences to process all bulk docs
 	lastSequence, err := rt1.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(3))
+	goassert.Equals(t, lastSequence, uint64(3))
 
 	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt2.Close()
@@ -1024,20 +1024,20 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//Sequence 3 does not get used here as its using a different sequence allocator
 	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc21Rev.Sequence, uint64(4))
+	goassert.Equals(t, doc21Rev.Sequence, uint64(4))
 
 	doc22Rev, err := rt2.GetDatabase().GetDocSyncData("bulk22")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc22Rev.Sequence, uint64(5))
+	goassert.Equals(t, doc22Rev.Sequence, uint64(5))
 
 	doc23Rev, err := rt2.GetDatabase().GetDocSyncData("bulk23")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc23Rev.Sequence, uint64(6))
+	goassert.Equals(t, doc23Rev.Sequence, uint64(6))
 
 	//Validate rev2 of doc "bulk1" has a new revision
 	doc1Rev2, err := rt2.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev2.Sequence, uint64(7))
+	goassert.Equals(t, doc1Rev2.Sequence, uint64(7))
 
 	//Get the revID for doc "bulk1"
 	doc1RevID2 := doc1Rev2.CurrentRev
@@ -1045,7 +1045,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//Get current sequence number
 	lastSequence, err = rt2.GetDatabase().LastSequence()
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, lastSequence, uint64(7))
+	goassert.Equals(t, lastSequence, uint64(7))
 
 	//Now send a bulk_doc to rt1 to update doc bulk1 again
 	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID2 + `", "n": 2}]}`
@@ -1055,14 +1055,14 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	//Sequence 8 should get used here as sequence 3 should have been dropped by the first sequence allocator
 	doc1Rev3, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev3.Sequence, uint64(8))
+	goassert.Equals(t, doc1Rev3.Sequence, uint64(8))
 
 	//validate the doc _sync metadata, should see last sequence lower than previous sequence
 	rs := doc1Rev3.RecentSequences
-	assert.Equals(t, len(rs), 3)
-	assert.Equals(t, rs[0], uint64(1))
-	assert.Equals(t, rs[1], uint64(7))
-	assert.Equals(t, rs[2], uint64(8))
+	goassert.Equals(t, len(rs), 3)
+	goassert.Equals(t, rs[0], uint64(1))
+	goassert.Equals(t, rs[1], uint64(7))
+	goassert.Equals(t, rs[2], uint64(8))
 
 }
 
@@ -1079,19 +1079,19 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 
 	doc1Rev, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev.Sequence, uint64(1))
+	goassert.Equals(t, doc1Rev.Sequence, uint64(1))
 
 	//Get the revID for doc "bulk1"
 	doc1RevID := doc1Rev.CurrentRev
 
 	doc3Rev, err := rt1.GetDatabase().GetDocSyncData("bulk3")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc3Rev.Sequence, uint64(2))
+	goassert.Equals(t, doc3Rev.Sequence, uint64(2))
 
 	//Get current sequence number, this will be 3, as SG allocates enough sequences to process all bulk docs
 	lastSequence, err := rt1.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(3))
+	goassert.Equals(t, lastSequence, uint64(3))
 
 	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt2.Close()
@@ -1120,16 +1120,16 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Sequence 3 does not get used here as its using a different sequence allocator
 	doc21Rev, err := rt2.GetDatabase().GetDocSyncData("bulk21")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc21Rev.Sequence, uint64(4))
+	goassert.Equals(t, doc21Rev.Sequence, uint64(4))
 
 	doc22Rev, err := rt2.GetDatabase().GetDocSyncData("bulk22")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc22Rev.Sequence, uint64(5))
+	goassert.Equals(t, doc22Rev.Sequence, uint64(5))
 
 	//Validate rev2 of doc "bulk1" has a new revision
 	doc1Rev2, err := rt2.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev2.Sequence, uint64(7))
+	goassert.Equals(t, doc1Rev2.Sequence, uint64(7))
 
 	//Get the revID for doc "bulk1"
 	doc1RevID2 := doc1Rev2.CurrentRev
@@ -1137,7 +1137,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Get current sequence number
 	lastSequence, err = rt2.GetDatabase().LastSequence()
 	assertNoError(t, err, "LastSequence error")
-	assert.Equals(t, lastSequence, uint64(7))
+	goassert.Equals(t, lastSequence, uint64(7))
 
 	//Now send a bulk_doc to rt1 to update doc bulk1 again
 	input = `{"docs": [{"_id": "bulk1", "_rev": "` + doc1RevID2 + `", "n": 2}]}`
@@ -1147,7 +1147,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Sequence 8 should get used here as sequence 3 should have been dropped by the first sequence allocator
 	doc1Rev3, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev3.Sequence, uint64(8))
+	goassert.Equals(t, doc1Rev3.Sequence, uint64(8))
 
 	//Get the revID for doc "bulk1"
 	doc1RevID3 := doc1Rev3.CurrentRev
@@ -1160,15 +1160,15 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	//Sequence 9 should get used here as sequence 6 should have been dropped by the second sequence allocator
 	doc1Rev4, err := rt1.GetDatabase().GetDocSyncData("bulk1")
 	assertNoError(t, err, "GetDocSyncData error")
-	assert.Equals(t, doc1Rev4.Sequence, uint64(9))
+	goassert.Equals(t, doc1Rev4.Sequence, uint64(9))
 
 	//validate the doc _sync metadata, should see last sequence lower than previous sequence
 	rs := doc1Rev4.RecentSequences
-	assert.Equals(t, len(rs), 4)
-	assert.Equals(t, rs[0], uint64(1))
-	assert.Equals(t, rs[1], uint64(7))
-	assert.Equals(t, rs[2], uint64(8))
-	assert.Equals(t, rs[3], uint64(9))
+	goassert.Equals(t, len(rs), 4)
+	goassert.Equals(t, rs[0], uint64(1))
+	goassert.Equals(t, rs[1], uint64(7))
+	goassert.Equals(t, rs[2], uint64(8))
+	goassert.Equals(t, rs[3], uint64(9))
 
 }
 
@@ -1214,10 +1214,10 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", nil)
@@ -1230,10 +1230,10 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	var docs []interface{}
 	json.Unmarshal(response.Body.Bytes(), &docs)
-	assert.Equals(t, len(docs), 2)
-	assert.DeepEquals(t, docs[0],
+	goassert.Equals(t, len(docs), 2)
+	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-afbcffa8a4641a0f4dd94d3fc9593e74", "id": "bulk1"})
-	assert.DeepEquals(t, docs[1],
+	goassert.DeepEquals(t, docs[1],
 		map[string]interface{}{"rev": "1-4d79588b9fe9c38faae61f0c1b9471c0", "id": "bulk2"})
 }
 
@@ -1261,7 +1261,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	user, err := authenticator.NewUser("user1", "letmein", nil)
 	user.SetExplicitRoles(channels.TimedSet{"role1": channels.NewVbSimpleSequence(1)})
 	err = authenticator.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Bulk docs with 2 docs.  First doc grants role1 access to chan1.  Second requires chan1 for write.
 	input := `{"docs": [
@@ -1282,10 +1282,10 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 
 	var docs []interface{}
 	json.Unmarshal(response.Body.Bytes(), &docs)
-	assert.Equals(t, len(docs), 2)
-	assert.DeepEquals(t, docs[0],
+	goassert.Equals(t, len(docs), 2)
+	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-17424d2a21bf113768dfdbcd344741ac", "id": "bulk1"})
-	assert.DeepEquals(t, docs[1],
+	goassert.DeepEquals(t, docs[1],
 		map[string]interface{}{"rev": "1-f120ccb33c0a6ef43ef202ade28f98ef", "id": "bulk2"})
 }
 
@@ -1303,10 +1303,10 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	assertStatus(t, response, 201)
 	var docs []interface{}
 	json.Unmarshal(response.Body.Bytes(), &docs)
-	assert.Equals(t, len(docs), 2)
-	assert.DeepEquals(t, docs[0],
+	goassert.Equals(t, len(docs), 2)
+	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "12-abc", "id": "bdne1"})
-	assert.DeepEquals(t, docs[1],
+	goassert.DeepEquals(t, docs[1],
 		map[string]interface{}{"rev": "34-def", "id": "bdne2"})
 
 	// Now update the first doc with two new revisions:
@@ -1317,8 +1317,8 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	response = rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 	json.Unmarshal(response.Body.Bytes(), &docs)
-	assert.Equals(t, len(docs), 1)
-	assert.DeepEquals(t, docs[0],
+	goassert.Equals(t, len(docs), 1)
+	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "14-jkl", "id": "bdne1"})
 }
 
@@ -1350,7 +1350,7 @@ func TestRevsDiff(t *testing.T) {
 	var diffResponse RevsDiffResponse
 	json.Unmarshal(response.Body.Bytes(), &diffResponse)
 	sort.Strings(diffResponse["rd1"]["possible_ancestors"])
-	assert.DeepEquals(t, diffResponse, RevsDiffResponse{
+	goassert.DeepEquals(t, diffResponse, RevsDiffResponse{
 		"rd1": RevDiffResponse{"missing": []string{"13-def", "12-xyz"},
 			"possible_ancestors": []string{"11-eleven", "12-abc"}},
 		"rd9": RevDiffResponse{"missing": []string{"1-a", "2-b", "3-c"}}})
@@ -1373,7 +1373,7 @@ func TestOpenRevs(t *testing.T) {
 	}
 	response = rt.SendRequestWithHeaders("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "", reqHeaders)
 	assertStatus(t, response, 200)
-	assert.Equals(t, response.Body.String(), `[
+	goassert.Equals(t, response.Body.String(), `[
 {"ok":{"_id":"or1","_rev":"12-abc","n":1}}
 ,{"missing":"10-ten"}
 ]`)
@@ -1443,14 +1443,14 @@ func TestBulkGetPerDocRevsLimit(t *testing.T) {
 				}
 			]
 		}`, docs["doc1"], docs["doc2"], docs["doc3"], docs["doc4"]))
-	assert.Equals(t, bulkGetResponse.Code, http.StatusOK)
+	goassert.Equals(t, bulkGetResponse.Code, http.StatusOK)
 
 	bulkGetResponse.DumpBody()
 
 	// Parse multipart/mixed docs and create reader
 	contentType, attrs, _ := mime.ParseMediaType(bulkGetResponse.Header().Get("Content-Type"))
 	log.Printf("content-type: %v.  attrs: %v", contentType, attrs)
-	assert.Equals(t, contentType, "multipart/mixed")
+	goassert.Equals(t, contentType, "multipart/mixed")
 	reader := multipart.NewReader(bulkGetResponse.Body, attrs["boundary"])
 
 readerLoop:
@@ -1483,18 +1483,18 @@ readerLoop:
 			exp = 1
 		case "doc3":
 			// revs_limit of zero should display no revision object at all
-			assert.Equals(t, partJSON[db.BodyRevisions], nil)
+			goassert.Equals(t, partJSON[db.BodyRevisions], nil)
 			break readerLoop
 		case "doc4":
 			// revs_limit must be >= 0
-			assert.Equals(t, partJSON["error"], "bad_request")
+			goassert.Equals(t, partJSON["error"], "bad_request")
 			break readerLoop
 		default:
 			t.Error("unrecognised part in response")
 		}
 
 		revisions := partJSON[db.BodyRevisions].(map[string]interface{})
-		assert.Equals(t, len(revisions[db.RevisionsIds].([]interface{})), exp)
+		goassert.Equals(t, len(revisions[db.RevisionsIds].([]interface{})), exp)
 	}
 
 }
@@ -1510,7 +1510,7 @@ func TestLocalDocs(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/_local/loc1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, response.Body.String(), `{"_id":"_local/loc1","_rev":"0-1","hi":"there"}`)
+	goassert.Equals(t, response.Body.String(), `{"_id":"_local/loc1","_rev":"0-1","hi":"there"}`)
 
 	response = rt.SendRequest("PUT", "/db/_local/loc1", `{"hi": "there"}`)
 	assertStatus(t, response, 409)
@@ -1518,14 +1518,14 @@ func TestLocalDocs(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/_local/loc1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, response.Body.String(), `{"_id":"_local/loc1","_rev":"0-2","hi":"again"}`)
+	goassert.Equals(t, response.Body.String(), `{"_id":"_local/loc1","_rev":"0-2","hi":"again"}`)
 
 	// Check the handling of large integers, which caused trouble for us at one point:
 	response = rt.SendRequest("PUT", "/db/_local/loc1", `{"big": 123456789, "_rev": "0-2"}`)
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/_local/loc1", "")
 	assertStatus(t, response, 200)
-	assert.Equals(t, response.Body.String(), `{"_id":"_local/loc1","_rev":"0-3","big":123456789}`)
+	goassert.Equals(t, response.Body.String(), `{"_id":"_local/loc1","_rev":"0-3","big":123456789}`)
 
 	response = rt.SendRequest("DELETE", "/db/_local/loc1", "")
 	assertStatus(t, response, 409)
@@ -1561,13 +1561,13 @@ func TestResponseEncoding(t *testing.T) {
 	response = rt.SendRequestWithHeaders("GET", "/db/_local/loc1", "",
 		map[string]string{"Accept-Encoding": "foo, gzip, bar"})
 	assertStatus(t, response, 200)
-	assert.DeepEquals(t, response.HeaderMap["Content-Encoding"], []string{"gzip"})
+	goassert.DeepEquals(t, response.HeaderMap["Content-Encoding"], []string{"gzip"})
 	unzip, err := gzip.NewReader(response.Body)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	unjson := json.NewDecoder(unzip)
 	var body db.Body
-	assert.Equals(t, unjson.Decode(&body), nil)
-	assert.Equals(t, body["long"], str)
+	goassert.Equals(t, unjson.Decode(&body), nil)
+	goassert.Equals(t, body["long"], str)
 }
 
 func TestLogin(t *testing.T) {
@@ -1576,14 +1576,14 @@ func TestLogin(t *testing.T) {
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	user, err = a.GetUser("")
-	assert.Equals(t, err, nil)
-	assert.True(t, user.Disabled())
+	goassert.Equals(t, err, nil)
+	goassert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
 	assertStatus(t, response, 401)
@@ -1596,7 +1596,7 @@ func TestLogin(t *testing.T) {
 	response = rt.SendRequest("POST", "/db/_session", `{"name":"pupshaw", "password":"letmein"}`)
 	assertStatus(t, response, 200)
 	log.Printf("Set-Cookie: %s", response.Header().Get("Set-Cookie"))
-	assert.True(t, response.Header().Get("Set-Cookie") != "")
+	goassert.True(t, response.Header().Get("Set-Cookie") != "")
 }
 
 func TestCustomCookieName(t *testing.T) {
@@ -1616,10 +1616,10 @@ func TestCustomCookieName(t *testing.T) {
 	// Disable guest user
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create a user
 	response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"1234"}`)
@@ -1627,25 +1627,25 @@ func TestCustomCookieName(t *testing.T) {
 
 	// Create a session
 	resp := rt.SendRequest("POST", "/db/_session", `{"name":"user1", "password":"1234"}`)
-	assert.Equals(t, resp.Code, 200)
+	goassert.Equals(t, resp.Code, 200)
 
 	// Extract the cookie from the create session response to verify the "Set-Cookie" value returned by Sync Gateway
 	cookies := resp.Result().Cookies()
-	assert.True(t, len(cookies) == 1)
+	goassert.True(t, len(cookies) == 1)
 	cookie := cookies[0]
-	assert.Equals(t, cookie.Name, customCookieName)
-	assert.Equals(t, cookie.Path, "/db")
+	goassert.Equals(t, cookie.Name, customCookieName)
+	goassert.Equals(t, cookie.Path, "/db")
 
 	// Attempt to use default cookie name to authenticate -- expect a 401 error
 	headers := map[string]string{}
 	headers["Cookie"] = fmt.Sprintf("%s=%s", auth.DefaultCookieName, cookie.Value)
 	resp = rt.SendRequestWithHeaders("GET", "/db/foo", `{}`, headers)
-	assert.Equals(t, resp.Result().StatusCode, 401)
+	goassert.Equals(t, resp.Result().StatusCode, 401)
 
 	// Attempt to use custom cookie name to authenticate
 	headers["Cookie"] = fmt.Sprintf("%s=%s", customCookieName, cookie.Value)
 	resp = rt.SendRequestWithHeaders("POST", "/db/", `{"_id": "foo", "key": "val"}`, headers)
-	assert.Equals(t, resp.Result().StatusCode, 200)
+	goassert.Equals(t, resp.Result().StatusCode, 200)
 
 }
 
@@ -1658,53 +1658,53 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",
 				"include_docs": true, "filter": "Melitta", "channels": "ABC,BBC"}`
 	feed, options, filter, channelsArray, _, _, err := h.readChangesOptionsFromJSON([]byte(optStr))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, feed, "longpoll")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, feed, "longpoll")
 
-	assert.Equals(t, options.Since.Seq, uint64(78))
-	assert.Equals(t, options.Since.TriggeredBy, uint64(123456))
-	assert.Equals(t, options.Limit, 123)
-	assert.Equals(t, options.Conflicts, true)
-	assert.Equals(t, options.IncludeDocs, true)
-	assert.Equals(t, options.HeartbeatMs, uint64(kDefaultHeartbeatMS))
-	assert.Equals(t, options.TimeoutMs, uint64(kDefaultTimeoutMS))
+	goassert.Equals(t, options.Since.Seq, uint64(78))
+	goassert.Equals(t, options.Since.TriggeredBy, uint64(123456))
+	goassert.Equals(t, options.Limit, 123)
+	goassert.Equals(t, options.Conflicts, true)
+	goassert.Equals(t, options.IncludeDocs, true)
+	goassert.Equals(t, options.HeartbeatMs, uint64(kDefaultHeartbeatMS))
+	goassert.Equals(t, options.TimeoutMs, uint64(kDefaultTimeoutMS))
 
-	assert.Equals(t, filter, "Melitta")
-	assert.DeepEquals(t, channelsArray, []string{"ABC", "BBC"})
+	goassert.Equals(t, filter, "Melitta")
+	goassert.DeepEquals(t, channelsArray, []string{"ABC", "BBC"})
 
 	// Attempt to set heartbeat, timeout to valid values
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":30000, "timeout":60000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, options.HeartbeatMs, uint64(30000))
-	assert.Equals(t, options.TimeoutMs, uint64(60000))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, options.HeartbeatMs, uint64(30000))
+	goassert.Equals(t, options.TimeoutMs, uint64(60000))
 
 	// Attempt to set valid timeout, no heartbeat
 	optStr = `{"feed":"longpoll", "since": "1", "timeout":2000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, options.TimeoutMs, uint64(2000))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, options.TimeoutMs, uint64(2000))
 
 	// Disable heartbeat, timeout by explicitly setting to zero
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":0, "timeout":0}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, options.HeartbeatMs, uint64(0))
-	assert.Equals(t, options.TimeoutMs, uint64(0))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, options.HeartbeatMs, uint64(0))
+	goassert.Equals(t, options.TimeoutMs, uint64(0))
 
 	// Attempt to set heartbeat less than minimum heartbeat, timeout greater than max timeout
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":1000, "timeout":1000000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, options.HeartbeatMs, uint64(kMinHeartbeatMS))
-	assert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, options.HeartbeatMs, uint64(kMinHeartbeatMS))
+	goassert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
 
 	// Set max heartbeat in server context, attempt to set heartbeat greater than max
 	h.server.config.MaxHeartbeat = 60
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	assert.Equals(t, err, nil)
-	assert.Equals(t, options.HeartbeatMs, uint64(60000))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, options.HeartbeatMs, uint64(60000))
 }
 
 // Test _all_docs API call under different security scenarios
@@ -1732,10 +1732,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 	// Create some docs:
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
@@ -1745,7 +1745,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create a user:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf("Cinemax"))
@@ -1771,14 +1771,14 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 3)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
-	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 3)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
+	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs limit option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?limit=1&channels=true", nil)
@@ -1788,10 +1788,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs startkey option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?startkey=doc5&channels=true", nil)
@@ -1801,10 +1801,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs startkey option with double quote
 	request, _ = http.NewRequest("GET", `/db/_all_docs?startkey="doc5"&channels=true`, nil)
@@ -1814,10 +1814,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs endkey option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?endkey=doc3&channels=true", nil)
@@ -1827,10 +1827,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs endkey option
 	request, _ = http.NewRequest("GET", `/db/_all_docs?endkey="doc3"&channels=true`, nil)
@@ -1840,10 +1840,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	// Check _all_docs with include_docs option:
 	request, _ = http.NewRequest("GET", "/db/_all_docs?include_docs=true", nil)
@@ -1853,11 +1853,11 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 3)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 3)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
 
 	// Check POST to _all_docs:
 	body := `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
@@ -1868,17 +1868,17 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 4)
-	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
-	assert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
-	assert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 4)
+	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
+	goassert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
 
 	// Check GET to _all_docs with keys parameter:
 	request, _ = http.NewRequest("GET", `/db/_all_docs?channels=true&keys=%5B%22doc4%22%2C%22doc1%22%2C%22doc3%22%2C%22b0gus%22%5D`, nil)
@@ -1888,17 +1888,17 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 4)
-	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
-	assert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
-	assert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 4)
+	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
+	goassert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
 
 	// Check POST to _all_docs with limit option:
 	body = `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
@@ -1909,11 +1909,11 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	// Check _all_docs as admin:
 	response = rt.SendAdminRequest("GET", "/db/_all_docs", "")
@@ -1921,10 +1921,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 5)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 5)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
 }
 
 // Test _all_docs API call when using vector sequences (accel), under different security scenarios
@@ -1953,10 +1953,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 	// Create some docs:
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
@@ -1966,7 +1966,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create a user:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf("Cinemax"))
@@ -1992,14 +1992,14 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 3)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
-	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 3)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
+	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs limit option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?limit=1&channels=true", nil)
@@ -2009,10 +2009,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs startkey option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?startkey=doc5&channels=true", nil)
@@ -2022,10 +2022,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs startkey option with double quote
 	request, _ = http.NewRequest("GET", `/db/_all_docs?startkey="doc5"&channels=true`, nil)
@@ -2035,10 +2035,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs endkey option
 	request, _ = http.NewRequest("GET", "/db/_all_docs?endkey=doc3&channels=true", nil)
@@ -2048,10 +2048,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	//Check all docs endkey option
 	request, _ = http.NewRequest("GET", `/db/_all_docs?endkey="doc3"&channels=true`, nil)
@@ -2061,10 +2061,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	// Check _all_docs with include_docs option:
 	request, _ = http.NewRequest("GET", "/db/_all_docs?include_docs=true", nil)
@@ -2074,11 +2074,11 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 3)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 3)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc5")
 
 	// Check POST to _all_docs:
 	body := `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
@@ -2089,17 +2089,17 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 4)
-	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
-	assert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
-	assert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 4)
+	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
+	goassert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
 
 	// Check GET to _all_docs with keys parameter:
 	request, _ = http.NewRequest("GET", `/db/_all_docs?channels=true&keys=%5B%22doc4%22%2C%22doc1%22%2C%22doc3%22%2C%22b0gus%22%5D`, nil)
@@ -2109,17 +2109,17 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 4)
-	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
-	assert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
-	assert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
-	assert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
-	assert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 4)
+	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
+	goassert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
 
 	// Check POST to _all_docs with limit option:
 	body = `{"keys": ["doc4", "doc1", "doc3", "b0gus"]}`
@@ -2130,11 +2130,11 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 
 	// Check _all_docs as admin:
 	response = rt.SendAdminRequest("GET", "/db/_all_docs", "")
@@ -2142,10 +2142,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 5)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 5)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
 
 }
 
@@ -2158,10 +2158,10 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create users:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf("zero"))
@@ -2174,7 +2174,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	alphaRevID := body["rev"].(string)
 
 	assertStatus(t, rt.Send(request("PUT", "/db/beta", `{"owner":"boadecia"}`)), 201) // seq=2
@@ -2192,15 +2192,15 @@ func TestChannelAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
 
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 1)
 	since := changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "g1")
-	assert.Equals(t, since.Seq, uint64(8))
+	goassert.Equals(t, changes.Results[0].ID, "g1")
+	goassert.Equals(t, since.Seq, uint64(8))
 
 	// Check user access:
 	alice, _ = a.GetUser("alice")
-	assert.DeepEquals(
+	goassert.DeepEquals(
 		t,
 		alice.Channels(),
 		channels.TimedSet{
@@ -2211,7 +2211,7 @@ func TestChannelAccessChanges(t *testing.T) {
 		})
 
 	zegpold, _ = a.GetUser("zegpold")
-	assert.DeepEquals(
+	goassert.DeepEquals(
 		t,
 		zegpold.Channels(),
 		channels.TimedSet{
@@ -2226,7 +2226,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Check user access again:
 	alice, _ = a.GetUser("alice")
-	assert.DeepEquals(
+	goassert.DeepEquals(
 		t,
 		alice.Channels(),
 		channels.TimedSet{
@@ -2236,7 +2236,7 @@ func TestChannelAccessChanges(t *testing.T) {
 		})
 
 	zegpold, _ = a.GetUser("zegpold")
-	assert.DeepEquals(
+	goassert.DeepEquals(
 		t,
 		zegpold.Channels(),
 		channels.TimedSet{
@@ -2252,21 +2252,21 @@ func TestChannelAccessChanges(t *testing.T) {
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 1)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, changes.Results[0].ID, "d1")
+	goassert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, changes.Results[0].ID, "d1")
 
 	// The complete _changes feed for zegpold contains docs a1 and g1:
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 2)
-	assert.Equals(t, changes.Results[0].ID, "g1")
-	assert.Equals(t, changes.Results[0].Seq.Seq, uint64(8))
-	assert.Equals(t, changes.Results[1].ID, "a1")
-	assert.Equals(t, changes.Results[1].Seq.Seq, uint64(5))
-	assert.Equals(t, changes.Results[1].Seq.TriggeredBy, uint64(9))
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, changes.Results[0].ID, "g1")
+	goassert.Equals(t, changes.Results[0].Seq.Seq, uint64(8))
+	goassert.Equals(t, changes.Results[1].ID, "a1")
+	goassert.Equals(t, changes.Results[1].Seq.Seq, uint64(5))
+	goassert.Equals(t, changes.Results[1].Seq.TriggeredBy, uint64(9))
 
 	// Changes feed with since=gamma:8 would ordinarily be empty, but zegpold got access to channel
 	// alpha after sequence 8, so the pre-existing docs in that channel are included:
@@ -2275,8 +2275,8 @@ func TestChannelAccessChanges(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 1)
-	assert.Equals(t, changes.Results[0].ID, "a1")
+	goassert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, changes.Results[0].ID, "a1")
 
 	// What happens if we call access() with a nonexistent username?
 	assertStatus(t, rt.Send(request("PUT", "/db/epsilon", `{"owner":"waldo"}`)), 201) // seq 10
@@ -2292,31 +2292,31 @@ func TestChannelAccessChanges(t *testing.T) {
 	database, _ := db.GetDatabase(dbc, nil)
 
 	changed, err := database.UpdateSyncFun(`function(doc) {access("alice", "beta");channel("beta");}`)
-	assert.Equals(t, err, nil)
-	assert.True(t, changed)
+	goassert.Equals(t, err, nil)
+	goassert.True(t, changed)
 	changeCount, err := database.UpdateAllDocChannels()
-	assert.Equals(t, err, nil)
-	assert.Equals(t, changeCount, 9)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, changeCount, 9)
 
 	expectedIDs := []string{"beta", "delta", "gamma", "a1", "b1", "d1", "g1", "alpha", "epsilon"}
 	changes, err = rt.WaitForChanges(len(expectedIDs), "/db/_changes", "alice", false)
 	assertNoError(t, err, "Unexpected error")
 	log.Printf("_changes looks like: %+v", changes)
-	assert.Equals(t, len(changes.Results), len(expectedIDs))
+	goassert.Equals(t, len(changes.Results), len(expectedIDs))
 
 	for i, expectedID := range expectedIDs {
 		if changes.Results[i].ID != expectedID {
 			log.Printf("changes.Results[i].ID != expectedID.  changes.Results: %+v, expectedIDs: %v", changes.Results, expectedIDs)
 		}
-		assert.Equals(t, changes.Results[i].ID, expectedID)
+		goassert.Equals(t, changes.Results[i].ID, expectedID)
 	}
 
 	// Check accumulated statistics:
-	assert.Equals(t, database.ChangesClientStats.TotalCount(), uint32(5))
-	assert.Equals(t, database.ChangesClientStats.MaxCount(), uint32(1))
+	goassert.Equals(t, database.ChangesClientStats.TotalCount(), uint32(5))
+	goassert.Equals(t, database.ChangesClientStats.MaxCount(), uint32(1))
 	database.ChangesClientStats.Reset()
-	assert.Equals(t, database.ChangesClientStats.TotalCount(), uint32(0))
-	assert.Equals(t, database.ChangesClientStats.MaxCount(), uint32(0))
+	goassert.Equals(t, database.ChangesClientStats.TotalCount(), uint32(0))
+	goassert.Equals(t, database.ChangesClientStats.MaxCount(), uint32(0))
 }
 
 func TestAccessOnTombstone(t *testing.T) {
@@ -2336,10 +2336,10 @@ func TestAccessOnTombstone(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create user:
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("zero"))
@@ -2350,7 +2350,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
 	rt.WaitForPendingChanges()
@@ -2363,10 +2363,10 @@ func TestAccessOnTombstone(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 1)
 	if len(changes.Results) > 0 {
-		assert.Equals(t, changes.Results[0].ID, "alpha")
+		goassert.Equals(t, changes.Results[0].ID, "alpha")
 	}
 
 	// Delete the document
@@ -2380,10 +2380,10 @@ func TestAccessOnTombstone(t *testing.T) {
 	changes.Results = nil
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, len(changes.Results), 1)
 	if len(changes.Results) > 0 {
-		assert.Equals(t, changes.Results[0].ID, "alpha")
-		assert.Equals(t, changes.Results[0].Deleted, true)
+		goassert.Equals(t, changes.Results[0].ID, "alpha")
+		goassert.Equals(t, changes.Results[0].Deleted, true)
 	}
 
 }
@@ -2402,10 +2402,10 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create user1
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2420,18 +2420,18 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	limit := 50
 	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(changesResults.Results), 50)
+	goassert.Equals(t, len(changesResults.Results), 50)
 	since := changesResults.Results[49].Seq
-	assert.Equals(t, changesResults.Results[49].ID, "doc48")
-	assert.Equals(t, since.Seq, uint64(50))
+	goassert.Equals(t, changesResults.Results[49].ID, "doc48")
+	goassert.Equals(t, since.Seq, uint64(50))
 
 	//// Check the _changes feed with  since and limit, to get second half of feed
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(changesResults.Results), 50)
+	goassert.Equals(t, len(changesResults.Results), 50)
 	since = changesResults.Results[49].Seq
-	assert.Equals(t, changesResults.Results[49].ID, "doc98")
-	assert.Equals(t, since.Seq, uint64(100))
+	goassert.Equals(t, changesResults.Results[49].ID, "doc98")
+	goassert.Equals(t, since.Seq, uint64(100))
 
 	// Create user2
 	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2440,8 +2440,8 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	//Retrieve all changes for user2 with no limits
 	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(changesResults.Results), 101)
-	assert.Equals(t, changesResults.Results[99].ID, "doc99")
+	goassert.Equals(t, len(changesResults.Results), 101)
+	goassert.Equals(t, changesResults.Results[99].ID, "doc99")
 
 	// Create user3
 	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2450,17 +2450,17 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	//Get first 50 document changes
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(changesResults.Results), 50)
+	goassert.Equals(t, len(changesResults.Results), 50)
 	since = changesResults.Results[49].Seq
-	assert.Equals(t, changesResults.Results[49].ID, "doc49")
-	assert.Equals(t, since.Seq, uint64(51))
-	assert.Equals(t, since.TriggeredBy, uint64(103))
+	goassert.Equals(t, changesResults.Results[49].ID, "doc49")
+	goassert.Equals(t, since.Seq, uint64(51))
+	goassert.Equals(t, since.TriggeredBy, uint64(103))
 
 	//// Get remainder of changes i.e. no limit parameter
 	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(changesResults.Results), 51)
-	assert.Equals(t, changesResults.Results[49].ID, "doc99")
+	goassert.Equals(t, len(changesResults.Results), 51)
+	goassert.Equals(t, changesResults.Results[49].ID, "doc99")
 
 	// Create user4
 	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2468,17 +2468,17 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(changesResults.Results), 50)
+	goassert.Equals(t, len(changesResults.Results), 50)
 	since = changesResults.Results[49].Seq
-	assert.Equals(t, changesResults.Results[49].ID, "doc49")
-	assert.Equals(t, since.Seq, uint64(51))
-	assert.Equals(t, since.TriggeredBy, uint64(104))
+	goassert.Equals(t, changesResults.Results[49].ID, "doc49")
+	goassert.Equals(t, since.Seq, uint64(51))
+	goassert.Equals(t, since.TriggeredBy, uint64(104))
 
 	//// Check the _changes feed with  since and limit, to get second half of feed
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changesResults.Results), 50)
-	assert.Equals(t, changesResults.Results[49].ID, "doc99")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changesResults.Results), 50)
+	goassert.Equals(t, changesResults.Results[49].ID, "doc99")
 
 }
 
@@ -2491,10 +2491,10 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// POST a role
 	response := rt.SendAdminRequest("POST", "/db/_role/", `{"name":"role1","admin_channels":["chan1"]}`)
@@ -2503,14 +2503,14 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "role1")
+	goassert.Equals(t, body["name"], "role1")
 
 	//Put document to trigger sync function
 	response = rt.Send(request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
 	assertStatus(t, response, 201)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 
 	// POST the new user the GET and verify that it shows the assigned role
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"letmein"}`)
@@ -2519,12 +2519,12 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assertStatus(t, response, 200)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["name"], "user1")
-	assert.DeepEquals(t, body["roles"], []interface{}{"role1"})
-	assert.DeepEquals(t, body["all_channels"], []interface{}{"!", "chan1"})
+	goassert.Equals(t, body["name"], "user1")
+	goassert.DeepEquals(t, body["roles"], []interface{}{"role1"})
+	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "chan1"})
 
-	//assert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
-	//assert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "fedoras", "fixies", "foo"})
+	//goassert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
+	//goassert.DeepEquals(t, body["all_channels"], []interface{}{"bar", "fedoras", "fixies", "foo"})
 }
 
 func TestRoleAccessChanges(t *testing.T) {
@@ -2536,10 +2536,10 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create users:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf("alpha"))
@@ -2556,7 +2556,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	fashionRevID := body["rev"].(string)
 
 	assertStatus(t, rt.Send(request("PUT", "/db/g1", `{"channel":"gamma"}`)), 201) // seq=2
@@ -2566,7 +2566,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	// Check user access:
 	alice, _ = a.GetUser("alice")
-	assert.DeepEquals(t,
+	goassert.DeepEquals(t,
 		alice.InheritedChannels(),
 		channels.TimedSet{
 			"!":     channels.NewVbSimpleSequence(0x1),
@@ -2574,7 +2574,7 @@ func TestRoleAccessChanges(t *testing.T) {
 			"gamma": channels.NewVbSimpleSequence(0x1),
 		},
 	)
-	assert.DeepEquals(t,
+	goassert.DeepEquals(t,
 		alice.RoleNames(),
 		channels.TimedSet{
 			"bogus":   channels.NewVbSimpleSequence(0x1),
@@ -2582,14 +2582,14 @@ func TestRoleAccessChanges(t *testing.T) {
 		},
 	)
 	zegpold, _ = a.GetUser("zegpold")
-	assert.DeepEquals(t,
+	goassert.DeepEquals(t,
 		zegpold.InheritedChannels(),
 		channels.TimedSet{
 			"!":    channels.NewVbSimpleSequence(0x1),
 			"beta": channels.NewVbSimpleSequence(0x1),
 		},
 	)
-	assert.DeepEquals(t, zegpold.RoleNames(), channels.TimedSet{})
+	goassert.DeepEquals(t, zegpold.RoleNames(), channels.TimedSet{})
 
 	// Check the _changes feed:
 	var changes struct {
@@ -2601,18 +2601,18 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("1st _changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, len(changes.Results), 2)
 	since := changes.Last_Seq
-	assert.Equals(t, since, fmt.Sprintf("%d", expectedSeq))
+	goassert.Equals(t, since, fmt.Sprintf("%d", expectedSeq))
 
 	expectedSeq = uint64(4)
 	rt.WaitForSequence(expectedSeq)
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("2nd _changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, len(changes.Results), 1)
 	since = changes.Last_Seq
-	assert.Equals(t, since, fmt.Sprintf("%d", expectedSeq))
+	goassert.Equals(t, since, fmt.Sprintf("%d", expectedSeq))
 
 	// Update "fashion" doc to grant zegpold the role "hipster" and take it away from alice:
 	str := fmt.Sprintf(`{"user":"zegpold", "role":"role:hipster", "_rev":%q}`, fashionRevID)
@@ -2620,7 +2620,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	// Check user access again:
 	alice, _ = a.GetUser("alice")
-	assert.DeepEquals(t,
+	goassert.DeepEquals(t,
 		alice.InheritedChannels(),
 		channels.TimedSet{
 			"!":     channels.NewVbSimpleSequence(0x1),
@@ -2628,7 +2628,7 @@ func TestRoleAccessChanges(t *testing.T) {
 		},
 	)
 	zegpold, _ = a.GetUser("zegpold")
-	assert.DeepEquals(t,
+	goassert.DeepEquals(t,
 		zegpold.InheritedChannels(),
 		channels.TimedSet{
 			"!":     channels.NewVbSimpleSequence(0x1),
@@ -2644,11 +2644,11 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("3rd _changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, len(changes.Results), 2)
 	log.Printf("changes: %+v", changes.Results)
-	assert.Equals(t, changes.Last_Seq, "6:2") // Test sporadically failing here.  See https://github.com/couchbase/sync_gateway/issues/3095
-	assert.Equals(t, changes.Results[0].ID, "b1")
-	assert.Equals(t, changes.Results[1].ID, "g1")
+	goassert.Equals(t, changes.Last_Seq, "6:2") // Test sporadically failing here.  See https://github.com/couchbase/sync_gateway/issues/3095
+	goassert.Equals(t, changes.Results[0].ID, "b1")
+	goassert.Equals(t, changes.Results[1].ID, "g1")
 
 	// Changes feed with since=4 would ordinarily be empty, but zegpold got access to channel
 	// gamma after sequence 4, so the pre-existing docs in that channel are included:
@@ -2656,8 +2656,8 @@ func TestRoleAccessChanges(t *testing.T) {
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, len(changes.Results), 1)
-	assert.Equals(t, changes.Results[0].ID, "g1")
+	goassert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, changes.Results[0].ID, "g1")
 }
 
 func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
@@ -2684,17 +2684,17 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create a doc
 	response := rt.Send(request("PUT", "/db/doc1", `{"foo":"bar", "channels":["ch1"]}`))
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	doc1RevID := body["rev"].(string)
 
 	// Run GET _all_docs as admin with channels=true:
@@ -2703,10 +2703,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
 
 	// Run POST _all_docs as admin with explicit docIDs and channels=true:
 	keys := `{"keys": ["doc1"]}`
@@ -2715,10 +2715,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
 
 	//Commit rev 2 that maps to a differenet channel
 	str := fmt.Sprintf(`{"foo":"bar", "channels":["ch2"], "_rev":%q}`, doc1RevID)
@@ -2731,10 +2731,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
 
 	// Run POST _all_docs as admin with explicit docIDs and channels=true
 	// Make sure that only the new channel appears in the docs channel list
@@ -2744,10 +2744,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 1)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
 }
 
 //Test for regression of issue #447
@@ -2769,12 +2769,12 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
 		t.Fatalf("No revid in response for PUT attachment")
 	}
-	assert.True(t, revIdAfterAttachment != doc1revId)
+	goassert.True(t, revIdAfterAttachment != doc1revId)
 
 	reqHeaders = map[string]string{
 		"Accept": "application/json",
@@ -2782,24 +2782,24 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 
 	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId)
 	response = rt.SendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId), "", reqHeaders)
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	//validate attachment has data property
 	json.Unmarshal(response.Body.Bytes(), &body)
 	log.Printf("response body revid1 = %s", body)
 	attachments := body["_attachments"].(map[string]interface{})
 	attach1 := attachments["attach1"].(map[string]interface{})
 	data := attach1["data"]
-	assert.True(t, data != nil)
+	goassert.True(t, data != nil)
 
 	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment)
 	response = rt.SendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment), "", reqHeaders)
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	log.Printf("response body revid1 = %s", body)
 	attachments = body["_attachments"].(map[string]interface{})
 	attach1 = attachments["attach1"].(map[string]interface{})
 	data = attach1["data"]
-	assert.True(t, data == nil)
+	goassert.True(t, data == nil)
 
 }
 
@@ -2822,10 +2822,10 @@ func TestOldDocHandling(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	// Create user:
 	frank, err := a.NewUser("charles", "1234", nil)
@@ -2836,7 +2836,7 @@ func TestOldDocHandling(t *testing.T) {
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	alphaRevID := body["rev"].(string)
 
 	// Update a document to validate oldDoc id handling.  Will reject if old doc id not available
@@ -2875,10 +2875,10 @@ func TestStarAccess(t *testing.T) {
 		Results []db.ChangeEntry
 	}
 	guest, err := a.GetUser("")
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":["books"]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["gifts"]}`), 201)
@@ -2890,7 +2890,7 @@ func TestStarAccess(t *testing.T) {
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
-	assert.Equals(t, err, nil)
+	goassert.Equals(t, err, nil)
 	//
 	// Part 1 - Tests for user with single channel access:
 	//
@@ -2916,12 +2916,12 @@ func TestStarAccess(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 3)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"books"})
-	assert.Equals(t, allDocsResult.Rows[1].ID, "doc3")
-	assert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"!"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 3)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"books"})
+	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc3")
+	goassert.DeepEquals(t, allDocsResult.Rows[1].Value.Channels, []string{"!"})
 
 	// Ensure docs have been processed before issuing changes requests
 	expectedSeq := uint64(6)
@@ -2931,38 +2931,38 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 3)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 3)
 	since := changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc1")
-	assert.Equals(t, since.Seq, uint64(1))
+	goassert.Equals(t, changes.Results[0].ID, "doc1")
+	goassert.Equals(t, since.Seq, uint64(1))
 
 	// GET /db/_changes for single channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=books", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 1)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 1)
 	since = changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc1")
-	assert.Equals(t, since.Seq, uint64(1))
+	goassert.Equals(t, changes.Results[0].ID, "doc1")
+	goassert.Equals(t, since.Seq, uint64(1))
 
 	// GET /db/_changes for ! channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc3")
-	assert.Equals(t, since.Seq, uint64(3))
+	goassert.Equals(t, changes.Results[0].ID, "doc3")
+	goassert.Equals(t, since.Seq, uint64(3))
 
 	// GET /db/_changes for unauthorized channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=gifts", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 0)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 0)
 
 	//
 	// Part 2 - Tests for user with * channel access
@@ -2987,30 +2987,30 @@ func TestStarAccess(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 6)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
-	assert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"books"})
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 6)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
+	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"books"})
 
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 6)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 6)
 	since = changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc1")
-	assert.Equals(t, since.Seq, uint64(1))
+	goassert.Equals(t, changes.Results[0].ID, "doc1")
+	goassert.Equals(t, since.Seq, uint64(1))
 
 	// GET /db/_changes for ! channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc3")
-	assert.Equals(t, since.Seq, uint64(3))
+	goassert.Equals(t, changes.Results[0].ID, "doc3")
+	goassert.Equals(t, since.Seq, uint64(3))
 
 	//
 	// Part 3 - Tests for user with no user channel access
@@ -3033,29 +3033,29 @@ func TestStarAccess(t *testing.T) {
 	assertStatus(t, response, 200)
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(allDocsResult.Rows), 2)
-	assert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(allDocsResult.Rows), 2)
+	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc3")
-	assert.Equals(t, since.Seq, uint64(3))
+	goassert.Equals(t, changes.Results[0].ID, "doc3")
+	goassert.Equals(t, since.Seq, uint64(3))
 
 	// GET /db/_changes for ! channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	assert.Equals(t, err, nil)
-	assert.Equals(t, len(changes.Results), 2)
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
-	assert.Equals(t, changes.Results[0].ID, "doc3")
-	assert.Equals(t, since.Seq, uint64(3))
+	goassert.Equals(t, changes.Results[0].ID, "doc3")
+	goassert.Equals(t, since.Seq, uint64(3))
 }
 
 // Test for issue #562
@@ -3086,7 +3086,7 @@ func TestBasicAuthWithSessionCookie(t *testing.T) {
 	// Create a session for the first user
 	response = rt.Send(requestByUser("POST", "/db/_session", `{"name":"bernard", "password":"letmein"}`, "bernard"))
 	log.Println("response.Header()", response.Header())
-	assert.True(t, response.Header().Get("Set-Cookie") != "")
+	goassert.True(t, response.Header().Get("Set-Cookie") != "")
 
 	cookie := response.Header().Get("Set-Cookie")
 
@@ -3142,10 +3142,10 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 
 	var dbConfig DbConfig
 	err := json.Unmarshal([]byte(configJSON), &dbConfig)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&dbConfig)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	sc.Close()
 
@@ -3177,11 +3177,11 @@ func TestEventConfigValidationInvalid(t *testing.T) {
 
 	var dbConfig DbConfig
 	err := json.Unmarshal([]byte(configJSON), &dbConfig)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&dbConfig)
-	assert.True(t, err != nil)
-	assert.True(t, strings.Contains(err.Error(), "document_scribbled_on"))
+	goassert.True(t, err != nil)
+	goassert.True(t, strings.Contains(err.Error(), "document_scribbled_on"))
 
 }
 
@@ -3369,7 +3369,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	// Parse multipart/mixed docs and create reader
 	contentType, attrs, _ := mime.ParseMediaType(bulkGetResponse.Header().Get("Content-Type"))
 	log.Printf("content-type: %v.  attrs: %v", contentType, attrs)
-	assert.Equals(t, contentType, "multipart/mixed")
+	goassert.Equals(t, contentType, "multipart/mixed")
 	reader := multipart.NewReader(bulkGetResponse.Body, attrs["boundary"])
 
 	// Make sure we see both docs
@@ -3427,7 +3427,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 			// expect an error
 			_, hasErr := partJson["error"]
 			assertTrue(t, hasErr, "Expected error field for this doc")
-			assert.Equals(t, docIdDoc1, rawId)
+			goassert.Equals(t, docIdDoc1, rawId)
 			sawDoc1 = true
 
 		}
@@ -3437,7 +3437,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 		if ok {
 			_, hasErr := partJson["error"]
 			assertTrue(t, !hasErr, "Did not expect error field for this doc")
-			assert.Equals(t, docIdDoc2, rawId)
+			goassert.Equals(t, docIdDoc2, rawId)
 			sawDoc2 = true
 		}
 
@@ -3463,7 +3463,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	_, ok := body["_exp"]
-	assert.Equals(t, ok, false)
+	goassert.Equals(t, ok, false)
 
 	bulkGetDocs := `{"docs": [{"id": "expNumericTTL", "rev": "1-ca9ad22802b66f662ff171f226211d5c"}]}`
 	response = rt.SendRequest("POST", "/db/_bulk_get", bulkGetDocs)
@@ -3481,7 +3481,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
-	assert.Equals(t, ok, true)
+	goassert.Equals(t, ok, true)
 
 	// Validate other exp formats
 	body = nil
@@ -3492,7 +3492,7 @@ func TestDocExpiry(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	log.Printf("numeric unix response: %s", response.Body.Bytes())
 	_, ok = body["_exp"]
-	assert.Equals(t, ok, true)
+	goassert.Equals(t, ok, true)
 
 	body = nil
 	response = rt.SendRequest("PUT", "/db/expNumericString", `{"val":1, "_exp":"100"}`)
@@ -3501,7 +3501,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
-	assert.Equals(t, ok, true)
+	goassert.Equals(t, ok, true)
 
 	body = nil
 	response = rt.SendRequest("PUT", "/db/expBadString", `{"_exp":"abc"}`)
@@ -3510,7 +3510,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 404)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
-	assert.Equals(t, ok, false)
+	goassert.Equals(t, ok, false)
 
 	body = nil
 	response = rt.SendRequest("PUT", "/db/expDateString", `{"_exp":"2105-01-01T00:00:00.000+00:00"}`)
@@ -3519,7 +3519,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
-	assert.Equals(t, ok, true)
+	goassert.Equals(t, ok, true)
 
 	body = nil
 	response = rt.SendRequest("PUT", "/db/expBadDateString", `{"_exp":"2105-0321-01T00:00:00.000+00:00"}`)
@@ -3528,7 +3528,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 404)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
-	assert.Equals(t, ok, false)
+	goassert.Equals(t, ok, false)
 
 }
 
@@ -3545,7 +3545,7 @@ func TestDocSyncFunctionExpiry(t *testing.T) {
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	value, ok := body["_exp"]
-	assert.Equals(t, ok, true)
+	goassert.Equals(t, ok, true)
 	log.Printf("value: %v", value)
 }
 
@@ -3606,7 +3606,7 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	var retrievedXattr map[string]interface{}
 	_, err = gocbBucket.GetWithXattr("-21SK00U-ujxUO9fU2HezxL", "_sync", &retrievedVal, &retrievedXattr)
 	assertNoError(t, err, "Unexpected Error")
-	assert.True(t, retrievedXattr["rev"].(string) == "2-466a1fab90a810dc0a63565b70680e4e")
+	goassert.True(t, retrievedXattr["rev"].(string) == "2-466a1fab90a810dc0a63565b70680e4e")
 
 }
 
@@ -3630,7 +3630,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 
 	// Create user:
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("PBS"))
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	a.Save(bernard)
 
 	// Issue is only reproducible when the wait counter is zero for all requested channels (including the user channel) - the count=0
@@ -3638,7 +3638,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// otherwise the count for the user pseudo-channel will always be non-zero
 	db, _ := rt.ServerContext().GetDatabase("db")
 	err = db.RestartListener()
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	// Put a document to increment the counter for the * channel
 	response := rt.Send(request("PUT", "/db/lost", `{"channel":["ABC"]}`))
 	assertStatus(t, response, 201)
@@ -3657,7 +3657,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
 		// Checkthat the changes loop isn't returning an empty result immediately (the previous bug) - should
 		// be waiting until entry 'sherlock', created below, appears.
-		assert.True(t, len(changes.Results) > 0)
+		goassert.True(t, len(changes.Results) > 0)
 	}()
 
 	// Send a doc that will properly close the longpoll response
@@ -3682,7 +3682,7 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	var testProviderOnlyConfig DbConfig
 	err := json.Unmarshal([]byte(testProviderOnlyJSON), &testProviderOnlyConfig)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&testProviderOnlyConfig)
 	assertNoError(t, err, "Error adding testProviderOnly database.")
@@ -3699,7 +3699,7 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	var viewsOnlyConfig DbConfig
 	err = json.Unmarshal([]byte(viewsOnlyJSON), &viewsOnlyConfig)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&viewsOnlyConfig)
 	assertNoError(t, err, "Error adding viewsOnlyConfig database.")
@@ -3720,7 +3720,7 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	var viewsAndTestConfig DbConfig
 	err = json.Unmarshal([]byte(viewsAndTestJSON), &viewsAndTestConfig)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&viewsAndTestConfig)
 	assertNoError(t, err, "Error adding viewsAndTestConfig database.")

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestChangesAccessNotifyInteger(t *testing.T) {
@@ -41,7 +41,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	// Create user:
 	a := it.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("ABC"))
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	a.Save(bernard)
 
 	// Put several documents in channel PBS
@@ -64,7 +64,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 		changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.Equals(t, len(changes.Results), 3)
+		goassert.Equals(t, len(changes.Results), 3)
 	}()
 
 	// Wait for changes to start.
@@ -104,7 +104,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	/*
 		a := it.ServerContext().Database("db").Authenticator()
 		bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("ABC"))
-		assert.True(t, err == nil)
+		goassert.True(t, err == nil)
 		a.Save(bernard)
 	*/
 
@@ -133,7 +133,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &initialChanges)
 	assertNoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
-	assert.Equals(t, lastSeq, "1")
+	goassert.Equals(t, lastSeq, "1")
 
 	// Start longpoll changes request, requesting (unavailable) channel PBS.  Should block.
 	var wg sync.WaitGroup
@@ -147,7 +147,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		sinceLastJSON := fmt.Sprintf(changesJSON, lastSeq)
 		changesResponse := it.Send(requestByUser("POST", "/db/_changes", sinceLastJSON, "bernard"))
 		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
-		assert.Equals(t, len(changes.Results), 1)
+		goassert.Equals(t, len(changes.Results), 1)
 	}()
 
 	// Wait to see if the longpoll will terminate before a document shows up on the channel

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChangesAccessNotifyInteger(t *testing.T) {
@@ -131,7 +132,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &initialChanges)
-	assertNoError(t, err, "Unexpected error unmarshalling initialChanges")
+	assert.NoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
 	goassert.Equals(t, lastSeq, "1")
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // This test performs the following steps against the Sync Gateway passive blip replicator:
@@ -34,7 +35,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Verify Sync Gateway will accept the doc revision that is about to be sent
@@ -47,9 +48,9 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	changesResponse := changesRequest.Response()
 	goassert.Equals(t, changesResponse.SerialNumber(), changesRequest.SerialNumber())
 	body, err := changesResponse.Body()
-	assertNoError(t, err, "Error reading changes response body")
+	assert.NoError(t, err, "Error reading changes response body")
 	err = json.Unmarshal(body, &changeList)
-	assertNoError(t, err, "Error unmarshalling response body")
+	assert.NoError(t, err, "Error unmarshalling response body")
 	goassert.Equals(t, len(changeList), 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow := changeList[0]
 	goassert.Equals(t, len(changeRow), 0) // Should be empty, meaning the server is saying it doesn't have the revision yet
@@ -64,7 +65,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	goassert.Equals(t, err, nil)
 
 	_, err = revResponse.Body()
-	assertNoError(t, err, "Error unmarshalling response body")
+	assert.NoError(t, err, "Error unmarshalling response body")
 
 	// Call changes with a hypothetical new revision, assert that it returns last pushed revision
 	var changeList2 [][]interface{}
@@ -76,9 +77,9 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	changesResponse2 := changesRequest2.Response()
 	goassert.Equals(t, changesResponse2.SerialNumber(), changesRequest2.SerialNumber())
 	body2, err := changesResponse2.Body()
-	assertNoError(t, err, "Error reading changes response body")
+	assert.NoError(t, err, "Error reading changes response body")
 	err = json.Unmarshal(body2, &changeList2)
-	assertNoError(t, err, "Error unmarshalling response body")
+	assert.NoError(t, err, "Error unmarshalling response body")
 	goassert.Equals(t, len(changeList2), 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow2 := changeList2[0]
 	goassert.Equals(t, len(changeRow2), 1) // Should have 1 item in row, which is the rev id of the previous revision pushed
@@ -99,7 +100,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
 			err = json.Unmarshal(body, &changeListReceived)
-			assertNoError(t, err, "Error unmarshalling changes received")
+			assert.NoError(t, err, "Error unmarshalling changes received")
 			goassert.Equals(t, len(changeListReceived), 1)
 			change := changeListReceived[0] // [1,"foo","1-abc"]
 			goassert.Equals(t, len(change), 3)
@@ -114,7 +115,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
 			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
-			assertNoError(t, err, "Error marshalling response")
+			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
 
@@ -138,7 +139,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
 	// Wait until we got the expected callback on the "changes" profile handler
 	timeoutErr := WaitWithTimeout(&receivedChangesRequestWg, time.Second*5)
-	assertNoError(t, timeoutErr, "Timed out waiting")
+	assert.NoError(t, timeoutErr, "Timed out waiting")
 }
 
 // Start subChanges w/ continuous=true, batchsize=20
@@ -149,7 +150,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Counter/Waitgroup to help ensure that all callbacks on continuous changes handler are received
@@ -169,7 +170,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
 			err = json.Unmarshal(body, &changeListReceived)
-			assertNoError(t, err, "Error unmarshalling changes received")
+			assert.NoError(t, err, "Error unmarshalling changes received")
 
 			for _, change := range changeListReceived {
 
@@ -201,7 +202,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
 			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
-			assertNoError(t, err, "Error marshalling response")
+			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
 
@@ -235,14 +236,14 @@ func TestContinuousChangesSubscription(t *testing.T) {
 		goassert.Equals(t, err, nil)
 
 		_, err = revResponse.Body()
-		assertNoError(t, err, "Error unmarshalling response body")
+		assert.NoError(t, err, "Error unmarshalling response body")
 
 	}
 
 	// Wait until all expected changes are received by change handler
 	// receivedChangesWg.Wait()
 	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*5)
-	assertNoError(t, timeoutErr, "Timed out waiting for all changes.")
+	assert.NoError(t, timeoutErr, "Timed out waiting for all changes.")
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
@@ -262,7 +263,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Counter/Waitgroup to help ensure that all callbacks on continuous changes handler are received
@@ -289,7 +290,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
 			err = json.Unmarshal(body, &changeListReceived)
-			assertNoError(t, err, "Error unmarshalling changes received")
+			assert.NoError(t, err, "Error unmarshalling changes received")
 
 			for _, change := range changeListReceived {
 
@@ -321,7 +322,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
 			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
-			assertNoError(t, err, "Error marshalling response")
+			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
 
@@ -341,7 +342,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 		)
 		goassert.Equals(t, err, nil)
 		_, err = revResponse.Body()
-		assertNoError(t, err, "Error unmarshalling response body")
+		assert.NoError(t, err, "Error unmarshalling response body")
 		receivedChangesWg.Add(1)
 	}
 
@@ -363,7 +364,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 	// Wait until all expected changes are received by change handler
 	// receivedChangesWg.Wait()
 	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*60)
-	assertNoError(t, timeoutErr, "Timed out waiting for all changes.")
+	assert.NoError(t, timeoutErr, "Timed out waiting for all changes.")
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
@@ -391,7 +392,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 		)
 		goassert.Equals(t, err, nil)
 		_, err = revResponse.Body()
-		assertNoError(t, err, "Error unmarshalling response body")
+		assert.NoError(t, err, "Error unmarshalling response body")
 		receivedChangesWg.Add(1)
 	}
 
@@ -408,7 +409,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	// Counter/Waitgroup to help ensure that all callbacks on continuous changes handler are received
@@ -443,7 +444,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
 			err = json.Unmarshal(body, &changeListReceived)
-			assertNoError(t, err, "Error unmarshalling changes received")
+			assert.NoError(t, err, "Error unmarshalling changes received")
 
 			for _, change := range changeListReceived {
 
@@ -485,7 +486,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
 			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
-			assertNoError(t, err, "Error marshalling response")
+			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
 
@@ -505,7 +506,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 		)
 		goassert.Equals(t, err, nil)
 		_, err = revResponse.Body()
-		assertNoError(t, err, "Error unmarshalling response body")
+		assert.NoError(t, err, "Error unmarshalling response body")
 	}
 	receivedChangesWg.Add(len(docIDsExpected))
 
@@ -525,7 +526,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 
 	body := subChangesBody{DocIDs: docIDsExpected}
 	bodyBytes, err := json.Marshal(body)
-	assertNoError(t, err, "Error marshalling subChanges body.")
+	assert.NoError(t, err, "Error marshalling subChanges body.")
 
 	subChangesRequest.SetBody(bodyBytes)
 
@@ -537,7 +538,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	// Wait until all expected changes are received by change handler
 	// receivedChangesWg.Wait()
 	timeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*15)
-	assertNoError(t, timeoutErr, "Timed out waiting for all changes.")
+	assert.NoError(t, timeoutErr, "Timed out waiting for all changes.")
 
 	// Since batch size was set to 10, and 15 docs were added, expect at _least_ 2 batches
 	numBatchesReceivedSnapshot := atomic.LoadInt32(&numbatchesReceived)
@@ -567,7 +568,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
 	})
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	proposeChangesRequest := blip.NewRequest()
@@ -586,11 +587,11 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 	goassert.True(t, sent)
 	proposeChangesResponse := proposeChangesRequest.Response()
 	body, err := proposeChangesResponse.Body()
-	assertNoError(t, err, "Error getting changes response body")
+	assert.NoError(t, err, "Error getting changes response body")
 
 	var changeList [][]interface{}
 	err = json.Unmarshal(body, &changeList)
-	assertNoError(t, err, "Error getting changes response body")
+	assert.NoError(t, err, "Error getting changes response body")
 
 	// The common case of an empty array response tells the sender to send all of the proposed revisions,
 	// so the changeList returned by Sync Gateway is expected to be empty
@@ -609,7 +610,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer btUser1.Close()
 
 	// Send the user1 doc
@@ -628,7 +629,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 		connectingUserChannelGrants: []string{"*"},      // user2 has access to all channels
 		restTester:                  btUser1.restTester, // re-use rest tester, otherwise it will create a new underlying bucket in walrus case
 	})
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer btUser2.Close()
 
 	// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access
@@ -672,7 +673,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 		restTester:         &rt,
 	}
 	bt, err := NewBlipTesterFromSpec(btSpec)
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Send non-deleted rev
@@ -685,7 +686,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	response := bt.restTester.SendAdminRequest("GET", "/db/sendAndGetRev?rev=1-abc", "")
 	assertStatus(t, response, 200)
 	var responseBody RestDocument
-	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
+	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
 	_, ok := responseBody[db.BodyDeleted]
 	goassert.False(t, ok)
 
@@ -700,7 +701,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	response = bt.restTester.SendAdminRequest("GET", "/db/sendAndGetRev?rev=2-bcd", "")
 	assertStatus(t, response, 200)
 	responseBody = RestDocument{}
-	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
+	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
 	deletedValue, deletedOK := responseBody[db.BodyDeleted].(bool)
 	goassert.True(t, deletedOK)
 	goassert.True(t, deletedValue)
@@ -722,7 +723,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 		restTester:         &rt,
 	}
 	bt, err := NewBlipTesterFromSpec(btSpec)
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Send non-deleted rev
@@ -778,7 +779,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 		restTester:         &rt,
 	}
 	bt, err := NewBlipTesterFromSpec(btSpec)
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Create new checkpoint
@@ -843,7 +844,7 @@ func TestReloadUser(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         &rt,
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Put document that triggers access grant for user to channel PBS
@@ -861,7 +862,7 @@ func TestReloadUser(t *testing.T) {
 
 	// Make assertions on response to make sure the change was accepted
 	addRevResponseBody, err := addRevResponse.Body()
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	errorCode, hasErrorCode := addRevResponse.Properties["Error-Code"]
 	goassert.False(t, hasErrorCode)
 	if hasErrorCode {
@@ -886,7 +887,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         &rt,
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Add a doc in the PBS channel
@@ -928,7 +929,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Add a doc in the PBS channel
@@ -967,7 +968,7 @@ func TestCheckpoint(t *testing.T) {
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	client := "testClient"
@@ -1002,7 +1003,7 @@ func TestCheckpoint(t *testing.T) {
 	}
 	checkpointResponse = requestSetCheckpoint.Response()
 	body, err := checkpointResponse.Body()
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	log.Printf("responseSetCheckpoint body: %s", body)
 
 	// Get the checkpoint and make sure it has the expected value
@@ -1016,7 +1017,7 @@ func TestCheckpoint(t *testing.T) {
 	}
 	checkpointResponse = requestGetCheckpoint2.Response()
 	body, err = checkpointResponse.Body()
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	log.Printf("body: %s", body)
 	goassert.True(t, strings.Contains(string(body), "Key"))
 	goassert.True(t, strings.Contains(string(body), "Value"))
@@ -1037,7 +1038,7 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	input := SendRevWithAttachmentInput{
@@ -1080,7 +1081,7 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // All channels
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	attachmentBody := "attach"
@@ -1143,7 +1144,7 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         &rt,
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Add a doc that will be rejected by sync function, since user
@@ -1182,7 +1183,7 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // All channels
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Add a doc that will be rejected by sync function, since user
@@ -1217,7 +1218,7 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val"}`), blip.Properties{})
@@ -1245,7 +1246,7 @@ func TestPutRevConflictsMode(t *testing.T) {
 	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: false,
 	})
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val"}`), blip.Properties{})
@@ -1292,7 +1293,7 @@ func TestGetRemovedDoc(t *testing.T) {
 		restTester:         &rt,
 	}
 	bt, err := NewBlipTesterFromSpec(btSpec)
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Add rev-1 in channel user1
@@ -1310,7 +1311,7 @@ func TestGetRemovedDoc(t *testing.T) {
 
 	// Try to get rev 2 via BLIP API and assert that _removed == false
 	resultDoc, err := bt.GetDocAtRev("foo", "2-bcd")
-	assertNoError(t, err, "Unexpected Error")
+	assert.NoError(t, err, "Unexpected Error")
 	goassert.False(t, resultDoc.IsRemoved())
 
 	// Add rev-3, remove from channel user1 and put into channel another_channel
@@ -1333,7 +1334,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	// Delete any temp revisions in case this prevents the bug from showing up (didn't make a difference)
 	tempRevisionDocId := "_sync:rev:foo:5:3-cde"
 	err = rt.GetDatabase().Bucket.Delete(tempRevisionDocId)
-	assertNoError(t, err, "Unexpected Error")
+	assert.NoError(t, err, "Unexpected Error")
 
 	// Workaround data race (https://gist.github.com/tleyden/0ace70b8a38b76a7beee95529610b6cf) that happens because
 	// there are multiple goroutines accessing the bt.blipContext.HandlerForProfile map.
@@ -1346,11 +1347,11 @@ func TestGetRemovedDoc(t *testing.T) {
 		restTester:                  &rt,
 	}
 	bt2, err := NewBlipTesterFromSpec(btSpec2)
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 
 	// Try to get rev 3 via BLIP API and assert that _removed == true
 	resultDoc, err = bt2.GetDocAtRev("foo", "3-cde")
-	assertNoError(t, err, "Unexpected Error")
+	assert.NoError(t, err, "Unexpected Error")
 	goassert.True(t, resultDoc.IsRemoved())
 
 	// Try to get rev 3 via REST API, and assert that _removed == true
@@ -1371,7 +1372,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	bt, err := NewBlipTester()
-	assertNoError(t, err, "Error creating BlipTester")
+	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
 	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
@@ -1380,7 +1381,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
 			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
-			assertNoError(t, err, "Error marshalling response")
+			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
 	}
@@ -1443,7 +1444,7 @@ func TestMissingNoRev(t *testing.T) {
 		restTester: &rt,
 	}
 	bt, err := NewBlipTesterFromSpec(btSpec)
-	assertNoError(t, err, "Unexpected error creating BlipTester")
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
 	// Create 5 docs
@@ -1457,14 +1458,14 @@ func TestMissingNoRev(t *testing.T) {
 
 	// Get a reference to the database
 	targetDbContext, err := rt.ServerContext().GetDatabase("db")
-	assertNoError(t, err, "failed")
+	assert.NoError(t, err, "failed")
 	targetDb, err := db.GetDatabase(targetDbContext, nil)
-	assertNoError(t, err, "failed")
+	assert.NoError(t, err, "failed")
 
 	// Purge one doc
 	doc0Id := fmt.Sprintf("doc-%d", 0)
 	err = targetDb.Purge(doc0Id)
-	assertNoError(t, err, "failed")
+	assert.NoError(t, err, "failed")
 
 	// Flush rev cache
 	targetDb.FlushRevisionCache()

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestAddRevision(t *testing.T) {
@@ -53,7 +53,7 @@ func TestAddRevision(t *testing.T) {
 		revMessage := &revMessage{
 			Message: &blipMessage,
 		}
-		assert.Equals(t, revMessage.deleted(), testCase.expectedDeletedVal)
+		goassert.Equals(t, revMessage.deleted(), testCase.expectedDeletedVal)
 	}
 
 }
@@ -78,10 +78,10 @@ func TestSubChangesSince(t *testing.T) {
 		zeroSinceVal,
 		testDb.ParseSequenceID,
 	)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 	seqId := subChangesParams.since()
-	assert.True(t, seqId.SeqType == db.IntSequenceType)
-	assert.True(t, seqId.Seq == 1)
+	goassert.True(t, seqId.SeqType == db.IntSequenceType)
+	goassert.True(t, seqId.Seq == 1)
 
 }

--- a/rest/debug_test.go
+++ b/rest/debug_test.go
@@ -3,7 +3,7 @@ package rest
 import (
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestMaxSnapshotsRingBuffer(t *testing.T) {
@@ -11,6 +11,6 @@ func TestMaxSnapshotsRingBuffer(t *testing.T) {
 	for i := 0; i < kMaxGoroutineSnapshots*2; i++ {
 		grTracker.recordSnapshot()
 	}
-	assert.True(t, len(grTracker.Snapshots) <= kMaxGoroutineSnapshots)
+	goassert.True(t, len(grTracker.Snapshots) <= kMaxGoroutineSnapshots)
 
 }

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestGetRestrictedIntQuery(t *testing.T) {
@@ -24,7 +24,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		false,
 	)
-	assert.Equals(t, restricted, defaultValue)
+	goassert.Equals(t, restricted, defaultValue)
 
 	// make sure it returns default value when passed Values that doesn't contain key
 	values.Set("bar", "99")
@@ -36,7 +36,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		false,
 	)
-	assert.Equals(t, restricted, defaultValue)
+	goassert.Equals(t, restricted, defaultValue)
 
 	// make sure it returns appropriate value from Values
 	values.Set("foo", "99")
@@ -48,7 +48,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		false,
 	)
-	assert.Equals(t, restricted, uint64(99))
+	goassert.Equals(t, restricted, uint64(99))
 
 	// make sure it is limited to max when value value is over max
 	values.Set("foo", "200")
@@ -60,7 +60,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		false,
 	)
-	assert.Equals(t, restricted, maxValue)
+	goassert.Equals(t, restricted, maxValue)
 
 	// make sure it is limited to min when value value is under min
 	values.Set("foo", "1")
@@ -72,7 +72,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		false,
 	)
-	assert.Equals(t, restricted, minValue)
+	goassert.Equals(t, restricted, minValue)
 
 	// Return zero when allowZero=true
 	values.Set("foo", "0")
@@ -84,7 +84,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		true,
 	)
-	assert.Equals(t, restricted, uint64(0))
+	goassert.Equals(t, restricted, uint64(0))
 
 	// Return minValue when allowZero=false
 	values.Set("foo", "0")
@@ -96,7 +96,7 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		maxValue,
 		false,
 	)
-	assert.Equals(t, restricted, minValue)
+	goassert.Equals(t, restricted, minValue)
 }
 
 func TestParseHTTPRangeHeader(t *testing.T) {
@@ -154,10 +154,10 @@ func TestParseHTTPRangeHeader(t *testing.T) {
 	for _, expected := range testcases {
 		status, start, end := parseHTTPRangeHeader(expected.header, expected.contentLength)
 		t.Logf("*** Range: %s  --> %d %d-%d", expected.header, status, start, end)
-		assert.Equals(t, status, expected.status)
+		goassert.Equals(t, status, expected.status)
 		if status == http.StatusPartialContent {
-			assert.Equals(t, start, expected.start)
-			assert.Equals(t, end, expected.end)
+			goassert.Equals(t, start, expected.start)
+			goassert.Equals(t, end, expected.end)
 		}
 	}
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/couchbase/gocb"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func SkipImportTestsIfNotEnabled(t *testing.T) {
@@ -77,7 +77,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
 	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -96,7 +96,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawUpdateResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -109,7 +109,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	assertNoError(t, err, "Unable to delete doc TestImportDelete")
 
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawDeleteResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
 	log.Printf("Post-delete: %s", response.Body.Bytes())
@@ -139,19 +139,19 @@ func TestXattrSGTombstone(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"channels":"ABC"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
 	// 2. Delete the doc through SG
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
 	// 3. Attempt to retrieve the doc through the SDK
@@ -184,11 +184,11 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	docBody["SG_write_count"] = "1"
 
 	response := rt.SendAdminRequest("PUT", "/db/TestCasFailureImport", `{"test":"TestCasFailureImport", "write_type":"SG_1"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["rev"], "1-111c27be37c17f18ae8fe9faa3bb4e0e")
+	goassert.Equals(t, body["rev"], "1-111c27be37c17f18ae8fe9faa3bb4e0e")
 	revId := body["rev"].(string)
 
 	// Attempt a second SG write, to be interrupted by an SDK update.  Should return a conflict
@@ -196,7 +196,7 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", key, revId), `{"write_type":"SG_2"}`)
-		assert.Equals(t, response.Code, 409)
+		goassert.Equals(t, response.Code, 409)
 		log.Printf("SG CAS failure write response: %s", response.Body.Bytes())
 		wg.Done()
 	}()
@@ -216,12 +216,12 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 
 	// Get to see where we ended up
 	response = rt.SendAdminRequest("GET", "/db/TestCasFailureImport", "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	log.Printf("Final get: %s", response.Body.Bytes())
 
 	// Get raw to see where the rev tree ended up
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestCasFailureImport", "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	log.Printf("Final get raw: %s", response.Body.Bytes())
 
 }
@@ -246,27 +246,27 @@ func TestXattrResurrectViaSG(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"channels":"ABC"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
 	// 2. Delete the doc through SG
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
 	// 3. Recreate the doc through the SG (with different data)
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", key, revId), `{"channels":"ABC"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
-	assert.Equals(t, body["rev"], "3-70c113f08c6622cd87af68f4f60d12e3")
+	goassert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["rev"], "3-70c113f08c6622cd87af68f4f60d12e3")
 
 }
 
@@ -295,7 +295,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
 	rawPath := fmt.Sprintf("/db/_raw/%s", key)
 	response := rt.SendAdminRequest("GET", rawPath, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -305,7 +305,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	assertNoError(t, err, "Unable to delete doc TestResurrectViaSDK")
 
 	response = rt.SendAdminRequest("GET", rawPath, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawDeleteResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
 	log.Printf("Post-delete: %s", response.Body.Bytes())
@@ -321,7 +321,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 
 	// Attempt to get the document via Sync Gateway, to trigger import.
 	response = rt.SendAdminRequest("GET", rawPath, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawUpdateResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -350,11 +350,11 @@ func TestXattrDoubleDelete(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"channels":"ABC"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
 	// 2. Delete the doc through the SDK
@@ -367,10 +367,10 @@ func TestXattrDoubleDelete(t *testing.T) {
 	// 3. Delete the doc through SG.  Expect a conflict, as the import of the SDK delete will create a new
 	//    tombstone revision
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
-	assert.Equals(t, response.Code, 409)
+	goassert.Equals(t, response.Code, 409)
 	log.Printf("delete response: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
 }
@@ -394,11 +394,11 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"channels":"ABC"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
 	sdk_key := "SDK_delete"
@@ -407,10 +407,10 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	docBody["channels"] = "ABC"
 
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", sdk_key), `{"channels":"ABC"}`)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 
 	// 2. Delete SDK_delete through the SDK
 	log.Printf("...............Delete through SDK.....................................")
@@ -419,15 +419,15 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	// Trigger import via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", sdk_key), "")
-	assert.Equals(t, response.Code, 404) // expect 404 deleted
+	goassert.Equals(t, response.Code, 404) // expect 404 deleted
 
 	// 3.  Delete SG_delete through SG.
 	log.Printf("...............Delete through SG.......................................")
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &body)
-	assert.Equals(t, body["ok"], true)
+	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
 	log.Printf("TestXattrDeleteDCPMutation done")
@@ -439,7 +439,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)
 	}
-	assert.Equals(t, len(results), 2)
+	goassert.Equals(t, len(results), 2)
 	assertTrue(t, strings.HasPrefix(results[0].RevID, "2-") && strings.HasPrefix(results[1].RevID, "2-"), "Unexpected revisions in view results post-delete")
 }
 
@@ -476,18 +476,18 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand import.
 	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	assertDocProperty(t, response, "type", "mobile")
 
 	response = rt.SendAdminRequest("GET", "/db/"+nonMobileKey, "")
-	assert.Equals(t, response.Code, 404)
+	goassert.Equals(t, response.Code, 404)
 	assertDocProperty(t, response, "reason", "Not imported")
 
 	// PUT to existing document that hasn't been imported.
 	sgWriteBody := `{"type":"whatever I want - I'm writing through SG",
 	                 "channels": "ABC"}`
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", nonMobileKey), sgWriteBody)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	assertDocProperty(t, response, "id", "TestImportFilterInvalid")
 	assertDocProperty(t, response, "rev", "1-25c26cdf9d7771e07f00be1d13f7fb7c")
 }
@@ -515,7 +515,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 
 	// Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
 	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
@@ -538,11 +538,11 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 
 	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
-	assert.Equals(t, newRevId, revId)
+	goassert.Equals(t, newRevId, revId)
 }
 
 // Test scenario where another actor updates a different xattr on a document.  Sync Gateway
@@ -568,7 +568,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 
 	// Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
 	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
@@ -592,13 +592,13 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	// Attempt to update the document again via Sync Gateway.  Should not trigger import, PUT should be successful,
 	// rev should have generation 2.
 	putResponse := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", mobileKey, revId), `{"updated":true}`)
-	assert.Equals(t, putResponse.Code, 201)
+	goassert.Equals(t, putResponse.Code, 201)
 	json.Unmarshal(putResponse.Body.Bytes(), &body)
 	log.Printf("Put response details: %s", putResponse.Body.Bytes())
 	newRevId, ok := body["rev"].(string)
 	assertTrue(t, ok, "Unable to cast rev to string")
 	log.Printf("Retrieved via Sync Gateway PUT after non-mobile update, revId:%v", newRevId)
-	assert.Equals(t, newRevId, "2-04bb60e2d65acedb2a846daa0ce882ea")
+	goassert.Equals(t, newRevId, "2-04bb60e2d65acedb2a846daa0ce882ea")
 }
 
 // Test scenario where another actor updates a different xattr on a document.  Sync Gateway
@@ -627,7 +627,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 
 	// Attempt to get the document via Sync Gateway.  Guarantees initial import is complete
 	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
@@ -665,16 +665,16 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	}
 
 	// Expect one crcMatch, no mismatches
-	assert.True(t, crcMatchesAfter-crcMatchesBefore == 1)
-	assert.True(t, crcMismatchesAfter-crcMismatchesBefore == 0)
+	goassert.True(t, crcMatchesAfter-crcMatchesBefore == 1)
+	goassert.True(t, crcMismatchesAfter-crcMismatchesBefore == 0)
 
 	// Get the doc again, validate rev hasn't changed
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	json.Unmarshal(response.Body.Bytes(), &body)
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
-	assert.Equals(t, newRevId, revId)
+	goassert.Equals(t, newRevId, revId)
 
 }
 
@@ -702,7 +702,7 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 
 	// 2. Attempt to get the document via Sync Gateway.  Will trigger on-demand import.
 	response := rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 	responseString := string(response.Body.Bytes())
 	if !strings.Contains(responseString, `9223372036854775807`) {
@@ -777,15 +777,15 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
 	response := rt.SendAdminRequest("GET", "/db/"+key, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 
 	// Get raw to retrieve metadata, and validate bodies have been moved to xattr
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
-	assert.Equals(t, rawResponse.Code, 200)
+	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
 	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)
-	assert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 3)
-	assert.Equals(t, len(doc.Meta.RevTree.BodyMap), 0)
+	goassert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 3)
+	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 0)
 
 }
 
@@ -842,15 +842,15 @@ func TestMigrateTombstone(t *testing.T) {
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
 	response := rt.SendAdminRequest("GET", "/db/"+key, "")
-	assert.Equals(t, response.Code, 404)
+	goassert.Equals(t, response.Code, 404)
 
 	// Get raw to retrieve metadata, and validate bodies have been moved to xattr
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
-	assert.Equals(t, rawResponse.Code, 200)
+	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
 	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)
-	assert.Equals(t, doc.Meta.CurrentRev, "2-6b1e1af9190829c1ceab6f1c8fb9fa3f")
-	assert.Equals(t, doc.Meta.Sequence, uint64(5))
+	goassert.Equals(t, doc.Meta.CurrentRev, "2-6b1e1af9190829c1ceab6f1c8fb9fa3f")
+	goassert.Equals(t, doc.Meta.Sequence, uint64(5))
 
 }
 
@@ -909,15 +909,15 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
 	response := rt.SendAdminRequest("GET", "/db/"+key, "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 
 	// Get raw to retrieve metadata, and validate bodies have been moved to xattr
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
-	assert.Equals(t, rawResponse.Code, 200)
+	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
 	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)
-	assert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 1)
-	assert.Equals(t, len(doc.Meta.RevTree.BodyMap), 2)
+	goassert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 1)
+	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 2)
 }
 
 // Write a doc via SDK with an expiry value.  Verify that expiry is preserved when doc is imported via DCP feed
@@ -958,7 +958,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 
 	log.Printf("changes: %+v", changes)
 	changeEntry := changes.Results[0]
-	assert.True(t, changeEntry.ID == mobileKey || changeEntry.ID == mobileKeyNoExpiry)
+	goassert.True(t, changeEntry.ID == mobileKey || changeEntry.ID == mobileKeyNoExpiry)
 
 	// Double-check to make sure that it's been imported by checking the Sync Metadata in the xattr
 	assertXattrSyncMetaRevGeneration(t, bucket, mobileKey, 1)
@@ -968,12 +968,12 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	gocbBucket, _ := base.AsGoCBBucket(bucket)
 	expiry, err := gocbBucket.GetExpiry(mobileKey)
 	assertNoError(t, err, "Error calling GetExpiry()")
-	assert.True(t, expiry == uint32(expiryUnixEpoch))
+	goassert.True(t, expiry == uint32(expiryUnixEpoch))
 
 	// Negative test case -- make sure no expiry was erroneously added by the the import
 	expiry, err = gocbBucket.GetExpiry(mobileKeyNoExpiry)
 	assertNoError(t, err, "Error calling GetExpiry()")
-	assert.True(t, expiry == 0)
+	goassert.True(t, expiry == 0)
 
 }
 
@@ -1009,7 +1009,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 	assertNoError(t, err, "Error waiting for changes")
 	changeEntry := changes.Results[0]
-	assert.Equals(t, changeEntry.ID, key)
+	goassert.Equals(t, changeEntry.ID, key)
 	log.Printf("Saw doc on changes feed after %v", time.Since(now))
 
 	// Double-check to make sure that it's been imported by checking the Sync Metadata in the xattr
@@ -1018,10 +1018,10 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	// Now get the doc expiry and validate that it has been migrated into the doc metadata
 	gocbBucket, _ := base.AsGoCBBucket(bucket)
 	expiry, err := gocbBucket.GetExpiry(key)
-	assert.True(t, expiry > 0)
+	goassert.True(t, expiry > 0)
 	assertNoError(t, err, "Error calling getExpiry()")
 	log.Printf("expiry: %v", expiry)
-	assert.True(t, expiry == uint32(testExpiry.Unix()))
+	goassert.True(t, expiry == uint32(testExpiry.Unix()))
 
 }
 
@@ -1054,13 +1054,13 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 	}
 	testCases := []testcase{
 		{
-			onDemandCallback: triggerOnDemandViaGet,
-			name:             "triggerOnDemandViaGet",
+			onDemandCallback:      triggerOnDemandViaGet,
+			name:                  "triggerOnDemandViaGet",
 			expectedRevGeneration: 1,
 		},
 		{
-			onDemandCallback: triggerOnDemandViaWrite,
-			name:             "triggerOnDemandViaWrite",
+			onDemandCallback:      triggerOnDemandViaWrite,
+			name:                  "triggerOnDemandViaWrite",
 			expectedRevGeneration: 1,
 		},
 	}
@@ -1088,7 +1088,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			gocbBucket, _ := base.AsGoCBBucket(bucket)
 			expiry, err := gocbBucket.GetExpiry(key)
 			assertNoError(t, err, "Error calling GetExpiry()")
-			assert.True(t, expiry == uint32(expiryUnixEpoch))
+			goassert.True(t, expiry == uint32(expiryUnixEpoch))
 
 			testCase.onDemandCallback(key)
 
@@ -1097,7 +1097,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			changes, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 			assertNoError(t, err, "Error waiting for changes")
 			changeEntry := changes.Results[0]
-			assert.Equals(t, changeEntry.ID, key)
+			goassert.Equals(t, changeEntry.ID, key)
 
 			// Double-check to make sure that it's been imported by checking the Sync Metadata in the xattr
 			assertXattrSyncMetaRevGeneration(t, bucket, key, testCase.expectedRevGeneration)
@@ -1105,7 +1105,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			// Verify the expiry has not been changed from the original expiry value
 			expiry, err = gocbBucket.GetExpiry(key)
 			assertNoError(t, err, "Error calling GetExpiry()")
-			assert.True(t, expiry == uint32(expiryUnixEpoch))
+			goassert.True(t, expiry == uint32(expiryUnixEpoch))
 
 		})
 	}
@@ -1123,7 +1123,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 	triggerOnDemandViaGet := func(key string) {
 		// Attempt to get the documents via Sync Gateway.  Will trigger on-demand migrate.
 		response := rt.SendAdminRequest("GET", "/db/"+key, "")
-		assert.Equals(t, response.Code, 200)
+		goassert.Equals(t, response.Code, 200)
 	}
 	triggerOnDemandViaWrite := func(key string) {
 		bodyString := rawDocWithSyncMeta()
@@ -1137,13 +1137,13 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 	}
 	testCases := []testcase{
 		{
-			onDemandCallback: triggerOnDemandViaGet,
-			name:             "triggerOnDemandViaGet",
+			onDemandCallback:      triggerOnDemandViaGet,
+			name:                  "triggerOnDemandViaGet",
 			expectedRevGeneration: 1,
 		},
 		{
-			onDemandCallback: triggerOnDemandViaWrite,
-			name:             "triggerOnDemandViaWrite",
+			onDemandCallback:      triggerOnDemandViaWrite,
+			name:                  "triggerOnDemandViaWrite",
 			expectedRevGeneration: 2,
 		},
 	}
@@ -1177,9 +1177,9 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			gocbBucket, _ := base.AsGoCBBucket(bucket)
 			expiry, err := gocbBucket.GetExpiry(key)
 			assertNoError(t, err, "Error calling GetExpiry()")
-			assert.True(t, expiry > 0)
+			goassert.True(t, expiry > 0)
 			log.Printf("expiry: %v", expiry)
-			assert.True(t, expiry == uint32(syncMetaExpiry.Unix()))
+			goassert.True(t, expiry == uint32(syncMetaExpiry.Unix()))
 
 		})
 	}
@@ -1211,7 +1211,7 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 	sgWriteBody := `{"type":"whatever I want - I'm writing through SG",
 	                 "channels": "ABC"}`
 	response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", sgWriteKey), sgWriteBody)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	assertDocProperty(t, response, "rev", "1-25c26cdf9d7771e07f00be1d13f7fb7c")
 
 	// 2. Update via SDK, not matching import filter.  Will not be available via SG
@@ -1224,14 +1224,14 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 	// Attempt to get the documents via Sync Gateway.  Will trigger on-demand import.
 
 	response = rt.SendAdminRequest("GET", "/db/"+sgWriteKey, "")
-	assert.Equals(t, response.Code, 404)
+	goassert.Equals(t, response.Code, 404)
 	assertDocProperty(t, response, "reason", "Not imported")
 
 	// 3. Rewrite through SG - should treat as new insert
 	sgWriteBody = `{"type":"SG client rewrite",
 	                 "channels": "NBC"}`
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", sgWriteKey), sgWriteBody)
-	assert.Equals(t, response.Code, 201)
+	goassert.Equals(t, response.Code, 201)
 	// Validate rev is 1, new rev id
 	assertDocProperty(t, response, "rev", "1-b9cdd5d413b572476799930f065657a6")
 }
@@ -1256,7 +1256,7 @@ func TestImportBinaryDoc(t *testing.T) {
 
 	// 2. Ensure we can't retrieve the document via SG
 	response := rt.SendAdminRequest("GET", "/db/binaryDoc", "")
-	assert.True(t, response.Code != 200)
+	goassert.True(t, response.Code != 200)
 }
 
 // Test creation of backup revision on import
@@ -1286,7 +1286,7 @@ func TestImportRevisionCopy(t *testing.T) {
 
 	// 2. Trigger import via SG retrieval
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -1301,7 +1301,7 @@ func TestImportRevisionCopy(t *testing.T) {
 
 	// 4. Trigger import of update via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 
@@ -1311,7 +1311,7 @@ func TestImportRevisionCopy(t *testing.T) {
 
 	// 6. Attempt to retrieve previous revision body
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s?rev=%s", key, rev1id), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 }
 
 // Test creation of backup revision on import, when rev is no longer available in rev cache.
@@ -1341,7 +1341,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 
 	// 2. Trigger import via SG retrieval
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -1360,13 +1360,13 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 
 	// 5. Trigger import of update via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 
 	// 6. Attempt to retrieve previous revision body.  Should return missing, as rev wasn't in rev cache when import occurred.
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s?rev=%s", key, rev1id), "")
-	assert.Equals(t, response.Code, 404)
+	goassert.Equals(t, response.Code, 404)
 }
 
 // Verify config flag for import creation of backup revision on import
@@ -1394,7 +1394,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 
 	// 2. Trigger import via SG retrieval
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
@@ -1409,7 +1409,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 
 	// 4. Trigger import of update via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
-	assert.Equals(t, response.Code, 200)
+	goassert.Equals(t, response.Code, 200)
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assertNoError(t, err, "Unable to unmarshal raw response")
 
@@ -1419,7 +1419,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 
 	// 6. Attempt to retrieve previous revision body.  Should fail, as backup wasn't persisted
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s?rev=%s", key, rev1id), "")
-	assert.Equals(t, response.Code, 404)
+	goassert.Equals(t, response.Code, 404)
 }
 
 // Test DCP backfill stats
@@ -1483,7 +1483,7 @@ func assertDocProperty(t *testing.T, getDocResponse *TestResponse, propertyName 
 	assertNoError(t, err, "Error unmarshalling document response")
 	value, ok := responseBody[propertyName]
 	assertTrue(t, ok, fmt.Sprintf("Expected property %s not found in response %s", propertyName, getDocResponse.Body.Bytes()))
-	assert.Equals(t, value, expectedPropertyValue)
+	goassert.Equals(t, value, expectedPropertyValue)
 }
 
 func rawDocWithSyncMeta() string {
@@ -1520,8 +1520,8 @@ func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key stri
 	_, err := bucket.GetWithXattr(key, "_sync", nil, &xattr)
 	assertNoError(t, err, "Error Getting Xattr")
 	revision, ok := xattr["rev"]
-	assert.True(t, ok)
+	goassert.True(t, ok)
 	generation, _ := db.ParseRevID(revision.(string))
 	log.Printf("assertXattrSyncMetaRevGeneration generation: %d rev: %s", generation, revision)
-	assert.True(t, generation == expectedRevGeneration)
+	goassert.True(t, generation == expectedRevGeneration)
 }

--- a/rest/login_test.go
+++ b/rest/login_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/tleyden/fakehttp"
 )
 
@@ -40,8 +40,8 @@ func TestVerifyFacebook(t *testing.T) {
 	}
 
 	log.Printf("facebookResponse: %s, err: %s", facebookResponse, err)
-	assert.True(t, true)
-	assert.Equals(t, facebookResponse.Email, "alice@dot.com")
+	goassert.True(t, true)
+	goassert.Equals(t, facebookResponse.Email, "alice@dot.com")
 
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 // Tests the ConfigServer feature.
@@ -38,13 +38,13 @@ func TestConfigServer(t *testing.T) {
 	sc.config.ConfigServer = &fakeConfigURL
 
 	dbc, err := sc.GetDatabase("db")
-	assert.Equals(t, err, nil)
-	assert.Equals(t, dbc.Name, "db")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, dbc.Name, "db")
 
 	dbc, err = sc.GetDatabase("db2")
-	assert.Equals(t, err, nil)
-	assert.Equals(t, dbc.Name, "db2")
-	assert.Equals(t, dbc.Bucket.GetName(), "fivez")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, dbc.Name, "db2")
+	goassert.Equals(t, dbc.Bucket.GetName(), "fivez")
 
 	rt.Bucket() // no-op that just keeps rt from being GC'd/finalized (bug CBL-9)
 }
@@ -90,13 +90,13 @@ func TestConfigServerWithSyncFunction(t *testing.T) {
 	sc.config.ConfigServer = &fakeConfigURL
 
 	dbc, err := sc.GetDatabase("db")
-	assert.Equals(t, err, nil)
-	assert.Equals(t, dbc.Name, "db")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, dbc.Name, "db")
 
 	dbc, err = sc.GetDatabase("db2")
-	assert.Equals(t, err, nil)
-	assert.Equals(t, dbc.Name, "db2")
-	assert.Equals(t, dbc.Bucket.GetName(), "fivez")
+	goassert.Equals(t, err, nil)
+	goassert.Equals(t, dbc.Name, "db2")
+	goassert.Equals(t, dbc.Bucket.GetName(), "fivez")
 
 	rt.Bucket() // no-op that just keeps rt from being GC'd/finalized (bug CBL-9)
 

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSgcollectFilename(t *testing.T) {
@@ -18,14 +19,14 @@ func TestSgcollectFilename(t *testing.T) {
 
 	pattern := `^sgcollectinfo\-\d{4}\-\d{2}\-\d{2}t\d{6}\-sga?@(\d{1,3}\.){4}zip$`
 	matched, err := regexp.Match(pattern, []byte(filename))
-	assertNoError(t, err, "unexpected regexp error")
-	assertTrue(t, matched, fmt.Sprintf("Filename: %s did not match pattern: %s", filename, pattern))
+	assert.NoError(t, err, "unexpected regexp error")
+	assert.True(t, matched, fmt.Sprintf("Filename: %s did not match pattern: %s", filename, pattern))
 }
 
 func TestSgcollectOptionsValidate(t *testing.T) {
 
 	binPath, err := os.Executable()
-	assertNoError(t, err, "unexpected error getting executable path")
+	assert.NoError(t, err, "unexpected error getting executable path")
 
 	tests := []struct {
 		options     *sgCollectOptions
@@ -103,7 +104,7 @@ func TestSgcollectOptionsValidate(t *testing.T) {
 
 func TestSgcollectOptionsArgs(t *testing.T) {
 	binPath, err := os.Executable()
-	assertNoError(t, err, "unexpected error getting executable path")
+	assert.NoError(t, err, "unexpected error getting executable path")
 
 	tests := []struct {
 		options      *sgCollectOptions

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"testing"
 
-	assert "github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestSgcollectFilename(t *testing.T) {
 	filename := sgcollectFilename()
 
 	// Check it doesn't have forbidden chars
-	assert.False(t, strings.ContainsAny(filename, "\\/:*?\"<>|"))
+	goassert.False(t, strings.ContainsAny(filename, "\\/:*?\"<>|"))
 
 	pattern := `^sgcollectinfo\-\d{4}\-\d{2}\-\d{2}t\d{6}\-sga?@(\d{1,3}\.){4}zip$`
 	matched, err := regexp.Match(pattern, []byte(filename))
@@ -93,8 +93,8 @@ func TestSgcollectOptionsValidate(t *testing.T) {
 				errStr = err.Error()
 			}
 
-			assert.Equals(ts, err != nil, test.errContains != "")
-			assert.StringContains(ts, errStr, test.errContains)
+			goassert.Equals(ts, err != nil, test.errContains != "")
+			goassert.StringContains(ts, errStr, test.errContains)
 
 		})
 	}
@@ -169,7 +169,7 @@ func TestSgcollectOptionsArgs(t *testing.T) {
 			_ = test.options.Validate()
 
 			args := test.options.Args()
-			assert.DeepEquals(ts, args, test.expectedArgs)
+			goassert.DeepEquals(ts, args, test.expectedArgs)
 		})
 	}
 }

--- a/rest/user_agent_version_test.go
+++ b/rest/user_agent_version_test.go
@@ -3,58 +3,58 @@ package rest
 import (
 	"testing"
 
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestUserAgentVersion(t *testing.T) {
 
 	userAgentVersion := NewUserAgentVersion("")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 0)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 0)
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.0.0")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 1)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 1)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 0)
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.1.0")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 1)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 1)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 1)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 1)
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.2 (suff/goes/here)")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 1)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 2)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 1)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 2)
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.2(suff.goes.here)")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 1)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 2)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 1)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 2)
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.2 suff.goes/here)")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 1)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 2)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 1)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 2)
 
 	userAgentVersion = NewUserAgentVersion("whatever/thing$$h3ysuz1!!///")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 0)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 0)
 
 	userAgentVersion = NewUserAgentVersion("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9")
-	assert.Equals(t, userAgentVersion.MajorVersion(), 0)
-	assert.Equals(t, userAgentVersion.MinorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MajorVersion(), 0)
+	goassert.Equals(t, userAgentVersion.MinorVersion(), 0)
 
 }
 
 func TestUserAgentVersionIsVersionAfter(t *testing.T) {
 
 	userAgentVersion := NewUserAgentVersion("CouchbaseLite/0.3 suff.goes/here)")
-	assert.True(t, userAgentVersion.IsBefore(1, 2))
-	assert.True(t, userAgentVersion.IsEqualToOrAfter(0, 2))
+	goassert.True(t, userAgentVersion.IsBefore(1, 2))
+	goassert.True(t, userAgentVersion.IsEqualToOrAfter(0, 2))
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.1.1 suff.goes/here)")
-	assert.True(t, userAgentVersion.IsBefore(1, 3))
-	assert.True(t, userAgentVersion.IsEqualToOrAfter(1, 0))
+	goassert.True(t, userAgentVersion.IsBefore(1, 3))
+	goassert.True(t, userAgentVersion.IsEqualToOrAfter(1, 0))
 
 	userAgentVersion = NewUserAgentVersion("CouchbaseLite/1.3 suff.goes/here)")
-	assert.True(t, userAgentVersion.IsEqualToOrAfter(1, 3))
-	assert.True(t, userAgentVersion.IsEqualToOrAfter(1, 2))
-	assert.True(t, userAgentVersion.IsBefore(1, 4))
+	goassert.True(t, userAgentVersion.IsEqualToOrAfter(1, 3))
+	goassert.True(t, userAgentVersion.IsEqualToOrAfter(1, 2))
+	goassert.True(t, userAgentVersion.IsBefore(1, 4))
 
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -21,7 +21,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 	"golang.org/x/net/websocket"
 )
 
@@ -206,7 +206,7 @@ func (rt *RestTester) GetDatabase() *db.DatabaseContext {
 
 func (rt *RestTester) MustWaitForDoc(docid string, t testing.TB) {
 	err := rt.WaitForDoc(docid)
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
 }
 

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestDocumentUnmarshal(t *testing.T) {
@@ -33,21 +33,21 @@ func TestDocumentUnmarshal(t *testing.T) {
 	if err != nil {
 		log.Printf("Error: %v", err)
 	}
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 	log.Printf("doc: %+v", doc)
 
-	assert.True(t, doc.ID() == "docid")
+	goassert.True(t, doc.ID() == "docid")
 
 	docFooField, hasFoo := doc["foo"]
-	assert.True(t, hasFoo)
+	goassert.True(t, hasFoo)
 	log.Printf("docFooField: %v", docFooField)
 
 	attachments, err := doc.GetAttachments()
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
-	assert.Equals(t, len(attachments), 1)
+	goassert.Equals(t, len(attachments), 1)
 	myattachment := attachments["myattachment"]
-	assert.Equals(t, myattachment.ContentType, "text")
+	goassert.Equals(t, myattachment.ContentType, "text")
 
 }
 
@@ -68,13 +68,13 @@ func TestAttachmentRoundTrip(t *testing.T) {
 	doc.SetAttachments(attachmentMap)
 
 	attachments, err := doc.GetAttachments()
-	assert.True(t, err == nil)
+	goassert.True(t, err == nil)
 
-	assert.Equals(t, len(attachments), 2)
+	goassert.Equals(t, len(attachments), 2)
 
 	for attachName, attachment := range attachments {
-		assert.Equals(t, attachment.ContentType, "text")
-		assert.True(t, attachName == "foo" || attachName == "bar")
+		goassert.Equals(t, attachment.ContentType, "text")
+		goassert.True(t, attachName == "foo" || attachName == "bar")
 	}
 
 }

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/couchbaselabs/go.assert"
+	goassert "github.com/couchbaselabs/go.assert"
 )
 
 func TestDesignDocs(t *testing.T) {
@@ -73,24 +73,24 @@ func TestViewQuery(t *testing.T) {
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
 	assertNoError(t, err, "Got unexpected error")
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: "ten"})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: "ten"})
 
 	result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?limit=1")
-	assert.Equals(t, len(result.Rows), 1)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
+	goassert.Equals(t, len(result.Rows), 1)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
 
 	result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?endkey=9")
-	assert.Equals(t, len(result.Rows), 1)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
+	goassert.Equals(t, len(result.Rows), 1)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
 
 	if base.UnitTestUrlIsWalrus() {
 		// include_docs=true only works with walrus as documented here:
 		// https://forums.couchbase.com/t/do-the-viewquery-options-omit-include-docs-on-purpose/12399
 		result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?include_docs=true&endkey=9")
-		assert.Equals(t, len(result.Rows), 1)
-		assert.DeepEquals(t, *result.Rows[0].Doc, map[string]interface{}{"key": 7.0, "value": "seven"})
+		goassert.Equals(t, len(result.Rows), 1)
+		goassert.DeepEquals(t, *result.Rows[0].Doc, map[string]interface{}{"key": 7.0, "value": "seven"})
 	}
 
 }
@@ -111,19 +111,19 @@ func TestViewQueryMultipleViews(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_age")
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)})
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_fname")
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)})
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_lname")
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)})
 }
 
 func TestViewQueryUserAccess(t *testing.T) {
@@ -143,16 +143,16 @@ func TestViewQueryUserAccess(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
 	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
 	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
 
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
 
 	// Create a user:
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -163,9 +163,9 @@ func TestViewQueryUserAccess(t *testing.T) {
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
 	assertNoError(t, err, "Unexpected error in WaitForNUserViewResults")
 
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
 
 	// Disable user view access, retry
 	rt.ServerContext().Database("db").SetUserViewsEnabled(false)
@@ -196,23 +196,23 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	assertStatus(t, response, 200)
 	var result sgbucket.ViewResult
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)})
 
 	response = rt.SendAdminRequest("GET", "/db/_design/foo/_view/by_fname", ``)
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)})
 
 	response = rt.SendAdminRequest("GET", "/db/_design/foo/_view/by_lname", ``)
 	assertStatus(t, response, 200)
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 2)
-	assert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)})
-	assert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)})
+	goassert.Equals(t, len(result.Rows), 2)
+	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)})
+	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)})
 }
 
 func TestUserViewQuery(t *testing.T) {
@@ -239,39 +239,39 @@ func TestUserViewQuery(t *testing.T) {
 
 	result, err := rt.WaitForNUserViewResults(1, "/db/_design/foo/_view/bar?include_docs=true", quinn, password)
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(result.Rows), 1)
-	assert.Equals(t, result.TotalRows, 1)
+	goassert.Equals(t, len(result.Rows), 1)
+	goassert.Equals(t, result.TotalRows, 1)
 	row := result.Rows[0]
-	assert.Equals(t, row.Key, float64(7))
-	assert.Equals(t, row.Value, "seven")
+	goassert.Equals(t, row.Key, float64(7))
+	goassert.Equals(t, row.Value, "seven")
 
 	if base.UnitTestUrlIsWalrus() {
 		// include_docs=true only works with walrus as documented here:
 		// https://forums.couchbase.com/t/do-the-viewquery-options-omit-include-docs-on-purpose/12399
-		assert.DeepEquals(t, *row.Doc, map[string]interface{}{"key": 7.0, "value": "seven", "channel": "Q"})
+		goassert.DeepEquals(t, *row.Doc, map[string]interface{}{"key": 7.0, "value": "seven", "channel": "Q"})
 	}
 
 	// Admin should see both rows:
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
 	assertNoError(t, err, "Unexpected error")
-	assert.Equals(t, len(result.Rows), 2)
+	goassert.Equals(t, len(result.Rows), 2)
 	row = result.Rows[0]
-	assert.Equals(t, row.Key, float64(7))
-	assert.Equals(t, row.Value, "seven")
+	goassert.Equals(t, row.Key, float64(7))
+	goassert.Equals(t, row.Value, "seven")
 	if base.UnitTestUrlIsWalrus() {
 		// include_docs=true only works with walrus as documented here:
 		// https://forums.couchbase.com/t/do-the-viewquery-options-omit-include-docs-on-purpose/12399
-		assert.DeepEquals(t, *row.Doc, map[string]interface{}{"key": 7.0, "value": "seven", "channel": "Q"})
+		goassert.DeepEquals(t, *row.Doc, map[string]interface{}{"key": 7.0, "value": "seven", "channel": "Q"})
 	}
 	row = result.Rows[1]
-	assert.Equals(t, row.Key, float64(10))
-	assert.Equals(t, row.Value, "ten")
+	goassert.Equals(t, row.Key, float64(10))
+	goassert.Equals(t, row.Value, "ten")
 
 	if base.UnitTestUrlIsWalrus() {
 		// include_docs=true only works with walrus as documented here:
 		// https://forums.couchbase.com/t/do-the-viewquery-options-omit-include-docs-on-purpose/12399
-		assert.DeepEquals(t, *row.Doc, map[string]interface{}{"key": 10.0, "value": "ten", "channel": "W"})
+		goassert.DeepEquals(t, *row.Doc, map[string]interface{}{"key": 10.0, "value": "ten", "channel": "W"})
 	}
 
 	// Make sure users are not allowed to query internal views:
@@ -307,10 +307,10 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	assertNoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
-	assert.Equals(t, len(result.Rows), 1)
+	goassert.Equals(t, len(result.Rows), 1)
 	row := result.Rows[0]
 	value := row.Value.(float64)
-	assert.True(t, value == 10)
+	goassert.True(t, value == 10)
 
 	// todo support group reduce, see #955
 	// // test group=true
@@ -318,13 +318,13 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	// assertStatus(t, response, 200)
 	// json.Unmarshal(response.Body.Bytes(), &result)
 	// // we should get 2 rows with the reduce result
-	// assert.Equals(t, len(result.Rows), 2)
+	// goassert.Equals(t, len(result.Rows), 2)
 	// row = result.Rows[0]
 	// value = row.Value.(float64)
-	// assert.True(t, value == 9)
+	// goassert.True(t, value == 9)
 	// row = result.Rows[1]
 	// value = row.Value.(float64)
-	// assert.True(t, value == 1)
+	// goassert.True(t, value == 1)
 }
 
 func TestAdminReduceSumQuery(t *testing.T) {
@@ -352,10 +352,10 @@ func TestAdminReduceSumQuery(t *testing.T) {
 	assertNoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
-	assert.Equals(t, len(result.Rows), 1)
+	goassert.Equals(t, len(result.Rows), 1)
 	row := result.Rows[0]
 	value := row.Value.(float64)
-	assert.Equals(t, value, 108.0)
+	goassert.Equals(t, value, 108.0)
 }
 
 func TestAdminGroupReduceSumQuery(t *testing.T) {
@@ -383,10 +383,10 @@ func TestAdminGroupReduceSumQuery(t *testing.T) {
 	assertNoError(t, err, "Unexpected error")
 
 	// we should get 2 row with the reduce result
-	assert.Equals(t, len(result.Rows), 2)
+	goassert.Equals(t, len(result.Rows), 2)
 	row := result.Rows[1]
 	value := row.Value.(float64)
-	assert.Equals(t, value, 99.0)
+	goassert.Equals(t, value, 99.0)
 }
 
 // Reproduces SG #3344.  Original issue only reproducible against Couchbase server (non-walrus)
@@ -415,7 +415,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 
 	var result sgbucket.ViewResult
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 1)
+	goassert.Equals(t, len(result.Rows), 1)
 
 	// Ensure that query for non-existent keys returns no rows
 	viewUrlPath = "/db/_design/foo/_view/bar?keys=%5B%22channel_b%22%5D&stale=false"
@@ -423,7 +423,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	assertStatus(t, response, 200) // Query string was parsed properly
 
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 0)
+	goassert.Equals(t, len(result.Rows), 0)
 
 }
 
@@ -452,7 +452,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	assertStatus(t, response, 200)
 	var result sgbucket.ViewResult
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 1)
+	goassert.Equals(t, len(result.Rows), 1)
 
 	// Ensure that a query for non-existent key returns no rows
 	viewUrlPath = "/db/_design/foo/_view/composite_key_test?keys=%5B%5B%22channel_b%22%2C%2055%5D%5D&stale=false"
@@ -460,7 +460,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 0)
+	goassert.Equals(t, len(result.Rows), 0)
 }
 
 func TestViewQueryWithIntKeys(t *testing.T) {
@@ -488,7 +488,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	assertStatus(t, response, 200)
 	var result sgbucket.ViewResult
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 1)
+	goassert.Equals(t, len(result.Rows), 1)
 
 	// Ensure that a query for non-existent key returns no rows
 	//   keys:[65,75]
@@ -497,7 +497,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	json.Unmarshal(response.Body.Bytes(), &result)
-	assert.Equals(t, len(result.Rows), 0)
+	goassert.Equals(t, len(result.Rows), 0)
 }
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
@@ -525,10 +525,10 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 	assertNoError(t, err, "Unexpected error")
 
 	// we should get 2 row with the reduce result
-	assert.Equals(t, len(result.Rows), 2)
+	goassert.Equals(t, len(result.Rows), 2)
 	row := result.Rows[1]
 	value := row.Value.(float64)
-	assert.Equals(t, value, 99.0)
+	goassert.Equals(t, value, 99.0)
 }
 
 func TestPostInstallCleanup(t *testing.T) {
@@ -558,31 +558,31 @@ func TestPostInstallCleanup(t *testing.T) {
 	response := rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
 	assertStatus(t, response, 200)
 	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
-	assert.Equals(t, postUpgradeResponse.Preview, true)
-	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
+	goassert.Equals(t, postUpgradeResponse.Preview, true)
+	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
 
 	// Run post-upgrade in non-preview mode
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
 	assertStatus(t, response, 200)
 	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
-	assert.Equals(t, postUpgradeResponse.Preview, false)
-	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
+	goassert.Equals(t, postUpgradeResponse.Preview, false)
+	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
 
 	// Run post-upgrade in preview mode again, expect no results for database
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
 	assertStatus(t, response, 200)
 	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
-	assert.Equals(t, postUpgradeResponse.Preview, true)
-	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
+	goassert.Equals(t, postUpgradeResponse.Preview, true)
+	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
 
 	// Run post-upgrade in non-preview mode again, expect no results for database
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
 	assertStatus(t, response, 200)
 	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
-	assert.Equals(t, postUpgradeResponse.Preview, false)
-	assert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
+	goassert.Equals(t, postUpgradeResponse.Preview, false)
+	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
 
 }

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDesignDocs(t *testing.T) {
@@ -71,7 +72,7 @@ func TestViewQuery(t *testing.T) {
 	// The wait is needed here because the query does not have stale=false.
 	// TODO: update the query to use stale=false and remove the wait
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
-	assertNoError(t, err, "Got unexpected error")
+	assert.NoError(t, err, "Got unexpected error")
 	json.Unmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
@@ -110,7 +111,7 @@ func TestViewQueryMultipleViews(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_age")
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)})
 	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)})
@@ -142,13 +143,13 @@ func TestViewQueryUserAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
-	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
+	assert.NoError(t, err, "Unexpected error in WaitForNAdminViewResults")
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
 	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"})
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
-	assertNoError(t, err, "Unexpected error in WaitForNAdminViewResults")
+	assert.NoError(t, err, "Unexpected error in WaitForNAdminViewResults")
 
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
@@ -161,7 +162,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	a.Save(testUser)
 
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
-	assertNoError(t, err, "Unexpected error in WaitForNUserViewResults")
+	assert.NoError(t, err, "Unexpected error in WaitForNUserViewResults")
 
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"})
@@ -238,7 +239,7 @@ func TestUserViewQuery(t *testing.T) {
 	// Have the user query the view:
 
 	result, err := rt.WaitForNUserViewResults(1, "/db/_design/foo/_view/bar?include_docs=true", quinn, password)
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, len(result.Rows), 1)
 	goassert.Equals(t, result.TotalRows, 1)
 	row := result.Rows[0]
@@ -254,7 +255,7 @@ func TestUserViewQuery(t *testing.T) {
 	// Admin should see both rows:
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, len(result.Rows), 2)
 	row = result.Rows[0]
 	goassert.Equals(t, row.Key, float64(7))
@@ -304,7 +305,7 @@ func TestAdminReduceViewQuery(t *testing.T) {
 
 	// Admin view query:
 	result, err := rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?reduce=true")
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
 	goassert.Equals(t, len(result.Rows), 1)
@@ -349,7 +350,7 @@ func TestAdminReduceSumQuery(t *testing.T) {
 
 	// Admin view query:
 	result, err := rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?reduce=true")
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
 	goassert.Equals(t, len(result.Rows), 1)
@@ -380,7 +381,7 @@ func TestAdminGroupReduceSumQuery(t *testing.T) {
 
 	// Admin view query:
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?reduce=true&group=true")
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 2 row with the reduce result
 	goassert.Equals(t, len(result.Rows), 2)
@@ -402,7 +403,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	// Create a view
 	response := rt.SendAdminRequest("PUT", "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
 	assertStatus(t, response, 201)
-	assertNoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/bar"), "Error waiting for view availability")
+	assert.NoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/bar"), "Error waiting for view availability")
 
 	// Create a doc
 	response = rt.SendAdminRequest("PUT", "/db/query_with_keys", `{"key":"channel_a", "value":99}`)
@@ -439,7 +440,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	// Create a view
 	response := rt.SendAdminRequest("PUT", "/db/_design/foo", `{"views":{"composite_key_test": {"map": "function(doc) {emit([doc.key, doc.seq], doc.value);}"}}}`)
 	assertStatus(t, response, 201)
-	assertNoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/composite_key_test"), "Error waiting for view availability")
+	assert.NoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/composite_key_test"), "Error waiting for view availability")
 
 	// Create a doc
 	response = rt.SendAdminRequest("PUT", "/db/doc_composite_key", `{"key":"channel_a", "seq":55, "value":99}`)
@@ -475,7 +476,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	// Create a view
 	response := rt.SendAdminRequest("PUT", "/db/_design/foo", `{"views":{"int_key_test": {"map": "function(doc) {emit(doc.seq, doc.value);}"}}}`)
 	assertStatus(t, response, 201)
-	assertNoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/int_key_test"), "Error waiting for view availability")
+	assert.NoError(t, rt.WaitForViewAvailable("/db/_design/foo/_view/int_key_test"), "Error waiting for view availability")
 
 	// Create a doc
 	response = rt.SendAdminRequest("PUT", "/db/doc_int_key", `{"key":"channel_a", "seq":55, "value":99}`)
@@ -522,7 +523,7 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 
 	// Admin view query:
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?reduce=true&group_level=2")
-	assertNoError(t, err, "Unexpected error")
+	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 2 row with the reduce result
 	goassert.Equals(t, len(result.Rows), 2)
@@ -544,20 +545,20 @@ func TestPostInstallCleanup(t *testing.T) {
 			"channels": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
-	assertNoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
+	assert.NoError(t, err, "Unable to create design doc (DesignDocSyncGatewayPrefix)")
 
 	err = bucket.PutDDoc(db.DesignDocSyncHousekeepingPrefix, sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			"all_docs": sgbucket.ViewDef{Map: mapFunction},
 		},
 	})
-	assertNoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
+	assert.NoError(t, err, "Unable to create design doc (DesignDocSyncHousekeepingPrefix)")
 
 	// Run post-upgrade in preview mode
 	var postUpgradeResponse PostUpgradeResponse
 	response := rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
 	assertStatus(t, response, 200)
-	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, true)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
 
@@ -565,7 +566,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
 	assertStatus(t, response, 200)
-	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, false)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
 
@@ -573,7 +574,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
 	assertStatus(t, response, 200)
-	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, true)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
 
@@ -581,7 +582,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
 	assertStatus(t, response, 200)
-	assertNoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, false)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
 


### PR DESCRIPTION
Use testify asserts for utility asserts previously cloned across packages.  Refactors go.assert usages to goassert - plan is to phase these usages out opportunistically.

Manifest change depends on https://issues.couchbase.com/browse/MB-31790