### PR TITLE
CBG-245 Fix for new attachments in delta sync pull

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -518,6 +518,21 @@ func GetBodyAttachments(body Body) AttachmentsMeta {
 	}
 }
 
+// AttachmentDigests returns a list of attachment digests contained in the given AttachmentsMeta
+func AttachmentDigests(attachments AttachmentsMeta) []string {
+	var digests = make([]string, 0, len(attachments))
+	for _, att := range attachments {
+		if attMap, ok := att.(map[string]interface{}); ok {
+			if digest, ok := attMap["digest"]; ok {
+				if digestString, ok := digest.(string); ok {
+					digests = append(digests, digestString)
+				}
+			}
+		}
+	}
+	return digests
+}
+
 func hasInlineAttachments(body Body) bool {
 	for _, value := range GetBodyAttachments(body) {
 		if meta, ok := value.(map[string]interface{}); ok && meta["data"] != nil {

--- a/db/crud.go
+++ b/db/crud.go
@@ -371,7 +371,7 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
-func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, attachments AttachmentsMeta, err error) {
+func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, attachmentDigests []string, err error) {
 
 	if docID == "" || fromRevID == "" || toRevID == "" {
 		return nil, nil, nil
@@ -389,7 +389,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, at
 		if fromRevision.Delta.ToRevID == toRevID {
 			// Case 2a. 'some rev' is the rev we're interested in - return the delta
 			db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheHits, 1)
-			return fromRevision.Delta.DeltaBytes, fromRevision.Delta.ToAttachments, nil
+			return fromRevision.Delta.DeltaBytes, fromRevision.Delta.AttachmentDigests, nil
 		} else {
 			// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
 			// until then, fall through to generating delta for given rev pair
@@ -424,7 +424,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, at
 		}
 		// Write the newly calculated delta back into the cache before returning
 		db.revisionCache.UpdateDelta(docID, fromRevID, toRevID, delta, toBody.Attachments)
-		return delta, toBody.Attachments, nil
+		return delta, AttachmentDigests(toBody.Attachments), nil
 	}
 
 	return nil, nil, nil

--- a/db/crud.go
+++ b/db/crud.go
@@ -371,17 +371,17 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
-func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, err error) {
+func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, attachments AttachmentsMeta, err error) {
 
 	if docID == "" || fromRevID == "" || toRevID == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	fromRevision, err := db.revisionCache.GetWithCopy(docID, fromRevID, BodyNoCopy)
 
 	// If neither body nor delta is available for fromRevId, the delta can't be generated
 	if fromRevision.Body == nil && fromRevision.Delta == nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// If delta is found, check whether it is a delta for the toRevID we want
@@ -389,7 +389,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, er
 		if fromRevision.Delta.ToRevID == toRevID {
 			// Case 2a. 'some rev' is the rev we're interested in - return the delta
 			db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheHits, 1)
-			return fromRevision.Delta.DeltaBytes, nil
+			return fromRevision.Delta.DeltaBytes, fromRevision.Delta.ToAttachments, nil
 		} else {
 			// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
 			// until then, fall through to generating delta for given rev pair
@@ -402,7 +402,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, er
 		db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		toBody, err := db.revisionCache.GetWithCopy(docID, toRevID, BodyDeepCopy)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// We didn't copy fromBody earlier (in case we could get by with just the delta), so need do it now
 		fromBodyCopy := fromRevision.Body.DeepCopy()
@@ -420,14 +420,14 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, er
 
 		delta, err = base.Diff(fromBodyCopy, toBody.Body)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// Write the newly calculated delta back into the cache before returning
-		db.revisionCache.UpdateDelta(docID, fromRevID, toRevID, delta)
-		return delta, nil
+		db.revisionCache.UpdateDelta(docID, fromRevID, toRevID, delta, toBody.Attachments)
+		return delta, toBody.Attachments, nil
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 // Returns the body of the active revision of a document, as well as the document's current channels

--- a/db/revision_cache.go
+++ b/db/revision_cache.go
@@ -112,9 +112,9 @@ type revCacheValue struct {
 }
 
 type RevCacheDelta struct {
-	ToRevID       string
-	DeltaBytes    []byte
-	ToAttachments AttachmentsMeta
+	ToRevID           string
+	DeltaBytes        []byte
+	AttachmentDigests []string
 }
 
 // Creates a revision cache with the given capacity and an optional loader function.
@@ -345,9 +345,13 @@ func (value *revCacheValue) store(docRev DocumentRevision) {
 func (value *revCacheValue) updateDelta(toRevID string, deltaBytes []byte, attachments AttachmentsMeta) {
 	value.lock.Lock()
 	defer value.lock.Unlock()
+
+	// Flatten the AttachmentsMeta into a list of digests
+	digests := AttachmentDigests(attachments)
+
 	value.delta = &RevCacheDelta{
-		ToRevID:       toRevID,
-		DeltaBytes:    deltaBytes,
-		ToAttachments: attachments,
+		ToRevID:           toRevID,
+		DeltaBytes:        deltaBytes,
+		AttachmentDigests: digests,
 	}
 }

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -277,7 +277,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	// Trigger load into cache
 	_, err := cache.Get("doc1", "rev1")
 	assert.NoError(t, err, "Error adding to cache")
-	cache.UpdateDelta("doc1", "rev1", "rev2", firstDelta)
+	cache.UpdateDelta("doc1", "rev1", "rev2", firstDelta, nil)
 
 	// Retrieve from cache
 	retrievedRev, err := cache.Get("doc1", "rev1")
@@ -286,7 +286,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Update delta again, validate data in retrievedRev isn't mutated
-	cache.UpdateDelta("doc1", "rev1", "rev3", secondDelta)
+	cache.UpdateDelta("doc1", "rev1", "rev3", secondDelta, nil)
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1525,7 +1525,8 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	defer client.Close()
 
 	client.ClientDeltas = true
-	client.StartPull()
+	err = client.StartPull()
+	assert.NoError(t, err)
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -1567,9 +1568,8 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	}
 }
 
-// TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,
-// and checks that full body replication still happens in CE.
-func TestBlipNonDeltaSyncPull(t *testing.T) {
+// TestBlipPullRevMessageHistory tests that a simple pull replication contains history in the rev message.
+func TestBlipPullRevMessageHistory(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
@@ -1580,8 +1580,8 @@ func TestBlipNonDeltaSyncPull(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	client.ClientDeltas = true
-	client.StartPull()
+	err = client.StartPull()
+	assert.NoError(t, err)
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -1623,7 +1623,8 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	defer client.Close()
 
 	client.ClientDeltas = true
-	client.StartPull()
+	err = client.StartPull()
+	assert.NoError(t, err)
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -1640,7 +1641,8 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	defer client2.Close()
 
 	client2.ClientDeltas = true
-	client2.StartOneshotPull()
+	err = client2.StartOneshotPull()
+	assert.NoError(t, err)
 
 	msg, ok := client2.pullReplication.WaitForMessage(3)
 	assert.True(t, ok)
@@ -1669,7 +1671,8 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 	// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
 	client2.ClientDeltas = true
-	client2.StartOneshotPull()
+	err = client2.StartOneshotPull()
+	assert.NoError(t, err)
 
 	msg2, ok := client2.pullReplication.WaitForMessage(6)
 	assert.True(t, ok)
@@ -1703,7 +1706,8 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	defer client.Close()
 
 	client.ClientDeltas = true
-	client.StartPull()
+	err = client.StartPull()
+	assert.NoError(t, err)
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)
@@ -1764,7 +1768,8 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	defer client.Close()
 
 	client.ClientDeltas = false
-	client.StartPull()
+	err = client.StartPull()
+	assert.NoError(t, err)
 
 	// create doc1 rev 1-0335a345b6ffed05707ccc4cbc1b67f4
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"greetings": [{"hello": "world!"}, {"hi": "alice"}]}`)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -153,17 +153,20 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 				panic(err)
 			}
 
+			var old db.Body
 			btc.docsLock.RLock()
 			oldBytes := btc.docs[docID][deltaSrc]
 			btc.docsLock.RUnlock()
-			if err := bodyJSON.Unmarshal(oldBytes); err != nil {
+			if err := old.Unmarshal(oldBytes); err != nil {
 				panic(err)
 			}
 
-			var oldMap = map[string]interface{}(bodyJSON)
+			var oldMap = map[string]interface{}(old)
 			if err := base.Patch(&oldMap, body); err != nil {
 				panic(err)
 			}
+
+			bodyJSON = oldMap
 		}
 
 		// Fetch any missing attachments (if required) during this rev processing
@@ -230,11 +233,13 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 				}
 			}
 
+		}
+
+		if bodyJSON != nil {
 			body, err = json.Marshal(bodyJSON)
 			if err != nil {
 				panic(err)
 			}
-
 		}
 
 		btc.docsLock.Lock()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -635,7 +635,7 @@ func (bh *blipHandler) sendRevAsDelta(sender *blip.Sender, seq db.SequenceID, do
 
 	bh.db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltasRequested, 1)
 
-	delta, attachments, err := bh.db.GetDelta(docID, deltaSrcRevID, revID)
+	delta, attDigests, err := bh.db.GetDelta(docID, deltaSrcRevID, revID)
 	if err != nil {
 		bh.Logf(base.LevelInfo, base.KeySync, "DELTA: error generating delta from %s to %s for key %s; falling back to full body replication.  err: %v", deltaSrcRevID, revID, base.UD(docID), err)
 		bh.sendRevOrNorev(sender, seq, docID, revID, knownRevs, maxHistory)
@@ -649,11 +649,11 @@ func (bh *blipHandler) sendRevAsDelta(sender *blip.Sender, seq db.SequenceID, do
 	}
 
 	bh.Logf(base.LevelTrace, base.KeySync, "docID: %s - delta: %v", base.UD(docID), base.UD(string(delta)))
-	bh.sendDelta(delta, deltaSrcRevID, sender, seq, docID, revID, knownRevs, maxHistory, attachments)
+	bh.sendDelta(delta, deltaSrcRevID, sender, seq, docID, revID, knownRevs, maxHistory, attDigests)
 	bh.db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltasSent, 1)
 }
 
-func (bh *blipHandler) sendDelta(delta []byte, deltaSrcRevID string, sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int, attachments db.AttachmentsMeta) {
+func (bh *blipHandler) sendDelta(delta []byte, deltaSrcRevID string, sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int, attDigests []string) {
 
 	var body db.Body
 	if err := body.Unmarshal(delta); err != nil {
@@ -663,7 +663,7 @@ func (bh *blipHandler) sendDelta(delta []byte, deltaSrcRevID string, sender *bli
 	}
 
 	bh.Logf(base.LevelDebug, base.KeySync, "Sending rev %q %s as delta based on %d known. DeltaSrc:%s  User:%s", base.UD(docID), revID, len(knownRevs), deltaSrcRevID, base.UD(bh.effectiveUsername))
-	bh.sendRevisionWithProperties(body, sender, seq, docID, revID, knownRevs, maxHistory, attachments, blip.Properties{revMessageDeltaSrc: deltaSrcRevID})
+	bh.sendRevisionWithProperties(body, sender, seq, docID, revID, knownRevs, maxHistory, attDigests, blip.Properties{revMessageDeltaSrc: deltaSrcRevID})
 }
 
 func (bh *blipHandler) sendRevOrNorev(sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int) {
@@ -699,12 +699,12 @@ func (bh *blipHandler) sendNoRev(err error, sender *blip.Sender, seq db.Sequence
 func (bh *blipHandler) sendRevision(body db.Body, sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int) {
 	bh.Logf(base.LevelDebug, base.KeySync, "Sending rev %q %s based on %d known.  User:%s", base.UD(docID), revID, len(knownRevs), base.UD(bh.effectiveUsername))
 	// extract attachments from body for sendRevisionWithProperties
-	attachments := db.GetBodyAttachments(body)
-	bh.sendRevisionWithProperties(body, sender, seq, docID, revID, knownRevs, maxHistory, attachments, nil)
+	attDigests := db.AttachmentDigests(db.GetBodyAttachments(body))
+	bh.sendRevisionWithProperties(body, sender, seq, docID, revID, knownRevs, maxHistory, attDigests, nil)
 }
 
 // Pushes a revision body to the client
-func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int, attachments db.AttachmentsMeta, properties blip.Properties) {
+func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sender, seq db.SequenceID, docID string, revID string, knownRevs map[string]bool, maxHistory int, attDigests []string, properties blip.Properties) {
 
 	// Get the revision's history as a descending array of ancestor revIDs:
 	history := db.ParseRevisions(body)[1:]
@@ -742,9 +742,9 @@ func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sen
 	}
 	bh.db.DbStats.StatsDatabase().Add(base.StatKeyNumDocReadsBlip, 1)
 
-	if attachments != nil {
+	if len(attDigests) > 0 {
 		// Allow client to download attachments in 'atts', but only while pulling this rev
-		bh.addAllowedAttachments(attachments)
+		bh.addAllowedAttachments(attDigests)
 		sender.Send(outrq.Message)
 		go func() {
 			defer func() {
@@ -753,7 +753,7 @@ func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sen
 					bh.close()
 				}
 			}()
-			defer bh.removeAllowedAttachments(attachments)
+			defer bh.removeAllowedAttachments(attDigests)
 			outrq.Response() // blocks till reply is received
 		}()
 	} else {
@@ -945,29 +945,25 @@ func (ctx *blipSyncContext) incrementSerialNumber() uint64 {
 	return atomic.AddUint64(&ctx.handlerSerialNumber, 1)
 }
 
-func (ctx *blipSyncContext) addAllowedAttachments(atts map[string]interface{}) {
+func (ctx *blipSyncContext) addAllowedAttachments(attDigests []string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	if ctx.allowedAttachments == nil {
 		ctx.allowedAttachments = make(map[string]int, 100)
 	}
-	for _, meta := range atts {
-		if digest, ok := meta.(map[string]interface{})["digest"].(string); ok {
-			ctx.allowedAttachments[digest] = ctx.allowedAttachments[digest] + 1
-		}
+	for _, digest := range attDigests {
+		ctx.allowedAttachments[digest] = ctx.allowedAttachments[digest] + 1
 	}
 }
 
-func (ctx *blipSyncContext) removeAllowedAttachments(atts map[string]interface{}) {
+func (ctx *blipSyncContext) removeAllowedAttachments(attDigests []string) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
-	for _, meta := range atts {
-		if digest, ok := meta.(map[string]interface{})["digest"].(string); ok {
-			if n := ctx.allowedAttachments[digest]; n > 1 {
-				ctx.allowedAttachments[digest] = n - 1
-			} else {
-				delete(ctx.allowedAttachments, digest)
-			}
+	for _, digest := range attDigests {
+		if n := ctx.allowedAttachments[digest]; n > 1 {
+			ctx.allowedAttachments[digest] = n - 1
+		} else {
+			delete(ctx.allowedAttachments, digest)
 		}
 	}
 }


### PR DESCRIPTION
- Wrote test `TestBlipDeltaSyncNewAttachmentPull` to reproduce CBG-245.
- Cherry picked BlipTesterClient attachment support from old branch for above test.
  - Added getAttachment support for mid-rev message processing on a pull replication.
- Changed `sendRevisionWithProperties` to be passed a list of digests instead of it being extracted from the body (fixes issue seen in CBG-245)
- Store a list of attachment digests for the "to revision" in RevCacheDelta so it can be retrieved on delta cache hit without extra lookup.