### PR TITLE
Some small tidy up

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -386,6 +386,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, er
 			return fromRevision.Delta.DeltaBytes, nil
 		} else {
 			// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
+			// until then, fall through to generating delta for given rev pair
 		}
 	}
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1676,7 +1676,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e on client
+	// create doc1 rev 2-abcxyz on client
 	newRev, err := client.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 	assert.NoError(t, err)
 	assert.Equal(t, "2-abcxyz", newRev)
@@ -1737,7 +1737,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
-	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e on client
+	// create doc1 rev 2-abcxyz on client
 	newRev, err := client.PushRev("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", []byte(`{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`))
 	assert.NoError(t, err)
 	assert.Equal(t, "2-abcxyz", newRev)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -267,7 +267,7 @@ func (btc *BlipTesterClient) StartPullSince(continuous, since string) (err error
 	return nil
 }
 
-// Close will empty GetServerUUIDthe stored docs, close the underlying replications, and finally close the rest tester.
+// Close will empty the stored docs and close the underlying replications.
 func (btc *BlipTesterClient) Close() {
 	btc.docsLock.Lock()
 	btc.docs = make(map[string]map[string][]byte, 0)
@@ -287,6 +287,7 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) (err error) {
 }
 
 // PushRev creates a revision on the client, and immediately sends a changes request for it.
+// The rev ID is always: "N-abcxyz", where N is rev generation for predictability.
 func (btc *BlipTesterClient) PushRev(docID, parentRev string, body []byte) (revID string, err error) {
 	var parentDocBody []byte
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -178,7 +178,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 	btr.bt.blipContext.DefaultHandler = func(msg *blip.Message) {
 		btr.storeMessage(msg)
-		panic("unexpected msg to DefaultHandler")
+		base.Panicf(base.KeyAll, "Unknown profile: %s caught by client DefaultHandler - msg: %#v", msg.Profile(), msg)
 	}
 }
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -752,6 +752,12 @@ func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sen
 		sender.Send(outrq.Message)
 	}
 
+	if response := outrq.Response(); response != nil {
+		if response.Type() == blip.ErrorType {
+			errorBody, _ := response.Body()
+			bh.Logf(base.LevelWarn, base.KeyAll, "Client returned error in rev response for doc %q / %q: %s", docID, revID, errorBody)
+		}
+	}
 }
 
 // Received a "rev" request, i.e. client is pushing a revision body

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -97,7 +97,7 @@ var kHandlersByProfile = map[string]blipHandlerMethod{
 	messageChanges:        userBlipHandler((*blipHandler).handleChanges),
 	messageRev:            userBlipHandler((*blipHandler).handleRev),
 	messageGetAttachment:  userBlipHandler((*blipHandler).handleGetAttachment),
-	messageProposeChanges: (*blipHandler).handleProposedChanges,
+	messageProposeChanges: (*blipHandler).handleProposeChanges,
 }
 
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
@@ -572,7 +572,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 }
 
 // Handles a "proposeChanges" request, similar to "changes" but in no-conflicts mode
-func (bh *blipHandler) handleProposedChanges(rq *blip.Message) error {
+func (bh *blipHandler) handleProposeChanges(rq *blip.Message) error {
 	var changeList [][]interface{}
 	if err := rq.ReadJSONBody(&changeList); err != nil {
 		return err


### PR DESCRIPTION
Pulled a few small fixes out of my delta sync attachments branch for separate review that seemed appropriate for Iridium.

- Log a warning when the client returns an error in a blip rev response (we weren't doing anything with it previously... we wouldn't know about it at all!)
- Renamed BLIP `handleProposedChanges` -> `handleProposeChanges` for consistency
- Improved panic message in blip test client when something calls the DefaultHandler
- Updated code comments