### PR TITLE
Fix BucketLock deadlock

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -63,13 +63,6 @@ func docIDForUserEmail(email string) string {
 	return "_sync:useremail:" + email
 }
 
-func (auth *Authenticator) UnmarshalPrincipal(data []byte, defaultName string, defaultSeq uint64, isUser bool) (Principal, error) {
-	if isUser {
-		return auth.UnmarshalUser(data, defaultName, defaultSeq)
-	}
-	return auth.UnmarshalRole(data, defaultName, defaultSeq)
-}
-
 func (auth *Authenticator) GetPrincipal(name string, isUser bool) (Principal, error) {
 	if isUser {
 		return auth.GetUser(name)

--- a/auth/role.go
+++ b/auth/role.go
@@ -10,7 +10,6 @@
 package auth
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -53,28 +52,6 @@ func (auth *Authenticator) NewRole(name string, channels base.Set) (Role, error)
 	if err := auth.rebuildChannels(role); err != nil {
 		return nil, err
 	}
-	return role, nil
-}
-
-func (auth *Authenticator) UnmarshalRole(data []byte, defaultName string, defaultSeq uint64) (Role, error) {
-	role := &roleImpl{}
-	if err := json.Unmarshal(data, role); err != nil {
-		return nil, err
-	}
-	if role.Name_ == "" {
-		role.Name_ = defaultName
-	}
-
-	defaultVbSeq := ch.NewVbSimpleSequence(defaultSeq)
-	for channel, seq := range role.ExplicitChannels_ {
-		if seq.Sequence == 0 {
-			role.ExplicitChannels_[channel] = defaultVbSeq
-		}
-	}
-	if err := role.validate(); err != nil {
-		return nil, err
-	}
-
 	return role, nil
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -94,26 +94,6 @@ func (auth *Authenticator) NewUser(username string, password string, channels ba
 	return user, nil
 }
 
-func (auth *Authenticator) UnmarshalUser(data []byte, defaultName string, defaultSequence uint64) (User, error) {
-	user := &userImpl{auth: auth}
-	if err := json.Unmarshal(data, user); err != nil {
-		return nil, err
-	}
-	if user.Name_ == "" {
-		user.Name_ = defaultName
-	}
-	defaultVbSequence := ch.NewVbSimpleSequence(defaultSequence)
-	for channel, seq := range user.ExplicitChannels_ {
-		if seq.Sequence == 0 {
-			user.ExplicitChannels_[channel] = defaultVbSequence
-		}
-	}
-	if err := user.validate(); err != nil {
-		return nil, err
-	}
-	return user, nil
-}
-
 // Checks whether this userImpl object contains valid data; if not, returns an error.
 func (user *userImpl) validate() error {
 	if err := (&user.roleImpl).validate(); err != nil {

--- a/db/database.go
+++ b/db/database.go
@@ -514,8 +514,8 @@ func (context *DatabaseContext) Close() {
 }
 
 func (context *DatabaseContext) IsClosed() bool {
-	context.BucketLock.Lock()
-	defer context.BucketLock.Unlock()
+	context.BucketLock.RLock()
+	defer context.BucketLock.RUnlock()
 	return context.Bucket == nil
 }
 


### PR DESCRIPTION
Fixes #3898.

Switch to simple unmarshalling when processing principal docs seen over DCP, as we don't need a full authenticator-backed (and bucket-backed) principal.