### PR TITLE
Revert "CBG-255: Created new constructor to avoid RestTester panic"

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -33,7 +33,7 @@ import (
 // Reproduces #3048 Panic when attempting to make invalid update to a conflicting document
 func TestNoPanicInvalidUpdate(t *testing.T) {
 
-	var rt = NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	docId := "conflictTest"
@@ -87,7 +87,7 @@ func TestNoPanicInvalidUpdate(t *testing.T) {
 func TestUserAPI(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	assertStatus(t, rt.SendAdminRequest("GET", "/db/_user/snej", ""), 404)
@@ -196,7 +196,7 @@ func TestUserAPI(t *testing.T) {
 func TestUserPasswordValidation(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)
@@ -246,7 +246,7 @@ func TestUserPasswordValidation(t *testing.T) {
 func TestUserAllowEmptyPassword(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	rt.BucketAllowEmptyPassword()
@@ -332,8 +332,7 @@ function(doc, oldDoc) {
 }
 
 `
-	rtConfig := RestTesterConfig{SyncFn: syncFunction}
-	var rt = NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: syncFunction}
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["profile-bernard"]}`)
@@ -435,7 +434,7 @@ function(doc, oldDoc) {
 }
 
 func TestLoggingKeys(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
@@ -511,7 +510,7 @@ func TestLoggingKeys(t *testing.T) {
 }
 
 func TestLoggingLevels(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
@@ -545,7 +544,7 @@ func TestLoggingLevels(t *testing.T) {
 }
 
 func TestLoggingCombined(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
@@ -570,8 +569,7 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyCache|base.KeyHTTP)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); if(doc.type == "setaccess") { access(doc.owner, doc.channel);}}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel); if(doc.type == "setaccess") { access(doc.owner, doc.channel);}}`}
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"name":"bernard", "password":"letmein", "admin_channels":["foo"]}`)
@@ -648,7 +646,7 @@ func readContinuousChanges(response *TestResponse) ([]db.ChangeEntry, error) {
 
 func TestRoleAPI(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// PUT a role
@@ -690,8 +688,7 @@ func TestGuestUser(t *testing.T) {
 
 	guestUserEndpoint := fmt.Sprintf("/db/_user/%s", base.GuestUsername)
 
-	rtConfig := RestTesterConfig{noAdminParty: true}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{noAdminParty: true}
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodGet, guestUserEndpoint, "")
@@ -728,7 +725,7 @@ func TestGuestUser(t *testing.T) {
 // fixes #974
 func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
@@ -784,7 +781,7 @@ func TestSessionExtension(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
@@ -836,7 +833,7 @@ func TestSessionExtension(t *testing.T) {
 
 func TestSessionAPI(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// create session test users
@@ -927,7 +924,7 @@ func TestFlush(t *testing.T) {
 		t.Skip("sgbucket.DeleteableBucket inteface only supported by Walrus")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	rt.createDoc(t, "doc1")
@@ -948,7 +945,7 @@ func TestFlush(t *testing.T) {
 //Test a single call to take DB offline
 func TestDBOfflineSingle(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -971,7 +968,7 @@ func TestDBOfflineSingle(t *testing.T) {
 // when both calls return
 func TestDBOfflineConcurrent(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1014,7 +1011,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 //Test that a DB can be created offline
 func TestStartDBOffline(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 	log.Printf("Taking DB offline")
@@ -1035,7 +1032,7 @@ func TestStartDBOffline(t *testing.T) {
 //fail with status 503
 func TestDBOffline503Response(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1059,7 +1056,7 @@ func TestDBOffline503Response(t *testing.T) {
 //Take DB offline and ensure can put db config
 func TestDBOfflinePutDbConfig(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1084,7 +1081,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 // Reproduces #2223
 func TestDBGetConfigNames(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1116,7 +1113,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1144,7 +1141,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	//create documents in DB to cause resync to take a few seconds
@@ -1197,7 +1194,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 // Single threaded bring DB online
 func TestDBOnlineSingle(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1231,7 +1228,7 @@ func TestDBOnlineSingle(t *testing.T) {
 //once both goroutines return
 func TestDBOnlineConcurrent(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1257,14 +1254,14 @@ func TestDBOnlineConcurrent(t *testing.T) {
 		defer wg.Done()
 		goroutineresponse1 = rt.SendAdminRequest("POST", "/db/_online", "")
 		assertStatus(t, goroutineresponse1, 200)
-	}(*rt)
+	}(rt)
 
 	var goroutineresponse2 *TestResponse
 	go func(rt RestTester) {
 		defer wg.Done()
 		goroutineresponse2 = rt.SendAdminRequest("POST", "/db/_online", "")
 		assertStatus(t, goroutineresponse2, 200)
-	}(*rt)
+	}(rt)
 
 	//This only waits until both _online requests have been posted
 	//They may not have been processed at this point
@@ -1283,7 +1280,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1328,7 +1325,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1382,7 +1379,7 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
@@ -1442,7 +1439,7 @@ func (rt *RestTester) createSession(t *testing.T, username string) string {
 
 func TestPurgeWithBadJsonPayload(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", "foo")
@@ -1451,7 +1448,7 @@ func TestPurgeWithBadJsonPayload(t *testing.T) {
 
 func TestPurgeWithNonArrayRevisionList(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":"list"}`)
@@ -1464,7 +1461,7 @@ func TestPurgeWithNonArrayRevisionList(t *testing.T) {
 
 func TestPurgeWithEmptyRevisionList(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":[]}`)
@@ -1477,7 +1474,7 @@ func TestPurgeWithEmptyRevisionList(t *testing.T) {
 
 func TestPurgeWithGreaterThanOneRevision(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":["rev1","rev2"]}`)
@@ -1490,7 +1487,7 @@ func TestPurgeWithGreaterThanOneRevision(t *testing.T) {
 
 func TestPurgeWithNonStarRevision(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"foo":["rev1"]}`)
@@ -1502,7 +1499,7 @@ func TestPurgeWithNonStarRevision(t *testing.T) {
 }
 
 func TestPurgeWithStarRevision(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
@@ -1518,7 +1515,7 @@ func TestPurgeWithStarRevision(t *testing.T) {
 }
 
 func TestPurgeWithMultipleValidDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
@@ -1539,7 +1536,7 @@ func TestPurgeWithMultipleValidDocs(t *testing.T) {
 // TestPurgeWithChannelCache will make sure thant upon calling _purge, the channel caches are also cleaned
 // This was fixed in #3765, previously channel caches were not cleaned up
 func TestPurgeWithChannelCache(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar", "channels": ["abc", "def"]}`), http.StatusCreated)
@@ -1564,7 +1561,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 }
 
 func TestPurgeWithSomeInvalidDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"foo":"bar"}`), 201)
@@ -1589,7 +1586,7 @@ func TestReplicateErrorConditions(t *testing.T) {
 		t.Skip("Skip replication tests during integration tests, since they might be leaving replications running in background")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	//Send empty JSON
@@ -1646,7 +1643,7 @@ func TestDocumentChangeReplicate(t *testing.T) {
 		t.Skip("Skip replication tests during integration tests, since they might be leaving replications running in background")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close() // Close RestTester, which closes ServerContext, which stops all replications
 
 	//Initiate synchronous one shot replication

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -59,9 +59,9 @@ func BenchmarkReadOps_Get(b *testing.B) {
 
 	defer base.DisableTestLogging()()
 
-	rt := NewRestTester(b, nil)
+	var rt RestTester
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
 	response := rt.SendAdminRequest("PUT", "/db/doc1k", doc1k_putDoc)
@@ -110,9 +110,9 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 	defer base.DisableTestLogging()()
 
-	rt := NewRestTester(b, nil)
+	var rt RestTester
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	// Get database handle
 	rtDatabase := rt.GetDatabase()
@@ -177,9 +177,9 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 
 	defer base.DisableTestLogging()()
 
-	rt := NewRestTester(b, nil)
+	var rt RestTester
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	// Create user
 	username := "user1"
@@ -250,9 +250,9 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 
 	defer base.DisableTestLogging()()
 
-	rt := NewRestTester(b, nil)
+	var rt RestTester
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	// Create target doc for revs_diff:
 	doc1k_bulkDocs_meta := `"_id":"doc1k", 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -48,7 +48,7 @@ func init() {
 //////// AND NOW THE TESTS:
 
 func TestRoot(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true
 	defer rt.Close()
 
@@ -82,7 +82,7 @@ func (rt *RestTester) createDoc(t *testing.T, docid string) string {
 }
 
 func TestDocLifecycle(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	revid := rt.createDoc(t, "doc")
@@ -94,7 +94,7 @@ func TestDocLifecycle(t *testing.T) {
 
 //Validate that Etag header value is surrounded with double quotes, see issue #808
 func TestDocEtag(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
@@ -164,7 +164,7 @@ func TestDocEtag(t *testing.T) {
 
 // Add and retrieve an attachment, including a subrange
 func TestDocAttachment(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
@@ -204,7 +204,7 @@ func TestDocAttachment(t *testing.T) {
 
 // Add an attachment to a document that has been removed from the users channels
 func TestDocAttachmentOnRemovedRev(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -242,7 +242,7 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 }
 
 func TestDocumentUpdateWithNullBody(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -268,7 +268,7 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 }
 
 func TestFunkyDocIDs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	rt.createDoc(t, "AC%2FDC")
@@ -309,7 +309,7 @@ func TestFunkyDocIDs(t *testing.T) {
 }
 
 func TestFunkyDocAndAttachmentIDs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	attachmentBody := "this is the body of attachment"
@@ -414,7 +414,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 }
 
 func TestCORSOrigin(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true
 	defer rt.Close()
 
@@ -459,7 +459,7 @@ func TestCORSOrigin(t *testing.T) {
 }
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -482,7 +482,7 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 
 // #issue 991
 func TestCORSLoginOriginOnSessionPostNoCORSConfig(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -498,7 +498,7 @@ func TestCORSLoginOriginOnSessionPostNoCORSConfig(t *testing.T) {
 }
 
 func TestNoCORSOriginOnSessionPost(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -513,7 +513,7 @@ func TestNoCORSOriginOnSessionPost(t *testing.T) {
 }
 
 func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -529,7 +529,7 @@ func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
 }
 
 func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -549,7 +549,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 }
 
 func TestNoCORSOriginOnSessionDelete(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	reqHeaders := map[string]string{
@@ -565,7 +565,7 @@ func TestNoCORSOriginOnSessionDelete(t *testing.T) {
 }
 
 func TestManualAttachment(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	doc1revId := rt.createDoc(t, "doc1")
@@ -691,7 +691,7 @@ func TestManualAttachment(t *testing.T) {
 
 // PUT attachment on non-existant docid should create empty doc
 func TestManualAttachmentNewDoc(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// attach to new document using bogus rev (should fail)
@@ -736,7 +736,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 }
 
 func TestBulkDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2}, {"_id": "_local/bulk3", "n": 3}]}`
@@ -771,7 +771,7 @@ func TestBulkDocs(t *testing.T) {
 }
 
 func TestBulkDocsIDGeneration(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	input := `{"docs": [{"n": 1}, {"_id": 123, "n": 2}]}`
@@ -791,8 +791,7 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 func TestBulkDocsUnusedSequences(t *testing.T) {
 
 	//We want a sync function that will reject some docs
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt.Close()
 
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "invalid"}, {"_id": "bulk3", "n": 3}]}`
@@ -839,8 +838,7 @@ func TestBulkDocsUnusedSequences(t *testing.T) {
 func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 
 	//We want a sync function that will reject some docs, create two to simulate two SG instances
-	rtConfig1 := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt1 := NewRestTester(t, &rtConfig1)
+	rt1 := RestTester{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt1.Close()
 
 	input := `{"docs": [{"_id": "bulk1", "n": 1}, {"_id": "bulk2", "n": 2, "type": "invalid"}, {"_id": "bulk3", "n": 3}]}`
@@ -860,8 +858,7 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 	assert.NoError(t, err, "LastSequence error")
 	goassert.Equals(t, lastSequence, uint64(3))
 
-	rtConfig2 := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt2 := NewRestTesterWithBucket(t, &rtConfig2, rt1.RestTesterBucket)
+	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt2.Close()
 
 	rt2.RestTesterServerContext = NewServerContext(&ServerConfig{
@@ -926,8 +923,7 @@ func TestBulkDocsUnusedSequencesMultipleSG(t *testing.T) {
 func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 
 	//We want a sync function that will reject some docs, create two to simulate two SG instances
-	rtConfig1 := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt1 := NewRestTester(t, &rtConfig1)
+	rt1 := RestTester{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt1.Close()
 
 	//add new docs, doc2 will be rejected by sync function
@@ -951,8 +947,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 	assert.NoError(t, err, "LastSequence error")
 	goassert.Equals(t, lastSequence, uint64(3))
 
-	rtConfig2 := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt2 := NewRestTesterWithBucket(t, &rtConfig2, rt1.RestTesterBucket)
+	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt2.Close()
 
 	rt2.RestTesterServerContext = NewServerContext(&ServerConfig{
@@ -1024,8 +1019,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc(t *testing.T) {
 func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 
 	//We want a sync function that will reject some docs, create two to simulate two SG instances
-	rtConfig1 := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt1 := NewRestTester(t, &rtConfig1)
+	rt1 := RestTester{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt1.Close()
 
 	//add new docs, doc2 will be rejected by sync function
@@ -1049,8 +1043,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 	assert.NoError(t, err, "LastSequence error")
 	goassert.Equals(t, lastSequence, uint64(3))
 
-	rtConfig2 := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
-	rt2 := NewRestTesterWithBucket(t, &rtConfig2, rt1.RestTesterBucket)
+	rt2 := RestTester{RestTesterBucket: rt1.RestTesterBucket, SyncFn: `function(doc) {if(doc.type == "invalid") {throw("Rejecting invalid doc")}}`}
 	defer rt2.Close()
 
 	rt2.RestTesterServerContext = NewServerContext(&ServerConfig{
@@ -1130,7 +1123,7 @@ func TestBulkDocsUnusedSequencesMultiRevDoc2SG(t *testing.T) {
 }
 
 func TestBulkDocsEmptyDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	input := `{}`
@@ -1139,7 +1132,7 @@ func TestBulkDocsEmptyDocs(t *testing.T) {
 }
 
 func TestBulkDocsMalformedDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	input := `{"docs":["A","B"]}`
@@ -1154,7 +1147,7 @@ func TestBulkDocsMalformedDocs(t *testing.T) {
 }
 
 func TestBulkGetEmptyDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	input := `{}`
@@ -1166,8 +1159,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccess)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {if(doc.type == "setaccess") {channel(doc.channel); access(doc.owner, doc.channel);} else { requireAccess(doc.channel)}}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -1199,7 +1191,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess)()
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc) {
 			if(doc.type == "roleaccess") {
 				channel(doc.channel);
@@ -1208,7 +1200,6 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 				requireAccess(doc.mustHaveAccess)
 			}
 		}`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	// Create a role with no channels assigned to it
@@ -1249,7 +1240,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 }
 
 func TestBulkDocsNoEdits(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	input := `{"new_edits":false, "docs": [
@@ -1285,7 +1276,7 @@ type RevDiffResponse map[string][]string
 type RevsDiffResponse map[string]RevDiffResponse
 
 func TestRevsDiff(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Create some docs:
@@ -1316,7 +1307,7 @@ func TestRevsDiff(t *testing.T) {
 }
 
 func TestOpenRevs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Create some docs:
@@ -1342,7 +1333,7 @@ func TestOpenRevs(t *testing.T) {
 // Covers feature implemented in issue #2992
 func TestBulkGetPerDocRevsLimit(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Map of doc IDs to latest rev IDs
@@ -1459,7 +1450,7 @@ readerLoop:
 }
 
 func TestLocalDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendRequest("GET", "/db/_local/loc1", "")
@@ -1512,7 +1503,7 @@ func TestResponseEncoding(t *testing.T) {
 	}
 	docJSON := fmt.Sprintf(`{"long": %q}`, str)
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendRequest("PUT", "/db/_local/loc1", docJSON)
@@ -1530,7 +1521,7 @@ func TestResponseEncoding(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
@@ -1560,7 +1551,7 @@ func TestLogin(t *testing.T) {
 
 func TestCustomCookieName(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// In order to test auth, you must disable admin party, which is set by default (should this really be set by default!?)
@@ -1669,7 +1660,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 // Test _all_docs API call under different security scenarios
 func TestAllDocsAccessControl(t *testing.T) {
 	//restTester := initRestTester(db.IntSequenceType, `function(doc) {channel(doc.channels);}`)
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 	type allDocsRow struct {
 		ID    string `json:"id"`
@@ -1889,7 +1880,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 // Test _all_docs API call when using vector sequences (accel), under different security scenarios
 func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
-	rt := initRestTester(db.ClockSequenceType, `function(doc) {channel(doc.channels);}`, t)
+	rt := initRestTester(db.ClockSequenceType, `function(doc) {channel(doc.channels);}`)
 	defer rt.Close()
 
 	type allDocsRow struct {
@@ -2114,8 +2105,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD|base.KeyAccel)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2279,7 +2269,7 @@ func TestAccessOnTombstone(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD|base.KeyAccel)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc,oldDoc) {
+	rt := RestTester{SyncFn: `function(doc,oldDoc) {
 			 if (doc.owner) {
 			 	access(doc.owner, doc.channel);
 			 }
@@ -2288,7 +2278,6 @@ func TestAccessOnTombstone(t *testing.T) {
 			 }
 			 channel(doc.channel)
 		 }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2354,8 +2343,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channels)}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2444,8 +2432,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2490,8 +2477,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2639,8 +2625,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 		Rows      []allDocsRow `json:"rows"`
 	}
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channels)}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2714,7 +2699,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 //Test for regression of issue #447
 func TestAttachmentsNoCrossTalk(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	doc1revId := rt.createDoc(t, "doc1")
@@ -2765,7 +2750,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 }
 
 func TestAddingAttachment(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 	defer func() { walrus.MaxDocSize = 0 }()
 
@@ -2825,7 +2810,7 @@ func TestAddingAttachment(t *testing.T) {
 
 func TestOldDocHandling(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc,oldDoc){
 			log("doc id:"+doc._id);
 			if(oldDoc){
@@ -2838,7 +2823,6 @@ func TestOldDocHandling(t *testing.T) {
 				}
 			}
 		}`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2888,7 +2872,7 @@ func TestStarAccess(t *testing.T) {
 	}
 
 	// Create some docs:
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
@@ -3081,7 +3065,7 @@ func TestStarAccess(t *testing.T) {
 
 // Test for issue #562
 func TestCreateTarget(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	//Attempt to create existing target DB on public API
@@ -3095,7 +3079,7 @@ func TestCreateTarget(t *testing.T) {
 // Test for issue 758 - basic auth with stale session cookie
 func TestBasicAuthWithSessionCookie(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	// Create two users
@@ -3210,7 +3194,7 @@ func TestEventConfigValidationInvalid(t *testing.T) {
 // NOTE: to repro, you must run with -race flag
 func TestBulkGetRevPruning(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	var body db.Body
@@ -3276,7 +3260,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 		t.Skip("This test only works with XATTRS disabled")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	var body db.Body
@@ -3468,7 +3452,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 // TestDocExpiry validates the value of the expiry as set in the document.  It doesn't validate actual expiration (not supported
 // in walrus).
 func TestDocExpiry(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	var body db.Body
@@ -3551,8 +3535,7 @@ func TestDocExpiry(t *testing.T) {
 
 // Validate that sync function based expiry writes the _exp property to SG metadata in addition to setting CBS expiry
 func TestDocSyncFunctionExpiry(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {expiry(doc.expiry)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {expiry(doc.expiry)}`}
 	defer rt.Close()
 
 	var body db.Body
@@ -3641,8 +3624,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq db.SequenceID
 	}
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel);}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -3748,7 +3730,7 @@ func TestUnsupportedConfig(t *testing.T) {
 }
 
 func TestConflictWithInvalidAttachment(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	//Create Doc
@@ -3806,7 +3788,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 }
 
 func TestConflictingBranchAttachments(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	//Create a document
@@ -3880,11 +3862,9 @@ func TestConflictingBranchAttachments(t *testing.T) {
 }
 
 func TestNumAccessErrors(t *testing.T) {
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc){if (doc.channels.indexOf("foo") > -1){requireRole("foobar")}}`,
 	}
-
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -3942,8 +3922,7 @@ func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
 
 func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 
-	qrtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
-	qrt := NewRestTester(b, &qrtConfig)
+	qrt := RestTester{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	defer qrt.Close()
 
 	b.ResetTimer()
@@ -3960,7 +3939,7 @@ func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
 
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyAll)()
 	//Create test documents
-	rt := NewRestTester(b, nil)
+	var rt RestTester
 	defer rt.Close()
 	keys := make([]string, 5000)
 	for i := 0; i < 5000; i++ {

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -36,7 +36,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP|base.KeyAccel)()
 
-	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`, t)
+	it := initIndexTester(false, `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`)
 	defer it.Close()
 
 	// Create user:
@@ -90,7 +90,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
 
-	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`, t)
+	it := initIndexTester(false, `function(doc) {channel(doc.channel);}`)
 	defer it.Close()
 
 	// Create user:

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -35,7 +35,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
-	bt, err := NewBlipTester(t)
+	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -150,7 +150,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges|base.KeyCache)()
 
-	bt, err := NewBlipTester(t)
+	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -271,7 +271,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
-	bt, err := NewBlipTester(t)
+	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -426,7 +426,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
-	bt, err := NewBlipTester(t)
+	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -593,7 +593,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -633,7 +633,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
-	btUser1, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	btUser1, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -650,7 +650,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 	)
 
 	// Create bliptester that is connected as user2, with access to the * channel
-	btUser2, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	btUser2, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
@@ -692,17 +692,16 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterFromSpec(btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -744,17 +743,16 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterFromSpec(btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -805,17 +803,16 @@ func TestBlipSetCheckpoint(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterFromSpec(btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -873,16 +870,15 @@ func TestReloadUser(t *testing.T) {
     `
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn:       syncFn,
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
@@ -918,16 +914,15 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn:       `function(doc) {channel(doc.channels); access(doc.accessUser, doc.accessChannel);}`,
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
@@ -966,7 +961,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -1005,7 +1000,7 @@ func TestCheckpoint(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -1075,7 +1070,7 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -1117,7 +1112,7 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
@@ -1177,16 +1172,15 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
     `
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn:       syncFn,
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
@@ -1221,7 +1215,7 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
@@ -1259,7 +1253,7 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: true,
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
@@ -1287,7 +1281,7 @@ func TestPutRevConflictsMode(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Create blip tester
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{
 		noConflictsMode: false,
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
@@ -1328,17 +1322,16 @@ func TestGetRemovedDoc(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
 	// Setup
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		noAdminParty: true,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
+		restTester:         &rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterFromSpec(btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1390,9 +1383,9 @@ func TestGetRemovedDoc(t *testing.T) {
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"user1"}, // so it can see user1's docs
-		restTester:                  rt,
+		restTester:                  &rt,
 	}
-	bt2, err := NewBlipTesterFromSpec(t, btSpec2)
+	bt2, err := NewBlipTesterFromSpec(btSpec2)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 
 	// Try to get rev 3 via BLIP API and assert that _removed == true
@@ -1417,7 +1410,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
 
-	bt, err := NewBlipTester(t)
+	bt, err := NewBlipTester()
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -1485,12 +1478,12 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 //   - Actual: only recieve 4 docs (4 revs)
 func TestMissingNoRev(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	rt := RestTester{}
 	btSpec := BlipTesterSpec{
-		restTester: rt,
+		restTester: &rt,
 	}
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterFromSpec(btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1530,13 +1523,12 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
-	rt := NewRestTester(t, &rtConfig)
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
 	deltaSentCount := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltasSent))
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1590,11 +1582,10 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
-	rt := NewRestTester(t, &rtConfig)
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
 	client.ClientDeltas = true
@@ -1634,11 +1625,10 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
-	rt := NewRestTester(t, &rtConfig)
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1656,7 +1646,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 	// Perform a one-shot pull as client 2 to pull down the first revision
 
-	client2, err := NewBlipTesterClient(t, rt)
+	client2, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client2.Close()
 
@@ -1718,11 +1708,10 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
-	rt := NewRestTester(t, &rtConfig)
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1781,11 +1770,10 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
-	rt := NewRestTester(t, &rtConfig)
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -1830,11 +1818,10 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
-	rt := NewRestTester(t, &rtConfig)
+	var rt = RestTester{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClient(&rt)
 	assert.NoError(t, err)
 	defer client.Close()
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/couchbase/go-blip"
@@ -337,8 +336,8 @@ func (btc *BlipTesterClient) getLastReplicatedRev(docID string) (revID string, o
 	return revID, ok
 }
 
-func newBlipTesterReplication(tester testing.TB, id string, btc *BlipTesterClient) (*BlipTesterReplicator, error) {
-	bt, err := NewBlipTesterFromSpec(tester, BlipTesterSpec{restTester: btc.rt})
+func newBlipTesterReplication(id string, btc *BlipTesterClient) (*BlipTesterReplicator, error) {
+	bt, err := NewBlipTesterFromSpec(BlipTesterSpec{restTester: btc.rt})
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +354,7 @@ func newBlipTesterReplication(tester testing.TB, id string, btc *BlipTesterClien
 }
 
 // NewBlipTesterClient returns a client which emulates the behaviour of a CBL client over BLIP.
-func NewBlipTesterClient(tester testing.TB, rt *RestTester) (client *BlipTesterClient, err error) {
+func NewBlipTesterClient(rt *RestTester) (client *BlipTesterClient, err error) {
 	btc := BlipTesterClient{
 		rt:                rt,
 		docs:              make(map[string]map[string][]byte),
@@ -368,10 +367,10 @@ func NewBlipTesterClient(tester testing.TB, rt *RestTester) (client *BlipTesterC
 		return nil, err
 	}
 
-	if btc.pushReplication, err = newBlipTesterReplication(tester, "push"+id.String(), &btc); err != nil {
+	if btc.pushReplication, err = newBlipTesterReplication("push"+id.String(), &btc); err != nil {
 		return nil, err
 	}
-	if btc.pullReplication, err = newBlipTesterReplication(tester, "pull"+id.String(), &btc); err != nil {
+	if btc.pullReplication, err = newBlipTesterReplication("pull"+id.String(), &btc); err != nil {
 		return nil, err
 	}
 

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -62,7 +62,7 @@ func TestAddRevision(t *testing.T) {
 // Reproduces SG #3283
 func TestSubChangesSince(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	testDb := rt.GetDatabase()

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -85,8 +85,7 @@ func TestDocumentNumbers(t *testing.T) {
      		channel(typeof doc.array[0])
   		}
 	}`
-	rtConfig := RestTesterConfig{SyncFn: syncFn}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: syncFn}
 	defer rt.Close()
 
 	for _, test := range tests {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -53,7 +53,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) {
 			if (oldDoc == null) {
 				channel("oldDocNil")
@@ -62,7 +62,6 @@ func TestXattrImportOldDoc(t *testing.T) {
 				channel("docDeleted")
 			}
 		}`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	bucket := rt.Bucket()
@@ -135,9 +134,8 @@ func TestXattrSGTombstone(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) { channel(doc.channels) }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	bucket := rt.Bucket()
@@ -243,9 +241,8 @@ func TestXattrResurrectViaSG(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) { channel(doc.channels) }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	rt.Bucket()
@@ -288,9 +285,8 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) { channel(doc.channels) }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	bucket := rt.Bucket()
@@ -349,9 +345,8 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) { channel(doc.channels) }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	bucket := rt.Bucket()
@@ -394,9 +389,8 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) { channel(doc.channels) }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	bucket := rt.Bucket()
@@ -464,13 +458,12 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	SkipImportTestsIfNotEnabled(t)
 
 	importFilter := `function (doc) { return doc.type == "mobile"}`
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportFilter: &importFilter,
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -515,10 +508,9 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -569,10 +561,9 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -626,13 +617,12 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			AutoImport: "continuous",
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -701,10 +691,9 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -747,10 +736,9 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -813,10 +801,9 @@ func TestMigrateTombstone(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -879,10 +866,9 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -952,10 +938,9 @@ func TestCheckForUpgradeOnRead(t *testing.T) {
 		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
 	}
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -1028,10 +1013,9 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
 	}
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -1110,10 +1094,9 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 		t.Skip("This test won't work under walrus until https://github.com/couchbase/sync_gateway/issues/2390")
 	}
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -1167,13 +1150,12 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			AutoImport: "continuous",
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -1225,13 +1207,12 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			AutoImport: "continuous",
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bucket := rt.Bucket()
 
@@ -1275,7 +1256,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	mobileBody := make(map[string]interface{})
@@ -1313,11 +1294,10 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 
-			rtConfig := RestTesterConfig{
+			rt = RestTester{
 				SyncFn:         `function(doc, oldDoc) { channel(doc.channels) }`,
 				DatabaseConfig: &DbConfig{},
 			}
-			rt := NewRestTester(t, &rtConfig)
 			defer rt.Close()
 			bucket := rt.Bucket()
 
@@ -1364,7 +1344,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	triggerOnDemandViaGet := func(key string) {
@@ -1400,10 +1380,9 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 
 			key := fmt.Sprintf("TestOnDemandGetWriteMigrateWithExpiry-%d", i)
 
-			rtConfig := RestTesterConfig{
+			rt = RestTester{
 				SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 			}
-			rt := NewRestTester(t, &rtConfig)
 			defer rt.Close()
 			bucket := rt.Bucket()
 
@@ -1440,13 +1419,12 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 	SkipImportTestsIfNotEnabled(t)
 
 	importFilter := `function (doc) { return doc.type == "mobile"}`
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportFilter: &importFilter,
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	log.Printf("Starting get bucket....")
@@ -1488,9 +1466,8 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 // Test to write a binary document to the bucket, ensure it's not imported.
 func TestImportBinaryDoc(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `
+	rt := RestTester{SyncFn: `
 		function(doc, oldDoc) { channel(doc.channels) }`}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	log.Printf("Starting get bucket....")
@@ -1514,13 +1491,12 @@ func TestImportRevisionCopy(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportBackupOldRev: true,
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	bucket := rt.Bucket()
@@ -1570,13 +1546,12 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportBackupOldRev: true,
 		},
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	if rt.GetDatabase().DeltaSyncEnabled() {
@@ -1631,10 +1606,9 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	SkipImportTestsIfNotEnabled(t)
 
 	// ImportBackupOldRev not set in config, defaults to false
-	rtConfig := RestTesterConfig{
+	rt := RestTester{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 	}
-	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
 	if rt.GetDatabase().DeltaSyncEnabled() {
@@ -1708,13 +1682,12 @@ func TestDcpBackfill(t *testing.T) {
 	log.Print("Creating new database context")
 
 	// Create a new context, with import docs enabled, to process backfill
-	newRtConfig := RestTesterConfig{
+	newRt := RestTester{
 		DatabaseConfig: &DbConfig{
 			AutoImport: "continuous",
 		},
 		NoFlush: true,
 	}
-	newRt := NewRestTester(t, &newRtConfig)
 	defer newRt.Close()
 	log.Printf("Poke the rest tester so it starts DCP processing:")
 	bucket = newRt.Bucket()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -17,11 +17,10 @@ import (
 	"net/http"
 	"testing"
 
-	"sync/atomic"
-
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"sync/atomic"
 )
 
 // Tests the ConfigServer feature.
@@ -34,7 +33,7 @@ func TestConfigServer(t *testing.T) {
 			"server": "walrus:/fake"
 		}`))
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true
 	defer rt.Close()
 
@@ -86,7 +85,7 @@ func TestConfigServerWithSyncFunction(t *testing.T) {
 	mockClient := NewMockClient()
 	mockClient.RespondToGET(fakeConfigURL+"/db2", MakeResponse(200, nil, responseBody))
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	rt.NoFlush = true
 	defer rt.Close()
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/couchbase/go-blip"
-	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -32,54 +32,21 @@ import (
 
 var gBucketCounter = 0
 
-type RestTesterConfig struct {
-	noAdminParty          bool      // Unless this is true, Admin Party is in full effect
-	SyncFn                string    // put the sync() function source in here (optional)
-	DatabaseConfig        *DbConfig // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
-	NoFlush               bool      // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
-	InitSyncSeq           uint64    // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
-	EnableNoConflictsMode bool      // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
-	distributedIndex      bool      // Test with walrus-based index bucket
-}
-
 type RestTester struct {
-	*RestTesterConfig
-	Testing                 testing.TB
 	RestTesterBucket        base.Bucket
 	RestTesterServerContext *ServerContext
+	noAdminParty            bool      // Unless this is true, Admin Party is in full effect
+	distributedIndex        bool      // Test with walrus-based index bucket
+	SyncFn                  string    // put the sync() function source in here (optional)
+	DatabaseConfig          *DbConfig // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
 	AdminHandler            http.Handler
 	PublicHandler           http.Handler
-}
-
-func NewRestTester(tester testing.TB, restConfig *RestTesterConfig) *RestTester {
-	var rt RestTester
-	if tester == nil {
-		panic("tester parameter cannot be nil")
-	}
-	rt.Testing = tester
-	if restConfig != nil {
-		rt.RestTesterConfig = restConfig
-	} else {
-		rt.RestTesterConfig = &RestTesterConfig{}
-	}
-	return &rt
-}
-
-func NewRestTesterWithBucket(tester testing.TB, restConfig *RestTesterConfig, bucket base.Bucket) *RestTester {
-	rt := NewRestTester(tester, restConfig)
-	if bucket == nil {
-		panic("nil bucket supplied. Use NewRestTester if you aren't supplying a bucket")
-	}
-	rt.RestTesterBucket = bucket
-
-	return rt
+	EnableNoConflictsMode   bool   // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
+	NoFlush                 bool   // Skip bucket flush step during creation.  Used by tests that need to simulate start/stop of Sync Gateway with backing bucket intact.
+	InitSyncSeq             uint64 // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
 }
 
 func (rt *RestTester) Bucket() base.Bucket {
-
-	if rt.Testing == nil {
-		panic("RestTester not properly initialized please use NewRestTester function")
-	}
 
 	if rt.RestTesterBucket != nil {
 		return rt.RestTesterBucket
@@ -96,15 +63,13 @@ func (rt *RestTester) Bucket() base.Bucket {
 				log.Printf("Initializing %s to %d", db.SyncSeqKey, rt.InitSyncSeq)
 				_, incrErr := tempBucket.Incr(db.SyncSeqKey, rt.InitSyncSeq, rt.InitSyncSeq, 0)
 				if incrErr != nil {
-					rt.Testing.Fatalf("Error initializing %s in test bucket: %v", db.SyncSeqKey, incrErr)
-					return nil
+					panic(fmt.Sprintf("Error initializing %s in test bucket: %v", db.SyncSeqKey, incrErr))
 				}
 			}
 			tempBucket.Close()
 		} else {
 			if rt.InitSyncSeq > 0 {
-				rt.Testing.Fatal("RestTester doesn't support NoFlush and InitSyncSeq in same test")
-				return nil
+				panic("RestTester doesn't support NoFlush and InitSyncSeq in same test")
 			}
 		}
 
@@ -165,8 +130,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 		_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(rt.DatabaseConfig)
 		if err != nil {
-			rt.Testing.Fatalf("Error from AddDatabaseFromConfig: %v", err)
-			return nil
+			panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))
 		}
 		rt.RestTesterBucket = rt.RestTesterServerContext.Database("db").Bucket
 
@@ -178,8 +142,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 					base.Infof(base.KeyAll, "WaitForIndexEmpty returned an error: %v.  Dropping indexes and retrying", err)
 					// if WaitForIndexEmpty returns error, drop the indexes and retry
 					if err := base.DropAllBucketIndexes(asGoCbBucket); err != nil {
-						rt.Testing.Fatalf("Failed to drop bucket indexes: %v", err)
-						return nil
+						panic(fmt.Sprintf("Failed to drop bucket indexes: %v", err))
 					}
 
 					continue // Go to the top of the for loop to retry
@@ -194,8 +157,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 		return rt.RestTesterBucket
 	}
 
-	rt.Testing.Fatalf("Failed to create a RestTesterBucket after multiple attempts")
-	return nil
+	panic(fmt.Sprintf("Failed to create a RestTesterBucket after multiple attempts"))
+
 }
 
 func (rt *RestTester) BucketAllowEmptyPassword() base.Bucket {
@@ -221,7 +184,7 @@ func (rt *RestTester) BucketAllowEmptyPassword() base.Bucket {
 	})
 
 	if err != nil {
-		rt.Testing.Fatalf("Error from AddDatabaseFromConfig: %v", err)
+		panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))
 	}
 	rt.RestTesterBucket = rt.RestTesterServerContext.Database("db").Bucket
 
@@ -302,9 +265,6 @@ func (rt *RestTester) DisableGuestUser() {
 }
 
 func (rt *RestTester) Close() {
-	if rt.Testing == nil {
-		panic("RestTester not properly initialized please use NewRestTester function")
-	}
 	if rt.RestTesterServerContext != nil {
 		rt.RestTesterServerContext.Close()
 	}
@@ -688,25 +648,24 @@ func (bt BlipTester) Close() {
 }
 
 // Create a BlipTester using the default spec
-func NewBlipTester(tester testing.TB) (*BlipTester, error) {
+func NewBlipTester() (*BlipTester, error) {
 	defaultSpec := BlipTesterSpec{}
-	return NewBlipTesterFromSpec(tester, defaultSpec)
+	return NewBlipTesterFromSpec(defaultSpec)
 }
 
 // Create a BlipTester using the given spec
-func NewBlipTesterFromSpec(tester testing.TB, spec BlipTesterSpec) (*BlipTester, error) {
+func NewBlipTesterFromSpec(spec BlipTesterSpec) (*BlipTester, error) {
 
 	bt := &BlipTester{}
 
 	if spec.restTester != nil {
 		bt.restTester = spec.restTester
 	} else {
-		rtConfig := RestTesterConfig{
+		rt := RestTester{
 			EnableNoConflictsMode: spec.noConflictsMode,
 			noAdminParty:          spec.noAdminParty,
 		}
-		var rt = NewRestTester(tester, &rtConfig)
-		bt.restTester = rt
+		bt.restTester = &rt
 	}
 
 	// Since blip requests all go over the public handler, wrap the public handler with the httptest server

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -29,7 +29,7 @@ func TestDesignDocs(t *testing.T) {
 		t.Skip("This test only works under walrus -- see https://github.com/couchbase/sync_gateway/issues/2954")
 	}
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendRequest("GET", "/db/_design/foo", "")
@@ -59,7 +59,7 @@ func TestDesignDocs(t *testing.T) {
 
 func TestViewQuery(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
@@ -99,7 +99,7 @@ func TestViewQuery(t *testing.T) {
 //Tests #1109, wh ere design doc contains multiple views
 func TestViewQueryMultipleViews(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	rt := RestTester{}
 	defer rt.Close()
 
 	//Define three views
@@ -129,7 +129,7 @@ func TestViewQueryMultipleViews(t *testing.T) {
 
 func TestViewQueryUserAccess(t *testing.T) {
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	rt.ServerContext().Database("db").SetUserViewsEnabled(true)
@@ -182,7 +182,7 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	// Currently fails against walrus bucket as '_sync' property will exist in doc object if it is emmitted in the map function
 	t.Skip("WARNING: TEST DISABLED")
 
-	rt := NewRestTester(t, nil)
+	var rt RestTester
 	defer rt.Close()
 
 	//Define three views
@@ -218,8 +218,7 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 
 func TestUserViewQuery(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -286,8 +285,7 @@ func TestUserViewQuery(t *testing.T) {
 // This includes a fix for #857
 func TestAdminReduceViewQuery(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -332,8 +330,7 @@ func TestAdminReduceViewQuery(t *testing.T) {
 
 func TestAdminReduceSumQuery(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -364,8 +361,7 @@ func TestAdminReduceSumQuery(t *testing.T) {
 
 func TestAdminGroupReduceSumQuery(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -401,8 +397,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 		t.Skip("Walrus does not support the 'keys' view parameter")
 	}
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view
@@ -439,8 +434,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 		t.Skip("Walrus does not support the 'keys' view parameter")
 	}
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view
@@ -476,8 +470,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 		t.Skip("Walrus does not support the 'keys' view parameter")
 	}
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view
@@ -510,8 +503,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	// Create a view with a reduce:
@@ -542,8 +534,7 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 
 func TestPostInstallCleanup(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
-	rt := NewRestTester(t, &rtConfig)
+	rt := RestTester{SyncFn: `function(doc) {channel(doc.channel)}`}
 	defer rt.Close()
 
 	bucket := rt.Bucket()


### PR DESCRIPTION
Reverts couchbase/sync_gateway#4004, until accel uptake is completed