### PR TITLE
CBG-369 - Late sequence handling enhancements

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -56,7 +56,6 @@ func logEntry(seq uint64, docid string, revid string, channelNames []string) *Lo
 }
 
 func testBucketContext(tester testing.TB) *DatabaseContext {
-
 	context, _ := NewDatabaseContext("db", testBucket(tester).Bucket, false, DatabaseContextOptions{})
 	return context
 }

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -923,7 +923,8 @@ func (c *singleChannelCache) initializeLateLogs() {
 }
 
 // Retrieve late-arriving sequences that have arrived since the previous sequence.  Retrieves set of sequences, and the last
-// sequence number in the list.  Note that lateLogs is sorted by arrival on feed, not sequence number.
+// sequence number in the list.  Note that lateLogs is sorted by arrival on feed, not sequence number. Error indicates
+// that sinceSequence isn't found in history, and caller should reset to low sequence.
 func (c *singleChannelCache) GetLateSequencesSince(sinceSequence uint64) (entries []*LogEntry, lastSequence uint64, err error) {
 
 	c.lateLogLock.RLock()


### PR DESCRIPTION
 ~Needs to be rebased on master when https://github.com/couchbase/sync_gateway/pull/4116 is merged.~

Ensures late sequence handlers are correctly released on disconnected changes feeds, and that errors on late sequence feed generation trigger rollback to the feed's low sequence value.