### PR TITLE
CBG-197 Change default console logging

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -90,22 +90,8 @@ func (lcc *ConsoleLoggerConfig) init() error {
 		return errors.New("nil LogConsoleConfig")
 	}
 
-	if lcc.Rotation.MaxSize == nil {
-		// A value of zero disables the log file rotation in Lumberjack.
-		zero := 0
-		lcc.Rotation.MaxSize = &zero
-	} else if *lcc.Rotation.MaxSize < 0 {
-		return fmt.Errorf(belowMinValueFmt, "MaxSize", "console", *lcc.Rotation.MaxSize, 0)
-	}
-
-	if lcc.Rotation.MaxAge == nil {
-		// A value of zero disables the age-based log cleanup in Lumberjack.
-		zero := 0
-		lcc.Rotation.MaxAge = &zero
-	} else if *lcc.Rotation.MaxAge < 0 {
-		return fmt.Errorf(belowMinValueFmt, "MaxAge", "console", *lcc.Rotation.MaxAge, 0)
-	} else if *lcc.Rotation.MaxAge > maxAgeLimit {
-		return fmt.Errorf(aboveMaxValueFmt, "MaxAge", "console", *lcc.Rotation.MaxAge, maxAgeLimit)
+	if err := lcc.initRotationConfig("console", 0, 0); err != nil {
+		return err
 	}
 
 	// Default to os.Stderr if alternative output is not set

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/natefinch/lumberjack"
 )
 
 // ConsoleLogger is a file logger with a default output of stderr, and tunable log level/keys.
