### PR TITLE
#3715 delta sync config

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -59,6 +59,8 @@ const (
 
 	DefaultDropIndexes = false // Whether Sync Gateway drops GSI indexes before each test while running in integration mode
 
+	DefaultOldRevExpirySeconds = uint32(300)
+
 	// Default value of _local document expiry
 	DefaultLocalDocExpirySecs = uint32(60 * 60 * 24 * 90) //90 days in seconds
 

--- a/base/constants.go
+++ b/base/constants.go
@@ -59,8 +59,6 @@ const (
 
 	DefaultDropIndexes = false // Whether Sync Gateway drops GSI indexes before each test while running in integration mode
 
-	DefaultOldRevExpirySeconds = uint32(300)
-
 	// Default value of _local document expiry
 	DefaultLocalDocExpirySecs = uint32(60 * 60 * 24 * 90) //90 days in seconds
 
@@ -87,7 +85,6 @@ const (
 	// Set this to true to dump stacktraces (for pkgerrors wrapped errors only) whenever an error is returned to
 	// an API client.  Currently only works with REST API calls.
 	StacktraceOnAPIErrors = false
-
 )
 
 func UnitTestUrl() string {

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -569,8 +569,8 @@ func TestPruneRevisionsPostIssue2651ThreeBranches(t *testing.T) {
 
 	maxDepth := uint32(50)
 	numPruned, _ := revTree.pruneRevisions(maxDepth, "")
-	fmt.Printf("numPruned: %v", numPruned)
-	fmt.Printf("LongestBranch: %v", revTree.LongestBranch())
+	t.Logf("numPruned: %v", numPruned)
+	t.Logf("LongestBranch: %v", revTree.LongestBranch())
 
 	goassert.True(t, uint32(revTree.LongestBranch()) == maxDepth)
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -101,7 +101,7 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	var useDeltas bool
-	if enabled := h.server.GetDatabaseConfig(h.db.Name).DeltaSync.Enabled; enabled != nil {
+	if enabled := h.server.GetDatabaseConfig(h.db.Name).DeltaSync.Enable; enabled != nil {
 		useDeltas = *enabled
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -204,7 +204,7 @@ type DbConfig struct {
 }
 
 type DeltaSyncConfig struct {
-	Enabled          *bool   `json:"enable,omitempty"`              // Whether delta sync is enabled (EE only)
+	Enable           *bool   `json:"enable,omitempty"`              // Whether delta sync is enabled (EE only)
 	RevMaxAgeSeconds *uint32 `json:"rev_max_age_seconds,omitempty"` // The number of seconds old revs are available for
 }
 
@@ -361,8 +361,8 @@ func (dbConfig *DbConfig) setup(name string) error {
 	}
 
 	// Set DeltaSync defaults
-	if dbConfig.DeltaSync.Enabled == nil {
-		dbConfig.DeltaSync.Enabled = &defaultDeltaSyncEnable
+	if dbConfig.DeltaSync.Enable == nil {
+		dbConfig.DeltaSync.Enable = &defaultDeltaSyncEnable
 	}
 	if dbConfig.DeltaSync.RevMaxAgeSeconds == nil || *dbConfig.DeltaSync.RevMaxAgeSeconds < 0 {
 		dbConfig.DeltaSync.RevMaxAgeSeconds = &defaultDeltaSyncRevMaxAge
@@ -409,7 +409,7 @@ func (dbConfig DbConfig) validate() error {
 	}
 
 	// Error if Delta Sync is explicitly enabled in CE
-	if *dbConfig.DeltaSync.Enabled && !base.IsEnterpriseEdition() {
+	if *dbConfig.DeltaSync.Enable && !base.IsEnterpriseEdition() {
 		return fmt.Errorf("Delta sync not supported in CE - disable via config with delta_sync.enable: false")
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -171,41 +171,41 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                          string                         `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
-	Sync                          *string                        `json:"sync,omitempty"`                         // Sync function defines which users can see which data
-	Users                         map[string]*db.PrincipalConfig `json:"users,omitempty"`                        // Initial user accounts
-	Roles                         map[string]*db.PrincipalConfig `json:"roles,omitempty"`                        // Initial roles
-	RevsLimit                     *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
-	AutoImport                    interface{}                    `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
-	ImportFilter                  *string                        `json:"import_filter,omitempty"`                // Filter function (import)
-	ImportBackupOldRev            bool                           `json:"import_backup_old_rev"`                  // Whether import should attempt to create a temporary backup of the previous revision body, when available.
-	Shadow                        *ShadowConfig                  `json:"shadow,omitempty"`                       // This is where the ShadowConfig used to be.  If found, it should throw an error
-	EventHandlers                 interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
-	FeedType                      string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword            bool                           `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
-	CacheConfig                   *CacheConfig                   `json:"cache,omitempty"`                        // Cache settings
-	ChannelIndex                  *ChannelIndexConfig            `json:"channel_index,omitempty"`                // Channel index settings
-	RevCacheSize                  *uint32                        `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache
-	StartOffline                  bool                           `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
-	Unsupported                   db.UnsupportedOptions          `json:"unsupported,omitempty"`                  // Config for unsupported features
-	Deprecated                    DeprecatedOptions              `json:"deprecated,omitempty"`                   // Config for Deprecated features
-	OIDCConfig                    *auth.OIDCOptions              `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
-	DeprecatedOldRevExpirySeconds *uint32                        `json:"old_rev_expiry_seconds,omitempty"`       // Deprecated - Replaced by DeltaSync:rev_max_age_seconds - The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs          *uint32                        `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
-	LocalDocExpirySecs            *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
-	EnableXattrs                  *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
-	SessionCookieName             string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
-	AllowConflicts                *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
-	NumIndexReplicas              *uint                          `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
-	UseViews                      bool                           `json:"use_views"`                              // Force use of views instead of GSI
-	SendWWWAuthenticateHeader     *bool                          `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
-	BucketOpTimeoutMs             *uint32                        `json:"bucket_op_timeout_ms,omitempty"`         // // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	DeltaSync                     DeltaSyncConfig                `json:"delta_sync,omitempty"`
+	Name                      string                         `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
+	Sync                      *string                        `json:"sync,omitempty"`                         // Sync function defines which users can see which data
+	Users                     map[string]*db.PrincipalConfig `json:"users,omitempty"`                        // Initial user accounts
+	Roles                     map[string]*db.PrincipalConfig `json:"roles,omitempty"`                        // Initial roles
+	RevsLimit                 *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
+	AutoImport                interface{}                    `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
+	ImportFilter              *string                        `json:"import_filter,omitempty"`                // Filter function (import)
+	ImportBackupOldRev        bool                           `json:"import_backup_old_rev"`                  // Whether import should attempt to create a temporary backup of the previous revision body, when available.
+	Shadow                    *ShadowConfig                  `json:"shadow,omitempty"`                       // This is where the ShadowConfig used to be.  If found, it should throw an error
+	EventHandlers             interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
+	FeedType                  string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword        bool                           `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
+	CacheConfig               *CacheConfig                   `json:"cache,omitempty"`                        // Cache settings
+	ChannelIndex              *ChannelIndexConfig            `json:"channel_index,omitempty"`                // Channel index settings
+	RevCacheSize              *uint32                        `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache
+	StartOffline              bool                           `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
+	Unsupported               db.UnsupportedOptions          `json:"unsupported,omitempty"`                  // Config for unsupported features
+	Deprecated                DeprecatedOptions              `json:"deprecated,omitempty"`                   // Config for Deprecated features
+	OIDCConfig                *auth.OIDCOptions              `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds       *uint32                        `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs      *uint32                        `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
+	LocalDocExpirySecs        *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
+	EnableXattrs              *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
+	SessionCookieName         string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
+	AllowConflicts            *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
+	NumIndexReplicas          *uint                          `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
+	UseViews                  bool                           `json:"use_views"`                              // Force use of views instead of GSI
+	SendWWWAuthenticateHeader *bool                          `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	BucketOpTimeoutMs         *uint32                        `json:"bucket_op_timeout_ms,omitempty"`         // // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	DeltaSync                 DeltaSyncConfig                `json:"delta_sync,omitempty"`
 }
 
 type DeltaSyncConfig struct {
 	Enable           *bool   `json:"enable,omitempty"`              // Whether delta sync is enabled (EE only)
-	RevMaxAgeSeconds *uint32 `json:"rev_max_age_seconds,omitempty"` // The number of seconds old revs are available for
+	RevMaxAgeSeconds *uint32 `json:"rev_max_age_seconds,omitempty"` // The number of seconds deltas for old revs are available for
 }
 
 type DeprecatedOptions struct {
@@ -352,12 +352,6 @@ func (dbConfig *DbConfig) setup(name string) error {
 			urlStr := url.String()
 			dbConfig.ChannelIndex.Server = &urlStr
 		}
-	}
-
-	// Warn if DeprecatedOldRevExpirySeconds is used and set RevMaxAgeSeconds instead.
-	if dbConfig.DeprecatedOldRevExpirySeconds != nil {
-		base.Warnf(base.KeyAll, "Using deprecated config option: %q. Use %q instead.", "old_rev_expiry_seconds", "delta_sync.rev_max_age_seconds")
-		dbConfig.DeltaSync.RevMaxAgeSeconds = dbConfig.DeprecatedOldRevExpirySeconds
 	}
 
 	// Set DeltaSync defaults

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -336,7 +336,7 @@ func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 // existing DatabaseContext or an error based on the useExisting flag.
 func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisting bool) (*db.DatabaseContext, error) {
 
-	oldRevExpirySeconds := defaultDeltaSyncRevMaxAge
+	oldRevExpirySeconds := base.DefaultOldRevExpirySeconds
 
 	// Connect to the bucket and add the database:
 	spec, err := GetBucketSpec(config)
@@ -349,8 +349,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		dbName = spec.BucketName
 	}
 
-	if config.DeltaSync.RevMaxAgeSeconds != nil && *config.DeltaSync.RevMaxAgeSeconds >= 0 {
-		oldRevExpirySeconds = *config.DeltaSync.RevMaxAgeSeconds
+	if config.OldRevExpirySeconds != nil && *config.OldRevExpirySeconds >= 0 {
+		oldRevExpirySeconds = *config.OldRevExpirySeconds
 	}
 
 	localDocExpirySecs := base.DefaultLocalDocExpirySecs

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -336,7 +336,7 @@ func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 // existing DatabaseContext or an error based on the useExisting flag.
 func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisting bool) (*db.DatabaseContext, error) {
 
-	oldRevExpirySeconds := base.DefaultOldRevExpirySeconds
+	oldRevExpirySeconds := defaultDeltaSyncRevMaxAge
 
 	// Connect to the bucket and add the database:
 	spec, err := GetBucketSpec(config)
@@ -349,8 +349,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		dbName = spec.BucketName
 	}
 
-	if config.OldRevExpirySeconds != nil && *config.OldRevExpirySeconds >= 0 {
-		oldRevExpirySeconds = *config.OldRevExpirySeconds
+	if config.DeltaSync.RevMaxAgeSeconds != nil && *config.DeltaSync.RevMaxAgeSeconds >= 0 {
+		oldRevExpirySeconds = *config.DeltaSync.RevMaxAgeSeconds
 	}
 
 	localDocExpirySecs := base.DefaultLocalDocExpirySecs


### PR DESCRIPTION
Closes #3715 

Adds new `delta_sync` config property and propagates config through to BlipSyncContext for use in replication
```json
"delta_sync": {
    "enable": true,
    "rev_max_age_seconds": 86400
}
```

- Defaults `delta_sync.enable` to true for EE, and false otherwise
- Only allows `delta_sync.enable` to be enabled for EE, otherwise SG errors on startup
- ~Deprecates `old_rev_expiry_seconds` in favour of `delta_sync.rev_max_age_seconds`~
