### PR TITLE
CBG-342 - Check for explicit KeyNotFound in gocb Incr's amt=0 handling

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1796,9 +1796,14 @@ func (bucket *CouchbaseBucketGoCB) Incr(k string, amt, def uint64, exp uint32) (
 	if amt == 0 {
 		var result uint64
 		_, err := bucket.Get(k, &result)
-		if err != nil {
+		if bucket.IsKeyNotFoundError(err) {
+			// Return Incr value as zero
 			return uint64(0), nil
+		} else if err != nil {
+			// Got an error when trying to fetch the value
+			return 0, err
 		}
+		// Got a non-zero value to return
 		return result, nil
 	}
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -22,7 +22,6 @@ import (
 	goassert "github.com/couchbaselabs/go.assert"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"gopkg.in/couchbase/gocbcore.v7"
 )
 
@@ -477,17 +476,11 @@ func TestIncrCounter(t *testing.T) {
 // TestIncrAmtZero covers the special handling in Incr for when amt=0 on an unknown key
 func TestIncrAmtZero(t *testing.T) {
 
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
 	testBucket := GetTestBucketOrPanic()
 	defer testBucket.Close()
+	bucket := testBucket.Bucket
 
 	key := "TestIncrAmtZero"
-
-	bucket, ok := AsGoCBBucket(GetTestBucketOrPanic())
-	require.True(t, ok, "bucket was not a gocb bucket")
 
 	defer func() {
 		err := bucket.Delete(key)
@@ -497,7 +490,7 @@ func TestIncrAmtZero(t *testing.T) {
 	}()
 
 	// key hasn't been created, so we'll fall into the special 'Get' handling in Incr
-	val, err := bucket.Incr(key, 0, 1, 0)
+	val, err := bucket.Incr(key, 0, 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), val)
 
@@ -507,7 +500,7 @@ func TestIncrAmtZero(t *testing.T) {
 	assert.Equal(t, uint64(1), val)
 
 	// Do another amt=0 to make sure we get the new incremented value
-	val, err = bucket.Incr(key, 0, 1, 0)
+	val, err = bucket.Incr(key, 0, 0, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(1), val)
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -481,11 +481,20 @@ func TestIncrAmtZero(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
+	testBucket := GetTestBucketOrPanic()
+	defer testBucket.Close()
+
 	key := "TestIncrAmtZero"
 
 	bucket, ok := AsGoCBBucket(GetTestBucketOrPanic())
 	require.True(t, ok, "bucket was not a gocb bucket")
-	defer bucket.Close()
+
+	defer func() {
+		err := bucket.Delete(key)
+		if err != nil {
+			t.Errorf("Error removing counter from bucket")
+		}
+	}()
 
 	// key hasn't been created, so we'll fall into the special 'Get' handling in Incr
 	val, err := bucket.Incr(key, 0, 1, 0)

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -21,7 +21,7 @@ type LeakyBucket struct {
 // The config object that controls the LeakyBucket behavior
 type LeakyBucketConfig struct {
 
-	// Incr() fails 3 times before finally succeeding
+	// Incr() fails N times before finally succeeding
 	IncrTemporaryFailCount uint16
 
 	// Allows us to force a number of failed executions of GetDDoc, DeleteDDoc and DropIndex. It will fail the


### PR DESCRIPTION
CBG-342

- Check for explicit KeyNotFoundError in gocbbucket.Incr's amt=0 handling

Prevents Incr from reporting incorrect zero value under cases where the Get fails for other unexpected reasons (like persistent network timeouts)

Couldn't force an artificial error in Get from LeakyBucket, as the gocb Incr op is calling the gocb version of Get directly, so no LeakyBucket-defined behaviour.

## Integration Test
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1105/