### PR TITLE
Manifest updates for 2.1, 2.5

### DIFF
--- a/manifest/2.1/2.1.3.xml
+++ b/manifest/2.1/2.1.3.xml
@@ -22,14 +22,14 @@
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="build" path="cbbuild" remote="couchbase" revision="51cdfb4ae316289e072ca631cc14eb27b671cc15">
-        <annotation name="VERSION" value="2.1.4" keep="true"/>
+        <annotation name="VERSION" value="2.1.3" keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/2.1.4"/>
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="7143b132dca9aacb245d2208e5b022e7dbf4b736"/>
 
 
     <!-- Sync Gateway Accel-->

--- a/manifest/2.5.xml
+++ b/manifest/2.5.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+
+    <default remote="couchbase" revision="master"/>
+
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="72d5b6031e2bcc209c8bb22521ac9d03916fbe40">
+        <annotation name="VERSION" value="2.5.1"     keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
+
+
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/2.5.1"/>
+
+
+    <!-- Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="cb737fc9d7f506af5bed24ea601e867b1acdcec8"/>
+
+    <!-- Dependencies specific to Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>
+
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
+
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
+
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+
+
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b3109aea1fc8181c9e37e3201398da6c2e713c8a"/>
+
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="4fab5d18974b2155cd9986ecf8e0f1b898da38df"/>
+
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="eb0048566506484772bb1be22c1cf0c8cd9def05"/>
+
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="7b68c492c29f3f952a00a4ba97dac14cc4b2b57e"/>
+
+    <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
+
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
+
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
+
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="54483acdf6d9df0bdc75e1dcd76b87ca17efc66e"/>
+
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="65a9de96d944d83b64dff9d8753fa46e58b58236"/>
+
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="255290930ae30483b28f3f1b19966f8b3e2ce8e8"/>
+
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2b4072e9bf3f329db64686c3ce5f941a001b340e"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+
+    <!-- gozip tools -->
+    <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>
+
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+
+
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+
+
+</manifest>

