### PR TITLE
CBG-357 Replace Incr(k, 0, ...) with GetCounter helper

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -448,6 +448,16 @@ func WriteCasRaw(bucket Bucket, key string, value []byte, cas uint64, exp uint32
 	}
 }
 
+// GetCounter returns a uint64 result for the given counter key.
+// If the given key is not found in the bucket, this function returns a result of zero.
+func GetCounter(bucket Bucket, k string) (result uint64, err error) {
+	_, err = bucket.Get(k, &result)
+	if IsKeyNotFoundError(bucket, err) {
+		return 0, nil
+	}
+	return result, err
+}
+
 func IsKeyNotFoundError(bucket Bucket, err error) bool {
 
 	if err == nil {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1784,27 +1784,10 @@ func (bucket *CouchbaseBucketGoCB) WriteWithXattr(k string, xattrKey string, exp
 	}
 }
 
-// Increment the atomic counter k by amt.
-//
-// - If amt is 0 and the atomic counter for that key exists, this is treated as a GET operation that returns the current value.
-// - If amt is 0 but the key does not exist, then it will return 0
+// Increment the atomic counter k by amt, where amt must be a non-zero delta for the counter.
 func (bucket *CouchbaseBucketGoCB) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
-
-	// GoCB's Counter returns an error if amt=0 and the counter exists.  If amt=0, instead first
-	// attempt a simple get, which gocb will transcode to uint64.  The call to Get includes its own
-	// retry handling, so doesn't need redundant retry handling here.
 	if amt == 0 {
-		var result uint64
-		_, err := bucket.Get(k, &result)
-		if bucket.IsKeyNotFoundError(err) {
-			// Return Incr value as zero
-			return uint64(0), nil
-		} else if err != nil {
-			// Got an error when trying to fetch the value
-			return 0, err
-		}
-		// Got a non-zero value to return
-		return result, nil
+		return 0, errors.New("amt passed to Incr must be non-zero")
 	}
 
 	// This is an actual incr, not just counter retrieval.

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -455,10 +455,11 @@ func TestIncrCounter(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error incrementing non-existent counter")
 	}
+	// key did not exist - so expect the "initial" value of 1
 	goassert.Equals(t, value, uint64(1))
 
-	// Retrieve an existing counter using delta=0
-	retrieval, err := bucket.Incr(key, 0, 0, 0)
+	// Retrieve existing counter value using GetCounter
+	retrieval, err := GetCounter(bucket, key)
 	if err != nil {
 		t.Errorf("Error retrieving value for existing counter")
 	}
@@ -469,40 +470,9 @@ func TestIncrCounter(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error incrementing value for existing counter")
 	}
+	// and now increment the existing value
 	goassert.Equals(t, retrieval, uint64(2))
 
-}
-
-// TestIncrAmtZero covers the special handling in Incr for when amt=0 on an unknown key
-func TestIncrAmtZero(t *testing.T) {
-
-	testBucket := GetTestBucketOrPanic()
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
-	key := "TestIncrAmtZero"
-
-	defer func() {
-		err := bucket.Delete(key)
-		if err != nil {
-			t.Errorf("Error removing counter from bucket")
-		}
-	}()
-
-	// key hasn't been created, so we'll fall into the special 'Get' handling in Incr
-	val, err := bucket.Incr(key, 0, 0, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(0), val)
-
-	// Actually increment key to create it
-	val, err = bucket.Incr(key, 1, 1, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(1), val)
-
-	// Do another amt=0 to make sure we get the new incremented value
-	val, err = bucket.Incr(key, 0, 0, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(1), val)
 }
 
 func TestGetAndTouchRaw(t *testing.T) {

--- a/base/sharded_sequence_clock.go
+++ b/base/sharded_sequence_clock.go
@@ -256,7 +256,7 @@ func (s *ShardedClock) write() (err error) {
 // entries in the bucket for the clock.
 func (s *ShardedClock) Load() (isChanged bool, err error) {
 
-	newCounter, err := s.bucket.Incr(s.countKey, 0, 0, 0)
+	newCounter, err := GetCounter(s.bucket, s.countKey)
 	if err != nil {
 		Warnf(KeyAll, "Error getting count for %s:%v", s.countKey, err)
 		Debugf(KeyAccel, "Error getting count:%v", err)
@@ -645,7 +645,7 @@ func (p *ShardedClockPartition) resize(seq uint64) {
 // Count retrieval - utility for use outside of the context of a sharded clock.
 func LoadClockCounter(baseKey string, bucket Bucket) (uint64, error) {
 	countKey := fmt.Sprintf(kCountKeyFormat, baseKey)
-	return bucket.Incr(countKey, 0, 0, 0)
+	return GetCounter(bucket, countKey)
 }
 
 // Index partitions for unit tests

--- a/db/kv_change_index_reader.go
+++ b/db/kv_change_index_reader.go
@@ -466,7 +466,7 @@ func (k *kvChangeIndexReader) pollPrincipals() {
 	defer indexReaderPollPrincipalsCount.AddValue(int64(len(k.activePrincipalCounts)))
 
 	// Check whether ANY principals have been updated since last poll, before doing the work of retrieving individual keys
-	overallCount, err := k.indexReadBucket.Incr(base.KTotalPrincipalCountKey, 0, 0, 0)
+	overallCount, err := base.GetCounter(k.indexReadBucket, base.KTotalPrincipalCountKey)
 	if err != nil {
 		base.Warnf(base.KeyAll, "Principal polling encountered error getting overall count:%v", err)
 		return
@@ -512,7 +512,7 @@ func (k *kvChangeIndexReader) pollPrincipals() {
 		// There's been a change - check whether any of our active principals have changed
 		for principalID, currentCount := range k.activePrincipalCounts {
 			key := fmt.Sprintf(base.KPrincipalCountKeyFormat, principalID)
-			newCount, err := k.indexReadBucket.Incr(key, 0, 0, 0)
+			newCount, err := base.GetCounter(k.indexReadBucket, key)
 			if err != nil {
 				base.Warnf(base.KeyAll, "Principal polling encountered error getting overall count for key %s:%v", base.UD(key), err)
 				continue
@@ -542,7 +542,7 @@ func (k *kvChangeIndexReader) addActivePrincipals(keys []string) {
 		if !ok {
 			// Get the count
 			countKey := fmt.Sprintf(base.KPrincipalCountKeyFormat, key)
-			currentCount, err := k.indexReadBucket.Incr(countKey, 0, 0, 0)
+			currentCount, err := base.GetCounter(k.indexReadBucket, countKey)
 			if err != nil {
 				currentCount = 0
 			}

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -134,9 +134,9 @@ func (s *sequenceAllocator) lastSequence() (uint64, error) {
 		return lastSeq, nil
 	}
 	s.dbStats.StatsDatabase().Add(base.StatKeySequenceGetCount, 1)
-	last, err := s.incrementSequence(0)
+	last, err := s.getSequence()
 	if err != nil {
-		base.Warnf(base.KeyAll, "Error from Incr in lastSequence(): %v", err)
+		base.Warnf(base.KeyAll, "Error from Get in getSequence(): %v", err)
 	}
 	return last, err
 }
@@ -189,6 +189,11 @@ func (s *sequenceAllocator) _reserveSequenceRange() error {
 	s.reserveNotify <- struct{}{}
 	s.dbStats.StatsDatabase().Add(base.StatKeySequenceReservedCount, 1)
 	return nil
+}
+
+// Gets the _sync:seq document value.  Retry handling provided by bucket.Get.
+func (s *sequenceAllocator) getSequence() (max uint64, err error) {
+	return base.GetCounter(s.bucket, base.SyncSeqKey)
 }
 
 // Increments the _sync:seq document.  Retry handling provided by bucket.Incr.


### PR DESCRIPTION
- Replaces all instances where we call `Incr()` with a zero amount/delta with a `GetCounter()` helper.
- `TestIncrCounter` modified to check Walrus and GoCB are OK with using `Get()` on a counter.