### PR TITLE
Unit tests should use num_replicas:0

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -100,18 +100,16 @@ func (rt *RestTester) Bucket() base.Bucket {
 		useXattrs := base.TestUseXattrs()
 
 		if rt.DatabaseConfig == nil {
-
 			// If no db config was passed in, create one
 			rt.DatabaseConfig = &DbConfig{}
 
 			// By default, does NOT use views when running against couchbase server, since should use GSI
 			rt.DatabaseConfig.UseViews = base.TestUseViews()
-
-			// numReplicas set to 0 for test buckets, since it should assume that there is only one node.
-			numReplicas := uint(0)
-			rt.DatabaseConfig.NumIndexReplicas = &numReplicas
-
 		}
+
+		// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.
+		numReplicas := uint(0)
+		rt.DatabaseConfig.NumIndexReplicas = &numReplicas
 
 		rt.DatabaseConfig.BucketConfig = BucketConfig{
 			Server:   &server,


### PR DESCRIPTION
Setting was being skipped when a custom DatabaseConfig was provided by the test.