### PR TITLE
sgcollect_info: Keep rotated log files separate

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -359,7 +359,8 @@ def make_collect_logs_tasks(zip_dir, sg_url):
         log_file_path = os.path.abspath(guessed_log_file_path)
 
         for log_file_name in sg_log_files:
-            # iterate over all log files, including those with a timestamp
+            # iterate over all log files, including those with a rotation timestamp
+            # e.g: sg_info-2018-12-31T13-33-41.055.log
             name, ext = os.path.splitext(log_file_name)
             log_file_pattern = "{0}*{1}".format(name, ext)
             rotated_logs_pattern = os.path.join(
@@ -379,6 +380,7 @@ def make_collect_logs_tasks(zip_dir, sg_url):
                 sg_log_file_paths[sg_log_file_path] = sg_log_file_path
 
             # try gzipped logs too
+            # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
             log_file_pattern = "{0}*{1}.gz".format(name, ext)
             rotated_logs_pattern = os.path.join(
                log_file_path,
@@ -390,7 +392,7 @@ def make_collect_logs_tasks(zip_dir, sg_url):
                 # As long as a task that monitors this log file path has not already been added, add a new task
                 if sg_log_file_path not in sg_log_file_paths:
                     print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
-                    task = add_gzip_file_task(sourcefile_path=log_file_item_path, log_file_name="{0}{1}".format(name, ext))
+                    task = add_gzip_file_task(sourcefile_path=log_file_item_path)
                     sg_tasks.append(task)
 
                 # Track which log file paths have been added so far

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -449,7 +449,7 @@ def make_curl_task(name, url, user="", password="", content_postprocessors=[],
     )
 
 
-def add_gzip_file_task(sourcefile_path, log_file_name, content_postprocessors=[]):
+def add_gzip_file_task(sourcefile_path, content_postprocessors=[]):
     """
     Adds the extracted contents of a file to the output zip
 
@@ -462,10 +462,14 @@ def add_gzip_file_task(sourcefile_path, log_file_name, content_postprocessors=[]
                 contents = content_postprocessor(contents)
             return contents
 
+    log_file = os.path.basename(sourcefile_path)
+    if log_file.endswith('.gz'):
+        log_file = log_file[:-3]
+
     task = PythonTask(
         description="Extracted contents of {0}".format(sourcefile_path),
         callable=python_add_file_task,
-        log_file=log_file_name,
+        log_file=log_file,
         log_exception=False,
     )
 


### PR DESCRIPTION
Still extracts gzipped logs, but does not concatenate them into a single file, to make it easier when dealing with huge sets of logs.

/cc @JFlath @malarky 

![screen shot 2018-12-31 at 14 16 41](https://user-images.githubusercontent.com/1525809/50561854-b9d1a580-0d06-11e9-93fa-88449406425c.png)
