### PR TITLE
Jenkinsfile: Set GOCACHE=off

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
         GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/godeps"
+        GOCACHE = "off"
         BRANCH = "${BRANCH_NAME}"
         COVERALLS_TOKEN = credentials('SG_COVERALLS_TOKEN')
         EE_BUILD_TAG = "cb_sg_enterprise"


### PR DESCRIPTION
These jobs don't really benefit from any build/test caching, as most builds are new commits.
It has caused disk-space issues in the past, so better off to just disable completely.