### PR TITLE
Improve console logging changes

### DIFF
--- a/base/log_level.go
+++ b/base/log_level.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	logLevelNames      = []string{"none", "error", "warn", "info", "debug", "trace"}
-	logLevelNamesPrint = []string{"NON", "ERR", "WRN", "INF", "DBG", "TRC"}
+	logLevelNamesPrint = []string{"---", "ERR", "WRN", "INF", "DBG", "TRC"}
 )
 
 // Set will override the log level with the given log level.

--- a/base/log_level.go
+++ b/base/log_level.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	logLevelNames      = []string{"none", "error", "warn", "info", "debug", "trace"}
-	logLevelNamesPrint = []string{"---", "ERR", "WRN", "INF", "DBG", "TRC"}
+	logLevelNamesPrint = []string{"NON", "ERR", "WRN", "INF", "DBG", "TRC"}
 )
 
 // Set will override the log level with the given log level.

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -49,7 +49,8 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		LogKey:       &logKey,
 		ColorEnabled: *config.ColorEnabled && isStderr,
 		FileLogger: FileLogger{
-			logger: log.New(config.Output, "", 0),
+			Enabled: *config.Enabled,
+			logger:  log.New(config.Output, "", 0),
 		},
 		isStderr: isStderr,
 	}
@@ -69,7 +70,11 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		}
 
 		warnings = append(warnings, func() {
-			fmt.Println(addPrefixes(fmt.Sprintf("Logging console output to: %v", consoleOutput), nil, LevelInfo, KeyAll))
+			Consolef(LevelNone, KeyNone, "Logging: Console to %v", consoleOutput)
+		})
+	} else {
+		warnings = append(warnings, func() {
+			Consolef(LevelNone, KeyNone, "Logging: Console disabled")
 		})
 	}
 

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -121,9 +121,17 @@ func (lcc *ConsoleLoggerConfig) init() error {
 		}
 	}
 
-	// Default to false
-	if lcc.Enabled == nil || !*lcc.Enabled {
-		lcc.Enabled = BoolPtr(false)
+	// Default to disabled only when a log key or log level has not been specified
+	if lcc.Enabled == nil {
+		if lcc.LogLevel != nil || len(lcc.LogKeys) > 0 {
+			lcc.Enabled = BoolPtr(true)
+		} else {
+			lcc.Enabled = BoolPtr(false)
+		}
+	}
+
+	// Turn off console logging if disabled
+	if !*lcc.Enabled {
 		newLevel := LevelNone
 		lcc.LogLevel = &newLevel
 		lcc.LogKeys = []string{}

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -70,11 +70,11 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		}
 
 		warnings = append(warnings, func() {
-			Consolef(LevelNone, KeyNone, "Logging: Console to %v", consoleOutput)
+			Consolef(LevelInfo, KeyNone, "Logging: Console to %v", consoleOutput)
 		})
 	} else {
 		warnings = append(warnings, func() {
-			Consolef(LevelNone, KeyNone, "Logging: Console disabled")
+			Consolef(LevelInfo, KeyNone, "Logging: Console disabled")
 		})
 	}
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -57,11 +57,9 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 	// If there's nowhere to specified put log files, we'll log an error, but continue anyway.
 	if !hasLogFilePath(&c.LogFilePath, defaultLogFilePath) {
 		warnings = append(warnings, func() {
-			if !consoleLogger.isStderr {
-				// Explicitly log this error to stderr
-				fmt.Println(addPrefixes(ErrUnsetLogFilePath.Error(), nil, LevelError, KeyAll))
-			}
-			Errorf(KeyAll, "%v", ErrUnsetLogFilePath)
+			Consolef(LevelNone, KeyNone, "Logging: Files disabled")
+			// Explicitly log this error to console
+			Consolef(LevelError, KeyNone, ErrUnsetLogFilePath.Error())
 		})
 		return warnings, nil
 	}
