### PR TITLE
CBG-351 BypassRevisionCache implementation

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -70,6 +70,7 @@ const (
 	// StatsCache
 	StatKeyRevisionCacheHits          = "rev_cache_hits"
 	StatKeyRevisionCacheMisses        = "rev_cache_misses"
+	StatKeyRevisionCacheBypass        = "rev_cache_bypass"
 	StatKeyChannelCacheHits           = "chan_cache_hits"
 	StatKeyChannelCacheMisses         = "chan_cache_misses"
 	StatKeyChannelCacheRevsActive     = "chan_cache_active_revs"

--- a/db/database.go
+++ b/db/database.go
@@ -245,9 +245,9 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	dbContext.terminator = make(chan bool)
 
-	dbContext.revisionCache = NewShardedLRURevisionCache(
+	dbContext.revisionCache = NewRevisionCache(
 		options.RevisionCacheCapacity,
-		dbContext.revCacheLoader,
+		dbContext,
 		dbContext.DbStats.StatsCache(),
 	)
 
@@ -1212,9 +1212,9 @@ func (context *DatabaseContext) SetUserViewsEnabled(value bool) {
 // For test usage
 func (context *DatabaseContext) FlushRevisionCacheForTest() {
 
-	context.revisionCache = NewShardedLRURevisionCache(
+	context.revisionCache = NewRevisionCache(
 		context.Options.RevisionCacheCapacity,
-		context.revCacheLoader,
+		context,
 		context.DbStats.StatsCache(),
 	)
 

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -84,6 +84,7 @@ func initEmptyStatsMap(key string) *expvar.Map {
 		result.Set(base.StatKeyNumSkippedSeqs, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyRevisionCacheHits, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyRevisionCacheMisses, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyRevisionCacheBypass, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheHits, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheMisses, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheRevsActive, base.ExpvarIntVal(0))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	"expvar"
 	"fmt"
 	"log"
 	"strings"
@@ -388,7 +389,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache())
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int))
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -472,7 +473,7 @@ func TestGetRemoved(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache())
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int))
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -547,7 +548,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache())
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int))
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -388,7 +388,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext.revCacheLoader, db.DatabaseContext.DbStats.StatsCache())
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache())
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -472,7 +472,7 @@ func TestGetRemoved(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext.revCacheLoader, db.DatabaseContext.DbStats.StatsCache())
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache())
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -547,7 +547,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext.revCacheLoader, db.DatabaseContext.DbStats.StatsCache())
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache())
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -389,7 +389,8 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int))
+	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -473,7 +474,8 @@ func TestGetRemoved(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int))
+	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -548,7 +550,8 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually remove the temporary backup doc from the bucket
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int))
+	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/import.go
+++ b/db/import.go
@@ -323,7 +323,7 @@ func (db *Database) backupPreImportRevision(docid, revid string) error {
 		return nil
 	}
 
-	previousRev, ok := db.revisionCache.Peek(docid, revid)
+	previousRev, ok := db.revisionCache.Peek(docid, revid, BodyShallowCopy)
 	if !ok {
 		return nil
 	}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -1,40 +1,57 @@
 package db
 
-import "github.com/pkg/errors"
+import (
+	"expvar"
 
-// BypassRevisionCache is an implementation of the RevisionCache interface that does perform any caching.
-// For any Get operation, it will always immediately fetch the requested revision from the bucket.
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/pkg/errors"
+)
+
+// BypassRevisionCache is an implementation of the RevisionCache interface that does not perform any caching.
+// For any Get operation, it will always immediately fetch the requested revision from the backing store.
 type BypassRevisionCache struct {
-	loaderFunc RevisionCacheLoaderFunc
+	backingStore RevisionCacheBackingStore
+	bypassStat   *expvar.Int
+}
+
+func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, statsMap *expvar.Map) (*BypassRevisionCache, error) {
+	if backingStore == nil {
+		return nil, errors.New("nil backingStore")
+	}
+
+	return &BypassRevisionCache{
+		backingStore: backingStore,
+		bypassStat:   statsMap.Get(base.StatKeyRevisionCacheBypass).(*expvar.Int),
+	}, nil
 }
 
 // Get fetches the revision for the given docID and revID immediately from the bucket.
 func (rc *BypassRevisionCache) Get(docID, revID string, copyType BodyCopyType) (docRev DocumentRevision, err error) {
-	if rc.loaderFunc == nil {
-		return DocumentRevision{}, errors.New("nil loaderFunc")
-	}
-
 	docRev.RevID = revID
-	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = rc.loaderFunc(IDAndRev{DocID: docID, RevID: revID})
+	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = revCacheLoader(rc.backingStore, IDAndRev{DocID: docID, RevID: revID})
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+
+	rc.bypassStat.Add(1)
 
 	return docRev, nil
 }
 
 // GetActive fetches the active revision for the given docID immediately from the bucket.
