### PR TITLE
CBG-411 - Add 'active' stat for sg-replicate replications

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -177,12 +177,12 @@ const (
 	StatKeyViewQueryTimeExpvarFormat       = "%s.%s_time"        // Design doc, view
 
 	// StatsReplication
+	StatKeySgrActive                     = "sgr_active"
 	StatKeySgrNumDocsPushed              = "sgr_num_docs_pushed"
 	StatKeySgrNumDocsFailedToPush        = "sgr_num_docs_failed_to_push"
 	StatKeySgrNumAttachmentsTransferred  = "sgr_num_attachments_transferred"
 	StatKeySgrAttachmentBytesTransferred = "sgr_num_attachment_bytes_transferred"
 	StatKeySgrDocsCheckedSent            = "sgr_docs_checked_sent"
-	StatKeySgrActive                     = "sgr_active"
 )
 
 const (
@@ -258,15 +258,6 @@ func NewStatsResourceUtilization() *expvar.Map {
 	stats.Set(StatKeyErrorCount, ExpvarIntVal(0))
 	stats.Set(StatKeyWarnCount, ExpvarIntVal(0))
 	return stats
-}
-
-// Removes the per-replication stats for this replication id by
-// regenerating a new expvar map without that particular replicationUuid
-func RemovePerReplicationStats(replicationUuid string) {
-
-	// Clear out the stats for this replication since they will no longer be updated.
-	PerReplicationStats.Set(replicationUuid, new(expvar.Map).Init())
-
 }
 
 // Removes the per-database stats for this database by
@@ -594,6 +585,7 @@ func NewIntRollingMeanVar(capacity int) IntRollingMeanVar {
 		entries:  make([]int64, 0, capacity),
 	}
 }
+
 func (v *IntRollingMeanVar) String() string {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
@@ -610,6 +602,7 @@ func (v *IntRollingMeanVar) AddValue(value int64) {
 		v.replaceValue(value)
 	}
 }
+
 func (v *IntRollingMeanVar) AddSince(start time.Time) {
 	v.AddValue(time.Since(start).Nanoseconds())
 }

