### PR TITLE
Remove the default capacity for channel cache log slice

### DIFF
--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -107,7 +107,7 @@ func newChannelCache(context *DatabaseContext, channelName string, validFrom uin
 		ChannelCacheMaxLength: DefaultChannelCacheMaxLength,
 		ChannelCacheAge:       DefaultChannelCacheAge,
 	}
-	cache.logs = make(LogEntries, 0, cache.options.ChannelCacheMaxLength)
+	cache.logs = make(LogEntries, 0)
 
 	return cache
 }


### PR DESCRIPTION
- Remove the default capacity for channel cache log slice
  - Reduces empty channel cache memory overhead from 4392 bytes to 296 bytes