### PR TITLE
Remove parallel "go install" stages from pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,21 +78,17 @@ pipeline {
             }
         }
 
-        stage('Build') {
-            parallel {
-                stage('CE Build') {
-                    steps {
-                        withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                            sh './build.sh -v'
-                        }
-                    }
+        stage('CE Build') {
+            steps {
+                withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                    sh './build.sh -v'
                 }
-                stage('EE Build') {
-                    steps {
-                        withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                            sh './build.sh -v'
-                        }
-                    }
+            }
+        }
+        stage('EE Build') {
+            steps {
+                withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                    sh './build.sh -v'
                 }
             }
         }


### PR DESCRIPTION
Go will choke when running installs in parallel due to the contention of the `$GOPATH/pkg` directory and `.a` files. These stages are fast enough that they don't need to be run in parallel anyway.

E.g:
```
+ ./build.sh -v
Building only CE
  Building edition: CE
    Building Sync Gateway
      Success!
      Binary compiled to: /var/jenkins/workspace/hub_pipeline_sync_gateway_master/godeps/bin/sync_gateway_ce
    Building Sync Gateway Accel with 'go install' ...
      Success!
        Binary compiled to: godeps/bin/sync-gateway-accel

+ ./build.sh -v
Building only EE
  Building edition: EE
    Building Sync Gateway
      Success!
      Binary compiled to: /var/jenkins/workspace/hub_pipeline_sync_gateway_master/godeps/bin/sync_gateway
    Building Sync Gateway Accel with 'go install' ...
go install github.com/couchbaselabs/sync-gateway-accel/sg_accel: build output "/var/jenkins/workspace/hub_pipeline_sync_gateway_master/godeps/pkg/linux_amd64/github.com/couchbaselabs/sync-gateway-accel/sg_accel.a" already exists and is not an object file
script returned exit code 1
```
