### PR TITLE
CBG-227 CheckForUpgrade tests and fixes for read, write, feed

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -443,9 +443,9 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		}
 	}
 
-	if !syncData.HasValidSyncData(c.context.writeSequences()) {
+	if !c.context.UseXattrs() && !syncData.HasValidSyncData(c.context.writeSequences()) {
 		// No sync metadata found - check whether we're mid-upgrade and attempting to read a doc w/ metadata stored in xattr
-		migratedDoc, _ := c.context.checkForUpgrade(docID)
+		migratedDoc, _ := c.context.checkForUpgrade(docID, DocUnmarshalNoHistory)
 		if migratedDoc != nil && migratedDoc.Cas == event.Cas {
 			base.Infof(base.KeyCache, "Found mobile xattr on doc %q without _sync property - caching, assuming upgrade in progress.", base.UD(docID))
 			syncData = &migratedDoc.syncData

--- a/db/crud.go
+++ b/db/crud.go
@@ -83,7 +83,7 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 
 		if !doc.HasValidSyncData(db.writeSequences()) {
 			// Check whether doc has been upgraded to use xattrs
-			upgradeDoc, _ := db.checkForUpgrade(docid, DocUnmarshalAll)
+			upgradeDoc, _ := db.checkForUpgrade(docid, unmarshalLevel)
 			if upgradeDoc == nil {
 				return nil, base.HTTPErrorf(404, "Not imported")
 			}

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -927,6 +927,224 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 2)
 }
 
+// Test retrieval of a document stored w/ xattrs when running in non-xattr mode (upgrade handling).
+func TestCheckForUpgradeOnRead(t *testing.T) {
+
+	// Only run when xattrs are disabled, but requires couchbase server since we're writing an xattr directly to the bucket
+	if base.TestUseXattrs() {
+		t.Skip("Check for upgrade test only runs w/ SG_TEST_USE_XATTRS=false")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
+	}
+
+	rt := RestTester{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+	}
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+
+	// Write doc in SG format (doc + xattr) directly to the bucket
+	key := "TestCheckForUpgrade"
+	bodyString := `
+{
+  "value": "2-d"
+}`
+	xattrString := `
+{
+    "rev": "2-d",
+    "flags": 24,
+    "sequence": 5,
+    "recent_sequences": [1,2,3,4,5],
+    "history": {
+      "revs": [
+        "1-089c019bbfaba27047008599143bc66f",
+        "2-b92296d32600ec90dc05ff18ae61a1e8",
+        "2-b",
+        "2-c",
+        "2-d"
+      ],
+      "parents": [-1,0,0,0,0],
+      "bodymap": {
+        "2": "{\"value\":\"%s\"}",
+        "3": "{\"value\":\"%s\"}"
+      },
+      "bodyKeyMap": {
+      	"1": "_sync:rb:test"
+      },
+      "channels": [null,null,null,null,null]
+    },
+    "cas": "",
+    "time_saved": "2017-09-14T23:54:25.975220906-07:00"
+}`
+
+	// Create via the SDK with sync metadata intact
+	_, err := bucket.WriteCasWithXattr(key, "_sync", 0, 0, []byte(bodyString), []byte(xattrString))
+	assert.NoError(t, err, "Error writing doc w/ xattr")
+
+	// Attempt to get the documents via Sync Gateway.  Should successfully retrieve doc by triggering
+	// checkForUpgrade handling to detect metadata in xattr.
+	response := rt.SendAdminRequest("GET", "/db/"+key, "")
+	assert.Equal(t, 200, response.Code)
+	log.Printf("response:%s", response.Body.Bytes())
+
+	// Validate non-xattr write doesn't get upgraded
+	nonMobileKey := "TestUpgradeNoXattr"
+	nonMobileBody := make(map[string]interface{})
+	nonMobileBody["channels"] = "ABC"
+	_, err = bucket.Add(nonMobileKey, 0, nonMobileBody)
+	assert.NoError(t, err, "Error writing SDK doc")
+
+	// Attempt to get the non-mobile via Sync Gateway.  Should return 404.
+	response = rt.SendAdminRequest("GET", "/db/"+nonMobileKey, "")
+	assert.Equal(t, 404, response.Code)
+}
+
+// Test retrieval of a document stored w/ xattrs when running in non-xattr mode (upgrade handling).
+func TestCheckForUpgradeOnWrite(t *testing.T) {
+
+	// Only run when xattrs are disabled, but requires couchbase server since we're writing an xattr directly to the bucket
+	if base.TestUseXattrs() {
+		t.Skip("Check for upgrade test only runs w/ SG_TEST_USE_XATTRS=false")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
+	}
+
+	rt := RestTester{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+	}
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true, "Cache+":true}`)
+
+	// Write doc in SG format (doc + xattr) directly to the bucket
+	key := "TestCheckForUpgrade"
+	bodyString := `
+{
+  "value": "2-d"
+}`
+	xattrString := `
+{
+    "rev": "2-d",
+    "flags": 24,
+    "sequence": 5,
+    "recent_sequences": [1,2,3,4,5],
+    "history": {
+      "revs": [
+        "1-089c019bbfaba27047008599143bc66f",
+        "2-b92296d32600ec90dc05ff18ae61a1e8",
+        "2-b",
+        "2-c",
+        "2-d"
+      ],
+      "parents": [-1,0,0,0,0],
+      "bodymap": {
+        "2": "{\"value\":\"%s\"}",
+        "3": "{\"value\":\"%s\"}"
+      },
+      "bodyKeyMap": {
+      	"1": "_sync:rb:test"
+      },
+      "channels": [null,null,null,null,null]
+    },
+    "cas": "",
+    "time_saved": "2017-09-14T23:54:25.975220906-07:00"
+}`
+
+	// Create via the SDK with sync metadata intact
+	_, err := bucket.WriteCasWithXattr(key, "_sync", 0, 0, []byte(bodyString), []byte(xattrString))
+	assert.NoError(t, err, "Error writing doc w/ xattr")
+	rt.WaitForSequence(5)
+
+	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
+	response := rt.SendAdminRequest("PUT", "/db/"+key+"?rev=2-d", `{"updated":true}`)
+	assert.Equal(t, 201, response.Code)
+	log.Printf("response:%s", response.Body.Bytes())
+
+	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
+	assert.Equal(t, 200, rawResponse.Code)
+	log.Printf("raw response:%s", rawResponse.Body.Bytes())
+	rt.WaitForSequence(6)
+
+	// Validate non-xattr document doesn't get upgraded on attempted write
+	nonMobileKey := "TestUpgradeNoXattr"
+	nonMobileBody := make(map[string]interface{})
+	nonMobileBody["channels"] = "ABC"
+	_, err = bucket.Add(nonMobileKey, 0, nonMobileBody)
+	assert.NoError(t, err, "Error writing SDK doc")
+
+	// Attempt to update the non-mobile document via Sync Gateway.  Should return
+	response = rt.SendAdminRequest("PUT", "/db/"+nonMobileKey, `{"updated":true}`)
+	assert.Equal(t, 409, response.Code)
+	log.Printf("response:%s", response.Body.Bytes())
+}
+
+// Test feed processing of a document stored w/ xattrs when running in non-xattr mode (upgrade handling).
+func TestCheckForUpgradeFeed(t *testing.T) {
+
+	// Only run when xattrs are disabled, but requires couchbase server since we're writing an xattr directly to the bucket
+	if base.TestUseXattrs() {
+		t.Skip("Check for upgrade test only runs w/ SG_TEST_USE_XATTRS=false")
+	}
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
+	}
+
+	rt := RestTester{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+	}
+	defer rt.Close()
+	bucket := rt.Bucket()
+
+	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true, "Cache+":true}`)
+
+	// Write doc in SG format (doc + xattr) directly to the bucket
+	key := "TestCheckForUpgrade"
+	bodyString := `
+{
+  "value": "2-d"
+}`
+	xattrString := `
+{
+    "rev": "1-089c019bbfaba27047008599143bc66f",
+    "sequence": 1,
+    "recent_sequences": [1],
+    "history": {
+      "revs": [
+        "1-089c019bbfaba27047008599143bc66f"
+      ],
+      "parents": [-1],
+      "channels": [null]
+    },
+    "cas": "",
+    "time_saved": "2017-09-14T23:54:25.975220906-07:00"
+}`
+
+	// Create via the SDK with sync metadata intact
+	_, err := bucket.WriteCasWithXattr(key, "_sync", 0, 0, []byte(bodyString), []byte(xattrString))
+	assert.NoError(t, err, "Error writing doc w/ xattr")
+	rt.WaitForSequence(1)
+
+	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
+	response := rt.SendAdminRequest("GET", "/db/_changes", "")
+	assert.Equal(t, 200, response.Code)
+	log.Printf("response:%s", response.Body.Bytes())
+
+	// Validate non-xattr document doesn't get processed on attempted feed read
+	nonMobileKey := "TestUpgradeNoXattr"
+	nonMobileBody := make(map[string]interface{})
+	nonMobileBody["channels"] = "ABC"
+	_, err = bucket.Add(nonMobileKey, 0, nonMobileBody)
+	assert.NoError(t, err, "Error writing SDK doc")
+
+	// don't have a way to
+	time.Sleep(2 * time.Second)
+}
+
 // Write a doc via SDK with an expiry value.  Verify that expiry is preserved when doc is imported via DCP feed
 func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1141,8 +1141,8 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	_, err = bucket.Add(nonMobileKey, 0, nonMobileBody)
 	assert.NoError(t, err, "Error writing SDK doc")
 
-	// don't have a way to
-	time.Sleep(2 * time.Second)
+	// We don't have a way to wait for a upgrade that doesn't happen.  To manually test this handling, re-enable the sleep below
+	// time.Sleep(2 * time.Second)
 }
 
 // Write a doc via SDK with an expiry value.  Verify that expiry is preserved when doc is imported via DCP feed


### PR DESCRIPTION
Add tests to validate upgrade handling in read, write, feed processing scenarios; fixed scenarios where document wasn't fully unmarshalled after successful upgrade check, causing subsequent read/write to fail.

- [ ] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/980/
- [ ] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/981/