### PR TITLE
Use http.DefaultTransport for webhook connections

### DIFF
--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -57,8 +57,10 @@ func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, e
 	}
 
 	// Initialize transport and client
-	transport := &http.Transport{DisableKeepAlives: false}
-	wh.client = &http.Client{Transport: transport, Timeout: wh.timeout}
+	t := http.DefaultTransport.(*http.Transport)
+	transport := *t
+	transport.DisableKeepAlives = false
+	wh.client = &http.Client{Transport: &transport, Timeout: wh.timeout}
 
 	return wh, err
 }


### PR DESCRIPTION
Fixes #3792 

This is the only place where we're creating a HTTP client with a custom Transport. The other places (OIDC, CBS connections) all pick up the default transport anyway.