### PR TITLE
CBG-358 Deprecate legacy "import_docs": "continuous"

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -54,6 +54,8 @@ const (
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"
 
+	DefaultAutoImport = false // Whether Sync Gateway should auto-import docs, if not specified in the config
+
 	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config
 

--- a/examples/config-shared-bucket-filter.json
+++ b/examples/config-shared-bucket-filter.json
@@ -4,7 +4,7 @@
       "server": "http://localhost:8091",
       "bucket": "default",
       "password": "password",
-      "import_docs": "continuous",
+      "import_docs": true,
       "enable_shared_bucket_access":true,  
       "import_filter": `
 		function(doc) {

--- a/examples/config-shared-bucket.json
+++ b/examples/config-shared-bucket.json
@@ -4,7 +4,7 @@
       "server": "http://localhost:8091",
       "bucket": "default",
       "password": "password",
-      "import_docs": "continuous",
+      "import_docs": true,
       "enable_shared_bucket_access":true,
       "allow_conflicts": false,
       "revs_limit": 20

--- a/rest/config.go
+++ b/rest/config.go
@@ -415,7 +415,7 @@ func (dbConfig *DbConfig) AutoImportEnabled() (bool, error) {
 		return true, nil
 	}
 
-	return false, fmt.Errorf("Unrecognized value for import_docs: %#v.  Must be set to true, false, or be omitted entirely", dbConfig.AutoImport)
+	return false, fmt.Errorf("Unrecognized value for import_docs: %#v. Valid values are true and false.", dbConfig.AutoImport)
 }
 
 func (dbConfig DbConfig) validate() error {

--- a/rest/config.go
+++ b/rest/config.go
@@ -401,21 +401,21 @@ func (dbConfig *DbConfig) setup(name string) error {
 }
 
 func (dbConfig *DbConfig) AutoImportEnabled() (bool, error) {
-
-	autoImport := false
-	switch dbConfig.AutoImport {
-	case nil:
-	case false:
-	case true:
-		autoImport = true
-	case "continuous":
-		autoImport = true
-	default:
-		return false, fmt.Errorf("Unrecognized value for import_docs: %#v.  Must be set to 'continuous', true or false, or be omitted entirely", dbConfig.AutoImport)
+	if dbConfig.AutoImport == nil {
+		return base.DefaultAutoImport, nil
 	}
 
-	return autoImport, nil
+	if b, ok := dbConfig.AutoImport.(bool); ok {
+		return b, nil
+	}
 
+	str, ok := dbConfig.AutoImport.(string)
+	if ok && str == "continuous" {
+		base.Warnf(base.KeyAll, `Using deprecated config value for "import_docs": "continuous". Use "import_docs": true instead.`)
+		return true, nil
+	}
+
+	return false, fmt.Errorf("Unrecognized value for import_docs: %#v.  Must be set to true, false, or be omitted entirely", dbConfig.AutoImport)
 }
 
 func (dbConfig DbConfig) validate() error {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -159,3 +159,55 @@ func TestTLSMinimumVersionSetting(t *testing.T) {
 	}
 
 }
+
+func TestAutoImportEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		configValue interface{}
+		want        bool
+		wantErr     bool
+	}{
+		{
+			"default",
+			nil,
+			base.DefaultAutoImport,
+			false,
+		},
+		{
+			"true",
+			true,
+			true,
+			false,
+		},
+		{
+			"false",
+			false,
+			false,
+			false,
+		},
+		{
+			"continuous",
+			"continuous",
+			true,
+			false,
+		},
+		{
+			"unknown",
+			"unknown",
+			false,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dbConfig := &DbConfig{AutoImport: test.configValue}
+
+			got, err := dbConfig.AutoImportEnabled()
+			assert.Equal(t, test.wantErr, err != nil, "unexpected error from AutoImportEnabled")
+			assert.Equal(t, test.want, got, "unexpected value from AutoImportEnabled")
+			if got != test.want {
+				t.Errorf("DbConfig.AutoImportEnabled() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -164,8 +164,8 @@ func TestAutoImportEnabled(t *testing.T) {
 	tests := []struct {
 		name        string
 		configValue interface{}
-		want        bool
-		wantErr     bool
+		expected    bool
+		hasError    bool
 	}{
 		{
 			"default",
@@ -203,11 +203,8 @@ func TestAutoImportEnabled(t *testing.T) {
 			dbConfig := &DbConfig{AutoImport: test.configValue}
 
 			got, err := dbConfig.AutoImportEnabled()
-			assert.Equal(t, test.wantErr, err != nil, "unexpected error from AutoImportEnabled")
-			assert.Equal(t, test.want, got, "unexpected value from AutoImportEnabled")
-			if got != test.want {
-				t.Errorf("DbConfig.AutoImportEnabled() = %v, want %v", got, test.want)
-			}
+			assert.Equal(t, test.hasError, err != nil, "unexpected error from AutoImportEnabled")
+			assert.Equal(t, test.expected, got, "unexpected value from AutoImportEnabled")
 		})
 	}
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -671,7 +671,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
-			AutoImport: "continuous",
+			AutoImport: true,
 		},
 	}
 	rt := NewRestTester(t, &rtConfig)
@@ -1212,7 +1212,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
-			AutoImport: "continuous",
+			AutoImport: true,
 		},
 	}
 	rt := NewRestTester(t, &rtConfig)
@@ -1270,7 +1270,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
-			AutoImport: "continuous",
+			AutoImport: true,
 		},
 	}
 	rt := NewRestTester(t, &rtConfig)
@@ -1746,7 +1746,7 @@ func TestDcpBackfill(t *testing.T) {
 	// Create a new context, with import docs enabled, to process backfill
 	newRtConfig := RestTesterConfig{
 		DatabaseConfig: &DbConfig{
-			AutoImport: "continuous",
+			AutoImport: true,
 		},
 		NoFlush: true,
 	}


### PR DESCRIPTION
SG 2.1.0 removed "legacy import", i.e. the `"continuous"` option on `import_docs`, but was left in for backwards compatibility (see: https://github.com/couchbase/sync_gateway/pull/3443#pullrequestreview-111744893 )

This PR deprecates that configuration value, so that in the future we are able to remove it, and simplify the configuration to a bool.

- Changed example config values for `"import_docs": "continuous"` to `"import_docs": true`
- Deprecate `"import_docs": "continuous"` in favour of `true`
  - Prints warning when deprecated option is used:
![Screenshot 2019-05-14 at 12 47 12](https://user-images.githubusercontent.com/1525809/57695530-696c3c00-7646-11e9-8a83-d39e863e49df.png)
