### PR TITLE
CBG-266 Fix patching of pushed doc with modified attachments

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -836,6 +836,11 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 		delete(deltaSrcBody, db.BodyId)
 		delete(deltaSrcBody, db.BodyRev)
 
+		// Convert attachments of type AttachmentsMeta into a plain type we can patch
+		if atts, ok := deltaSrcBody[db.BodyAttachments].(db.AttachmentsMeta); ok {
+			deltaSrcBody[db.BodyAttachments] = map[string]interface{}(atts)
+		}
+
 		deltaSrcMap := map[string]interface{}(deltaSrcBody)
 		err = base.Patch(&deltaSrcMap, delta)
 		if err != nil {


### PR DESCRIPTION
CBG-266 Fix patching of pushed attachments by converting the `AttachmentsMeta` type into a patchable `map[string]interface{}`

The same is done for pull already in `GetDelta`:

https://github.com/couchbase/sync_gateway/blob/fd30c86bc3147446ef3abdcb94f42079f961c4ed/db/crud.go#L413-L415

## Testing
- [x] Manual attachment update with iOS

### Before
```
2019-03-15T14:53:19.148Z [DBG] WS+: c:[369b55a2] Received frame: MSG#7~ (flags=    1000, length=215)
2019-03-15T14:53:19.148Z [DBG] WSFrame+: c:[369b55a2] Incoming BLIP Request: MSG#7~
2019-03-15T14:53:19.149Z [DBG] SyncMsg+: c:[369b55a2] #7: Type:rev Id:mydoc Rev:2-127ea9aaa014c670175f0d85f59fef64c745a400 DeltaSrc:1-9bb8bf8d8fce0ae1f77357b87a20cc4e Sequence:2  User:admin
2019-03-15T14:53:19.149Z [INF] SyncMsg: c:[369b55a2] #7: Type:rev   --> 500 Error patching deltaSrc with delta: property [_attachments] was of unpatchable type db.AttachmentsMeta, but we had a delta to apply to it Time:319.439µs User:admin
2019-03-15T14:53:19.149Z [DBG] WS+: c:[369b55a2] Push ERR#7
2019-03-15T14:53:19.149Z [DBG] WS+: c:[369b55a2] Sending frame: ERR#7 (flags=      10, size=  171)
```

### After
```
2019-03-15T14:54:56.460Z [DBG] WS+: c:[265f614a] Received frame: MSG#7~ (flags=    1000, length=215)
2019-03-15T14:54:56.460Z [DBG] WSFrame+: c:[265f614a] Incoming BLIP Request: MSG#7~
2019-03-15T14:54:56.460Z [DBG] SyncMsg+: c:[265f614a] #7: Type:rev Id:mydoc Rev:2-127ea9aaa014c670175f0d85f59fef64c745a400 DeltaSrc:1-9bb8bf8d8fce0ae1f77357b87a20cc4e Sequence:2  User:admin
2019-03-15T14:54:56.460Z [TRC] Sync: c:[265f614a] docID: mydoc - body after patching: map[_attachments:map[blob_/myblob:map[content_type:image/png digest:sha1-kjMyuTOF0wAPc2GqUflILISzaPM= length:10623 revpos:2 stub:true] hello:map[digest:sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0= length:11 revpos:1 stub:true]] myblob:map[@type:blob content_type:image/png digest:sha1-kjMyuTOF0wAPc2GqUflILISzaPM= length:10623] mystring:Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. updatenum:2]
```