### PR TITLE
CBG-428 Use walrus for default serviceconfig

### DIFF
--- a/examples/serviceconfig.json
+++ b/examples/serviceconfig.json
@@ -3,10 +3,7 @@
   "interface": "0.0.0.0:4984",
   "databases": {
     "db": {
-      "server": "couchbase://localhost",
-      "username": "username",
-      "password": "password",
-      "bucket": "default",
+      "server": "walrus:data",
       "users": {
         "GUEST": {"disabled": false, "admin_channels": ["*"] }
       },


### PR DESCRIPTION
Retain the existing behaviour for initial startup of SG via service (start successfully using a walrus bucket).  
