### PR TITLE
CBG-392: Re-enable go vet stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,8 +150,6 @@ pipeline {
                     }
                 }
                 stage('go vet') {
-                    // TODO: Remove skip
-                    when { expression { return false } }
                     steps {
                         withEnv(["PATH+=${GO}:${GOPATH}/bin"]) {
                             warnError(message: "go vet failed") {


### PR DESCRIPTION
Go vet is expected to fail until other go vet fix PRs are merged.