### PR TITLE
TestContinuousChangesSubscription fix

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -750,8 +750,6 @@ func (c *changeCache) _addPendingLogs() base.Set {
 			heap.Pop(&c.pendingLogs)
 			changedChannels = changedChannels.Union(c._addToCache(change))
 		} else if len(c.pendingLogs) > c.options.CachePendingSeqMaxNum || time.Since(c.pendingLogs[0].TimeReceived) >= c.options.CachePendingSeqMaxWait {
-			base.Infof(base.KeyCache, "Skipping sequence %d based on len(c.pendingLogs):%v, CachePendingSeqMaxNum: %v, time.Since(c.pendingLogs[0].TimeReceived): %v, c.options.CachePendingSeqMaxWait",
-				len(c.pendingLogs), c.options.CachePendingSeqMaxNum, time.Since(c.pendingLogs[0].TimeReceived), c.options.CachePendingSeqMaxWait)
 			c.context.DbStats.StatsCache().Add(base.StatKeyNumSkippedSeqs, 1)
 			c.PushSkipped(c.nextSequence)
 			c.nextSequence++

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -750,6 +750,8 @@ func (c *changeCache) _addPendingLogs() base.Set {
 			heap.Pop(&c.pendingLogs)
 			changedChannels = changedChannels.Union(c._addToCache(change))
 		} else if len(c.pendingLogs) > c.options.CachePendingSeqMaxNum || time.Since(c.pendingLogs[0].TimeReceived) >= c.options.CachePendingSeqMaxWait {
+			base.Infof(base.KeyCache, "Skipping sequence %d based on len(c.pendingLogs):%v, CachePendingSeqMaxNum: %v, time.Since(c.pendingLogs[0].TimeReceived): %v, c.options.CachePendingSeqMaxWait",
+				len(c.pendingLogs), c.options.CachePendingSeqMaxNum, time.Since(c.pendingLogs[0].TimeReceived), c.options.CachePendingSeqMaxWait)
 			c.context.DbStats.StatsCache().Add(base.StatKeyNumSkippedSeqs, 1)
 			c.PushSkipped(c.nextSequence)
 			c.nextSequence++

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
@@ -81,6 +82,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket) error {
 				}
 			}()
 			for event := range listener.tapFeed.Events() {
+				event.TimeReceived = time.Now()
 				listener.ProcessFeedEvent(event)
 			}
 		}()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -148,7 +148,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges)()
 
 	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -148,7 +148,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges|base.KeyCache)()
 
 	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -436,7 +436,7 @@ func (bh *blipHandler) handleChangesResponse(sender *blip.Sender, response *blip
 
 	if response.Type() == blip.ErrorType {
 		errorBody, _ := response.Body()
-		base.Warnf(base.KeyAll, "[%s] Unexpected error while handling changes response: %s", bh.blipContext.ID, errorBody)
+		base.Infof(base.KeyAll, "[%s] Client returned error in changesResponse: %s", bh.blipContext.ID, errorBody)
 		return
 	}
 


### PR DESCRIPTION
Fixes #3869

Tap feed processing wasn't setting TimeReceived on feed events, resulting in skipped sequences and non-integer compound sequences to be sent under load.  

The 'client' changes handler used by the blip test was assuming integers, and panicking on type conversion.  The panic was recovered and sent as an error message type by the blip code, but SG's changesResponse handler wasn't checking for error, and was attempting to unmarshal the error message as JSON.
