### PR TITLE
Improve skipped sequence locking and query during clean

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -114,9 +114,7 @@ var (
 )
 
 func UnitTestUrl() string {
-	backingStore := os.Getenv(TestEnvSyncGatewayBackingStore)
-	switch {
-	case strings.ToLower(backingStore) == strings.ToLower(TestEnvBackingStoreCouchbase):
+	if TestUseCouchbaseServer() {
 		testCouchbaseServerUrl := os.Getenv(TestEnvCouchbaseServerUrl)
 		if testCouchbaseServerUrl != "" {
 			// If user explicitly set a Test Couchbase Server URL, use that
@@ -124,7 +122,7 @@ func UnitTestUrl() string {
 		}
 		// Otherwise fallback to hardcoded default
 		return kTestCouchbaseServerURL
-	default:
+	} else {
 		return kTestWalrusURL
 	}
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -205,11 +205,6 @@ func TestUseCouchbaseServer() bool {
 	return strings.ToLower(backingStore) == strings.ToLower(TestEnvBackingStoreCouchbase)
 }
 
-// Use views for walrus testing
-func TestUseViews() bool {
-	return !TestUseCouchbaseServer()
-}
-
 type TestAuthenticator struct {
 	Username   string
 	Password   string

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1009,9 +1009,15 @@ func TestSkippedViewRetrieval(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache)()
 
+	originalBatchSize := SkippedSeqCleanViewBatch
+	SkippedSeqCleanViewBatch = 4
+	defer func() {
+		SkippedSeqCleanViewBatch = originalBatchSize
+	}()
+
 	// Use leaky bucket to have the tap feed 'lose' document 3
 	leakyConfig := base.LeakyBucketConfig{
-		TapFeedMissingDocs: []string{"doc-3"},
+		TapFeedMissingDocs: []string{"doc-3", "doc-7", "doc-10", "doc-13", "doc-14"},
 	}
 	db := setupTestLeakyDBWithCacheOptions(t, shortWaitCache(), leakyConfig)
 	defer tearDownTestDB(t, db)
@@ -1024,21 +1030,43 @@ func TestSkippedViewRetrieval(t *testing.T) {
 	WriteDirect(db, []string{"ABC"}, 1)
 	WriteDirect(db, []string{"ABC"}, 2)
 	WriteDirect(db, []string{"ABC"}, 3)
+	WriteDirect(db, []string{"ABC"}, 7)
+	WriteDirect(db, []string{"ABC"}, 10)
+	WriteDirect(db, []string{"ABC"}, 13)
+	WriteDirect(db, []string{"ABC"}, 14)
+	WriteDirect(db, []string{"ABC"}, 15)
 
+	//db.Options.UnsupportedOptions.DisableCleanSkippedQuery = true
 	changeCache, ok := db.changeCache.(*changeCache)
 	assert.True(t, ok, "Testing skipped sequences without a change cache")
 
-	// Artificially add 3 skipped, and back date skipped entry by 2 hours to trigger attempted view retrieval during Clean call
+	// Artificially add skipped sequences to queue, and back date skipped entry by 2 hours to trigger attempted view retrieval during Clean call
+	// Sequences '3', '7', '10', '13' and '14' exist, should be found.
 	changeCache.skippedSeqs.Push(&SkippedSequence{3, time.Now().Add(time.Duration(time.Hour * -2))})
 	changeCache.skippedSeqs.Push(&SkippedSequence{5, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{6, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{7, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{10, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{11, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{12, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{13, time.Now().Add(time.Duration(time.Hour * -2))})
+	changeCache.skippedSeqs.Push(&SkippedSequence{14, time.Now().Add(time.Duration(time.Hour * -2))})
 	changeCache.CleanSkippedSequenceQueue()
 
-	// Validate that 3 is in the channel cache, 5 isn't
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 3}, base.DefaultWaitForSequenceTesting)
+	// Validate expected entries
+	db.changeCache.waitForSequenceID(SequenceID{Seq: 15}, base.DefaultWaitForSequenceTesting)
 	entries, err := db.changeCache.GetChanges("ABC", ChangesOptions{Since: SequenceID{Seq: 2}})
 	assert.NoError(t, err, "Get Changes returned error")
-	goassert.Equals(t, len(entries), 1)
-	goassert.Equals(t, entries[0].DocID, "doc-3")
+	goassert.Equals(t, len(entries), 6)
+	log.Printf("entries: %v", entries)
+	if len(entries) == 6 {
+		goassert.Equals(t, entries[0].DocID, "doc-3")
+		goassert.Equals(t, entries[1].DocID, "doc-7")
+		goassert.Equals(t, entries[2].DocID, "doc-10")
+		goassert.Equals(t, entries[3].DocID, "doc-13")
+		goassert.Equals(t, entries[4].DocID, "doc-14")
+		goassert.Equals(t, entries[5].DocID, "doc-15")
+	}
 
 }
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"

--- a/db/database.go
+++ b/db/database.go
@@ -131,10 +131,11 @@ type APIEndpoints struct {
 }
 
 type UnsupportedOptions struct {
-	UserViews         UserViewsOptions        `json:"user_views,omitempty"`         // Config settings for user views
-	OidcTestProvider  OidcTestProviderOptions `json:"oidc_test_provider,omitempty"` // Config settings for OIDC Provider
-	APIEndpoints      APIEndpoints            `json:"api_endpoints,omitempty"`      // Config settings for API endpoints
-	WarningThresholds WarningThresholds       `json:"warning_thresholds,omitempty"`
+	UserViews                UserViewsOptions        `json:"user_views,omitempty"`                  // Config settings for user views
+	OidcTestProvider         OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`          // Config settings for OIDC Provider
+	APIEndpoints             APIEndpoints            `json:"api_endpoints,omitempty"`               // Config settings for API endpoints
+	WarningThresholds        WarningThresholds       `json:"warning_thresholds,omitempty"`          // Warning thresholds related to _sync size
+	DisableCleanSkippedQuery bool                    `json:"disable_clean_skipped_query,omitempty"` // Clean skipped sequence processing bypasses final check
 }
 
 type WarningThresholds struct {

--- a/db/query.go
+++ b/db/query.go
@@ -292,7 +292,6 @@ func (context *DatabaseContext) QueryChannels(channelName string, startSeq uint6
 
 	if context.Options.UseViews {
 		opts := changesViewOptions(channelName, startSeq, endSeq, limit)
-		base.Infof(base.KeyCRUD, "issuing view query")
 		return context.ViewQueryWithStats(DesignDocSyncGateway(), ViewChannels, opts)
 	}
 
@@ -314,7 +313,6 @@ func (context *DatabaseContext) QuerySequences(sequences []uint64) (sgbucket.Que
 
 	if context.Options.UseViews {
 		opts := changesViewForSequencesOptions(sequences)
-		base.Infof(base.KeyCRUD, "issuing view query")
 		return context.ViewQueryWithStats(DesignDocSyncGateway(), ViewChannels, opts)
 	}
 
@@ -483,12 +481,12 @@ func (context *DatabaseContext) QueryTombstones(olderThan time.Time) (sgbucket.Q
 	return context.N1QLQueryWithStats(QueryTypeTombstones, tombstoneQueryStatement, params, gocb.NotBounded, QueryTombstones.adhoc)
 }
 
-func changesViewOptions(channelName string, startSeq, endSeq uint64, limit int) Body {
+func changesViewOptions(channelName string, startSeq, endSeq uint64, limit int) map[string]interface{} {
 	endKey := []interface{}{channelName, endSeq}
 	if endSeq == 0 {
 		endKey[1] = map[string]interface{}{} // infinity
 	}
-	optMap := Body{
+	optMap := map[string]interface{}{
 		"stale":    false,
 		"startkey": []interface{}{channelName, startSeq},
 		"endkey":   endKey,
@@ -499,7 +497,7 @@ func changesViewOptions(channelName string, startSeq, endSeq uint64, limit int) 
 	return optMap
 }
 
-func changesViewForSequencesOptions(sequences []uint64) Body {
+func changesViewForSequencesOptions(sequences []uint64) map[string]interface{} {
 
 	keys := make([]interface{}, len(sequences))
 	for i, sequence := range sequences {
@@ -507,7 +505,7 @@ func changesViewForSequencesOptions(sequences []uint64) Body {
 		keys[i] = key
 	}
 
-	optMap := Body{
+	optMap := map[string]interface{}{
 		"stale": false,
 		"keys":  keys,
 	}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -62,7 +62,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f631191f3fa478a73d259840a38b2d5d6b1e99fb"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="54483acdf6d9df0bdc75e1dcd76b87ca17efc66e"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -103,9 +103,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 		if rt.DatabaseConfig == nil {
 			// If no db config was passed in, create one
 			rt.DatabaseConfig = &DbConfig{}
+		}
 
-			// By default, does NOT use views when running against couchbase server, since should use GSI
-			rt.DatabaseConfig.UseViews = base.TestUseViews()
+		// Force views if running against walrus
+		if !base.TestUseCouchbaseServer() {
+			rt.DatabaseConfig.UseViews = true
 		}
 
 		// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.


### PR DESCRIPTION
Fixes #3823.

Releases the skippedSeqLock lock before issuing view queries during CleanSkippedSequenceQueue.

Modifies view and n1ql queries used by clean to check for multiple sequences per query (using existing view/indexes).  Issues queries in batches of up to 50, to minimize risk of query timeouts in cases with very large sets of skipped sequences.

Adds unsupported config option to bypass query during CleanSkippedSequenceQueue.

