### PR TITLE
Jenkinsfile: Add gofmt and Windows service build stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                     }
                 }
 
-                stage('Go') {
+                stage(' ') {
                     stages {
                         stage('Go') {
                             steps {
@@ -83,14 +83,7 @@ pipeline {
                 stage('gofmt check') {
                     steps {
                         withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                            script {
-                                try {
-                                    sh "test -z \"\$(gofmt -d -e ${GOPATH}/src/github.com/couchbase/sync_gateway)\""
-                                } catch (Exception err) {
-                                    // if gofmt fails, mark the build as 'unstable', so other stages (like tests, still run)
-                                    currentBuild.result = 'UNSTABLE'
-                                }
-                            }
+                            sh "test -z \"\$(gofmt -d -e ${GOPATH}/src/github.com/couchbase/sync_gateway)\""
                         }
                     }
                 }
@@ -102,16 +95,16 @@ pipeline {
                         }
                     }
                 }
-                stage('') {
+                stage(' ') {
                     stages {
-                        stage('Build CE') {
+                        stage('CE') {
                             steps {
                                 withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
                                     sh './build.sh -v'
                                 }
                             }
                         }
-                        stage('Build EE') {
+                        stage('EE') {
                             steps {
                                 withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
                                     sh './build.sh -v'
@@ -124,78 +117,82 @@ pipeline {
         }
 
         stage('Test') {
-            stages {
-                stage('CE -cover') {
-                    steps{
-                        withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                            // Build public and private coverprofiles (private containing accel code too)
-                            sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
-                            sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+            parallel {
+                stage(' ') {
+                    stages {
+                        stage('CE -cover') {
+                            steps{
+                                withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
+                                    // Build public and private coverprofiles (private containing accel code too)
+                                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
 
-                            // Print total coverage stats
-                            sh 'go tool cover -func=cover_ce_public.out | awk \'END{print "Total SG CE Coverage: " $3}\''
-                            sh 'go tool cover -func=cover_ce_private.out | awk \'END{print "Total SG CE+SGA Coverage: " $3}\''
+                                    // Print total coverage stats
+                                    sh 'go tool cover -func=cover_ce_public.out | awk \'END{print "Total SG CE Coverage: " $3}\''
+                                    sh 'go tool cover -func=cover_ce_private.out | awk \'END{print "Total SG CE+SGA Coverage: " $3}\''
 
-                            sh 'mkdir -p reports'
+                                    sh 'mkdir -p reports'
 
-                            // Generate junit-formatted test report
-                            // sh 'cat test_ce.out | go-junit-report > reports/test-ce.xml'
+                                    // Generate junit-formatted test report
+                                    // sh 'cat test_ce.out | go-junit-report > reports/test-ce.xml'
 
-                            // Generate HTML coverage report
-                            sh 'go tool cover -html=cover_ce_private.out -o reports/coverage-ce.html'
+                                    // Generate HTML coverage report
+                                    sh 'go tool cover -html=cover_ce_private.out -o reports/coverage-ce.html'
 
-                            // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
-                            sh 'gocov convert cover_ce_private.out | gocov-xml > reports/coverage-ce.xml'
+                                    // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
+                                    sh 'gocov convert cover_ce_private.out | gocov-xml > reports/coverage-ce.xml'
+                                }
+                            }
                         }
-                    }
-                }
 
-                stage('CE Coveralls') {
-                    steps {
-                        // Travis-related variables are required as coveralls only officially supports a certain set of CI tools.
-                        withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
-                            // Replace covermode values with set just for coveralls to reduce the variability in reports.
-                            sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce_public.out > cover_ce_coveralls.out'
+                        stage('CE Coveralls') {
+                            steps {
+                                // Travis-related variables are required as coveralls only officially supports a certain set of CI tools.
+                                withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
+                                    // Replace covermode values with set just for coveralls to reduce the variability in reports.
+                                    sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce_public.out > cover_ce_coveralls.out'
 
-                            // Send just the SG coverage report to coveralls.io - **NOT** accel! It will expose the private codebase!!!
-                            sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                                    // Send just the SG coverage report to coveralls.io - **NOT** accel! It will expose the private codebase!!!
+                                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                                }
+                            }
                         }
-                    }
-                }
 
-                stage('EE -cover') {
-                    steps {
-                        withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                            sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
-                            sh 'go tool cover -func=cover_ee_private.out | awk \'END{print "Total SG EE+SGA Coverage: " $3}\''
+                        stage('EE -cover') {
+                            steps {
+                                withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
+                                    sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
+                                    sh 'go tool cover -func=cover_ee_private.out | awk \'END{print "Total SG EE+SGA Coverage: " $3}\''
 
-                            sh 'mkdir -p reports'
+                                    sh 'mkdir -p reports'
 
-                            // Generate junit-formatted test report
-                            // sh 'cat test_ee.out | go-junit-report > reports/test-ee.xml'
+                                    // Generate junit-formatted test report
+                                    // sh 'cat test_ee.out | go-junit-report > reports/test-ee.xml'
 
-                            sh 'go tool cover -html=cover_ee_private.out -o reports/coverage-ee.html'
+                                    sh 'go tool cover -html=cover_ee_private.out -o reports/coverage-ee.html'
 
-                            // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
-                            sh 'gocov convert cover_ee_private.out | gocov-xml > reports/coverage-ee.xml'
+                                    // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
+                                    sh 'gocov convert cover_ee_private.out | gocov-xml > reports/coverage-ee.xml'
+                                }
+                            }
                         }
-                    }
-                }
 
-                stage('CE -race') {
-                    steps {
-                        echo 'Testing with -race..'
-                        withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                            sh './test.sh -race -count=1'
+                        stage('CE -race') {
+                            steps {
+                                echo 'Testing with -race..'
+                                withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                                    sh './test.sh -race -count=1'
+                                }
+                            }
                         }
-                    }
-                }
 
-                stage('EE -race') {
-                    steps {
-                        echo 'Testing with -race..'
-                        withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                            sh './test.sh -race -count=1'
+                        stage('EE -race') {
+                            steps {
+                                echo 'Testing with -race..'
+                                withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                                    sh './test.sh -race -count=1'
+                                }
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,100 +78,126 @@ pipeline {
             }
         }
 
-        stage('Windows Service build') {
-            steps {
-                withEnv(["GOOS=windows", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-service'
-                    sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-accel-service'
+        stage('Build') {
+            parallel {
+                stage('gofmt check') {
+                    steps {
+                        withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
+                            script {
+                                try {
+                                    sh "test -z \"\$(gofmt -d -e ${GOPATH}/src/github.com/couchbase/sync_gateway)\""
+                                } catch (Exception err) {
+                                    // if gofmt fails, mark the build as 'unstable', so other stages (like tests, still run)
+                                    currentBuild.result = 'UNSTABLE'
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-        stage('CE Build') {
-            steps {
-                withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './build.sh -v'
+                stage('Windows Service') {
+                    steps {
+                        withEnv(["GOOS=windows", "PATH+=${GO}:${GOPATH}/bin"]) {
+                            sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-service'
+                            sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-accel-service'
+                        }
+                    }
                 }
-            }
-        }
-        stage('EE Build') {
-            steps {
-                withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './build.sh -v'
-                }
-            }
-        }
-
-        stage('CE -cover') {
-            steps{
-                withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                    // Build public and private coverprofiles (private containing accel code too)
-                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
-                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
-
-                    // Print total coverage stats
-                    sh 'go tool cover -func=cover_ce_public.out | awk \'END{print "Total SG CE Coverage: " $3}\''
-                    sh 'go tool cover -func=cover_ce_private.out | awk \'END{print "Total SG CE+SGA Coverage: " $3}\''
-
-                    sh 'mkdir -p reports'
-
-                    // Generate junit-formatted test report
-                    // sh 'cat test_ce.out | go-junit-report > reports/test-ce.xml'
-
-                    // Generate HTML coverage report
-                    sh 'go tool cover -html=cover_ce_private.out -o reports/coverage-ce.html'
-
-                    // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
-                    sh 'gocov convert cover_ce_private.out | gocov-xml > reports/coverage-ce.xml'
-                }
-            }
-        }
-
-        stage('CE Coveralls') {
-            steps {
-                // Travis-related variables are required as coveralls only officially supports a certain set of CI tools.
-                withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
-                    // Replace covermode values with set just for coveralls to reduce the variability in reports.
-                    sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce_public.out > cover_ce_coveralls.out'
-
-                    // Send just the SG coverage report to coveralls.io - **NOT** accel! It will expose the private codebase!!!
-                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                stage('') {
+                    stages {
+                        stage('Build CE') {
+                            steps {
+                                withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                                    sh './build.sh -v'
+                                }
+                            }
+                        }
+                        stage('Build EE') {
+                            steps {
+                                withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                                    sh './build.sh -v'
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        stage('EE -cover') {
-            steps {
-                withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
-                    sh 'go tool cover -func=cover_ee_private.out | awk \'END{print "Total SG EE+SGA Coverage: " $3}\''
+        stage('Test') {
+            stages {
+                stage('CE -cover') {
+                    steps{
+                        withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
+                            // Build public and private coverprofiles (private containing accel code too)
+                            sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                            sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
 
-                    sh 'mkdir -p reports'
+                            // Print total coverage stats
+                            sh 'go tool cover -func=cover_ce_public.out | awk \'END{print "Total SG CE Coverage: " $3}\''
+                            sh 'go tool cover -func=cover_ce_private.out | awk \'END{print "Total SG CE+SGA Coverage: " $3}\''
 
-                    // Generate junit-formatted test report
-                    // sh 'cat test_ee.out | go-junit-report > reports/test-ee.xml'
+                            sh 'mkdir -p reports'
 
-                    sh 'go tool cover -html=cover_ee_private.out -o reports/coverage-ee.html'
+                            // Generate junit-formatted test report
+                            // sh 'cat test_ce.out | go-junit-report > reports/test-ce.xml'
 
-                    // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
-                    sh 'gocov convert cover_ee_private.out | gocov-xml > reports/coverage-ee.xml'
+                            // Generate HTML coverage report
+                            sh 'go tool cover -html=cover_ce_private.out -o reports/coverage-ce.html'
+
+                            // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
+                            sh 'gocov convert cover_ce_private.out | gocov-xml > reports/coverage-ce.xml'
+                        }
+                    }
                 }
-            }
-        }
 
-        stage('CE -race') {
-            steps {
-                echo 'Testing with -race..'
-                withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './test.sh -race -count=1'
+                stage('CE Coveralls') {
+                    steps {
+                        // Travis-related variables are required as coveralls only officially supports a certain set of CI tools.
+                        withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
+                            // Replace covermode values with set just for coveralls to reduce the variability in reports.
+                            sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce_public.out > cover_ce_coveralls.out'
+
+                            // Send just the SG coverage report to coveralls.io - **NOT** accel! It will expose the private codebase!!!
+                            sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                        }
+                    }
                 }
-            }
-        }
 
-        stage('EE -race') {
-            steps {
-                echo 'Testing with -race..'
-                withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
-                    sh './test.sh -race -count=1'
+                stage('EE -cover') {
+                    steps {
+                        withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
+                            sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
+                            sh 'go tool cover -func=cover_ee_private.out | awk \'END{print "Total SG EE+SGA Coverage: " $3}\''
+
+                            sh 'mkdir -p reports'
+
+                            // Generate junit-formatted test report
+                            // sh 'cat test_ee.out | go-junit-report > reports/test-ee.xml'
+
+                            sh 'go tool cover -html=cover_ee_private.out -o reports/coverage-ee.html'
+
+                            // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
+                            sh 'gocov convert cover_ee_private.out | gocov-xml > reports/coverage-ee.xml'
+                        }
+                    }
+                }
+
+                stage('CE -race') {
+                    steps {
+                        echo 'Testing with -race..'
+                        withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                            sh './test.sh -race -count=1'
+                        }
+                    }
+                }
+
+                stage('EE -race') {
+                    steps {
+                        echo 'Testing with -race..'
+                        withEnv(["SG_EDITION=EE", "PATH+=${GO}:${GOPATH}/bin"]) {
+                            sh './test.sh -race -count=1'
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,14 @@ pipeline {
             }
         }
 
+        stage('Windows Service build') {
+            steps {
+                withEnv(["GOOS=windows", "PATH+=${GO}:${GOPATH}/bin"]) {
+                    sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-service'
+                    sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-accel-service'
+                }
+            }
+        }
         stage('CE Build') {
             steps {
                 withEnv(["SG_EDITION=CE", "PATH+=${GO}:${GOPATH}/bin"]) {

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -1,13 +1,13 @@
 package base
 
 // LogContextKey is used to key a LogContext value
-type LogContextKey struct {}
+type LogContextKey struct{}
 
 // LogContext stores values which may be useful to include in logs
 type LogContext struct {
 	// CorrelationID is a pre-formatted identifier used to correlate logs.
 	// E.g: Either blip context ID or HTTP Serial number.
-	CorrelationID           string
+	CorrelationID string
 }
 
 // addContext returns a string format with additional log context if present.

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -459,7 +459,7 @@ func (c *changeCache) DocChangedSynchronous(event sgbucket.FeedEvent) {
 		// No sync metadata found - check whether we're mid-upgrade and attempting to read a doc w/ metadata stored in xattr
 		migratedDoc, _ := c.context.checkForUpgrade(docID)
 		if migratedDoc != nil && migratedDoc.Cas == event.Cas {
-			base.Infof(base.KeyCache, "Found mobile xattr on doc %q without _sync property - caching, assuming upgrade in progress.",  base.UD(docID))
+			base.Infof(base.KeyCache, "Found mobile xattr on doc %q without _sync property - caching, assuming upgrade in progress.", base.UD(docID))
 			syncData = &migratedDoc.syncData
 		} else {
 			base.Warnf(base.KeyAll, "changeCache: Doc %q does not have valid sync data.", base.UD(docID))


### PR DESCRIPTION
Will be easier to view the diff without whitespace: https://github.com/couchbase/sync_gateway/pull/3949/files?utf8=%E2%9C%93&diff=split&w=1

## Changes
- Adds `gofmt` stage which fails when `sync_gateway` repo has any `gofmt` issues.
- Adds stage to make sure the Windows service scripts can be compiled.
- Reorganised build stages to be grouped into 3 main groups: 'Setup', 'Build' and 'Test'.
- Run `gofmt`

## Pipeline screenshots
![screenshot 2019-02-04 at 20 50 10](https://user-images.githubusercontent.com/1525809/52236370-9332fb80-28be-11e9-99da-d12f6c36568b.png)

Note: on a gofmt fail, the pipeline stops... Tests are not executed. This behaviour is reliant on [JENKINS-45579](https://issues.jenkins-ci.org/browse/JENKINS-45579), [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203), and/or [JENKINS-43995](https://issues.jenkins-ci.org/browse/JENKINS-43995) being implemented, to mark the single stage as a "fail but continue"

![screenshot 2019-02-04 at 20 53 38](https://user-images.githubusercontent.com/1525809/52236527-0177be00-28bf-11e9-80a0-206d8abec883.png)
