### PR TITLE
CBG-410 Ensure changes consistency during cache eviction

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -847,7 +847,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 //    2. Start a goroutine to issue a changes request
 //        - when view executes, will trigger callback handling above
 //    3. Start a second goroutine to issue another changes request.
-//        - will block waiting for viewLock, which increments StatKeyChannelCachePendingQueries stat
+//        - will block waiting for queryLock, which increments StatKeyChannelCachePendingQueries stat
 //    4. Wait until StatKeyChannelCachePendingQueries is incremented
 //    5. Terminate second changes request
 //    6. Unblock the initial view query

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -50,11 +50,6 @@ type ChannelCache interface {
 	// Returns the highest cached sequence, used for changes synchronization
 	GetHighCacheSequence() uint64
 
-	// Late sequence handling
-	GetLateSequencesSince(channelName string, sinceSequence uint64) (entries []*LogEntry, lastSequence uint64, err error)
-	RegisterLateSequenceClient(channelName string) uint64
-	ReleaseLateSequenceClient(channelName string, currentSeq uint64) bool
-
 	// Access to individual channel cache, intended for testing
 	getSingleChannelCache(channelName string) *singleChannelCache
 }
@@ -223,6 +218,7 @@ func (c *channelCacheImpl) Remove(docIDs []string, startTime time.Time) (count i
 }
 
 func (c *channelCacheImpl) GetChanges(channelName string, options ChangesOptions) ([]*LogEntry, error) {
+
 	return c.getChannelCache(channelName).GetChanges(options)
 }
 
@@ -230,18 +226,6 @@ func (c *channelCacheImpl) GetCachedChanges(channelName string) []*LogEntry {
 	options := ChangesOptions{Since: SequenceID{Seq: 0}}
 	_, changes := c.getChannelCache(channelName).getCachedChanges(options)
 	return changes
-}
-
-func (c *channelCacheImpl) GetLateSequencesSince(channelName string, sinceSequence uint64) (entries []*LogEntry, lastSequence uint64, err error) {
-	return c.getChannelCache(channelName).GetLateSequencesSince(sinceSequence)
-}
-
-func (c *channelCacheImpl) RegisterLateSequenceClient(channelName string) uint64 {
-	return c.getChannelCache(channelName).RegisterLateSequenceClient()
-}
-
-func (c *channelCacheImpl) ReleaseLateSequenceClient(channelName string, currentSequence uint64) bool {
-	return c.getChannelCache(channelName).ReleaseLateSequenceClient(currentSequence)
 }
 
 // CleanAgedItems prunes the caches based on age of items. Error returned to fulfill BackgroundTaskFunc signature.

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -229,21 +229,6 @@ func (k *kvChangeIndex) GetCachedChanges(channelName string, options ChangesOpti
 	return uint64(0), changes
 }
 
-func (k *kvChangeIndex) InitLateSequenceClient(channelName string) uint64 {
-	// no-op when not buffering sequences
-	return 0
-}
-
-func (k *kvChangeIndex) GetLateSequencesSince(channelName string, sinceSequence uint64) (entries []*LogEntry, lastSequence uint64, err error) {
-	// no-op when not buffering sequences
-	return entries, lastSequence, nil
-}
-
-func (k *kvChangeIndex) ReleaseLateSequenceClient(channelName string, sequence uint64) error {
-	// no-op when not buffering sequences
-	return nil
-}
-
 // Add late sequence information to channel cache
 func (k *kvChangeIndex) addLateSequence(channelName string, change *LogEntry) error {
 	// TODO: no-op for now


### PR DESCRIPTION
Adds handling to ensure that the same channel cache instance is used for the late feed and normal feed during a given changes iteration, and strengthens the check to guarantee that the active late handler is associated with the current cache instance.  In case of mismatch, triggers the normal feed to roll back to the stable sequence.