### PR TITLE
Improve cache validFrom handling

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -75,20 +75,17 @@ func nextChannelQueryEntry(results sgbucket.QueryResultIterator) (*LogEntry, boo
 
 // Queries the 'channels' view to get a range of sequences of a single channel as LogEntries.
 func (dbc *DatabaseContext) getChangesInChannelFromQuery(
-	channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
+	channelName string, startSeq, endSeq uint64, limit int, activeOnly bool) (LogEntries, error) {
 	if dbc.Bucket == nil {
-		return nil, errors.New("No bucket available for channel view query")
+		return nil, errors.New("No bucket available for channel query")
 	}
 	start := time.Now()
-
-	startSeq := options.Since.SafeSequence() + 1
-
 	usingViews := dbc.Options.UseViews
 
 	entries := make(LogEntries, 0)
 	activeEntryCount := 0
 
-	base.Infof(base.KeyCache, "  Querying 'channels' view for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, options.Limit)
+	base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), startSeq, endSeq, limit)
 
 	// Loop for active-only and limit handling.
 	// The set of changes we get back from the query applies the limit, but includes both active and non-active entries.  When retrieving changes w/ activeOnly=true and a limit,
@@ -96,7 +93,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	for {
 
 		// Query the view or index
-		queryResults, err := dbc.QueryChannels(channelName, startSeq, endSeq, options.Limit)
+		queryResults, err := dbc.QueryChannels(channelName, startSeq, endSeq, limit)
 		if err != nil {
 			return nil, err
 		}
@@ -121,7 +118,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 
 			// If active-only, track the number of non-removal, non-deleted revisions we've seen in the view results
 			// for limit calculation below.
-			if options.ActiveOnly {
+			if activeOnly {
 				if entry.IsActive() {
 					activeEntryCount++
 				}
@@ -144,10 +141,11 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 			return nil, nil
 		}
 
-		// If active-only, loop until either retrieve (limit) entries, or reach endSeq
-		if options.ActiveOnly {
+		// If active-only, loop until either retrieve (limit) active entries, or reach endSeq.  Non-active entries are still
+		// included in the result set for potential cache prepend
+		if activeOnly {
 			// If we've reached limit, we're done
-			if activeEntryCount >= options.Limit || options.Limit == 0 {
+			if activeEntryCount >= limit || limit == 0 {
 				break
 			}
 			// If we've reached endSeq, we're done
@@ -157,7 +155,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 			// Otherwise update startkey and re-query
 
 			startSeq = highSeq + 1
-			base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, options.Limit)
+			base.Infof(base.KeyCache, "  Querying 'channels' for %q (start=#%d, end=#%d, limit=%d)", base.UD(channelName), highSeq+1, endSeq, limit)
 		} else {
 			// If not active-only, we only need one iteration of the loop - the limit applied to the view query is sufficient
 			break
@@ -170,7 +168,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	}
 	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
 		base.Infof(base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
-			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, options.Limit)
+			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, limit)
 	}
 	changeCacheExpvars.Add("view_queries", 1)
 	return entries, nil
@@ -227,6 +225,6 @@ func (dbc *DatabaseContext) getChangesForSequences(sequences []uint64) (LogEntri
 }
 
 // Public channel view call - for unit test support
-func (dbc *DatabaseContext) ChannelViewTest(channelName string, endSeq uint64, options ChangesOptions) (LogEntries, error) {
-	return dbc.getChangesInChannelFromQuery(channelName, endSeq, options)
+func (dbc *DatabaseContext) ChannelViewTest(channelName string, startSeq, endSeq uint64) (LogEntries, error) {
+	return dbc.getChangesInChannelFromQuery(channelName, startSeq, endSeq, 0, false)
 }

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -223,7 +223,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended := cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended := cache.prependChanges(changesToPrepend, 5, 14)
 	assert.Equals(t, numPrepended, 3)
 
 	// Validate cache
@@ -245,7 +245,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	assert.Equals(t, numPrepended, 2)
 
 	// Validate cache
@@ -280,7 +280,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// Prepend empty set, validate validFrom update
-	cache.prependChanges(LogEntries{}, 5, true)
+	cache.prependChanges(LogEntries{}, 5, 14)
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
 	assert.Equals(t, validFrom, uint64(5))
 	assert.Equals(t, len(cachedChanges), 4)
@@ -302,7 +302,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	assert.Equals(t, numPrepended, 1)
 
 	// Validate cache
@@ -336,8 +336,10 @@ func TestPrependChanges(t *testing.T) {
 		e(12, "doc4", "2-a"),
 		e(14, "doc1", "2-a"),
 	}
-	numPrepended = cache.prependChanges(changesToPrepend, 5, true)
+
+	numPrepended = cache.prependChanges(changesToPrepend, 5, 14)
 	assert.Equals(t, numPrepended, 0)
+
 	validFrom, cachedChanges = cache.getCachedChanges(ChangesOptions{})
 	assert.Equals(t, validFrom, uint64(5))
 	assert.Equals(t, len(cachedChanges), 4)
@@ -370,7 +372,7 @@ func TestPrependChanges(t *testing.T) {
 		e(14, "doc1", "2-a"),
 	}
 
-	numPrepended = cache.prependChanges(changesToPrepend, 6, true)
+	numPrepended = cache.prependChanges(changesToPrepend, 6, 14)
 	assert.Equals(t, numPrepended, 0)
 
 	// Validate cache
@@ -425,6 +427,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
 	cache.Remove([]string{"doc5"}, time.Now().Add(-time.Second*5))
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
+
 	assert.Equals(t, len(entries), 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1478,7 +1478,7 @@ func TestChannelView(t *testing.T) {
 	// Query view (retry loop to wait for indexing)
 	for i := 0; i < 10; i++ {
 		var err error
-		entries, err = db.getChangesInChannelFromQuery("*", 0, ChangesOptions{})
+		entries, err = db.getChangesInChannelFromQuery("*", 0, 100, 0, false)
 
 		assertNoError(t, err, "Couldn't create document")
 		if len(entries) >= 1 {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -434,7 +434,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	// Attempt to retrieve via view.  Above operations were all synchronous (on-demand import of SDK delete, SG delete), so
 	// stale=false view results should be immediately updated.
-	results, err := rt.GetDatabase().ChannelViewTest("ABC", 1000, db.ChangesOptions{})
+	results, err := rt.GetDatabase().ChannelViewTest("ABC", 0, 1000)
 	assertNoError(t, err, "Error issuing channel view query")
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)
@@ -1022,13 +1022,13 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 	}
 	testCases := []testcase{
 		{
-			onDemandCallback: triggerOnDemandViaGet,
-			name:             "triggerOnDemandViaGet",
+			onDemandCallback:      triggerOnDemandViaGet,
+			name:                  "triggerOnDemandViaGet",
 			expectedRevGeneration: 1,
 		},
 		{
-			onDemandCallback: triggerOnDemandViaWrite,
-			name:             "triggerOnDemandViaWrite",
+			onDemandCallback:      triggerOnDemandViaWrite,
+			name:                  "triggerOnDemandViaWrite",
 			expectedRevGeneration: 1,
 		},
 	}
@@ -1105,13 +1105,13 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 	}
 	testCases := []testcase{
 		{
-			onDemandCallback: triggerOnDemandViaGet,
-			name:             "triggerOnDemandViaGet",
+			onDemandCallback:      triggerOnDemandViaGet,
+			name:                  "triggerOnDemandViaGet",
 			expectedRevGeneration: 1,
 		},
 		{
-			onDemandCallback: triggerOnDemandViaWrite,
-			name:             "triggerOnDemandViaWrite",
+			onDemandCallback:      triggerOnDemandViaWrite,
+			name:                  "triggerOnDemandViaWrite",
 			expectedRevGeneration: 2,
 		},
 	}


### PR DESCRIPTION
Avoids scenarios where query range and cache validFrom result in query results not being prepended to the cache, or redundant queries being issued because cache validFrom isn't associated with a sequence in the cache.

Backport of #3872 to 2.1.3.1