### PR TITLE
CBG-180 Add sharding to rev cache

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -72,7 +72,7 @@ type DatabaseContext struct {
 	RevsLimit          uint32                  // Max depth a document's revision tree can grow to
 	autoImport         bool                    // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
 	Shadower           *Shadower               // Tracks an external Couchbase bucket
-	revisionCache      *RevisionCache          // Cache of recently-accessed doc revisions
+	revisionCache      *ShardedRevisionCache   // Cache of recently-accessed doc revisions
 	changeCache        ChangeIndex             //
 	EventMgr           *EventManager           // Manages notification events
 	AllowEmptyPassword bool                    // Allow empty passwords?  Defaults to false
@@ -1157,7 +1157,7 @@ func (context *DatabaseContext) FlushRevisionCacheForTest() {
 }
 
 // For test usage
-func (context *DatabaseContext) GetRevisionCacheForTest() *RevisionCache {
+func (context *DatabaseContext) GetRevisionCacheForTest() *ShardedRevisionCache {
 	return context.revisionCache
 }
 

--- a/db/revision_cache.go
+++ b/db/revision_cache.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"errors"
 	"expvar"
+	"github.com/couchbase/sg-bucket"
 	"sync"
 	"time"
 
@@ -12,6 +13,60 @@ import (
 
 // Number of recently-accessed doc revisions to cache in RAM
 var KDefaultRevisionCacheCapacity uint32 = 5000
+var KDefaultNumCacheShards uint16 = 8
+
+type ShardedRevisionCache struct {
+	caches    []*RevisionCache
+	numShards uint16
+}
+
+// Creates a revision cache with the given capacity and an optional loader function.
+func NewRevisionCache(capacity uint32, loaderFunc RevisionCacheLoaderFunc, statsCache *expvar.Map) *ShardedRevisionCache {
+
+	numShards := KDefaultNumCacheShards
+	if capacity == 0 {
+		capacity = KDefaultRevisionCacheCapacity
+	}
+
+	caches := make([]*RevisionCache, numShards)
+	perCacheCapacity := uint32(capacity/uint32(numShards)) + 1
+	for i := 0; i < int(numShards); i++ {
+		caches[i] = NewRevisionCacheShard(perCacheCapacity, loaderFunc, statsCache)
+	}
+
+	return &ShardedRevisionCache{
+		caches:    caches,
+		numShards: numShards,
+	}
+}
+
+func (sc *ShardedRevisionCache) getShard(docID string) uint32 {
+	return sgbucket.VBHash(docID, sc.numShards)
+}
+
+func (sc *ShardedRevisionCache) Get(docID, revID string) (DocumentRevision, error) {
+	return sc.caches[sc.getShard(docID)].Get(docID, revID)
+}
+
+func (sc *ShardedRevisionCache) GetCached(docID, revID string) (DocumentRevision, error) {
+	return sc.caches[sc.getShard(docID)].GetCached(docID, revID)
+}
+
+func (sc *ShardedRevisionCache) GetWithCopy(docID, revID string, copyType BodyCopyType) (DocumentRevision, error) {
+	return sc.caches[sc.getShard(docID)].GetWithCopy(docID, revID, copyType)
+}
+
+func (sc *ShardedRevisionCache) UpdateDelta(docID, revID string, toRevID string, delta []byte) {
+	sc.caches[sc.getShard(docID)].UpdateDelta(docID, revID, toRevID, delta)
+}
+
+func (sc *ShardedRevisionCache) GetActive(docID string, context *DatabaseContext) (docRev DocumentRevision, err error) {
+	return sc.caches[sc.getShard(docID)].GetActive(docID, context)
+}
+
+func (sc *ShardedRevisionCache) Put(docID string, docRev DocumentRevision) {
+	sc.caches[sc.getShard(docID)].Put(docID, docRev)
+}
 
 // An LRU cache of document revision bodies, together with their channel access.
 type RevisionCache struct {
@@ -62,7 +117,7 @@ type RevCacheDelta struct {
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.
-func NewRevisionCache(capacity uint32, loaderFunc RevisionCacheLoaderFunc, statsCache *expvar.Map) *RevisionCache {
+func NewRevisionCacheShard(capacity uint32, loaderFunc RevisionCacheLoaderFunc, statsCache *expvar.Map) *RevisionCache {
 
 	if capacity == 0 {
 		capacity = KDefaultRevisionCacheCapacity

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3265,16 +3265,6 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 
 	var body db.Body
 
-	// Disable rev cache so that the _bulk_get request is forced to go back to the bucket to load the doc
-	// rather than loading it from the (stale) rev cache.  The rev cache will be stale since the test
-	// short-circuits Sync Gateway and directly updates the bucket.
-	// Reset at the end of the test, to avoid bleed into other tests
-	normalCapacity := db.KDefaultRevisionCacheCapacity
-	db.KDefaultRevisionCacheCapacity = 0
-	defer func() {
-		db.KDefaultRevisionCacheCapacity = normalCapacity
-	}()
-
 	docIdDoc1 := "doc"
 	attachmentName := "attach1"
 
@@ -3356,6 +3346,12 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	// Put the doc back into couchbase
 	err = bucket.Set(docIdDoc1, 0, couchbaseDoc)
 	assert.NoError(t, err, "Error putting couchbaseDoc")
+
+	// Flush rev cache so that the _bulk_get request is forced to go back to the bucket to load the doc
+	// rather than loading it from the (stale) rev cache.  The rev cache will be stale since the test
+	// short-circuits Sync Gateway and directly updates the bucket.
+	// Reset at the end of the test, to avoid bleed into other tests
+	rt.GetDatabase().FlushRevisionCacheForTest()
 
 	// Get latest rev id
 	response = rt.SendRequest("GET", resource, "")


### PR DESCRIPTION
Reduce contention by sharding the rev cache.  Sharded cache guarantees at least [capacity], may exceed due to rounding on per shard sizing.

Shows significant throughput improvement in high concurrency benchmark and perf tests.

Integration tests:
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/963/