### PR TITLE
Jenkinsfile: Run tests only once per edition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,12 +93,12 @@ pipeline {
             }
         }
 
-        stage('CE -cover') {
+        stage('CE -cover -race') {
             steps{
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
                     // Build public and private coverprofiles (private containing accel code too)
-                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
-                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                    sh 'go test -timeout=20m -race -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                    sh 'go test -timeout=20m -race -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
 
                     // Print total coverage stats
                     sh 'go tool cover -func=cover_ce_public.out | awk \'END{print "Total SG CE Coverage: " $3}\''
@@ -131,10 +131,10 @@ pipeline {
             }
         }
 
-        stage('EE -cover') {
+        stage('EE -cover -race') {
             steps {
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
+                    sh "go test -timeout=20m -race -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
                     sh 'go tool cover -func=cover_ee_private.out | awk \'END{print "Total SG EE+SGA Coverage: " $3}\''
 
                     sh 'mkdir -p reports'
@@ -146,24 +146,6 @@ pipeline {
 
                     // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
                     sh 'gocov convert cover_ee_private.out | gocov-xml > reports/coverage-ee.xml'
-                }
-            }
-        }
-
-        stage('CE -race') {
-            steps {
-                echo 'Testing with -race..'
-                withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './test.sh -race -count=1'
-                }
-            }
-        }
-
-        stage('EE -race') {
-            steps {
-                echo 'Testing with -race..'
-                withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './test.sh -race -count=1'
                 }
             }
         }


### PR DESCRIPTION
Should speed up branch/PR builds a bit

- Removes the separate `-race` test stages and run the `-cover` tests with `-race` instead