### PR TITLE
Remove invalid asserts on failing tests

### DIFF
--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -845,8 +845,6 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 		t.Errorf("Unexpected number of changes results.  Last_Seq: %v  len(changes): %v", changes.Last_Seq, len(changes.Results))
 	}
 
-	goassert.Equals(t, len(changes.Results), 8)
-	goassert.Equals(t, changes.Last_Seq, "13")
 }
 
 // Test low sequence handling of late arriving sequences to a one-shot changes feed, ensuring that
@@ -974,8 +972,6 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 		t.Errorf("Unexpected number of changes results.  Last_Seq: %v  len(changes): %v", changes.Last_Seq, len(changes.Results))
 	}
 
-	goassert.Equals(t, len(changes.Results), 8)
-	goassert.Equals(t, changes.Last_Seq, "13")
 }
 
 // Test low sequence handling of late arriving sequences to a longpoll changes feed, ensuring that


### PR DESCRIPTION
The length of changes.Results and expected Last_Seq are already covered (under all race conditions) in the preceding switch statement.  The removed asserts were not guaranteed to pass depending on race timing.