### PR TITLE
Improve cache validFrom handling

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -73,22 +73,22 @@ func nextChannelQueryEntry(results sgbucket.QueryResultIterator) (*LogEntry, boo
 
 }
 
+//	startSeq := options.Since.SafeSequence() + 1
+// limit = options.Limit
+
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
 func (dbc *DatabaseContext) getChangesInChannelFromQuery(
-	channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
+	channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
 	if dbc.Bucket == nil {
-		return nil, errors.New("No bucket available for channel view query")
+		return nil, errors.New("No bucket available for channel query")
 	}
 	start := time.Now()
-
-	startSeq := options.Since.SafeSequence() + 1
-
 	usingViews := dbc.Options.UseViews
 
 	entries := make(LogEntries, 0)
 	activeEntryCount := 0
 
-	base.Infof(base.KeyCache, "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, options.Limit)
+	base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, limit)
 
 	// Loop for active-only and limit handling.
 	// The set of changes we get back from the query applies the limit, but includes both active and non-active entries.  When retrieving changes w/ activeOnly=true and a limit,
@@ -96,7 +96,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	for {
 
 		// Query the view or index
-		queryResults, err := dbc.QueryChannels(channelName, startSeq, endSeq, options.Limit)
+		queryResults, err := dbc.QueryChannels(channelName, startSeq, endSeq, limit)
 		if err != nil {
 			return nil, err
 		}
@@ -121,7 +121,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 
 			// If active-only, track the number of non-removal, non-deleted revisions we've seen in the view results
 			// for limit calculation below.
-			if options.ActiveOnly {
+			if activeOnly {
 				if entry.IsActive() {
 					activeEntryCount++
 				}
@@ -144,10 +144,11 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 			return nil, nil
 		}
 
-		// If active-only, loop until either retrieve (limit) entries, or reach endSeq
-		if options.ActiveOnly {
+		// If active-only, loop until either retrieve (limit) active entries, or reach endSeq.  Non-active entries are still
+		// included in the result set for potential cache prepend
+		if activeOnly {
 			// If we've reached limit, we're done
-			if activeEntryCount >= options.Limit || options.Limit == 0 {
+			if activeEntryCount >= limit || limit == 0 {
 				break
 			}
 			// If we've reached endSeq, we're done
@@ -157,7 +158,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 			// Otherwise update startkey and re-query
 
 			startSeq = highSeq + 1
-			base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, options.Limit)
+			base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, limit)
 		} else {
 			// If not active-only, we only need one iteration of the loop - the limit applied to the view query is sufficient
 			break
@@ -170,13 +171,13 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	}
 	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
 		base.Infof(base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
-			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, options.Limit)
+			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, limit)
 	}
 	changeCacheExpvars.Add("view_queries", 1)
 	return entries, nil
 }
 
 // Public channel view call - for unit test support
