### PR TITLE
Fix crash caused by BLIP double-close when recovering from panic

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -759,7 +759,6 @@ func (bh *blipHandler) sendRevisionWithProperties(body db.Body, sender *blip.Sen
 			defer func() {
 				if panicked := recover(); panicked != nil {
 					base.Warnf(base.KeyAll, "[%s] PANIC handling 'sendRevision' response: %v\n%s", bh.blipContext.ID, panicked, debug.Stack())
-					bh.close()
 				}
 			}()
 			defer bh.removeAllowedAttachments(attDigests)


### PR DESCRIPTION
Fix panic caused by double-close when recovering from getAttachment goroutine panic.

Repro steps here: https://issues.couchbase.com/browse/CBG-259?focusedCommentId=319587&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-319587

When a BLIP connection times out, the connection is context is already closed, and this goroutine gets a panic from `outrq.Response()`, resulting in a double close, and SG crashing, rather than recovering from the original panic.

```
2019-03-11T12:06:07.481Z [WRN] [7b06ccd5] PANIC handling 'sendRevision' response: Can't get response before message has been sent
goroutine 710 [running]:
runtime/debug.Stack(0xc0157c2e78, 0x480d4a0, 0x4a97250)
    /usr/local/Cellar/go/1.12/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/couchbase/sync_gateway/rest.(*blipHandler).sendRevisionWithProperties.func1.1(0xc002d89080)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:761 +0x6e
panic(0x480d4a0, 0x4a97250)
    /usr/local/Cellar/go/1.12/libexec/src/runtime/panic.go:522 +0x1b5
github.com/couchbase/go-blip.(*Message).Response(0xc002d91170, 0x0)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/go-blip/message.go:214 +0x281
github.com/couchbase/sync_gateway/rest.(*blipHandler).sendRevisionWithProperties.func1(0xc002d89080, 0xc00aa50e50, 0x1, 0x1, 0xc001b708a8)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:766 +0x9f
created by github.com/couchbase/sync_gateway/rest.(*blipHandler).sendRevisionWithProperties
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:758 +0x7af
 -- rest.(*blipHandler).sendRevisionWithProperties.func1.1() at blip_sync.go:761
panic: Can't get response before message has been sent [recovered]
    panic: close of closed channel

goroutine 668 [running]:
github.com/couchbase/sync_gateway/rest.(*blipSyncContext).close(0xc0050c32c0)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:204 +0x39
github.com/couchbase/sync_gateway/rest.(*blipHandler).sendRevisionWithProperties.func1.1(0xc002d89080)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:762 +0x188
panic(0x480d4a0, 0x4a97250)
    /usr/local/Cellar/go/1.12/libexec/src/runtime/panic.go:522 +0x1b5
github.com/couchbase/go-blip.(*Message).Response(0xc0012b0d80, 0x0)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/go-blip/message.go:214 +0x281
github.com/couchbase/sync_gateway/rest.(*blipHandler).sendRevisionWithProperties.func1(0xc002d89080, 0xc009602b20, 0x1, 0x1, 0xc000010cf8)
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:766 +0x9f
created by github.com/couchbase/sync_gateway/rest.(*blipHandler).sendRevisionWithProperties
    /Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/blip_sync.go:758 +0x7af
```