### PR TITLE
#3815 HTTP/Blip logging context

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -567,7 +567,7 @@ func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey L
 	}
 
 	if ctx != nil {
-		if logCtx, ok := ctx.Value(SGLogContextKey).(LogContext); ok {
+		if logCtx, ok := ctx.Value(LogContextKey{}).(LogContext); ok {
 			format = logCtx.addContext(format)
 		}
 	}

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -16,7 +16,7 @@ func (lc *LogContext) addContext(format string) string {
 	}
 
 	if lc.CorrelationID != "" {
-		format = "cID=" + lc.CorrelationID + " " + format
+		format = "c:" + lc.CorrelationID + " " + format
 	}
 
 	return format

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -1,6 +1,7 @@
 package base
 
-const SGLogContextKey = "sg_log_context"
+// LogContextKey is used to key a LogContext value
+type LogContextKey struct {}
 
 // LogContext stores values which may be useful to include in logs
 type LogContext struct {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -1,0 +1,23 @@
+package base
+
+const SGLogContextKey = "sg_log_context"
+
+// LogContext stores values which may be useful to include in logs
+type LogContext struct {
+	// CorrelationID is a pre-formatted identifier used to correlate logs.
+	// E.g: Either blip context ID or HTTP Serial number.
+	CorrelationID           string
+}
+
+// addContext returns a string format with additional log context if present.
+func (lc *LogContext) addContext(format string) string {
+	if lc == nil {
+		return ""
+	}
+
+	if lc.CorrelationID != "" {
+		format = "cID=" + lc.CorrelationID + " " + format
+	}
+
+	return format
+}

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -321,10 +321,10 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	cacheValidFrom, resultFromCache := c.getCachedChanges(options)
 	numFromCache := len(resultFromCache)
 	if numFromCache > 0 || resultFromCache == nil {
-		base.Infof(base.KeyCache, "getCachedChanges(%q, %s) --> %d changes valid from #%d",
+		base.InfofCtx(options.Ctx, base.KeyCache, "getCachedChanges(%q, %s) --> %d changes valid from #%d",
 			base.UD(c.channelName), options.Since.String(), numFromCache, cacheValidFrom)
 	} else if resultFromCache == nil {
-		base.Infof(base.KeyCache, "getCachedChanges(%q, %s) --> nothing cached",
+		base.InfofCtx(options.Ctx, base.KeyCache, "getCachedChanges(%q, %s) --> nothing cached",
 			base.UD(c.channelName), options.Since.String())
 	}
 	startSeq := options.Since.SafeSequence() + 1
@@ -342,7 +342,7 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 	// the cache, so repeat the above:
 	cacheValidFrom, resultFromCache = c.getCachedChanges(options)
 	if len(resultFromCache) > numFromCache {
-		base.Infof(base.KeyCache, "2nd getCachedChanges(%q, %s) got %d more, valid from #%d!",
+		base.InfofCtx(options.Ctx, base.KeyCache, "2nd getCachedChanges(%q, %s) got %d more, valid from #%d!",
 			base.UD(c.channelName), options.Since.String(), len(resultFromCache)-numFromCache, cacheValidFrom)
 	}
 	if cacheValidFrom <= startSeq {
@@ -383,7 +383,7 @@ func (c *channelCache) GetChanges(options ChangesOptions) ([]*LogEntry, error) {
 		}
 		result = append(result, resultFromCache[0:n]...)
 	}
-	base.Infof(base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelName), len(result))
+	base.InfofCtx(options.Ctx, base.KeyCache, "GetChangesInChannel(%q) --> %d rows", base.UD(c.channelName), len(result))
 
 	return result, nil
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -716,7 +716,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 		newRev := createRevID(generation, matchRev, body)
 		body[BodyRev] = newRev
 		if err := doc.History.addRevision(docid, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
-			base.Infof(base.KeyCRUD, "Failed to add revision ID: %s, error: %v", newRev, err)
+			base.InfofCtx(db.Ctx, base.KeyCRUD, "Failed to add revision ID: %s, for doc: %s, error: %v", newRev, base.UD(docid), err)
 			return nil, nil, nil, base.ErrRevTreeAddRevFailure
 		}
 

--- a/db/database.go
+++ b/db/database.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -146,6 +147,7 @@ type ImportOptions struct {
 type Database struct {
 	*DatabaseContext
 	user auth.User
+	Ctx  context.Context
 }
 
 func ValidateDatabaseName(dbName string) error {
@@ -606,11 +608,11 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 
 // Makes a Database object given its name and bucket.
 func GetDatabase(context *DatabaseContext, user auth.User) (*Database, error) {
-	return &Database{context, user}, nil
+	return &Database{DatabaseContext: context, user: user}, nil
 }
 
 func CreateDatabase(context *DatabaseContext) (*Database, error) {
-	return &Database{context, nil}, nil
+	return &Database{DatabaseContext: context}, nil
 }
 
 func (db *Database) SameAs(otherdb *Database) bool {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -358,6 +358,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, params *subChangesParams
 		Continuous: bh.continuous,
 		ActiveOnly: bh.activeOnly,
 		Terminator: bh.blipSyncContext.terminator,
+		Ctx:        bh.db.Ctx,
 	}
 
 	channelSet := bh.channels

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -66,8 +66,13 @@ func userBlipHandler(underlyingMethod blipHandlerMethod) blipHandlerMethod {
 
 	wrappedBlipHandler := func(bh *blipHandler, bm *blip.Message) error {
 
-		// Reload the user on each blip request (otherwise runs into SG issue #2717)
-		newUser, err := bh.db.Authenticator().GetUser(bh.db.User().Name())
+		oldUser := bh.db.User()
+		if oldUser == nil {
+			return fmt.Errorf("nil user for blip handler")
+		}
+
+		// Create a new user-scoped database on each blip request (otherwise runs into SG issue #2717)
+		newUser, err := bh.db.Authenticator().GetUser(oldUser.Name())
 		if err != nil {
 			return err
 		}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -136,7 +136,7 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	ctx.blipContext.FatalErrorHandler = func(err error) {
-		ctx.Logf(base.LevelInfo, base.KeyHTTP, "#%03d:     --> BLIP+WebSocket connection error: %v", h.serialNumber, err)
+		ctx.Logf(base.LevelInfo, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", h.formatSerialNumber(), err)
 	}
 
 	// Create a BLIP WebSocket handler and have it handle the request:
@@ -146,7 +146,7 @@ func (h *handler) handleBLIPSync() error {
 		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol. User:%s.", blipContext.ID, ctx.effectiveUsername))
 		defer func() {
 			conn.Close() // in case it wasn't closed already
-			ctx.Logf(base.LevelDebug, base.KeyHTTP, "#%03d:    --> BLIP+WebSocket connection closed", h.serialNumber)
+			ctx.Logf(base.LevelInfo, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())
 		}()
 		defaultHandler(conn)
 	}
@@ -200,18 +200,17 @@ func (ctx *blipSyncContext) notFound(rq *blip.Message) {
 }
 
 func (ctx *blipSyncContext) Logf(logLevel base.LogLevel, logKey base.LogKey, format string, args ...interface{}) {
-	formatWithContextID, paramsWithContextID := base.PrependContextID(ctx.blipContext.ID, format, args...)
 	switch logLevel {
 	case base.LevelError:
-		base.Errorf(logKey, formatWithContextID, paramsWithContextID...)
+		base.ErrorfCtx(ctx.db.Ctx, logKey, format, args...)
 	case base.LevelWarn:
-		base.Warnf(logKey, formatWithContextID, paramsWithContextID...)
+		base.WarnfCtx(ctx.db.Ctx, logKey, format, args...)
 	case base.LevelInfo:
-		base.Infof(logKey, formatWithContextID, paramsWithContextID...)
+		base.InfofCtx(ctx.db.Ctx, logKey, format, args...)
 	case base.LevelDebug:
-		base.Debugf(logKey, formatWithContextID, paramsWithContextID...)
+		base.DebugfCtx(ctx.db.Ctx, logKey, format, args...)
 	case base.LevelTrace:
-		base.Tracef(logKey, formatWithContextID, paramsWithContextID...)
+		base.TracefCtx(ctx.db.Ctx, logKey, format, args...)
 	}
 }
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -67,9 +67,13 @@ func userBlipHandler(underlyingMethod blipHandlerMethod) blipHandlerMethod {
 	wrappedBlipHandler := func(bh *blipHandler, bm *blip.Message) error {
 
 		// Reload the user on each blip request (otherwise runs into SG issue #2717)
-		if err := bh.db.ReloadUser(); err != nil {
+		newUser, err := bh.db.Authenticator().GetUser(bh.db.User().Name())
+		if err != nil {
 			return err
 		}
+		newDatabase, err := db.GetDatabase(bh.db.DatabaseContext, newUser)
+		newDatabase.Ctx = bh.db.Ctx
+		bh.db = newDatabase
 
 		// Call down to underlying method and return it's value
 		return underlyingMethod(bh, bm)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -106,9 +106,8 @@ func (h *handler) handleBLIPSync() error {
 	blipContext.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)
 	blipContext.LogFrames = base.LogDebugEnabled(base.KeyWebSocketFrame)
 
-	// Overwrite the logging context with the blip context ID
-	// Retaining other contextual information like db and username are not required for blip logging
-	h.db.Ctx = context.WithValue(h.db.Ctx, base.SGLogContextKey,
+	// Overwrite the existing logging context with the blip context ID
+	h.db.Ctx = context.WithValue(h.db.Ctx, base.LogContextKey{},
 		base.LogContext{CorrelationID: formatBlipContextID(blipContext.ID)},
 	)
 	blipContext.Logger = DefaultBlipLogger(h.db.Ctx)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -122,7 +122,7 @@ func (h *handler) handleBLIPSync() error {
 	defer ctx.close()
 
 	// determine if SG has delta sync enabled for the given database
-	ctx.sgCanUseDeltas = ctx.db.DatabaseContext.DeltaSyncEnabled()
+	ctx.sgCanUseDeltas = ctx.db.DeltaSyncEnabled()
 
 	blipContext.DefaultHandler = ctx.notFound
 	for profile, handlerFn := range kHandlersByProfile {
@@ -967,7 +967,7 @@ func (ctx *blipSyncContext) setUseDeltas(clientCanUseDeltas bool) {
 
 	shouldUseDeltas := clientCanUseDeltas && ctx.sgCanUseDeltas
 	if !ctx.useDeltas && shouldUseDeltas {
-		ctx.db.DatabaseContext.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaPullReplicationCount, 1)
+		ctx.db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaPullReplicationCount, 1)
 	}
 	ctx.useDeltas = shouldUseDeltas
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -227,7 +227,7 @@ func (h *handler) logRequestLine() {
 	}
 
 	queryValues := h.getQueryValues()
-	base.Infof(base.KeyHTTP, " #%03d: %s %s%s%s", h.serialNumber, h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, h.currentEffectiveUserNameAsUser())
+	base.Infof(base.KeyHTTP, " %s: %s %s%s%s", h.formatSerialNumber(), h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, h.currentEffectiveUserNameAsUser())
 }
 
 func (h *handler) logRequestBody() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -195,7 +195,7 @@ func (h *handler) invoke(method handlerMethod) error {
 		if err != nil {
 			return err
 		}
-		h.db.Ctx = context.WithValue(context.Background(), base.SGLogContextKey,
+		h.db.Ctx = context.WithValue(context.Background(), base.LogContextKey{},
 			base.LogContext{CorrelationID: h.formatSerialNumber()},
 		)
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -721,7 +722,11 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 
 	// Make BLIP/Websocket connection
 	bt.blipContext = blip.NewContext(BlipCBMobileReplication)
-	bt.blipContext.Logger = DefaultBlipLogger(bt.blipContext.ID)
+	bt.blipContext.Logger = DefaultBlipLogger(
+		context.WithValue(context.Background(), base.SGLogContextKey,
+			base.LogContext{CorrelationID: formatBlipContextID(bt.blipContext.ID)},
+		),
+	)
 
 	bt.blipContext.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)
 	bt.blipContext.LogFrames = base.LogDebugEnabled(base.KeyWebSocketFrame)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -723,7 +723,7 @@ func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 	// Make BLIP/Websocket connection
 	bt.blipContext = blip.NewContext(BlipCBMobileReplication)
 	bt.blipContext.Logger = DefaultBlipLogger(
-		context.WithValue(context.Background(), base.SGLogContextKey,
+		context.WithValue(context.Background(), base.LogContextKey{},
 			base.LogContext{CorrelationID: formatBlipContextID(bt.blipContext.ID)},
 		),
 	)


### PR DESCRIPTION
Fixes #3815 

Adds a new `c:###` field in logs for HTTP/Blip requests which can be used to correlate sets of logs together.

The context ID for blip requests is the blip context ID: `[a0b1c2d]`, and for HTTP requests, it's the HTTP request serial number: `#001`

- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/954/
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/955/

## Examples

### Blip
```
2019-01-09T16:49:38.623Z [INF] HTTP:  #001: GET /travel-sample/_blipsync (as demo)
2019-01-09T16:49:38.623Z [INF] HTTP+: #001:     --> 101 [5b31e98] Upgraded to BLIP+WebSocket protocol. User:demo.  (0.0 ms)
2019-01-09T16:49:38.623Z [INF] WS: c:[5b31e98] Start BLIP/Websocket handler
2019-01-09T16:49:38.624Z [DBG] WS+: c:[5b31e98] Sender starting
2019-01-09T16:49:38.624Z [DBG] WS+: c:[5b31e98] Received frame: MSG#1 (flags=       0, length=62)
2019-01-09T16:49:38.624Z [DBG] WSFrame+: c:[5b31e98] Incoming BLIP Request: MSG#1
2019-01-09T16:49:38.624Z [INF] SyncMsg: c:[5b31e98] #1: Type:getCheckpoint Client:cp-1cintY0NZiJ19PEsMC8205UKrZU= User:demo
2019-01-09T16:49:38.625Z [DBG] SyncMsg+: c:[5b31e98] #1: Type:getCheckpoint   --> OK Time:837.554µs User:demo
2019-01-09T16:49:38.625Z [DBG] WS+: c:[5b31e98] Push RPY#1
2019-01-09T16:49:38.626Z [DBG] WS+: c:[5b31e98] Sending frame: RPY#1 (flags=       1, size=   68)
2019-01-09T16:49:38.627Z [DBG] WS+: c:[5b31e98] Received frame: MSG#2 (flags=       0, length=109)
2019-01-09T16:49:38.627Z [DBG] WSFrame+: c:[5b31e98] Incoming BLIP Request: MSG#2
2019-01-09T16:49:38.628Z [INF] SyncMsg: c:[5b31e98] #2: Type:subChanges Since:8386 Continuous:true Filter:sync_gateway/bychannel Channels:channel.demo  User:demo
2019-01-09T16:49:38.628Z [DBG] WS+: c:[5b31e98] Push RPY#2
2019-01-09T16:49:38.628Z [DBG] WS+: c:[5b31e98] Sending frame: RPY#2 (flags=       1, size=    1)
2019-01-09T16:49:38.628Z [INF] Sync: c:[5b31e98] Sending changes since 8386. User:demo
2019-01-09T16:49:38.628Z [DBG] Changes+: c:[5b31e98] Int sequence multi changes feed...
2019-01-09T16:49:38.628Z [INF] Changes: c:[5b31e98] MultiChangesFeed(channels: {channel.demo}, options: {Since:8386 Limit:0 Conflicts:false IncludeDocs:false Wait:true Continuous:true Terminator:0xc0002c46c0 HeartbeatMs:0 TimeoutMs:0 ActiveOnly:false}) ...   (to demo)
2019-01-09T16:49:38.629Z [DBG] WS+: c:[5b31e98] Received frame: MSG#3! (flags=  110000, length=26)
2019-01-09T16:49:38.629Z [DBG] WSFrame+: c:[5b31e98] Incoming BLIP Request: MSG#3!
2019-01-09T16:49:38.629Z [INF] SyncMsg: c:[5b31e98] #3: Type:proposeChanges #Changes: 0 User:demo
2019-01-09T16:49:38.629Z [DBG] SyncMsg+: c:[5b31e98] #3: Type:proposeChanges   --> OK Time:23.837µs User:demo
2019-01-09T16:49:38.629Z [DBG] Changes+: c:[5b31e98] MultiChangesFeed: channels expand to "channel.demo:4" ...   (to demo)
2019-01-09T16:49:38.629Z [INF] Cache: Initialized cache for channel "channel.demo" with options: &{ChannelCacheMinLength:50 ChannelCacheMaxLength:500 ChannelCacheAge:1m0s}
2019-01-09T16:49:38.629Z [INF] Cache: getCachedChanges("channel.demo", 8386) --> 0 changes valid from #8387
2019-01-09T16:49:38.629Z [DBG] Changes+: c:[5b31e98] [changesFeed] Found 0 changes for channel channel.demo
2019-01-09T16:49:38.629Z [DBG] Changes+: c:[5b31e98] MultiChangesFeed waiting...   (to demo)
2019-01-09T16:49:38.629Z [DBG] Changes+: No new changes to send to change listener.  Waiting for "travel-sample"'s count to pass 0
2019-01-09T16:49:38.629Z [DBG] Sync+: c:[5b31e98]     Sending 0 changes. User:demo
2019-01-09T16:49:38.629Z [DBG] WSFrame+: c:[5b31e98] Queued MSG#1
2019-01-09T16:49:38.629Z [DBG] WS+: c:[5b31e98] Push MSG#1
2019-01-09T16:49:38.629Z [INF] Sync: c:[5b31e98] Sent all changes to client. User:demo
2019-01-09T16:49:38.629Z [DBG] WS+: c:[5b31e98] Sending frame: MSG#1 (flags=  100000, size=   51)
2019-01-09T16:49:39.724Z [DBG] WS+: c:[5b31e98] receiveLoop stopped
2019-01-09T16:49:39.724Z [DBG] WS+: c:[5b31e98] parseLoop stopped
2019-01-09T16:49:39.724Z [INF] HTTP: c:[5b31e98] #001:    --> BLIP+WebSocket connection closed
2019-01-09T16:49:39.724Z [DBG] WS+: c:[5b31e98] Sender stopped
2019-01-09T16:49:39.724Z [DBG] Changes+: Notifying to check for _changes feed termination
2019-01-09T16:49:39.724Z [DBG] SyncMsg+: c:[5b31e98] #2: Type:subChanges   --> Time:1.095937948s User:demo
2019-01-09T16:49:39.724Z [INF] Changes: c:[5b31e98] MultiChangesFeed done   (to demo)
```

### HTTP _changes request
```
2019-01-09T16:49:52.446Z [INF] HTTP:  #002: GET /travel-sample/_changes?since=0 (as ADMIN)
2019-01-09T16:49:52.446Z [DBG] Changes+: c:#002 Int sequence multi changes feed...
2019-01-09T16:49:52.446Z [INF] Changes: c:#002 MultiChangesFeed(channels: {*}, options: {Since:0 Limit:0 Conflicts:false IncludeDocs:false Wait:false Continuous:false Terminator:0xc000092480 HeartbeatMs:0 TimeoutMs:300000 ActiveOnly:false}) ...
2019-01-09T16:49:52.446Z [DBG] Changes+: c:#002 MultiChangesFeed: channels expand to "" ...
2019-01-09T16:49:52.446Z [INF] Cache: Initialized cache for channel "*" with options: &{ChannelCacheMinLength:50 ChannelCacheMaxLength:500 ChannelCacheAge:1m0s}
2019-01-09T16:49:52.446Z [INF] Cache: getCachedChanges("*", 0) --> 0 changes valid from #8387
2019-01-09T16:49:52.446Z [INF] Cache:   Querying 'channels' view for "*" (start=#1, end=#8387, limit=0)
2019-01-09T16:49:52.720Z [INF] Cache:     Got 8376 rows from query for "*": #5 ... #8386
2019-01-09T16:49:52.720Z [INF] Channel query took 273.67409ms to return 8376 rows.  Channel: * StartSeq: 1 EndSeq: 8387 Limit: 0
2019-01-09T16:49:52.720Z [INF] Cache:   Initialized cache of "*" with 500 entries from view (#7883--#8386)
2019-01-09T16:49:52.720Z [INF] Cache: GetChangesInChannel("*") --> 8376 rows
2019-01-09T16:49:52.720Z [DBG] Changes+: c:#002 [changesFeed] Found 8376 changes for channel *
2019-01-09T16:49:52.720Z [DBG] Changes+: c:#002 Channel feed processing seq:5 in channel *
2019-01-09T16:49:52.720Z [DBG] Changes+: c:#002 Channel feed processing seq:6 in channel *
2019-01-09T16:49:52.720Z [DBG] Changes+: c:#002 Channel feed processing seq:7 in channel *
2019-01-09T16:49:52.720Z [DBG] Changes+: c:#002 MultiChangesFeed sending {Seq:5, ID:airline_18241, Changes:[map[rev:1-8f5be8c50c6db672d9dff443874f1a5f]]}
2019-01-09T16:49:52.720Z [DBG] Changes+: c:#002 MultiChangesFeed sending {Seq:6, ID:airline_2009, Changes:[map[rev:1-5942999871586caf63c80b04d5e1797a]]}
```