### PR TITLE
CBG-420 - Validate stats_log_freq_secs is >= 10

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -317,7 +317,7 @@ type SequenceHashConfig struct {
 
 type UnsupportedServerConfig struct {
 	Http2Config           *Http2Config `json:"http2,omitempty"`               // Config settings for HTTP2
-	StatsLogFrequencySecs *int         `json:"stats_log_freq_secs,omitempty"` // How often should stats be written to stats logs
+	StatsLogFrequencySecs *uint        `json:"stats_log_freq_secs,omitempty"` // How often should stats be written to stats logs
 }
 
 type Http2Config struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1024,7 +1024,7 @@ type statsWrapper struct {
 
 func (sc *ServerContext) startStatsLogger() {
 
-	statsLogFrequencySecs := DefaultStatsLogFrequencySecs
+	statsLogFrequencySecs := uint(DefaultStatsLogFrequencySecs)
 	if sc.config.Unsupported != nil && sc.config.Unsupported.StatsLogFrequencySecs != nil {
 		if *sc.config.Unsupported.StatsLogFrequencySecs == 0 {
 			// don't start the stats logger when explicitly zero

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1025,8 +1025,13 @@ type statsWrapper struct {
 func (sc *ServerContext) startStatsLogger() {
 
 	statsLogFrequencySecs := DefaultStatsLogFrequencySecs
-	if sc.config.Unsupported != nil && sc.config.Unsupported.StatsLogFrequencySecs > 0 {
-		statsLogFrequencySecs = sc.config.Unsupported.StatsLogFrequencySecs
+	if sc.config.Unsupported != nil && sc.config.Unsupported.StatsLogFrequencySecs != nil {
+		if *sc.config.Unsupported.StatsLogFrequencySecs == 0 {
+			// don't start the stats logger when explicitly zero
+			return
+		} else if *sc.config.Unsupported.StatsLogFrequencySecs > 0 {
+			statsLogFrequencySecs = *sc.config.Unsupported.StatsLogFrequencySecs
+		}
 	}
 
 	interval := time.Second * time.Duration(statsLogFrequencySecs)


### PR DESCRIPTION
- Add validation for unsupported.stats_log_freq_secs to be >= 10
- Disable stats logging when config value is explicitly zero