### PR TITLE
Add SG_EDITION and SG_FILENAME build args to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN wget https://raw.githubusercontent.com/couchbase/sync_gateway/$COMMIT/bootst
     chmod +x bootstrap.sh && \
     ./bootstrap.sh -c $COMMIT -p sg
 
+ARG SG_EDITION=CE
+
 # Build the Sync Gateway binary
 RUN ./build.sh -v
 
@@ -30,6 +32,8 @@ RUN ./build.sh -v
 # Stage to run the SG binary from the previous stage
 FROM ubuntu:latest as runner
 
-COPY --from=builder /go/godeps/bin/sync_gateway .
+ARG SG_FILENAME=sync_gateway_ce
+
+COPY --from=builder /go/godeps/bin/$SG_FILENAME .
 
 ENTRYPOINT ["/sync_gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ FROM ubuntu:latest as runner
 
 ARG SG_FILENAME=sync_gateway_ce
 
-COPY --from=builder /go/godeps/bin/$SG_FILENAME .
+COPY --from=builder /go/godeps/bin/$SG_FILENAME /sync_gateway
 
 ENTRYPOINT ["/sync_gateway"]


### PR DESCRIPTION
By default, the build.sh script builds both community and enterprise editions of Sync Gateway; this can be configured using the `SG_EDITION` environment variable.

https://github.com/couchbase/sync_gateway/blob/99744b03382750601e4063d39ee6e16f8e0073d3/build.sh#L13-L21

This adds `SG_EDITION` to the Dockerfile as a build arg so it can be passed through to the build script.

As the output filename is customised according to the edition being built, this also adds an `SG_FILENAME` build arg for specifying the output filename that should be copied to the final image.