### PR TITLE
Jenkinsfile: Remove sg-accel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,6 @@ pipeline {
                     steps {
                         withEnv(["GOOS=windows", "PATH+=${GO}:${GOPATH}/bin"]) {
                             sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-service'
-                            sh 'go build -v github.com/couchbase/sync_gateway/service/sg-windows/sg-accel-service'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,14 +123,13 @@ pipeline {
                     stages {
                         stage('CE -cover') {
                             steps{
-                                withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                                    // Build public and private coverprofiles (private containing accel code too)
-                                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce_public.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
-                                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ce_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/...'
+                                // Travis-related variables are required as coveralls.io only officially supports a certain set of CI tools.
+                                withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
+                                    // Build CE coverprofiles
+                                    sh 'go test -timeout=20m -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ce.out github.com/couchbase/sync_gateway/...'
 
                                     // Print total coverage stats
-                                    sh 'go tool cover -func=cover_ce_public.out | awk \'END{print "Total SG CE Coverage: " $3}\''
-                                    sh 'go tool cover -func=cover_ce_private.out | awk \'END{print "Total SG CE+SGA Coverage: " $3}\''
+                                    sh 'go tool cover -func=cover_ce.out | awk \'END{print "Total SG CE Coverage: " $3}\''
 
                                     sh 'mkdir -p reports'
 
@@ -138,42 +137,35 @@ pipeline {
                                     // sh 'cat test_ce.out | go-junit-report > reports/test-ce.xml'
 
                                     // Generate HTML coverage report
-                                    sh 'go tool cover -html=cover_ce_private.out -o reports/coverage-ce.html'
+                                    sh 'go tool cover -html=cover_ce.out -o reports/coverage-ce.html'
 
                                     // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
-                                    sh 'gocov convert cover_ce_private.out | gocov-xml > reports/coverage-ce.xml'
+                                    sh 'gocov convert cover_ce.out | gocov-xml > reports/coverage-ce.xml'
                                 }
-                            }
-                        }
 
-                        stage('CE Coveralls') {
-                            steps {
-                                // Travis-related variables are required as coveralls only officially supports a certain set of CI tools.
-                                withEnv(["PATH+=${GO}:${GOPATH}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {
-                                    // Replace covermode values with set just for coveralls to reduce the variability in reports.
-                                    sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce_public.out > cover_ce_coveralls.out'
-
-                                    // Send just the SG coverage report to coveralls.io - **NOT** accel! It will expose the private codebase!!!
-                                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
-                                }
+                                // Publish CE coverage to coveralls.io
+                                // Replace covermode values with set just for coveralls to reduce the variability in reports.
+                                sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce.out > cover_ce_coveralls.out'
+                                sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
                             }
                         }
 
                         stage('EE -cover') {
                             steps {
                                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
-                                    sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/...,github.com/couchbaselabs/sync-gateway-accel/... -coverprofile=cover_ee_private.out github.com/couchbase/sync_gateway/... github.com/couchbaselabs/sync-gateway-accel/..."
-                                    sh 'go tool cover -func=cover_ee_private.out | awk \'END{print "Total SG EE+SGA Coverage: " $3}\''
+                                    // Build EE coverprofiles
+                                    sh "go test -timeout=20m -tags ${EE_BUILD_TAG} -coverpkg=github.com/couchbase/sync_gateway/... -coverprofile=cover_ee.out github.com/couchbase/sync_gateway/..."
+                                    sh 'go tool cover -func=cover_ee.out | awk \'END{print "Total SG EE Coverage: " $3}\''
 
                                     sh 'mkdir -p reports'
 
                                     // Generate junit-formatted test report
                                     // sh 'cat test_ee.out | go-junit-report > reports/test-ee.xml'
 
-                                    sh 'go tool cover -html=cover_ee_private.out -o reports/coverage-ee.html'
+                                    sh 'go tool cover -html=cover_ee.out -o reports/coverage-ee.html'
 
                                     // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
-                                    sh 'gocov convert cover_ee_private.out | gocov-xml > reports/coverage-ee.xml'
+                                    sh 'gocov convert cover_ee.out | gocov-xml > reports/coverage-ee.xml'
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,12 +140,12 @@ pipeline {
 
                                     // Generate Cobertura XML report that can be parsed by the Jenkins Cobertura Plugin
                                     sh 'gocov convert cover_ce.out | gocov-xml > reports/coverage-ce.xml'
-                                }
 
-                                // Publish CE coverage to coveralls.io
-                                // Replace covermode values with set just for coveralls to reduce the variability in reports.
-                                sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce.out > cover_ce_coveralls.out'
-                                sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                                    // Publish CE coverage to coveralls.io
+                                    // Replace covermode values with set just for coveralls to reduce the variability in reports.
+                                    sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce.out > cover_ce_coveralls.out'
+                                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                                }
                             }
                         }
 

--- a/build.sh
+++ b/build.sh
@@ -55,15 +55,6 @@ doBuild () {
         echo "      Binary compiled to: ${GOPATH}/bin/sync_gateway${binarySuffix}"
     fi
 
-    # Go install Sg Accel
-    if [ -d godeps/src/github.com/couchbaselabs/sync-gateway-accel ]; then
-        echo "    Building Sync Gateway Accel with 'go install' ..."
-        go install "${@:2}" github.com/couchbaselabs/sync-gateway-accel/...
-        echo "      Success!"
-        if [ -f "godeps/bin/sync-gateway-accel" ]; then
-            echo "        Binary compiled to: godeps/bin/sync-gateway-accel"
-        fi
-    fi
 }
 
 for edition in "${build_editions[@]}"; do

--- a/test.sh
+++ b/test.sh
@@ -53,10 +53,6 @@ doTest () {
         go test ${buildTags} "${@:2}" $EXTRA_FLAGS github.com/couchbase/sync_gateway/...
     fi
 
-    if [ -d godeps/src/github.com/couchbaselabs/sync-gateway-accel ]; then
-        echo "    Running Sync Gateway Accel unit tests:"
-        go test ${buildTags} "${@:2}" $EXTRA_FLAGS github.com/couchbaselabs/sync-gateway-accel/...
-    fi
 }
 
 for edition in "${build_editions[@]}"; do


### PR DESCRIPTION
Removed accel from `Jenkinsfile` and `test.sh`/`build.sh`

I've kept the accel flag in `bootstrap.sh` as we currently rely on it for pulling in EE-only code via the manifest.