### PR TITLE
CBG-280 Add stat to track instances of imports cancelled due to CAS

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -112,6 +112,7 @@ const (
 
 	// StatsSharedBucketImport
 	StatKeyImportCount          = "import_count"
+	StatKeyImportCancelCAS      = "import_cancel_cas"
 	StatKeyImportErrorCount     = "import_error_count"
 	StatKeyImportProcessingTime = "import_processing_time"
 

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -121,6 +121,7 @@ func initEmptyStatsMap(key string) *expvar.Map {
 		result.Set(base.StatKeyDeltaPushDocCount, base.ExpvarIntVal(0))
 	case base.StatsGroupKeySharedBucketImport:
 		result.Set(base.StatKeyImportCount, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyImportCancelCAS, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyImportErrorCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyImportProcessingTime, base.ExpvarIntVal(0))
 	case base.StatsGroupKeyCblReplicationPush:

--- a/db/import.go
+++ b/db/import.go
@@ -241,6 +241,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		return nil, err
 	case base.ErrImportCasFailure:
 		// Import was cancelled due to CAS failure.
+		db.DbStats.SharedBucketImport().Add(base.StatKeyImportCancelCAS, 1)
 		return nil, err
 	case base.ErrImportCancelledPurged:
 		// Import ignored


### PR DESCRIPTION
Add a stat to track instances of imports cancelled due to CAS.  Useful for reconciling counts in cases described in https://issues.couchbase.com/browse/CBG-280