### PR TITLE
Prepend database-level logging with database name

### DIFF
--- a/db/assimilator.go
+++ b/db/assimilator.go
@@ -10,9 +10,9 @@ func (c *DatabaseContext) watchDocChanges() {
 	if c.mutationListener.DocChannel == nil {
 		return
 	}
-	base.Infof(base.KeyShadow, "Watching doc changes...")
+	c.Infof(base.KeyShadow, "Watching doc changes...")
 	for event := range c.mutationListener.DocChannel {
-		base.Infof(base.KeyShadow, "Got shadow event:%s", base.UD(event.Key))
+		c.Infof(base.KeyShadow, "Got shadow event:%s", base.UD(event.Key))
 		doc, err := unmarshalDocument(string(event.Key), event.Value)
 		if err == nil {
 			if doc.HasValidSyncData(c.writeSequences()) {

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -193,7 +193,7 @@ func (db *Database) setAttachment(attachment []byte) (AttachmentKey, error) {
 	key := AttachmentKey(Sha1DigestKey(attachment))
 	_, err := db.Bucket.AddRaw(attachmentKeyToString(key), 0, attachment)
 	if err == nil {
-		base.Infof(base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
+		db.Infof(base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
 	}
 	return key, err
 }
@@ -202,7 +202,7 @@ func (db *Database) setAttachments(attachments AttachmentData) error {
 	for key, data := range attachments {
 		_, err := db.Bucket.AddRaw(attachmentKeyToString(key), 0, data)
 		if err == nil {
-			base.Infof(base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
+			db.Infof(base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
 		} else {
 			return err
 		}
@@ -287,7 +287,7 @@ func (db *Database) WriteMultipartDocument(body Body, writer *multipart.Writer, 
 			info.contentType, _ = meta["content_type"].(string)
 			info.data, err = decodeAttachment(meta["data"])
 			if info.data == nil {
-				base.Warnf(base.KeyAll, "Couldn't decode attachment %q of doc %q: %v", base.UD(name), base.UD(body[BodyId]), err)
+				db.Warnf(base.KeyAll, "Couldn't decode attachment %q of doc %q: %v", base.UD(name), base.UD(body[BodyId]), err)
 				meta["stub"] = true
 				delete(meta, "data")
 			} else if len(info.data) > kMaxInlineAttachmentSize {

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -88,7 +88,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket) error {
 	default:
 		// DCP Feed
 		//    DCP receiver isn't go-channel based - DCPReceiver calls ProcessEvent directly.
-		base.Infof(base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.UD(bucket.GetName()))
+		base.Infof(base.KeyDCP, "Using DCP feed for bucket: %q (based on feed_type specified in config file)", base.MD(bucket.GetName()))
 		return bucket.StartDCPFeed(listener.FeedArgs, listener.ProcessFeedEvent)
 	}
 }
@@ -129,7 +129,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 // Stops a changeListener. Any pending Wait() calls will immediately return false.
 func (listener *changeListener) Stop() {
 
-	base.Debugf(base.KeyChanges, "changeListener.Stop() called")
+	base.Debugf(base.KeyChanges, "changeListener.Stop() called for bucket %s", base.MD(listener.bucketName))
 
 	if listener.terminator != nil {
 		close(listener.terminator)
@@ -182,7 +182,7 @@ func (listener *changeListener) NotifyCheckForTermination(keys base.Set) {
 		listener.terminateCheckCounter = 0
 	}
 
-	base.Debugf(base.KeyChanges, "Notifying to check for _changes feed termination")
+	base.Debugf(base.KeyChanges, "Notifying to check for _changes feed termination for bucket %s", base.MD(listener.bucketName))
 	listener.tapNotifier.Broadcast()
 	listener.tapNotifier.L.Unlock()
 }
@@ -191,7 +191,7 @@ func (listener *changeListener) notifyStopping() {
 	listener.tapNotifier.L.Lock()
 	listener.counter = 0
 	listener.keyCounts = map[string]uint64{}
-	base.Debugf(base.KeyChanges, "Notifying that changeListener is stopping")
+	base.Debugf(base.KeyChanges, "Notifying that changeListener is stopping for bucket %s", base.MD(listener.bucketName))
 	listener.tapNotifier.Broadcast()
 	listener.tapNotifier.L.Unlock()
 }

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -88,7 +88,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	entries := make(LogEntries, 0)
 	activeEntryCount := 0
 
-	base.Infof(base.KeyCache, "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, options.Limit)
+	dbc.Infof(base.KeyCache, "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, options.Limit)
 
 	// Loop for active-only and limit handling.
 	// The set of changes we get back from the query applies the limit, but includes both active and non-active entries.  When retrieving changes w/ activeOnly=true and a limit,
@@ -140,7 +140,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 			if len(entries) > 0 {
 				break
 			}
-			base.Infof(base.KeyCache, "    Got no rows from query for channel:%q", base.UD(channelName))
+			dbc.Infof(base.KeyCache, "    Got no rows from query for channel:%q", base.UD(channelName))
 			return nil, nil
 		}
 
@@ -157,7 +157,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 			// Otherwise update startkey and re-query
 
 			startSeq = highSeq + 1
-			base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, options.Limit)
+			dbc.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, options.Limit)
 		} else {
 			// If not active-only, we only need one iteration of the loop - the limit applied to the view query is sufficient
 			break
@@ -165,11 +165,11 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	}
 
 	if len(entries) > 0 {
-		base.Infof(base.KeyCache, "    Got %d rows from query for %q: #%d ... #%d",
+		dbc.Infof(base.KeyCache, "    Got %d rows from query for %q: #%d ... #%d",
 			len(entries), base.UD(channelName), entries[0].Sequence, entries[len(entries)-1].Sequence)
 	}
 	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
-		base.Infof(base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
+		dbc.Infof(base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
 			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, options.Limit)
 	}
 	changeCacheExpvars.Add("view_queries", 1)

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -300,7 +300,7 @@ func InitializeViews(bucket base.Bucket) error {
 
 	// If not present, install design docs and views
 	if !ddocsExist {
-		base.Infof(base.KeyAll, "Design docs for current view version (%s) do not exist - creating...", DesignDocVersion)
+		base.Infof(base.KeyAll, "Design docs for current view version (%s) do not exist for bucket %s - creating...", base.MD(bucket.GetName()), DesignDocVersion)
 		if err := installViews(bucket); err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func checkExistingDDocs(bucket base.Bucket) bool {
 	sgHousekeepingDDocExists := getDDocErr == nil && result != nil
 
 	if sgDDocExists && sgHousekeepingDDocExists {
-		base.Infof(base.KeyAll, "Design docs for current SG view version (%s) found.", DesignDocVersion)
+		base.Infof(base.KeyAll, "Design docs for current SG view version (%s) found for bucket %s.", DesignDocVersion, base.MD(bucket.GetName()))
 		return true
 	}
 
@@ -546,7 +546,7 @@ func installViews(bucket base.Bucket) error {
 		worker := func() (shouldRetry bool, err error, value interface{}) {
 			err = bucket.PutDDoc(designDocName, designDoc)
 			if err != nil {
-				base.Warnf(base.KeyAll, "Error installing Couchbase design doc: %v", err)
+				base.Warnf(base.KeyAll, "Error installing Couchbase design doc for bucket %s: %v", base.MD(bucket.GetName()), err)
 			}
 			return err != nil, err, nil
 		}
@@ -559,7 +559,7 @@ func installViews(bucket base.Bucket) error {
 		}
 	}
 
-	base.Infof(base.KeyAll, "Design docs successfully created for view version %s.", DesignDocVersion)
+	base.Infof(base.KeyAll, "Design docs successfully created for view version %s, bucket %s", DesignDocVersion, base.MD(bucket.GetName()))
 
 	return nil
 }
@@ -645,7 +645,7 @@ func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool) (removedDesi
 			if !previewOnly {
 				removeDDocErr := bucket.DeleteDDoc(ddocName)
 				if removeDDocErr != nil && !IsMissingDDocError(removeDDocErr) {
-					base.Warnf(base.KeyAll, "Unexpected error when removing design doc %q: %s", ddocName, removeDDocErr)
+					base.Warnf(base.KeyAll, "Unexpected error when removing design doc %q for bucket %s: %s", ddocName, base.MD(bucket.GetName()), removeDDocErr)
 					return removedDesignDocs, removeDDocErr
 				}
 				// Only include in list of removedDesignDocs if it was actually removed
@@ -656,7 +656,7 @@ func removeObsoleteDesignDocs(bucket base.Bucket, previewOnly bool) (removedDesi
 				var result interface{}
 				existsDDocErr := bucket.GetDDoc(ddocName, &result)
 				if existsDDocErr != nil && !IsMissingDDocError(existsDDocErr) {
-					base.Warnf(base.KeyAll, "Unexpected error when checking existence of design doc %q: %s", ddocName, existsDDocErr)
+					base.Warnf(base.KeyAll, "Unexpected error when checking existence of design doc %q for bucket %s: %s", ddocName, base.MD(bucket.GetName()), existsDDocErr)
 				}
 				// Only include in list of removedDesignDocs if it exists
 				if existsDDocErr == nil {

--- a/db/document.go
+++ b/db/document.go
@@ -105,7 +105,7 @@ func (doc *document) Body() Body {
 	if doc._body == nil && doc.rawBody != nil {
 		err := doc._body.Unmarshal(doc.rawBody)
 		if err != nil {
-			base.Warnf(base.KeyAll, "Unable to unmarshal document body from raw body : %s", err)
+			base.Warnf(base.KeyAll, "Unable to unmarshal document body from raw body for doc %s: %s", base.UD(doc.ID), err)
 			return nil
 		}
 		doc.rawBody = nil

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -30,7 +30,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 		to = fmt.Sprintf("  (to %s)", db.user.Name())
 		userVbNo = uint16(db.Bucket.VBHash(db.user.DocID()))
 	}
-	base.Debugf(base.KeyChanges, "Vector MultiChangesFeed(channels: %s, options: %+v) ... %s", base.UD(chans), options, base.UD(to))
+	db.Debugf(base.KeyChanges, "Vector MultiChangesFeed(channels: %s, options: %+v) ... %s", base.UD(chans), options, base.UD(to))
 
 	output := make(chan *ChangeEntry, 50)
 
@@ -41,7 +41,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 		var lastHashedValue string
 		hashedEntryCount := 0
 		defer func() {
-			base.Debugf(base.KeyChanges, "MultiChangesFeed done %s", base.UD(to))
+			db.Debugf(base.KeyChanges, "MultiChangesFeed done %s", base.UD(to))
 			base.StatsExpvars.Add("vectorChanges_active", -1)
 			close(output)
 		}()
@@ -72,7 +72,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 				if err := db.ReloadUser(); err != nil {
 					change := makeErrorEntry("User not found during reload - terminating changes feed")
 					output <- &change
-					base.Warnf(base.KeyAll, "Error reloading user during changes initialization %q: %v", base.UD(db.user.Name()), err)
+					db.Warnf(base.KeyAll, "Error reloading user during changes initialization %q: %v", base.UD(db.user.Name()), err)
 					return
 				}
 			}
@@ -93,7 +93,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 			// Get the last polled stable sequence.  We don't return anything later than stable sequence in each iteration
 			stableClock, err := db.changeCache.GetStableClock(true)
 			if err != nil {
-				base.Warnf(base.KeyAll, "MultiChangesFeed got error reading stable sequence: %v", err)
+				db.Warnf(base.KeyAll, "MultiChangesFeed got error reading stable sequence: %v", err)
 				change := makeErrorEntry("Error reading stable sequence")
 				output <- &change
 				return
@@ -103,7 +103,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 			if changeWaiter != nil {
 				changeWaiter.UpdateChannels(channelsSince)
 			}
-			base.Debugf(base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince.String()), base.UD(to))
+			db.Debugf(base.KeyChanges, "MultiChangesFeed: channels expand to %#v ... %s", base.UD(channelsSince.String()), base.UD(to))
 
 			// postStableSeqsFound tracks whether we hit any sequences later than the stable sequence.  In this scenario the user
 			// may not get another wait notification, so we bypass wait loop processing.
@@ -112,7 +112,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 			// Build the channel feeds.
 			feeds, postStableSeqsFound, err := db.initializeChannelFeeds(channelsSince, secondaryTriggers, options, addedChannels, userVbNo, cumulativeClock, stableClock)
 			if err != nil {
-				base.Warnf(base.KeyAll, "Error building channel feeds: %v", err)
+				db.Warnf(base.KeyAll, "Error building channel feeds: %v", err)
 				change := makeErrorEntry("Error building channel feeds")
 				output <- &change
 				return
@@ -188,7 +188,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 					if minEntry.Seq.TriggeredByClock.GetHashedValue() == "" {
 						clockHash, err := db.SequenceHasher.GetHash(cumulativeClock)
 						if err != nil {
-							base.Warnf(base.KeyAll, "Error calculating hash for triggered by clock:%v", base.PrintClock(cumulativeClock))
+							db.Warnf(base.KeyAll, "Error calculating hash for triggered by clock:%v", base.PrintClock(cumulativeClock))
 						} else {
 							minEntry.Seq.TriggeredByClock.SetHashedValue(clockHash)
 						}
@@ -196,7 +196,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 				}
 
 				// Send the entry, and repeat the loop:
-				base.Debugf(base.KeyChanges, "MultiChangesFeed sending %s %s", base.UD(minEntry), base.UD(to))
+				db.Debugf(base.KeyChanges, "MultiChangesFeed sending %s %s", base.UD(minEntry), base.UD(to))
 				select {
 				case <-options.Terminator:
 					return
@@ -226,7 +226,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 
 			// If nothing found, and in wait mode: wait for the db to change, then run again.
 			// First notify the reader that we're waiting by sending a nil.
-			base.Debugf(base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
+			db.Debugf(base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
 			output <- nil
 
 		waitForChanges:
@@ -265,7 +265,7 @@ func (db *Database) VectorMultiChangesFeed(chans base.Set, options ChangesOption
 			}
 			if err != nil {
 				change := makeErrorEntry("User not found during reload - terminating changes feed")
-				base.Debugf(base.KeyChanges, "User not found during reload - terminating changes feed with entry %+v", base.UD(change))
+				db.Debugf(base.KeyChanges, "User not found during reload - terminating changes feed with entry %+v", base.UD(change))
 				output <- &change
 				return
 			}
@@ -282,12 +282,12 @@ func (db *Database) checkForUserUpdatesSince(userChangeCount uint64, changeWaite
 	// we can reload only when there's been a user change notification
 	if newCount > userChangeCount || !isContinuous {
 		var newChannels base.Set
-		base.Debugf(base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(db.user))
+		db.Debugf(base.KeyChanges, "MultiChangesFeed reloading user %+v", base.UD(db.user))
 		userChangeCount = newCount
 
 		if db.user != nil {
 			if err := db.ReloadUser(); err != nil {
-				base.Warnf(base.KeyAll, "Error reloading user %q: %v", base.UD(db.user.Name()), err)
+				db.Warnf(base.KeyAll, "Error reloading user %q: %v", base.UD(db.user.Name()), err)
 				return false, 0, nil, err
 			}
 			// check whether channels have changed
@@ -300,7 +300,7 @@ func (db *Database) checkForUserUpdatesSince(userChangeCount uint64, changeWaite
 				}
 			}
 			if len(newChannels) > 0 {
-				base.Debugf(base.KeyChanges, "New channels found after user reload: %v", base.UD(newChannels))
+				db.Debugf(base.KeyChanges, "New channels found after user reload: %v", base.UD(newChannels))
 			}
 		}
 		return true, newCount, newChannels, nil
@@ -460,7 +460,7 @@ func (db *Database) calculateHashWhenNeeded(options ChangesOptions, entry *Chang
 	if *hashedEntryCount == 0 || forceHash {
 		clockHash, err := db.SequenceHasher.GetHash(cumulativeClock)
 		if err != nil {
-			base.Warnf(base.KeyAll, "Error calculating hash for clock:%v", base.PrintClock(cumulativeClock))
+			db.Warnf(base.KeyAll, "Error calculating hash for clock:%v", base.PrintClock(cumulativeClock))
 			return lastHashedValue
 		} else {
 			entry.Seq.Clock = base.NewSyncSequenceClock()
@@ -482,7 +482,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 	feeds := make([]<-chan *ChangeEntry, 0, len(channelsSince))
 	hasPostChangesTriggers := false
 
-	base.Debugf(base.KeyChanges, "GotChannelSince... %v", base.UD(channelsSince))
+	db.Debugf(base.KeyChanges, "GotChannelSince... %v", base.UD(channelsSince))
 	for name, vbSeqAddedAt := range channelsSince {
 		seqAddedAt := vbSeqAddedAt.Sequence
 
@@ -502,7 +502,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 			vbAddedAt = *vbSeqAddedAt.VbNo
 		}
 
-		base.Debugf(base.KeyChanges, "Starting for channel... %s, %d.%d", base.UD(name), vbAddedAt, seqAddedAt)
+		db.Debugf(base.KeyChanges, "Starting for channel... %s, %d.%d", base.UD(name), vbAddedAt, seqAddedAt)
 		chanOpts := options
 
 		// Check whether requires backfill based on addedChannels in this _changes feed
@@ -534,7 +534,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 		// If backfill required and the triggering seq is after the stable sequence, skip this channel in this iteration
 		stableSeq := stableClock.GetSequence(vbAddedAt)
 		if backfillRequired && seqAddedAt > stableSeq {
-			base.Debugf(base.KeyChanges, "Trigger for channel [%s] is post-stable sequence - skipped for this iteration.  userVbNo:[%d] vbAddedAt:[%d] Seq:[%d] Stable seq:[%d]", base.UD(name), userVbNo, vbAddedAt, seqAddedAt, stableSeq)
+			db.Debugf(base.KeyChanges, "Trigger for channel [%s] is post-stable sequence - skipped for this iteration.  userVbNo:[%d] vbAddedAt:[%d] Seq:[%d] Stable seq:[%d]", base.UD(name), userVbNo, vbAddedAt, seqAddedAt, stableSeq)
 			hasPostChangesTriggers = true
 			continue
 		}
@@ -547,7 +547,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 				TriggeredBy:     seqAddedAt,
 				TriggeredByVbNo: vbAddedAt,
 			}
-			base.Debugf(base.KeyChanges, "Starting backfill for channel... %s, %+v", base.UD(name), chanOpts.Since.Print())
+			db.Debugf(base.KeyChanges, "Starting backfill for channel... %s, %+v", base.UD(name), chanOpts.Since.Print())
 		} else if backfillInProgress {
 			// Case 3.  Backfill in progress.
 			chanOpts.Since = SequenceID{
@@ -557,7 +557,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 				TriggeredByVbNo:  vbAddedAt,
 				TriggeredByClock: options.Since.TriggeredByClock,
 			}
-			base.Debugf(base.KeyChanges, "Backfill in progress for channel... %s, %+v", base.UD(name), chanOpts.Since.Print())
+			db.Debugf(base.KeyChanges, "Backfill in progress for channel... %s, %+v", base.UD(name), chanOpts.Since.Print())
 		} else if backfillInOtherChannel {
 			chanOpts.Since = SequenceID{
 				Clock: options.Since.TriggeredByClock, // Update Clock to TriggeredByClock if we're in other backfill
@@ -568,7 +568,7 @@ func (db *Database) initializeChannelFeeds(channelsSince channels.TimedSet, seco
 
 		feed, err := db.vectorChangesFeed(name, chanOpts, secondaryTriggers[name], cumulativeClock, stableClock)
 		if err != nil {
-			base.Warnf(base.KeyAll, "MultiChangesFeed got error reading changes feed %q: %v", base.UD(name), err)
+			db.Warnf(base.KeyAll, "MultiChangesFeed got error reading changes feed %q: %v", base.UD(name), err)
 			return feeds, false, err
 		}
 		feeds = append(feeds, feed)
@@ -658,7 +658,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 		if err != nil {
 			return nil, err
 		}
-		base.Debugf(base.KeyChanges, "[changesFeed] Found %d changes for channel %s", len(log), base.UD(channel))
+		db.Debugf(base.KeyChanges, "[changesFeed] Found %d changes for channel %s", len(log), base.UD(channel))
 	case ChannelFeedType_ActiveBackfill:
 		// In-progress backfill for this channel
 		// Backfill position: (vb,seq) position in the backfill. e.g. [0,0] if we're just starting the backfill, [vb,seq] if we're midway through.
@@ -672,14 +672,14 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 		if err != nil {
 			return nil, err
 		}
-		base.Debugf(base.KeyChanges, "[changesFeed] Found %d backfill changes for channel %s", len(backfillLog), base.UD(channel))
+		db.Debugf(base.KeyChanges, "[changesFeed] Found %d backfill changes for channel %s", len(backfillLog), base.UD(channel))
 		// If we still have room, get non-backfill entries
 		if options.Limit == 0 || len(backfillLog) < options.Limit {
 			log, err = changeIndex.reader.GetChangesForRange(channel, backfillTo, nil, options.Limit, options.ActiveOnly)
 			if err != nil {
 				return nil, err
 			}
-			base.Debugf(base.KeyChanges, "[changesFeed] Found %d non-backfill changes for channel %s", len(log), base.UD(channel))
+			db.Debugf(base.KeyChanges, "[changesFeed] Found %d non-backfill changes for channel %s", len(log), base.UD(channel))
 		}
 	case ChannelFeedType_PendingBackfill:
 		// Pending backfill for this channel
@@ -729,7 +729,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 			for _, changeEntry := range pendingBackfillLog {
 				select {
 				case <-options.Terminator:
-					base.Debugf(base.KeyChanges, "Aborting changesFeed")
+					db.Debugf(base.KeyChanges, "Aborting changesFeed")
 					return
 				case feed <- changeEntry:
 				}
@@ -745,7 +745,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 			options.Since.TriggeredByClock = base.NewSequenceClockImpl()
 			clockHash, err := db.SequenceHasher.GetHash(cumulativeClock)
 			if err != nil {
-				base.Warnf(base.KeyAll, "Error calculating hash for triggered by clock:%v", base.PrintClock(cumulativeClock))
+				db.Warnf(base.KeyAll, "Error calculating hash for triggered by clock:%v", base.PrintClock(cumulativeClock))
 				return
 			}
 			options.Since.TriggeredByClock.SetHashedValue(clockHash)
@@ -753,7 +753,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 			// Get everything from zero to the cumulative clock as backfill
 			backfillLog, err = changeIndex.reader.GetChangesForRange(channel, base.NewSequenceClockImpl(), cumulativeClock, options.Limit, options.ActiveOnly)
 			if err != nil {
-				base.Warnf(base.KeyAll, "Error processing backfill changes for channel %s: %v", base.UD(channel), err)
+				db.Warnf(base.KeyAll, "Error processing backfill changes for channel %s: %v", base.UD(channel), err)
 				return
 			}
 
@@ -761,10 +761,10 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 			if options.Limit == 0 || len(backfillLog) < options.Limit {
 				log, err = changeIndex.reader.GetChangesForRange(channel, cumulativeClock, stableClock, options.Limit, options.ActiveOnly)
 				if err != nil {
-					base.Warnf(base.KeyAll, "Error processing changes for channel %s: %v", base.UD(channel), err)
+					db.Warnf(base.KeyAll, "Error processing changes for channel %s: %v", base.UD(channel), err)
 					return
 				}
-				base.Debugf(base.KeyChanges, "[changesFeed] Found %d non-backfill changes for channel %s", len(log), base.UD(channel))
+				db.Debugf(base.KeyChanges, "[changesFeed] Found %d non-backfill changes for channel %s", len(log), base.UD(channel))
 			}
 		}
 
@@ -781,7 +781,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 			change := makeChangeEntry(logEntry, seqID, channel)
 			select {
 			case <-options.Terminator:
-				base.Debugf(base.KeyChanges, "Aborting changesFeed")
+				db.Debugf(base.KeyChanges, "Aborting changesFeed")
 				return
 			case feed <- &change:
 			}
@@ -801,7 +801,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 
 			select {
 			case <-options.Terminator:
-				base.Debugf(base.KeyChanges, "Aborting changesFeed")
+				db.Debugf(base.KeyChanges, "Aborting changesFeed")
 				return
 			case feed <- &backfillCompleteEntry:
 			}
@@ -818,7 +818,7 @@ func (db *Database) vectorChangesFeed(channel string, options ChangesOptions, se
 			change := makeChangeEntry(logEntry, seqID, channel)
 			select {
 			case <-options.Terminator:
-				base.Debugf(base.KeyChanges, "Aborting changesFeed")
+				db.Debugf(base.KeyChanges, "Aborting changesFeed")
 				return
 			case feed <- &change:
 			}

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -179,7 +179,7 @@ func (k *kvChangeIndex) setIndexPartitionMap(partitionMap base.IndexPartitionMap
 
 func (k *kvChangeIndex) DocChanged(event sgbucket.FeedEvent) {
 	// no-op for reader
-	base.Warnf(base.KeyAll, "DocChanged called in index reader for doc %s, will be ignored.", base.UD(event.Key))
+	k.context.Warnf(base.KeyAll, "DocChanged called in index reader for doc %s, will be ignored.", base.UD(event.Key))
 }
 
 // No-ops - pending refactoring of change_cache.go to remove usage (or deprecation of
@@ -413,7 +413,7 @@ func (k *kvChangeIndex) generatePartitionStats() (PartitionStats, error) {
 }
 
 // The following are no-ops for kvChangeIndex.
-func (k *kvChangeIndex) Start() (error) { return nil }
+func (k *kvChangeIndex) Start() error { return nil }
 
 func IsNotFoundError(err error) bool {
 	return strings.Contains(strings.ToLower(err.Error()), "not found")

--- a/db/query.go
+++ b/db/query.go
@@ -236,7 +236,7 @@ func (context *DatabaseContext) QueryAccess(username string) (sgbucket.QueryResu
 
 	// N1QL Query
 	if username == "" {
-		base.Warnf(base.KeyAll, "QueryAccess called with empty username - returning empty result iterator")
+		context.Warnf(base.KeyAll, "QueryAccess called with empty username - returning empty result iterator")
 		return &EmptyResultIterator{}, nil
 	}
 
@@ -257,7 +257,7 @@ func (context *DatabaseContext) QueryRoleAccess(username string) (sgbucket.Query
 
 	// N1QL Query
 	if username == "" {
-		base.Warnf(base.KeyAll, "QueryRoleAccess called with empty username")
+		context.Warnf(base.KeyAll, "QueryRoleAccess called with empty username")
 		return &EmptyResultIterator{}, nil
 	}
 
@@ -272,7 +272,7 @@ func (context *DatabaseContext) QueryChannels(channelName string, startSeq uint6
 
 	if context.Options.UseViews {
 		opts := changesViewOptions(channelName, startSeq, endSeq, limit)
-		base.Infof(base.KeyCRUD, "issuing view query")
+		context.Infof(base.KeyCRUD, "issuing view query")
 		return context.ViewQueryWithStats(DesignDocSyncGateway(), ViewChannels, opts)
 	}
 

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -123,7 +123,7 @@ This is how the view is iterated:
                                                     NumProcessed: 0
 
 * It starts with an empty start key
-* For the next pageo, it uses the last key processed as the new start key
+* For the next page, it uses the last key processed as the new start key
 * Since the start key is inclusive, it will see the start key twice (on first page, and on next page)
 * If it's iterating a result page and sees a doc with the start key (eg, doc3 in above), it will ignore it so it doesn't process it twice
 * Stop condition: if NumProcessed is 0, because the only doc in result set had already been processed.

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -123,7 +123,7 @@ This is how the view is iterated:
                                                     NumProcessed: 0
 
 * It starts with an empty start key
-* For the next page, it uses the last key processed as the new start key
+* For the next pageo, it uses the last key processed as the new start key
 * Since the start key is inclusive, it will see the start key twice (on first page, and on next page)
 * If it's iterating a result page and sees a doc with the start key (eg, doc3 in above), it will ignore it so it doesn't process it twice
 * Stop condition: if NumProcessed is 0, because the only doc in result set had already been processed.

--- a/db/revision.go
+++ b/db/revision.go
@@ -106,7 +106,7 @@ const nonJSONPrefix = byte(1)
 func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byte, error) {
 	data, _, err := db.Bucket.GetRaw(oldRevisionKey(docid, revid))
 	if base.IsDocNotFoundError(err) {
-		base.Debugf(base.KeyCRUD, "No old revision %q / %q", base.UD(docid), revid)
+		db.Debugf(base.KeyCRUD, "No old revision %q / %q", base.UD(docid), revid)
 		err = base.HTTPErrorf(404, "missing")
 	}
 	if data != nil {
@@ -114,13 +114,13 @@ func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byt
 		if len(data) > 0 && data[0] == nonJSONPrefix {
 			data = data[1:]
 		}
-		base.Debugf(base.KeyCRUD, "Got old revision %q / %q --> %d bytes", base.UD(docid), revid, len(data))
+		db.Debugf(base.KeyCRUD, "Got old revision %q / %q --> %d bytes", base.UD(docid), revid, len(data))
 	}
 	return data, err
 }
 
 func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte) error {
-	base.Debugf(base.KeyCRUD, "Saving old revision %q / %q (%d bytes)", base.UD(docid), revid, len(body))
+	db.Debugf(base.KeyCRUD, "Saving old revision %q / %q (%d bytes)", base.UD(docid), revid, len(body))
 
 	// Set old revisions to expire after Options.OldRevExpirySeconds.  Defaults to 5 minutes.
 
@@ -135,7 +135,7 @@ func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte) 
 
 // Currently only used by unit tests - deletes an archived old revision from the database
 func (db *Database) purgeOldRevisionJSON(docid string, revid string) error {
-	base.Debugf(base.KeyCRUD, "Purging old revision backup %q / %q ", base.UD(docid), revid)
+	db.Debugf(base.KeyCRUD, "Purging old revision backup %q / %q ", base.UD(docid), revid)
 	return db.Bucket.Delete(oldRevisionKey(docid, revid))
 }
 

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -110,7 +110,7 @@ func (tree RevTree) MarshalJSON() ([]byte, error) {
 func (tree RevTree) UnmarshalJSON(inputjson []byte) (err error) {
 
 	if tree == nil {
-		// base.Warnf(base.KeyAll, "No RevTree for input %q", inputjson)
+		// db.Warnf(base.KeyAll, "No RevTree for input %q", inputjson)
 		return nil
 	}
 	var rep revTreeList


### PR DESCRIPTION
Fixes #3815 

Sample modified log format (where 'default' is the db name):
```
2018-11-05T15:21:04.304-08:00 [INF] HTTP:  #001: GET /default/_changes (as ADMIN)
2018-11-05T15:21:04.304-08:00 [INF] Changes: [default] MultiChangesFeed(channels: {*}, options: {Since:0 Limit:0 Conflicts:false IncludeDocs:false Wait:false Continuous:false Terminator:0xc0001eaba0 HeartbeatMs:0 TimeoutMs:300000 ActiveOnly:false}) ... 
2018-11-05T15:21:04.344-08:00 [INF] Changes: [default] MultiChangesFeed done 
```

