### PR TITLE
CBG-416 - Make new cache management config options EE-only

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -390,7 +390,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
 	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(defaultRevisionCacheShardCount, defaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -475,7 +475,7 @@ func TestGetRemoved(t *testing.T) {
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
 	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(defaultRevisionCacheShardCount, defaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 
@@ -551,7 +551,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 	// Manually flush the rev cache
 	// After expiry from the rev cache and removal of doc backup, try again
 	cacheHitCounter, cacheMissCounter := db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheHits).(*expvar.Int), db.DatabaseContext.DbStats.StatsCache().Get(base.StatKeyRevisionCacheMisses).(*expvar.Int)
-	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(defaultRevisionCacheShardCount, defaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
+	db.DatabaseContext.revisionCache = NewShardedLRURevisionCache(DefaultRevisionCacheShardCount, DefaultRevisionCacheSize, db.DatabaseContext, cacheHitCounter, cacheMissCounter)
 	err = db.purgeOldRevisionJSON("doc1", rev2id)
 	assert.NoError(t, err, "Purge old revision JSON")
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -8,11 +8,11 @@ import (
 )
 
 const (
-	// defaultRevisionCacheSize is the number of recently-accessed doc revisions to cache in RAM
-	defaultRevisionCacheSize = 5000
+	// DefaultRevisionCacheSize is the number of recently-accessed doc revisions to cache in RAM
+	DefaultRevisionCacheSize = 5000
 
-	// defaultRevisionCacheShardCount is the default number of shards to use for the revision cache
-	defaultRevisionCacheShardCount = 8
+	// DefaultRevisionCacheShardCount is the default number of shards to use for the revision cache
+	DefaultRevisionCacheShardCount = 8
 )
 
 // RevisionCache is an interface that can be used to fetch a DocumentRevision for a Doc ID and Rev ID pair.
@@ -67,8 +67,8 @@ type RevisionCacheOptions struct {
 
 func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 	return &RevisionCacheOptions{
-		Size:       defaultRevisionCacheSize,
-		ShardCount: defaultRevisionCacheShardCount,
+		Size:       DefaultRevisionCacheSize,
+		ShardCount: DefaultRevisionCacheShardCount,
 	}
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -457,15 +457,15 @@ func (dbConfig DbConfig) validate() []error {
 			if !base.IsEnterpriseEdition() {
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber; val != nil {
 					base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.channel_cache.max_number", *val, db.DefaultChannelCacheMaxNumber)
-					dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber = &db.DefaultChannelCacheMaxNumber
+					dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber = nil
 				}
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent; val != nil {
 					base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.channel_cache.compact_high_watermark_pct", *val, db.DefaultCompactHighWatermarkPercent)
-					dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent = &db.DefaultCompactHighWatermarkPercent
+					dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent = nil
 				}
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent; val != nil {
 					base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.channel_cache.compact_low_watermark_pct", *val, db.DefaultCompactLowWatermarkPercent)
-					dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent = &db.DefaultCompactLowWatermarkPercent
+					dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent = nil
 				}
 			}
 
@@ -517,7 +517,7 @@ func (dbConfig DbConfig) validate() []error {
 			revCacheSize := dbConfig.CacheConfig.RevCacheConfig.Size
 			if !base.IsEnterpriseEdition() && revCacheSize != nil && *revCacheSize == 0 {
 				base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.rev_cache.size", *revCacheSize, db.DefaultRevisionCacheSize)
-				dbConfig.CacheConfig.RevCacheConfig.Size = base.Uint32Ptr(db.DefaultRevisionCacheSize)
+				dbConfig.CacheConfig.RevCacheConfig.Size = nil
 			}
 
 			if dbConfig.CacheConfig.RevCacheConfig.ShardCount != nil {
@@ -539,7 +539,7 @@ func (dbConfig DbConfig) validate() []error {
 	// EE: delta sync
 	if !base.IsEnterpriseEdition() && dbConfig.DeltaSync != nil && dbConfig.DeltaSync.Enabled != nil {
 		base.Warnf(base.KeyAll, eeOnlyWarningMsg, "delta_sync.enabled", *dbConfig.DeltaSync.Enabled, false)
-		dbConfig.DeltaSync.Enabled = base.BoolPtr(false)
+		dbConfig.DeltaSync.Enabled = nil
 	}
 
 	return errorMessages

--- a/rest/config.go
+++ b/rest/config.go
@@ -54,6 +54,10 @@ var (
 var config *ServerConfig
 
 const (
+	eeOnlyWarningMsg   = "EE only configuration option %s=%v - Reverting to default value for CE: %v"
+	minValueErrorMsg   = "minimum value for %s is: %v"
+	rangeValueErrorMsg = "valid range for %s is: %s"
+
 	DefaultMaxCouchbaseConnections         = 16
 	DefaultMaxCouchbaseOverflowConnections = 0
 
@@ -439,38 +443,52 @@ func (dbConfig DbConfig) validate() []error {
 		}
 	}
 
-	if dbConfig.CompactIntervalDays != nil {
-		if *dbConfig.CompactIntervalDays < db.CompactIntervalMinDays && *dbConfig.CompactIntervalDays != 0 {
-			errorMessages = append(errorMessages, fmt.Errorf("compact_interval_days cannot be lower than %g", db.CompactIntervalMinDays))
-		}
-		if *dbConfig.CompactIntervalDays > db.CompactIntervalMinDays && *dbConfig.CompactIntervalDays != 0 {
-			errorMessages = append(errorMessages, fmt.Errorf("compact_interval_days cannot be higher than %g", db.CompactIntervalMaxDays))
-		}
+	// Make sure a non-zero compact_interval_days config is within the valid range
+	if val := dbConfig.CompactIntervalDays; val != nil && *val != 0 &&
+		(*val < db.CompactIntervalMinDays || *val > db.CompactIntervalMaxDays) {
+		errorMessages = append(errorMessages, fmt.Errorf(rangeValueErrorMsg, "compact_interval_days", fmt.Sprintf("%g-%g", db.CompactIntervalMinDays, db.CompactIntervalMaxDays)))
 	}
 
 	if dbConfig.CacheConfig != nil {
 
 		if dbConfig.CacheConfig.ChannelCacheConfig != nil {
+
+			// EE: channel cache
+			if !base.IsEnterpriseEdition() {
+				if val := dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber; val != nil {
+					base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.channel_cache.max_number", *val, db.DefaultChannelCacheMaxNumber)
+					dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber = &db.DefaultChannelCacheMaxNumber
+				}
+				if val := dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent; val != nil {
+					base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.channel_cache.compact_high_watermark_pct", *val, db.DefaultCompactHighWatermarkPercent)
+					dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent = &db.DefaultCompactHighWatermarkPercent
+				}
+				if val := dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent; val != nil {
+					base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.channel_cache.compact_low_watermark_pct", *val, db.DefaultCompactLowWatermarkPercent)
+					dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent = &db.DefaultCompactLowWatermarkPercent
+				}
+			}
+
 			if dbConfig.CacheConfig.ChannelCacheConfig.MaxNumPending != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MaxNumPending < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.max_num_pending is 1"))
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.max_num_pending", 1))
 			}
 			if dbConfig.CacheConfig.ChannelCacheConfig.MaxWaitPending != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MaxWaitPending < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.max_wait_pending is 1"))
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.max_wait_pending", 1))
 			}
 			if dbConfig.CacheConfig.ChannelCacheConfig.MaxWaitSkipped != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MaxWaitSkipped < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.max_wait_skipped is 1"))
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.max_wait_skipped", 1))
 			}
 			if dbConfig.CacheConfig.ChannelCacheConfig.MaxLength != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MaxLength < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.max_length is 1"))
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.max_length", 1))
 			}
 			if dbConfig.CacheConfig.ChannelCacheConfig.MinLength != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MinLength < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.min_length is 1"))
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.min_length", 1))
 			}
 			if dbConfig.CacheConfig.ChannelCacheConfig.ExpirySeconds != nil && *dbConfig.CacheConfig.ChannelCacheConfig.ExpirySeconds < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.expiry_seconds is 1"))
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.expiry_seconds", 1))
 			}
-			if dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber < 1 {
-				errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.channel_cache.max_number is 1"))
+			if dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber != nil && *dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber < db.MinimumChannelCacheMaxNumber {
+				errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.channel_cache.max_number", db.MinimumChannelCacheMaxNumber))
 			}
 
 			// Compact watermark validation
@@ -478,13 +496,13 @@ func (dbConfig DbConfig) validate() []error {
 			lwm := db.DefaultCompactLowWatermarkPercent
 			if dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent != nil {
 				if *dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent < 1 || *dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent > 100 {
-					errorMessages = append(errorMessages, fmt.Errorf("valid range for cache.channel_cache.compact_high_watermark_pct is 0-100"))
+					errorMessages = append(errorMessages, fmt.Errorf(rangeValueErrorMsg, "cache.channel_cache.compact_high_watermark_pct", "0-100"))
 				}
 				hwm = *dbConfig.CacheConfig.ChannelCacheConfig.HighWatermarkPercent
 			}
 			if dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent != nil {
 				if *dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent < 1 || *dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent > 100 {
-					errorMessages = append(errorMessages, fmt.Errorf("valid range for cache.channel_cache.compact_low_watermark_pct is 0-100"))
+					errorMessages = append(errorMessages, fmt.Errorf(rangeValueErrorMsg, "cache.channel_cache.compact_low_watermark_pct", "0-100"))
 				}
 				lwm = *dbConfig.CacheConfig.ChannelCacheConfig.LowWatermarkPercent
 			}
@@ -495,10 +513,16 @@ func (dbConfig DbConfig) validate() []error {
 		}
 
 		if dbConfig.CacheConfig.RevCacheConfig != nil {
+			// EE: disable revcache
+			revCacheSize := dbConfig.CacheConfig.RevCacheConfig.Size
+			if !base.IsEnterpriseEdition() && revCacheSize != nil && *revCacheSize == 0 {
+				base.Warnf(base.KeyAll, eeOnlyWarningMsg, "cache.rev_cache.size", *revCacheSize, db.DefaultRevisionCacheSize)
+				dbConfig.CacheConfig.RevCacheConfig.Size = base.Uint32Ptr(db.DefaultRevisionCacheSize)
+			}
+
 			if dbConfig.CacheConfig.RevCacheConfig.ShardCount != nil {
 				if *dbConfig.CacheConfig.RevCacheConfig.ShardCount < 1 {
-					errorMessages = append(errorMessages, fmt.Errorf("minimum value for cache.rev_cache.shard_count is 1"))
-
+					errorMessages = append(errorMessages, fmt.Errorf(minValueErrorMsg, "cache.rev_cache.shard_count", 1))
 				}
 			}
 		}
@@ -512,12 +536,10 @@ func (dbConfig DbConfig) validate() []error {
 		}
 	}
 
-	// Error if Delta Sync is explicitly enabled in CE
-	if dbConfig.DeltaSync != nil && dbConfig.DeltaSync.Enabled != nil {
-		if *dbConfig.DeltaSync.Enabled && !base.IsEnterpriseEdition() {
-			errorMessages = append(errorMessages, fmt.Errorf("Delta sync is not supported in CE"))
-
-		}
+	// EE: delta sync
+	if !base.IsEnterpriseEdition() && dbConfig.DeltaSync != nil && dbConfig.DeltaSync.Enabled != nil {
+		base.Warnf(base.KeyAll, eeOnlyWarningMsg, "delta_sync.enabled", *dbConfig.DeltaSync.Enabled, false)
+		dbConfig.DeltaSync.Enabled = base.BoolPtr(false)
 	}
 
 	return errorMessages

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -123,11 +122,12 @@ func TestConfigValidationDeltaSync(t *testing.T) {
 
 	require.NotNil(t, config.Databases["db"])
 	require.NotNil(t, config.Databases["db"].DeltaSync)
-	require.NotNil(t, config.Databases["db"].DeltaSync.Enabled)
 	if base.IsEnterpriseEdition() {
+		require.NotNil(t, config.Databases["db"].DeltaSync.Enabled)
 		assert.True(t, *config.Databases["db"].DeltaSync.Enabled)
 	} else {
-		assert.False(t, *config.Databases["db"].DeltaSync.Enabled)
+		// CE disallowed - should be nil
+		assert.Nil(t, config.Databases["db"].DeltaSync.Enabled)
 	}
 }
 
@@ -144,35 +144,39 @@ func TestConfigValidationCache(t *testing.T) {
 	require.NotNil(t, config.Databases["db"])
 	require.NotNil(t, config.Databases["db"].CacheConfig)
 
-	expectedRevCacheSize := db.DefaultRevisionCacheSize
-	if base.IsEnterpriseEdition() {
-		expectedRevCacheSize = 0
-	}
 	require.NotNil(t, config.Databases["db"].CacheConfig.RevCacheConfig)
-	require.NotNil(t, config.Databases["db"].CacheConfig.RevCacheConfig.Size)
-	assert.Equal(t, expectedRevCacheSize, int(*config.Databases["db"].CacheConfig.RevCacheConfig.Size))
-
-	expectedChanCacheMaxNum := db.DefaultChannelCacheMaxNumber
 	if base.IsEnterpriseEdition() {
-		expectedChanCacheMaxNum = 100
+		require.NotNil(t, config.Databases["db"].CacheConfig.RevCacheConfig.Size)
+		assert.Equal(t, 0, int(*config.Databases["db"].CacheConfig.RevCacheConfig.Size))
+	} else {
+		// CE disallowed - should be nil
+		assert.Nil(t, config.Databases["db"].CacheConfig.RevCacheConfig.Size)
 	}
+
 	require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig)
-	require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.MaxNumber)
-	assert.Equal(t, expectedChanCacheMaxNum, int(*config.Databases["db"].CacheConfig.ChannelCacheConfig.MaxNumber))
-
-	expectedChanCacheHWM := db.DefaultCompactHighWatermarkPercent
 	if base.IsEnterpriseEdition() {
-		expectedChanCacheHWM = 95
+		require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.MaxNumber)
+		assert.Equal(t, 100, int(*config.Databases["db"].CacheConfig.ChannelCacheConfig.MaxNumber))
+	} else {
+		// CE disallowed - should be nil
+		assert.Nil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.MaxNumber)
 	}
-	require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.HighWatermarkPercent)
-	assert.Equal(t, expectedChanCacheHWM, int(*config.Databases["db"].CacheConfig.ChannelCacheConfig.HighWatermarkPercent))
 
-	expectedChanCacheLWM := db.DefaultCompactLowWatermarkPercent
 	if base.IsEnterpriseEdition() {
-		expectedChanCacheLWM = 25
+		require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.HighWatermarkPercent)
+		assert.Equal(t, 95, int(*config.Databases["db"].CacheConfig.ChannelCacheConfig.HighWatermarkPercent))
+	} else {
+		// CE disallowed - should be nil
+		assert.Nil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.HighWatermarkPercent)
 	}
-	require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.LowWatermarkPercent)
-	assert.Equal(t, expectedChanCacheLWM, int(*config.Databases["db"].CacheConfig.ChannelCacheConfig.LowWatermarkPercent))
+
+	if base.IsEnterpriseEdition() {
+		require.NotNil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.LowWatermarkPercent)
+		assert.Equal(t, 25, int(*config.Databases["db"].CacheConfig.ChannelCacheConfig.LowWatermarkPercent))
+	} else {
+		// CE disallowed - should be nil
+		assert.Nil(t, config.Databases["db"].CacheConfig.ChannelCacheConfig.LowWatermarkPercent)
+	}
 }
 
 // TestLoadServerConfigExamples will run LoadServerConfig for configs found under the examples directory.

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -412,11 +412,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 				cacheOptions.ChannelCacheAge = time.Duration(*config.CacheConfig.ChannelCacheConfig.ExpirySeconds) * time.Second
 			}
 			if config.CacheConfig.ChannelCacheConfig.MaxNumber != nil {
-				if *config.CacheConfig.ChannelCacheConfig.MaxNumber < db.MinimumChannelCacheMaxNumber {
-					base.Warnf(base.KeyAll, "Config value for channel_cache.max_number (%d) is lower than minimum allowed value (%d).  Reverting to default value (%d)", *config.CacheConfig.ChannelCacheConfig.MaxNumber, db.MinimumChannelCacheMaxNumber, cacheOptions.MaxNumChannels)
-				} else {
-					cacheOptions.MaxNumChannels = *config.CacheConfig.ChannelCacheConfig.MaxNumber
-				}
+				cacheOptions.MaxNumChannels = *config.CacheConfig.ChannelCacheConfig.MaxNumber
 			}
 			if config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent != nil && *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent > 0 {
 				cacheOptions.CompactHighWatermarkPercent = *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent


### PR DESCRIPTION
- Moved validation of `channel_cache.max_number` up to other existing validation rules.

- Made the following config options EE-only by warning and reverting to default value:
  - `cache.rev_cache.size=0`
  - `cache.channel_cache.max_number`
  - `cache.channel_cache.compact_high_watermark_pct`
  - `cache.channel_cache.compact_low_watermark_pct`

- Changed existing EE-only config options to match warn/revert behaviour above. Previously this option when set in CE errored and failed to start.
  - `delta_sync.enabled=true`


## Examples:

### CE
<img width="1033" alt="Screenshot 2019-06-18 at 13 22 09" src="https://user-images.githubusercontent.com/1525809/59681954-10f00780-91cd-11e9-8b8c-ec9e0bb392e8.png">

### EE
<img width="1032" alt="Screenshot 2019-06-18 at 13 22 17" src="https://user-images.githubusercontent.com/1525809/59681960-13eaf800-91cd-11e9-946d-9d2e2273ce3d.png">
