### PR TITLE
CBG-325 - Remove remaining "(as user)" logs (changes feed) and rely on context logging

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -193,7 +193,7 @@ func (db *Database) setAttachment(attachment []byte) (AttachmentKey, error) {
 	key := AttachmentKey(Sha1DigestKey(attachment))
 	_, err := db.Bucket.AddRaw(attachmentKeyToString(key), 0, attachment)
 	if err == nil {
-		base.Infof(base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
+		base.InfofCtx(db.Ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
 	}
 	return key, err
 }
@@ -204,7 +204,7 @@ func (db *Database) setAttachments(attachments AttachmentData) error {
 		attachmentSize := int64(len(data))
 		_, err := db.Bucket.AddRaw(attachmentKeyToString(key), 0, data)
 		if err == nil {
-			base.Infof(base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
+			base.InfofCtx(db.Ctx, base.KeyCRUD, "\tAdded attachment %q", base.UD(key))
 			db.DbStats.CblReplicationPush().Add(base.StatKeyAttachmentPushCount, 1)
 			db.DbStats.CblReplicationPush().Add(base.StatKeyAttachmentPushBytes, attachmentSize)
 		} else {
@@ -291,7 +291,7 @@ func (db *Database) WriteMultipartDocument(body Body, writer *multipart.Writer, 
 			info.contentType, _ = meta["content_type"].(string)
 			info.data, err = decodeAttachment(meta["data"])
 			if info.data == nil {
-				base.Warnf(base.KeyAll, "Couldn't decode attachment %q of doc %q: %v", base.UD(name), base.UD(body[BodyId]), err)
+				base.WarnfCtx(db.Ctx, base.KeyAll, "Couldn't decode attachment %q of doc %q: %v", base.UD(name), base.UD(body[BodyId]), err)
 				meta["stub"] = true
 				delete(meta, "data")
 			} else if len(info.data) > kMaxInlineAttachmentSize {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1360,7 +1360,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 				if isRole {
 					for roleName := range db.user.RoleNames() {
 						if roleName == changedPrincipalName {
-							base.Debugf(base.KeyAccess, "Active user belongs to role %q with modified channel access - user %q will be reloaded.", base.UD(roleName), base.UD(db.user.Name()))
+							base.DebugfCtx(db.Ctx, base.KeyAccess, "Active user belongs to role %q with modified channel access - user %q will be reloaded.", base.UD(roleName), base.UD(db.user.Name()))
 							reloadActiveUser = true
 							break
 						}
@@ -1381,7 +1381,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 			db.invalUserRoles(name)
 			//If this is the current in memory db.user, reload to generate updated roles
 			if db.user != nil && db.user.Name() == name {
-				base.Debugf(base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
+				base.DebugfCtx(db.Ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))
 				reloadActiveUser = true
 
 			}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -131,7 +131,7 @@ func (h *handler) handleBLIPSync() error {
 	ctx := blipSyncContext{
 		blipContext:       blipContext,
 		db:                h.db,
-		effectiveUsername: h.currentEffectiveUserName(),
+		effectiveUsername: h.taggedEffectiveUserName(),
 		terminator:        make(chan bool),
 	}
 	defer ctx.close()

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -152,7 +152,7 @@ func (h *handler) handleBLIPSync() error {
 	server := blipContext.WebSocketServer()
 	defaultHandler := server.Handler
 	server.Handler = func(conn *websocket.Conn) {
-		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol. User:%s.", blipContext.ID, ctx.effectiveUsername))
+		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol%s.", blipContext.ID, formatEffectiveUserName(ctx.effectiveUsername)))
 		defer func() {
 			conn.Close() // in case it wasn't closed already
 			ctx.Logf(base.LevelInfo, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -402,13 +402,13 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			case <-heartbeat:
 				_, err = h.response.Write([]byte("\n"))
 				h.flush()
-				base.Debugf(base.KeyChanges, "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserNameAsUser())
+				base.Debugf(base.KeyChanges, "heartbeat written to _changes feed for request received %s", h.formatEffectiveUserName())
 			case <-timeout:
 				message = "OK (timeout)"
 				forceClose = true
 				break loop
 			case <-closeNotify:
-				base.Infof(base.KeyChanges, "Connection lost from client: %v", h.currentEffectiveUserNameAsUser())
+				base.Infof(base.KeyChanges, "Connection lost from client: %v", h.formatEffectiveUserName())
 				forceClose = true
 				break loop
 			case <-h.db.ExitChanges:
@@ -591,14 +591,14 @@ loop:
 		case <-heartbeat:
 			err = send(nil)
 			if h != nil {
-				base.DebugfCtx(database.Ctx, base.KeyChanges, "heartbeat written to _changes feed for request received %s", h.currentEffectiveUserNameAsUser())
+				base.DebugfCtx(database.Ctx, base.KeyChanges, "heartbeat written to _changes feed for request received %s", h.formatEffectiveUserName())
 			}
 		case <-timeout:
 			forceClose = true
 			break loop
 		case <-closeNotify:
 			if h != nil {
-				base.DebugfCtx(database.Ctx, base.KeyChanges, "Client connection lost: %v", h.currentEffectiveUserNameAsUser())
+				base.DebugfCtx(database.Ctx, base.KeyChanges, "Client connection lost: %v", h.formatEffectiveUserName())
 			} else {
 				base.DebugfCtx(database.Ctx, base.KeyChanges, "Client connection lost")
 			}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -227,7 +227,7 @@ func (h *handler) logRequestLine() {
 	}
 
 	queryValues := h.getQueryValues()
-	base.Infof(base.KeyHTTP, " %s: %s %s%s%s", h.formatSerialNumber(), h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, h.formatEffectiveUserName())
+	base.Infof(base.KeyHTTP, " %s: %s %s%s%s", h.formatSerialNumber(), h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, formatEffectiveUserName(h.taggedEffectiveUserName()))
 }
 
 func (h *handler) logRequestBody() {
@@ -539,12 +539,12 @@ func (h *handler) taggedEffectiveUserName() string {
 
 // formatEffectiveUserName formats an effective name for appending to logs.
 // e.g: 'Did xyz (as %s)' or 'Did xyz (as <ud>alice</ud>)'
-func (h *handler) formatEffectiveUserName() string {
-	if name := h.taggedEffectiveUserName(); name != "" {
-		return " (as " + name + ")"
+func formatEffectiveUserName(effectiveUserName string) string {
+	if effectiveUserName == "" {
+		return ""
 	}
 
-	return ""
+	return " (as " + effectiveUserName + ")"
 }
 
 //////// RESPONSES:

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -227,7 +227,7 @@ func (h *handler) logRequestLine() {
 	}
 
 	queryValues := h.getQueryValues()
-	base.Infof(base.KeyHTTP, " %s: %s %s%s%s", h.formatSerialNumber(), h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, formatEffectiveUserName(h.taggedEffectiveUserName()))
+	base.Infof(base.KeyHTTP, " %s: %s %s%s%s", h.formatSerialNumber(), h.rq.Method, base.SanitizeRequestURL(h.rq, &queryValues), proto, h.formattedEffectiveUserName())
 }
 
 func (h *handler) logRequestBody() {
@@ -537,14 +537,14 @@ func (h *handler) taggedEffectiveUserName() string {
 	return "GUEST"
 }
 
-// formatEffectiveUserName formats an effective name for appending to logs.
+// formattedEffectiveUserName formats an effective name for appending to logs.
 // e.g: 'Did xyz (as %s)' or 'Did xyz (as <ud>alice</ud>)'
-func formatEffectiveUserName(effectiveUserName string) string {
-	if effectiveUserName == "" {
-		return ""
+func (h *handler) formattedEffectiveUserName() string {
+	if name := h.taggedEffectiveUserName(); name != "" {
+		return " (as " + name + ")"
 	}
 
-	return " (as " + effectiveUserName + ")"
+	return ""
 }
 
 //////// RESPONSES:


### PR DESCRIPTION
CBG-325 was to properly redact the username _inside_ `(as %s)`, but this was already done in https://github.com/couchbase/sync_gateway/pull/3535

Took the opportunity to do some tidy up of the code/comments instead...
- Removed `effectiveUsername` from the BlipSyncContext struct - we only ever use it in the place where we can access the REST handler to log it.
- Moved remaining changes logs with `(as user)` to use the context logging instead.
- Tidied up `currentEffectiveUserName` and `currentEffectiveUserNameAsUser`