### PR TITLE
Log SG panics to all outputs before exiting

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -1223,11 +1224,7 @@ func PanicHandler() (panicHandler func()) {
 	return func() {
 		// Recover from any panics to allow for graceful shutdown.
 		if r := recover(); r != nil {
-			base.Errorf(base.KeyAll, "Handling panic: %v", r)
-			// Ensure log buffers are flushed before exiting.
-			base.FlushLogBuffers()
-
-			panic(r)
+			base.Fatalf(base.KeyAll, "Handling panic: %v\n%v", r, string(debug.Stack()))
 		}
 	}
 


### PR DESCRIPTION
No need to re-panic, we can rely on the Fatalf logging (which flushes buffers before exiting)

```
18:01 $ go build && ./sync_gateway sg_config.json
2019-06-07T18:01:41.416+01:00 [INF] Logging: Console to stderr
2019-06-07T18:01:41.417+01:00 [INF] Logging: Files to /tmp/sglog5
2019-06-07T18:01:41.417+01:00 [ERR] Handling panic: aaaa!!!
goroutine 1 [running]:
runtime/debug.Stack(0xc0002a7d30, 0x4819aa0, 0x4aac910)
	/usr/local/Cellar/go/1.12.5/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/couchbase/sync_gateway/rest.PanicHandler.func1()
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:1229 +0x57
panic(0x4819aa0, 0x4aac910)
	/usr/local/Cellar/go/1.12.5/libexec/src/runtime/panic.go:522 +0x1b5
github.com/couchbase/sync_gateway/rest.(*DbConfig).setup(0xc0001ba540, 0xc0002b2800, 0x2, 0x1, 0x400b80b)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:368 +0x28c
github.com/couchbase/sync_gateway/rest.(*ServerConfig).setupAndValidateDatabases(0xc000159b80, 0xc00007cc80, 0x2, 0x2)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:783 +0xca
github.com/couchbase/sync_gateway/rest.ServerMain(0xc0000a8000)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:1278 +0x202
main.main()
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/main.go:25 +0x26
 -- rest.PanicHandler.func1() at config.go:1229
```

```
18:06 $ tail -n18 /tmp/sglog5/sg_error.log
2019-06-07T18:01:41.415+01:00 ==== /() CE ====
2019-06-07T18:01:41.417+01:00 [ERR] Handling panic: aaaa!!!
goroutine 1 [running]:
runtime/debug.Stack(0xc0002a7d30, 0x4819aa0, 0x4aac910)
	/usr/local/Cellar/go/1.12.5/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/couchbase/sync_gateway/rest.PanicHandler.func1()
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:1229 +0x57
panic(0x4819aa0, 0x4aac910)
	/usr/local/Cellar/go/1.12.5/libexec/src/runtime/panic.go:522 +0x1b5
github.com/couchbase/sync_gateway/rest.(*DbConfig).setup(0xc0001ba540, 0xc0002b2800, 0x2, 0x1, 0x400b80b)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:368 +0x28c
github.com/couchbase/sync_gateway/rest.(*ServerConfig).setupAndValidateDatabases(0xc000159b80, 0xc00007cc80, 0x2, 0x2)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:783 +0xca
github.com/couchbase/sync_gateway/rest.ServerMain(0xc0000a8000)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:1278 +0x202
main.main()
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/main.go:25 +0x26
 -- rest.PanicHandler.func1() at config.go:1229
```