### PR TITLE
Kick off integration tests for master merges

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,6 +195,15 @@ pipeline {
                                 }
                             }
                         }
+
+                        stage('Integration Test') {
+                            when { branch 'master' }
+                            steps {
+                                echo 'Queueing Integration test for branch 'master' ...'
+                                // Queues up an async integration test run for the master branch, but waits up to an hour for all merges into master before actually running (via quietPeriod)
+                                build job: 'sync-gateway-integration-master', quietPeriod: 3600, wait: false
+                            }
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,12 +198,11 @@ pipeline {
                     }
                 }
                 stage('Integration') {
-                    //when { branch 'master' }
+                    when { branch 'master' }
                     steps {
                         echo 'Queueing Integration test for branch "master" ...'
                         // Queues up an async integration test run for the master branch, but waits up to an hour for all merges into master before actually running (via quietPeriod)
-                        build job: 'sync-gateway-integration-master', wait: false
-                        //build job: 'sync-gateway-integration-master', quietPeriod: 3600, wait: false
+                        build job: 'sync-gateway-integration-master', quietPeriod: 3600, wait: false
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,15 +195,15 @@ pipeline {
                                 }
                             }
                         }
-
-                        stage('Integration Test') {
-                            when { branch 'master' }
-                            steps {
-                                echo 'Queueing Integration test for branch 'master' ...'
-                                // Queues up an async integration test run for the master branch, but waits up to an hour for all merges into master before actually running (via quietPeriod)
-                                build job: 'sync-gateway-integration-master', quietPeriod: 3600, wait: false
-                            }
-                        }
+                    }
+                }
+                stage('Integration') {
+                    //when { branch 'master' }
+                    steps {
+                        echo 'Queueing Integration test for branch "master" ...'
+                        // Queues up an async integration test run for the master branch, but waits up to an hour for all merges into master before actually running (via quietPeriod)
+                        build job: 'sync-gateway-integration-master', wait: false
+                        //build job: 'sync-gateway-integration-master', quietPeriod: 3600, wait: false
                     }
                 }
             }


### PR DESCRIPTION
- Automatically starts an integration test run with default params for merges into master.

Will wait an hour to de-dupe jobs before kicking off (via `quietPeriod`) to avoid lots of queued up integration runs.

![Screenshot 2019-05-13 at 15 32 40](https://user-images.githubusercontent.com/1525809/57630182-09698d00-7595-11e9-822e-bf4d6cd99d51.png)
