### PR TITLE
CBG-248 Handle _revisions as Revisions or map[string]interface{}

### DIFF
--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -709,7 +709,8 @@ func TestParseRevisions(t *testing.T) {
 	}
 	for _, c := range cases {
 		var body Body
-		assert.NoError(t, json.Unmarshal([]byte(c.json), &body), "base JSON in test case")
+		unmarshalErr := body.Unmarshal([]byte(c.json))
+		assert.NoError(t, unmarshalErr, "base JSON in test case")
 		ids := ParseRevisions(body)
 		goassert.DeepEquals(t, ids, c.ids)
 	}


### PR DESCRIPTION
When parsing revisions, need to handle case where _revisions is map[string]interface{} (from unmarshalling a document with _revisions inline), or Revisions (property injected into document from rev cache).

- [ ] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/975/