### PR TITLE
CBG-346 Active channel tracking

### DIFF
--- a/auth/principal.go
+++ b/auth/principal.go
@@ -134,9 +134,5 @@ type User interface {
 	// to the same channel, priority is given to values prior to the specified since.
 	FilterToAvailableChannelsForSince(channels base.Set, since base.SequenceClock) (ch.TimedSet, ch.TimedSet)
 
-	// Returns a Set containing channels that the user has access to, that aren't present in the
-	// input set
-	GetAddedChannels(channels ch.TimedSet) base.Set
-
 	setRolesSince(ch.TimedSet)
 }

--- a/base/expvar.go
+++ b/base/expvar.go
@@ -77,6 +77,7 @@ const (
 	StatKeyChannelCacheRevsRemoval    = "chan_cache_removal_revs"
 	StatKeyChannelCacheNumChannels    = "chan_cache_num_channels"
 	StatKeyChannelCacheMaxEntries     = "chan_cache_max_entries"
+	StatKeyChannelCacheActiveChannels = "num_active_channels"
 	StatKeyChannelCachePendingQueries = "chan_cache_pending_queries"
 	StatKeyNumSkippedSeqs             = "num_skipped_seqs"
 	StatKeyAbandonedSeqs              = "abandoned_seqs"

--- a/channels/active_channels.go
+++ b/channels/active_channels.go
@@ -1,0 +1,89 @@
+package channels
+
+import (
+	"expvar"
+	"sync"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// activeChannels is a concurrency-safe map of active replications per channel, modified via
+// incr/decr operations.
+// Incrementing a channel not already in the map adds it to the map.
+// Decrementing a channel's active count to zero removes its entry from the map.
+//
+// Note: private properties shouldn't be accessed directly, to support potential
+// refactoring of activeChannels to use a sharded map as needed.
+type ActiveChannels struct {
+	channelCounts map[string]uint64 // Count of active pull replications (changes) per channel
+	lock          sync.RWMutex      // Mutex for channelCounts map access
+	countStat     *expvar.Int       // Channel count stat
+}
+
+func NewActiveChannels(activeChannelCountStat *expvar.Int) ActiveChannels {
+	return ActiveChannels{
+		channelCounts: make(map[string]uint64),
+		countStat:     activeChannelCountStat,
+	}
+}
+
+// Update changed increments/decrements active channel counts based on a set of changed channels.  Triggered
+// when the set of channels being replicated by a given replication changes.
+func (ac *ActiveChannels) UpdateChanged(changedChannels ChangedKeys) {
+	ac.lock.Lock()
+	for channelName, isIncrement := range changedChannels {
+		if isIncrement {
+			ac._incr(channelName)
+		} else {
+			ac._decr(channelName)
+		}
+	}
+
+	ac.lock.Unlock()
+}
+
+// Active channel counts track channels being replicated by an active changes request.
+func (ac *ActiveChannels) IncrChannels(chans TimedSet) {
+	ac.lock.Lock()
+	for channelName, _ := range chans {
+		ac._incr(channelName)
+	}
+	ac.lock.Unlock()
+}
+
+func (ac *ActiveChannels) DecrChannels(chans TimedSet) {
+	ac.lock.Lock()
+	for channelName, _ := range chans {
+		ac._decr(channelName)
+	}
+	ac.lock.Unlock()
+}
+
+func (ac *ActiveChannels) isActive(channelName string) bool {
+	ac.lock.RLock()
+	_, ok := ac.channelCounts[channelName]
+	ac.lock.RUnlock()
+	return ok
+}
+
+func (ac *ActiveChannels) _incr(channelName string) {
+	current, ok := ac.channelCounts[channelName]
+	if !ok {
+		ac.countStat.Add(1)
+	}
+	ac.channelCounts[channelName] = current + 1
+}
+
+func (ac *ActiveChannels) _decr(channelName string) {
+	current, ok := ac.channelCounts[channelName]
+	if !ok {
+		base.Warnf(base.KeyCache, "Attempt made to decrement inactive channel %s - will be ignored", base.UD(channelName))
+		return
+	}
+	if current <= 1 {
+		delete(ac.channelCounts, channelName)
+		ac.countStat.Add(-1)
+	} else {
+		ac.channelCounts[channelName] = current - 1
+	}
+}

--- a/channels/active_channels_test.go
+++ b/channels/active_channels_test.go
@@ -1,0 +1,53 @@
+package channels
+
+import (
+	"expvar"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveChannelsConcurrency(t *testing.T) {
+
+	activeChannelStat := &expvar.Int{}
+	ac := NewActiveChannels(activeChannelStat)
+	var wg sync.WaitGroup
+
+	// Concurrent Incr, Decr
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ac.IncrChannels(TimedSetFromString("ABC:1,DEF:2,GHI:3,JKL:1,MNO:1"))
+			ac.DecrChannels(TimedSetFromString("ABC:1,DEF:2"))
+		}()
+	}
+	wg.Wait()
+	assert.False(t, ac.isActive("ABC"))
+	assert.False(t, ac.isActive("DEF"))
+	assert.True(t, ac.isActive("GHI"))
+	assert.True(t, ac.isActive("JKL"))
+	assert.True(t, ac.isActive("MNO"))
+	assert.Equal(t, int64(3), activeChannelStat.Value())
+
+	// Concurrent UpdateChanged
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			changedKeys := ChangedKeys{"ABC": true, "DEF": true, "GHI": false, "MNO": true}
+			ac.UpdateChanged(changedKeys)
+			changedKeys = ChangedKeys{"DEF": false}
+			ac.UpdateChanged(changedKeys)
+		}()
+	}
+	wg.Wait()
+	assert.True(t, ac.isActive("ABC"))
+	assert.False(t, ac.isActive("DEF"))
+	assert.False(t, ac.isActive("GHI"))
+	assert.True(t, ac.isActive("JKL"))
+	assert.True(t, ac.isActive("MNO"))
+	assert.Equal(t, int64(3), activeChannelStat.Value())
+
+}

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -237,6 +237,42 @@ func (set TimedSet) UpdateIfPresent(other TimedSet) {
 	}
 }
 
