### PR TITLE
Fix typo in 'Unrecognized value for import_docs' error message

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -364,7 +364,7 @@ func (dbConfig *DbConfig) AutoImportEnabled() (bool, error) {
 	case "continuous":
 		autoImport = true
 	default:
-		return false, fmt.Errorf("Unrecognized value for import_docs: %#v.  Must be set to 'continous', true or false, or be omitted entirely", dbConfig.AutoImport)
+		return false, fmt.Errorf("Unrecognized value for import_docs: %#v.  Must be set to 'continuous', true or false, or be omitted entirely", dbConfig.AutoImport)
 	}
 
 	return autoImport, nil


### PR DESCRIPTION
Error message is super confusing, as you could copy-paste the recommended value and have it not work.