### PR TITLE
CBG-167 Store calculated deltas in rev cache

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -93,6 +93,8 @@ const (
 	StatKeyDeltasRequested           = "deltas_requested"
 	StatKeyDeltasSent                = "deltas_sent"
 	StatKeyDeltaPullReplicationCount = "delta_pull_replication_count"
+	StatKeyDeltaCacheHits            = "delta_cache_hit"
+	StatKeyDeltaCacheMisses          = "delta_cache_miss"
 
 	// StatsSharedBucketImport
 	StatKeyImportBacklog    = "import_backlog"

--- a/db/crud.go
+++ b/db/crud.go
@@ -12,7 +12,6 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	"strings"
@@ -364,13 +363,12 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 	return revision.Body, nil
 }
 
-// GetDeltaOrRev attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
+// GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
 func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, err error) {
 
 	fromRevision, err := db.revisionCache.GetWithCopy(docID, fromRevID, BodyNoCopy)
 
-	log.Printf("rev cache returned delta: %+v", fromRevision.Delta)
 	// If neither body nor delta is available for fromRevId, the delta can't be generated
 	if fromRevision.Body == nil && fromRevision.Delta == nil {
 		return nil, err

--- a/db/crud.go
+++ b/db/crud.go
@@ -363,6 +363,47 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 	return revision.Body, nil
 }
 
+// GetDeltaOrRev attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
+// returns nil.
+func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, err error) {
+
+	fromRevision, err := db.revisionCache.GetWithCopy(docID, fromRevID, BodyNoCopy)
+
+	// If neither body nor delta is available for fromRevId, the delta can't be generated
+	if fromRevision.Body == nil && fromRevision.Delta == nil {
+		return nil, err
+	}
+
+	// If delta is found, check whether it is a delta for the toRevID we want
+	if fromRevision.Delta != nil {
+		if fromRevision.Delta.ToRevID == toRevID {
+			// Case 2a. 'some rev' is the rev we're interested in - return the delta
+			return fromRevision.Delta.DeltaBytes, nil
+		} else {
+			// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
+		}
+	}
+
+	// Delta is unavailable, but the body is available.
+	if fromRevision.Body != nil {
+		toBody, err := db.revisionCache.GetWithCopy(docID, toRevID, BodyDeepCopy)
+		if err != nil {
+			return nil, err
+		}
+		// We didn't copy fromBody earlier (in case we could get by with just the delta), so need do it now
+		fromBodyCopy := fromRevision.Body.DeepCopy()
+		delta, err = base.Diff(fromBodyCopy, toBody.Body)
+		if err != nil {
+			return nil, err
+		}
+		// Write the newly calculated delta back into the cache before returning
+		db.revisionCache.UpdateDelta(docID, fromRevID, toRevID, delta)
+		return delta, nil
+	}
+
+	return nil, nil
+}
+
 // Returns the body of the active revision of a document, as well as the document's current channels
 // and the user/roles it grants channel access to.
 func (db *Database) GetDocAndActiveRev(docid string) (populatedDoc *document, body Body, err error) {

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -107,6 +107,8 @@ func initEmptyStatsMap(key string) *expvar.Map {
 		result.Set(base.StatKeyDeltasRequested, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyDeltasSent, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyDeltaPullReplicationCount, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyDeltaCacheHits, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyDeltaCacheMisses, base.ExpvarIntVal(0))
 	case base.StatsGroupKeySharedBucketImport:
 		result.Set(base.StatKeyImportBacklog, base.ExpvarIntVal(0))
 	case base.StatsGroupKeyCblReplicationPush:

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1539,7 +1539,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	}
 }
 
-// TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,
+// TestBlipDeltaSyncPullRevCache tests that a simple pull replication uses deltas in EE,
 // Second pull validates use of rev cache for previously generated deltas.
 func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	blip "github.com/couchbase/go-blip"