@@ -71,7 +69,7 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 		return warnings, err
 	} else {
 		warnings = append(warnings, func() {
-			fmt.Println(addPrefixes(fmt.Sprintf("Logging files to: %v", c.LogFilePath), nil, LevelInfo, KeyAll))
+			Consolef(LevelNone, KeyNone, "Logging: Files to %v", c.LogFilePath)
 		})
 	}
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -57,7 +57,7 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 	// If there's nowhere to specified put log files, we'll log an error, but continue anyway.
 	if !hasLogFilePath(&c.LogFilePath, defaultLogFilePath) {
 		warnings = append(warnings, func() {
-			Consolef(LevelNone, KeyNone, "Logging: Files disabled")
+			Consolef(LevelInfo, KeyNone, "Logging: Files disabled")
 			// Explicitly log this error to console
 			Consolef(LevelError, KeyNone, ErrUnsetLogFilePath.Error())
 		})
@@ -69,7 +69,7 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 		return warnings, err
 	} else {
 		warnings = append(warnings, func() {
-			Consolef(LevelNone, KeyNone, "Logging: Files to %v", c.LogFilePath)
+			Consolef(LevelInfo, KeyNone, "Logging: Files to %v", c.LogFilePath)
 		})
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -976,10 +976,10 @@ func RunServer(config *ServerConfig) {
 
 	go sc.PostStartup()
 
-	base.Consolef(base.LevelNone, base.KeyAll, "Starting admin server on %s", *config.AdminInterface)
+	base.Consolef(base.LevelInfo, base.KeyAll, "Starting admin server on %s", *config.AdminInterface)
 	go config.Serve(*config.AdminInterface, CreateAdminHandler(sc))
 
-	base.Consolef(base.LevelNone, base.KeyAll, "Starting server on %s ...", *config.Interface)
+	base.Consolef(base.LevelInfo, base.KeyAll, "Starting server on %s ...", *config.Interface)
 	config.Serve(*config.Interface, CreatePublicHandler(sc))
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -976,10 +976,10 @@ func RunServer(config *ServerConfig) {
 
 	go sc.PostStartup()
 
-	base.Infof(base.KeyAll, "Starting admin server on %s", base.UD(*config.AdminInterface))
+	base.Consolef(base.LevelNone, base.KeyAll, "Starting admin server on %s", *config.AdminInterface)
 	go config.Serve(*config.AdminInterface, CreateAdminHandler(sc))
 
-	base.Infof(base.KeyAll, "Starting server on %s ...", base.UD(*config.Interface))
+	base.Consolef(base.LevelNone, base.KeyAll, "Starting server on %s ...", *config.Interface)
 	config.Serve(*config.Interface, CreatePublicHandler(sc))
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -938,9 +938,9 @@ func (config *ServerConfig) NumIndexWriters() int {
 func RunServer(config *ServerConfig) {
 	PrettyPrint = config.Pretty
 
-	base.Infof(base.KeyAll, "Console LogKeys: %v", base.ConsoleLogKey().EnabledLogKeys())
-	base.Infof(base.KeyAll, "Console LogLevel: %v", base.ConsoleLogLevel())
-	base.Infof(base.KeyAll, "Log Redaction Level: %s", config.Logging.RedactionLevel)
+	base.Infof(base.KeyAll, "Logging: Console level: %v", base.ConsoleLogLevel())
+	base.Infof(base.KeyAll, "Logging: Console keys: %v", base.ConsoleLogKey().EnabledLogKeys())
+	base.Infof(base.KeyAll, "Logging: Redaction level: %s", config.Logging.RedactionLevel)
 
 	if os.Getenv("GOMAXPROCS") == "" && runtime.GOMAXPROCS(0) == 1 {
 		cpus := runtime.NumCPU()
@@ -1073,7 +1073,7 @@ func ServerMain(runMode SyncGatewayRunMode) {
 	}
 
 	// This is the earliest opportunity to log a startup indicator
-	// that will be persisted in log files.
+	// that will be persisted in all log files.
 	base.LogSyncGatewayVersion()
 
 	// Execute any deferred warnings from setup.


### PR DESCRIPTION
- Enable console logging by default when a `log_level` or `log_keys` property is set.
- Move some normal startup messages to `Consolef` to always be printed to stderr (see below)

## Examples of config and console output:

### Default
![screenshot 2019-02-25 at 18 00 24](https://user-images.githubusercontent.com/1525809/53358227-a2d6ba80-3927-11e9-90ce-2d4a029b2489.png)
![screenshot 2019-02-25 at 18 00 36](https://user-images.githubusercontent.com/1525809/53358229-a2d6ba80-3927-11e9-8ef4-47e6008456d7.png)

### log key (or log level) set
![screenshot 2019-02-25 at 17 57 15](https://user-images.githubusercontent.com/1525809/53358270-c0a41f80-3927-11e9-989c-40872e404914.png)
![screenshot 2019-02-25 at 17 57 36](https://user-images.githubusercontent.com/1525809/53358271-c13cb600-3927-11e9-905e-961c0b24c9a1.png)

### Console `enabled:false`
![screenshot 2019-02-25 at 17 59 14](https://user-images.githubusercontent.com/1525809/53360011-593c9e80-392c-11e9-8232-d779340b2961.png)
![screenshot 2019-02-25 at 17 59 22](https://user-images.githubusercontent.com/1525809/53360012-593c9e80-392c-11e9-8cb6-f6e99771cbbd.png)

