### PR TITLE
CBG-251 Include revision history when sending delta

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -371,17 +371,17 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 // GetDelta attempts to return the delta between fromRevId and toRevId.  If the delta can't be generated,
 // returns nil.
-func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, attachmentDigests []string, err error) {
+func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionDelta, err error) {
 
 	if docID == "" || fromRevID == "" || toRevID == "" {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	fromRevision, err := db.revisionCache.GetWithCopy(docID, fromRevID, BodyNoCopy)
 
 	// If neither body nor delta is available for fromRevId, the delta can't be generated
 	if fromRevision.Body == nil && fromRevision.Delta == nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// If delta is found, check whether it is a delta for the toRevID we want
@@ -389,7 +389,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, at
 		if fromRevision.Delta.ToRevID == toRevID {
 			// Case 2a. 'some rev' is the rev we're interested in - return the delta
 			db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheHits, 1)
-			return fromRevision.Delta.DeltaBytes, fromRevision.Delta.AttachmentDigests, nil
+			return fromRevision.Delta, nil
 		} else {
 			// TODO: Recurse and merge deltas when gen(revCacheDelta.toRevID) < gen(toRevId)
 			// until then, fall through to generating delta for given rev pair
@@ -402,7 +402,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, at
 		db.DbStats.StatsDeltaSync().Add(base.StatKeyDeltaCacheMisses, 1)
 		toBody, err := db.revisionCache.GetWithCopy(docID, toRevID, BodyDeepCopy)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		// We didn't copy fromBody earlier (in case we could get by with just the delta), so need do it now
 		fromBodyCopy := fromRevision.Body.DeepCopy()
@@ -418,16 +418,18 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta []byte, at
 			toBody.Body[BodyAttachments] = map[string]interface{}(toBody.Attachments)
 		}
 
-		delta, err = base.Diff(fromBodyCopy, toBody.Body)
+		deltaBytes, err := base.Diff(fromBodyCopy, toBody.Body)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
+		revCacheDelta := NewRevCacheDelta(deltaBytes, fromRevID, toBody)
+
 		// Write the newly calculated delta back into the cache before returning
-		db.revisionCache.UpdateDelta(docID, fromRevID, toRevID, delta, toBody.Attachments)
-		return delta, AttachmentDigests(toBody.Attachments), nil
+		db.revisionCache.UpdateDelta(docID, fromRevID, revCacheDelta)
+		return revCacheDelta, nil
 	}
 
-	return nil, nil, nil
+	return nil, nil
 }
 
 // Returns the body of the active revision of a document, as well as the document's current channels

--- a/db/revision.go
+++ b/db/revision.go
@@ -122,6 +122,41 @@ func (revisions Revisions) findAncestor(ancestors []string) (revId string) {
 	return ""
 }
 
+// Returns revisions as a slice of revids.
+func (revisions Revisions) parseRevisions() []string {
+	start, ids := splitRevisionList(revisions)
+	if ids == nil {
+		return nil
+	}
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, fmt.Sprintf("%d-%s", start, id))
+		start--
+	}
+	return result
+}
+
+// Returns revisions as a slice of ancestor revids, from the parent to the target ancestor.
+func (revisions Revisions) parseAncestorRevisions(toAncestorRevID string) []string {
+	start, ids := splitRevisionList(revisions)
+	if ids == nil || len(ids) < 2 {
+		return nil
+	}
+	result := make([]string, 0)
+
+	// Start at the parent, end at toAncestorRevID
+	start = start - 1
+	for i := 1; i < len(ids); i++ {
+		revID := fmt.Sprintf("%d-%s", start, ids[i])
+		result = append(result, revID)
+		if revID == toAncestorRevID {
+			break
+		}
+		start--
+	}
+	return result
+}
+
 func (attachments AttachmentsMeta) ShallowCopy() AttachmentsMeta {
 	if attachments == nil {
 		return attachments

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -277,7 +277,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	// Trigger load into cache
 	_, err := cache.Get("doc1", "rev1")
 	assert.NoError(t, err, "Error adding to cache")
-	cache.UpdateDelta("doc1", "rev1", "rev2", firstDelta, nil)
+	cache.UpdateDelta("doc1", "rev1", &RevisionDelta{ToRevID: "rev2", DeltaBytes: firstDelta})
 
 	// Retrieve from cache
 	retrievedRev, err := cache.Get("doc1", "rev1")
@@ -286,7 +286,7 @@ func TestRevisionImmutableDelta(t *testing.T) {
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 
 	// Update delta again, validate data in retrievedRev isn't mutated
-	cache.UpdateDelta("doc1", "rev1", "rev3", secondDelta, nil)
+	cache.UpdateDelta("doc1", "rev1", &RevisionDelta{ToRevID: "rev3", DeltaBytes: secondDelta})
 	assert.Equal(t, "rev2", retrievedRev.Delta.ToRevID)
 	assert.Equal(t, firstDelta, retrievedRev.Delta.DeltaBytes)
 

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -70,3 +70,17 @@ func TestBodyUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRevisionsToAncestor(t *testing.T) {
+	revisions := Revisions{RevisionsStart: 5, RevisionsIds: []string{"five", "four", "three", "two", "one"}}
+
+	assert.Equal(t, []string{"4-four", "3-three"}, revisions.parseAncestorRevisions("3-three"))
+	assert.Equal(t, []string{"4-four"}, revisions.parseAncestorRevisions("4-four"))
+	assert.Equal(t, []string{"4-four", "3-three", "2-two", "1-one"}, revisions.parseAncestorRevisions("1-one"))
+	assert.Equal(t, []string{"4-four", "3-three", "2-two", "1-one"}, revisions.parseAncestorRevisions("5-five"))
+	assert.Equal(t, []string{"4-four", "3-three", "2-two", "1-one"}, revisions.parseAncestorRevisions("0-zero"))
+	assert.Equal(t, []string{"4-four", "3-three", "2-two", "1-one"}, revisions.parseAncestorRevisions("3-threeve"))
+
+	shortRevisions := Revisions{RevisionsStart: 3, RevisionsIds: []string{"three"}}
+	assert.Equal(t, []string(nil), shortRevisions.parseAncestorRevisions("2-two"))
+}

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -743,16 +743,7 @@ func ParseRevisions(body Body) []string {
 		return nil
 	}
 
-	start, ids := splitRevisionList(revisions)
-	if ids == nil {
-		return nil
-	}
-	result := make([]string, 0, len(ids))
-	for _, id := range ids {
-		result = append(result, fmt.Sprintf("%d-%s", start, id))
-		start--
-	}
-	return result
+	return revisions.parseRevisions()
 }
 
 // Splits out the "start" and "ids" properties from encoded revision list

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1573,12 +1573,14 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
-	var rt = RestTester{DatabaseConfig: &DbConfig{}}
+	sgUseDeltas := base.IsEnterpriseEdition()
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
 	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
+	client.ClientDeltas = true
 
 	err = client.StartPull()
 	assert.NoError(t, err)


### PR DESCRIPTION
Added revision history to RevCacheDelta for inclusion when sending a delta rev.

Refactored RevCacheDelta to RevisionDelta, and used this in several places instead of passing around the contents separately:
- blipHandler.sendDelta
- db.GetDelta
- RevisionCache.UpdateDelta, revCacheValue.updateDelta, ShardedRevisionCache.UpdateDelta

Refactored sendRevisionWithProperties to accept computed revisionHistory to support shared use for delta and non-delta revs - moved non-delta generation of history up into sendRevision.