### PR TITLE
CBG-163 Modify old revision backup handling for delta sync

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -857,6 +857,39 @@ func (bucket *CouchbaseBucketGoCB) GetAndTouchRaw(k string, exp uint32) (rv []by
 
 }
 
+func (bucket *CouchbaseBucketGoCB) Touch(k string, exp uint32) (cas uint64, err error) {
+
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		casGoCB, err := bucket.Bucket.Touch(k, 0, exp)
+		shouldRetry = isRecoverableGoCBError(err)
+		return shouldRetry, err, uint64(casGoCB)
+
+	}
+
+	// Kick off retry loop
+	description := fmt.Sprintf("Touch for key %v", UD(k))
+	err, result := RetryLoop(description, worker, bucket.spec.RetrySleeper())
+
+	// If the retry loop returned a nil result, set to 0 to prevent type assertion on nil error
+	if result == nil {
+		result = uint64(0)
+	}
+
+	// Type assertion of result
+	cas, ok := result.(uint64)
+	if !ok {
+		return 0, RedactErrorf("Touch: Error doing type assertion of %v into a uint64", UD(result))
+	}
+
+	return cas, err
+
+}
+
 func (bucket *CouchbaseBucketGoCB) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	bucket.singleOps <- struct{}{}
 	defer func() {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -872,7 +872,7 @@ func (bucket *CouchbaseBucketGoCB) Touch(k string, exp uint32) (cas uint64, err 
 	}
 
 	// Kick off retry loop
-	description := fmt.Sprintf("Touch for key %v", UD(k))
+	description := fmt.Sprintf("Touch for key %v", k)
 	err, result := RetryLoop(description, worker, bucket.spec.RetrySleeper())
 
 	// If the retry loop returned a nil result, set to 0 to prevent type assertion on nil error

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -57,6 +57,9 @@ func (b *LeakyBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
 func (b *LeakyBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64, err error) {
 	return b.bucket.GetAndTouchRaw(k, exp)
 }
+func (b *LeakyBucket) Touch(k string, exp uint32) (cas uint64, err error) {
+	return b.bucket.Touch(k, exp)
+}
 func (b *LeakyBucket) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	return b.bucket.Add(k, exp, v)
 }

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -30,6 +30,11 @@ func (b *LoggingBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint
 	defer func() { Tracef(KeyBucket, "GetAndTouchRaw(%q) [%v]", UD(k), time.Since(start)) }()
 	return b.bucket.GetAndTouchRaw(k, exp)
 }
+func (b *LoggingBucket) Touch(k string, exp uint32) (cas uint64, err error) {
+	start := time.Now()
+	defer func() { Tracef(KeyBucket, "Touch(%q) [%v]", UD(k), time.Since(start)) }()
+	return b.bucket.Touch(k, exp)
+}
 func (b *LoggingBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
 	start := time.Now()
 	defer func() { Tracef(KeyBucket, "GetBulkRaw(%q) [%v]", UD(keys), time.Since(start)) }()

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -105,6 +105,9 @@ func (b *StatsBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64
 	b.docRead(1, len(v))
 	return v, cas, err
 }
+func (b *StatsBucket) Touch(k string, exp uint32) (cas uint64, err error) {
+	return b.bucket.Touch(k, exp)
+}
 func (b *StatsBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
 	results, err := b.bucket.GetBulkRaw(keys)
 	for _, value := range results {

--- a/db/revision.go
+++ b/db/revision.go
@@ -230,7 +230,7 @@ func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte, 
 	body[0] = nonJSONPrefix
 	err := db.Bucket.SetRaw(oldRevisionKey(docid, revid), expiry, base.BinaryDocument(body))
 	if err == nil {
-		base.Debugf(base.KeyCRUD, "Backed up revision body %q/%q (%d bytes)", base.UD(docid), revid, len(body))
+		base.Debugf(base.KeyCRUD, "Backed up revision body %q/%q (%d bytes, ttl:%d)", base.UD(docid), revid, len(body), expiry)
 	} else {
 		base.Warnf(base.KeyAll, "setOldRevisionJSON failed: doc=%q rev=%q err=%v", base.UD(docid), revid, err)
 	}

--- a/db/revision.go
+++ b/db/revision.go
@@ -197,10 +197,11 @@ func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byt
 //      - new revision stored (as duplicate), with expiry rev_max_age_seconds
 //   delta=true, shared_bucket_access=false
 //      - old revision stored, with expiry rev_max_age_seconds
+// Ignores
 func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody Body, oldBody []byte) {
 
 	if !db.DeltaSyncEnabled() {
-		db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.OldRevExpirySeconds)
+		_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.OldRevExpirySeconds)
 		return
 	}
 
@@ -210,12 +211,12 @@ func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody
 			base.Warnf(base.KeyAll, "Unable to marshal new revision body during backupRevisionJSON: doc=%q rev=%q err=%v ", base.UD(docId), newRevId, marshalErr)
 			return
 		}
-		db.setOldRevisionJSON(docId, newRevId, newBodyBytes, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+		_ = db.setOldRevisionJSON(docId, newRevId, newBodyBytes, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
 
 		// Refresh the expiry on the previous revision backup
-		db.refreshPreviousRevisionBackup(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+		_ = db.refreshPreviousRevisionBackup(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
 	} else {
-		db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+		_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
 	}
 }
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -46,7 +46,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2cb422a5c9c2de908e579ef2ad184d28cb59b3f1"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="c2c0332581299cd6669e32153b89931a951868ce"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="4fab5d18974b2155cd9986ecf8e0f1b898da38df"/>
 
@@ -62,7 +62,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="5135af3a8b71fad49f97f7a5c12d69fb347dac78"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f631191f3fa478a73d259840a38b2d5d6b1e99fb"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -46,7 +46,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b716fa6c74c10db0ac0b3ad3815325a86a1451e9"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2cb422a5c9c2de908e579ef2ad184d28cb59b3f1"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="4fab5d18974b2155cd9986ecf8e0f1b898da38df"/>
 
@@ -62,7 +62,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="3377ae8c57a8437714106efc16f788f5f190ce73"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="5135af3a8b71fad49f97f7a5c12d69fb347dac78"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1487,7 +1487,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
-	rt := RestTester{DeltaSyncEnabled: base.IsEnterpriseEdition()}
+	var rt RestTester
 	defer rt.Close()
 
 	client, err := NewBlipTesterClient(&rt)
@@ -1540,7 +1540,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 func TestBlipDeltaSyncPush(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
-	rt := RestTester{DeltaSyncEnabled: base.IsEnterpriseEdition()}
+	var rt RestTester
 	defer rt.Close()
 
 	client, err := NewBlipTesterClient(&rt)
@@ -1600,7 +1600,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 func TestBlipNonDeltaSyncPush(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
-	rt := RestTester{DeltaSyncEnabled: base.IsEnterpriseEdition()}
+	var rt RestTester
 	defer rt.Close()
 
 	client, err := NewBlipTesterClient(&rt)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -119,11 +119,7 @@ func (h *handler) handleBLIPSync() error {
 	defer ctx.close()
 
 	// determine if SG has delta sync enabled for the given database
-	if dbc := h.server.GetDatabaseConfig(ctx.dbc.Name); dbc != nil {
-		if sgDeltaEnable := dbc.DeltaSync.Enable; sgDeltaEnable != nil {
-			ctx.sgCanUseDeltas = *sgDeltaEnable
-		}
-	}
+	ctx.sgCanUseDeltas = ctx.dbc.DeltaSyncEnabled()
 
 	blipContext.DefaultHandler = ctx.notFound
 	for profile, handlerFn := range kHandlersByProfile {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -568,6 +568,20 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		sc.TakeDbOnline(dbContext)
 	}
 
+	deltaSyncOptions := db.DeltaSyncOptions{
+		Enabled:          db.DefaultDeltaSyncEnable,
+		RevMaxAgeSeconds: db.DefaultDeltaSyncRevMaxAge,
+	}
+
+	if config.DeltaSync != nil {
+		if config.DeltaSync.Enable != nil {
+			deltaSyncOptions.Enabled = *config.DeltaSync.Enable
+		}
+		if config.DeltaSync.RevMaxAgeSeconds != nil {
+			deltaSyncOptions.RevMaxAgeSeconds = *config.DeltaSync.RevMaxAgeSeconds
+		}
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		IndexOptions:              channelIndexOptions,
@@ -586,6 +600,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		AllowConflicts:            config.ConflictsAllowed(),
 		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
 		UseViews:                  useViews,
+		DeltaSyncOptions:          deltaSyncOptions,
 	}
 
 	// Create the DB Context
@@ -1013,7 +1028,6 @@ func (sc *ServerContext) logStats() error {
 
 }
 
-
 // Updates stats that are more efficient to calculate at stats collection time
 func (sc *ServerContext) updateCalculatedStats() {
 	sc.lock.RLock()
@@ -1023,7 +1037,6 @@ func (sc *ServerContext) updateCalculatedStats() {
 	}
 
 }
-
 
 // For test use
 func (sc *ServerContext) Database(name string) *db.DatabaseContext {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -43,7 +43,6 @@ type RestTester struct {
 	EnableNoConflictsMode   bool   // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
 	NoFlush                 bool   // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
 	InitSyncSeq             uint64 // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
-	DeltaSyncEnabled        bool
 }
 
 func (rt *RestTester) Bucket() base.Bucket {
@@ -106,13 +105,6 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 			// By default, does NOT use views when running against couchbase server, since should use GSI
 			rt.DatabaseConfig.UseViews = base.TestUseViews()
-		}
-
-		if rt.DeltaSyncEnabled {
-			if !base.IsEnterpriseEdition() {
-				panic("RestTester doesn't support DeltaSyncEnabled when running as non-enterprise")
-			}
-			rt.DatabaseConfig.DeltaSync.Enable = &rt.DeltaSyncEnabled
 		}
 
 		// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.


### PR DESCRIPTION
When delta sync is enabled, extends expiry of old revision backups based on DeltaSyncRevMaxAge.

When detla sync and shared bucket access are enabled, backs up current revision to ensure it's available for delta generation in the event of an SDK update.

Also refactors delta sync config handling to store runtime options in database context, and cleans up RestTester handling of deltaSyncEnabled.

Integration Tests:
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/947/
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/945/