### PR TITLE
Avoid data race accessing hasActiveSubChanges

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -48,7 +48,7 @@ type blipSyncContext struct {
 	allowedAttachments  map[string]int
 	handlerSerialNumber uint64    // Each handler within a context gets a unique serial number for logging
 	terminator          chan bool // Closed during blipSyncContext.close(). Ensures termination of async goroutines.
-	hasActiveSubChanges bool      // Track whether there is a subChanges subscription currently active
+	activeSubChanges    uint32    // Flag for whether there is a subChanges subscription currently active.  Atomic access
 	useDeltas           bool      // Whether deltas can be used for this connection - This should be set via setUseDeltas()
 	sgCanUseDeltas      bool      // Whether deltas can be used by Sync Gateway for this connection
 }
@@ -281,11 +281,11 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	}
 
 	// Ensure that only _one_ subChanges subscription can be open on this blip connection at any given time.  SG #3222.
-	if bh.hasActiveSubChanges {
+	if bh.hasActiveSubChanges() {
 		return fmt.Errorf("blipHandler already has an outstanding continous subChanges.  Cannot open another one.")
 	}
 
-	bh.hasActiveSubChanges = true
+	bh.setActiveSubChanges(true)
 
 	if len(subChangesParams.docIDs()) > 0 && subChangesParams.continuous() {
 		return base.HTTPErrorf(http.StatusBadRequest, "DocIDs filter not supported for continuous subChanges")
@@ -326,7 +326,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		}
 
 		defer func() {
-			bh.hasActiveSubChanges = false
+			bh.setActiveSubChanges(false)
 		}()
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()
@@ -959,6 +959,18 @@ func (ctx *blipSyncContext) isAttachmentAllowed(digest string) bool {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	return ctx.allowedAttachments[digest] > 0
+}
+
+func (ctx *blipSyncContext) hasActiveSubChanges() bool {
+	return atomic.LoadUint32(&ctx.activeSubChanges) == uint32(1)
+}
+
+func (ctx *blipSyncContext) setActiveSubChanges(changesActive bool) {
+	if changesActive {
+		atomic.StoreUint32(&ctx.activeSubChanges, uint32(1))
+	} else {
+		atomic.StoreUint32(&ctx.activeSubChanges, uint32(0))
+	}
 }
 
 // setUseDeltas will set useDeltas on the blipSyncContext as long as both sides of the connection have it enabled.


### PR DESCRIPTION
Switched flag to atomic (instead of trying to reuse blipSyncContext.lock) for better isolation.