### PR TITLE
CBG-166 Specify body copy policy on rev cache retrieval

### DIFF
--- a/base/version.go
+++ b/base/version.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 // IsEnterpriseEdition returns true if this Sync Gateway node is enterprise edition. This can be used to restrict config options, etc. at runtime.
-// This should not be used as a condtional around private/EE-only code, as CE builds will fail to compile. Use the build tag for condtional compilation instead.
+// This should not be used as a condtional around private/EE-only code, as CE builds will fail to compile. Use the build tag for conditional compilation instead.
 func IsEnterpriseEdition() bool {
 	return productEditionEnterprise == true
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -114,7 +114,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 
 	// Retrieve the non-inline revision
-	db.FlushRevisionCache()
+	db.FlushRevisionCacheForTest()
 	rev2aGet, err := db.GetRev("doc1", "2-a", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 2-a")
 	goassert.DeepEquals(t, rev2aGet, rev2a_body)
@@ -192,7 +192,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	goassert.Equals(t, len(newRevTree.BodyKeyMap), 1) // tombstone 3-c
 
 	// Retrieve the non-inline tombstone revision
-	db.FlushRevisionCache()
+	db.FlushRevisionCacheForTest()
 	rev3cGet, err := db.GetRev("doc1", "3-c", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 3-c")
 	goassert.DeepEquals(t, rev3cGet, rev3c_body)
@@ -280,7 +280,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 
 	// Retrieve the non-inline revision
-	db.FlushRevisionCache()
+	db.FlushRevisionCacheForTest()
 	rev2aGet, err := db.GetRev("doc1", "2-a", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 2-a")
 	goassert.DeepEquals(t, rev2aGet, rev2a_body)
@@ -300,7 +300,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
 
 	// Retrieve tombstone
-	db.FlushRevisionCache()
+	db.FlushRevisionCacheForTest()
 	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
 	assert.NoError(t, err, "Couldn't get rev 3-b")
 	goassert.DeepEquals(t, rev3bGet, rev3b_body)
@@ -335,7 +335,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}, false), "add 8-a")
 
 	// Verify that 3-b is still present at this point
-	db.FlushRevisionCache()
+	db.FlushRevisionCacheForTest()
 	rev3bGet, err = db.GetRev("doc1", "3-b", false, nil)
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
@@ -344,7 +344,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	// Verify that 3-b has been pruned
 	log.Printf("Attempt to retrieve 3-b, expect pruned")
-	db.FlushRevisionCache()
+	db.FlushRevisionCacheForTest()
 	rev3bGet, err = db.GetRev("doc1", "3-b", false, nil)
 	goassert.Equals(t, err.Error(), "404 missing")
 

--- a/db/database.go
+++ b/db/database.go
@@ -1119,7 +1119,7 @@ func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 }
 
 // For test usage
