### PR TITLE
Fix for missing directory on first build run

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,8 @@ doBuild () {
         binarySuffix=""
     fi
 
+    mkdir -p "${GOPATH}/bin"
+
     ## Go Install Sync Gateway
     echo "    Building Sync Gateway"
     go build -o sync_gateway${binarySuffix} ${buildTags} "${@:2}" github.com/couchbase/sync_gateway


### PR DESCRIPTION
On a fresh bootstrap.sh run, `$GOPATH/bin` doesn't exist, so the subsequent move fails.

This was broken in the CE/EE build PR: #3812 