### PR TITLE
Fix missing "unset log file path" warning under new default configuration

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -62,6 +62,15 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		go logCollationWorker(logger.collateBuffer, logger.logger, *config.CollationBufferSize)
 	}
 
+	consoleOutput := "stderr"
+	if config.FileOutput != "" {
+		consoleOutput = config.FileOutput
+	}
+
+	warnings = append(warnings, func() {
+		fmt.Println(addPrefixes(fmt.Sprintf("Logging console output to: %v", consoleOutput), nil, LevelInfo, KeyAll))
+	})
+
 	return logger, warnings, nil
 }
 

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -62,14 +62,16 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		go logCollationWorker(logger.collateBuffer, logger.logger, *config.CollationBufferSize)
 	}
 
-	consoleOutput := "stderr"
-	if config.FileOutput != "" {
-		consoleOutput = config.FileOutput
-	}
+	if *config.Enabled {
+		consoleOutput := "stderr"
+		if config.FileOutput != "" {
+			consoleOutput = config.FileOutput
+		}
 
-	warnings = append(warnings, func() {
-		fmt.Println(addPrefixes(fmt.Sprintf("Logging console output to: %v", consoleOutput), nil, LevelInfo, KeyAll))
-	})
+		warnings = append(warnings, func() {
+			fmt.Println(addPrefixes(fmt.Sprintf("Logging console output to: %v", consoleOutput), nil, LevelInfo, KeyAll))
+		})
+	}
 
 	return logger, warnings, nil
 }

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -42,7 +42,7 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 	}
 
 	logKey, warnings := ToLogKey(config.LogKeys)
-	isStderr := config.FileOutput == ""
+	isStderr := config.FileOutput == "" && *config.Enabled
 
 	logger := &ConsoleLogger{
 		LogLevel:     config.LogLevel,
@@ -112,6 +112,7 @@ func (lcc *ConsoleLoggerConfig) init() error {
 
 	// Default to false
 	if lcc.Enabled == nil || !*lcc.Enabled {
+		lcc.Enabled = BoolPtr(false)
 		newLevel := LevelNone
 		lcc.LogLevel = &newLevel
 		lcc.LogKeys = []string{}

--- a/base/logging.go
+++ b/base/logging.go
@@ -531,10 +531,10 @@ func LogSyncGatewayVersion() {
 
 	if !consoleLogger.isStderr {
 		fmt.Println(msg)
-	}
-	if consoleLogger.logger != nil {
+	} else if consoleLogger.logger != nil {
 		consoleLogger.logger.Print(color(msg, LevelNone))
 	}
+
 	if errorLogger.shouldLog(LevelNone) {
 		errorLogger.logger.Printf(msg)
 	}

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -69,6 +69,10 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 	err = validateLogFilePath(&c.LogFilePath, defaultLogFilePath)
 	if err != nil {
 		return warnings, err
+	} else {
+		warnings = append(warnings, func() {
+			fmt.Println(addPrefixes(fmt.Sprintf("Logging files to: %v", c.LogFilePath), nil, LevelInfo, KeyAll))
+		})
 	}
 
 	errorLogger, err = NewFileLogger(c.Error, LevelError, LevelError.String(), c.LogFilePath, errorMinAge)

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -28,7 +28,7 @@ const (
 )
 
 // ErrUnsetLogFilePath is returned when no log_file_path, or --defaultLogFilePath fallback can be used.
-var ErrUnsetLogFilePath = errors.New("No log_file_path configured, and --defaultLogFilePath flag is not set. Log files required for product support are not being generated.")
+var ErrUnsetLogFilePath = errors.New("No log_file_path property specified in config, and --defaultLogFilePath command line flag was not set. Log files required for product support are not being generated.")
 
 type LoggingConfig struct {
 	LogFilePath    string              `json:"log_file_path,omitempty"`   // Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file.


### PR DESCRIPTION
- Set`isStderr` to `true` only when console is enabled.
- Make the "unset log file path" error more descriptive.
- Prints to stderr where console and file loggers are being output to on startup... e.g:

```
18:35 $ go build && ./sync_gateway --defaultLogFilePath '/tmp/defaultsglogs' sg_config.json
2019-02-12T18:37:07.210Z ==== /() CE ====
2019-02-12T18:37:07.210Z [INF] Logging console output to: stderr
2019-02-12T18:37:07.210Z [INF] Logging files to: /tmp/defaultsglogs
2019-02-12T18:37:07.210Z [INF] Console LogKeys: [* HTTP]
2019-02-12T18:37:07.210Z [INF] Console LogLevel: trace
2019-02-12T18:37:07.210Z [INF] Log Redaction Level: none
2019-02-12T18:37:07.210Z [INF] requestedSoftFDLimit < currentSoftFdLimit (5000 < 64000) no action needed
2019-02-12T18:37:07.210Z [INF] Logging stats with frequency: 1m0s
2019-02-12T18:37:07.210Z [INF] Opening db /db as bucket "db", pool "default", server <walrus:>
2019-02-12T18:37:07.210Z [INF] Opening Walrus database db on <walrus:>
```

Fixes the case where there is no unset log file path warning under a default configuration since #3935 