### PR TITLE
Update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # Stage to build Sync Gateway binary
-FROM golang:1.8-stretch as builder
+FROM golang:1.12-stretch as builder
 
 # Customize this with the commit hash or branch name you want to build
 ENV COMMIT master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 # Stage to build Sync Gateway binary
-FROM golang:1.12-stretch as builder
+FROM golang:1.11.5-stretch as builder
 
 # Customize this with the commit hash or branch name you want to build
 ENV COMMIT master


### PR DESCRIPTION
The Sync Gateway code uses `math.Round` which was only added in Go 1.10, so the base image for the Dockerfile needs to be at least `golang:1.10-stretch`. 

https://github.com/couchbase/sync_gateway/blob/e19d433f07165b468cee177081380d34923e03ef/db/channel_cache.go#L97-L98

This sets it to the latest image, `golang:1.12-stretch`.

Without this, building the Docker image fails with this error:

```
godeps/src/github.com/couchbase/sync_gateway/db/channel_cache.go:97: undefined: math.Round
```