### PR TITLE
CBG-286: Xattr only on supported CB

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -382,11 +382,11 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {
-			xattrsSupported, errServerVersion := IsMinimumServerVersion(bucket, 5, 0)
+			xattrSupported, errServerVersion := IsXattrSupported(&bucket)
 			if errServerVersion != nil {
 				return nil, errServerVersion
 			}
-			if !xattrsSupported {
+			if !xattrSupported {
 				Warnf(KeyAll, "If using XATTRS, Couchbase Server version must be >= 5.0.")
 				return nil, ErrFatalBucketConnection
 			}
@@ -398,6 +398,17 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		bucket = &LoggingBucket{bucket: bucket}
 	}
 	return
+}
+
+func IsXattrSupported(bucket *Bucket) (bool, error) {
+	xattrsSupported, errServerVersion := IsMinimumServerVersion(*bucket, 5, 0)
+	if errServerVersion != nil {
+		return false, errServerVersion
+	}
+	if !xattrsSupported {
+		return false, ErrFatalBucketConnection
+	}
+	return true, nil
 }
 
 func WriteCasJSON(bucket Bucket, key string, value interface{}, cas uint64, exp uint32, callback func(v interface{}) (interface{}, error)) (casOut uint64, err error) {

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -382,11 +382,7 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {
-			xattrSupported, errServerVersion := IsXattrSupported(&bucket)
-			if errServerVersion != nil {
-				return nil, errServerVersion
-			}
-			if !xattrSupported {
+			if !IsXattrSupported(bucket) {
 				Warnf(KeyAll, "If using XATTRS, Couchbase Server version must be >= 5.0.")
 				return nil, ErrFatalBucketConnection
 			}
@@ -400,15 +396,9 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 	return
 }
 
-func IsXattrSupported(bucket *Bucket) (bool, error) {
-	xattrsSupported, errServerVersion := IsMinimumServerVersion(*bucket, 5, 0)
-	if errServerVersion != nil {
-		return false, errServerVersion
-	}
-	if !xattrsSupported {
-		return false, ErrFatalBucketConnection
-	}
-	return true, nil
+func IsXattrSupported(bucket Bucket) bool {
+	xattrsSupported, _ := IsMinimumServerVersion(bucket, 5, 0)
+	return xattrsSupported
 }
 
 func WriteCasJSON(bucket Bucket, key string, value interface{}, cas uint64, exp uint32, callback func(v interface{}) (interface{}, error)) (casOut uint64, err error) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1665,11 +1665,17 @@ func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel Docum
 	if context.UseXattrs() {
 		return nil, nil
 	}
-	doc, rawDocument, err := context.GetDocWithXattr(key, unmarshalLevel)
-	if err != nil || doc == nil || !doc.HasValidSyncData(context.writeSequences()) {
-		return nil, nil
+
+	xattrSupported, _ := base.IsXattrSupported(&context.Bucket)
+
+	if xattrSupported {
+		doc, rawDocument, err := context.GetDocWithXattr(key, unmarshalLevel)
+		if err != nil || doc == nil || !doc.HasValidSyncData(context.writeSequences()) {
+			return nil, nil
+		}
+		return doc, rawDocument
 	}
-	return doc, rawDocument
+	return nil, nil
 }
 
 //////// REVS_DIFF:

--- a/db/crud.go
+++ b/db/crud.go
@@ -1662,18 +1662,16 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 
 // Checks whether a document has a mobile xattr.  Used when running in non-xattr mode to support no downtime upgrade.
 func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*document, *sgbucket.BucketDocument) {
-	if context.UseXattrs() {
+	//If we are using xattrs or Couchbase Server doesn't support them exit out
+	if context.UseXattrs() || !base.IsXattrSupported(context.Bucket) {
 		return nil, nil
 	}
 
-	if base.IsXattrSupported(context.Bucket) {
-		doc, rawDocument, err := context.GetDocWithXattr(key, unmarshalLevel)
-		if err != nil || doc == nil || !doc.HasValidSyncData(context.writeSequences()) {
-			return nil, nil
-		}
-		return doc, rawDocument
+	doc, rawDocument, err := context.GetDocWithXattr(key, unmarshalLevel)
+	if err != nil || doc == nil || !doc.HasValidSyncData(context.writeSequences()) {
+		return nil, nil
 	}
-	return nil, nil
+	return doc, rawDocument
 }
 
 //////// REVS_DIFF:

--- a/db/crud.go
+++ b/db/crud.go
@@ -1662,7 +1662,7 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 
 // Checks whether a document has a mobile xattr.  Used when running in non-xattr mode to support no downtime upgrade.
 func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*document, *sgbucket.BucketDocument) {
-	//If we are using xattrs or Couchbase Server doesn't support them exit out
+	// If we are using xattrs or Couchbase Server doesn't support them, an upgrade isn't going to be in progress
 	if context.UseXattrs() || !base.IsXattrSupported(context.Bucket) {
 		return nil, nil
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1666,9 +1666,7 @@ func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel Docum
 		return nil, nil
 	}
 
-	xattrSupported, _ := base.IsXattrSupported(&context.Bucket)
-
-	if xattrSupported {
+	if base.IsXattrSupported(context.Bucket) {
 		doc, rawDocument, err := context.GetDocWithXattr(key, unmarshalLevel)
 		if err != nil || doc == nil || !doc.HasValidSyncData(context.writeSequences()) {
 			return nil, nil


### PR DESCRIPTION
When processing a document that has been seen over DCP we check whether a document has any sync data xattr, even when running in non-xattr mode. This allows an upgrade to shared bucket access with no down-time. 
However, this check is even performed when the target server doesn't support SUBDOC operations. This is an issue when using Couchbase Server 4.x as this doesn't support SUBDOC operations. Therefore when a SUBDOC operation is attempted an error occurs and the connection that the operation was performed on closes. 
If there are any other operations waiting on that connection they get a 500 error and this is seen in Sync Gateway / gocb as a network error.

With this in mind we now check the server version before attempting to perform a SUBDOC operation. 

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1077/
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1079/