--- a/base/expvar.go
+++ b/base/expvar.go
@@ -182,6 +182,7 @@ const (
 	StatKeySgrNumAttachmentsTransferred  = "sgr_num_attachments_transferred"
 	StatKeySgrAttachmentBytesTransferred = "sgr_num_attachment_bytes_transferred"
 	StatKeySgrDocsCheckedSent            = "sgr_docs_checked_sent"
+	StatKeySgrActive                     = "sgr_active"
 )
 
 const (

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -90,6 +90,7 @@ func (r *Replicator) writeStats(repID string, replication sgreplicate.SGReplicat
 	statsExpvars.Set(StatKeySgrNumAttachmentsTransferred, ExpvarInt64Val(int64(stats.GetNumAttachmentsTransferred())))
 	statsExpvars.Set(StatKeySgrAttachmentBytesTransferred, ExpvarInt64Val(int64(stats.GetAttachmentBytesTransferred())))
 	statsExpvars.Set(StatKeySgrDocsCheckedSent, ExpvarInt64Val(int64(stats.GetDocsCheckedSent())))
+	statsExpvars.Set(StatKeySgrActive, NewAtomicBool(stats.GetActive()))
 }
 
 // StopReplications stops all active replications.
@@ -299,5 +300,6 @@ func NewReplicationStats() (expvarMap *expvar.Map) {
 	result.Set(StatKeySgrNumAttachmentsTransferred, ExpvarIntVal(0))
 	result.Set(StatKeySgrAttachmentBytesTransferred, ExpvarIntVal(0))
 	result.Set(StatKeySgrDocsCheckedSent, ExpvarIntVal(0))
+	result.Set(StatKeySgrActive, &AtomicBool{value: 1})
 	return result
 }

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -197,15 +197,15 @@ func (r *Replicator) runContinuousReplication(parameters sgreplicate.Replication
 	factory := func(parameters sgreplicate.ReplicationParameters, notificationChan chan sgreplicate.ReplicationNotification) sgreplicate.Runnable {
 		parameters.Lifecycle = sgreplicate.ONE_SHOT
 		stats := &sgreplicate.ReplicationStats{
-			DocsRead: parameters.Stats.DocsRead,
-			DocsWritten: parameters.Stats.DocsWritten,
-			DocWriteFailures: parameters.Stats.DocWriteFailures,
-			StartLastSeq: parameters.Stats.StartLastSeq,
-			NumAttachmentsTransferred: parameters.Stats.NumAttachmentsTransferred,
+			DocsRead:                   parameters.Stats.DocsRead,
+			DocsWritten:                parameters.Stats.DocsWritten,
+			DocWriteFailures:           parameters.Stats.DocWriteFailures,
+			StartLastSeq:               parameters.Stats.StartLastSeq,
+			NumAttachmentsTransferred:  parameters.Stats.NumAttachmentsTransferred,
 			AttachmentBytesTransferred: parameters.Stats.AttachmentBytesTransferred,
-			DocsCheckedSent: parameters.Stats.DocsCheckedSent,
-			EndLastSeq: parameters.Stats.EndLastSeq,
-			// Set 'Active' to a new AtomicBool for the oneshot replication to have it's own active stat
+			DocsCheckedSent:            parameters.Stats.DocsCheckedSent,
+			EndLastSeq:                 parameters.Stats.EndLastSeq,
+			// Set 'Active' to a new AtomicBool for the child oneshot replication so the parent's is unaffected
 			Active: &sgreplicate.AtomicBool{},
 		}
 		parameters.Stats = stats

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -243,8 +243,6 @@ func (r *Replicator) stopReplication(parameters sgreplicate.ReplicationParameter
 	delete(r.replications, repID)
 	delete(r.replicationParams, repID)
 
-	RemovePerReplicationStats(repID)
-
 	return taskForReplication(replication, parameters), nil
 }
 

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -194,6 +194,19 @@ func (r *Replicator) runContinuousReplication(parameters sgreplicate.Replication
 
 	factory := func(parameters sgreplicate.ReplicationParameters, notificationChan chan sgreplicate.ReplicationNotification) sgreplicate.Runnable {
 		parameters.Lifecycle = sgreplicate.ONE_SHOT
+		stats := &sgreplicate.ReplicationStats{
+			DocsRead: parameters.Stats.DocsRead,
+			DocsWritten: parameters.Stats.DocsWritten,
+			DocWriteFailures: parameters.Stats.DocWriteFailures,
+			StartLastSeq: parameters.Stats.StartLastSeq,
+			NumAttachmentsTransferred: parameters.Stats.NumAttachmentsTransferred,
+			AttachmentBytesTransferred: parameters.Stats.AttachmentBytesTransferred,
+			DocsCheckedSent: parameters.Stats.DocsCheckedSent,
+			EndLastSeq: parameters.Stats.EndLastSeq,
+			// Set 'Active' to a new AtomicBool for the oneshot replication to have it's own active stat
+			Active: &sgreplicate.AtomicBool{},
+		}
+		parameters.Stats = stats
 		return sgreplicate.NewReplication(parameters, notificationChan)
 	}
 

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -60,7 +60,9 @@ func (r *Replicator) ActiveTasks() []Task {
 	for repID, replication := range r.replications {
 		params := r.replicationParams[repID]
 		task := taskForReplication(replication, params)
-		tasks = append(tasks, *task)
+		if task != nil {
+			tasks = append(tasks, *task)
+		}
 	}
 
 	return tasks

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -19,8 +19,7 @@ func TestReplicator(t *testing.T) {
 	}
 	_, err := r.Replicate(params, false)
 	goassert.Equals(t, err, nil)
-	time.Sleep(time.Millisecond * 100)
-	goassert.Equals(t, len(r.ActiveTasks()), 1)
+	waitForActiveTasks(t, r, 1)
 
 	params = sgreplicate.ReplicationParameters{
 		ReplicationId: "rep1",
@@ -28,18 +27,29 @@ func TestReplicator(t *testing.T) {
 	}
 	_, err = r.Replicate(params, false)
 	goassert.Equals(t, err, nil)
-	time.Sleep(time.Millisecond * 100)
-	goassert.Equals(t, len(r.ActiveTasks()), 2)
+	waitForActiveTasks(t, r, 2)
 
 	// now stop it
 	_, err = r.Replicate(params, true)
 	goassert.Equals(t, err, nil)
-	goassert.Equals(t, len(r.ActiveTasks()), 1)
+	waitForActiveTasks(t, r, 1)
 
 	// stop all
 	err = r.StopReplications()
 	goassert.Equals(t, err, nil)
-	goassert.Equals(t, len(r.ActiveTasks()), 0)
+	waitForActiveTasks(t, r, 0)
+}
+
+func waitForActiveTasks(t *testing.T, r *Replicator, taskCount int) {
+	for i := 0; i < 20; i++ {
+		if i == 20 {
+			t.Fatalf("failed to find active task")
+		}
+		if len(r.ActiveTasks()) == taskCount {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
 }
 
 func TestReplicatorDuplicateID(t *testing.T) {

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -3,6 +3,7 @@ package base
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	goassert "github.com/couchbaselabs/go.assert"
 	sgreplicate "github.com/couchbaselabs/sg-replicate"
@@ -18,6 +19,7 @@ func TestReplicator(t *testing.T) {
 	}
 	_, err := r.Replicate(params, false)
 	goassert.Equals(t, err, nil)
+	time.Sleep(time.Millisecond * 100)
 	goassert.Equals(t, len(r.ActiveTasks()), 1)
 
 	params = sgreplicate.ReplicationParameters{
@@ -26,6 +28,7 @@ func TestReplicator(t *testing.T) {
 	}
 	_, err = r.Replicate(params, false)
 	goassert.Equals(t, err, nil)
+	time.Sleep(time.Millisecond * 100)
 	goassert.Equals(t, len(r.ActiveTasks()), 2)
 
 	// now stop it

--- a/base/util.go
+++ b/base/util.go
@@ -1146,6 +1146,9 @@ func (ab *AtomicBool) IsTrue() bool {
 
 // String allows AtomicBool to satisfy the expvar.Var interface.
 func (ab *AtomicBool) String() string {
+	if ab == nil {
+		return "null"
+	}
 	return strconv.FormatBool(ab.IsTrue())
 }
 

--- a/base/util.go
+++ b/base/util.go
@@ -1119,8 +1119,17 @@ func ContainsString(s []string, e string) bool {
 	return false
 }
 
+// AtomicBool is a bool that can be set or read atomically, and also satisfies the expvar.Var interface.
 type AtomicBool struct {
 	value int32
+}
+
+// NewAtomicBool initializes a new AtomicBool with the given value.
+func NewAtomicBool(val bool) *AtomicBool {
+	if val {
+		return &AtomicBool{value: 1}
+	}
+	return &AtomicBool{value: 0}
 }
 
 func (ab *AtomicBool) Set(flag bool) {
@@ -1134,3 +1143,11 @@ func (ab *AtomicBool) Set(flag bool) {
 func (ab *AtomicBool) IsTrue() bool {
 	return atomic.LoadInt32(&ab.value) == 1
 }
+
+// String allows AtomicBool to satisfy the expvar.Var interface.
+func (ab *AtomicBool) String() string {
+	return strconv.FormatBool(ab.IsTrue())
+}
+
+// compile-time interface check for expvar.Var
+var _ expvar.Var = &AtomicBool{}

--- a/base/util.go
+++ b/base/util.go
@@ -1119,17 +1119,9 @@ func ContainsString(s []string, e string) bool {
 	return false
 }
 
-// AtomicBool is a bool that can be set or read atomically, and also satisfies the expvar.Var interface.
+// AtomicBool is a bool that can be set or read atomically
 type AtomicBool struct {
 	value int32
-}
-
-// NewAtomicBool initializes a new AtomicBool with the given value.
-func NewAtomicBool(val bool) *AtomicBool {
-	if val {
-		return &AtomicBool{value: 1}
-	}
-	return &AtomicBool{value: 0}
 }
 
 func (ab *AtomicBool) Set(flag bool) {
@@ -1143,14 +1135,3 @@ func (ab *AtomicBool) Set(flag bool) {
 func (ab *AtomicBool) IsTrue() bool {
 	return atomic.LoadInt32(&ab.value) == 1
 }
-
-// String allows AtomicBool to satisfy the expvar.Var interface.
-func (ab *AtomicBool) String() string {
-	if ab == nil {
-		return "null"
-	}
-	return strconv.FormatBool(ab.IsTrue())
-}
-
-// compile-time interface check for expvar.Var
-var _ expvar.Var = &AtomicBool{}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="d73786b7838573ed290b4a64479579e76db04f03"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="6b7957ecaade324dee376b7a9bef6f5e7260b7b3"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="a3021acb7d2a8e8ced95e964d53b55a44d155193"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="4c0d33bd072b252c5262ce41b2751878139a5586"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="4c0d33bd072b252c5262ce41b2751878139a5586"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="dc67a55ae5f0c2b7f266827b5c7936e99715925a"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="6b7957ecaade324dee376b7a9bef6f5e7260b7b3"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="a3021acb7d2a8e8ced95e964d53b55a44d155193"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -89,7 +89,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="dc67a55ae5f0c2b7f266827b5c7936e99715925a"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="d6eb45633e5784f5161973b04317e192931972a3"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -287,7 +287,7 @@ type RevCacheConfig struct {
 type ChannelCacheConfig struct {
 	MaxNumber            *int    `json:"max_number,omitempty"`                 // Maximum number of channel caches which will exist at any one point
 	HighWatermarkPercent *int    `json:"compact_high_watermark_pct,omitempty"` // High watermark for channel cache eviction (percent)
-	LowWatermarkPercent  *int    `json:"compact_low_watermark_pct,omitempty"`  // High watermark for channel cache eviction (percent)
+	LowWatermarkPercent  *int    `json:"compact_low_watermark_pct,omitempty"`  // Low watermark for channel cache eviction (percent)
 	MaxWaitPending       *uint32 `json:"max_wait_pending,omitempty"`           // Max wait for pending sequence before skipping
 	MaxNumPending        *int    `json:"max_num_pending,omitempty"`            // Max number of pending sequences before skipping
 	MaxWaitSkipped       *uint32 `json:"max_wait_skipped,omitempty"`           // Max wait for skipped sequence before abandoning

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1064,8 +1064,6 @@ func (sc *ServerContext) logStats() error {
 		base.Warnf(base.KeyAll, "Error getting sigar based system resource stats: %v", err)
 	}
 
-	sc.replicator.SnapshotStats()
-
 	sc.updateCalculatedStats()
 	// Create wrapper expvar map in order to add a timestamp field for logging purposes
 	currentTime := time.Now()


### PR DESCRIPTION
- Create `ReplicationStats` in Sync Gateway and pass down to sg-replicate by reference for live-updates of replication stats without the stat snapshots
- Stop SG from wiping out existing replication stats when finished/cancelled
- Keep existing stats for identical replication IDs

## TODO
- [x] Bump sg-replicate manifest when https://github.com/couchbaselabs/sg-replicate/pull/68 is merged