-func (dbc *DatabaseContext) ChannelViewTest(channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
-	return dbc.getChangesInChannelFromQuery(channelName, endSeq, options)
+func (dbc *DatabaseContext) ChannelViewTest(channelName string, startSeq, endSeq uint64) (LogEntries, error) {
+	return dbc.getChangesInChannelFromQuery(channelName, startSeq, endSeq, 0, false)
 }

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -73,9 +73,6 @@ func nextChannelQueryEntry(results sgbucket.QueryResultIterator) (*LogEntry, boo
 
 }
 
-//	startSeq := options.Since.SafeSequence() + 1
-// limit = options.Limit
-
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
 func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -354,7 +354,6 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	// overlap, which helps confirm that we've got everything.
 	c.context.DbStats.StatsCache().Add(base.StatKeyChannelCacheMisses, 1)
 	endSeq := cacheValidFrom
-	// limit = options.Limit
 	resultFromView, err := c.context.getChangesInChannelFromQuery(c.channelName, startSeq, endSeq, options.Limit, options.ActiveOnly)
 	if err != nil {
 		return nil, err

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -275,7 +275,7 @@ func (c *channelCache) getCachedChanges(options ChangesOptions) (validFrom uint6
 	//we don't know how many non active entries will be discarded from the entry set
 	//by the caller, so the additional entries may be needed to return up to the limit requested
 	if options.ActiveOnly {
-		options.Limit = 0
+		limit = 0
 	}
 
 	return c._getCachedChanges(sinceSeq, limit)

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -360,9 +360,15 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 		return nil, err
 	}
 
-	// Cache some of the view results, if there's room in the cache:
+	// Cache some of the query results, if there's room in the cache.  If query hit the limit,
+	// the query results are only valid for the range of sequences in the result set.
+	resultValidTo := endSeq
+	numResults := len(resultFromView)
+	if options.Limit != 0 && numResults >= options.Limit {
+		resultValidTo = resultFromView[numResults-1].Sequence
+	}
 	if len(resultFromCache) < c.options.ChannelCacheMaxLength {
-		c.prependChanges(resultFromView, startSeq, options.Limit == 0)
+		c.prependChanges(resultFromView, startSeq, resultValidTo)
 	}
 
 	result := resultFromView
@@ -506,90 +512,92 @@ func (c *channelCache) insertChange(log *LogEntries, change *LogEntry) {
 // the cache.
 //
 // Returns the number of entries actually prepended.
-func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint64, openEnded bool) int {
+func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint64, changesValidTo uint64) int {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if len(c.logs) == 0 {
-		// If my cache is empty, just copy the new changes:
-		if len(changes) > 0 {
-			if !openEnded && changes[len(changes)-1].Sequence < c.validFrom {
-				return 0 // changes might not go all the way to the current time
-			}
-			if excess := len(changes) - c.options.ChannelCacheMaxLength; excess > 0 {
-				changes = changes[excess:]
-				changesValidFrom = changes[0].Sequence
-			}
-			c.logs = make(LogEntries, len(changes))
-			copy(c.logs, changes)
-			base.Infof(base.KeyCache, "  Initialized cache of %q with %d entries from view (#%d--#%d)",
-				base.UD(c.channelName), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
+	// If set of changes to prepend is empty, check whether validFrom should be updated
+	if len(changes) == 0 {
+		if changesValidFrom < c.validFrom && changesValidTo >= c.validFrom {
+			base.Debugf(base.KeyCache, " changesValidFrom (%d) < c.validFrom < changesValidTo (%d), setting c.validFrom from %v -> %v",
+				changesValidFrom, changesValidTo, c.validFrom, changesValidFrom)
+			c.validFrom = changesValidFrom
 		}
+		return 0
+	}
+
+	// Ensure changes are valid to the cache's validFrom, otherwise unsafe to prepend
+	if changesValidTo < c.validFrom {
+		return 0
+	}
+
+	// If my cache is empty, just copy the new changes
+	if len(c.logs) == 0 {
+		if excess := len(changes) - c.options.ChannelCacheMaxLength; excess > 0 {
+			changes = changes[excess:]
+			changesValidFrom = changes[0].Sequence
+		}
+		c.logs = make(LogEntries, len(changes))
+		copy(c.logs, changes)
+		base.Infof(base.KeyCache, "  Initialized cache of %q with %d entries from view (#%d--#%d)",
+			base.UD(c.channelName), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
+
 		c.validFrom = changesValidFrom
 		c.addDocIDs(changes)
 		return len(changes)
 
-	} else if len(changes) == 0 {
+	}
 
-		if openEnded && changesValidFrom < c.validFrom {
-			base.Debugf(base.KeyCache, " openEnded && changesValidFrom < c.validFrom, setting c.validFrom from %v -> %v",
-				c.validFrom, changesValidFrom)
-			c.validFrom = changesValidFrom
-		}
-		return 0
-
-	} else {
-		// Look for an overlap, and prepend everything up to that point:
-		firstSequence := c.logs[0].Sequence
-		if changes[0].Sequence <= firstSequence {
-			// Found overlap - iterate backwards over query results from the overlap point, building set
-			// of entries to append.  Ignore docIDs already in the cache.  Stop when we have enough to
-			// fill to ChannelCacheMaxLength (or run out of query results)
-			for i := len(changes) - 1; i >= 0; i-- {
-				// Found overlap, iterate over remaining to build set to prepend
-				if changes[i].Sequence == firstSequence {
-					cacheCapacity := c.options.ChannelCacheMaxLength - len(c.logs)
-					if cacheCapacity == 0 {
-						return 0
-					}
-					// Build the set of entries to prepend by iterating backwards from the overlap point to the beginning of changes[]
-					entriesToPrepend := make(LogEntries, 0, cacheCapacity)
-					for changeIndex := i; changeIndex >= 0; changeIndex-- {
-						change := changes[changeIndex]
-
-						// If docid is already in cache, existing revision must be for a later sequence; can ignore this revision.
-						if _, docIdExists := c.cachedDocIDs[change.DocID]; docIdExists {
-							continue
-						}
-						entriesToPrepend = append(entriesToPrepend, nil)
-						copy(entriesToPrepend[1:], entriesToPrepend)
-						entriesToPrepend[0] = change
-						c.cachedDocIDs[change.DocID] = struct{}{}
-						c.UpdateCacheUtilization(change, 1)
-
-						if len(entriesToPrepend) >= cacheCapacity {
-							// If we reach capacity before prepending the entire set of changes, set changesValidFrom to the oldest sequence
-							// that's been prepended to the cache
-							changesValidFrom = change.Sequence
-							break
-						}
-					}
-
-					numToPrepend := len(entriesToPrepend)
-					if numToPrepend > 0 {
-						c.logs = append(entriesToPrepend, c.logs...)
-						base.Infof(base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
-							numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channelName))
-					}
-					base.Debugf(base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",
-						c.validFrom, changesValidFrom)
-					c.validFrom = changesValidFrom
-					return numToPrepend
-				}
-			}
-		}
+	// Prepending changes to a non-empty cache
+	// Check whether there's capacity to prepend
+	cacheCapacity := c.options.ChannelCacheMaxLength - len(c.logs)
+	if cacheCapacity <= 0 {
 		return 0
 	}
+
+	// Check whether the results to prepend are contiguous with the cache
+	if changesValidFrom >= c.validFrom {
+		return 0
+	}
+
+	// Iterate backward over changes set, building set to prepend.
+	//   - Don't prepend any sequence values already in the cache (later than c.validFrom)
+	//   - Ignore docIDs already in the cache
+	//   - Stop when we have enough to fill to ChannelCacheMaxLength (or run out of query results)
+	entriesToPrepend := make(LogEntries, 0, cacheCapacity)
+	for i := len(changes) - 1; i >= 0; i-- {
+		change := changes[i]
+		if change != nil && change.Sequence < c.validFrom {
+			// If docid is already in cache, existing revision must be for a later sequence; can ignore this revision.
+			if _, docIdExists := c.cachedDocIDs[change.DocID]; docIdExists {
+				continue
+			}
+			entriesToPrepend = append(entriesToPrepend, nil)
+			copy(entriesToPrepend[1:], entriesToPrepend)
+			entriesToPrepend[0] = change
+			c.cachedDocIDs[change.DocID] = struct{}{}
+			c.UpdateCacheUtilization(change, 1)
+
+			if len(entriesToPrepend) >= cacheCapacity {
+				// If we reach capacity before prepending the entire set of changes, set changesValidFrom to the oldest sequence
+				// that's been prepended to the cache
+				changesValidFrom = change.Sequence
+				break
+			}
+		}
+	}
+
+	numToPrepend := len(entriesToPrepend)
+	if numToPrepend > 0 {
+		c.logs = append(entriesToPrepend, c.logs...)
+		base.Infof(base.KeyCache, "  Added %d entries from query (#%d--#%d) to cache of %q",
+			numToPrepend, entriesToPrepend[0].Sequence, entriesToPrepend[numToPrepend-1].Sequence, base.UD(c.channelName))
+	}
+	base.Debugf(base.KeyCache, " Backfill cache from query c.validFrom from %v -> %v",
+		c.validFrom, changesValidFrom)
+	c.validFrom = changesValidFrom
+	return numToPrepend
+
 }
 
 func (c *channelCache) GetSize() int {

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -225,7 +225,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended := cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended := cache.prependChanges(changesToPrepend, 5, 14)
 	goassert.Equals(t, numPrepended, 3)
 
 	// Validate cache
@@ -247,7 +247,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	goassert.Equals(t, numPrepended, 2)
 
 	// Validate cache
@@ -282,7 +282,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// Prepend empty set, validate validFrom update
-	cache.prependChanges(LogEntries{}, 5, true)
+	cache.prependChanges(LogEntries{}, 5, 14)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
 	goassert.Equals(t, validFrom, uint64(5))
 	goassert.Equals(t, len(cachedChanges), 4)
@@ -304,7 +304,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	goassert.Equals(t, numPrepended, 1)
 
 	// Validate cache
@@ -338,7 +338,7 @@ func TestPrependChanges(t *testing.T) {
 		e(12, "doc4", "2-a"),
 		e(14, "doc1", "2-a"),
 	}
-	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	goassert.Equals(t, numPrepended, 0)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
 	goassert.Equals(t, validFrom, uint64(5))
@@ -372,7 +372,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 6, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 6, 14)
 	goassert.Equals(t, numPrepended, 0)
 
 	// Validate cache
@@ -541,7 +541,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
 
-	cache := newChannelCache(context, "Test1", 0)
+	cache := newChannelCache(context, "Test1", 99)
 	cache.options.ChannelCacheMaxLength = 15
 
 	// Add 9 entries to cache, 3 of each type
@@ -561,14 +561,13 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	assert.Equal(t, 3, removals)
 
 	// Attempt to prepend entries with later sequences already in cache.  Shouldn't modify stats (note that prepend expects one overlap)
-	prependDuplicatesSet := make(LogEntries, 6)
+	prependDuplicatesSet := make(LogEntries, 5)
 	prependDuplicatesSet[0] = (e(50, "active1", "1-a"))
 	prependDuplicatesSet[1] = (et(51, "active2", "1-a"))
 	prependDuplicatesSet[2] = (e(52, "removal1", "1-a"))
 	prependDuplicatesSet[3] = (et(53, "tombstone1", "1-a"))
 	prependDuplicatesSet[4] = (e(54, "tombstone3", "1-a"))
-	prependDuplicatesSet[5] = (e(100, "active1", "2-a"))
-	cache.prependChanges(prependDuplicatesSet, 50, false)
+	cache.prependChanges(prependDuplicatesSet, 50, 99)
 
 	active, tombstones, removals = getCacheUtilization(context)
 	assert.Equal(t, 3, active)
@@ -587,8 +586,8 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	prependSet[7] = (et(47, "new8", "1-a"))
 	prependSet[8] = (e(48, "new9", "1-a"))
 	prependSet[9] = (et(49, "new10", "1-a"))
-	prependSet[10] = (e(100, "active1", "2-a"))
-	cache.prependChanges(prependSet, 40, false)
+	prependSet[10] = (et(50, "active1", "1-a"))
+	cache.prependChanges(prependSet, 40, 50)
 	active, tombstones, removals = getCacheUtilization(context)
 	assert.Equal(t, 6, active)
 	assert.Equal(t, 6, tombstones)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1458,7 +1458,7 @@ func TestChannelView(t *testing.T) {
 	// Query view (retry loop to wait for indexing)
 	for i := 0; i < 10; i++ {
 		var err error
-		entries, err = db.getChangesInChannelFromQuery("*", 0, ChangesOptions{})
+		entries, err = db.getChangesInChannelFromQuery("*", 0, 100, 0, false)
 
 		assert.NoError(t, err, "Couldn't create document")
 		if len(entries) >= 1 {

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1817,6 +1817,101 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 
 }
 
+// Validate that non-contiguous query results (due to limit) are not prepended to the cache
+func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+
+	rt := RestTester{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	defer rt.Close()
+
+	// Create user:
+	a := rt.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("PBS"))
+	goassert.True(t, err == nil)
+	a.Save(bernard)
+
+	// Write 30 docs to the bucket, 10 from channel PBS.  Expected sequence assignment:
+	//  1, 4, 7, ...   ABC
+	//  2, 5, 8, ...   PBS
+	//  3, 6, 9, ...   NBC
+	for i := 1; i <= 10; i++ {
+		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/abc%d", i), `{"channels":["ABC"]}`)
+		assertStatus(t, response, 201)
+		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/pbs%d", i), `{"channels":["PBS"]}`)
+		assertStatus(t, response, 201)
+		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/nbc%d", i), `{"channels":["NBC"]}`)
+		assertStatus(t, response, 201)
+	}
+
+	testDb := rt.ServerContext().Database("db")
+	testDb.WaitForSequence(30)
+
+	// Flush the channel cache
+	testDb.FlushChannelCache()
+
+	// Issue a since=0 changes request, with limit less than the number of PBS documents
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+
+	// Issue a since=0, limit 5 changes request.
+	changes.Results = nil
+	changesJSON := `{"since":0, "limit":5}`
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	goassert.Equals(t, len(changes.Results), 5)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+
+	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	log.Printf("After initial changes request, query count is :%d", queryCount)
+
+	// Issue another since=0, limit 5 changes request.  Validate that there is another a view-based backfill
+	changes.Results = nil
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	goassert.Equals(t, len(changes.Results), 5)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	// Validate that there has been one more view query
+	secondQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	goassert.Equals(t, secondQueryCount, queryCount+1)
+
+	// Issue a since=20, limit 5 changes request.  Results should be prepended to the cache (seqs 23, 26, 29)
+	changes.Results = nil
+	changesJSON = `{"since":20, "limit":5}`
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	goassert.Equals(t, len(changes.Results), 3)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	// Validate that there has been one more view query
+	thirdQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	goassert.Equals(t, thirdQueryCount, secondQueryCount+1)
+
+	// Issue a since=20, limit 5 changes request again.  Results should be served from the cache (seqs 23, 26, 29)
+	changes.Results = nil
+	changesJSON = `{"since":20, "limit":5}`
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	goassert.Equals(t, len(changes.Results), 3)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	// Validate that there hasn't been another view query
+	fourthQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	goassert.Equals(t, fourthQueryCount, thirdQueryCount)
+}
+
 // Tests multiple view backfills and validates that results are prepended to cache
 func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 
@@ -1868,7 +1963,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
-	// Issue a since=0 changes request.  Validate that there is not another a view-based backfill
+	// Issue a since=0 changes request.  Expect a second view query to retrieve the additional results
 	changes.Results = nil
 	changesJSON = `{"since":0, "limit":50}`
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
@@ -1894,6 +1989,87 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	// Validate that there haven't been any more view queries
 	thirdQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
 	goassert.Equals(t, thirdQueryCount, secondQueryCount)
+
+}
+
+// Tests multiple view backfills and validates that results are prepended to cache
+func TestChangesViewBackfillNoOverlap(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+
+	rt := RestTester{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	defer rt.Close()
+
+	// Create user:
+	a := rt.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf("PBS"))
+	goassert.True(t, err == nil)
+	a.Save(bernard)
+
+	// Write 30 docs to the bucket, 10 from channel PBS.  Expected sequence assignment:
+	//  1, 4, 7, ...   ABC
+	//  2, 5, 8, ...   PBS
+	//  3, 6, 9, ...   NBC
+	for i := 1; i <= 10; i++ {
+		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/abc%d", i), `{"channels":["ABC"]}`)
+		assertStatus(t, response, 201)
+		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/pbs%d", i), `{"channels":["PBS"]}`)
+		assertStatus(t, response, 201)
+		response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/nbc%d", i), `{"channels":["NBC"]}`)
+		assertStatus(t, response, 201)
+	}
+
+	testDb := rt.ServerContext().Database("db")
+	testDb.WaitForSequence(30)
+
+	// Flush the channel cache
+	testDb.FlushChannelCache()
+
+	// Write some more docs to the bucket, with a gap before the first PBS sequence
+	response := rt.SendAdminRequest("PUT", "/db/abc11", `{"channels":["ABC"]}`)
+	assertStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/db/abc12", `{"channels":["ABC"]}`)
+	assertStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/db/abc13", `{"channels":["ABC"]}`)
+	assertStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/db/abc14", `{"channels":["ABC"]}`)
+	assertStatus(t, response, 201)
+	response = rt.SendAdminRequest("PUT", "/db/pbs11", `{"channels":["PBS"]}`)
+	assertStatus(t, response, 201)
+
+	testDb.WaitForSequence(35)
+
+	// Issue a since=n changes request, where 0 < n < 30 (high sequence at cache init)Validate that there's a view-based backfill
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+	changesJSON := `{"since":15, "limit":50}`
+	changes.Results = nil
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	goassert.Equals(t, len(changes.Results), 6)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+
+	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	log.Printf("After initial changes request, query count is :%d", queryCount)
+
+	// Issue the same changes request.  Validate that there is not another a view-based backfill
+	changes.Results = nil
+	changesJSON = `{"since":15, "limit":50}`
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	goassert.Equals(t, len(changes.Results), 6)
+	for _, entry := range changes.Results {
+		log.Printf("Entry:%+v", entry)
+	}
+	// Validate that there has been one more view query
+	secondQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	goassert.Equals(t, secondQueryCount, queryCount)
 
 }
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -444,7 +444,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	// Attempt to retrieve via view.  Above operations were all synchronous (on-demand import of SDK delete, SG delete), so
 	// stale=false view results should be immediately updated.
-	results, err := rt.GetDatabase().ChannelViewTest("ABC", 1000, db.ChangesOptions{})
+	results, err := rt.GetDatabase().ChannelViewTest("ABC", 0, 1000)
 	assert.NoError(t, err, "Error issuing channel view query")
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)


### PR DESCRIPTION
Fixes #3872.

Avoids scenarios where query range and cache validFrom result in query results not being prepended to the cache, or redundant queries being issued because cache validFrom isn't associated with a sequence in the cache.  

Replaces 'one entry overlap' prepend approach with comparison of query range vs. cache validFrom/validTo at prepend time.  Adds several tests for scenarios that were previously generating unnecessary queries.

Refactors some cache-related APIs to make it clearer what sequence ranges are being requested/served (previously depended on relatively opaque changes.Options processing.