### PR TITLE
CBG-295 Backport

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1551,9 +1551,13 @@ func (bucket *CouchbaseBucketGoCB) Update(k string, exp uint32, callback sgbucke
 			}
 		}
 
-		// If there was no error, we're done
-		if err == nil {
-			return nil
+		if pkgerrors.Cause(err) == gocb.ErrKeyExists {
+			// retry on cas failure
+		} else if isRecoverableGoCBError(err) {
+			// retry on recoverable failure
+		} else {
+			// err will be nil if successful
+			return err
 		}
 
 	}
@@ -1626,9 +1630,14 @@ func (bucket *CouchbaseBucketGoCB) WriteUpdate(k string, exp uint32, callback sg
 
 			}
 		}
-		// If there was no error, we're done
-		if err == nil {
-			return nil
+
+		if pkgerrors.Cause(err) == gocb.ErrKeyExists {
+			// retry on cas failure
+		} else if isRecoverableGoCBError(err) {
+			// retry on recoverable failure
+		} else {
+			// err will be nil if successful
+			return err
 		}
 	}
 }
@@ -1690,6 +1699,7 @@ func (bucket *CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey strin
 		// Attempt to write the updated document to the bucket.  Mark body for deletion if previous body was non-empty
 		deleteBody := len(value) > 0
 		casOut, writeErr := bucket.WriteWithXattr(k, xattrKey, exp, cas, updatedValue, updatedXattrValue, isDelete, deleteBody)
+
 		switch pkgerrors.Cause(writeErr) {
 		case nil:
 			return casOut, nil

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -12,7 +12,6 @@ package base
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"expvar"
 	"fmt"
 	"sync"
@@ -21,9 +20,9 @@ import (
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
-	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 )
 
 var dcpExpvars *expvar.Map
@@ -463,7 +462,7 @@ func (r *DCPReceiver) initFeed(backfillType uint64) error {
 
 	statsUuids, highSeqnos, err := r.bucket.GetStatsVbSeqno(r.maxVbNo, false)
 	if err != nil {
-		return errors.New("Error retrieving stats-vbseqno - DCP not supported")
+		return pkgerrors.Wrap(err, "Error retrieving stats-vbseqno - DCP not supported")
 	}
 
 	r.vbuuids = statsUuids


### PR DESCRIPTION
Backport #3691 to 2.1.4

Only retry a bucket Update/WriteUpdate with a CAS failure (#3691)
* Only retry a bucket Update/WriteUpdate with a CAS failure
* Fix missing return to prevent loop from exiting