### PR TITLE
Remove explicit references to Views in logging

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -303,7 +303,7 @@ func (c *changeCache) CleanSkippedSequenceQueue() {
 		//       the doc won't be flagged as removed from that channel in the in-memory channel cache.
 		entries, err := c.context.getChangesForSequences(skippedSeqBatch)
 		if err != nil {
-			base.Warnf(base.KeyAll, "Error retrieving sequences via view during skipped sequence clean - #%d sequences treated as not found: %v", len(skippedSeqBatch), err)
+			base.Warnf(base.KeyAll, "Error retrieving sequences via query during skipped sequence clean - #%d sequences treated as not found: %v", len(skippedSeqBatch), err)
 			continue
 		}
 
@@ -317,7 +317,7 @@ func (c *changeCache) CleanSkippedSequenceQueue() {
 		// Add queried sequences not in the resultset to pendingRemovals
 		for _, skippedSeq := range skippedSeqBatch {
 			if _, ok := foundMap[skippedSeq]; !ok {
-				base.Warnf(base.KeyAll, "Skipped Sequence %d didn't show up in MaxChannelLogMissingWaitTime, and isn't available from the * channel view.  If it's a valid sequence, it won't be replicated until Sync Gateway is restarted.", skippedSeq)
+				base.Warnf(base.KeyAll, "Skipped Sequence %d didn't show up in MaxChannelLogMissingWaitTime, and isn't available from a * channel query.  If it's a valid sequence, it won't be replicated until Sync Gateway is restarted.", skippedSeq)
 				pendingRemovals = append(pendingRemovals, skippedSeq)
 			}
 		}

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -552,7 +552,7 @@ func (c *channelCache) prependChanges(changes LogEntries, changesValidFrom uint6
 		}
 		c.logs = make(LogEntries, len(changes))
 		copy(c.logs, changes)
-		base.Infof(base.KeyCache, "  Initialized cache of %q with %d entries from view (#%d--#%d)",
+		base.Infof(base.KeyCache, "  Initialized cache of %q with %d entries from query (#%d--#%d)",
 			base.UD(c.channelName), len(changes), changes[0].Sequence, changes[len(changes)-1].Sequence)
 
 		c.validFrom = changesValidFrom


### PR DESCRIPTION
Super minor, but in a few places we explicitly referenced Views regardless of mode. "Query" technically applies to both - i.e. "View Query", so this just makes the logs a tad less confusing.