-func (context *DatabaseContext) FlushRevisionCache() {
+func (context *DatabaseContext) FlushRevisionCacheForTest() {
 
 	context.revisionCache = NewRevisionCache(
 		context.Options.RevisionCacheCapacity,
@@ -1127,6 +1127,11 @@ func (context *DatabaseContext) FlushRevisionCache() {
 		context.DbStats.StatsCache(),
 	)
 
+}
+
+// For test usage
+func (context *DatabaseContext) GetRevisionCacheForTest() *RevisionCache {
+	return context.revisionCache
 }
 
 func (context *DatabaseContext) AllowConflicts() bool {

--- a/db/revision_cache.go
+++ b/db/revision_cache.go
@@ -69,38 +69,26 @@ func NewRevisionCache(capacity uint32, loaderFunc RevisionCacheLoaderFunc, stats
 // If the cache has a loaderFunction, it will be called if the revision isn't in the cache;
 // any error returned by the loaderFunction will be returned from Get.
 func (rc *RevisionCache) Get(docid, revid string) (DocumentRevision, error) {
-	value := rc.getValue(docid, revid, rc.loaderFunc != nil)
-	if value == nil {
-		return DocumentRevision{}, nil
-	}
-	docRev, statEvent, err := value.load(rc.loaderFunc)
-	rc.statsRecorderFunc(statEvent)
-
-	if err != nil {
-		rc.removeValue(value) // don't keep failed loads in the cache
-	}
-	return docRev, err
+	return rc.getFromCache(docid, revid, BodyShallowCopy, rc.loaderFunc != nil)
 }
 
-func (rc *RevisionCache) statsRecorderFunc(cacheHit bool) {
-	if rc.statsCache == nil {
-		return
-	}
-	if cacheHit {
-		rc.statsCache.Add(base.StatKeyRevisionCacheHits, 1)
-	} else {
-		rc.statsCache.Add(base.StatKeyRevisionCacheMisses, 1)
-	}
-}
-
-// Looks up a revision from the cache-only.  Will not fall back to loader function if not
+// Looks up a revision from the cache only.  Will not fall back to loader function if not
 // present in the cache.
 func (rc *RevisionCache) GetCached(docid, revid string) (DocumentRevision, error) {
-	value := rc.getValue(docid, revid, false)
+	return rc.getFromCache(docid, revid, BodyShallowCopy, false)
+}
+
+// Returns the body of the revision based on the specified body copy policy (deep/shallow/none)
+func (rc *RevisionCache) GetWithCopy(docid, revid string, copyType BodyCopyType) (DocumentRevision, error) {
+	return rc.getFromCache(docid, revid, copyType, rc.loaderFunc != nil)
+}
+
+func (rc *RevisionCache) getFromCache(docid, revid string, copyType BodyCopyType, loadOnCacheMiss bool) (DocumentRevision, error) {
+	value := rc.getValue(docid, revid, loadOnCacheMiss)
 	if value == nil {
 		return DocumentRevision{}, nil
 	}
-	docRev, statEvent, err := value.load(rc.loaderFunc)
+	docRev, statEvent, err := value.load(rc.loaderFunc, copyType)
 	rc.statsRecorderFunc(statEvent)
 
 	if err != nil {
@@ -127,13 +115,24 @@ func (rc *RevisionCache) GetActive(docid string, context *DatabaseContext) (docR
 
 	// Retrieve from or add to rev cache
 	value := rc.getValue(docid, bucketDoc.CurrentRev, true)
-	docRev, statEvent, err := value.loadForDoc(bucketDoc, context)
+	docRev, statEvent, err := value.loadForDoc(bucketDoc, context, BodyShallowCopy)
 	rc.statsRecorderFunc(statEvent)
 
 	if err != nil {
 		rc.removeValue(value) // don't keep failed loads in the cache
 	}
 	return docRev, err
+}
+
+func (rc *RevisionCache) statsRecorderFunc(cacheHit bool) {
+	if rc.statsCache == nil {
+		return
+	}
+	if cacheHit {
+		rc.statsCache.Add(base.StatKeyRevisionCacheHits, 1)
+	} else {
+		rc.statsCache.Add(base.StatKeyRevisionCacheMisses, 1)
+	}
 }
 
 // Adds a revision to the cache.
@@ -182,7 +181,7 @@ func (rc *RevisionCache) purgeOldest_() {
 // Gets the body etc. out of a revCacheValue. If they aren't present already, the loader func
 // will be called. This is synchronized so that the loader will only be called once even if
 // multiple goroutines try to load at the same time.
-func (value *revCacheValue) load(loaderFunc RevisionCacheLoaderFunc) (DocumentRevision, bool, error) {
+func (value *revCacheValue) load(loaderFunc RevisionCacheLoaderFunc, copyType BodyCopyType) (DocumentRevision, bool, error) {
 
 	value.lock.Lock()
 	defer value.lock.Unlock()
@@ -198,7 +197,7 @@ func (value *revCacheValue) load(loaderFunc RevisionCacheLoaderFunc) (DocumentRe
 
 	docRev := DocumentRevision{
 		RevID:       value.key.RevID,
-		Body:        value.body.ShallowCopy(), // Never let the caller mutate the stored body
+		Body:        value.body.Copy(copyType), // Never let the caller mutate the stored body
 		History:     value.history,
 		Channels:    value.channels,
 		Expiry:      value.expiry,
@@ -209,7 +208,7 @@ func (value *revCacheValue) load(loaderFunc RevisionCacheLoaderFunc) (DocumentRe
 
 // Retrieves the body etc. out of a revCacheValue.  If they aren't already present, loads into the cache value using
 // the provided document.
-func (value *revCacheValue) loadForDoc(doc *document, context *DatabaseContext) (DocumentRevision, bool, error) {
+func (value *revCacheValue) loadForDoc(doc *document, context *DatabaseContext, copyType BodyCopyType) (DocumentRevision, bool, error) {
 	value.lock.Lock()
 	defer value.lock.Unlock()
 
@@ -221,10 +220,10 @@ func (value *revCacheValue) loadForDoc(doc *document, context *DatabaseContext) 
 
 	}
 
-	// Never let the caller mutate the stored body, attachments
+	// Copy stored body based on copyType, always copy attachments
 	docRev := DocumentRevision{
 		RevID:       value.key.RevID,
-		Body:        value.body.ShallowCopy(), // Never let the caller mutate the stored body
+		Body:        value.body.Copy(copyType), // Never let the caller mutate the stored body
 		History:     value.history,
 		Channels:    value.channels,
 		Expiry:      value.expiry,

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -149,7 +149,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 	for _, bm := range getBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			var getResponse *TestResponse
-			rtDatabase.FlushRevisionCache()
+			rtDatabase.FlushRevisionCacheForTest()
 			for i := 0; i < b.N; i++ {
 				// update key in URI
 				docNum := i % numDocs

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1583,7 +1583,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	}
 
 	// Flush the rev cache, and issue changes again to ensure successful handling for rev cache misses
-	testDB.FlushRevisionCache()
+	testDB.FlushRevisionCacheForTest()
 	// Also nuke temporary revision backup of doc_pruned.  Validates that the body for the pruned revision is generated correctly when no longer resident in the rev cache
 	testDB.Bucket.Delete("_sync:rev:doc_pruned:34:2-5afcb73bd3eb50615470e3ba54b80f00")
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1305,7 +1305,7 @@ func TestImportRevisionCopy(t *testing.T) {
 
 	// 5. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
 	//    at simulating multiple SG instances)
-	rt.GetDatabase().FlushRevisionCache()
+	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// 6. Attempt to retrieve previous revision body
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s?rev=%s", key, rev1id), "")
@@ -1347,7 +1347,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 
 	// 3. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
 	//    at simulating multiple SG instances)
-	rt.GetDatabase().FlushRevisionCache()
+	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// 4. Update via SDK
 	updatedBody := make(map[string]interface{})
@@ -1413,7 +1413,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 
 	// 5. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
 	//    at simulating multiple SG instances)
-	rt.GetDatabase().FlushRevisionCache()
+	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// 6. Attempt to retrieve previous revision body.  Should fail, as backup wasn't persisted
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s?rev=%s", key, rev1id), "")


### PR DESCRIPTION
Avoids duplicate copy during delta processing (shallow, then deep).
