### PR TITLE
Convert json.Number to number for use in sync function

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -264,60 +264,6 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 	assertStatus(t, response, 400)
 }
 
-// expand to multiple test cases, verifying number values in sync function
-func TestDocumentLargeNumbers(t *testing.T) {
-
-	tests := []struct {
-		name            string
-		body            string
-		expectedString  string
-		expectedChannel string
-	}{
-		{"largeInt", `{"number": 9223372036854775807}`, "9223372036854775807", "largeInt"},
-		{"precisionFloat", `{"number": 9223.372036854775807}`, "9223.372036854775807", "precisionFloat"},
-		{"largeInt2", `{"number": 9223372036854775808}`, "9223372036854775808", "largeInt2"},
-	}
-
-	// Use channels to ensure numbers are making it to sync function intact
-	// Note that the sync function is comparing doc.number to string for the large int cases, since javascript
-	// doesn't support 64-bit integers. (https://www.ecma-international.org/ecma-262/5.1/#sec-8.5)
-	syncFn := `function(doc) {` +
-		`if (doc.number == 9223.372036854775807) { channel("precisionFloat")} ` +
-		`if (doc.number == "9223372036854775807") { channel("largeInt")} ` +
-		`if (doc.number == "9223372036854775808") { channel("largeInt2")} ` +
-		`}`
-	rt := RestTester{SyncFn: syncFn}
-	defer rt.Close()
-
-	for _, test := range tests {
-		t.Run(test.name, func(ts *testing.T) {
-			//Create document
-			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", test.name), test.body)
-			assertStatus(t, response, 201)
-
-			// Get document, validate number value
-			getResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", test.name), "")
-			assertStatus(t, getResponse, 200)
-
-			// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
-			responseString := string(getResponse.Body.Bytes())
-			if !strings.Contains(responseString, test.expectedString) {
-				t.Errorf("Response does not contain the expected number format.  Response: %s", responseString)
-			}
-
-			// Check channel assignment
-			getRawResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", test.name), "")
-			var rawResponse RawResponse
-			json.Unmarshal(getRawResponse.Body.Bytes(), &rawResponse)
-			log.Printf("raw response: %s", getRawResponse.Body.Bytes())
-			goassert.Equals(t, len(rawResponse.Sync.Channels), 1)
-			assert.True(t, HasActiveChannel(rawResponse.Sync.Channels, test.expectedChannel), fmt.Sprintf("Expected channel %s was not found in document channels", test.expectedChannel))
-
-		})
-	}
-
-}
-
 func TestFunkyDocIDs(t *testing.T) {
 	var rt RestTester
 	defer rt.Close()

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests ConvertJSONNumber handling for the sync function, and preservation of large numbers in the
+// stored document.
+func TestDocumentNumbers(t *testing.T) {
+
+	tests := []struct {
+		name                  string
+		body                  string
+		expectedString        string
+		expectedFormatChannel string
+	}{
+		{"maxInt64",
+			`{"number": 9223372036854775807}`,
+			"9223372036854775807",
+			"string"},
+		{"minInt64",
+			`{"number": -9223372036854775808}`,
+			"-9223372036854775808",
+			"string"},
+		{"greaterThanMaxInt64",
+			`{"number": 9223372036854775808}`,
+			"9223372036854775808",
+			"string"},
+		{"lessThanMinInt64",
+			`{"number": -9223372036854775809}`,
+			"9223372036854775809",
+			"string"},
+		{"javascriptMaxSafeInt",
+			`{"number": 9007199254740991}`,
+			"9007199254740991",
+			"number"},
+		{"javascriptMinSafeInt",
+			`{"number": -9007199254740991}`,
+			"-9007199254740991",
+			"number"},
+		{"javascriptGreaterThanMaxSafeInt",
+			`{"number": 9007199254740992}`,
+			"9007199254740992",
+			"string"},
+		{"javascriptLessThanMinSafeInt",
+			`{"number": -9007199254740992}`,
+			"-9007199254740992",
+			"string"},
+		{"simpleFloat",
+			`{"number": -234.56}`,
+			"-234.56",
+			"number"},
+		{"highPrecisionFloat",
+			`{"number": 9223.372036854775807}`,
+			"9223.372036854775807",
+			"number"},
+		{"scientificFloat",
+			`{"number": 6.0221409e+23}`,
+			"6.0221409e+23",
+			"number"},
+		{"integerArray",
+			`{"array":[1234]}`,
+			`"array":[1234]`,
+			"number",
+		},
+		{"floatArray",
+			`{"array":[12.34]}`,
+			`"array":[12.34]`,
+			"number",
+		},
+	}
+
+	// Use channels to ensure numbers are making it to sync function with expected formats
+	syncFn := `function(doc) {
+		if (doc.number) {
+			channel(typeof(doc.number))
+		}
+  		if (doc.array) {
+     		channel(typeof doc.array[0])
+  		}
+	}`
+	rt := RestTester{SyncFn: syncFn}
+	defer rt.Close()
+
+	for _, test := range tests {
+		t.Run(test.name, func(ts *testing.T) {
+			//Create document
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", test.name), test.body)
+			assertStatus(t, response, 201)
+
+			// Get document, validate number value
+			getResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", test.name), "")
+			assertStatus(t, getResponse, 200)
+
+			// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
+			responseString := string(getResponse.Body.Bytes())
+			if !strings.Contains(responseString, test.expectedString) {
+				t.Errorf("Response does not contain the expected number format (%s).  Response: %s", test.name, responseString)
+			}
+
+			// Check channel assignment
+			getRawResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", test.name), "")
+			var rawResponse RawResponse
+			json.Unmarshal(getRawResponse.Body.Bytes(), &rawResponse)
+			log.Printf("raw response: %s", getRawResponse.Body.Bytes())
+			assert.Equal(t, 1, len(rawResponse.Sync.Channels))
+			assert.True(t, HasActiveChannel(rawResponse.Sync.Channels, test.expectedFormatChannel), fmt.Sprintf("Expected channel %s was not found in document channels (%s)", test.expectedFormatChannel, test.name))
+
+		})
+	}
+
+}


### PR DESCRIPTION
Converts to int64/float64 where appropriate.

Fixes #3819