### PR TITLE
WaitForDBOnline before counting error stat in test

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3811,6 +3811,9 @@ func TestDocIDFilterResurrection(t *testing.T) {
 }
 
 func TestSyncFunctionErrorLogging(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyJavascript)()
+
 	rt := RestTester{SyncFn: `
 		function(doc) {
 			console.error("Error");
@@ -3819,6 +3822,9 @@ func TestSyncFunctionErrorLogging(t *testing.T) {
 		}`}
 
 	defer rt.Close()
+
+	// Wait for the DB to be ready before attempting to get initial error count
+	assert.NoError(t, rt.WaitForDBOnline())
 
 	numErrors, err := strconv.Atoi(base.StatsResourceUtilization().Get(base.StatKeyErrorCount).String())
 	assert.NoError(t, err)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3734,9 +3734,6 @@ func TestUnsupportedConfig(t *testing.T) {
 }
 
 func TestImportingPurgedDocument(t *testing.T) {
-	var rt RestTester
-	defer rt.Close()
-
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
 	}
@@ -3745,8 +3742,13 @@ func TestImportingPurgedDocument(t *testing.T) {
 		t.Skip("XATTR based tests not enabled.  Enable via SG_TEST_USE_XATTRS=true environment variable")
 	}
 
+	var rt RestTester
+	defer rt.Close()
+
 	body := `{"_purged": true, "foo": "bar"}`
-	rt.Bucket().Add("key", 0, []byte(body))
+	ok, err := rt.Bucket().Add("key", 0, []byte(body))
+	assert.NoError(t, err)
+	assert.True(t, ok)
 
 	numErrors, err := strconv.Atoi(base.StatsResourceUtilization().Get(base.StatKeyErrorCount).String())
 	assert.NoError(t, err)

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -522,8 +522,9 @@ func TestImportFilterLogging(t *testing.T) {
 	body := make(map[string]interface{})
 	body["type"] = "mobile"
 	body["channels"] = "A"
-	_, err := bucket.Add(key, 0, body)
+	ok, err := rt.Bucket().Add(key, 0, body)
 	assert.NoError(t, err)
+	assert.True(t, ok)
 
 	//Get number of errors before
 	numErrors, err := strconv.Atoi(base.StatsResourceUtilization().Get(base.StatKeyErrorCount).String())

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -515,7 +515,6 @@ func TestImportFilterLogging(t *testing.T) {
 		},
 	}
 	defer rt.Close()
-	bucket := rt.Bucket()
 
 	//Add document to bucket
 	key := "ValidImport"


### PR DESCRIPTION
Fixes failing integration test `TestSyncFunctionErrorLogging` from #3955 

Call `WaitForDBOnline` before getting error count stats to prevent the following GoCB errors counting towards the test stat:

```
2019-02-22T15:21:09.582Z [ERR] gocb: Pipeline ioLoop started with no parent -- base.GoCBCoreLogger.Log() at logger_external.go:47
2019-02-22T15:21:09.582Z [ERR] gocb: memdClient read failure: read tcp [::1]:50099->[::1]:11210: use of closed network connection -- base.GoCBCoreLogger.Log() at logger_external.go:47
2019-02-22T15:21:09.582Z [ERR] gocb: Failed to shut down client connection (close tcp [::1]:50099->[::1]:11210: use of closed network connection) -- base.GoCBCoreLogger.Log() at logger_external.go:47
2019-02-22T15:21:09.582Z [ERR] gocb: memdClient read failure: read tcp [::1]:50098->[::1]:11210: use of closed network connection -- base.GoCBCoreLogger.Log() at logger_external.go:47
2019-02-22T15:21:09.582Z [ERR] gocb: Failed to shut down client connection (close tcp [::1]:50098->[::1]:11210: use of closed network connection) -- base.GoCBCoreLogger.Log() at logger_external.go:47
```

- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/974/