### PR TITLE
CBG-372: Incorrect struct tag on xattrEnabledDesignDoc

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1929,7 +1929,7 @@ func (bucket *CouchbaseBucketGoCB) PutDDoc(docname string, value interface{}) er
 
 type XattrEnabledDesignDoc struct {
 	*gocb.DesignDocument
-	IndexXattrOnTombstones bool `json:"index_xattr_on_deleted_docs, omitempty"`
+	IndexXattrOnTombstones bool `json:"index_xattr_on_deleted_docs,omitempty"`
 }
 
 // For the view engine to index tombstones, we need to set an explicit property in the design doc.


### PR DESCRIPTION
Change will now correctly omit empty fields instead of always including them (even though the code only ever sets this value to true)

E.g: https://play.golang.org/p/N1J5Svfg0DM