### PR TITLE
CBG-302: Backport CBG-239 & CBG-244 to  2.5.1

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -348,6 +348,11 @@ func (h *handler) handlePprofThreadcreate() error {
 	return nil
 }
 
+func (h *handler) handlePprofMutex() error {
+	httpprof.Handler("mutex").ServeHTTP(h.response, h.rq)
+	return nil
+}
+
 type stats struct {
 	MemStats runtime.MemStats
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -238,6 +238,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, (*handler).handlePprofBlock)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/threadcreate",
 		makeHandler(sc, adminPrivs, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
+	r.Handle("/_debug/pprof/mutex",
+		makeHandler(sc, adminPrivs, (*handler).handlePprofMutex)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/trace",
 		makeHandler(sc, adminPrivs, (*handler).handlePprofTrace)).Methods("GET", "POST")
 	r.Handle("/_post_upgrade",

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -204,7 +204,7 @@ def extract_element_from_logging_config(element, config):
             return
 
 
-def make_collect_logs_tasks(zip_dir, sg_url):
+def make_collect_logs_tasks(zip_dir, sg_url, salt):
 
     sg_log_files = {
         "sg_error.log": "sg_error.log",
@@ -329,7 +329,7 @@ def make_collect_logs_tasks(zip_dir, sg_url):
                 # As long as a task that monitors this log file path has not already been added, add a new task
                 if log_file_item_path not in sg_log_file_paths:
                     print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
-                    task = add_gzip_file_task(sourcefile_path=log_file_item_path)
+                    task = add_gzip_file_task(sourcefile_path=log_file_item_path, salt=salt)
                     sg_tasks.append(task)
 
                 # Track which log file paths have been added so far
@@ -513,7 +513,7 @@ def make_download_expvars_task(sg_url):
     )
 
 
-def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway_executable_path, should_redact):
+def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway_executable_path, should_redact, salt):
 
     # Get path to sg binary (reliable) and config (not reliable)
     sg_binary_path, sg_config_path = get_paths_from_expvars(sg_url)
@@ -526,7 +526,7 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
         sg_binary_path = sync_gateway_executable_path
 
     # Collect logs
-    collect_logs_tasks = make_collect_logs_tasks(zip_dir, sg_url)
+    collect_logs_tasks = make_collect_logs_tasks(zip_dir, sg_url, salt)
 
     py_expvar_task = make_download_expvars_task(sg_url)
 
@@ -687,7 +687,7 @@ def main():
     sg_binary_path = discover_sg_binary_path(options, sg_url)
 
     # Run SG specific tasks
-    for task in make_sg_tasks(zip_dir, sg_url, options.sync_gateway_config, options.sync_gateway_executable, should_redact):
+    for task in make_sg_tasks(zip_dir, sg_url, options.sync_gateway_config, options.sync_gateway_executable, should_redact, options.salt_value):
         runner.run(task)
 
     if sg_binary_path is not None and sg_binary_path != "" and os.path.exists(sg_binary_path):
@@ -707,13 +707,8 @@ def main():
 
     # Build redacted zip file
     if options.redact_level != "none":
-        # We don't want to attempt to redact binary/pprof files, as this could result in corruption
-        blacklist = [
-            'pprof_profile.pb.gz', 'pprof_heap.pb.gz', 'pprof_goroutine.pb.gz',
-            'pprof_block.pb.gz', 'pprof_mutex.pb.gz',
-        ]
         log("Redacting log files to level: %s" % options.redact_level)
-        runner.redact_and_zip(redact_zip_file, 'sgcollect_info', options.salt_value, platform.node(), blacklist)
+        runner.redact_and_zip(redact_zip_file, 'sgcollect_info', options.salt_value, platform.node())
 
     # Build the actual zip file
     runner.zip(zip_filename, 'sgcollect_info', platform.node())

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -126,6 +126,8 @@ def make_http_client_pprof_tasks(sg_url):
         "profile",
         "heap",
         "goroutine",
+        "block",
+        "mutex",
     ]
 
     base_pprof_url = "{0}/_debug/pprof".format(sg_url)
@@ -133,80 +135,13 @@ def make_http_client_pprof_tasks(sg_url):
     pprof_tasks = []
     for profile_type in profile_types:
         sg_pprof_url = "{0}/{1}".format(base_pprof_url, profile_type)
