### PR TITLE
CBG-316 - Run tests with default sequence allocation

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -29,6 +29,8 @@ const (
 	discoveryConfigPath = "/.well-known/openid-configuration"
 )
 
+var OIDCDiscoveryRetryWait = 500 * time.Millisecond
+
 // Options for OpenID Connect
 type OIDCOptions struct {
 	Providers       OIDCProviderMap `json:"providers,omitempty"`        // List of OIDC issuers
@@ -204,7 +206,7 @@ func (op *OIDCProvider) DiscoverConfig() (config *oidc.ProviderConfig, shouldSyn
 			}
 			base.Debugf(base.KeyAuth, "Unable to fetch provider config from discovery endpoint for %s (attempt %v/%v): %v",
 				base.UD(op.Issuer), i, maxRetryAttempts, err)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(OIDCDiscoveryRetryWait)
 		}
 	}
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -11,6 +11,7 @@ package auth
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
@@ -231,6 +232,12 @@ func TestOIDCProvider_InitOIDCClient(t *testing.T) {
 			ExpectOIDCClient: true,
 		},
 	}
+
+	defaultWait := OIDCDiscoveryRetryWait
+	OIDCDiscoveryRetryWait = 10 * time.Millisecond
+	defer func() {
+		OIDCDiscoveryRetryWait = defaultWait
+	}()
 
 	for _, test := range tests {
 		t.Run(test.Name, func(tt *testing.T) {

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOIDCProviderMap_GetDefaultProvider(t *testing.T) {
@@ -164,7 +165,7 @@ func TestOIDCUsername(t *testing.T) {
 	}
 
 	err := provider.InitUserPrefix()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, provider.UserPrefix, "www.someprovider.com")
 
 	// test username suffix
@@ -181,14 +182,14 @@ func TestOIDCUsername(t *testing.T) {
 	provider.UserPrefix = ""
 	provider.Issuer = "http://www.someprovider.com/extra"
 	err = provider.InitUserPrefix()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, provider.UserPrefix, "www.someprovider.com%2Fextra")
 
 	// test invalid URL
 	provider.UserPrefix = ""
 	provider.Issuer = "http//www.someprovider.com"
 	err = provider.InitUserPrefix()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	// falls back to provider name:
 	goassert.Equals(t, provider.UserPrefix, "Some_Provider")
 

--- a/auth/password_hash_test.go
+++ b/auth/password_hash_test.go
@@ -7,6 +7,7 @@ import (
 
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -39,7 +40,7 @@ func TestBcryptDefaultCostTime(t *testing.T) {
 	duration := time.Since(startTime)
 
 	t.Logf("bcrypt.GenerateFromPassword with cost %d took: %v", bcryptDefaultCost, duration)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.True(t, minimumDuration < duration)
 }
 
@@ -50,17 +51,17 @@ func TestSetBcryptCost(t *testing.T) {
 	goassert.False(t, bcryptCostChanged)
 
 	err = SetBcryptCost(0) // use default value
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, bcryptCost, bcryptDefaultCost)
 	goassert.False(t, bcryptCostChanged) // Not explicitly changed
 
 	err = SetBcryptCost(bcryptDefaultCost + 1) // use increased value
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, bcryptCost, bcryptDefaultCost+1)
 	goassert.True(t, bcryptCostChanged)
 
 	err = SetBcryptCost(bcryptDefaultCost) // back to explicit default value, check changed is still true
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, bcryptCost, bcryptDefaultCost)
 	goassert.True(t, bcryptCostChanged)
 }

--- a/auth/session.go
+++ b/auth/session.go
@@ -51,8 +51,10 @@ func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.Re
 		session.Ttl = kDefaultSessionTTL
 	}
 	duration := session.Ttl
-	sessionTimeElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Seconds())
-	tenPercentOfTtl := int(duration.Seconds()) / 10
+
+	// SessionTimeElapsed and tenPercentOfTtl use Nanoseconds for more precision when converting to int
+	sessionTimeElapsed := int((time.Now().Add(duration).Sub(session.Expiration)).Nanoseconds())
+	tenPercentOfTtl := int(duration.Nanoseconds()) / 10
 	if sessionTimeElapsed > tenPercentOfTtl {
 		session.Expiration = time.Now().Add(duration)
 		if err = auth.bucket.Set(docIDForSession(session.ID), base.DurationToCbsExpiry(duration), session); err != nil {

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -23,7 +24,7 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.NotEquals(t, u, nil)
 
 	goassert.False(t, u.Disabled())
@@ -62,7 +63,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.NotEquals(t, u, nil)
 
 	user := u.(*userImpl)
@@ -70,7 +71,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 
 	// Make sure their password was hashed with the desired cost
 	cost, err := bcrypt.Cost(user.PasswordHash_)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, cost, bcryptDefaultCost)
 
 	// Try to auth with an incorrect password
@@ -89,12 +90,12 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 
 	// Check the cost is still the old value
 	cost, err = bcrypt.Cost(user.PasswordHash_)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, cost, bcryptDefaultCost)
 
 	// Now bump the global bcrypt cost
 	err = SetBcryptCost(newBcryptCost)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Authenticate incorrectly again
 	goassert.False(t, u.Authenticate("test"))
