### PR TITLE
Change GoCB log level mapping to no-op Sched logs

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -29,7 +29,7 @@ var _ gocb.Logger = GoCBLogger{}
 //   Info   -> SG Debug
 //   Debug  -> SG Trace
 //   Trace  -> SG Trace
-//   Others -> SG Trace
+//   Others -> no-op
 func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
@@ -38,7 +38,7 @@ func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...inter
 		Warnf(KeyGoCB, format, v...)
 	case gocb.LogInfo:
 		Debugf(KeyGoCB, format, v...)
-	default:
+	case gocb.LogDebug, gocb.LogTrace:
 		Tracef(KeyGoCB, format, v...)
 	}
 	return nil
@@ -58,7 +58,7 @@ var _ gocbcore.Logger = GoCBCoreLogger{}
 //   Info   -> SG Debug
 //   Debug  -> SG Trace
 //   Trace  -> SG Trace
-//   Others -> SG Trace
+//   Others -> no-op
 func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:
@@ -67,7 +67,7 @@ func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v 
 		Warnf(KeyGoCB, format, v...)
 	case gocbcore.LogInfo:
 		Debugf(KeyGoCB, format, v...)
-	default:
+	case gocbcore.LogDebug, gocbcore.LogTrace:
 		Tracef(KeyGoCB, format, v...)
 	}
 	return nil


### PR DESCRIPTION
Related to #4042 

gocb/gocbcore logs 3 at least lines **_per underlying memcached request_** at `gocb.Sched` level.
For a single bucket stats call with 1024 vbuckets and 2 CB nodes, and 1 vbucket replica per node, this can amount to **15,000+ log lines**.

![Screenshot 2019-04-25 at 13 16 27](https://user-images.githubusercontent.com/1525809/56735068-60313300-675c-11e9-96bf-7c42bb641530.png)

This amount of logging when running SG with trace logging and the gocb log key can be slow enough for it to timeout the bucket stats op (for vbseqnos) on startup. The data isn't useful for diagnosing SG issues, and could be obtained through packet captures instead if required.