-func (rc *BypassRevisionCache) GetActive(docID string, context *DatabaseContext, copyType BodyCopyType) (docRev DocumentRevision, err error) {
-	doc, err := context.GetDocument(docID, DocUnmarshalAll)
+func (rc *BypassRevisionCache) GetActive(docID string, copyType BodyCopyType) (docRev DocumentRevision, err error) {
+	doc, err := rc.backingStore.GetDocument(docID, DocUnmarshalAll)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
 
 	docRev.RevID = doc.CurrentRev
-	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = context.revCacheLoaderForDocument(doc, doc.syncData.CurrentRev)
+	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.syncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
+
+	rc.bypassStat.Add(1)
 
 	return docRev, nil
 }

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -1,0 +1,55 @@
+package db
+
+import "github.com/pkg/errors"
+
+// BypassRevisionCache is an implementation of the RevisionCache interface that does perform any caching.
+// For any Get operation, it will always immediately fetch the requested revision from the bucket.
+type BypassRevisionCache struct {
+	loaderFunc RevisionCacheLoaderFunc
+}
+
+// Get fetches the revision for the given docID and revID immediately from the bucket.
+func (rc *BypassRevisionCache) Get(docID, revID string, copyType BodyCopyType) (docRev DocumentRevision, err error) {
+	if rc.loaderFunc == nil {
+		return DocumentRevision{}, errors.New("nil loaderFunc")
+	}
+
+	docRev.RevID = revID
+	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = rc.loaderFunc(IDAndRev{DocID: docID, RevID: revID})
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	return docRev, nil
+}
+
+// GetActive fetches the active revision for the given docID immediately from the bucket.
+func (rc *BypassRevisionCache) GetActive(docID string, context *DatabaseContext, copyType BodyCopyType) (docRev DocumentRevision, err error) {
+	doc, err := context.GetDocument(docID, DocUnmarshalAll)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	docRev.RevID = doc.CurrentRev
+	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = context.revCacheLoaderForDocument(doc, doc.syncData.CurrentRev)
+	if err != nil {
+		return DocumentRevision{}, err
+	}
+
+	return docRev, nil
+}
+
+// Peek is a no-op for a BypassRevisionCache, and always returns an empty DocumentRevision with a false 'found' value.
+func (rc *BypassRevisionCache) Peek(docID, revID string) (docRev DocumentRevision, found bool) {
+	return DocumentRevision{}, false
+}
+
+// Put is a no-op for a BypassRevisionCache
+func (rc *BypassRevisionCache) Put(docID string, docRev DocumentRevision) {
+	// no-op
+}
+
+// UpdateDelta is a no-op for a BypassRevisionCache
+func (rc *BypassRevisionCache) UpdateDelta(docID, revID string, toDelta *RevisionDelta) {
+	// no-op
+}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -3,7 +3,6 @@ package db
 import (
 	"expvar"
 
-	"github.com/couchbase/sync_gateway/base"
 	"github.com/pkg/errors"
 )
 
@@ -14,14 +13,14 @@ type BypassRevisionCache struct {
 	bypassStat   *expvar.Int
 }
 
-func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, statsMap *expvar.Map) (*BypassRevisionCache, error) {
+func NewBypassRevisionCache(backingStore RevisionCacheBackingStore, bypassStat *expvar.Int) (*BypassRevisionCache, error) {
 	if backingStore == nil {
 		return nil, errors.New("nil backingStore")
 	}
 
 	return &BypassRevisionCache{
 		backingStore: backingStore,
-		bypassStat:   statsMap.Get(base.StatKeyRevisionCacheBypass).(*expvar.Int),
+		bypassStat:   bypassStat,
 	}, nil
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -57,7 +57,7 @@ func (rc *BypassRevisionCache) GetActive(docID string, copyType BodyCopyType) (d
 }
 
 // Peek is a no-op for a BypassRevisionCache, and always returns an empty DocumentRevision with a false 'found' value.
-func (rc *BypassRevisionCache) Peek(docID, revID string) (docRev DocumentRevision, found bool) {
+func (rc *BypassRevisionCache) Peek(docID, revID string, copyType BodyCopyType) (docRev DocumentRevision, found bool) {
 	return DocumentRevision{}, false
 }
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -26,7 +26,7 @@ type RevisionCache interface {
 
 // Force compile-time check of RevisionCache types for interface
 var _ RevisionCache = &LRURevisionCache{}
-var _ RevisionCache = &ShardedRevisionCache{}
+var _ RevisionCache = &ShardedLRURevisionCache{}
 
 // Revision information as returned by the rev cache
 type DocumentRevision struct {

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -27,6 +27,7 @@ type RevisionCache interface {
 // Force compile-time check of RevisionCache types for interface
 var _ RevisionCache = &LRURevisionCache{}
 var _ RevisionCache = &ShardedLRURevisionCache{}
+var _ RevisionCache = &BypassRevisionCache{}
 
 // Revision information as returned by the rev cache
 type DocumentRevision struct {
@@ -44,6 +45,7 @@ type IDAndRev struct {
 	RevID string
 }
 
+// RevisionDelta stores data about a delta between a revision and ToRevID.
 type RevisionDelta struct {
 	ToRevID           string   // Target revID for the delta
 	DeltaBytes        []byte   // The actual delta

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
@@ -387,17 +386,6 @@ func TestRevisionImmutableDelta(t *testing.T) {
 }
 
 func BenchmarkRevisionCacheRead(b *testing.B) {
-
-	//Create test document
-	_ = func(backingStore RevisionCacheBackingStore, id IDAndRev) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
-		body = Body{
-			BodyId:  id.DocID,
-			BodyRev: id.RevID,
-		}
-		history = Revisions{RevisionsStart: 1}
-		channels = base.SetOf("*")
-		return
-	}
 
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := expvar.Int{}, expvar.Int{}, expvar.Int{}, expvar.Int{}
 	cache := NewLRURevisionCache(5000, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)


### PR DESCRIPTION
- Added the concept of a `RevisionCacheBackingStore` which is an interface that provides `GetDocument()` and `getRevision()` methods for the revcache loader function, which is now a fixed function for all revision caches.
The backing store can be stubbed out in tests (as seen in the `testBackingStore` of `revision_cache_test.go`) but otherwise the existing `*databaseContext` can be passed in.

- Adds a `BypassRevisionCache` type which always fetches documents from the backing store.

- Adds a generic `NewRevisionCache` constructor, which will read the defined options and return a typed revcache based on those.

## Integration test:
- [ ] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1108/