### PR TITLE
Map gocb log level info to SG debug

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -24,12 +24,12 @@ var _ gocb.Logger = GoCBLogger{}
 
 // Log wraps the levelled SG logs for gocb to use.
 // Log levels are mapped as follows:
-// Error  -> SG Error
-// Warn   -> SG Warn
-// Info   -> SG Debug
-// Debug  -> SG Trace
-// Trace  -> SG Trace
-// Others -> SG Trace
+//   Error  -> SG Error
+//   Warn   -> SG Warn
+//   Info   -> SG Debug
+//   Debug  -> SG Trace
+//   Trace  -> SG Trace
+//   Others -> SG Trace
 func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
@@ -53,12 +53,12 @@ var _ gocbcore.Logger = GoCBCoreLogger{}
 
 // Log wraps the levelled SG logs for gocbcore to use.
 // Log levels are mapped as follows:
-// Error  -> SG Error
-// Warn   -> SG Warn
-// Info   -> SG Debug
-// Debug  -> SG Trace
-// Trace  -> SG Trace
-// Others -> SG Trace
+//   Error  -> SG Error
+//   Warn   -> SG Warn
+//   Info   -> SG Debug
+//   Debug  -> SG Trace
+//   Trace  -> SG Trace
+//   Others -> SG Trace
 func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -22,12 +22,22 @@ type GoCBLogger struct{}
 
 var _ gocb.Logger = GoCBLogger{}
 
+// Log wraps the levelled SG logs for gocb to use.
+// Log levels are mapped as follows:
+// Error  -> SG Error
+// Warn   -> SG Warn
+// Info   -> SG Debug
+// Debug  -> SG Trace
+// Trace  -> SG Trace
+// Others -> SG Trace
 func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
 		Errorf(KeyGoCB, format, v...)
 	case gocb.LogWarn:
 		Warnf(KeyGoCB, format, v...)
+	case gocb.LogInfo:
+		Debugf(KeyGoCB, format, v...)
 	default:
 		Tracef(KeyGoCB, format, v...)
 	}
@@ -41,12 +51,22 @@ type GoCBCoreLogger struct{}
 
 var _ gocbcore.Logger = GoCBCoreLogger{}
 
+// Log wraps the levelled SG logs for gocbcore to use.
+// Log levels are mapped as follows:
+// Error  -> SG Error
+// Warn   -> SG Warn
+// Info   -> SG Debug
+// Debug  -> SG Trace
+// Trace  -> SG Trace
+// Others -> SG Trace
 func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:
 		Errorf(KeyGoCB, format, v...)
 	case gocbcore.LogWarn:
 		Warnf(KeyGoCB, format, v...)
+	case gocbcore.LogInfo:
+		Debugf(KeyGoCB, format, v...)
 	default:
 		Tracef(KeyGoCB, format, v...)
 	}


### PR DESCRIPTION
Previously, gocb info logging was being logged to trace. It would probably help diagnose some things if this were able to be picked up by sgcollect_info, so bumped to SG debug.