### PR TITLE
#3826 Create user's home directory if it does not exist

### DIFF
--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -32,12 +32,18 @@ EOF
       exit 1
     fi
 
+    # create home dir if it does not exist (maybe it has been deleted upon previous uninstall)
+    if [ ! -d "@@PREFIX@@" ]; then
+      mkdir -p @@PREFIX@@
+    fi
+
     chown -R @@PRODUCT_BASE@@:@@PRODUCT_BASE@@ @@PREFIX@@
 
     chmod 755 @@PREFIX@@/service/@@PRODUCT_EXEC@@_service_install.sh
 
     chmod 755 @@PREFIX@@/examples
 
+    # create user if it does not exist
     if [ -z `id -u @@PRODUCT_EXEC@@ 2>/dev/null` ]; then
       useradd -m @@PRODUCT_EXEC@@
     fi

--- a/build/preinst.tmpl
+++ b/build/preinst.tmpl
@@ -19,7 +19,7 @@ case "$1" in
       groupadd -r @@PRODUCT_BASE@@ || exit 1
     getent passwd @@PRODUCT_BASE@@ >/dev/null || \
       useradd -r -g @@PRODUCT_BASE@@ -d @@PREFIX@@ -s /bin/bash \
-              -c "@@PRODUCT_BASE_CAP@@ system user" @@PRODUCT_BASE@@ || exit 1
+              -c "@@PRODUCT_BASE_CAP@@ system user" --create-home @@PRODUCT_BASE@@ || exit 1
     exit 0
     ;;
 

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -61,7 +61,7 @@ getent group @@PRODUCT_BASE@@ >/dev/null || \
    groupadd -r @@PRODUCT_BASE@@ || exit 1
 getent passwd @@PRODUCT_BASE@@ >/dev/null || \
    useradd -r -g @@PRODUCT_BASE@@ -d $RPM_INSTALL_PREFIX0 -s /bin/sh \
-           -c "@@PRODUCT_BASE@@ system user" @@PRODUCT_BASE@@ || exit 1
+           -c "@@PRODUCT_BASE@@ system user" --create-home @@PRODUCT_BASE@@ || exit 1
 
 if [ -d @@PREFIX@@ ]
 then
@@ -78,8 +78,15 @@ fi
 
 # ln -f -s $RPM_INSTALL_PREFIX0 @@PREFIX@@
 
+# create user if it does not exist
 if [ -z `id -u @@PRODUCT_EXEC@@ 2>/dev/null` ]; then
   useradd -m @@PRODUCT_EXEC@@
+fi
+
+# create home dir if it does not exist (maybe it has been deleted upon uninstall)
+if [ ! -d "$RPM_INSTALL_PREFIX0" ]; then
+  mkdir -p $RPM_INSTALL_PREFIX0
+  chown @@PRODUCT_BASE@@:@@PRODUCT_BASE@@ $RPM_INSTALL_PREFIX0
 fi
 
 cd @@PREFIX@@/service


### PR DESCRIPTION
Fixes #3826 

- [x] rpm - Create user's home directory if it does not exist, even if the user already exists.
- [x] deb - Create user's home directory if it does not exist, even if the user already exists.
- [x] ~Windows - n/a~
- [x] ~macOS - n/a~