@@ -114,11 +116,12 @@ func (lcc *ConsoleLoggerConfig) init() error {
 		if err := validateLogFileOutput(lcc.FileOutput); err != nil {
 			return err
 		}
-		lcc.Output = newLumberjackOutput(
-			filepath.FromSlash(lcc.FileOutput),
-			*lcc.Rotation.MaxSize,
-			*lcc.Rotation.MaxAge,
-		)
+		lcc.Output = &lumberjack.Logger{
+			Filename: filepath.FromSlash(lcc.FileOutput),
+			MaxSize:  *lcc.Rotation.MaxSize,
+			MaxAge:   *lcc.Rotation.MaxAge,
+			Compress: false,
+		}
 	}
 
 	// Default to false

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -90,8 +90,10 @@ func TestConsoleShouldLog(t *testing.T) {
 		l := newConsoleLoggerOrPanic(&ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
-			Output:   ioutil.Discard,
-		})
+			FileLoggerConfig: FileLoggerConfig{
+				Enabled: BoolPtr(true),
+				Output:  ioutil.Discard,
+			}})
 
 		t.Run(name, func(ts *testing.T) {
 			got := l.shouldLog(test.logToLevel, test.logToKey)

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -11,8 +11,7 @@ import (
 )
 
 var (
-	ErrInvalidLogFilePath   = errors.New("Invalid LogFilePath")
-	ErrInvalidLoggingMaxAge = errors.New("Invalid MaxAge")
+	ErrInvalidLogFilePath = errors.New("invalid log file path")
 
 	maxAgeLimit             = 9999 // days
 	defaultMaxSize          = 100  // 100 MB

--- a/base/logging.go
+++ b/base/logging.go
@@ -381,7 +381,7 @@ func init() {
 	// initializing a logging config, and when running under a test scenario.
 	initialCollationBufferSize := 0
 
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{CollationBufferSize: &initialCollationBufferSize})
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 
@@ -529,6 +529,9 @@ func LogSyncGatewayVersion() {
 	format := addPrefixes("==== %s ====", context.Background(), LevelNone, KeyNone)
 	msg := fmt.Sprintf(format, LongVersionString)
 
+	if !consoleLogger.isStderr {
+		fmt.Println(msg)
+	}
 	if consoleLogger.logger != nil {
 		consoleLogger.logger.Print(color(msg, LevelNone))
 	}

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -29,7 +29,7 @@ func assertLogContains(t *testing.T, s string, f func()) {
 
 	// temporarily override logger for the function call
 	level := LevelDebug
-	consoleLogger = &ConsoleLogger{LogLevel: &level, logger: log.New(&b, "", 0)}
+	consoleLogger = &ConsoleLogger{LogLevel: &level, FileLogger: FileLogger{Enabled: true, logger: log.New(&b, "", 0)}}
 	defer func() { consoleLogger = originalLogger }()
 
 	f()

--- a/rest/config.go
+++ b/rest/config.go
@@ -14,6 +14,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -1061,6 +1062,9 @@ func ServerMain(runMode SyncGatewayRunMode) {
 	// configuration and setup logging now
 	warnings, err := config.setupAndValidateLogging()
 	if err != nil {
+		// If we didn't set up logging correctly, we *probably* can't log via normal means...
+		// as a best-effort, last-ditch attempt, we'll log to stderr as well.
+		log.Printf("[ERR] Error setting up logging: %v", err)
 		base.Fatalf(base.KeyAll, "Error setting up logging: %v", err)
 	}
 

--- a/service/script_templates/com.couchbase.mobile.sync_gateway.plist
+++ b/service/script_templates/com.couchbase.mobile.sync_gateway.plist
@@ -17,9 +17,5 @@
         </array>
         <key>KeepAlive</key>
         <true/>
-        <key>StandardOutPath</key>
-        <string>${LOGS_TEMPLATE_VAR}/${SERVICE_NAME}_access.log</string> 
-        <key>StandardErrorPath</key>
-        <string>${LOGS_TEMPLATE_VAR}/${SERVICE_NAME}_error.log</string>
 </dict>
 </plist>

--- a/service/script_templates/systemd_debian_sync_gateway.tpl
+++ b/service/script_templates/systemd_debian_sync_gateway.tpl
@@ -17,7 +17,7 @@ ExecStartPre=/bin/mkdir -p ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/mkdir -p ${RUNBASE_TEMPLATE_VAR}/data
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${RUNBASE_TEMPLATE_VAR}/data
-ExecStart=/bin/bash -c '\${GATEWAY} --defaultLogFilePath \"\${LOGS}\" \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
+ExecStart=/bin/bash -c '\${GATEWAY} --defaultLogFilePath \"\${LOGS}\" \${CONFIG}'
 Restart=on-failure
 
 # Give a reasonable amount of time for the server to start up/shut down

--- a/service/script_templates/systemd_sync_gateway.tpl
+++ b/service/script_templates/systemd_sync_gateway.tpl
@@ -17,7 +17,7 @@ ExecStartPre=/bin/mkdir -p ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${LOGS_TEMPLATE_VAR}
 ExecStartPre=/bin/mkdir -p ${RUNBASE_TEMPLATE_VAR}/data
 ExecStartPre=/bin/chown -R ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${RUNBASE_TEMPLATE_VAR}/data
-ExecStart=/usr/bin/bash -c '\${GATEWAY} --defaultLogFilePath \"\${LOGS}\" \${CONFIG} >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log'
+ExecStart=/usr/bin/bash -c '\${GATEWAY} --defaultLogFilePath \"\${LOGS}\" \${CONFIG}'
 Restart=on-failure
 
 # Give a reasonable amount of time for the server to start up/shut down

--- a/service/script_templates/sysv_sync_gateway.tpl
+++ b/service/script_templates/sysv_sync_gateway.tpl
@@ -17,8 +17,6 @@ CONFIG=${CONFIG_TEMPLATE_VAR}
 LOGS=${LOGS_TEMPLATE_VAR}
 
 name=${SERVICE_NAME}
-stdout_log=\${LOGS}/\${name}_access.log
-stderr_log=\${LOGS}/\${name}_error.log
 
 get_pid() {
     cat \"\$PIDFILE\"    
@@ -41,10 +39,10 @@ case \"\$1\" in
         else
             echo "Starting $name"
             cd \"\$RUNBASE\"
-            sudo -u \"\$RUNAS\" \$GATEWAY --defaultLogFilePath \"\$LOGS\" \$CONFIG >> \"\$stdout_log\" 2>> \"\$stderr_log\" &
+            sudo -u \"\$RUNAS\" \$GATEWAY --defaultLogFilePath \"\$LOGS\" \$CONFIG &
             echo \$! > \"\$PIDFILE\"
             if ! is_running; then
-                echo "Unable to start, see \$stdout_log and \$stderr_log"
+                echo "Unable to start"
                 exit 1
             fi
         fi

--- a/service/script_templates/upstart_redhat_sync_gateway.tpl
+++ b/service/script_templates/upstart_redhat_sync_gateway.tpl
@@ -29,7 +29,7 @@ script
   # Keep a pid around
   echo \$\$ > \$PIDFILE
   cd \$RUNBASE
-  su --session-command \"\$GATEWAY --defaultLogFilePath \"\$LOGS\" \$CONFIG >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log\" \$RUNAS
+  su --session-command \"\$GATEWAY --defaultLogFilePath \"\$LOGS\" \$CONFIG\" \$RUNAS
 end script
  
 # Remove pid file when we stop the server

--- a/service/script_templates/upstart_ubuntu_sync_gateway.tpl
+++ b/service/script_templates/upstart_ubuntu_sync_gateway.tpl
@@ -24,4 +24,4 @@ pre-start script
   chown -R \${RUNAS}:\${RUNAS} \${RUNBASE}/data
 end script
 
-exec start-stop-daemon --start --chuid \$RUNAS --chdir \$RUNBASE --make-pidfile --pidfile \$PIDFILE --startas \$GATEWAY -- --defaultLogFilePath \"\$LOGS\" \$CONFIG >> \${LOGS}/\${NAME}_access.log 2>> \${LOGS}/\${NAME}_error.log
+exec start-stop-daemon --start --chuid \$RUNAS --chdir \$RUNBASE --make-pidfile --pidfile \$PIDFILE --startas \$GATEWAY -- --defaultLogFilePath \"\$LOGS\" \$CONFIG


### PR DESCRIPTION
- Console logging now **disabled** by default.
- `ConsoleLogger` now extends `FileLogger`, with a default output of `stderr`.
  - This allows for rotatable console file output via a new `logging.console.file_output` option.
  - The rotated console log files are never compressed, unlike the `sg_*.log` files.
- Certain things, like logging config errors are still logged to `stderr`, even when console logging is disabled, or redirected, as a best-effort way of getting important information to the customer.
  - Startup indicator: <pre>=== Couchbase Sync Gateway/change_default_console_logging(0b63ee9+CHANGES) CE ====</pre>
  - No support logs warning: <pre>No log_file_path configured, and --defaultLogFilePath flag is not set. Log files required for product support are not being generated.</pre>
  - Error setting up log files: <pre>Error setting up logging: Invalid LogFilePath: open /dev/sglog: permission denied</pre>
- Removed old stdout/stderr service scripts log file redirection

This opens up the door for some future refactoring to de-duplicate most of the ConsoleLogger/FileLogger code, but didn't want to rip apart *too much* this late in Iridium's release.