### PR TITLE
CBG-374 - Continue parsing config with unknown fields so we can log to sg_error.log

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -746,7 +746,7 @@ func decodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
 		// Special handling for unknown field errors
 		// json.Decode continues to decode the full data into the struct
 		// so it's safe to use even after this error
-		return errors.Wrap(ErrUnknownField, err.Error())
+		return errors.WithMessage(ErrUnknownField, err.Error())
 	}
 	return err
 }
@@ -939,16 +939,16 @@ func ParseCommandLine(runMode SyncGatewayRunMode) (err error) {
 			newConfig, newConfigErr := LoadServerConfig(runMode, filename)
 			if errors.Cause(newConfigErr) == ErrUnknownField {
 				// Delay returning this error so we can continue with other setup
-				err = errors.Wrapf(newConfigErr, "Error reading config file %s", base.UD(filename))
+				err = errors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", base.UD(filename)))
 			} else if newConfigErr != nil {
-				return errors.Wrapf(newConfigErr, "Error reading config file %s", base.UD(filename))
+				return errors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", base.UD(filename)))
 			}
 
 			if config == nil {
 				config = newConfig
 			} else {
 				if err := config.MergeWith(newConfig); err != nil {
-					base.Fatalf(base.KeyAll, "Error reading config file %s: %v", base.UD(filename), err)
+					return errors.WithMessage(err, fmt.Sprintf("Error reading config file %s", base.UD(filename)))
 				}
 			}
 		}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -36,7 +36,7 @@ func TestReadServerConfig(t *testing.T) {
 		{
 			name:   "unknown field",
 			config: `{"invalid": true}`,
-			err:    `json: unknown field "invalid"`,
+			err:    `json: unknown field "invalid": unrecognized config value`,
 		},
 		{
 			name:   "incorrect type",

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -57,10 +57,13 @@ func TestReadServerConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			_, err := readServerConfig(SyncGatewayRunModeNormal, buf)
+			_, unknownFields, err := readServerConfig(SyncGatewayRunModeNormal, buf)
 			if test.err == "" {
 				assert.NoError(tt, err, "unexpected error for test config")
 			} else {
+				if err == nil && unknownFields != nil {
+					err = unknownFields
+				}
 				assert.EqualError(tt, err, test.err, "expecting error for test config")
 			}
 		})
@@ -97,7 +100,7 @@ func TestConfigValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			config, err := readServerConfig(SyncGatewayRunModeNormal, buf)
+			config, _, err := readServerConfig(SyncGatewayRunModeNormal, buf)
 			assert.NoError(tt, err)
 			errorMessages := config.setupAndValidateDatabases()
 			if test.err != "" {
@@ -139,7 +142,7 @@ func TestLoadServerConfigExamples(t *testing.T) {
 		}
 
 		t.Run(configPath, func(tt *testing.T) {
-			_, err := LoadServerConfig(runMode, configPath)
+			_, _, err := LoadServerConfig(runMode, configPath)
 			assert.NoError(tt, err, "unexpected error validating example config")
 		})
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -57,13 +57,10 @@ func TestReadServerConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			_, unknownFields, err := readServerConfig(SyncGatewayRunModeNormal, buf)
+			_, err := readServerConfig(SyncGatewayRunModeNormal, buf)
 			if test.err == "" {
 				assert.NoError(tt, err, "unexpected error for test config")
 			} else {
-				if err == nil && unknownFields != nil {
-					err = unknownFields
-				}
 				assert.EqualError(tt, err, test.err, "expecting error for test config")
 			}
 		})
@@ -100,7 +97,7 @@ func TestConfigValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			buf := bytes.NewBufferString(test.config)
-			config, _, err := readServerConfig(SyncGatewayRunModeNormal, buf)
+			config, err := readServerConfig(SyncGatewayRunModeNormal, buf)
 			assert.NoError(tt, err)
 			errorMessages := config.setupAndValidateDatabases()
 			if test.err != "" {
@@ -142,7 +139,7 @@ func TestLoadServerConfigExamples(t *testing.T) {
 		}
 
 		t.Run(configPath, func(tt *testing.T) {
-			_, _, err := LoadServerConfig(runMode, configPath)
+			_, err := LoadServerConfig(runMode, configPath)
 			assert.NoError(tt, err, "unexpected error validating example config")
 		})
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -11,7 +11,6 @@ package rest
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -26,6 +25,7 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/pkg/errors"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -997,13 +997,9 @@ func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error)
 	var config DbConfig
 	defer resp.Body.Close()
 
-	unknownFields, err := decodeAndSanitiseConfig(resp.Body, &config)
-	if err != nil {
+	if err := decodeAndSanitiseConfig(resp.Body, &config); err != nil {
 		return nil, base.HTTPErrorf(http.StatusBadGateway,
 			"Bad response from config server: %v", err)
-	} else if unknownFields != nil {
-		return nil, base.HTTPErrorf(http.StatusBadGateway,
-			"Unknown fields from config server: %v", unknownFields)
 	}
 
 	if err = config.setup(dbName); err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -11,6 +11,7 @@ package rest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,7 +26,6 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
-	"github.com/pkg/errors"
 	pkgerrors "github.com/pkg/errors"
 )
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -997,9 +997,13 @@ func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error)
 	var config DbConfig
 	defer resp.Body.Close()
 
-	if err := decodeAndSanitiseConfig(resp.Body, &config); err != nil {
+	unknownFields, err := decodeAndSanitiseConfig(resp.Body, &config)
+	if err != nil {
 		return nil, base.HTTPErrorf(http.StatusBadGateway,
 			"Bad response from config server: %v", err)
+	} else if unknownFields != nil {
+		return nil, base.HTTPErrorf(http.StatusBadGateway,
+			"Unknown fields from config server: %v", unknownFields)
 	}
 
 	if err = config.setup(dbName); err != nil {


### PR DESCRIPTION
The JSON decoder continues to decode the JSON into the target struct even when it encounters unknown fields, which allows us to only do the unmarshal once, and separate the non-critical unknown field error and other fatal errors.

https://play.golang.org/p/zQoYy_wxnGu 