### PR TITLE
Fixes CBG-159 test

### DIFF
--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -138,7 +138,7 @@ func TestViewQueryWithParams(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc2", `{"value": "foo", "key": "test2"}`)
 	assertStatus(t, response, 201)
 
-	result, err := rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&endkey="test2"&end_key="test2"&endkey_docid=doc2&end_key_doc_id=doc2&startkey="test1"&start_key="test1"&startkey_docid=doc1`)
+	result, err := rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&endkey="test2"&endkey_docid=doc2&end_key_doc_id=doc2&startkey="test1"&startkey_docid=doc1`)
 	assert.NoError(t, err, "Unexpected error")
 	assert.Equal(t, 2, len(result.Rows))
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc1", Key: "test1", Value: interface{}(nil)})

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -138,12 +138,17 @@ func TestViewQueryWithParams(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc2", `{"value": "foo", "key": "test2"}`)
 	assertStatus(t, response, 201)
 
-	result, err := rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&end_key=doc2&endkey_docid=dockeys2&end_key_doc_id=doc2&inclusive_end=true&key=&limit=1000&skip=&stale=true&start_key=doc1&startkey_docid=doc1&update_seq=2751&keys=["test1", "test2"]&startkey="test1"&endkey="test2"`)
+	result, err := rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&endkey="test2"&end_key="test2"&endkey_docid=doc2&end_key_doc_id=doc2&startkey="test1"&start_key="test1"&startkey_docid=doc1`)
 	assert.NoError(t, err, "Unexpected error")
 	assert.Equal(t, 2, len(result.Rows))
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc1", Key: "test1", Value: interface{}(nil)})
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc2", Key: "test2", Value: interface{}(nil)})
 
+	result, err = rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&conflicts=true&descending=false&keys=["test1", "test2"]`)
+	assert.NoError(t, err, "Unexpected error")
+	assert.Equal(t, 2, len(result.Rows))
+	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc1", Key: "test1", Value: interface{}(nil)})
+	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc2", Key: "test2", Value: interface{}(nil)})
 }
 
 func TestViewQueryUserAccess(t *testing.T) {


### PR DESCRIPTION
Split the test in two as `keys` cannot be used in conjunction with `startkey` and `endkey`.