### PR TITLE
Remove dump of non-annotated principal struct

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -184,7 +184,7 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 	// always grant access to the public document channel
 	channels.AddChannel(ch.DocumentStarChannel, 1)
 
-	base.Infof(base.KeyAccess, "Computed channels for %q: %s", base.UD(princ.Name()), base.UD(channels))
+	base.Infof(base.KeyAccess, "Recomputed channels for %q: %s", base.UD(princ.Name()), base.UD(channels))
 	princ.SetPreviousChannels(nil)
 	princ.setChannels(channels)
 
@@ -250,7 +250,7 @@ func (auth *Authenticator) Save(p Principal) error {
 			//FIX: Unregister old email address if any
 		}
 	}
-	base.Infof(base.KeyAuth, "Saved %s: %s", base.UD(p.DocID()), base.UD(p))
+	base.Infof(base.KeyAuth, "Saved principal w/ name:%s, seq: #%d", base.UD(p.Name()), p.Sequence())
 	return nil
 }
 


### PR DESCRIPTION
Dumping the full principal object on mutate doesn't have particular value, results in log bloat.