+	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/google/uuid"
@@ -206,6 +206,10 @@ func NewBlipTesterClient(rt *RestTester) (client *BlipTesterClient, err error) {
 // StartPull will begin a continuous pull replication since 0 between the client and server
 func (btc *BlipTesterClient) StartPull() (err error) {
 	return btc.StartPullSince("true", "0")
+}
+
+func (btc *BlipTesterClient) StartOneshotPull() (err error) {
+	return btc.StartPullSince("false", "0")
 }
 
 // StartPullSince will begin a pull replication between the client and server with the given params.

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -603,21 +603,21 @@ func (bh *blipHandler) handleProposedChanges(rq *blip.Message) error {
 func (bh *blipHandler) sendRevAsDelta(sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int) {
 
 	bh.db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltasRequested, 1)
-	bh.Logf(base.LevelTrace, base.KeySync, "DELTA: getting newBody docID: %s - rev: %v", base.UD(docID), revID)
+	// TODO: determine whether we need to fetch the current rev in order to identify the 'from' rev for the delta,
+	//      or can skip straight to GetDelta with knownRevs[0]
 	newBody, err := bh.db.GetRev(docID, revID, true, nil)
 	if err != nil {
-		bh.Logf(base.LevelWarn, base.KeySync, "DELTA: couldn't get newBody - sending NoRev... err: %v", err)
+		bh.Logf(base.LevelDebug, base.KeySync, "DELTA: couldn't get newBody in order to find common ancestor - sending NoRev... err: %v", err)
 		// If we can't get the new doc, we won't be able to fall back either, so NoRev with error
 		bh.sendNoRev(err, sender, seq, docID, revID)
 		return
 	}
 
 	// Get the client's highest known rev ID to use as deltaSrc
-	bh.Logf(base.LevelTrace, base.KeySync, "DELTA: Figuring out deltaSrcRevID from client's highest known revID...")
 	var deltaSrcRevID string
 	newBodyRevisions, ok := newBody[db.BodyRevisions].(db.Revisions)
 	if !ok {
-		bh.Logf(base.LevelWarn, base.KeySync, "DELTA: couldn't get newBody[_revisions] - sending NoRev... err: %v", err)
+		bh.Logf(base.LevelDebug, base.KeySync, "DELTA: couldn't get newBody[_revisions] - sending NoRev... err: %v", err)
 		// If we can't get ancestor revisions, fall back to sending full body
 		bh.sendRevOrNorev(sender, seq, docID, revID, knownRevs, maxHistory)
 		return
@@ -631,24 +631,17 @@ func (bh *blipHandler) sendRevAsDelta(sender *blip.Sender, seq db.SequenceID, do
 		}
 	}
 
-	bh.Logf(base.LevelDebug, base.KeySync, "DELTA: getting oldBody docID: %s - deltaSrcRevID: %v", base.UD(docID), deltaSrcRevID)
-	oldBody, err := bh.db.GetRev(docID, deltaSrcRevID, true, nil)
-	if err != nil {
-		bh.Logf(base.LevelDebug, base.KeySync, "DELTA: couldn't get oldBody - falling back to full body replication... err: %v", err)
-		// fall back to standard full-body replication if we can't do a delta
-		bh.sendRevOrNorev(sender, seq, docID, revID, knownRevs, maxHistory)
-		return
-	}
-
-	// generate delta
-	delta, err := base.Diff(oldBody, newBody)
-	if err != nil {
-		bh.Logf(base.LevelWarn, base.KeySync, "DELTA: couldn't generate delta - falling back to full body replication... err: %v", err)
+	delta, err := bh.db.GetDelta(docID, deltaSrcRevID, revID)
+	if err != nil || delta == nil {
+		if err != nil {
+			bh.Logf(base.LevelInfo, base.KeySync, "DELTA: error generating delta from %s to %s for key %s; falling back to full body replication.  err: %v", deltaSrcRevID, revID, base.UD(docID), err)
+		} else {
+			bh.Logf(base.LevelDebug, base.KeySync, "DELTA: unable to generate delta from %s to %s for key %s; falling back to full body replication.", deltaSrcRevID, revID, base.UD(docID))
+		}
 		// fall back to standard full-body replication if we can't diff
 		bh.sendRevOrNorev(sender, seq, docID, revID, knownRevs, maxHistory)
 		return
 	}
-	bh.Logf(base.LevelDebug, base.KeySync, "DELTA: generated delta: %s", base.UD(delta))
 
 	bh.sendDelta(delta, deltaSrcRevID, sender, seq, docID, revID, knownRevs, maxHistory)
 	bh.db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltasSent, 1)


### PR DESCRIPTION
Stores forward deltas in the rev cache with the source revision.  