### PR TITLE
 CBG-344 Initialize per-channel cache on query only

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -536,7 +536,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		TimeSaved:    syncData.TimeSaved,
 		Channels:     syncData.Channels,
 	}
-	base.Infof(base.KeyCache, "Received #%d after %3dms (%q / %q)", change.Sequence, int(feedLatency/time.Millisecond), base.UD(change.DocID), change.RevID)
+	base.Infof(base.KeyDCP, "Received #%d after %3dms (%q / %q)", change.Sequence, int(feedLatency/time.Millisecond), base.UD(change.DocID), change.RevID)
 
 	changedChannels := c.processEntry(change)
 	changedChannelsCombined = changedChannelsCombined.Update(changedChannels)
@@ -659,7 +659,7 @@ func (c *changeCache) processPrincipalDoc(docID string, docJSON []byte, isUser b
 		change.DocID = "_role/" + princ.Name
 	}
 
-	base.Infof(base.KeyCache, "Received #%d (%q)", change.Sequence, base.UD(change.DocID))
+	base.Infof(base.KeyDCP, "Received #%d (%q)", change.Sequence, base.UD(change.DocID))
 
 	changedChannels := c.processEntry(change)
 	if c.notifyChange != nil && len(changedChannels) > 0 {
@@ -777,7 +777,7 @@ func (c *changeCache) _addToCache(change *LogEntry) base.Set {
 			updatedChannels = updatedChannels.Add(channels.UserStarChannel)
 		}
 
-		base.Infof(base.KeyCache, "#%d ==> channels %v", change.Sequence, base.UD(updatedChannels))
+		base.Infof(base.KeyDCP, " #%d ==> channels %v", change.Sequence, base.UD(updatedChannels))
 	}()
 
 	if !change.TimeReceived.IsZero() {

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -44,8 +44,6 @@ type ChangeIndex interface {
 
 	// Retrieve changes in a channel
 	GetChanges(channelName string, options ChangesOptions) ([]*LogEntry, error)
-	// Retrieve in-memory changes in a channel
-	GetCachedChanges(channelName string, options ChangesOptions) (validFrom uint64, entries []*LogEntry)
 
 	// Called to add a document to the index
 	DocChanged(event sgbucket.FeedEvent)

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -656,7 +656,7 @@ func (c *channelCache) initializeLateLogs() {
 }
 
 // Retrieve late-arriving sequences that have arrived since the previous sequence.  Retrieves set of sequences, and the last
-// sequence number in the list.  Note that lateLogs is sorted by arrival on Tap, not sequence number.
+// sequence number in the list.  Note that lateLogs is sorted by arrival on feed, not sequence number.
 func (c *channelCache) GetLateSequencesSince(sinceSequence uint64) (entries []*LogEntry, lastSequence uint64, err error) {
 
 	c.lateLogLock.RLock()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2929,8 +2929,8 @@ func TestStarAccess(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc3", `{"channels":["!"]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["gifts"]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":["!"]}`), 201)
-	// document added to "*" channel should only end up available to users with * access
-	assertStatus(t, rt.SendRequest("PUT", "/db/doc6", `{"channels":["*"]}`), 201)
+	// document added to no channel should only end up available to users with * access
+	assertStatus(t, rt.SendRequest("PUT", "/db/doc6", `{"channels":[]}`), 201)
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)


### PR DESCRIPTION
DCP feed processing now only caches data for previously queried channels.  Cache validFrom handling is modified to use high buffered sequences at per-channel cache initialization time, instead of overall cache initialization time.

Inactive channels still trigger sequence buffering and notification during feed processing.