### PR TITLE
CBG-408 - Don't reprocess unused sequence docs on expiry

### DIFF
--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -108,7 +108,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			}
 			listener.Notify(base.SetOf(key))
 		} else if strings.HasPrefix(key, base.UnusedSeqPrefix) || strings.HasPrefix(key, base.UnusedSeqRangePrefix) { // SG unused sequence marker docs
-			if listener.OnDocChanged != nil {
+			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
 		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix) { // SG DCP checkpoint docs


### PR DESCRIPTION
Reprocessing documents didn't have a functional impact because sequences were already accounted for, but should just avoid the processing for performance reasons.