### PR TITLE
Fix goroutine leak for disconnected BLIP clients

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -101,6 +101,7 @@ const (
 	StatKeyDcpReceivedTime         = "dcp_received_time"
 	StatKeyDcpCachingCount         = "dcp_caching_count"
 	StatKeyDcpCachingTime          = "dcp_caching_time"
+	StatKeyNumLeakedBLIPGoroutines = "num_leaked_blip_goroutines"
 
 	// StatsDeltaSync
 	StatKeyDeltasRequested           = "deltas_requested"

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -106,7 +106,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="255290930ae30483b28f3f1b19966f8b3e2ce8e8"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="4bb96db12c650ee54300bb954760d7c50e040f75"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"encoding/base64"
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"log"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This test performs the following steps against the Sync Gateway passive blip replicator:
@@ -1520,7 +1522,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 
 	deltaSentCount := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltasSent))
 
-	client, err := NewBlipTesterClient(&rt)
+	client, err := NewBlipTesterClient(&rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1577,7 +1579,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(&rt)
+	client, err := NewBlipTesterClient(&rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 	client.ClientDeltas = true
@@ -1620,8 +1622,8 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(&rt)
-	assert.NoError(t, err)
+	client, err := NewBlipTesterClient(&rt, nil)
+	require.NoError(t, err)
 	defer client.Close()
 
 	client.ClientDeltas = true
@@ -1638,13 +1640,13 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 	// Perform a one-shot pull as client 2 to pull down the first revision
 
-	client2, err := NewBlipTesterClient(&rt)
-	assert.NoError(t, err)
+	client2, err := NewBlipTesterClient(&rt, nil)
+	require.NoError(t, err)
 	defer client2.Close()
 
 	client2.ClientDeltas = true
 	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	msg, ok := client2.pullReplication.WaitForMessage(3)
 	assert.True(t, ok)
@@ -1674,7 +1676,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	// Run another one shot pull to get the 2nd revision - validate it comes as delta, and uses cached version
 	client2.ClientDeltas = true
 	err = client2.StartOneshotPull()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	msg2, ok := client2.pullReplication.WaitForMessage(6)
 	assert.True(t, ok)
@@ -1703,7 +1705,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(&rt)
+	client, err := NewBlipTesterClient(&rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1765,7 +1767,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(&rt)
+	client, err := NewBlipTesterClient(&rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1813,7 +1815,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(&rt)
+	client, err := NewBlipTesterClient(&rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1866,4 +1868,54 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/doc1?rev=2-04f16608671387d26f9f3ecd2c68d9a2", "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-04f16608671387d26f9f3ecd2c68d9a2","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
+}
+
+// TestBlipDisconnectBetweenRevReqResp reproduces a goroutine leak seen when disconnecting during a pull replication in-between a rev request being sent, and a rev response being received.
+func TestBlipDisconnectBetweenRevReqResp(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+
+	var rt = RestTester{}
+	defer rt.Close()
+
+	client, err := NewBlipTesterClient(&rt, &BlipTesterClientForcedErrors{
+		PullReplication: BlipTesterReplicatorForcedErrors{
+			// Rev message number for doc5
+			CloseConnectionAtRev: blip.MessageNumber(8),
+		},
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	// Create 10 docs with attachments
+	for i := 0; i < 10; i++ {
+		resp := rt.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/doc%d", i), `{"test":true, "_attachments": {"hello.txt": {"data": ""}}}`)
+		assert.Equal(t, http.StatusCreated, resp.Code)
+	}
+
+	err = rt.WaitForPendingChanges()
+	assert.NoError(t, err)
+
+	err = client.StartPull()
+	assert.NoError(t, err)
+
+	_, found := client.pullReplication.WaitForMessage(8)
+	assert.True(t, found)
+	assert.True(t, atomic.LoadUint32(client.pullReplication.state) == replicatorStateClosed)
+
+	// Give the stats below a chance to be incremented
+	time.Sleep(time.Second * 1)
+
+	// Inspect go-blip's expvars to determine we have not leaked any async_readers
+	var goBlipStats struct {
+		GoroutinesAsyncRead int `json:"goroutines_async_read"`
+	}
+	err = json.Unmarshal([]byte(expvar.Get("goblip").String()), &goBlipStats)
+	assert.NoError(t, err, "error parsing goblip expvar stats")
+	assert.Equal(t, 0, goBlipStats.GoroutinesAsyncRead, "leaked asyncRead goroutines in go-blip")
+
+	// Check our goroutine ref counting stat
+	numLeakedBLIPGoroutines := rt.GetDatabase().DbStats.StatsDatabase().Get(base.StatKeyNumLeakedBLIPGoroutines)
+	assert.Nil(t, numLeakedBLIPGoroutines, "expected num_leaked_blip_goroutines to be uninitialised")
+
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -651,7 +651,6 @@ func (btr *BlipTesterReplicator) GetMessage(serialNumber blip.MessageNumber) (ms
 func (btr *BlipTesterReplicator) WaitForMessage(serialNumber blip.MessageNumber) (msg *blip.Message, found bool) {
 	// Quick return for found message
 	if msg, ok := btr.GetMessage(serialNumber); ok {
-		fmt.Println("WaitForMessage found message instantly")
 		return msg, ok
 	}
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -794,7 +794,7 @@ func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sen
 
 	if err := outrq.setSequence(seq); err != nil {
 		// FIXME: err was previously left unhandled as unable to determine scenarios for which this would be hit
-		fmt.Printf("error during rev push from setSequence: %v\n", err)
+		bh.Logf(base.LevelDebug, base.KeySync, "error during rev push from setSequence: %v\n", err)
 	}
 	outrq.setHistory(revisionHistory)
 


### PR DESCRIPTION
- Adds goroutine ref counting to the blip context, and logs a warning on close when these are not also removed
- Catches errors from BLIP's `sender.Send()` and exits early to avoid goroutines being spawned
- Add test to reproduce goroutine leak from disconnecting clients mid-rev message
- Enhanced BlipTesterClient to force errors for above test

## TODO
- [x] manifest bump after https://github.com/couchbase/go-blip/pull/36