@@ -112,6 +113,6 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 
 	// Cost should now match newBcryptCost
 	cost, err = bcrypt.Cost(user.PasswordHash_)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, cost, newBcryptCost)
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -41,12 +41,12 @@ func TestTranscoder(t *testing.T) {
 	resultBytes, flags, err := transcoder.Encode([]byte(jsonBody))
 	goassert.Equals(t, bytes.Compare(resultBytes, jsonBytes), 0)
 	goassert.Equals(t, flags, jsonFlags)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	resultBytes, flags, err = transcoder.Encode(BinaryDocument(jsonBody))
 	goassert.Equals(t, bytes.Compare(resultBytes, jsonBytes), 0)
 	goassert.Equals(t, flags, binaryFlags)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 }
 
 func TestSetGetRaw(t *testing.T) {

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -60,32 +60,32 @@ func TestRedactionLevelMarshalText(t *testing.T) {
 	var level RedactionLevel
 	level = RedactNone
 	text, err := level.MarshalText()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, string(text), "none")
 
 	level = RedactPartial
 	text, err = level.MarshalText()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, string(text), "partial")
 
 	level = RedactFull
 	text, err = level.MarshalText()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, string(text), "full")
 }
 
 func TestRedactionLevelUnmarshalText(t *testing.T) {
 	var level RedactionLevel
 	err := level.UnmarshalText([]byte("none"))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, level, RedactNone)
 
 	err = level.UnmarshalText([]byte("partial"))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, level, RedactPartial)
 
 	err = level.UnmarshalText([]byte("full"))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, level, RedactFull)
 
 	err = level.UnmarshalText([]byte("asdf"))

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -3,10 +3,10 @@ package base
 import (
 	"net/http"
 	"testing"
-	"time"
 
 	goassert "github.com/couchbaselabs/go.assert"
 	sgreplicate "github.com/couchbaselabs/sg-replicate"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReplicator(t *testing.T) {
@@ -18,38 +18,26 @@ func TestReplicator(t *testing.T) {
 		Lifecycle: sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	goassert.Equals(t, err, nil)
-	waitForActiveTasks(t, r, 1)
+	assert.NoError(t, err)
+	goassert.Equals(t, len(r.ActiveTasks()), 1)
 
 	params = sgreplicate.ReplicationParameters{
 		ReplicationId: "rep1",
 		Lifecycle:     sgreplicate.CONTINUOUS,
 	}
 	_, err = r.Replicate(params, false)
-	goassert.Equals(t, err, nil)
-	waitForActiveTasks(t, r, 2)
+	assert.NoError(t, err)
+	goassert.Equals(t, len(r.ActiveTasks()), 2)
 
 	// now stop it
 	_, err = r.Replicate(params, true)
-	goassert.Equals(t, err, nil)
-	waitForActiveTasks(t, r, 1)
+	assert.NoError(t, err)
+	goassert.Equals(t, len(r.ActiveTasks()), 1)
 
 	// stop all
 	err = r.StopReplications()
-	goassert.Equals(t, err, nil)
-	waitForActiveTasks(t, r, 0)
-}
-
-func waitForActiveTasks(t *testing.T, r *Replicator, taskCount int) {
-	for i := 0; i < 20; i++ {
-		if i == 20 {
-			t.Fatalf("failed to find active task")
-		}
-		if len(r.ActiveTasks()) == taskCount {
-			break
-		}
-		time.Sleep(time.Millisecond * 100)
-	}
+	assert.NoError(t, err)
+	goassert.Equals(t, len(r.ActiveTasks()), 0)
 }
 
 func TestReplicatorDuplicateID(t *testing.T) {
@@ -60,7 +48,7 @@ func TestReplicatorDuplicateID(t *testing.T) {
 		Lifecycle:     sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Should get an error because ReplicationIDs are identical.
 	_, err = r.Replicate(params, false)
@@ -75,7 +63,7 @@ func TestReplicatorDuplicateParams(t *testing.T) {
 		Lifecycle: sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Should get an error even if ReplicationIDs are different,
 	// as they both share the same parameters.

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -3,41 +3,53 @@ package base
 import (
 	"net/http"
 	"testing"
+	"time"
 
-	goassert "github.com/couchbaselabs/go.assert"
-	sgreplicate "github.com/couchbaselabs/sg-replicate"
+	"github.com/couchbaselabs/sg-replicate"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestReplicator(t *testing.T) {
 	r := NewReplicator()
-	goassert.Equals(t, len(r.ActiveTasks()), 0)
+	assert.Equal(t, 0, len(r.ActiveTasks()))
 
 	params := sgreplicate.ReplicationParameters{
 		SourceDb:  "db1",
 		Lifecycle: sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	assert.NoError(t, err)
-	goassert.Equals(t, len(r.ActiveTasks()), 1)
+	assert.Equal(t, nil, err)
+	waitForActiveTasks(t, r, 1)
 
 	params = sgreplicate.ReplicationParameters{
 		ReplicationId: "rep1",
 		Lifecycle:     sgreplicate.CONTINUOUS,
 	}
 	_, err = r.Replicate(params, false)
-	assert.NoError(t, err)
-	goassert.Equals(t, len(r.ActiveTasks()), 2)
+	assert.Equal(t, nil, err)
+	waitForActiveTasks(t, r, 2)
 
 	// now stop it
 	_, err = r.Replicate(params, true)
-	assert.NoError(t, err)
-	goassert.Equals(t, len(r.ActiveTasks()), 1)
+	assert.Equal(t, nil, err)
+	waitForActiveTasks(t, r, 1)
 
 	// stop all
 	err = r.StopReplications()
-	assert.NoError(t, err)
-	goassert.Equals(t, len(r.ActiveTasks()), 0)
+	assert.Equal(t, nil, err)
+	waitForActiveTasks(t, r, 0)
+}
+
+func waitForActiveTasks(t *testing.T, r *Replicator, taskCount int) {
+	for i := 0; i < 20; i++ {
+		if i == 20 {
+			t.Fatalf("failed to find active task")
+		}
+		if len(r.ActiveTasks()) == taskCount {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
 }
 
 func TestReplicatorDuplicateID(t *testing.T) {
@@ -48,7 +60,7 @@ func TestReplicatorDuplicateID(t *testing.T) {
 		Lifecycle:     sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	assert.NoError(t, err)
+	assert.Equal(t, nil, err)
 
 	// Should get an error because ReplicationIDs are identical.
 	_, err = r.Replicate(params, false)
@@ -63,7 +75,7 @@ func TestReplicatorDuplicateParams(t *testing.T) {
 		Lifecycle: sgreplicate.CONTINUOUS,
 	}
 	_, err := r.Replicate(params, false)
-	assert.NoError(t, err)
+	assert.Equal(t, nil, err)
 
 	// Should get an error even if ReplicationIDs are different,
 	// as they both share the same parameters.
@@ -73,8 +85,8 @@ func TestReplicatorDuplicateParams(t *testing.T) {
 
 func assertHTTPError(t *testing.T, err error, status int) {
 	if httpErr, ok := err.(*HTTPError); !ok {
-		goassert.Errorf(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
+		assert.Fail(t, "assertHTTPError: Expected an HTTP %d; got error %T %v", status, err, err)
 	} else {
-		goassert.Equals(t, httpErr.Status, status)
+		assert.Equal(t, status, httpErr.Status)
 	}
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -320,19 +320,19 @@ func TestReflectExpiry(t *testing.T) {
 	goassert.Equals(t, expiry, (*uint32)(nil))
 
 	expiry, err = ReflectExpiry(int64(1234))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, *expiry, uint32(1234))
 
 	expiry, err = ReflectExpiry(float64(1234))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, *expiry, uint32(1234))
 
 	expiry, err = ReflectExpiry("1234")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, *expiry, uint32(1234))
 
 	expiry, err = ReflectExpiry(exp.Format(time.RFC3339))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, *expiry, uint32(exp.Unix()))
 
 	expiry, err = ReflectExpiry("invalid")
@@ -340,7 +340,7 @@ func TestReflectExpiry(t *testing.T) {
 	goassert.Equals(t, expiry, (*uint32)(nil))
 
 	expiry, err = ReflectExpiry(nil)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, expiry, (*uint32)(nil))
 }
 

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRequireUser(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireUser(oldDoc._names) }`
 	runner, err := NewSyncRunner(funcSource)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), parse(`{"name": "alpha"}`))
 	assertNotRejected(t, result)
@@ -23,7 +24,7 @@ func TestRequireUser(t *testing.T) {
 func TestRequireRole(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireRole(oldDoc._roles) }`
 	runner, err := NewSyncRunner(funcSource)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), parse(`{"name": "", "roles": {"alpha":""}}`))
 	assertNotRejected(t, result)
@@ -36,7 +37,7 @@ func TestRequireRole(t *testing.T) {
 func TestRequireAccess(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAccess(oldDoc._access) }`
 	runner, err := NewSyncRunner(funcSource)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), parse(`{"name": "", "channels": ["alpha"]}`))
 	assertNotRejected(t, result)
@@ -49,7 +50,7 @@ func TestRequireAccess(t *testing.T) {
 func TestRequireAdmin(t *testing.T) {
 	const funcSource = `function(doc, oldDoc) { requireAdmin() }`
 	runner, err := NewSyncRunner(funcSource)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	var result interface{}
 	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{}`))
 	assertNotRejected(t, result)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -918,10 +918,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	feed, err := db.MultiChangesFeed(base.SetOf("*"), options)
 	goassert.True(t, err == nil)
 
-	// Go-routine to work the feed channel and write to an array for use by assertions
 	var changes = make([]*ChangeEntry, 0, 50)
-
-	time.Sleep(500 * time.Millisecond)
 
 	// Validate the initial sequences arrive as expected
 	err = appendFromFeed(&changes, feed, 3, base.DefaultWaitForSequenceTesting)
@@ -940,10 +937,8 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	assert.NoError(t, err, "UpdatePrincipal failed")
 
 	WriteDirect(db, []string{"PBS"}, 9)
-
 	db.changeCache.waitForSequence(9, base.DefaultWaitForSequenceTesting, t)
 
-	time.Sleep(500 * time.Millisecond)
 	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequenceTesting)
 	assert.NoError(t, err, "Expected more changes to be sent on feed, but never received")
 	goassert.Equals(t, len(changes), 7)
@@ -1383,7 +1378,7 @@ func TestStopChangeCache(t *testing.T) {
 	tearDownTestDB(t, db)
 
 	// Hang around a while to see if the housekeeping tasks fire and panic
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 
 }
 

--- a/db/channel_index_test.go
+++ b/db/channel_index_test.go
@@ -545,6 +545,8 @@ func TestChannelIndexPartitionReadBulk(t *testing.T) {
 
 func TestVbucket(t *testing.T) {
 
+	t.Skip("Development-only test - skipping")
+
 	index := NewChannelIndex(1024, 0, "basicChannel", t)
 	defer index.indexBucket.Close()
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -125,9 +125,6 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, ba
 
 func testBucket(tester testing.TB) base.TestBucket {
 
-	//TODO: Temporary fix until sequence allocation unit test enhancements - CBG-316
-	MaxSequenceIncrFrequency = 0 * time.Millisecond
-
 	// Retry loop in case the GSI indexes don't handle the flush and we need to drop them and retry
 	for i := 0; i < 2; i++ {
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -786,11 +786,14 @@ func TestConflicts(t *testing.T) {
 	// Instantiate channel cache for channel 'all'
 	db.changeCache.getChannelCache().getSingleChannelCache("all")
 
+	cacheWaiter := db.NewDCPCachingCountWaiter(t)
+
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
 	assert.NoError(t, db.PutExistingRev("doc", body, []string{"1-a"}, false), "add 1-a")
 
-	time.Sleep(time.Second) // Wait for tap feed to catch up
+	// Wait for rev to be cached
+	cacheWaiter.AddAndWait(1)
 
 	changeLog := db.GetChangeLog("all", 0)
 	goassert.Equals(t, len(changeLog), 1)
@@ -803,7 +806,7 @@ func TestConflicts(t *testing.T) {
 	body["channels"] = []string{"all", "2a"}
 	assert.NoError(t, db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false), "add 2-a")
 
-	time.Sleep(time.Second) // Wait for tap feed to catch up
+	cacheWaiter.Add(2)
 
 	rawBody, _, _ := db.Bucket.GetRaw("doc")
 
@@ -823,7 +826,7 @@ func TestConflicts(t *testing.T) {
 		"channels": []string{"all", "2a"}})
 
 	// Verify the change-log of the "all" channel:
-	db.changeCache.waitForSequence(3, base.DefaultWaitForSequenceTesting, t)
+	cacheWaiter.Wait()
 	changeLog = db.GetChangeLog("all", 0)
 	goassert.Equals(t, len(changeLog), 1)
 	goassert.Equals(t, changeLog[0].Sequence, uint64(3))
@@ -862,8 +865,10 @@ func TestConflicts(t *testing.T) {
 	goassert.True(t, chan2a == nil)             // currently in 2a
 	goassert.True(t, doc.Channels["2b"] != nil) // has been removed from 2b
 
+	// Wait for delete mutation to arrive over feed
+	cacheWaiter.AddAndWait(1)
+
 	// Verify the _changes feed:
-	db.changeCache.waitForSequence(4, base.DefaultWaitForSequenceTesting, t)
 	changes, err = db.GetChanges(channels.SetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")
 	goassert.Equals(t, len(changes), 1)
@@ -1574,24 +1579,29 @@ func TestViewCustom(t *testing.T) {
 	}
 	assert.True(t, err == nil)
 
-	// Workaround race condition where queryAllDocs doesn't return the doc we just added
-	// TODO: stale=false will guarantee no race when using a couchbase bucket, but this test
-	// may hit something related to https://github.com/couchbaselabs/walrus/issues/18.  Can remove sleep when
-	// that gets fixed
-	time.Sleep(time.Second * 1)
-
 	// query all docs using ViewCustom query.
 	opts := Body{"stale": false, "reduce": false}
 	viewResult := sgbucket.ViewResult{}
-	errViewCustom := db.Bucket.ViewCustom(DesignDocSyncHousekeeping(), ViewAllDocs, opts, &viewResult)
-	assert.True(t, errViewCustom == nil)
 
-	// assert that the doc added earlier is in the results
+	// Add retry to avoid race condition where queryAllDocs doesn't return the doc we just added
+	// TODO: stale=false guarantees no race when using a couchbase bucket, but this test
+	//	may be hitting something related to https://github.com/couchbaselabs/walrus/issues/18.  Can remove sleep when
+	// that gets fixed
 	foundDoc := false
-	for _, viewRow := range viewResult.Rows {
-		if viewRow.ID == docId {
-			foundDoc = true
+	for i := 0; i < 10; i++ {
+		errViewCustom := db.Bucket.ViewCustom(DesignDocSyncHousekeeping(), ViewAllDocs, opts, &viewResult)
+		assert.True(t, errViewCustom == nil)
+
+		// assert that the doc added earlier is in the results
+		for _, viewRow := range viewResult.Rows {
+			if viewRow.ID == docId {
+				foundDoc = true
+			}
 		}
+		if foundDoc {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	assert.True(t, foundDoc)
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -240,7 +240,7 @@ func TestImportNullDoc(t *testing.T) {
 	// Do a valid on-demand import from a null document
 	body = Body{"new": true}
 	importedDoc, err = db.importDoc(key+"2", body, false, existingDoc, ImportOnDemand)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	assert.False(t, importedDoc == nil, "Expected imported doc")
 }
 

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -104,6 +104,8 @@ func TestShadowerPullWithNotifications(t *testing.T) {
 
 	db := setupTestDBForShadowing(t)
 
+	cacheWaiter := db.NewDCPCachingCountWaiter(t)
+
 	//Create an event manager and start it
 	em := db.EventMgr
 	em.Start(0, -1)
@@ -144,7 +146,7 @@ func TestShadowerPullWithNotifications(t *testing.T) {
 	})
 
 	// wait for Event Manager queue worker to process
-	time.Sleep(500 * time.Millisecond)
+	cacheWaiter.AddAndWait(4)
 
 	channelSize := len(resultChannel)
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"expvar"
 	"fmt"
 	"math"
 	"testing"
@@ -137,4 +138,52 @@ func (db *DatabaseContext) WaitForCaughtUp(targetCount int64) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return errors.New("WaitForCaughtUp didn't catch up")
+}
+
+type StatWaiter struct {
+	initCount   int64       // Document cached count when NewStatWaiter is called
+	targetCount int64       // Target count used when Wait is called
+	stat        *expvar.Int // Expvar to wait on
+	tb          testing.TB  // Raises tb.Fatalf on wait timeout
+}
+
+func (db *DatabaseContext) NewStatWaiter(stat *expvar.Int, tb testing.TB) *StatWaiter {
+	return &StatWaiter{
+		initCount:   stat.Value(),
+		targetCount: stat.Value(),
+		stat:        stat,
+		tb:          tb,
+	}
+}
+
+func (db *DatabaseContext) NewDCPCachingCountWaiter(tb testing.TB) *StatWaiter {
+	stat, ok := db.DbStats.StatsDatabase().Get(base.StatKeyDcpCachingCount).(*expvar.Int)
+	if !ok {
+		tb.Fatalf("Unable to retrieve StatKeyDcpCachingCount during StatWaiter initialization ")
+	}
+	return db.NewStatWaiter(stat, tb)
+}
+
+func (sw *StatWaiter) Add(count int) {
+	sw.targetCount += int64(count)
+}
+
+// Wait uses backoff retry for up to ~27s
+func (sw *StatWaiter) Wait() {
+	actualCount := sw.stat.Value()
+	if actualCount >= sw.targetCount {
+		return
+	}
+
+	waitTime := 1 * time.Millisecond
+	for i := 0; i < 13; i++ {
+		waitTime = waitTime * 2
+		time.Sleep(waitTime)
+		actualCount = sw.stat.Value()
+		if actualCount >= sw.targetCount {
+			return
+		}
+	}
+
+	sw.tb.Fatalf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d)", sw.targetCount, actualCount)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -384,7 +384,7 @@ function(doc, oldDoc) {
 			changesResponse := rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?feed=continuous&since=%s&timeout=2000", since), "", "bernard"))
 
 			changes, err := readContinuousChanges(changesResponse)
-			goassert.Equals(t, err, nil)
+			assert.NoError(t, err)
 
 			changesAccumulated = append(changesAccumulated, changes...)
 
@@ -618,7 +618,7 @@ func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 			// case 2 - ensure no error processing the changes response.  The number of entries may vary, depending
 			// on whether the changes loop performed an additional iteration before catching the deleted user.
 			_, err := readContinuousChanges(changesResponse)
-			goassert.Equals(t, err, nil)
+			assert.NoError(t, err)
 		}
 	}()
 
@@ -754,13 +754,13 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	user, err = a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
@@ -780,7 +780,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 
 	log.Printf("expires %s", body["expires"].(string))
 	expires, err := time.Parse(layout, body["expires"].(string)[:19])
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	//create a session with a ttl value one second greater thatn the max offset ttl 2592001 seconds
 	response = rt.SendAdminRequest("POST", "/db/_session", `{"name":"pupshaw", "ttl":2592001}`)
@@ -790,7 +790,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	log.Printf("expires2 %s", body["expires"].(string))
 	expires2, err := time.Parse(layout, body["expires"].(string)[:19])
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	//Allow a ten second drift between the expires dates, to pass test on slow servers
 	acceptableTimeDelta := time.Duration(10) * time.Second
@@ -810,13 +810,13 @@ func TestSessionExtension(t *testing.T) {
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	user, err = a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
@@ -1408,7 +1408,6 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 	rt.NoFlush = true // No need to flush since this test doesn't add any data to the bucket
 	defer rt.Close()
 
-	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1385,7 +1385,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	json.Unmarshal(response.Body.Bytes(), &body)
 	goassert.True(t, body["state"].(string) == "Online")
 
-	// Wait until after the 2 second delay, since the online request explicitly asked for a delay
+	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
 	time.Sleep(1500 * time.Millisecond)
 
 	// Wait for DB to come online (retry loop)

--- a/rest/api.go
+++ b/rest/api.go
@@ -188,7 +188,7 @@ func (h *handler) instanceStartTime() int64 {
 type DatabaseRoot struct {
 	DBName                        string `json:"db_name"`
 	SequenceNumber                uint64 `json:"update_seq"`
-	CommittedUpdateSequenceNumber uint64 `json:"committed_update_seq"`
+	CommittedUpdateSequenceNumber uint64 `json:"committed_update_seq"` // Used by perf tests, shouldn't be removed
 	InstanceStartTime             int64  `json:"instance_start_time"`
 	CompactRunning                bool   `json:"compact_running"`
 	PurgeSequenceNumber           uint64 `json:"purge_seq"`

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -231,10 +231,10 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
@@ -269,10 +269,10 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
@@ -1196,10 +1196,10 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", nil)
@@ -1244,7 +1244,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	user, err := authenticator.NewUser("user1", "letmein", nil)
 	user.SetExplicitRoles(channels.TimedSet{"role1": channels.NewVbSimpleSequence(1)})
 	err = authenticator.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Bulk docs with 2 docs.  First doc grants role1 access to chan1.  Second requires chan1 for write.
 	input := `{"docs": [
@@ -1546,7 +1546,7 @@ func TestResponseEncoding(t *testing.T) {
 	assertStatus(t, response, 200)
 	assert.Equal(t, "gzip", response.Header().Get("Content-Encoding"))
 	unzip, err := gzip.NewReader(response.Body)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	unjson := json.NewDecoder(unzip)
 	var body db.Body
 	assert.Equal(t, nil, unjson.Decode(&body))
@@ -1559,13 +1559,13 @@ func TestLogin(t *testing.T) {
 
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	user, err = a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.True(t, user.Disabled())
 
 	response := rt.SendRequest("PUT", "/db/doc", `{"hi": "there"}`)
@@ -1618,10 +1618,10 @@ func TestCustomCookieName(t *testing.T) {
 	// Disable guest user
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	user, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	user.SetDisabled(true)
 	err = a.Save(user)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create a user
 	response := rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"1234"}`)
@@ -1660,7 +1660,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",
 				"include_docs": true, "filter": "Melitta", "channels": "ABC,BBC"}`
 	feed, options, filter, channelsArray, _, _, err := h.readChangesOptionsFromJSON([]byte(optStr))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, feed, "longpoll")
 
 	goassert.Equals(t, options.Since.Seq, uint64(78))
@@ -1677,27 +1677,27 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	// Attempt to set heartbeat, timeout to valid values
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":30000, "timeout":60000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, options.HeartbeatMs, uint64(30000))
 	goassert.Equals(t, options.TimeoutMs, uint64(60000))
 
 	// Attempt to set valid timeout, no heartbeat
 	optStr = `{"feed":"longpoll", "since": "1", "timeout":2000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, options.TimeoutMs, uint64(2000))
 
 	// Disable heartbeat, timeout by explicitly setting to zero
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":0, "timeout":0}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, options.HeartbeatMs, uint64(0))
 	goassert.Equals(t, options.TimeoutMs, uint64(0))
 
 	// Attempt to set heartbeat less than minimum heartbeat, timeout greater than max timeout
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":1000, "timeout":1000000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, options.HeartbeatMs, uint64(kMinHeartbeatMS))
 	goassert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
 
@@ -1705,7 +1705,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	h.server.config.MaxHeartbeat = 60
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, options.HeartbeatMs, uint64(60000))
 }
 
@@ -1734,10 +1734,10 @@ func TestAllDocsAccessControl(t *testing.T) {
 	// Create some docs:
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc4", `{"channels":["WB", "Cinemax"]}`), 201)
@@ -1747,7 +1747,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create a user:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "Cinemax"))
@@ -1773,7 +1773,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -1790,7 +1790,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -1803,7 +1803,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -1816,7 +1816,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -1829,7 +1829,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -1842,7 +1842,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -1855,7 +1855,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
@@ -1870,7 +1870,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
@@ -1890,7 +1890,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
@@ -1911,7 +1911,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
@@ -1923,7 +1923,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 5)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
@@ -1955,10 +1955,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 	// Create some docs:
 	a := auth.NewAuthenticator(rt.Bucket(), nil)
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["CBS"]}`), 201)
@@ -1967,10 +1967,10 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc5", `{"channels":"Cinemax"}`), 201)
 
 	guest, err = a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(true)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create a user:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "Cinemax"))
@@ -1996,7 +1996,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -2013,7 +2013,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -2026,7 +2026,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -2039,7 +2039,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -2052,7 +2052,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -2065,7 +2065,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
@@ -2078,7 +2078,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc4")
@@ -2093,7 +2093,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
@@ -2113,7 +2113,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
@@ -2134,7 +2134,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
@@ -2146,7 +2146,7 @@ func TestVbSeqAllDocsAccessControl(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 5)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[1].ID, "doc2")
@@ -2163,10 +2163,10 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create users:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "zero"))
@@ -2197,7 +2197,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
 
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 1)
 	since := changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "g1")
@@ -2258,14 +2258,14 @@ func TestChannelAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	json.Unmarshal(response.Body.Bytes(), &changes)
 	goassert.Equals(t, len(changes.Results), 1)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, changes.Results[0].ID, "d1")
 
 	// The complete _changes feed for zegpold contains docs a1 and g1:
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	goassert.Equals(t, changes.Results[0].ID, "g1")
 	goassert.Equals(t, changes.Results[0].Seq.Seq, uint64(8))
@@ -2297,10 +2297,10 @@ func TestChannelAccessChanges(t *testing.T) {
 	database, _ := db.GetDatabase(dbc, nil)
 
 	changed, err := database.UpdateSyncFun(`function(doc) {access("alice", "beta");channel("beta");}`)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.True(t, changed)
 	changeCount, err := database.UpdateAllDocChannels()
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, changeCount, 9)
 
 	expectedIDs := []string{"beta", "delta", "gamma", "a1", "b1", "d1", "g1", "alpha", "epsilon"}
@@ -2336,10 +2336,10 @@ func TestAccessOnTombstone(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create user:
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "zero"))
@@ -2363,7 +2363,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 1)
 	if len(changes.Results) > 0 {
 		goassert.Equals(t, changes.Results[0].ID, "alpha")
@@ -2395,7 +2395,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2403,10 +2403,10 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.Equal(t, nil, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.Equal(t, nil, err)
 
 	// Create user1
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2421,18 +2421,16 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	limit := 50
 	changesResults, err := rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
-	goassert.Equals(t, len(changesResults.Results), 50)
+	assert.Equal(t, 50, len(changesResults.Results))
 	since := changesResults.Results[49].Seq
-	goassert.Equals(t, changesResults.Results[49].ID, "doc48")
-	goassert.Equals(t, since.Seq, uint64(50))
+	assert.Equal(t, "doc48", changesResults.Results[49].ID)
 
 	//// Check the _changes feed with  since and limit, to get second half of feed
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=\"%s\"&limit=%d", since, limit), "user1", false)
 	assert.NoError(t, err, "Unexpected error")
-	goassert.Equals(t, len(changesResults.Results), 50)
+	assert.Equal(t, 50, len(changesResults.Results))
 	since = changesResults.Results[49].Seq
-	goassert.Equals(t, changesResults.Results[49].ID, "doc98")
-	goassert.Equals(t, since.Seq, uint64(100))
+	assert.Equal(t, "doc98", changesResults.Results[49].ID)
 
 	// Create user2
 	response = rt.SendAdminRequest("PUT", "/db/_user/user2", `{"email":"user2@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2441,45 +2439,54 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 	//Retrieve all changes for user2 with no limits
 	changesResults, err = rt.WaitForChanges(101, fmt.Sprintf("/db/_changes"), "user2", false)
 	assert.NoError(t, err, "Unexpected error")
-	goassert.Equals(t, len(changesResults.Results), 101)
-	goassert.Equals(t, changesResults.Results[99].ID, "doc99")
+	assert.Equal(t, 101, len(changesResults.Results))
+	assert.Equal(t, "doc99", changesResults.Results[99].ID)
 
 	// Create user3
 	response = rt.SendAdminRequest("PUT", "/db/_user/user3", `{"email":"user3@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
 	assertStatus(t, response, 201)
 
-	//Get first 50 document changes
+	getUserResponse := rt.SendAdminRequest("GET", "/db/_user/user3", "")
+	assertStatus(t, getUserResponse, 200)
+	log.Printf("create user response: %s", getUserResponse.Body.Bytes())
+
+	// Get the sequence from the user doc to validate against the triggered by value in the changes results
+	user3, _ := rt.GetDatabase().Authenticator().GetUser("user3")
+	userSequence := user3.Sequence()
+
+	//Get first 50 document changes.
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
-	goassert.Equals(t, len(changesResults.Results), 50)
+	assert.Equal(t, 50, len(changesResults.Results))
 	since = changesResults.Results[49].Seq
-	goassert.Equals(t, changesResults.Results[49].ID, "doc49")
-	goassert.Equals(t, since.Seq, uint64(51))
-	goassert.Equals(t, since.TriggeredBy, uint64(103))
+	assert.Equal(t, "doc49", changesResults.Results[49].ID)
+	assert.Equal(t, userSequence, since.TriggeredBy)
 
 	//// Get remainder of changes i.e. no limit parameter
 	changesResults, err = rt.WaitForChanges(51, fmt.Sprintf("/db/_changes?since=\"%s\"", since), "user3", false)
 	assert.NoError(t, err, "Unexpected error")
-	goassert.Equals(t, len(changesResults.Results), 51)
-	goassert.Equals(t, changesResults.Results[49].ID, "doc99")
+	assert.Equal(t, 51, len(changesResults.Results))
+	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 	// Create user4
 	response = rt.SendAdminRequest("PUT", "/db/_user/user4", `{"email":"user4@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
 	assertStatus(t, response, 201)
+	// Get the sequence from the user doc to validate against the triggered by value in the changes results
+	user4, _ := rt.GetDatabase().Authenticator().GetUser("user4")
+	user4Sequence := user4.Sequence()
 
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?limit=%d", limit), "user4", false)
 	assert.NoError(t, err, "Unexpected error")
-	goassert.Equals(t, len(changesResults.Results), 50)
+	assert.Equal(t, 50, len(changesResults.Results))
 	since = changesResults.Results[49].Seq
-	goassert.Equals(t, changesResults.Results[49].ID, "doc49")
-	goassert.Equals(t, since.Seq, uint64(51))
-	goassert.Equals(t, since.TriggeredBy, uint64(104))
+	assert.Equal(t, "doc49", changesResults.Results[49].ID)
+	assert.Equal(t, user4Sequence, since.TriggeredBy)
 
 	//// Check the _changes feed with  since and limit, to get second half of feed
 	changesResults, err = rt.WaitForChanges(50, fmt.Sprintf("/db/_changes?since=%s&limit=%d", since, limit), "user4", false)
-	goassert.Equals(t, err, nil)
-	goassert.Equals(t, len(changesResults.Results), 50)
-	goassert.Equals(t, changesResults.Results[49].ID, "doc99")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 50, len(changesResults.Results))
+	assert.Equal(t, "doc99", changesResults.Results[49].ID)
 
 }
 
@@ -2493,10 +2500,10 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// POST a role
 	response := rt.SendAdminRequest("POST", "/db/_role/", `{"name":"role1","admin_channels":["chan1"]}`)
@@ -2505,14 +2512,14 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assertStatus(t, response, 200)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	goassert.Equals(t, body["name"], "role1")
+	assert.Equal(t, "role1", body["name"])
 
 	//Put document to trigger sync function
 	response = rt.Send(request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
 	assertStatus(t, response, 201)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	goassert.Equals(t, body["ok"], true)
+	assert.Equal(t, true, body["ok"])
 
 	// POST the new user the GET and verify that it shows the assigned role
 	response = rt.SendAdminRequest("POST", "/db/_user/", `{"name":"user1", "password":"letmein"}`)
@@ -2521,7 +2528,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	assertStatus(t, response, 200)
 	body = nil
 	json.Unmarshal(response.Body.Bytes(), &body)
-	goassert.Equals(t, body["name"], "user1")
+	assert.Equal(t, "user1", body["name"])
 	goassert.DeepEquals(t, body["roles"], []interface{}{"role1"})
 	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "chan1"})
 
@@ -2539,30 +2546,42 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create users:
-	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "alpha"))
-	a.Save(alice)
-	zegpold, err := a.NewUser("zegpold", "letmein", channels.SetOf(t, "beta"))
-	a.Save(zegpold)
+	response := rt.SendAdminRequest("PUT", "/db/_user/alice", `{"password":"letmein", "admin_channels":["alpha"]}`)
+	assertStatus(t, response, 201)
 
-	hipster, err := a.NewRole("hipster", channels.SetOf(t, "gamma"))
-	a.Save(hipster)
+	response = rt.SendAdminRequest("PUT", "/db/_user/zegpold", `{"password":"letmein", "admin_channels":["beta"]}`)
+	assertStatus(t, response, 201)
+
+	response = rt.SendAdminRequest("PUT", "/db/_role/hipster", `{"admin_channels":["gamma"]}`)
+	assertStatus(t, response, 201)
+	/*
+		alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "alpha"))
+		a.Save(alice)
+		zegpold, err := a.NewUser("zegpold", "letmein", channels.SetOf(t, "beta"))
+		a.Save(zegpold)
+
+		hipster, err := a.NewRole("hipster", channels.SetOf(t, "gamma"))
+		a.Save(hipster)
+	*/
 
 	// Create some docs in the channels:
 	cacheWaiter := rt.ServerContext().Database("db").NewDCPCachingCountWaiter(t)
 	cacheWaiter.Add(1)
-	response := rt.Send(request("PUT", "/db/fashion",
+	response = rt.Send(request("PUT", "/db/fashion",
 		`{"user":"alice","role":["role:hipster","role:bogus"]}`))
 	assertStatus(t, response, 201)
 	var body db.Body
 	json.Unmarshal(response.Body.Bytes(), &body)
-	goassert.Equals(t, body["ok"], true)
+	assert.Equal(t, true, body["ok"])
 	fashionRevID := body["rev"].(string)
+
+	roleGrantSequence := rt.GetDocumentSequence("fashion")
 
 	cacheWaiter.Add(4)
 	assertStatus(t, rt.Send(request("PUT", "/db/g1", `{"channel":"gamma"}`)), 201)
@@ -2571,28 +2590,28 @@ func TestRoleAccessChanges(t *testing.T) {
 	assertStatus(t, rt.Send(request("PUT", "/db/d1", `{"channel":"delta"}`)), 201)
 
 	// Check user access:
-	alice, _ = a.GetUser("alice")
+	alice, _ := a.GetUser("alice")
 	goassert.DeepEquals(t,
 		alice.InheritedChannels(),
 		channels.TimedSet{
-			"!":     channels.NewVbSimpleSequence(0x1),
-			"alpha": channels.NewVbSimpleSequence(0x1),
-			"gamma": channels.NewVbSimpleSequence(0x1),
+			"!":     channels.NewVbSimpleSequence(1),
+			"alpha": channels.NewVbSimpleSequence(alice.Sequence()),
+			"gamma": channels.NewVbSimpleSequence(roleGrantSequence),
 		},
 	)
 	goassert.DeepEquals(t,
 		alice.RoleNames(),
 		channels.TimedSet{
-			"bogus":   channels.NewVbSimpleSequence(0x1),
-			"hipster": channels.NewVbSimpleSequence(0x1),
+			"bogus":   channels.NewVbSimpleSequence(roleGrantSequence),
+			"hipster": channels.NewVbSimpleSequence(roleGrantSequence),
 		},
 	)
-	zegpold, _ = a.GetUser("zegpold")
+	zegpold, _ := a.GetUser("zegpold")
 	goassert.DeepEquals(t,
 		zegpold.InheritedChannels(),
 		channels.TimedSet{
-			"!":    channels.NewVbSimpleSequence(0x1),
-			"beta": channels.NewVbSimpleSequence(0x1),
+			"!":    channels.NewVbSimpleSequence(1),
+			"beta": channels.NewVbSimpleSequence(zegpold.Sequence()),
 		},
 	)
 	goassert.DeepEquals(t, zegpold.RoleNames(), channels.TimedSet{})
@@ -2607,21 +2626,25 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("1st _changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	require.Equal(t, 2, len(changes.Results))
-	assert.Equal(t, "g1", changes.Results[0].ID)
-	assert.Equal(t, "a1", changes.Results[1].ID)
+	require.Equal(t, 3, len(changes.Results))
+	assert.Equal(t, "_user/alice", changes.Results[0].ID)
+	assert.Equal(t, "g1", changes.Results[1].ID)
+	assert.Equal(t, "a1", changes.Results[2].ID)
 
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("2nd _changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
-	require.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, "b1", changes.Results[0].ID)
+	require.Equal(t, 2, len(changes.Results))
+	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
+	assert.Equal(t, "b1", changes.Results[1].ID)
 	lastSeqPreGrant := changes.Last_Seq
 
 	// Update "fashion" doc to grant zegpold the role "hipster" and take it away from alice:
 	cacheWaiter.Add(1)
 	str := fmt.Sprintf(`{"user":"zegpold", "role":"role:hipster", "_rev":%q}`, fashionRevID)
-	assertStatus(t, rt.Send(request("PUT", "/db/fashion", str)), 201) // seq=6
+	assertStatus(t, rt.Send(request("PUT", "/db/fashion", str)), 201)
+
+	updatedRoleGrantSequence := rt.GetDocumentSequence("fashion")
 
 	// Check user access again:
 	alice, _ = a.GetUser("alice")
@@ -2629,7 +2652,7 @@ func TestRoleAccessChanges(t *testing.T) {
 		alice.InheritedChannels(),
 		channels.TimedSet{
 			"!":     channels.NewVbSimpleSequence(0x1),
-			"alpha": channels.NewVbSimpleSequence(0x1),
+			"alpha": channels.NewVbSimpleSequence(alice.Sequence()),
 		},
 	)
 	zegpold, _ = a.GetUser("zegpold")
@@ -2637,8 +2660,8 @@ func TestRoleAccessChanges(t *testing.T) {
 		zegpold.InheritedChannels(),
 		channels.TimedSet{
 			"!":     channels.NewVbSimpleSequence(0x1),
-			"beta":  channels.NewVbSimpleSequence(0x1),
-			"gamma": channels.NewVbSimpleSequence(0x6),
+			"beta":  channels.NewVbSimpleSequence(zegpold.Sequence()),
+			"gamma": channels.NewVbSimpleSequence(updatedRoleGrantSequence),
 		},
 	)
 
@@ -2649,12 +2672,13 @@ func TestRoleAccessChanges(t *testing.T) {
 	log.Printf("3rd _changes looks like: %s", response.Body.Bytes())
 	json.Unmarshal(response.Body.Bytes(), &changes)
 	log.Printf("changes: %+v", changes.Results)
-	require.Equal(t, len(changes.Results), 2)
-	assert.Equal(t, "b1", changes.Results[0].ID)
-	assert.Equal(t, "g1", changes.Results[1].ID)
+	require.Equal(t, len(changes.Results), 3)
+	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
+	assert.Equal(t, "b1", changes.Results[1].ID)
+	assert.Equal(t, "g1", changes.Results[2].ID)
 
-	// Changes feed with since=4 would ordinarily be empty, but zegpold got access to channel
-	// gamma after sequence 4, so the pre-existing docs in that channel are included:
+	// Changes feed with since=lastSeqPreGrant would ordinarily be empty, but zegpold got access to channel
+	// gamma after lastSeqPreGrant, so the pre-existing docs in that channel are included:
 	response = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%v", lastSeqPreGrant), "", "zegpold"))
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
@@ -2688,10 +2712,10 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create a doc
 	response := rt.Send(request("PUT", "/db/doc1", `{"foo":"bar", "channels":["ch1"]}`))
@@ -2707,7 +2731,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
@@ -2719,7 +2743,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch1")
@@ -2735,7 +2759,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
@@ -2748,7 +2772,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[0].Value.Channels[0], "ch2")
@@ -2900,10 +2924,10 @@ func TestOldDocHandling(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Create user:
 	frank, err := a.NewUser("charles", "1234", nil)
@@ -2953,10 +2977,10 @@ func TestStarAccess(t *testing.T) {
 		Results []db.ChangeEntry
 	}
 	guest, err := a.GetUser("")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc1", `{"channels":["books"]}`), 201)
 	assertStatus(t, rt.SendRequest("PUT", "/db/doc2", `{"channels":["gifts"]}`), 201)
@@ -2968,7 +2992,7 @@ func TestStarAccess(t *testing.T) {
 
 	guest.SetDisabled(true)
 	err = a.Save(guest)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	//
 	// Part 1 - Tests for user with single channel access:
 	//
@@ -2994,7 +3018,7 @@ func TestStarAccess(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"books"})
@@ -3009,7 +3033,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 3)
 	since := changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc1")
@@ -3019,7 +3043,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=books", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 1)
 	since = changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc1")
@@ -3029,7 +3053,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc3")
@@ -3039,7 +3063,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=gifts", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 0)
 
 	//
@@ -3065,7 +3089,7 @@ func TestStarAccess(t *testing.T) {
 
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 6)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"books"})
@@ -3074,7 +3098,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 6)
 	since = changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc1")
@@ -3084,7 +3108,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc3")
@@ -3111,7 +3135,7 @@ func TestStarAccess(t *testing.T) {
 	assertStatus(t, response, 200)
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 2)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 
@@ -3119,7 +3143,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc3")
@@ -3129,7 +3153,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	err = json.Unmarshal(response.Body.Bytes(), &changes)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
 	goassert.Equals(t, changes.Results[0].ID, "doc3")

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -406,7 +406,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 	}
 
 	// Wait long enough to ensure the changes aren't being sent
-	expectedTimeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*3)
+	expectedTimeoutErr := WaitWithTimeout(&receivedChangesWg, time.Second*1)
 	if expectedTimeoutErr == nil {
 		t.Errorf("Received additional changes after one-shot should have been closed.")
 	}
@@ -530,11 +530,10 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 		assert.NoError(t, err, "Error unmarshalling response body")
 	}
 	receivedChangesWg.Add(len(docIDsExpected))
-	cacheWaiter.Add(len(docIDsExpected))
 
 	// Wait for documents to be processed and available for changes
 	// 105 docs +
-	cacheWaiter.Wait()
+	cacheWaiter.AddAndWait(len(docIDsExpected))
 
 	// TODO: Attempt a subChanges w/ continuous=true and docID filter
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -64,7 +64,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 		[]byte(`{"key": "val"}`),
 		blip.Properties{},
 	)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	_, err = revResponse.Body()
 	assert.NoError(t, err, "Error unmarshalling response body")
@@ -233,7 +233,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 			[]byte(`{"key": "val"}`),
 			blip.Properties{},
 		)
-		goassert.Equals(t, err, nil)
+		assert.NoError(t, err)
 
 		_, err = revResponse.Body()
 		assert.NoError(t, err, "Error unmarshalling response body")
@@ -350,7 +350,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 			[]byte(`{"key": "val"}`),
 			blip.Properties{},
 		)
-		goassert.Equals(t, err, nil)
+		assert.NoError(t, err)
 		_, err = revResponse.Body()
 		assert.NoError(t, err, "Error unmarshalling response body")
 		receivedChangesWg.Add(1)
@@ -399,7 +399,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 			[]byte(`{"key": "val"}`),
 			blip.Properties{},
 		)
-		goassert.Equals(t, err, nil)
+		assert.NoError(t, err)
 		_, err = revResponse.Body()
 		assert.NoError(t, err, "Error unmarshalling response body")
 		receivedChangesWg.Add(1)
@@ -525,7 +525,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 			[]byte(`{"key": "val"}`),
 			blip.Properties{},
 		)
