### PR TITLE
Add retry handling for GetStatsVbSeqno

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2219,10 +2219,13 @@ func (bucket *CouchbaseBucketGoCB) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeq
 
 	// Kick off retry loop
 	err, result := RetryLoop("getStatsVbSeqno", worker, bucket.spec.RetrySleeper())
-
-	// If the retry loop returned a nil result, set to 0 to prevent type assertion on nil error
-	if result == nil {
+	if err != nil {
 		return uuids, highSeqnos, err
+	}
+
+	// If the retry loop returned a nil result, return error
+	if result == nil {
+		return uuids, highSeqnos, errors.New("Nil response returned from bucket.Stats call")
 	}
 
 	// Type assertion of result

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -97,7 +97,7 @@ type DCPReceiver struct {
 	backfill               backfillStatus                 // Backfill state and stats
 }
 
-func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool) (Receiver, error) {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool) Receiver {
 
 	r := &DCPReceiver{
 		bucket:                 bucket,
@@ -113,10 +113,10 @@ func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxV
 	if LogDebugEnabled(KeyDCP) {
 		Infof(KeyDCP, "Using DCP Logging Receiver.")
 		logRec := &DCPLoggingReceiver{rec: r}
-		return logRec, nil
+		return logRec
 	}
 
-	return r, nil
+	return r
 }
 
 func (r *DCPReceiver) SetBucketNotifyFn(notify sgbucket.BucketNotifyFn) {
@@ -551,11 +551,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		persistCheckpoints = true
 	}
 
-	dcpReceiver, err := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints)
-	if err != nil {
-		return err
-	}
-
+	dcpReceiver := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints)
 	dcpReceiver.SetBucketNotifyFn(args.Notify)
 
 	// Initialize the feed based on the backfill type

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -97,7 +97,7 @@ type DCPReceiver struct {
 	backfill               backfillStatus                 // Backfill state and stats
 }
 
-func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, backfillType uint64) (Receiver, error) {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool) (Receiver, error) {
 
 	r := &DCPReceiver{
 		bucket:                 bucket,
@@ -107,13 +107,7 @@ func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxV
 		meta:                   make([][]byte, maxVbNo),
 		vbuuids:                make(map[uint16]uint64, maxVbNo),
 		updatesSinceCheckpoint: make([]uint64, maxVbNo),
-	}
-
-	r.callback = callback
-	initErr := r.initFeed(backfillType)
-
-	if initErr != nil {
-		return nil, initErr
+		callback:               callback,
 	}
 
 	if LogDebugEnabled(KeyDCP) {
@@ -557,7 +551,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		persistCheckpoints = true
 	}
 
-	dcpReceiver, err := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, args.Backfill)
+	dcpReceiver, err := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #3829.

Also removes redundant stats call (dcp feed was being initialized twice).

- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/952/
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/953/