### PR TITLE
CBG-297: Backport of CBG-286 to 2.1.4

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -25,8 +25,8 @@ import (
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/gocb"
 	"github.com/couchbase/gomemcached"
-	"github.com/couchbase/gomemcached/client"
-	"github.com/couchbase/sg-bucket"
+	memcached "github.com/couchbase/gomemcached/client"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
@@ -686,11 +686,7 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {
-			xattrsSupported, errServerVersion := IsMinimumServerVersion(bucket, 5, 0)
-			if errServerVersion != nil {
-				return nil, errServerVersion
-			}
-			if !xattrsSupported {
+			if !IsXattrSupported(bucket) {
 				Warnf(KeyAll, "If using XATTRS, Couchbase Server version must be >= 5.0.")
 				return nil, ErrFatalBucketConnection
 			}
@@ -702,6 +698,11 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 		bucket = &LoggingBucket{bucket: bucket}
 	}
 	return
+}
+
+func IsXattrSupported(bucket Bucket) bool {
+	xattrsSupported, _ := IsMinimumServerVersion(bucket, 5, 0)
+	return xattrsSupported
 }
 
 func WriteCasJSON(bucket Bucket, key string, value interface{}, cas uint64, exp uint32, callback func(v interface{}) (interface{}, error)) (casOut uint64, err error) {

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -701,6 +701,9 @@ func GetBucket(spec BucketSpec, callback sgbucket.BucketNotifyFn) (bucket Bucket
 }
 
 func IsXattrSupported(bucket Bucket) bool {
+	if bucket == nil {
+		return false
+	}
 	xattrsSupported, _ := IsMinimumServerVersion(bucket, 5, 0)
 	return xattrsSupported
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -683,7 +683,7 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 		}
 		if currentRevIndex == 0 {
 			base.Debugf(base.KeyCRUD, "PutExistingRev(%q): No new revisions to add", base.UD(docid))
-			body["_rev"] = newRev                        // The _rev field is expected by some callers.  If missing, may cause problems for callers.
+			body["_rev"] = newRev                      // The _rev field is expected by some callers.  If missing, may cause problems for callers.
 			return nil, nil, nil, base.ErrUpdateCancel // No new revisions to add
 		}
 
@@ -1463,7 +1463,8 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 
 // Checks whether a document has a mobile xattr.  Used when running in non-xattr mode to support no downtime upgrade.
 func (context *DatabaseContext) checkForUpgrade(key string) (*document, *sgbucket.BucketDocument) {
-	if context.UseXattrs() {
+	// If we are using xattrs or Couchbase Server doesn't support them, an upgrade isn't going to be in progress
+	if context.UseXattrs() || !base.IsXattrSupported(context.Bucket) {
 		return nil, nil
 	}
 	doc, rawDocument, err := context.GetDocWithXattr(key, DocUnmarshalNoHistory)


### PR DESCRIPTION
Backport of [CBG-286 ](https://issues.couchbase.com/browse/CBG-286):
Xattr operations only performed on supported CB