### PR TITLE
Run build.sh with bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/usr/bin/env bash -e
 
 # This script builds sync gateway using pinned dependencies via the repo tool
 #

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 
 # This script builds sync gateway using pinned dependencies via the repo tool
 #

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # This script builds sync gateway using pinned dependencies via the repo tool
 #


### PR DESCRIPTION
The build.sh script contains _bash_ syntax (`build_editions=( "CE" "EE" )`) that isn't supported by _dash_ - the default shell in Debian, which the golang image used in the Dockerfile is based on - so needs to run in bash.

Without this, building the Docker image fails with this error:

```
./build.sh: 15: ./build.sh: Syntax error: "(" unexpected
The command '/bin/sh -c ./build.sh -v' returned a non-zero code: 2
```

https://github.com/couchbase/sync_gateway/blob/master/Dockerfile#L27

The code that fails was added in https://github.com/couchbase/sync_gateway/pull/3812/

The `-e` flag was redundant, as it's already set by `set -e`, below.