### PR TITLE
Log Delta Sync config option on startup

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -582,6 +582,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
+	base.Infof(base.KeyAll, "Delta sync enabled=%t for database %s", deltaSyncOptions.Enabled, dbName)
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		IndexOptions:              channelIndexOptions,


### PR DESCRIPTION
Something we'd agreed to do to signal when Delta Sync is enabled or disabled on startup.

Outputs: ```2019-01-08T21:24:31.202Z [INF] Delta sync enabled=true for database travel-sample```