### PR TITLE
CBG-389 - Bypass single channel cache

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -84,6 +84,7 @@ const (
 	StatKeyChannelCacheChannelsEvictedNRU      = "chan_cache_channels_evicted_nru"
 	StatKeyChannelCacheCompactCount            = "chan_cache_compact_count"
 	StatKeyChannelCacheCompactTime             = "chan_cache_compact_time"
+	StatKeyChannelCacheBypassCount             = "chan_cache_bypass_count"
 	StatKeyActiveChannels                      = "num_active_channels"
 	StatKeyNumSkippedSeqs                      = "num_skipped_seqs"
 	StatKeyAbandonedSeqs                       = "abandoned_seqs"

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -317,7 +317,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 	// Modify the cache's late logs to remove the changes feed's lateFeedHandler sequence from the
 	// cache's lateLogs.  This will trigger an error on the next feed iteration, which should trigger
 	// rollback to resend all changes since low sequence (1)
-	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC")
+	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC").(*singleChannelCacheImpl)
 	abcCache.lateLogs[0].logEntry.Sequence = 1
 
 	// Write sequence 3.  Error should trigger rollback that resends everything since low sequence (1)
@@ -513,16 +513,16 @@ func TestChannelCacheBackfill(t *testing.T) {
 	WriteDirect(db, []string{"CBS"}, 7)
 	db.changeCache.waitForSequenceID(SequenceID{Seq: 7}, base.DefaultWaitForSequenceTesting, t)
 	// verify insert at start (PBS)
-	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache("PBS")
+	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache("PBS").(*singleChannelCacheImpl)
 	goassert.True(t, verifyCacheSequences(pbsCache, []uint64{3, 5, 6}))
 	// verify insert at middle (ABC)
-	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC")
+	abcCache := db.changeCache.getChannelCache().getSingleChannelCache("ABC").(*singleChannelCacheImpl)
 	goassert.True(t, verifyCacheSequences(abcCache, []uint64{1, 2, 3, 5, 6}))
 	// verify insert at end (NBC)
-	nbcCache := db.changeCache.getChannelCache().getSingleChannelCache("NBC")
+	nbcCache := db.changeCache.getChannelCache().getSingleChannelCache("NBC").(*singleChannelCacheImpl)
 	goassert.True(t, verifyCacheSequences(nbcCache, []uint64{1, 3}))
 	// verify insert to empty cache (TBS)
-	tbsCache := db.changeCache.getChannelCache().getSingleChannelCache("TBS")
+	tbsCache := db.changeCache.getChannelCache().getSingleChannelCache("TBS").(*singleChannelCacheImpl)
 	goassert.True(t, verifyCacheSequences(tbsCache, []uint64{3}))
 
 	// verify changes has three entries (needs to resend all since previous LowSeq, which
@@ -1309,7 +1309,7 @@ func TestChannelCacheSize(t *testing.T) {
 	// Validate that cache stores the expected number of values
 	changeCache, ok := db.changeCache.(*changeCache)
 	assert.True(t, ok, "Testing skipped sequences without a change cache")
-	abcCache := changeCache.getChannelCache().getSingleChannelCache("ABC")
+	abcCache := changeCache.getChannelCache().getSingleChannelCache("ABC").(*singleChannelCacheImpl)
 	goassert.Equals(t, len(abcCache.logs), 600)
 }
 
@@ -1348,7 +1348,7 @@ func verifySkippedSequences(list *SkippedSequenceList, sequences []uint64) bool 
 	return true
 }
 
-func verifyCacheSequences(cache *singleChannelCache, sequences []uint64) bool {
+func verifyCacheSequences(cache *singleChannelCacheImpl, sequences []uint64) bool {
 	if len(cache.logs) != len(sequences) {
 
 		log.Printf("verifyCacheSequences: cache size (%v) not equals to sequences size (%v)",

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -136,9 +136,10 @@ func (c *channelCacheImpl) updateHighCacheSequence(sequence uint64) {
 	c.seqLock.Unlock()
 }
 
-// GetSingleChannelCache will create the cache for the channel if it doesn't exist.  Intended for test
-// usage only - otherwise management of per-channel caches should be opaque to ChannelCache consumers.
+// GetSingleChannelCache will create the cache for the channel if it doesn't exist.  If the cache is at
+// capacity, will return a bypass channel cache.
 func (c *channelCacheImpl) getSingleChannelCache(channelName string) SingleChannelCache {
+
 	return c.getChannelCache(channelName)
 }
 
@@ -224,7 +225,7 @@ func (c *channelCacheImpl) GetChanges(channelName string, options ChangesOptions
 
 func (c *channelCacheImpl) GetCachedChanges(channelName string) []*LogEntry {
 	options := ChangesOptions{Since: SequenceID{Seq: 0}}
-	_, changes := c.getChannelCache(channelName).getCachedChanges(options)
+	_, changes := c.getChannelCache(channelName).GetCachedChanges(options)
 	return changes
 }
 
@@ -244,14 +245,26 @@ func (c *channelCacheImpl) cleanAgedItems(ctx context.Context) error {
 	return nil
 }
 
-func (c *channelCacheImpl) getChannelCache(channelName string) *singleChannelCacheImpl {
+func (c *channelCacheImpl) getChannelCache(channelName string) SingleChannelCache {
 
 	cacheValue, found := c.channelCaches.Get(channelName)
 	if found {
 		return AsSingleChannelCache(cacheValue)
 	}
 
-	return c.addChannelCache(channelName)
+	// Attempt to add a singleChannelCache for the channel name.  If unsuccessful, return a bypass channel cache
+	singleChannelCache, ok := c.addChannelCache(channelName)
+	if ok {
+		return singleChannelCache
+	}
+
+	bypassChannelCache := &bypassChannelCache{
+		channelName:  channelName,
+		queryHandler: c.queryHandler,
+	}
+	c.statsMap.Add(base.StatKeyChannelCacheBypassCount, 1)
+	return bypassChannelCache
+
 }
 
 // Converts an RangeSafeCollection value to a singleChannelCacheImpl.  On type
@@ -272,7 +285,12 @@ func AsSingleChannelCache(cacheValue interface{}) *singleChannelCacheImpl {
 //	//     4. addChannelCache initializes cache with validFrom=10 and adds to c.channelCaches
 //	//  This scenario would result in sequence 11 missing from the cache.  Locking seqLock ensures that
 //	//  step 3 blocks until step 4 is complete (and so sees the channel as active)
-func (c *channelCacheImpl) addChannelCache(channelName string) *singleChannelCacheImpl {
+func (c *channelCacheImpl) addChannelCache(channelName string) (*singleChannelCacheImpl, bool) {
+
+	// Return nil if the cache at capacity.
+	if c.channelCaches.Length() >= c.maxChannels {
+		return nil, false
+	}
 
 	c.seqLock.Lock()
 
@@ -294,7 +312,7 @@ func (c *channelCacheImpl) addChannelCache(channelName string) *singleChannelCac
 		c.statsMap.Add(base.StatKeyChannelCacheChannelsAdded, 1)
 	}
 
-	return singleChannelCache
+	return singleChannelCache, true
 }
 
 func (c *channelCacheImpl) getActiveChannelCache(channelName string) (*singleChannelCacheImpl, bool) {

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -858,9 +858,3 @@ func (b *bypassChannelCache) RegisterLateSequenceClient() (latestLateSeq uint64)
 func (b *bypassChannelCache) ReleaseLateSequenceClient(sequence uint64) (success bool) {
 	return false
 }
-
-// BypassQueryHandler limits the number of concurrent bypass queries being executed.  Calls
-// to getChangesInChannelFromQuery will block if the limit is exceeded, and will time out after
-// 30 seconds.
-type bypassQueryHandler struct {
-}

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -140,6 +140,7 @@ func initEmptyStatsMap(key string, d *DatabaseStats) *expvar.Map {
 		result.Set(base.StatKeyChannelCacheChannelsEvictedNRU, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheCompactCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyChannelCacheCompactTime, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyChannelCacheBypassCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyActiveChannels, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyNumSkippedSeqs, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyAbandonedSeqs, base.ExpvarIntVal(0))


### PR DESCRIPTION
When channel cache is at capacity, bypass the cache overhead and issue query to serve changes requests.