### PR TITLE
sgcollect_info: De-duplicate log files found more than once

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -344,9 +344,14 @@ def make_collect_logs_tasks(zip_dir, sg_url):
 
         for log_file_item_name in glob.iglob(rotated_logs_pattern):
             log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
-            print('Capturing rotated log file {0}'.format(log_file_item_path))
-            task = add_file_task(sourcefile_path=log_file_item_path)
-            sg_tasks.append(task)
+            # As long as a task that monitors this log file path has not already been added, add a new task
+            if sg_log_file_path not in sg_log_file_paths:
+                print('Capturing rotated log file {0}'.format(log_file_item_path))
+                task = add_file_task(sourcefile_path=log_file_item_path)
+                sg_tasks.append(task)
+
+            # Track which log file paths have been added so far
+            sg_log_file_paths[sg_log_file_path] = sg_log_file_path
 
     # Find log file path from SGW 2.1 style logging config
     guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)
@@ -364,9 +369,14 @@ def make_collect_logs_tasks(zip_dir, sg_url):
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                print('Capturing rotated log file {0}'.format(log_file_item_path))
-                task = add_file_task(sourcefile_path=log_file_item_path)
-                sg_tasks.append(task)
+                # As long as a task that monitors this log file path has not already been added, add a new task
+                if sg_log_file_path not in sg_log_file_paths:
+                    print('Capturing rotated log file {0}'.format(log_file_item_path))
+                    task = add_file_task(sourcefile_path=log_file_item_path)
+                    sg_tasks.append(task)
+
+                # Track which log file paths have been added so far
+                sg_log_file_paths[sg_log_file_path] = sg_log_file_path
 
             # try gzipped logs too
             log_file_pattern = "{0}*{1}.gz".format(name, ext)
@@ -377,9 +387,14 @@ def make_collect_logs_tasks(zip_dir, sg_url):
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
-                task = add_gzip_file_task(sourcefile_path=log_file_item_path, log_file_name="{0}{1}".format(name, ext))
-                sg_tasks.append(task)
+                # As long as a task that monitors this log file path has not already been added, add a new task
+                if sg_log_file_path not in sg_log_file_paths:
+                    print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
+                    task = add_gzip_file_task(sourcefile_path=log_file_item_path, log_file_name="{0}{1}".format(name, ext))
+                    sg_tasks.append(task)
+
+                # Track which log file paths have been added so far
+                sg_log_file_paths[sg_log_file_path] = sg_log_file_path
 
     return sg_tasks
 


### PR DESCRIPTION
Fixes #3878 

Log files found multiple times were being concatenated to output files for each instance it was being found.

Once for the known default paths + filename combinations, and then secondly by a logFilePath search, when the two overlapped (in the case of a default log file path).