-		goassert.Equals(t, err, nil)
+		assert.NoError(t, err)
 		_, err = revResponse.Body()
 		assert.NoError(t, err, "Error unmarshalling response body")
 	}
@@ -704,7 +704,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	// Send non-deleted rev
 	sent, _, resp, err := bt.SendRev("sendAndGetRev", "1-abc", []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, resp.Properties["Error-Code"], "")
 
 	// Get non-deleted rev
@@ -719,7 +719,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	history := []string{"1-abc"}
 	sent, _, resp, err = bt.SendRevWithHistory("sendAndGetRev", "2-bcd", history, []byte(`{"key": "val", "channels": ["user1"]}`), blip.Properties{"deleted": "true"})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, resp.Properties["Error-Code"], "")
 
 	// Get the tombstoned document
@@ -756,7 +756,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 	// Send non-deleted rev
 	sent, _, resp, err := bt.SendRev("largeNumberRev", "1-abc", []byte(`{"key": "val", "largeNumber":9223372036854775807, "channels": ["user1"]}`), blip.Properties{})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, resp.Properties["Error-Code"], "")
 
 	// Get non-deleted rev
@@ -818,7 +818,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 	checkpointBody := []byte(`{"client_seq":"1000"}`)
 	sent, _, resp, err := bt.SetCheckpoint("testclient", "", checkpointBody)
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, resp.Properties["Error-Code"], "")
 
 	checkpointRev := resp.Rev()
