### PR TITLE
Modify Update, WriteUpdate to return cas

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -104,7 +104,7 @@ func (auth *Authenticator) GetRole(name string) (Role, error) {
 func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) (Principal, error) {
 	var princ Principal
 
-	err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
+	_, err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// Be careful: this block can be invoked multiple times if there are races!
 		if currentValue == nil {
 			princ = nil
@@ -444,7 +444,7 @@ func (auth *Authenticator) UpdateUserVbucketSequences(docID string, sequence uin
 func (auth *Authenticator) updateVbucketSequences(docID string, factory func() Principal, seq uint64) error {
 
 	sequence := ch.NewVbSimpleSequence(seq)
-	err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
+	_, err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// Be careful: this block can be invoked multiple times if there are races!
 		if currentValue == nil {
 			return nil, nil, base.ErrUpdateCancel

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -401,10 +401,13 @@ func TestUpdate(t *testing.T) {
 			return valUpdated, nil, nil
 		}
 	}
-
-	err = bucket.Update(key, 0, updateFunc)
+	var cas uint64
+	cas, err = bucket.Update(key, 0, updateFunc)
 	if err != nil {
 		t.Errorf("Error calling Update: %v", err)
+	}
+	if cas == 0 {
+		t.Errorf("Unexpected cas returned by bucket.Update")
 	}
 
 	rv, _, err := bucket.GetRaw(key)
@@ -412,9 +415,12 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("%v != %v", string(rv), string(valInitial))
 	}
 
-	err = bucket.Update(key, 0, updateFunc)
+	cas, err = bucket.Update(key, 0, updateFunc)
 	if err != nil {
 		t.Errorf("Error calling Update: %v", err)
+	}
+	if cas == 0 {
+		t.Errorf("Unexpected cas returned by bucket.Update")
 	}
 
 	rv, _, err = bucket.GetRaw(key)

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -89,10 +89,10 @@ func (b *LeakyBucket) Write(k string, flags int, exp uint32, v interface{}, opt 
 func (b *LeakyBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
-func (b *LeakyBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (err error) {
+func (b *LeakyBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (casOut uint64, err error) {
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *LeakyBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (err error) {
+func (b *LeakyBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
 func (b *LeakyBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -84,12 +84,12 @@ func (b *LoggingBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v 
 	}()
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
-func (b *LoggingBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (err error) {
+func (b *LoggingBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() { Tracef(KeyBucket, "Update(%q, %d, ...) --> %v [%v]", UD(k), exp, err, time.Since(start)) }()
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *LoggingBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (err error) {
+func (b *LoggingBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
 	start := time.Now()
 	defer func() { Tracef(KeyBucket, "WriteUpdate(%q, %d, ...) --> %v [%v]", UD(k), exp, err, time.Since(start)) }()
 	return b.bucket.WriteUpdate(k, exp, callback)

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -162,11 +162,11 @@ func (b *StatsBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v in
 	}
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
-func (b *StatsBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (err error) {
+func (b *StatsBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (casOut uint64, err error) {
 	defer b.docWrite(1, -1)
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *StatsBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (err error) {
+func (b *StatsBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
 	defer b.docWrite(1, -1)
 	return b.bucket.WriteUpdate(k, exp, callback)
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1047,7 +1047,7 @@ func (db *Database) updateAndReturnDoc(
 	upgradeInProgress := false
 	if !db.UseXattrs() {
 		// Update the document, storing metadata in _sync property
-		err = db.Bucket.WriteUpdate(key, expiry, func(currentValue []byte) (raw []byte, writeOpts sgbucket.WriteOptions, syncFuncExpiry *uint32, err error) {
+		_, err = db.Bucket.WriteUpdate(key, expiry, func(currentValue []byte) (raw []byte, writeOpts sgbucket.WriteOptions, syncFuncExpiry *uint32, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocument(docid, currentValue); err != nil {
 				return

--- a/db/database.go
+++ b/db/database.go
@@ -857,7 +857,7 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 		Sync string
 	}
 
-	err = context.Bucket.Update(kSyncDataKey, 0, func(currentValue []byte) ([]byte, *uint32, error) {
+	_, err = context.Bucket.Update(kSyncDataKey, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// The first time opening a new db, currentValue will be nil. Don't treat this as a change.
 		if currentValue != nil {
 			parseErr := json.Unmarshal(currentValue, &syncData)
@@ -979,7 +979,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 			}
 			_, err = db.Bucket.WriteUpdateWithXattr(key, KSyncXattrName, 0, nil, writeUpdateFunc)
 		} else {
-			err = db.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, error) {
+			_, err = db.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 				// Be careful: this block can be invoked multiple times if there are races!
 				if currentValue == nil {
 					return nil, nil, base.ErrUpdateCancel // someone deleted it?!

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -187,7 +187,7 @@ func (r RepairBucket) RepairBucket() (results []RepairBucketResult, err error) {
 			key := realDocID(docid)
 			var backupOrDryRunDocId string
 
-			err = r.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, error) {
+			_, err = r.Bucket.Update(key, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 				// Be careful: this block can be invoked multiple times if there are races!
 				if currentValue == nil {
 					return nil, nil, base.ErrUpdateCancel // someone deleted it?!

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -58,7 +58,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 	if expPresent && expiry == 0 && doctype == "local" {
 		expiry = uint32(base.SecondsToCbsExpiry(int(db.DatabaseContext.Options.LocalDocExpirySecs)))
 	}
-	err = db.Bucket.Update(key, expiry, func(value []byte) ([]byte, *uint32, error) {
+	_, err = db.Bucket.Update(key, expiry, func(value []byte) ([]byte, *uint32, error) {
 		if len(value) == 0 {
 			if matchRev != "" || body == nil {
 				return nil, nil, base.HTTPErrorf(http.StatusNotFound, "No previous revision to replace")

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,7 +45,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="d4ba19e5088b179f1e38b49c84f5a3628aa2bcff"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="701cd1ec079d40188c615b14eee22aad047817a0"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="16db1f1fe037412f12738fa4d8448c549c4edd77"/>
 
@@ -61,7 +61,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="bb6cc50e91c1002f5a1b522c1f3b990a8fa8f90f"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="43c0b3fb76997837f7f72f99f9e0d5363e795ee8"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,7 +45,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="61b5ac22b62ad0e06bd461c8989cfb49a4d3169e"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="d4ba19e5088b179f1e38b49c84f5a3628aa2bcff"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="16db1f1fe037412f12738fa4d8448c549c4edd77"/>
 
@@ -61,7 +61,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e774e379a0452bfff199a69e053dc565918d680c"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="bb6cc50e91c1002f5a1b522c1f3b990a8fa8f90f"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
Update and WriteUpdate perform a cas-safe update using a callback function.  However, they don't return the final cas value of the updated document - this is useful in cases where Update/WriteUpdate are used to perform additional processing during Get (e.g. getPrincipal).

The equivalent functionality already exists for the xattr version of the operation.

Prerequisite for #3414.