### PR TITLE
Fix revcache size config for zero

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -252,18 +252,18 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	cacheSize := KDefaultRevisionCacheCapacity
 
 	if options.RevisionCacheOptions != nil {
-		if options.RevisionCacheOptions.ShardNumber != 0 {
-			numShards = options.RevisionCacheOptions.ShardNumber
+		if options.RevisionCacheOptions.ShardCount != nil {
+			numShards = *options.RevisionCacheOptions.ShardCount
 		}
 
-		if options.RevisionCacheOptions.Size != 0 {
-			cacheSize = options.RevisionCacheOptions.Size
+		if options.RevisionCacheOptions.Size != nil {
+			cacheSize = *options.RevisionCacheOptions.Size
 		}
 	}
 
 	revisionCacheOptions := RevisionCacheOptions{
-		Size:        cacheSize,
-		ShardNumber: numShards,
+		Size:       &cacheSize,
+		ShardCount: &numShards,
 	}
 
 	dbContext.Options.RevisionCacheOptions = &revisionCacheOptions

--- a/db/database.go
+++ b/db/database.go
@@ -248,28 +248,8 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	dbContext.terminator = make(chan bool)
 
-	numShards := KDefaultNumCacheShards
-	cacheSize := KDefaultRevisionCacheCapacity
-
-	if options.RevisionCacheOptions != nil {
-		if options.RevisionCacheOptions.ShardCount != nil {
-			numShards = *options.RevisionCacheOptions.ShardCount
-		}
-
-		if options.RevisionCacheOptions.Size != nil {
-			cacheSize = *options.RevisionCacheOptions.Size
-		}
-	}
-
-	revisionCacheOptions := RevisionCacheOptions{
-		Size:       &cacheSize,
-		ShardCount: &numShards,
-	}
-
-	dbContext.Options.RevisionCacheOptions = &revisionCacheOptions
-
 	dbContext.revisionCache = NewRevisionCache(
-		&revisionCacheOptions,
+		dbContext.Options.RevisionCacheOptions,
 		dbContext,
 		dbContext.DbStats.StatsCache(),
 	)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -390,7 +390,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
 	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(defaultRevisionCacheShardCount, defaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -475,7 +475,7 @@ func TestGetRemoved(t *testing.T) {
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
 	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(defaultRevisionCacheShardCount, defaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -551,7 +551,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
 	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(KDefaultNumCacheShards, KDefaultRevisionCacheCapacity, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(defaultRevisionCacheShardCount, defaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -33,18 +33,18 @@ var _ RevisionCache = &BypassRevisionCache{}
 // NewRevisionCache returns a RevisionCache implementation for the given config options.
 func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStore RevisionCacheBackingStore, statsCache *expvar.Map) RevisionCache {
 
-	if cacheOptions.Size == 0 {
+	if *cacheOptions.Size == 0 {
 		bypassStat := statsCache.Get(base.StatKeyRevisionCacheBypass).(*expvar.Int)
 		return NewBypassRevisionCache(backingStore, bypassStat)
 	}
 
 	cacheHitStat := statsCache.Get(base.StatKeyRevisionCacheHits).(*expvar.Int)
 	cacheMissStat := statsCache.Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	if cacheOptions.ShardNumber > 1 {
-		return NewShardedLRURevisionCache(cacheOptions.ShardNumber, cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
+	if *cacheOptions.ShardCount > 1 {
+		return NewShardedLRURevisionCache(*cacheOptions.ShardCount, *cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
 	}
 
-	return NewLRURevisionCache(cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
+	return NewLRURevisionCache(*cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
 }
 
 // RevisionCacheBackingStore is the inteface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -7,6 +7,14 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+const (
+	// defaultRevisionCacheSize is the number of recently-accessed doc revisions to cache in RAM
+	defaultRevisionCacheSize = 5000
+
+	// defaultRevisionCacheShardCount is the default number of shards to use for the revision cache
+	defaultRevisionCacheShardCount = 8
+)
+
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
 type RevisionCache interface {
 	// Get returns the given revision, and stores if not already cached
@@ -33,18 +41,35 @@ var _ RevisionCache = &BypassRevisionCache{}
 // NewRevisionCache returns a RevisionCache implementation for the given config options.
 func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStore RevisionCacheBackingStore, statsCache *expvar.Map) RevisionCache {
 
-	if *cacheOptions.Size == 0 {
+	// If cacheOptions is not passed in, use defaults
+	if cacheOptions == nil {
+		cacheOptions = &RevisionCacheOptions{Size: defaultRevisionCacheSize, ShardCount: defaultRevisionCacheShardCount}
+	}
+
+	if cacheOptions.Size == 0 {
 		bypassStat := statsCache.Get(base.StatKeyRevisionCacheBypass).(*expvar.Int)
 		return NewBypassRevisionCache(backingStore, bypassStat)
 	}
 
 	cacheHitStat := statsCache.Get(base.StatKeyRevisionCacheHits).(*expvar.Int)
 	cacheMissStat := statsCache.Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	if *cacheOptions.ShardCount > 1 {
-		return NewShardedLRURevisionCache(*cacheOptions.ShardCount, *cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
+	if cacheOptions.ShardCount > 1 {
+		return NewShardedLRURevisionCache(cacheOptions.ShardCount, cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
 	}
 
-	return NewLRURevisionCache(*cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
+	return NewLRURevisionCache(cacheOptions.Size, backingStore, cacheHitStat, cacheMissStat)
+}
+
+type RevisionCacheOptions struct {
+	Size       uint32
+	ShardCount uint16
+}
+
+func DefaultRevisionCacheOptions() *RevisionCacheOptions {
+	return &RevisionCacheOptions{
+		Size:       defaultRevisionCacheSize,
+		ShardCount: defaultRevisionCacheShardCount,
+	}
 }
 
 // RevisionCacheBackingStore is the inteface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -43,7 +43,7 @@ func NewRevisionCache(cacheOptions *RevisionCacheOptions, backingStore RevisionC
 
 	// If cacheOptions is not passed in, use defaults
 	if cacheOptions == nil {
-		cacheOptions = &RevisionCacheOptions{Size: defaultRevisionCacheSize, ShardCount: defaultRevisionCacheShardCount}
+		cacheOptions = DefaultRevisionCacheOptions()
 	}
 
 	if cacheOptions.Size == 0 {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -20,8 +20,8 @@ type ShardedLRURevisionCache struct {
 }
 
 type RevisionCacheOptions struct {
-	Size        uint32
-	ShardNumber uint16
+	Size       *uint32
+	ShardCount *uint16
 }
 
 // Creates a sharded revision cache with the given capacity and an optional loader function.

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -10,18 +10,9 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-// Number of recently-accessed doc revisions to cache in RAM
-var KDefaultRevisionCacheCapacity uint32 = 5000
-var KDefaultNumCacheShards uint16 = 8
-
 type ShardedLRURevisionCache struct {
 	caches    []*LRURevisionCache
 	numShards uint16
-}
-
-type RevisionCacheOptions struct {
-	Size       *uint32
-	ShardCount *uint16
 }
 
 // Creates a sharded revision cache with the given capacity and an optional loader function.

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -121,7 +121,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 	}
 
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
-	numDocs := int(revCacheOptions.Size + 1)
+	numDocs := int(*revCacheOptions.Size + 1)
 	var revid string
 	for i := 0; i < numDocs; i++ {
 		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc1k_%d", i), doc1k_putDoc)

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -116,12 +116,10 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 	// Get database handle
 	rtDatabase := rt.GetDatabase()
-	revCacheOptions := db.RevisionCacheOptions{
-		Size: rtDatabase.Options.RevisionCacheOptions.Size,
-	}
+	revCacheSize := rtDatabase.Options.RevisionCacheOptions.Size
 
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
-	numDocs := int(*revCacheOptions.Size + 1)
+	numDocs := int(revCacheSize + 1)
 	var revid string
 	for i := 0; i < numDocs; i++ {
 		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc1k_%d", i), doc1k_putDoc)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -386,7 +386,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	// Set cache properties, if present
 	cacheOptions := db.CacheOptions{}
-	revCacheOptions := db.RevisionCacheOptions{}
+	revCacheOptions := db.DefaultRevisionCacheOptions()
 	if config.CacheConfig != nil {
 		if config.CacheConfig.ChannelCacheConfig != nil {
 			if config.CacheConfig.ChannelCacheConfig.MaxNumPending != nil {
@@ -418,10 +418,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 		if config.CacheConfig.RevCacheConfig != nil {
 			if config.CacheConfig.RevCacheConfig.Size != nil {
-				revCacheOptions.Size = config.CacheConfig.RevCacheConfig.Size
+				revCacheOptions.Size = *config.CacheConfig.RevCacheConfig.Size
 			}
 			if config.CacheConfig.RevCacheConfig.ShardCount != nil {
-				revCacheOptions.ShardCount = config.CacheConfig.RevCacheConfig.ShardCount
+				revCacheOptions.ShardCount = *config.CacheConfig.RevCacheConfig.ShardCount
 			}
 		}
 	}
@@ -631,7 +631,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
-		RevisionCacheOptions:      &revCacheOptions,
+		RevisionCacheOptions:      revCacheOptions,
 		IndexOptions:              channelIndexOptions,
 		SequenceHashOptions:       sequenceHashOptions,
 		OldRevExpirySeconds:       oldRevExpirySeconds,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -418,10 +418,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 		if config.CacheConfig.RevCacheConfig != nil {
 			if config.CacheConfig.RevCacheConfig.Size != nil {
-				revCacheOptions.Size = *config.CacheConfig.RevCacheConfig.Size
+				revCacheOptions.Size = config.CacheConfig.RevCacheConfig.Size
 			}
 			if config.CacheConfig.RevCacheConfig.ShardCount != nil {
-				revCacheOptions.ShardNumber = *config.CacheConfig.RevCacheConfig.ShardCount
+				revCacheOptions.ShardCount = config.CacheConfig.RevCacheConfig.ShardCount
 			}
 		}
 	}


### PR DESCRIPTION
Previously, when the `rev_cache.size` option was set to zero, the default value of `5000` is being used.