-        task = make_curl_task(name="Collect {0} pprof via http client".format(profile_type),
-                              user="",
-                              password="",
-                              url=sg_pprof_url,
-                              log_file="pprof_http_{0}.log".format(profile_type))
-
-        pprof_tasks.append(task)
-
-    return pprof_tasks
-
-
-def make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url):
-
-    """
-    These tasks use "go tool" to try to collect the pprof data.  This only works if "go" is
-    installed on the target system, but has the advantage that the output will be pre-rendered,
-    possibly into PDFs, which means less work will be required to generate human readable pprof
-    output
-    """
-
-    pprof_tasks = []
-
-    profile_types = [
-        "profile",
-        "heap",
-        "goroutine",
-    ]
-
-    format_types = [
-        "dot",
-        "pdf",
-        "text",
-        "raw",
-    ]
-
-    if sg_binary_path is None:
-        sg_binary_path = ""
-
-    # if sg_binary_path does not point to a file, generate a new path by starting with the location of sgcollect_info script
-    if not os.path.isfile(sg_binary_path):
-        # the filename of the sg_binary without any path information, eg, "sync_gateway"
-        sg_binary_filename = os.path.basename(sg_binary_path)
-
-        # generate path to sync_gateway root folder relative to the location of this sgcollect_info binary (__file__)
-        root_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-
-        sg_binary_path = os.path.join(root_path, "bin", sg_binary_filename)
-
-    sg_pprof_url = "{0}/_debug/pprof".format(sg_url)
-
-    # make sure raw profile gz files end up in results dir
-    os.environ["PPROF_TMPDIR"] = tempfile.mkdtemp()
-
-    for profile_type in profile_types:
-        for format_type in format_types:
-            out_filename = "{0}.{1}".format(profile_type, format_type)
-            dest_path = os.path.join(os.environ["PPROF_TMPDIR"], out_filename)
-            cmd = 'go tool pprof -{0} -seconds=5 "{1}" {2}/{3}'.format(
-                format_type,
-                sg_binary_path,
-                sg_pprof_url,
-                profile_type,
-            )
-            description = "Running go tool pprof -- which can take several seconds: {0} format: {1}".format(
-                profile_type,
-                format_type
-            )
-
-            task = AllOsTask(
-                description,
-                cmd,
-                log_file=dest_path,
-            )
-            pprof_tasks.append(task)
+        clean_task = make_curl_task(name="Collect {0} pprof via http client".format(profile_type),
+                                    user="",
+                                    password="",
+                                    url=sg_pprof_url,
+                                    log_file="pprof_{0}.pb.gz".format(profile_type))
+        clean_task.no_header = True
+        pprof_tasks.append(clean_task)
 
     return pprof_tasks
 
@@ -599,9 +534,6 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
     if sync_gateway_config_path_option is not None and len(sync_gateway_config_path_option) > 0 and os.path.exists(sync_gateway_config_path_option):
         sg_config_path = sync_gateway_config_path_option
 
-    # Add a task to collect pprofs
-    go_tool_pprof_tasks = make_collect_gotool_pprof_tasks(zip_dir, sg_binary_path, sg_url)
-
     http_client_pprof_tasks = make_http_client_pprof_tasks(sg_url)
 
     # Add a task to collect Sync Gateway config
@@ -616,7 +548,6 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
             collect_logs_tasks,
             py_expvar_task,
             http_client_pprof_tasks,
-            go_tool_pprof_tasks,
             config_tasks,
             status_tasks,
         ]
@@ -778,20 +709,14 @@ def main():
     if options.redact_level != "none":
         # We don't want to attempt to redact binary/pprof files, as this could result in corruption
         blacklist = [
-            'profile.text',           'goroutine.text',           'heap.text',
-            'profile.raw',            'goroutine.raw',            'heap.raw',
-            'profile.dot',            'goroutine.dot',            'heap.dot',
-            'profile.pdf',            'goroutine.pdf',            'heap.pdf',
-            'pprof_http_profile.log', 'pprof_http_goroutine.log', 'pprof_http_heap.log'
+            'pprof_profile.pb.gz', 'pprof_heap.pb.gz', 'pprof_goroutine.pb.gz',
+            'pprof_block.pb.gz', 'pprof_mutex.pb.gz',
         ]
         log("Redacting log files to level: %s" % options.redact_level)
         runner.redact_and_zip(redact_zip_file, 'sgcollect_info', options.salt_value, platform.node(), blacklist)
 
     # Build the actual zip file
     runner.zip(zip_filename, 'sgcollect_info', platform.node())
