### PR TITLE
Never send noreply in rev messages

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -138,6 +138,8 @@ const (
 	StatKeyRevSendCount                     = "rev_send_count"
 	StatKeyRevSendLatency                   = "rev_send_latency"
 	StatKeyRevProcessingTime                = "rev_processing_time"
+	StatKeyRevRespCount                     = "rev_resp_count" // Number of non-nil responses we received to a rev request
+	StatKeyRevRespTime                      = "rev_resp_time"  // Total time in nanoseconds it took for rev requests to receive a non-nil response
 	StatKeyMaxPending                       = "max_pending"
 	StatKeyAttachmentPullCount              = "attachment_pull_count"
 	StatKeyAttachmentPullBytes              = "attachment_pull_bytes"


### PR DESCRIPTION
Nothing in the replication protocol mandates noreply in sent revs:
> The recipient MUST send a response unless the request was sent 'noreply'. It MUST not send a success response until it has durably added the revision to its database, or has failed to add it.

Allows us to record 2 new stats in the following expvars:
- `rev_resp_count` - Number of non-nil responses we received to a rev request.
- `rev_resp_time`  - Total time in nanoseconds it took for rev requests to receive a non-nil response.

These numbers are probably more interesting when sending batches of >1
![screenshot 2019-03-08 at 10 21 35](https://user-images.githubusercontent.com/1525809/54023099-fb118600-418b-11e9-8e28-50af8fd03bc1.png)
