### PR TITLE
Switch assert.NoError to require.NoError in N1QL tests

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/couchbase/gocb"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var testN1qlOptions = &N1qlIndexOptions{
@@ -70,7 +71,7 @@ func TestN1qlQuery(t *testing.T) {
 	}()
 
 	readyErr := bucket.WaitForIndexOnline("testIndex_value")
-	assert.NoError(t, readyErr, "Error validating index online")
+	require.NoError(t, readyErr, "Error validating index online")
 
 	// Query the index
 	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE val > $minvalue", BucketQueryToken)
@@ -78,7 +79,7 @@ func TestN1qlQuery(t *testing.T) {
 	params["minvalue"] = 2
 
 	queryResults, queryErr := bucket.Query(queryExpression, params, gocb.RequestPlus, false)
-	assert.NoError(t, queryErr, "Error executing n1ql query")
+	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
 	var queryResult struct {
@@ -155,7 +156,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 	// Wait for index readiness
 	readyErr := bucket.WaitForIndexOnline("testIndex_filtered_value")
-	assert.NoError(t, readyErr, "Error validating index online")
+	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
 	defer func() {
@@ -169,7 +170,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 	// Query the index
 	queryExpression := fmt.Sprintf("SELECT META().id, val FROM %s WHERE %s AND META().id = 'doc1'", BucketQueryToken, filterExpression)
 	queryResults, queryErr := bucket.Query(queryExpression, nil, gocb.RequestPlus, false)
-	assert.NoError(t, queryErr, "Error executing n1ql query")
+	require.NoError(t, queryErr, "Error executing n1ql query")
 
 	// Struct to receive the query response (META().id, val)
 	var queryResult struct {
@@ -220,7 +221,7 @@ func TestIndexMeta(t *testing.T) {
 	}
 
 	readyErr := bucket.WaitForIndexOnline("testIndex_value")
-	assert.NoError(t, readyErr, "Error validating index online")
+	require.NoError(t, readyErr, "Error validating index online")
 
 	// Defer index teardown
 	defer func() {


### PR DESCRIPTION
Prevents the test from carrying on when the index cannot be created in time, and causing subsequent nil pointers during the test.

e.g.:
```
--- FAIL: TestN1qlFilterExpression (320.58s)
    bucket_n1ql_test.go:158: 
        	Error Trace:	bucket_n1ql_test.go:158
        	Error:      	Received unexpected error:
        	            	RetryLoop for GetIndexMeta for index testIndex_filtered_value giving up after 26 attempts
        	Test:       	TestN1qlFilterExpression
        	Messages:   	Error validating index online
    bucket_n1ql_test.go:172: 
        	Error Trace:	bucket_n1ql_test.go:172
        	Error:      	Received unexpected error:
        	            	[4000] No index available on keyspace test_data_bucket that matches your query. Use CREATE INDEX or CREATE PRIMARY INDEX to create an index, or check that your expected index is online.
        	            	github.com/couchbase/sync_gateway/base.(*CouchbaseBucketGoCB).Query
        	            		/var/jenkins/workspace/sync-gateway-integration-master/godeps/src/github.com/couchbase/sync_gateway/base/bucket_n1ql.go:78
        	            	github.com/couchbase/sync_gateway/base.TestN1qlFilterExpression
        	            		/var/jenkins/workspace/sync-gateway-integration-master/godeps/src/github.com/couchbase/sync_gateway/base/bucket_n1ql_test.go:171
        	            	testing.tRunner
        	            		/root/.gvm/gos/go1.11.5/src/testing/testing.go:827
        	            	runtime.goexit
        	            		/root/.gvm/gos/go1.11.5/src/runtime/asm_amd64.s:1333
        	Test:       	TestN1qlFilterExpression
        	Messages:   	Error executing n1ql query
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x97e031]

goroutine 1243 [running]:
testing.tRunner.func1(0xc00015a000)
	/root/.gvm/gos/go1.11.5/src/testing/testing.go:792 +0x387
panic(0xa676a0, 0x11fab70)
	/root/.gvm/gos/go1.11.5/src/runtime/panic.go:513 +0x1b9
github.com/couchbase/sync_gateway/base.TestN1qlFilterExpression(0xc00015a000)
	/var/jenkins/workspace/sync-gateway-integration-master/godeps/src/github.com/couchbase/sync_gateway/base/bucket_n1ql_test.go:184 +0x7e1
testing.tRunner(0xc00015a000, 0xb49580)
	/root/.gvm/gos/go1.11.5/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/root/.gvm/gos/go1.11.5/src/testing/testing.go:878 +0x35c
FAIL	github.com/couchbase/sync_gateway/base	758.208s
```