### PR TITLE
Use sync.Once to initialize RestTester handlers

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1274,18 +1274,18 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	wg.Add(2)
 
 	var goroutineresponse1 *TestResponse
-	go func(rt RestTester) {
+	go func(rt *RestTester) {
 		defer wg.Done()
 		goroutineresponse1 = rt.SendAdminRequest("POST", "/db/_online", "")
 		assertStatus(t, goroutineresponse1, 200)
-	}(*rt)
+	}(rt)
 
 	var goroutineresponse2 *TestResponse
-	go func(rt RestTester) {
+	go func(rt *RestTester) {
 		defer wg.Done()
 		goroutineresponse2 = rt.SendAdminRequest("POST", "/db/_online", "")
 		assertStatus(t, goroutineresponse2, 200)
-	}(*rt)
+	}(rt)
 
 	//This only waits until both _online requests have been posted
 	//They may not have been processed at this point

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -61,7 +61,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
 	response := rt.SendAdminRequest("PUT", "/db/doc1k", doc1k_putDoc)
@@ -112,7 +112,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	// Get database handle
 	rtDatabase := rt.GetDatabase()
@@ -179,7 +179,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	// Create user
 	username := "user1"
@@ -252,7 +252,7 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 
 	rt := NewRestTester(b, nil)
 	defer rt.Close()
-	defer PurgeDoc(*rt, "doc1k")
+	defer PurgeDoc(rt, "doc1k")
 
 	// Create target doc for revs_diff:
 	doc1k_bulkDocs_meta := `"_id":"doc1k", 
@@ -304,7 +304,7 @@ func BenchmarkReadOps_RevsDiff(b *testing.B) {
 
 }
 
-func PurgeDoc(rt RestTester, docid string) {
+func PurgeDoc(rt *RestTester, docid string) {
 	response := rt.SendAdminRequest("POST", "/db/_purge", fmt.Sprintf(`{"%s":["*"]}`, docid))
 	if response.Code != 200 {
 		log.Printf("Unexpected purge response: %d  %s", response.Code, response.Body.Bytes())

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -48,7 +48,9 @@ type RestTester struct {
 	RestTesterBucket        base.Bucket
 	RestTesterServerContext *ServerContext
 	AdminHandler            http.Handler
+	adminHandlerOnce        sync.Once
 	PublicHandler           http.Handler
+	publicHandlerOnce       sync.Once
 }
 
 func NewRestTester(tb testing.TB, restConfig *RestTesterConfig) *RestTester {
@@ -342,23 +344,20 @@ func (rt *RestTester) Send(request *http.Request) *TestResponse {
 
 func (rt *RestTester) TestAdminHandlerNoConflictsMode() http.Handler {
 	rt.EnableNoConflictsMode = true
-	if rt.AdminHandler == nil {
-		rt.AdminHandler = CreateAdminHandler(rt.ServerContext())
-	}
-	return rt.AdminHandler
+	return rt.TestAdminHandler()
 }
 
 func (rt *RestTester) TestAdminHandler() http.Handler {
-	if rt.AdminHandler == nil {
+	rt.adminHandlerOnce.Do(func() {
 		rt.AdminHandler = CreateAdminHandler(rt.ServerContext())
-	}
+	})
 	return rt.AdminHandler
 }
 
 func (rt *RestTester) TestPublicHandler() http.Handler {
-	if rt.PublicHandler == nil {
+	rt.publicHandlerOnce.Do(func() {
 		rt.PublicHandler = CreatePublicHandler(rt.ServerContext())
-	}
+	})
 	return rt.PublicHandler
 }
 


### PR DESCRIPTION
Prevents data race seen in https://github.com/couchbase/sync_gateway/pull/4157 