### PR TITLE
CBG-390 Additional compaction-related tests

### DIFF
--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -269,7 +269,9 @@ func (c *singleChannelCacheImpl) _pruneCacheLength() (pruned int) {
 		c.logs = c.logs[pruned:]
 	}
 
-	base.Debugf(base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelName))
+	if pruned > 0 {
+		base.Debugf(base.KeyCache, "Pruned %d entries from channel %q", pruned, base.UD(c.channelName))
+	}
 
 	return pruned
 }


### PR DESCRIPTION
Includes fixes for two issues caught by new tests:
- late sequence rollback wasn't using the correct sequence due to the timing for lowSequence updates.  Changed to use the last sent sequence to clarify behaviour
- active channel tracker wasn't being properly initialized before cache