### PR TITLE
CBG-378 - Verify downloaded attachments match the supplied metadata

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1075,12 +1076,16 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
+	attachmentBody := "attach"
+	digest := db.Sha1DigestKey([]byte(attachmentBody))
+
 	input := SendRevWithAttachmentInput{
 		docId:            "doc",
 		revId:            "1-rev1",
 		attachmentName:   "myAttachment",
-		attachmentBody:   "attach",
-		attachmentDigest: "fakedigest",
+		attachmentLength: len(attachmentBody),
+		attachmentBody:   attachmentBody,
+		attachmentDigest: digest,
 	}
 	bt.SendRevWithAttachment(input)
 
@@ -1119,7 +1124,6 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	defer bt.Close()
 
 	attachmentBody := "attach"
-
 	digest := db.Sha1DigestKey([]byte(attachmentBody))
 
 	// Send revision with attachment
@@ -1127,6 +1131,7 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 		docId:            "doc",
 		revId:            "1-rev1",
 		attachmentName:   "myAttachment",
+		attachmentLength: len(attachmentBody),
 		attachmentBody:   attachmentBody,
 		attachmentDigest: digest,
 	}
@@ -1153,6 +1158,81 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	goassert.Equals(t, retrievedAttachment.Length, len(attachmentBody))
 	goassert.Equals(t, input.attachmentDigest, retrievedAttachment.Digest)
 
+}
+
+// Reproduces the issue seen in https://github.com/couchbase/couchbase-lite-core/issues/790
+// Makes sure that Sync Gateway rejects attachments sent to it that does not match the given digest and/or length
+func TestPutInvalidAttachment(t *testing.T) {
+
+	tests := []struct {
+		name                  string
+		correctAttachmentBody string
+		invalidAttachmentBody string
+		expectedType          blip.MessageType
+		expectedErrorCode     string
+	}{
+		{
+			name:                  "truncated",
+			correctAttachmentBody: "attach",
+			invalidAttachmentBody: "att", // truncate so length and digest are incorrect
+			expectedType:          blip.ErrorType,
+			expectedErrorCode:     strconv.Itoa(http.StatusBadRequest),
+		},
+		{
+			name:                  "malformed",
+			correctAttachmentBody: "attach",
+			invalidAttachmentBody: "attahc", // swap two chars so only digest doesn't match
+			expectedType:          blip.ErrorType,
+			expectedErrorCode:     strconv.Itoa(http.StatusBadRequest),
+		},
+		{
+			name:                  "correct",
+			correctAttachmentBody: "attach",
+			invalidAttachmentBody: "attach",
+			expectedType:          blip.ResponseType,
+			expectedErrorCode:     "",
+		},
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+
+	// Create blip tester
+	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+		noAdminParty:                true,
+		connectingUsername:          "user1",
+		connectingPassword:          "1234",
+		connectingUserChannelGrants: []string{"*"}, // All channels
+	})
+	assert.NoError(t, err, "Unexpected error creating BlipTester")
+	defer bt.Close()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			digest := db.Sha1DigestKey([]byte(test.correctAttachmentBody))
+
+			// Send revision with attachment
+			input := SendRevWithAttachmentInput{
+				docId:            test.name,
+				revId:            "1-rev1",
+				attachmentName:   "myAttachment",
+				attachmentLength: len(test.correctAttachmentBody),
+				attachmentBody:   test.invalidAttachmentBody,
+				attachmentDigest: digest,
+			}
+			sent, _, resp := bt.SendRevWithAttachment(input)
+			assert.True(t, sent)
+
+			// Make sure we get the expected response back
+			assert.Equal(t, test.expectedType, resp.Type())
+			if test.expectedErrorCode != "" {
+				assert.Equal(t, test.expectedErrorCode, resp.Properties["Error-Code"])
+			}
+
+			respBody, err := resp.Body()
+			assert.NoError(t, err)
+			t.Logf("resp.Body: %v", string(respBody))
+		})
+	}
 }
 
 // Put a revision that is rejected by the sync function and assert that Sync Gateway

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -999,7 +999,23 @@ func (bh *blipHandler) downloadOrVerifyAttachments(body db.Body, minRevpos int, 
 				if !sender.Send(outrq) {
 					return nil, ErrClosedBLIPSender
 				}
-				return outrq.Response().Body()
+				attBody, err := outrq.Response().Body()
+				if err != nil {
+					return nil, err
+				}
+
+				lNum, metaLengthOK := meta["length"].(json.Number)
+				metaLength, err := lNum.Int64()
+				if err != nil {
+					return nil, err
+				}
+
+				// Verify that the attachment we received matches the metadata stored in the document
+				if !metaLengthOK || len(attBody) != int(metaLength) || db.Sha1DigestKey(attBody) != digest {
+					return nil, base.HTTPErrorf(http.StatusBadRequest, "Incorrect data sent for attachment with digest: %s", digest)
+				}
+
+				return attBody, nil
 			}
 		})
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -975,6 +975,7 @@ type SendRevWithAttachmentInput struct {
 	docId            string
 	revId            string
 	attachmentName   string
+	attachmentLength int
 	attachmentBody   string
 	attachmentDigest string
 }
@@ -991,7 +992,7 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 	myAttachment := db.DocAttachment{
 		ContentType: "application/json",
 		Digest:      input.attachmentDigest,
-		Length:      6,
+		Length:      input.attachmentLength,
 		Revpos:      1,
 		Stub:        true,
 	}
@@ -1020,15 +1021,12 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 
 	// Push a rev with an attachment.
 	getAttachmentWg.Add(1)
-	sent, req, res, err = bt.SendRev(
+	sent, req, res, _ = bt.SendRev(
 		input.docId,
 		input.revId,
 		docBody,
 		blip.Properties{},
 	)
-	if err != nil {
-		panic(fmt.Sprintf("Error sending rev: %v", err))
-	}
 
 	// Expect a callback to the getAttachment endpoint
 	getAttachmentWg.Wait()


### PR DESCRIPTION
- Verifies that the downloaded attachment matches the given length, and also hashes to the same digest
- Added `TestPutInvalidAttachment` to verify the fix for https://github.com/couchbase/couchbase-lite-core/issues/790