### PR TITLE
Delta Sync: Fix large number precision by using json.Number

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -588,11 +589,13 @@ func DeepCopyInefficient(dst interface{}, src interface{}) error {
 	if src == nil {
 		return fmt.Errorf("src cannot be nil")
 	}
-	bytes, err := json.Marshal(src)
+	b, err := json.Marshal(src)
 	if err != nil {
 		return fmt.Errorf("Unable to marshal src: %s", err)
 	}
-	err = json.Unmarshal(bytes, dst)
+	d := json.NewDecoder(bytes.NewBuffer(b))
+	d.UseNumber()
+	err = d.Decode(dst)
 	if err != nil {
 		return fmt.Errorf("Unable to unmarshal into dst: %s", err)
 	}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -119,7 +119,7 @@
   <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
   <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="0d6061f5f12560d22291d632a4c0b1cc9b67b233"/>
+  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="3f65cf0eafc5c49d96a6808d60c2d5c4aefbf6c6"/>
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
   <!-- gozip tools -->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -119,7 +119,7 @@
   <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
   <!-- Enterprise edition dependencies -->
-  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="f7aac3c7ac54f31de5820a4d7c65d4b2e078e77a"/>
+  <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="0d6061f5f12560d22291d632a4c0b1cc9b67b233"/>
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
   <!-- gozip tools -->

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1536,12 +1536,12 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"}]}`, string(data))
 
 	// create doc1 rev 2-959f0e9ad32d84ff652fb91d8d0caa7e
-	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev=1-0335a345b6ffed05707ccc4cbc1b67f4", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": "bob"}]}`)
+	resp = rt.SendAdminRequest(http.MethodPut, "/db/doc1?rev=1-0335a345b6ffed05707ccc4cbc1b67f4", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}, {"howdy": 12345678901234567890}]}`)
 	assert.Equal(t, http.StatusCreated, resp.Code)
 
-	data, ok = client.WaitForRev("doc1", "2-959f0e9ad32d84ff652fb91d8d0caa7e")
+	data, ok = client.WaitForRev("doc1", "2-26359894b20d89c97638e71c40482f28")
 	assert.True(t, ok)
-	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(data))
+	assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(data))
 
 	msg, ok := client.pullReplication.WaitForMessage(5)
 	assert.True(t, ok)
@@ -1553,7 +1553,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		// Check the request body was the actual delta
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)
-		assert.Equal(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
+		assert.Equal(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
 		assert.Equal(t, deltaSentCount+1, base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltasSent)))
 	} else {
 		// Check the request was NOT sent with a deltaSrc property
@@ -1561,8 +1561,8 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		// Check the request body was NOT the delta
 		msgBody, err := msg.Body()
 		assert.NoError(t, err)
-		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":"bob"}]}}`, string(msgBody))
-		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, string(msgBody))
+		assert.NotEqual(t, `{"greetings":{"2-":[{"howdy":12345678901234567890}]}}`, string(msgBody))
+		assert.Equal(t, `{"greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":12345678901234567890}]}`, string(msgBody))
 		assert.Equal(t, deltaSentCount, base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltasSent)))
 	}
 }


### PR DESCRIPTION
- `DeepCopyInefficient` now uses `decoder.UseNumber()` to preserve large numbers
- `BlipTesterClient` now uses `decoder.UseNumber()` to preserve large numbers
- Modified a delta sync test to include a large number in the dataset

## TODO
- [x] Bump go-fleecedelta manifest for json.Number handling - https://github.com/couchbaselabs/go-fleecedelta/pull/20