### PR TITLE
Added DocWritesBytesBlip and fixed DocReadsBytesBlip

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -91,6 +91,7 @@ const (
 	StatKeyDocWritesBytes          = "doc_writes_bytes"
 	StatKeyNumDocReadsRest         = "num_doc_reads_rest"
 	StatKeyNumDocReadsBlip         = "num_doc_reads_blip"
+	StatKeyDocWritesBytesBlip      = "doc_writes_bytes_blip"
 	StatKeyDocReadsBytesBlip       = "doc_reads_bytes_blip"
 	StatKeyWarnXattrSizeCount      = "warn_xattr_size_count"
 	StatKeyWarnChannelsPerDocCount = "warn_channels_per_doc_count"

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -102,6 +102,7 @@ func initEmptyStatsMap(key string) *expvar.Map {
 		result.Set(base.StatKeyDocWritesBytes, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyNumDocReadsRest, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyNumDocReadsBlip, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyDocWritesBytesBlip, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyDocReadsBytesBlip, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyWarnXattrSizeCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyWarnChannelsPerDocCount, base.ExpvarIntVal(0))

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -727,7 +727,7 @@ func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sen
 	outrq.SetJSONBody(body)
 
 	// Update read stats
-	if messageBody, err := outrq.Body(); err != nil {
+	if messageBody, err := outrq.Body(); err == nil {
 		bh.db.DbStats.StatsDatabase().Add(base.StatKeyDocReadsBytesBlip, int64(len(messageBody)))
 	}
 	bh.db.DbStats.StatsDatabase().Add(base.StatKeyNumDocReadsBlip, 1)
@@ -769,6 +769,10 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	var body db.Body
 	if err := rq.ReadJSONBody(&body); err != nil {
 		return err
+	}
+
+	if bodyBytes, err := rq.Body(); err == nil {
+		bh.db.DbStats.StatsDatabase().Add(base.StatKeyDocWritesBytesBlip, int64(len(bodyBytes)))
 	}
 
 	// Doc metadata comes from the BLIP message metadata, not magic document properties:


### PR DESCRIPTION
For CBG-179, enhanced byte count stats for blip replication, for testing delta sync.

- Fixed bug with stat `DocReadsBytesBlip` not working in pull replications
- Added stat `DocWritesBytesBlip` for push replications