-
-    # Clean up intermediate pprof files
-    shutil.rmtree(os.environ["PPROF_TMPDIR"], ignore_errors=True)
 
     # Upload the zip to the URL to S3 if required
     if upload_url:

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- python -*-
+import StringIO
 import os
 import sys
 import tempfile
@@ -24,12 +25,9 @@ import traceback
 
 
 class LogRedactor:
-    def __init__(self, salt, tmpdir, blacklist=[]):
+    def __init__(self, salt, tmpdir):
         self.target_dir = os.path.join(tmpdir, "redacted")
         os.makedirs(self.target_dir)
-
-        self.blacklist = blacklist
-        print('Redaction blacklist: {0}'.format(blacklist))
 
         self.couchbase_log = CouchbaseLogProcessor(salt)
         self.regular_log = RegularLogProcessor(salt)
@@ -48,12 +46,16 @@ class LogRedactor:
     def redact_file(self, name, ifile):
         ofile = os.path.join(self.target_dir, name)
         _, filename = os.path.split(name)
-        if any(s in filename for s in self.blacklist):
-            print('WARNING: Not redacting blacklisted file {0}'.format(filename))
+        if ".gz" in filename:
+            print('WARNING: Not redacting binary file file {0}'.format(filename))
             return ifile
         self._process_file(ifile, ofile, self.regular_log)
         return ofile
 
+    def redact_string(self, istring):
+        ostring = self.couchbase_log.do("RedactLevel")
+        ostring += self.regular_log.do(istring)
+        return ostring
 
 class CouchbaseLogProcessor:
     def __init__(self, salt):
@@ -319,9 +321,9 @@ class TaskRunner(object):
         elif self.verbosity >= 2:
             log('Skipping "%s" (%s): not for platform %s' % (task.description, task.command_to_print, sys.platform))
 
-    def redact_and_zip(self, filename, log_type, salt, node, blacklist=[]):
+    def redact_and_zip(self, filename, log_type, salt, node):
         files = []
-        redactor = LogRedactor(salt, self.tmpdir, blacklist)
+        redactor = LogRedactor(salt, self.tmpdir)
 
         for name, fp in self.files.iteritems():
             files.append(redactor.redact_file(name, fp.name))
@@ -449,7 +451,7 @@ def make_curl_task(name, url, user="", password="", content_postprocessors=[],
     )
 
 
-def add_gzip_file_task(sourcefile_path, content_postprocessors=[]):
+def add_gzip_file_task(sourcefile_path, salt, content_postprocessors=[]):
     """
     Adds the extracted contents of a file to the output zip
 
@@ -460,11 +462,15 @@ def add_gzip_file_task(sourcefile_path, content_postprocessors=[]):
             contents = infile.read()
             for content_postprocessor in content_postprocessors:
                 contents = content_postprocessor(contents)
-            return contents
+            redactor = LogRedactor(salt, tempfile.mkdtemp())
+            contents = redactor.redact_string(contents)
+
+        out = StringIO.StringIO()
+        with gzip.GzipFile(fileobj=out, mode="w") as f:
+            f.write(contents)
+        return out.getvalue()
 
     log_file = os.path.basename(sourcefile_path)
-    if log_file.endswith('.gz'):
-        log_file = log_file[:-3]
 
     task = PythonTask(
         description="Extracted contents of {0}".format(sourcefile_path),
@@ -472,6 +478,8 @@ def add_gzip_file_task(sourcefile_path, content_postprocessors=[]):
         log_file=log_file,
         log_exception=False,
     )
+
+    task.no_header = True
 
     return task
 

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -317,7 +317,7 @@ class TaskRunner(object):
             fp.flush()
 
         elif self.verbosity >= 2:
-            log('Skipping "%s" (%s): not for platform %s' % (task.description, command_to_print, sys.platform))
+            log('Skipping "%s" (%s): not for platform %s' % (task.description, task.command_to_print, sys.platform))
 
     def redact_and_zip(self, filename, log_type, salt, node, blacklist=[]):
         files = []


### PR DESCRIPTION
Initial CBG called for the backport of CBG-244, however, given that sgcollect_info is mostly stand-alone and that there are a number of sgcollect_info PRs which are beneficial to the product, I opted to add a number of them to the backport.