### PR TITLE
CBG-230 Avoid attempted document retrieval for principal docs

### DIFF
--- a/channels/change_log.go
+++ b/channels/change_log.go
@@ -32,6 +32,7 @@ type LogEntry struct {
 	Type         LogEntryType // Log entry type
 	Value        []byte       // Snapshot metadata (when Type=LogEntryCheckpoint)
 	PrevSequence uint64       // Sequence of previous active revision
+	IsPrincipal  bool         // Whether the log-entry is a tracking entry for a principal doc
 }
 
 func (l LogEntry) String() string {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -77,10 +77,10 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 		ID:      "doc1",
 		Changes: []ChangeRev{{"rev": revid}}})
 	goassert.DeepEquals(t, changes[2], &ChangeEntry{ // Seq 2, from ABC and PBS
-		Seq:       SequenceID{Seq: 2},
-		ID:        "_user/naomi",
-		Changes:   []ChangeRev{},
-		pseudoDoc: true})
+		Seq:          SequenceID{Seq: 2},
+		ID:           "_user/naomi",
+		Changes:      []ChangeRev{},
+		principalDoc: true})
 	lastSeq := getLastSeq(changes)
 	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
 

--- a/db/index_changes.go
+++ b/db/index_changes.go
@@ -844,10 +844,10 @@ func (db *Database) appendVectorUserFeed(feeds []<-chan *ChangeEntry, names []st
 				name = base.GuestUsername
 			}
 			entry := ChangeEntry{
-				Seq:       userSeq,
-				ID:        "_user/" + name,
-				Changes:   []ChangeRev{},
-				pseudoDoc: true,
+				Seq:          userSeq,
+				ID:           "_user/" + name,
+				Changes:      []ChangeRev{},
+				principalDoc: true,
 			}
 			userFeed := make(chan *ChangeEntry, 1)
 			userFeed <- &entry


### PR DESCRIPTION
Ensure principal change notification entries aren't included for star channel, admin changes requests.  Principal notification docs are only needed for backfill sequence tracking for the user receiving a grant, and shouldn't be sent as part of star channel or admin changes feeds to anyone other than the user.