+// TimedSetDiff stores the result of TimedSet.CompareKeys
+// Elements present in the set but not in the other are returned with value true
+// Elements present in the other set but not in set are returned with value false
+// Unchanged elements are not included in ChangedKeys
+type ChangedKeys map[string]bool
+
+// CompareKeys returns sets of added and removed keys between two sets.
+// Elements present in the set but not in the other are returned as 'added'.
+// Elements present in the other set but not in set are returned as 'removed'.
+// of false.
+func (set TimedSet) CompareKeys(other TimedSet) ChangedKeys {
+
+	changed := make(ChangedKeys)
+
+	// Elements in set but not in other
+	for ch := range set {
+		if _, ok := other[ch]; !ok {
+			changed[ch] = true
+		}
+	}
+
+	// If no additions and lengths are the same, then set keys are identical
+	if len(changed) == 0 && len(other) == len(set) {
+		return changed
+	}
+
+	// Elements in other but not in set
+	for ch := range other {
+		if _, ok := set[ch]; !ok {
+			changed[ch] = false
+		}
+	}
+	return changed
+
+}
+
 // TimedSet can unmarshal from either:
 //   1. The regular format {"channel":vbSequence, ...}
 //   2. The sequence-only format {"channel":uint64, ...} or

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -91,6 +91,7 @@ func initEmptyStatsMap(key string) *expvar.Map {
 		result.Set(base.StatKeyChannelCacheRevsTombstone, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheNumChannels, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheMaxEntries, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyChannelCacheActiveChannels, base.ExpvarIntVal(0))
 	case base.StatsGroupKeyDatabase:
 		result.Set(base.StatKeySequenceGetCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeySequenceReservedCount, base.ExpvarIntVal(0))

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1540,9 +1540,9 @@ func TestConcurrentImport(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			doc, err := db.GetDocument("directWrite", DocUnmarshalAll)
-			goassert.True(t, doc != nil)
+			assert.True(t, doc != nil)
 			assert.NoError(t, err, "Document retrieval error")
-			goassert.Equals(t, doc.syncData.CurrentRev, "1-36fa688dc2a2c39a952ddce46ab53d12")
+			assert.Equal(t, "1-36fa688dc2a2c39a952ddce46ab53d12", doc.syncData.CurrentRev)
 		}()
 	}
 	wg.Wait()
@@ -1568,7 +1568,7 @@ func TestViewCustom(t *testing.T) {
 	if err != nil {
 		log.Printf("error putting doc: %v", err)
 	}
-	goassert.True(t, err == nil)
+	assert.True(t, err == nil)
 
 	// Workaround race condition where queryAllDocs doesn't return the doc we just added
 	// TODO: stale=false will guarantee no race when using a couchbase bucket, but this test
@@ -1580,7 +1580,7 @@ func TestViewCustom(t *testing.T) {
 	opts := Body{"stale": false, "reduce": false}
 	viewResult := sgbucket.ViewResult{}
 	errViewCustom := db.Bucket.ViewCustom(DesignDocSyncHousekeeping(), ViewAllDocs, opts, &viewResult)
-	goassert.True(t, errViewCustom == nil)
+	assert.True(t, errViewCustom == nil)
 
 	// assert that the doc added earlier is in the results
 	foundDoc := false
@@ -1589,7 +1589,7 @@ func TestViewCustom(t *testing.T) {
 			foundDoc = true
 		}
 	}
-	goassert.True(t, foundDoc)
+	assert.True(t, foundDoc)
 
 }
 

--- a/db/utils.go
+++ b/db/utils.go
@@ -1,10 +1,10 @@
 package db
 
 import (
+	"context"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"golang.org/x/net/context"
 )
 
 type BackgroundTaskFunc func(ctx context.Context) error

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -292,7 +292,7 @@ func (h *handler) handleChanges() error {
 	// Overall replication counts
 	h.db.DatabaseContext.DbStats.StatsDatabase().Add(base.StatKeyNumReplicationsActive, 1)
 	h.db.DatabaseContext.DbStats.StatsDatabase().Add(base.StatKeyNumReplicationsTotal, 1)
-	defer h.db.DatabaseContext.DbStats.StatsCblReplicationPull().Add(base.StatKeyNumReplicationsActive, -1)
+	defer h.db.DatabaseContext.DbStats.StatsDatabase().Add(base.StatKeyNumReplicationsActive, -1)
 
 	options.Terminator = make(chan bool)
 


### PR DESCRIPTION
Tracks the set of channels that are being actively replicated.  Total active channel count is tracked in expvars as cache.num_active_channels.

Also fixes active replication stat (CBG-336)