### PR TITLE
Adds the ability to set the domain at which Sync Gateway's session cookie is set

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,6 +12,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
@@ -22,9 +23,10 @@ import (
 
 /** Manages user authentication for a database. */
 type Authenticator struct {
-	bucket            base.Bucket
-	channelComputer   ChannelComputer
-	sessionCookieName string // Custom per-database session cookie name
+	bucket               base.Bucket
+	channelComputer      ChannelComputer
+	sessionCookieName    string            // Custom per-database session cookie name
+	sessionCookieDomains map[string]string // Custom session cookie domain per incoming request origin
 }
 
 // Interface for deriving the set of channels and roles a User/Role has access to.
@@ -52,8 +54,28 @@ func (auth *Authenticator) SessionCookieName() string {
 	return auth.sessionCookieName
 }
 
+func (auth *Authenticator) SessionCookieDomains() map[string]string {
+	return auth.sessionCookieDomains
+}
+
 func (auth *Authenticator) SetSessionCookieName(cookieName string) {
 	auth.sessionCookieName = cookieName
+}
+
+func (auth *Authenticator) SetSessionCookieDomains(cookieDomains map[string]string) {
+	auth.sessionCookieDomains = cookieDomains
+}
+
+func (auth *Authenticator) AddDomainToCookie(rq *http.Request, cookie *http.Cookie) {
+	origin := rq.Header.Get("Origin")
+	if len(origin) == 0 {
+		return
+	}
+	domain := auth.SessionCookieDomains()[origin]
+	if domain == "" {
+		return
+	}
+	cookie.Domain = domain
 }
 
 func docIDForUserEmail(email string) string {

--- a/auth/session.go
+++ b/auth/session.go
@@ -61,6 +61,7 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 			return nil, err
 		}
 		base.AddDbPathToCookie(rq, cookie)
+		auth.AddDomainToCookie(rq, cookie)
 		cookie.Expires = session.Expiration
 		http.SetCookie(response, cookie)
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -93,12 +93,13 @@ type DatabaseContextOptions struct {
 	OIDCOptions               *auth.OIDCOptions
 	DBOnlineCallback          DBOnlineCallback // Callback function to take the DB back online
 	ImportOptions             ImportOptions
-	EnableXattr               bool   // Use xattr for _sync
-	LocalDocExpirySecs        uint32 // The _local doc expiry time in seconds
-	SessionCookieName         string // Pass-through DbConfig.SessionCookieName
-	AllowConflicts            *bool  // False forbids creating conflicts
-	SendWWWAuthenticateHeader *bool  // False disables setting of 'WWW-Authenticate' header
-	UseViews                  bool   // Force use of views
+	EnableXattr               bool              // Use xattr for _sync
+	LocalDocExpirySecs        uint32            // The _local doc expiry time in seconds
+	SessionCookieName         string            // Pass-through DbConfig.SessionCookieName
+	SessionCookieDomains      map[string]string // Pass-through DbConfig.SessionCookieDomains
+	AllowConflicts            *bool             // False forbids creating conflicts
+	SendWWWAuthenticateHeader *bool             // False disables setting of 'WWW-Authenticate' header
+	UseViews                  bool              // Force use of views
 }
 
 type OidcTestProviderOptions struct {
@@ -574,6 +575,7 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 	if context.Options.SessionCookieName != "" {
 		authenticator.SetSessionCookieName(context.Options.SessionCookieName)
 	}
+	authenticator.SetSessionCookieDomains(context.Options.SessionCookieDomains)
 	return authenticator
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -189,6 +189,7 @@ type DbConfig struct {
 	LocalDocExpirySecs        *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
 	EnableXattrs              *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
 	SessionCookieName         string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
+	SessionCookieDomains      map[string]string            	 `json:"session_cookie_domains,omitempty"`       // Cookie domain name per request origin: keys = origins, values = domain name to set for session cookies from that origin.
 	AllowConflicts            *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
 	NumIndexReplicas          *uint                          `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
 	UseViews                  bool                           `json:"use_views"`                              // Force use of views instead of GSI

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -578,6 +578,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		ImportOptions:             importOptions,
 		EnableXattr:               config.UseXattrs(),
 		SessionCookieName:         config.SessionCookieName,
+		SessionCookieDomains:      config.SessionCookieDomains,
 		AllowConflicts:            config.ConflictsAllowed(),
 		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
 		UseViews:                  useViews,

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -130,6 +130,7 @@ func (h *handler) makeSessionWithTTL(user auth.User, expiry time.Duration) (sess
 	}
 	cookie := auth.MakeSessionCookie(session)
 	base.AddDbPathToCookie(h.rq, cookie)
+	auth.AddDomainToCookie(h.rq, cookie)
 	http.SetCookie(h.response, cookie)
 	return session.ID, nil
 }


### PR DESCRIPTION
Adds the ability to customize the domain at which SG sets its cookies, largely to avoid issues with making session cookie authorized Sync Gateway calls from cross-origin requests made by a browser based client.

With these changes, the cookie domain can be optionally set per incoming request origin, allowing for SG set cookies to work in at least the following scenarios:

1. browser based frontend application at subdomain `spa.x` of domain `x` wanting to receive and post back cookies set by Sync Gateway at sg.x. In our case Sync Gateway's cookie is set by an API server, let's call it `api.x`, which in turn makes API calls with `sg.x` -- `api.x` cannot set a cookie for `sg.x` (which is SG's effective behaviour presently at session extension time because the Domain property is not set in the cookie => browser's default behaviour is to treat the domain as the domain for where the response came from) but it can for `x`. This change makes it possible for the cookie to behave sensibly at session expiry extension time (it becomes possible to configure SG to respond with `Domain=x`, effectively extending the already set cookie for `x` instead of setting a new cookie for `sg.x`).
2. SG exposed as sg.x and sg.y for two different browser based client applications at domains x and y.