### PR TITLE
Minor tidy of logging "Ptr" util functions

### DIFF
--- a/base/log_level.go
+++ b/base/log_level.go
@@ -82,3 +82,8 @@ func (l *LogLevel) UnmarshalText(text []byte) error {
 	}
 	return fmt.Errorf("unrecognized log level: %q (valid options: %v)", string(text), logLevelNames)
 }
+
+// logLevelPtr is a convenience function that returns a pointer to the given logLevel
+func logLevelPtr(logLevel LogLevel) *LogLevel {
+	return &logLevel
+}

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -126,9 +126,6 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 }
 
 func TestConsoleLogDefaults(t *testing.T) {
-	logLevelPtr := func(level LogLevel) *LogLevel { return &level }
-	logKeyPtr := func(key LogKey) *LogKey { return &key }
-
 	tests := []struct {
 		name     string
 		config   ConsoleLoggerConfig


### PR DESCRIPTION
- Moved `logLevelPtr` to a standalone util function like the `logKeyPtr` one