### PR TITLE
CBG-308 Recover on panic in SimpleChangesFeed goroutine (#4051)

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"time"
 
@@ -360,7 +361,11 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 	go func() {
 
 		defer func() {
-			base.InfofCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed done %s", base.UD(to))
+			if panicked := recover(); panicked != nil {
+				base.WarnfCtx(db.Ctx, base.KeyChanges, "[%s] Unexpected panic sending changes - terminating changes: \n %s", panicked, debug.Stack())
+			} else {
+				base.InfofCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed done %s", base.UD(to))
+			}
 			close(output)
 		}()
 


### PR DESCRIPTION
In the event of a panic, the feed generation goroutine in SimpleChangesFeed should only terminate the associated changes request, not Sync Gateway.

Backports CBG-308 to Iridium.