### PR TITLE
delta_sync startup msg: "enable" -> "enabled"

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -587,7 +587,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			deltaSyncOptions.RevMaxAgeSeconds = *revMaxAge
 		}
 	}
-	base.Infof(base.KeyAll, "delta_sync enable=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)
+	base.Infof(base.KeyAll, "delta_sync enabled=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)
 
 	if config.Unsupported.WarningThresholds.XattrSize == nil {
 		val := uint32(base.DefaultWarnThresholdXattrSize)


### PR DESCRIPTION
Updates delta_sync startup message to be consistent with the new config option 'enable*d*'

```
2019-01-18T18:41:03.564Z [INF] delta_sync enabled=true with rev_max_age_seconds=86400 for database db
```