--- a/manifest/2.5/2.5.0.xml
+++ b/manifest/2.5/2.5.0.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+    <remote fetch="https://github.com/couchbase/" name="couchbase"/>
+    <remote fetch="https://github.com/couchbaselabs/" name="couchbaselabs"/>
+    <remote fetch="https://github.com/couchbasedeps/" name="couchbasedeps"/>
+
+    <remote fetch="https://github.com/tleyden/" name="tleyden"/>
+
+    <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
+
+    <default remote="couchbase" revision="master"/>
+
+    <!-- Build Scripts (required on CI servers) -->
+    <project name="product-texts" path="product-texts" remote="couchbase"/>
+    <project name="build" path="cbbuild" remote="couchbase" revision="72d5b6031e2bcc209c8bb22521ac9d03916fbe40">
+        <annotation name="VERSION" value="2.5.0"     keep="true"/>
+        <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
+        <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
+    </project>
+
+
+    <!-- Sync Gateway -->
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="d3be8100ff9de76cb8cc687ca8b49856b4b55685"/>
+
+
+    <!-- Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="sync-gateway-accel" path="godeps/src/github.com/couchbaselabs/sync-gateway-accel" remote="couchbaselabs_private" revision="cb737fc9d7f506af5bed24ea601e867b1acdcec8"/>
+
+    <!-- Dependencies specific to Sync Gateway Accel-->
+    <project groups="notdefault,sg-accel" name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="97e27ff20421ea35bda1b49c1d12799ba11ef2fe"/>
+
+    <project groups="notdefault,sg-accel" name="go-metrics" path="godeps/src/github.com/rcrowley/go-metrics" remote="couchbasedeps" revision="7aeccdae5c4ea7140b90c8af1dcf9563065cc6dd"/>
+
+    <project groups="notdefault,sg-accel" name="cbauth" path="godeps/src/github.com/couchbase/cbauth" remote="couchbase" revision="1323b92ac2619c29d50e588e59d7a6b4839da629"/>
+
+    <project groups="notdefault,sg-accel" name="cb-heartbeat" path="godeps/src/github.com/couchbase/cb-heartbeat" remote="couchbase" revision="aedb0776e80d25a79d4b17c1f322a75a2c52a518"/>
+
+    <project groups="notdefault,sg-accel" name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="3d39b57188c372649beedd5c13c9003156d5a055"/>
+
+
+    <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
+
+    <project name="go.assert" path="godeps/src/github.com/couchbaselabs/go.assert" remote="couchbaselabs" revision="cfb33e3a0dac05ae1ecbc0e97188c5cf746a1b78"/>
+
+    <project name="retriever" path="godeps/src/github.com/couchbase/retriever" remote="couchbase" revision="19c5a5d92a2f34fb96ae91d26901e4a7076b8020"/>
+
+    <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
+
+    <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b3109aea1fc8181c9e37e3201398da6c2e713c8a"/>
+
+    <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="4fab5d18974b2155cd9986ecf8e0f1b898da38df"/>
+
+    <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="eb0048566506484772bb1be22c1cf0c8cd9def05"/>
+
+    <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="7b68c492c29f3f952a00a4ba97dac14cc4b2b57e"/>
+
+    <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
+
+    <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
+
+    <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="710456e087a6d497e87f41d0a9d98d6a75672186"/>
+
+    <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
+
+    <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="54483acdf6d9df0bdc75e1dcd76b87ca17efc66e"/>
+
+    <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
+
+    <project name="context" path="godeps/src/github.com/gorilla/context" remote="couchbasedeps" revision="215affda49addc4c8ef7e2534915df2c8c35c6cd"/>
+
+    <project name="mux" path="godeps/src/github.com/gorilla/mux" remote="couchbasedeps" revision="043ee6597c29786140136a5747b6a886364f5282"/>
+
+    <project name="npipe" path="godeps/src/github.com/natefinch/npipe" remote="couchbasedeps" revision="0938d701e50e580f5925c773055eb6d6b32a0cbc"/>
+
+    <project name="lumberjack" path="godeps/src/github.com/natefinch/lumberjack" remote="couchbasedeps" revision="aee4629129445bbdfb69aa565537dcfa16544311"/>
+
+    <project name="otto" path="godeps/src/github.com/robertkrimen/otto" remote="couchbasedeps" revision="a813c59b1b4471ff7ecd3b533bac2f7e7d178784"/>
+
+    <project name="go-metrics-1" path="godeps/src/github.com/samuel/go-metrics" remote="couchbasedeps" revision="52e6232924c9e785c3c4117b63a3e58b1f724544"/>
+
+    <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
+
+    <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="sys" path="godeps/src/golang.org/x/sys" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
+
+    <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="65a9de96d944d83b64dff9d8753fa46e58b58236"/>
+
+    <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
+
+    <project name="service" path="godeps/src/github.com/kardianos/service" remote="couchbasedeps" revision="2954cfdd7b0c8ab45ef2aa22a44b5f086201836f"/>
+
+    <project name="osext" path="godeps/src/github.com/kardianos/osext" remote="couchbasedeps" revision="29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc"/>
+
+    <project name="go-oidc" path="godeps/src/github.com/coreos/go-oidc" remote="couchbasedeps" revision="5aa9381f6e998aa16cc96b4347d33dcc29792864"/>
+
+    <project name="go-systemd" path="godeps/src/github.com/coreos/go-systemd" remote="couchbasedeps" revision="1d9051fe7a349daf6dac904c0b277c3520c09368"/>
+
+    <project name="pkg" path="godeps/src/github.com/coreos/pkg" remote="couchbasedeps" revision="160ae6282d8c48a33d8c150e4e4817fdef8a5cde"/>
+
+    <project name="clockwork" path="godeps/src/github.com/jonboulle/clockwork" remote="couchbasedeps" revision="ed104f61ea4877bea08af6f759805674861e968d"/>
+
+    <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
+
+    <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="255290930ae30483b28f3f1b19966f8b3e2ce8e8"/>
+
+    <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
+
+    <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
+
+    <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>
+
+    <project name="opentracing-go" path="godeps/src/github.com/opentracing/opentracing-go" remote="couchbasedeps" revision="6c572c00d1830223701e155de97408483dfcd14a"/>
+
+    <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
+
+    <!-- Enterprise edition dependencies -->
+    <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="2b4072e9bf3f329db64686c3ce5f941a001b340e"/>
+    <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
+
+    <!-- gozip tools -->
+    <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>
+
+    <!-- gosigar -->
+    <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
+    <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>
+    <project name="go-ole" path="godeps/src/github.com/go-ole/go-ole" remote="couchbasedeps" revision="ae2e2a20879aabdd3a51104ab6a4328af2773948"/>
+
+
+    <project name="gopsutil" path="godeps/src/github.com/shirou/gopsutil" remote="couchbasedeps" revision="cce2d16538b41615132a07ec08d5bdc91c1851e3"/>
+
+
+</manifest>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -14,7 +14,7 @@
   <!-- Build Scripts (required on CI servers) -->
   <project name="product-texts" path="product-texts" remote="couchbase"/>
   <project name="build" path="cbbuild" remote="couchbase">
-    <annotation name="VERSION" value="2.5.0"     keep="true"/>
+    <annotation name="VERSION" value="2.6.0"     keep="true"/>
     <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
     <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
   </project>

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -89,6 +89,14 @@
             "go_version": "1.8.5",
             "start_build": 1
         },
+        "manifest/2.1/2.1.3.xml": {
+            "release": "2.1.3",
+            "release_name": "Couchbase Sync Gateway 2.1.3",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.8.5",
+            "start_build": 1
+        },
         "manifest/2.1/2.1.2.1.xml": {
             "release": "2.1.2.1",
             "release_name": "Couchbase Sync Gateway 2.1.2.1",
@@ -98,12 +106,28 @@
             "start_build": 1
         },
         "manifest/2.1.xml": {
-            "release": "2.1.3",
-            "release_name": "Couchbase Sync Gateway 2.1.3",
+            "release": "2.1.4",
+            "release_name": "Couchbase Sync Gateway 2.1.4",
             "production": true,
             "interval": 120,
             "go_version": "1.8.5",
             "start_build": 1
+        },
+        "manifest/2.5.xml": {
+            "release": "2.5.1",
+            "release_name": "Couchbase Sync Gateway 2.5.1",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.11.5",
+            "start_build": 1
+        },
+        "manifest/2.5/2.5.0.xml": {
+            "release": "2.5.0",
+            "release_name": "Couchbase Sync Gateway 2.5.0",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.11.5",
+            "start_build": 270
         },
         "manifest/dev.xml": {
             "release": "dev",

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -2,7 +2,7 @@
     "product": "sync_gateway",
     "manifests": {
         "manifest/default.xml": {
-            "release": "2.5.0",
+            "release": "2.6.0",
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,


### PR DESCRIPTION
- Pins manifests for the final 2.1.3, 2.5.0 builds
- Update 2.1 manifest for the next (2.1.4) release
- Add 2.5 manifest, update for next (2.5.1) release