### PR TITLE
Store attachment and expiry metadata in rev cache

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -157,6 +157,8 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	_, err = db.Put("doc1", unjson(rev1input))
 	assert.NoError(t, err, "Couldn't create document")
 
+	initCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")
+	assert.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
 	rev1output := `{"_attachments":{"bye.txt":{"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA==","digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
 	gotbody, err := db.GetRev("doc1", "1-54f3a105fb903018c160712ffddb74dc", false, []string{})
 	assert.NoError(t, err, "Couldn't get document")
@@ -164,7 +166,7 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 
 	getCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")
 	assert.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
-	assert.Equal(t, 0, getCount)
+	assert.Equal(t, initCount, getCount)
 
 	// Repeat, validate no additional get operations
 	gotbody, err = db.GetRev("doc1", "1-54f3a105fb903018c160712ffddb74dc", false, []string{})
@@ -172,5 +174,5 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	assert.Equal(t, rev1output, tojson(gotbody))
 	getCount, countErr = base.GetExpvarAsInt("syncGateway_db", "document_gets")
 	assert.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
-	assert.Equal(t, 0, getCount)
+	assert.Equal(t, initCount, getCount)
 }

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
-	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -61,7 +60,7 @@ func TestAttachments(t *testing.T) {
 	rev1output := `{"_attachments":{"bye.txt":{"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA==","digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
 	gotbody, err := db.GetRev("doc1", "", false, []string{})
 	assert.NoError(t, err, "Couldn't get document")
-	goassert.Equals(t, tojson(gotbody), rev1output)
+	assert.Equal(t, rev1output, tojson(gotbody))
 
 	log.Printf("Create rev 2...")
 	rev2str := `{"_attachments": {"hello.txt": {"stub":true, "revpos":1}, "bye.txt": {"data": "YnllLXlh"}}}`
@@ -70,19 +69,19 @@ func TestAttachments(t *testing.T) {
 	body2[BodyRev] = revid
 	revid, err = db.Put("doc1", body2)
 	assert.NoError(t, err, "Couldn't update document")
-	goassert.Equals(t, revid, "2-08b42c51334c0469bd060e6d9e6d797b")
+	assert.Equal(t, "2-08b42c51334c0469bd060e6d9e6d797b", revid)
 
 	log.Printf("Retrieve doc...")
 	rev2output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
 	assert.NoError(t, err, "Couldn't get document")
-	goassert.Equals(t, tojson(gotbody), rev2output)
+	assert.Equal(t, rev2output, tojson(gotbody))
 
 	log.Printf("Retrieve doc with atts_since...")
 	rev2Aoutput := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2},"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_id":"doc1","_rev":"2-08b42c51334c0469bd060e6d9e6d797b"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{"1-54f3a105fb903018c160712ffddb74dc", "1-foo", "993-bar"})
 	assert.NoError(t, err, "Couldn't get document")
-	goassert.Equals(t, tojson(gotbody), rev2Aoutput)
+	assert.Equal(t, rev2Aoutput, tojson(gotbody))
 
 	log.Printf("Create rev 3...")
 	rev3str := `{"_attachments": {"bye.txt": {"stub":true,"revpos":2}}}`
@@ -91,13 +90,13 @@ func TestAttachments(t *testing.T) {
 	body3[BodyRev] = revid
 	revid, err = db.Put("doc1", body3)
 	assert.NoError(t, err, "Couldn't update document")
-	goassert.Equals(t, revid, "3-252b9fa1f306930bffc07e7d75b77faf")
+	assert.Equal(t, "3-252b9fa1f306930bffc07e7d75b77faf", revid)
 
 	log.Printf("Retrieve doc...")
 	rev3output := `{"_attachments":{"bye.txt":{"data":"YnllLXlh","digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A=","length":6,"revpos":2}},"_id":"doc1","_rev":"3-252b9fa1f306930bffc07e7d75b77faf"}`
 	gotbody, err = db.GetRev("doc1", "", false, []string{})
 	assert.NoError(t, err, "Couldn't get document")
-	goassert.Equals(t, tojson(gotbody), rev3output)
+	assert.Equal(t, rev3output, tojson(gotbody))
 
 	log.Printf("Expire body of rev 1, then add a child...") // test fix of #498
 	err = db.Bucket.Delete(oldRevisionKey("doc1", rev1id))
@@ -153,18 +152,25 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Test creating & updating a document:
-	log.Printf("Create rev 1...")
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
-	var body Body
-	json.Unmarshal([]byte(rev1input), &body)
 	_, err = db.Put("doc1", unjson(rev1input))
-	//rev1id := revid
 	assert.NoError(t, err, "Couldn't create document")
 
-	log.Printf("Retrieve doc...")
 	rev1output := `{"_attachments":{"bye.txt":{"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA==","digest":"sha1-l+N7VpXGnoxMm8xfvtWPbz2YvDc=","length":19,"revpos":1},"hello.txt":{"data":"aGVsbG8gd29ybGQ=","digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1}},"_id":"doc1","_rev":"1-54f3a105fb903018c160712ffddb74dc"}`
-	gotbody, err := db.GetRev("doc1", "", false, []string{})
+	gotbody, err := db.GetRev("doc1", "1-54f3a105fb903018c160712ffddb74dc", false, []string{})
 	assert.NoError(t, err, "Couldn't get document")
-	goassert.Equals(t, tojson(gotbody), rev1output)
+	assert.Equal(t, rev1output, tojson(gotbody))
+
+	getCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")
+	assert.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
+	assert.Equal(t, 0, getCount)
+
+	// Repeat, validate no additional get operations
+	gotbody, err = db.GetRev("doc1", "1-54f3a105fb903018c160712ffddb74dc", false, []string{})
+	assert.NoError(t, err, "Couldn't get document")
+	assert.Equal(t, rev1output, tojson(gotbody))
+	getCount, countErr = base.GetExpvarAsInt("syncGateway_db", "document_gets")
+	assert.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
+	assert.Equal(t, 0, getCount)
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -231,7 +231,7 @@ func TestDatabase(t *testing.T) {
 	// Test the _revisions property:
 	log.Printf("Check _revisions...")
 	gotbody, err = db.GetRev("doc1", rev2id, true, nil)
-	revisions := gotbody[BodyRevisions].(map[string]interface{})
+	revisions := gotbody[BodyRevisions].(Revisions)
 	goassert.Equals(t, revisions[RevisionsStart], 2)
 	goassert.DeepEquals(t, revisions[RevisionsIds],
 		[]string{"488724414d0ed6b398d6d2aeb228d797",
@@ -296,7 +296,7 @@ func TestGetDeleted(t *testing.T) {
 		BodyId:        "doc1",
 		BodyRev:       rev2id,
 		BodyDeleted:   true,
-		BodyRevisions: map[string]interface{}{RevisionsStart: 2, RevisionsIds: []string{"bc6d97f6e97c0d034a34f8aac2bf8b44", "dfd5e19813767eeddd08270fc5f385cd"}},
+		BodyRevisions: Revisions{RevisionsStart: 2, RevisionsIds: []string{"bc6d97f6e97c0d034a34f8aac2bf8b44", "dfd5e19813767eeddd08270fc5f385cd"}},
 	}
 	goassert.DeepEquals(t, body, expectedResult)
 
@@ -355,7 +355,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	expectedResult := Body{
 		"key1":     1234,
 		"channels": []string{"NBC"},
-		BodyRevisions: map[string]interface{}{
+		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 		BodyId:  "doc1",
@@ -386,7 +386,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 		BodyId:     "doc1",
 		BodyRev:    rev2id,
 		"_removed": true,
-		BodyRevisions: map[string]interface{}{
+		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
@@ -439,7 +439,7 @@ func TestGetRemoved(t *testing.T) {
 	expectedResult := Body{
 		"key1":     1234,
 		"channels": []string{"NBC"},
-		BodyRevisions: map[string]interface{}{
+		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 		BodyId:  "doc1",
@@ -461,7 +461,7 @@ func TestGetRemoved(t *testing.T) {
 		BodyId:     "doc1",
 		BodyRev:    rev2id,
 		"_removed": true,
-		BodyRevisions: map[string]interface{}{
+		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}
@@ -514,7 +514,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	expectedResult := Body{
 		"key1":      1234,
 		BodyDeleted: true,
-		BodyRevisions: map[string]interface{}{
+		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 		BodyId:  "doc1",
@@ -537,7 +537,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		BodyRev:     rev2id,
 		"_removed":  true,
 		BodyDeleted: true,
-		BodyRevisions: map[string]interface{}{
+		BodyRevisions: Revisions{
 			RevisionsStart: 2,
 			RevisionsIds:   []string{rev2digest, rev1digest}},
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -42,23 +42,25 @@ const (
 // Maps what users have access to what channels or roles, and when they got that access.
 type UserAccessMap map[string]channels.TimedSet
 
+type AttachmentsMeta map[string]interface{} // AttachmentsMeta metadata as included in sync metadata
+
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type syncData struct {
-	CurrentRev      string                 `json:"rev"`
-	NewestRev       string                 `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
-	Flags           uint8                  `json:"flags,omitempty"`
-	Sequence        uint64                 `json:"sequence,omitempty"`
-	UnusedSequences []uint64               `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
-	RecentSequences []uint64               `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
-	History         RevTree                `json:"history"`
-	Channels        channels.ChannelMap    `json:"channels,omitempty"`
-	Access          UserAccessMap          `json:"access,omitempty"`
-	RoleAccess      UserAccessMap          `json:"role_access,omitempty"`
-	Expiry          *time.Time             `json:"exp,omitempty"`           // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
-	Cas             string                 `json:"cas"`                     // String representation of a cas value, populated via macro expansion
-	Crc32c          string                 `json:"value_crc32c"`            // String representation of crc32c hash of doc body, populated via macro expansion
-	TombstonedAt    int64                  `json:"tombstoned_at,omitempty"` // Time the document was tombstoned.  Used for view compaction
-	Attachments     map[string]interface{} `json:"attachments,omitempty"`
+	CurrentRev      string              `json:"rev"`
+	NewestRev       string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
+	Flags           uint8               `json:"flags,omitempty"`
+	Sequence        uint64              `json:"sequence,omitempty"`
+	UnusedSequences []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
+	RecentSequences []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
+	History         RevTree             `json:"history"`
+	Channels        channels.ChannelMap `json:"channels,omitempty"`
+	Access          UserAccessMap       `json:"access,omitempty"`
+	RoleAccess      UserAccessMap       `json:"role_access,omitempty"`
+	Expiry          *time.Time          `json:"exp,omitempty"`           // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
+	Cas             string              `json:"cas"`                     // String representation of a cas value, populated via macro expansion
+	Crc32c          string              `json:"value_crc32c"`            // String representation of crc32c hash of doc body, populated via macro expansion
+	TombstonedAt    int64               `json:"tombstoned_at,omitempty"` // Time the document was tombstoned.  Used for view compaction
+	Attachments     AttachmentsMeta     `json:"attachments,omitempty"`
 
 	// Fields used by bucket-shadowing:
 	UpstreamCAS *uint64 `json:"upstream_cas,omitempty"` // CAS value of remote doc

--- a/db/import.go
+++ b/db/import.go
@@ -305,16 +305,16 @@ func (db *Database) migrateMetadata(docid string, body Body, existingDoc *sgbuck
 // (https://github.com/couchbase/sync_gateway/issues/3740)
 func (db *Database) backupPreImportRevision(docid, revid string) error {
 
-	previousBody, _, _, err := db.revisionCache.GetCached(docid, revid)
+	previousRev, err := db.revisionCache.GetCached(docid, revid)
 	if err != nil {
 		return fmt.Errorf("Cache error: %v", err)
 	}
 
-	if previousBody == nil {
+	if previousRev.Body == nil {
 		return nil
 	}
 
-	bodyJson, marshalErr := json.Marshal(stripSpecialProperties(previousBody))
+	bodyJson, marshalErr := json.Marshal(stripSpecialProperties(previousRev.Body))
 	if marshalErr != nil {
 		return fmt.Errorf("Marshal error: %v", marshalErr)
 	}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,7 +45,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="c34599b076eb7194a53e8535397123a758700774"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b716fa6c74c10db0ac0b3ad3815325a86a1451e9"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="16db1f1fe037412f12738fa4d8448c549c4edd77"/>
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -600,7 +600,7 @@ func (bh *blipHandler) sendRevision(body db.Body, sender *blip.Sender, seq db.Se
 	delete(body, db.BodyDeleted)
 
 	outrq.SetJSONBody(body)
-	if atts := db.BodyAttachments(body); atts != nil {
+	if atts := db.GetBodyAttachments(body); atts != nil {
 		// Allow client to download attachments in 'atts', but only while pulling this rev
 		bh.addAllowedAttachments(atts)
 		sender.Send(outrq.Message)

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -71,7 +71,7 @@ func (h *handler) handleGetDoc() error {
 		}
 		h.setHeader("Etag", strconv.Quote(value[db.BodyRev].(string)))
 
-		hasBodies := (attachmentsSince != nil && value["_attachments"] != nil)
+		hasBodies := (attachmentsSince != nil && value[db.BodyAttachments] != nil)
 		if h.requestAccepts("multipart/") && (hasBodies || !h.requestAccepts("application/json")) {
 			canCompress := strings.Contains(h.rq.Header.Get("X-Accept-Part-Encoding"), "gzip")
 			return h.writeMultipart("related", func(writer *multipart.Writer) error {
@@ -149,7 +149,7 @@ func (h *handler) handleGetAttachment() error {
 	if body == nil {
 		return kNotFoundError
 	}
-	meta, ok := db.BodyAttachments(body)[attachmentName].(map[string]interface{})
+	meta, ok := db.GetBodyAttachments(body)[attachmentName].(map[string]interface{})
 	if !ok {
 		return base.HTTPErrorf(http.StatusNotFound, "missing attachment %s", attachmentName)
 	}
@@ -222,7 +222,7 @@ func (h *handler) handlePutAttachment() error {
 	}
 
 	// find attachment (if it existed)
-	attachments := db.BodyAttachments(body)
+	attachments := db.GetBodyAttachments(body)
 	if attachments == nil {
 		attachments = make(map[string]interface{})
 	}
@@ -234,7 +234,7 @@ func (h *handler) handlePutAttachment() error {
 
 	//attach it
 	attachments[attachmentName] = attachment
-	body["_attachments"] = attachments
+	body[db.BodyAttachments] = attachments
 
 	newRev, err := h.db.Put(docid, body)
 	if err != nil {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1352,12 +1352,12 @@ func (d RestDocument) SetRevID(revId string) {
 }
 
 func (d RestDocument) SetAttachments(attachments db.AttachmentMap) {
-	d["_attachments"] = attachments
+	d[db.BodyAttachments] = attachments
 }
 
 func (d RestDocument) GetAttachments() (db.AttachmentMap, error) {
 
-	rawAttachments, hasAttachments := d["_attachments"]
+	rawAttachments, hasAttachments := d[db.BodyAttachments]
 
 	// If the map doesn't even have the _attachments key, return an empty attachments map
 	if !hasAttachments {


### PR DESCRIPTION
Avoids additional bucket GET when retrieving attachment or expiry data when document is resident in the rev cache.

Includes refactoring to standardize interaction with _attachments.

Fixes #3688