### PR TITLE
CBG-366 Decouple sequence buffering and channel cache

### DIFF
--- a/db/change_index.go
+++ b/db/change_index.go
@@ -64,7 +64,7 @@ type ChangeIndex interface {
 	// Handling specific to change_cache.go's sequence handling.  Ideally should refactor usage in changes.go to push
 	// down into internal change_cache.go handling, but it's non-trivial refactoring
 	getOldestSkippedSequence() uint64
-	getChannelCache(channelName string) *channelCache
+	getChannelCache() ChannelCache
 
 	// Unit test support
 	waitForSequence(sequence uint64, maxWaitTime time.Duration, tb testing.TB)

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -34,7 +34,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAccel)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -131,7 +130,6 @@ func (c *channelCacheImpl) AddPrincipal(change *LogEntry) {
 // flag indicates whether it was a change arriving out of sequence
 func (c *channelCacheImpl) AddToCache(change *LogEntry) base.Set {
 
-	log.Printf("Main AddToCache: %s %d", change.DocID, change.Sequence)
 	// updatedChannels tracks the set of channels that should be notified of the change.  This includes
 	// the change's active channels, as well as any channel removals for the active revision.
 	updatedChannels := make(base.Set)
@@ -413,7 +411,6 @@ func (c *singleChannelCache) addToCache(change *LogEntry, isRemoval bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	log.Printf("Adding to cache %d (%s)", change.Sequence, c.channelName)
 	if c.wouldBeImmediatelyPruned(change) {
 		base.Infof(base.KeyCache, "Not adding change #%d doc %q / %q ==> channel %q, since it will be immediately pruned",
 			change.Sequence, base.UD(change.DocID), change.RevID, base.UD(c.channelName))
@@ -439,7 +436,6 @@ func (c *singleChannelCache) wouldBeImmediatelyPruned(change *LogEntry) bool {
 		return false
 	}
 
-	log.Printf("would be immediately pruned, validFrom: %d, %d", change.Sequence, c.validFrom)
 	// If older than validFrom, never try to cache it
 	return true
 
@@ -810,7 +806,6 @@ func (c *singleChannelCache) prependChanges(changes LogEntries, changesValidFrom
 	}
 
 	// Ensure changes are valid to the cache's validFrom, otherwise unsafe to prepend
-	log.Printf("Prepending, validFrom is %d", c.validFrom)
 	if changesValidTo < c.validFrom {
 		return 0
 	}

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -602,24 +602,19 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	defer context.Close()
 	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
 
-	context.changeCache.getChannelCache("TestA") // initialize, don't add any entries
-	cacheB := context.changeCache.getChannelCache("TestB")
-	cacheC := context.changeCache.getChannelCache("TestC")
-	cacheD := context.changeCache.getChannelCache("TestD")
+	cache := context.changeCache.getChannelCache()
 
-	// Add some entries to caches, leaving some empty cache
-	cacheB.addToCache(e(1, "doc1", "1-a"), false)
-	cacheB.addToCache(e(2, "doc2", "1-a"), false)
-	cacheB.addToCache(e(3, "doc3", "1-a"), false)
+	// Make channels active
+	cache.GetChanges("TestA", ChangesOptions{})
+	cache.GetChanges("TestB", ChangesOptions{})
+	cache.GetChanges("TestC", ChangesOptions{})
+	cache.GetChanges("TestD", ChangesOptions{})
 
-	cacheC.addToCache(e(1, "doc1", "1-a"), false)
-	cacheC.addToCache(e(2, "doc2", "1-a"), false)
-	cacheC.addToCache(e(3, "doc3", "1-a"), false)
-	cacheC.addToCache(e(4, "doc4", "1-a"), false)
-
-	cacheD.addToCache(e(1, "doc1", "1-a"), false)
-	cacheD.addToCache(e(2, "doc2", "1-a"), false)
-	cacheD.addToCache(e(3, "doc3", "1-a"), false)
+	// Add some entries to caches, leaving some empty caches
+	cache.AddToCache(logEntry(1, "doc1", "1-a", []string{"TestB", "TestC", "TestD"}))
+	cache.AddToCache(logEntry(2, "doc2", "1-a", []string{"TestB", "TestC", "TestD"}))
+	cache.AddToCache(logEntry(3, "doc3", "1-a", []string{"TestB", "TestC", "TestD"}))
+	cache.AddToCache(logEntry(4, "doc4", "1-a", []string{"TestC"}))
 
 	context.UpdateCalculatedStats()
 

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -169,7 +169,7 @@ func (db *DatabaseContext) UpdateCalculatedStats() {
 
 	// Max channel cache size
 	if cache, ok := db.changeCache.(*changeCache); ok {
-		db.DbStats.StatsCache().Set(base.StatKeyChannelCacheMaxEntries, base.ExpvarIntVal(cache.MaxCacheSize()))
+		db.DbStats.StatsCache().Set(base.StatKeyChannelCacheMaxEntries, base.ExpvarIntVal(cache.channelCache.MaxCacheSize()))
 	}
 
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -615,7 +615,7 @@ func TestAllDocsOnly(t *testing.T) {
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Trigger creation of the channel cache for channel "all"
-	db.changeCache.getChannelCache("all")
+	db.changeCache.getChannelCache().getSingleChannelCache("all")
 
 	ids := make([]AllDocsEntry, 100)
 	for i := 0; i < 100; i++ {
@@ -784,7 +784,7 @@ func TestConflicts(t *testing.T) {
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Instantiate channel cache for channel 'all'
-	db.changeCache.getChannelCache("all")
+	db.changeCache.getChannelCache().getSingleChannelCache("all")
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -188,9 +188,11 @@ func (k *kvChangeIndex) DocChanged(event sgbucket.FeedEvent) {
 func (k *kvChangeIndex) getOldestSkippedSequence() uint64 {
 	return uint64(0)
 }
-func (k *kvChangeIndex) getChannelCache(channelName string) *channelCache {
+
+func (k *kvChangeIndex) getChannelCache() ChannelCache {
 	return nil
 }
+
 func (k *kvChangeIndex) Remove(docIDs []string, startTime time.Time) int {
 	return 0
 }


### PR DESCRIPTION
Reduces mutex contention between sequence buffering and cache access.  Uses cache high sequence for validFrom and for changes feed synchronization.
Defines a new interface for ChannelCache, to better define cache interactions and support future cache implementations (e.g. sharded channel cache).
Includes LateSequenceHandling in channel cache, cleans up the API.