### PR TITLE
Improve logging on write error

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1238,9 +1238,6 @@ func (bucket *CouchbaseBucketGoCB) UpdateXattr(k string, xattrKey string, exp ui
 
 		if removeErr != nil {
 			shouldRetry = isRecoverableGoCBError(removeErr)
-			if !shouldRetry {
-				Warnf(KeyAll, "Unrecoverable error attempting to update xattr for key:%s cas:%d deleteBody:%v error:%v", UD(k), cas, deleteBody, removeErr)
-			}
 			return shouldRetry, removeErr, uint64(0)
 		}
 		return false, nil, uint64(docFragment.Cas())
@@ -1695,6 +1692,7 @@ func (bucket *CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey strin
 			// Retry on cas failure
 		default:
 			// WriteWithXattr already handles retry on recoverable errors, so fail on any errors other than ErrKeyExists
+			Infof(KeyCRUD, "Failed to update doc with xattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), err)
 			return emptyCas, writeErr
 		}
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1692,7 +1692,7 @@ func (bucket *CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey strin
 			// Retry on cas failure
 		default:
 			// WriteWithXattr already handles retry on recoverable errors, so fail on any errors other than ErrKeyExists
-			Infof(KeyCRUD, "Failed to update doc with xattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), err)
+			Warnf(KeyCRUD, "Failed to update doc with xattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), err)
 			return emptyCas, writeErr
 		}
 


### PR DESCRIPTION
Avoid logging a warning for handled errors.  In this case, cas failure during xattr update was emitting a warning to the logs.

For non-handled error, switch to info-level logging in bucket_gocb and rely on callers to escalate logging of any critical errors appropriately.