### PR TITLE
Add cas check to principal updates

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,6 +12,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
@@ -38,6 +39,8 @@ type ChannelComputer interface {
 type userByEmailInfo struct {
 	Username string
 }
+
+const PrincipalUpdateMaxCasRetries = 20 // Maximum number of attempted retries on cas failure updating principal
 
 // Creates a new Authenticator that stores user info in the given Bucket.
 func NewAuthenticator(bucket base.Bucket, channelComputer ChannelComputer) *Authenticator {
@@ -104,7 +107,7 @@ func (auth *Authenticator) GetRole(name string) (Role, error) {
 func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) (Principal, error) {
 	var princ Principal
 
-	_, err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
+	cas, err := auth.bucket.Update(docID, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// Be careful: this block can be invoked multiple times if there are races!
 		if currentValue == nil {
 			princ = nil
@@ -150,6 +153,12 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 	if err != nil && err != base.ErrUpdateCancel {
 		return nil, err
 	}
+
+	// If a principal was found, set the cas
+	if princ != nil {
+		princ.SetCas(cas)
+	}
+
 	return princ, nil
 }
 
@@ -224,15 +233,19 @@ func (auth *Authenticator) GetUserByEmail(email string) (User, error) {
 	return auth.GetUser(info.Username)
 }
 
-// Saves the information for a user/role.
+// CAS-safe save of the information for a user/role.  For updates, expects the incoming principal to have
+// p.Cas to be set correctly (done automatically for principals retrieved via auth functions).
 func (auth *Authenticator) Save(p Principal) error {
 	if err := p.validate(); err != nil {
 		return err
 	}
 
-	if err := auth.bucket.Set(p.DocID(), 0, p); err != nil {
-		return err
+	casOut, writeErr := auth.bucket.WriteCas(p.DocID(), 0, 0, p.Cas(), p, 0)
+	if writeErr != nil {
+		return writeErr
 	}
+	p.SetCas(casOut)
+
 	if user, ok := p.(User); ok {
 		if user.Email() != "" {
 			info := userByEmailInfo{user.Name()}
@@ -249,29 +262,149 @@ func (auth *Authenticator) Save(p Principal) error {
 
 // Invalidates the channel list of a user/role by saving its Channels() property as nil.
 func (auth *Authenticator) InvalidateChannels(p Principal) error {
-	if p != nil && p.Channels() != nil {
+	invalidateChannelsCallback := func(p Principal) (updatedPrincipal Principal, err error) {
+
+		if p == nil || p.Channels() == nil {
+			return p, base.ErrUpdateCancel
+		}
+
 		base.Infof(base.KeyAccess, "Invalidate access of %q", base.UD(p.Name()))
 		if auth.channelComputer != nil && !auth.channelComputer.UseGlobalSequence() {
 			p.SetPreviousChannels(p.Channels())
 		}
 		p.setChannels(nil)
-		if err := auth.Save(p); err != nil {
-			return err
-		}
+		return p, nil
 	}
-	return nil
+	return auth.casUpdatePrincipal(p, invalidateChannelsCallback)
 }
 
 // Invalidates the role list of a user by saving its Roles() property as nil.
 func (auth *Authenticator) InvalidateRoles(user User) error {
-	if user != nil && user.Channels() != nil {
+
+	invalidateRolesCallback := func(p Principal) (updatedPrincipal Principal, err error) {
+		user, ok := p.(User)
+		if !ok {
+			return p, base.ErrUpdateCancel
+		}
+		if user == nil || user.RoleNames() == nil {
+			return p, base.ErrUpdateCancel
+		}
 		base.Infof(base.KeyAccess, "Invalidate roles of %q", base.UD(user.Name()))
 		user.setRolesSince(nil)
-		if err := auth.Save(user); err != nil {
+		return user, nil
+	}
+
+	return auth.casUpdatePrincipal(user, invalidateRolesCallback)
+}
+
+// Updates user email and writes user doc
+func (auth *Authenticator) UpdateUserEmail(u User, email string) error {
+
+	updateUserEmailCallback := func(currentPrincipal Principal) (updatedPrincipal Principal, err error) {
+		currentUser, ok := currentPrincipal.(User)
+		if !ok {
+			return nil, base.ErrUpdateCancel
+		}
+
+		if currentUser.Email() == email {
+			return currentUser, base.ErrUpdateCancel
+		}
+
+		base.Debugf(base.KeyAuth, "Updating user %s email to: %v", base.UD(u.Name()), base.UD(email))
+		err = currentUser.SetEmail(email)
+		if err != nil {
+			return nil, err
+		}
+		return currentUser, nil
+	}
+
+	updateError := auth.casUpdatePrincipal(u, updateUserEmailCallback)
+	if updateError != nil {
+		base.Infof(base.KeyAuth, "Unable to update user email.  User:%s Error:%v", base.UD(u.Name()), updateError)
+	}
+	return updateError
+}
+
+// rehashPassword will check the bcrypt cost of the given hash
+// and will reset the user's password if the configured cost has since changed
+// Callers must verify password is correct before calling this
+func (auth *Authenticator) rehashPassword(user User, password string) error {
+
+	// Exit early if bcryptCost has not been set
+	if !bcryptCostChanged {
+		return nil
+	}
+	var hashCost int
+	rehashPasswordCallback := func(currentPrincipal Principal) (updatedPrincipal Principal, err error) {
+
+		currentUserImpl, ok := currentPrincipal.(*userImpl)
+		if !ok {
+			return nil, base.ErrUpdateCancel
+		}
+
+		hashCost, costErr := bcrypt.Cost(currentUserImpl.PasswordHash_)
+		if costErr == nil && hashCost != bcryptCost {
+			// the cost of the existing hash is different than the configured bcrypt cost.
+			// We'll re-hash the password to adopt the new cost:
+			currentUserImpl.SetPassword(password)
+			return currentUserImpl, nil
+		} else {
+			return nil, base.ErrUpdateCancel
+		}
+	}
+
+	err := auth.casUpdatePrincipal(user, rehashPasswordCallback)
+	if err != nil {
+		base.Warnf(base.KeyAll, "Unable to save user when rehashing password: %v", err)
+		return err
+	}
+	base.Debugf(base.KeyAuth, "User account %q changed password hash cost from %d to %d",
+		base.UD(user.Name()), hashCost, bcryptCost)
+	return nil
+}
+
+type casUpdatePrincipalCallback func(p Principal) (updatedPrincipal Principal, err error)
+
+// Updates principal using the specified callback function, then does a cas-safe write of the updated principal
+// to the bucket.  On CAS failure, reloads the principal and reapplies the update, with up to PrincipalUpdateMaxCasRetries
+func (auth *Authenticator) casUpdatePrincipal(p Principal, callback casUpdatePrincipalCallback) error {
+	var err error
+	for i := 1; i <= PrincipalUpdateMaxCasRetries; i++ {
+		updatedPrincipal, err := callback(p)
+		if err != nil {
+			if err == base.ErrUpdateCancel {
+				return nil
+			} else {
+				return err
+			}
+		}
+
+		saveErr := auth.Save(updatedPrincipal)
+		if saveErr == nil {
+			return nil
+		}
+
+		if !base.IsCasMismatch(saveErr) {
+			return err
+		}
+
+		base.Infof(base.KeyAuth, "CAS mismatch in casUpdatePrincipal, retrying.  Principal:%s", base.UD(p.Name()))
+
+		switch p.(type) {
+		case User:
+			p, err = auth.GetUser(p.Name())
+		case Role:
+			p, err = auth.GetRole(p.Name())
+		default:
+			return fmt.Errorf("Unsupported principal type in casUpdatePrincipal (%T)", p)
+		}
+
+		if err != nil {
 			return err
 		}
 	}
-	return nil
+	base.Infof(base.KeyAuth, "Unable to update principal after %d attempts.  Principal:%s Error:%v", PrincipalUpdateMaxCasRetries, base.UD(p.Name()), err)
+	return err
 }
 
 // Deletes a user/role.
@@ -384,13 +517,9 @@ func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider)
 	// If user found, check whether the email needs to be updated (e.g. user has changed email in
 	// external auth system)
 	if user != nil && identity.Email != "" {
-		if identity.Email != user.Email() {
-			base.Debugf(base.KeyAuth, "Updating user email to: %v", base.UD(identity.Email))
-			if err := user.SetEmail(identity.Email); err == nil {
-				auth.Save(user)
-			} else {
-				base.Warnf(base.KeyAll, "Unable to set user email to %v for OIDC", base.UD(identity.Email))
-			}
+		err := auth.UpdateUserEmail(user, identity.Email)
+		if err != nil {
+			base.Warnf(base.KeyAll, "Unable to set user email to %v for OIDC", base.UD(identity.Email))
 		}
 	}
 
@@ -400,7 +529,7 @@ func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider)
 		base.Debugf(base.KeyAuth, "Registering new user: %v with email: %v", base.UD(username), base.UD(identity.Email))
 		var err error
 		user, err = auth.RegisterNewUser(username, identity.Email)
-		if err != nil {
+		if err != nil && !base.IsCasMismatch(err) {
 			base.Debugf(base.KeyAuth, "Error registering new user: %v", err)
 			return nil, jwt, err
 		}
@@ -410,7 +539,8 @@ func (auth *Authenticator) authenticateJWT(jwt jose.JWT, provider *OIDCProvider)
 }
 
 // Registers a new user account based on the given verified username and optional email address.
-// Password will be random. The user will have access to no channels.
+// Password will be random. The user will have access to no channels.  If the user already exists,
+// returns the existing user along with the cas failure error
 func (auth *Authenticator) RegisterNewUser(username, email string) (User, error) {
 	user, err := auth.NewUser(username, base.GenerateRandomSecret(), base.Set{})
 	if err != nil {
@@ -422,7 +552,9 @@ func (auth *Authenticator) RegisterNewUser(username, email string) (User, error)
 	}
 
 	err = auth.Save(user)
-	if err != nil {
+	if base.IsCasMismatch(err) {
+		return auth.GetUser(username)
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -318,11 +318,7 @@ func (auth *Authenticator) UpdateUserEmail(u User, email string) error {
 		return currentUser, nil
 	}
 
-	updateError := auth.casUpdatePrincipal(u, updateUserEmailCallback)
-	if updateError != nil {
-		base.Infof(base.KeyAuth, "Unable to update user email.  User:%s Error:%v", base.UD(u.Name()), updateError)
-	}
-	return updateError
+	return auth.casUpdatePrincipal(u, updateUserEmailCallback)
 }
 
 // rehashPassword will check the bcrypt cost of the given hash
@@ -353,11 +349,10 @@ func (auth *Authenticator) rehashPassword(user User, password string) error {
 		}
 	}
 
-	err := auth.casUpdatePrincipal(user, rehashPasswordCallback)
-	if err != nil {
-		base.Warnf(base.KeyAll, "Unable to save user when rehashing password: %v", err)
+	if err := auth.casUpdatePrincipal(user, rehashPasswordCallback); err != nil {
 		return err
 	}
+
 	base.Debugf(base.KeyAuth, "User account %q changed password hash cost from %d to %d",
 		base.UD(user.Name()), hashCost, bcryptCost)
 	return nil

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -68,6 +68,10 @@ type Principal interface {
 	validate() error
 	setChannels(ch.TimedSet)
 	getVbNo(hashFunction VBHashFunction) uint16
+
+	// Cas value for the associated principal document in the bucket
+	Cas() uint64
+	SetCas(cas uint64)
 }
 
 // Role is basically the same as Principal, just concrete. Users can inherit channels from Roles.

--- a/auth/role.go
+++ b/auth/role.go
@@ -27,6 +27,7 @@ type roleImpl struct {
 	Sequence_         uint64      `json:"sequence"`
 	PreviousChannels_ ch.TimedSet `json:"previous_channels,omitempty"`
 	vbNo              *uint16
+	cas               uint64
 }
 
 var kValidNameRegexp = regexp.MustCompile(`^[-+.@%\w]*$`)
@@ -104,6 +105,13 @@ func (role *roleImpl) Sequence() uint64 {
 }
 func (role *roleImpl) SetSequence(sequence uint64) {
 	role.Sequence_ = sequence
+}
+
+func (role *roleImpl) Cas() uint64 {
+	return role.cas
+}
+func (role *roleImpl) SetCas(cas uint64) {
+	role.cas = cas
 }
 
 func (role *roleImpl) Channels() ch.TimedSet {

--- a/auth/user.go
+++ b/auth/user.go
@@ -211,7 +211,10 @@ func (user *userImpl) Authenticate(password string) bool {
 
 		// password was correct, we'll rehash the password if required
 		// e.g: in the case of bcryptCost changes
-		user.auth.rehashPassword(user, password)
+		if err := user.auth.rehashPassword(user, password); err != nil {
+			// rehash is best effort, just log a warning on error.
+			base.Warnf(base.KeyAll, "Error when rehashing password for user %s: %v", base.UD(user.Name()), err)
+		}
 	} else {
 		// no hash, but (incorrect) password provided
 		if password != "" {

--- a/db/users.go
+++ b/db/users.go
@@ -201,6 +201,6 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 		}
 	}
 
-	base.Infof(base.KeyAuth, "CAS mismatch updating principal %s - exceeded retry count. Latest failure: %v", base.UD(princ.Name()), err)
+	base.Errorf(base.KeyAuth, "CAS mismatch updating principal %s - exceeded retry count. Latest failure: %v", base.UD(princ.Name()), err)
 	return replaced, err
 }

--- a/db/users.go
+++ b/db/users.go
@@ -56,6 +56,7 @@ func (p PrincipalConfig) IsPasswordValid(allowEmptyPass bool) (isValid bool, rea
 	return true, ""
 }
 
+// Test-only version of GetPrincipal that doesn't trigger channel/role recalculation
 func (dbc *DatabaseContext) GetPrincipal(name string, isUser bool) (info *PrincipalConfig, err error) {
 	var princ auth.Principal
 	if isUser {
@@ -87,83 +88,89 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 	var princ auth.Principal
 	var user auth.User
 	authenticator := dbc.Authenticator()
-	if isUser {
-		user, err = authenticator.GetUser(*newInfo.Name)
-		princ = user
-	} else {
-		princ, err = authenticator.GetRole(*newInfo.Name)
-	}
-	if err != nil {
-		return
-	}
 
-	changed := false
-	replaced = (princ != nil)
-	if !replaced {
-		// If user/role didn't exist already, instantiate a new one:
+	// Retry handling for cas failure during principal update.  Limiting retry attempts
+	// to PrincipalUpdateMaxCasRetries defensively to avoid unexpected retry loops.
+	for i := 1; i <= auth.PrincipalUpdateMaxCasRetries; i++ {
 		if isUser {
+			user, err = authenticator.GetUser(*newInfo.Name)
+			princ = user
+		} else {
+			princ, err = authenticator.GetRole(*newInfo.Name)
+		}
+		if err != nil {
+			return replaced, err
+		}
+
+		changed := false
+		replaced = (princ != nil)
+		if !replaced {
+			// If user/role didn't exist already, instantiate a new one:
+			if isUser {
+				isValid, reason := newInfo.IsPasswordValid(dbc.AllowEmptyPassword)
+				if !isValid {
+					err = base.HTTPErrorf(http.StatusBadRequest, reason)
+					return replaced, err
+				}
+				user, err = authenticator.NewUser(*newInfo.Name, "", nil)
+				princ = user
+			} else {
+				princ, err = authenticator.NewRole(*newInfo.Name, nil)
+			}
+			if err != nil {
+				return replaced, err
+			}
+			changed = true
+		} else if !allowReplace {
+			err = base.HTTPErrorf(http.StatusConflict, "Already exists")
+			return
+		} else if isUser && newInfo.Password != nil {
 			isValid, reason := newInfo.IsPasswordValid(dbc.AllowEmptyPassword)
 			if !isValid {
 				err = base.HTTPErrorf(http.StatusBadRequest, reason)
-				return
+				return replaced, err
 			}
-			user, err = authenticator.NewUser(*newInfo.Name, "", nil)
-			princ = user
-		} else {
-			princ, err = authenticator.NewRole(*newInfo.Name, nil)
 		}
-		if err != nil {
-			return
-		}
-		changed = true
-	} else if !allowReplace {
-		err = base.HTTPErrorf(http.StatusConflict, "Already exists")
-		return
-	} else if isUser && newInfo.Password != nil {
-		isValid, reason := newInfo.IsPasswordValid(dbc.AllowEmptyPassword)
-		if !isValid {
-			err = base.HTTPErrorf(http.StatusBadRequest, reason)
-			return
-		}
-	}
 
-	updatedChannels := princ.ExplicitChannels()
-	if updatedChannels == nil {
-		updatedChannels = ch.TimedSet{}
-	}
-	if !updatedChannels.Equals(newInfo.ExplicitChannels) {
-		changed = true
-	}
-
-	var updatedRoles ch.TimedSet
-
-	// Then the user-specific fields like roles:
-	if isUser {
-		if newInfo.Email != user.Email() {
-			user.SetEmail(newInfo.Email)
-			changed = true
+		updatedChannels := princ.ExplicitChannels()
+		if updatedChannels == nil {
+			updatedChannels = ch.TimedSet{}
 		}
-		if newInfo.Password != nil {
-			user.SetPassword(*newInfo.Password)
-			changed = true
-		}
-		if newInfo.Disabled != user.Disabled() {
-			user.SetDisabled(newInfo.Disabled)
+		if !updatedChannels.Equals(newInfo.ExplicitChannels) {
 			changed = true
 		}
 
-		updatedRoles = user.ExplicitRoles()
-		if updatedRoles == nil {
-			updatedRoles = ch.TimedSet{}
-		}
-		if !updatedRoles.Equals(base.SetFromArray(newInfo.ExplicitRoleNames)) {
-			changed = true
+		var updatedRoles ch.TimedSet
+
+		// Then the user-specific fields like roles:
+		if isUser {
+			if newInfo.Email != user.Email() {
+				user.SetEmail(newInfo.Email)
+				changed = true
+			}
+			if newInfo.Password != nil {
+				user.SetPassword(*newInfo.Password)
+				changed = true
+			}
+			if newInfo.Disabled != user.Disabled() {
+				user.SetDisabled(newInfo.Disabled)
+				changed = true
+			}
+
+			updatedRoles = user.ExplicitRoles()
+			if updatedRoles == nil {
+				updatedRoles = ch.TimedSet{}
+			}
+			if !updatedRoles.Equals(base.SetFromArray(newInfo.ExplicitRoleNames)) {
+				changed = true
+			}
 		}
 
-	}
+		// And finally save the Principal:
+		if !changed {
+			return replaced, nil
+		}
 
-	// And finally save the Principal:
-	if changed {
 		// Update the persistent sequence number of this principal (only allocate a sequence when needed - issue #673):
 		nextSeq := uint64(0)
 		if dbc.writeSequences() {
@@ -186,6 +193,14 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 			}
 		}
 		err = authenticator.Save(princ)
+		// On cas error, retry.  Otherwise break out of loop
+		if base.IsCasMismatch(err) {
+			base.Infof(base.KeyAuth, "CAS mismatch updating principal %s - will retry", base.UD(princ.Name()))
+		} else {
+			return replaced, err
+		}
 	}
-	return
+
+	base.Infof(base.KeyAuth, "CAS mismatch updating principal %s - exceeded retry count. Latest failure: %v", base.UD(princ.Name()), err)
+	return replaced, err
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,7 +45,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="701cd1ec079d40188c615b14eee22aad047817a0"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="c34599b076eb7194a53e8535397123a758700774"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="16db1f1fe037412f12738fa4d8448c549c4edd77"/>
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -131,6 +131,8 @@ func TestUserAPI(t *testing.T) {
 	// POST a user
 	response = rt.SendAdminRequest("POST", "/db/_user", `{"name":"snej", "password":"letmein", "admin_channels":["foo", "bar"]}`)
 	assertStatus(t, response, 301)
+	rt.Bucket().Dump()
+
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"snej", "password":"letmein", "admin_channels":["foo", "bar"]}`)
 	assertStatus(t, response, 201)
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
@@ -896,7 +898,6 @@ func TestSessionAPI(t *testing.T) {
 	// 5. DELETE sessions when password is changed
 	// Change password for user3
 	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"password":"5678"}`)
-
 	assertStatus(t, response, 200)
 
 	// Validate that all sessions were deleted

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1965,6 +1965,8 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
 
+	guest, err = a.GetUser("")
+	goassert.Equals(t, err, nil)
 	guest.SetDisabled(true)
 	err = a.Save(guest)
 	goassert.Equals(t, err, nil)

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -153,7 +153,7 @@ func (h *handler) makeSessionFromNameAndEmail(username, email string, createUser
 			if email != user.Email() {
 				if err = h.db.Authenticator().UpdateUserEmail(user, email); err != nil {
 					// Failure to update email during session creation is non-critical, log and continue.
-					base.Infof(base.KeyAuth, "Unable to update email for user %s during session creation. Error:%v,", base.UD(username), err)
+					base.Infof(base.KeyAuth, "Unable to update email for user %s during session creation.  Session will still be created. Error:%v,", base.UD(username), err)
 				}
 			}
 		} else {
@@ -172,6 +172,7 @@ func (h *handler) makeSessionFromNameAndEmail(username, email string, createUser
 		}
 
 		// Create a User with the given username, email address, and a random password.
+		// CAS mismatch indicates the user has been created by another request underneath us, can continue with session creation
 		user, err = h.db.Authenticator().RegisterNewUser(username, email)
 		if err != nil && !base.IsCasMismatch(err) {
 			return err


### PR DESCRIPTION
Ensure that concurrent principal updates don't result in user/role attributes being unintentionally overwritten.  Cas is now stored w/ the principal and used for any update.

Retry on cas failure has been added for all non-test user writes.  Moved all such functionality to helper methods on auth for consistent use. 

Fixes #3414