### PR TITLE
Cache query enhancements

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -68,17 +68,18 @@ const (
 	StatKeyWarnCount                      = "warn_count"
 
 	// StatsCache
-	StatKeyRevisionCacheHits         = "rev_cache_hits"
-	StatKeyRevisionCacheMisses       = "rev_cache_misses"
-	StatKeyChannelCacheHits          = "chan_cache_hits"
-	StatKeyChannelCacheMisses        = "chan_cache_misses"
-	StatKeyChannelCacheRevsActive    = "chan_cache_active_revs"
-	StatKeyChannelCacheRevsTombstone = "chan_cache_tombstone_revs"
-	StatKeyChannelCacheRevsRemoval   = "chan_cache_removal_revs"
-	StatKeyChannelCacheNumChannels   = "chan_cache_num_channels"
-	StatKeyChannelCacheMaxEntries    = "chan_cache_max_entries"
-	StatKeyNumSkippedSeqs            = "num_skipped_seqs"
-	StatKeyAbandonedSeqs             = "abandoned_seqs"
+	StatKeyRevisionCacheHits          = "rev_cache_hits"
+	StatKeyRevisionCacheMisses        = "rev_cache_misses"
+	StatKeyChannelCacheHits           = "chan_cache_hits"
+	StatKeyChannelCacheMisses         = "chan_cache_misses"
+	StatKeyChannelCacheRevsActive     = "chan_cache_active_revs"
+	StatKeyChannelCacheRevsTombstone  = "chan_cache_tombstone_revs"
+	StatKeyChannelCacheRevsRemoval    = "chan_cache_removal_revs"
+	StatKeyChannelCacheNumChannels    = "chan_cache_num_channels"
+	StatKeyChannelCacheMaxEntries     = "chan_cache_max_entries"
+	StatKeyChannelCachePendingQueries = "chan_cache_pending_queries"
+	StatKeyNumSkippedSeqs             = "num_skipped_seqs"
+	StatKeyAbandonedSeqs              = "abandoned_seqs"
 
 	// StatsDatabase
 	StatKeySequenceGets          = "sequence_gets"
@@ -141,10 +142,11 @@ const (
 	StatKeyTotalAuthTime    = "total_auth_time"
 
 	// StatsGsiViews
-	StatKeyTotalQueriesPerSec      = "total_queries_per_sec"
-	StatKeyChannelQueriesPerSec    = "channel_queries_per_sec"
-	StatKeyRoleAccessQueriesPerSec = "role_access_queries_per_sec"
-	StatKeyQueryProcessingTime     = "query_processing_time"
+	// Gsi and View stat names are dynamically generated based on the following patterns
+	StatKeyN1qlQueryCountExpvarFormat      = "%s_count"          // Query name
+	StatKeyN1qlQueryErrorCountExpvarFormat = "%s_error_count"    // QueryName
+	StatKeyViewQueryCountExpvarFormat      = "%s.%s_count"       // Design doc, view
+	StatKeyViewQueryErrorCountExpvarFormat = "%s.%s_error_count" // Design doc, view
 
 	// StatsReplication
 	StatKeySgrNumDocsPushed              = "sgr_num_docs_pushed"

--- a/db/changes.go
+++ b/db/changes.go
@@ -713,7 +713,8 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 	return output, nil
 }
 
-// Synchronous convenience function that returns all changes as a simple array.
+// Synchronous convenience function that returns all changes as a simple array, FOR TEST USE ONLY
+// Returns error if initial feed creation fails, or if an error is returned with the changes entries
 func (db *Database) GetChanges(channels base.Set, options ChangesOptions) ([]*ChangeEntry, error) {
 	if options.Terminator == nil {
 		options.Terminator = make(chan bool)
@@ -724,6 +725,9 @@ func (db *Database) GetChanges(channels base.Set, options ChangesOptions) ([]*Ch
 	feed, err := db.MultiChangesFeed(channels, options)
 	if err == nil && feed != nil {
 		for entry := range feed {
+			if entry.Err != nil {
+				err = entry.Err
+			}
 			changes = append(changes, entry)
 		}
 	}

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -146,10 +146,7 @@ func initEmptyStatsMap(key string) *expvar.Map {
 		result.Set(base.StatKeyAuthFailedCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyTotalAuthTime, base.ExpvarIntVal(0))
 	case base.StatsGroupKeyGsiViews:
-		result.Set(base.StatKeyTotalQueriesPerSec, base.ExpvarFloatVal(0))
-		result.Set(base.StatKeyChannelQueriesPerSec, base.ExpvarFloatVal(0))
-		result.Set(base.StatKeyRoleAccessQueriesPerSec, base.ExpvarFloatVal(0))
-		result.Set(base.StatKeyQueryProcessingTime, base.ExpvarFloatVal(0))
+		// GsiView stat keys are dynamically generated based on query names - see query.go
 	}
 
 	return result

--- a/db/query.go
+++ b/db/query.go
@@ -30,13 +30,6 @@ const (
 	QueryTypeAllDocs      = "allDocs"
 )
 
-const (
-	n1qlQueryCountExpvarFormat      = "%s_count"          // Query name
-	n1qlQueryErrorCountExpvarFormat = "%s_error_count"    // QueryName
-	viewQueryCountExpvarFormat      = "%s.%s_count"       // Design doc, view
-	viewQueryErrorCountExpvarFormat = "%s.%s_error_count" // Design doc, view
-)
-
 type SGQuery struct {
 	name      string // Query name - used for logging/stats
 	statement string // Query statement
@@ -201,10 +194,10 @@ func (context *DatabaseContext) N1QLQueryWithStats(queryName string, statement s
 
 	results, err = gocbBucket.Query(statement, params, consistency, adhoc)
 	if err != nil {
-		context.DbStats.StatsGsiViews().Add(fmt.Sprintf(n1qlQueryErrorCountExpvarFormat, queryName), 1)
+		context.DbStats.StatsGsiViews().Add(fmt.Sprintf(base.StatKeyN1qlQueryErrorCountExpvarFormat, queryName), 1)
 	}
 
-	context.DbStats.StatsGsiViews().Add(fmt.Sprintf(n1qlQueryCountExpvarFormat, queryName), 1)
+	context.DbStats.StatsGsiViews().Add(fmt.Sprintf(base.StatKeyN1qlQueryCountExpvarFormat, queryName), 1)
 
 	return results, err
 }
@@ -218,9 +211,9 @@ func (context *DatabaseContext) ViewQueryWithStats(ddoc string, viewName string,
 
 	results, err = context.Bucket.ViewQuery(ddoc, viewName, params)
 	if err != nil {
-		context.DbStats.StatsGsiViews().Add(fmt.Sprintf(viewQueryErrorCountExpvarFormat, ddoc, viewName), 1)
+		context.DbStats.StatsGsiViews().Add(fmt.Sprintf(base.StatKeyViewQueryErrorCountExpvarFormat, ddoc, viewName), 1)
 	}
-	context.DbStats.StatsGsiViews().Add(fmt.Sprintf(viewQueryCountExpvarFormat, ddoc, viewName), 1)
+	context.DbStats.StatsGsiViews().Add(fmt.Sprintf(base.StatKeyViewQueryCountExpvarFormat, ddoc, viewName), 1)
 
 	return results, err
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -29,8 +29,8 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
-	queryCountExpvar := fmt.Sprintf(viewQueryCountExpvarFormat, DesignDocSyncGateway(), ViewChannels)
-	errorCountExpvar := fmt.Sprintf(viewQueryErrorCountExpvarFormat, DesignDocSyncGateway(), ViewChannels)
+	queryCountExpvar := fmt.Sprintf(base.StatKeyViewQueryCountExpvarFormat, DesignDocSyncGateway(), ViewChannels)
+	errorCountExpvar := fmt.Sprintf(base.StatKeyViewQueryErrorCountExpvarFormat, DesignDocSyncGateway(), ViewChannels)
 
 	channelQueryCountBefore := base.ExpvarVar2Int(db.DbStats.StatsGsiViews().Get(queryCountExpvar))
 	channelQueryErrorCountBefore := base.ExpvarVar2Int(db.DbStats.StatsGsiViews().Get(errorCountExpvar))
@@ -71,8 +71,8 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
-	queryCountExpvar := fmt.Sprintf(n1qlQueryCountExpvarFormat, QueryTypeChannels)
-	errorCountExpvar := fmt.Sprintf(n1qlQueryErrorCountExpvarFormat, QueryTypeChannels)
+	queryCountExpvar := fmt.Sprintf(base.StatKeyN1qlQueryCountExpvarFormat, QueryTypeChannels)
+	errorCountExpvar := fmt.Sprintf(base.StatKeyN1qlQueryErrorCountExpvarFormat, QueryTypeChannels)
 
 	channelQueryCountBefore := base.ExpvarVar2Int(db.DbStats.StatsGsiViews().Get(queryCountExpvar))
 	channelQueryErrorCountBefore := base.ExpvarVar2Int(db.DbStats.StatsGsiViews().Get(errorCountExpvar))


### PR DESCRIPTION
Fixes #3862

Exit early on changes termination after queueing for view lock, add stat for count of requests waiting for view lock.

Also cleans up gsi/view stats - obsolete stats were being initialized to zero.