### PR TITLE
Ensure doc retrieval uses unmarshalDocument

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -71,7 +71,6 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 			return nil, base.HTTPErrorf(404, "Not imported")
 		}
 	} else {
-		//doc = newDocument(docid)
 		rawDoc, _, getErr := db.Bucket.GetRaw(key)
 		if getErr != nil {
 			return nil, getErr

--- a/db/crud.go
+++ b/db/crud.go
@@ -71,11 +71,17 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 			return nil, base.HTTPErrorf(404, "Not imported")
 		}
 	} else {
-		doc = newDocument(docid)
-		_, err = db.Bucket.Get(key, doc)
+		//doc = newDocument(docid)
+		rawDoc, _, getErr := db.Bucket.GetRaw(key)
+		if getErr != nil {
+			return nil, getErr
+		}
+
+		doc, err = unmarshalDocument(key, rawDoc)
 		if err != nil {
 			return nil, err
 		}
+
 		if !doc.HasValidSyncData(db.writeSequences()) {
 			// Check whether doc has been upgraded to use xattrs
 			upgradeDoc, _ := db.checkForUpgrade(docid)


### PR DESCRIPTION
GetDocument wasn't using unmarshalDocument (required for decode/UseNumber) to unmarshal document bodies in the non-xattr case.  

Validated no performance degradation associated with this change here:
http://perf.jenkins.couchbase.com/job/syncgteway-hebe/2670/