### PR TITLE
Tweak delta logging for easier diagnosis

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1656,7 +1656,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 // and checks that full body replication is still supported in CE.
 func TestBlipDeltaSyncPush(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
 	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()


### PR DESCRIPTION
## Per rev logging
- Included `deltaSrcRevID` in log message when rev is being sent as a delta (pulled revs)
- Lowered `handleRev` from info to debug to match pulled rev logging level
- Removed `handleRev` log: `Received rev message as delta` - can be inferred from above's `DeltaSrc:...`
## Per replication logging
- Reworked `setUseDeltas()` to log once at info when the client disables deltas for a pull replication, or once at debug when both sides agree to enable deltas