### PR TITLE
CBG-300 - Backport CBG-279 to 2.5.1

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -107,7 +107,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="255290930ae30483b28f3f1b19966f8b3e2ce8e8"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="e3991efe0dd967e665fffd948d11894370c4d78e"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 


### PR DESCRIPTION
Bump go-blip manifest for 2.5.1 to uptake latest master version