@@ -835,7 +835,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 	checkpointBody = []byte(`{"client_seq":"1005"}`)
 	sent, _, resp, err = bt.SetCheckpoint("testclient", checkpointRev, checkpointBody)
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, resp.Properties["Error-Code"], "")
 	checkpointRev = resp.Rev()
 	goassert.Equals(t, checkpointRev, "0-2")
@@ -893,7 +893,7 @@ func TestReloadUser(t *testing.T) {
 		[]byte(`{"key": "val", "channels": ["PBS"]}`),
 		blip.Properties{},
 	)
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 
 	// Make assertions on response to make sure the change was accepted
 	addRevResponseBody, err := addRevResponse.Body()
@@ -1341,7 +1341,7 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val"}`), blip.Properties{})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	sent, _, resp, err = bt.SendRev("foo", "1-def", []byte(`{"key": "val"}`), blip.Properties{"noconflicts": "true"})
@@ -1369,12 +1369,12 @@ func TestPutRevConflictsMode(t *testing.T) {
 
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val"}`), blip.Properties{})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	sent, _, resp, err = bt.SendRev("foo", "1-def", []byte(`{"key": "val"}`), blip.Properties{"noconflicts": "false"})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	sent, _, resp, err = bt.SendRev("foo", "1-ghi", []byte(`{"key": "val"}`), blip.Properties{"noconflicts": "true"})
@@ -1419,14 +1419,14 @@ func TestGetRemovedDoc(t *testing.T) {
 	// Add rev-1 in channel user1
 	sent, _, resp, err := bt.SendRev("foo", "1-abc", []byte(`{"key": "val", "channels": ["user1"]}"`), blip.Properties{})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	// Add rev-2 in channel user1
 	history := []string{"1-abc"}
 	sent, _, resp, err = bt.SendRevWithHistory("foo", "2-bcd", history, []byte(`{"key": "val", "channels": ["user1"]}"`), blip.Properties{"noconflicts": "true"})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	// Try to get rev 2 via BLIP API and assert that _removed == false
@@ -1438,14 +1438,14 @@ func TestGetRemovedDoc(t *testing.T) {
 	history = []string{"2-bcd", "1-abc"}
 	sent, _, resp, err = bt.SendRevWithHistory("foo", "3-cde", history, []byte(`{"key": "val", "channels": ["another_channel"]}`), blip.Properties{"noconflicts": "true"})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	// Add rev-4, keeping it in channel another_channel
 	history = []string{"3-cde", "2-bcd", "1-abc"}
 	sent, _, resp, err = bt.SendRevWithHistory("foo", "4-def", history, []byte("{}"), blip.Properties{"noconflicts": "true", "deleted": "true"})
 	goassert.True(t, sent)
-	goassert.Equals(t, err, nil)                          // no error
+	assert.NoError(t, err)                                // no error
 	goassert.Equals(t, resp.Properties["Error-Code"], "") // no error
 
 	// Flush rev cache in case this prevents the bug from showing up (didn't make a difference)

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -30,15 +30,6 @@ func SkipImportTestsIfNotEnabled(t *testing.T) {
 	}
 }
 
-type SimpleSync struct {
-	Channels map[string]interface{}
-	Rev      string
-}
-
-type RawResponse struct {
-	Sync SimpleSync `json:"_sync"`
-}
-
 func HasActiveChannel(channelSet map[string]interface{}, channelName string) bool {
 	if channelSet == nil {
 		return false

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -41,11 +41,11 @@ func TestConfigServer(t *testing.T) {
 	sc.config.ConfigServer = &fakeConfigURL
 
 	dbc, err := sc.GetDatabase("db")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, dbc.Name, "db")
 
 	dbc, err = sc.GetDatabase("db2")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, dbc.Name, "db2")
 	goassert.Equals(t, dbc.Bucket.GetName(), "fivez")
 
@@ -93,11 +93,11 @@ func TestConfigServerWithSyncFunction(t *testing.T) {
 	sc.config.ConfigServer = &fakeConfigURL
 
 	dbc, err := sc.GetDatabase("db")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, dbc.Name, "db")
 
 	dbc, err = sc.GetDatabase("db2")
-	goassert.Equals(t, err, nil)
+	assert.NoError(t, err)
 	goassert.Equals(t, dbc.Name, "db2")
 	goassert.Equals(t, dbc.Bucket.GetName(), "fivez")
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -88,7 +88,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	}
 
 	//TODO: Temporary fix until sequence allocation unit test enhancements - CBG-316
-	db.MaxSequenceIncrFrequency = 0 * time.Millisecond
+	//db.MaxSequenceIncrFrequency = 0 * time.Millisecond
 
 	// Put this in a loop in case certain operations fail, like waiting for GSI indexes to be empty.
 	// Limit number of attempts to 2.
@@ -687,6 +687,15 @@ type BlipTester struct {
 // Close the bliptester
 func (bt BlipTester) Close() {
 	bt.restTester.Close()
+}
+
+// Returns database context for blipTester (assumes underlying rest tester is based on a single db - returns first it finds)
+func (bt BlipTester) DatabaseContext() *db.DatabaseContext {
+	dbs := bt.restTester.ServerContext().AllDatabases()
+	for _, database := range dbs {
+		return database
+	}
+	return nil
 }
 
 // Create a BlipTester using the default spec

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -556,6 +556,8 @@ type RawResponse struct {
 	Sync SimpleSync `json:"_sync"`
 }
 
+// GetDocumentSequence looks up the sequence for a document using the _raw endpoint.
+// Used by tests that need to validate sequences (for grants, etc)
 func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	if response.Code != 200 {


### PR DESCRIPTION
Previously tests were forcing non-batched sequence allocation.  Tests have been updated to avoid dependency on specific sequence values.  

Most tests that used 'waitForSequence' type scheduling have been changed to use expvar-based waits.  Added StatWaiter struct to simplify tracking of changed stats by tests, that follows the same Add(n) and Wait() semantics used by sync.WaitGroup.

