### PR TITLE
CBG-364 - Remove --create-home from useradd

### DIFF
--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -32,11 +32,6 @@ EOF
       exit 1
     fi
 
-    # create home dir if it does not exist (maybe it has been deleted upon previous uninstall)
-    if [ ! -d "@@PREFIX@@" ]; then
-      mkdir -p @@PREFIX@@
-    fi
-
     chown -R @@PRODUCT_BASE@@:@@PRODUCT_BASE@@ @@PREFIX@@
 
     chmod 755 @@PREFIX@@/service/@@PRODUCT_EXEC@@_service_install.sh

--- a/build/postinst.tmpl
+++ b/build/postinst.tmpl
@@ -45,7 +45,7 @@ EOF
 
     # create user if it does not exist
     if [ -z `id -u @@PRODUCT_EXEC@@ 2>/dev/null` ]; then
-      useradd -m @@PRODUCT_EXEC@@
+      useradd @@PRODUCT_EXEC@@
     fi
 
     cd @@PREFIX@@/service

--- a/build/preinst.tmpl
+++ b/build/preinst.tmpl
@@ -19,7 +19,7 @@ case "$1" in
       groupadd -r @@PRODUCT_BASE@@ || exit 1
     getent passwd @@PRODUCT_BASE@@ >/dev/null || \
       useradd -r -g @@PRODUCT_BASE@@ -d @@PREFIX@@ -s /bin/bash \
-              -c "@@PRODUCT_BASE_CAP@@ system user" --create-home @@PRODUCT_BASE@@ || exit 1
+              -c "@@PRODUCT_BASE_CAP@@ system user" @@PRODUCT_BASE@@ || exit 1
     exit 0
     ;;
 

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -57,11 +57,6 @@ if test X"$RPM_INSTALL_PREFIX0" = X"" ; then
   RPM_INSTALL_PREFIX0=@@PREFIX@@
 fi
 
-echo "prefix: @@PREFIX@@"
-echo "mkdir -p $RPM_INSTALL_PREFIX0"
-mkdir -p "$RPM_INSTALL_PREFIX0"
-echo $?
-
 getent group @@PRODUCT_BASE@@ >/dev/null || \
    groupadd -r @@PRODUCT_BASE@@ || exit 1
 getent passwd @@PRODUCT_BASE@@ >/dev/null || \
@@ -86,14 +81,6 @@ fi
 # create user if it does not exist
 if [ -z `id -u @@PRODUCT_EXEC@@ 2>/dev/null` ]; then
   useradd @@PRODUCT_EXEC@@
-fi
-
-echo "in post - RPM_INSTALL_PREFIX0 = $RPM_INSTALL_PREFIX0"
-# create home dir if it does not exist (maybe it has been deleted upon uninstall)
-if [ ! -d "$RPM_INSTALL_PREFIX0" ]; then
-  echo "mkdir -p $RPM_INSTALL_PREFIX0"
-  mkdir -p "$RPM_INSTALL_PREFIX0"
-  chown @@PRODUCT_BASE@@:@@PRODUCT_BASE@@ $RPM_INSTALL_PREFIX0
 fi
 
 cd @@PREFIX@@/service

--- a/build/rpm.spec.tmpl
+++ b/build/rpm.spec.tmpl
@@ -57,11 +57,16 @@ if test X"$RPM_INSTALL_PREFIX0" = X"" ; then
   RPM_INSTALL_PREFIX0=@@PREFIX@@
 fi
 
+echo "prefix: @@PREFIX@@"
+echo "mkdir -p $RPM_INSTALL_PREFIX0"
+mkdir -p "$RPM_INSTALL_PREFIX0"
+echo $?
+
 getent group @@PRODUCT_BASE@@ >/dev/null || \
    groupadd -r @@PRODUCT_BASE@@ || exit 1
 getent passwd @@PRODUCT_BASE@@ >/dev/null || \
    useradd -r -g @@PRODUCT_BASE@@ -d $RPM_INSTALL_PREFIX0 -s /bin/sh \
-           -c "@@PRODUCT_BASE@@ system user" --create-home @@PRODUCT_BASE@@ || exit 1
+           -c "@@PRODUCT_BASE@@ system user" @@PRODUCT_BASE@@ || exit 1
 
 if [ -d @@PREFIX@@ ]
 then
@@ -80,12 +85,14 @@ fi
 
 # create user if it does not exist
 if [ -z `id -u @@PRODUCT_EXEC@@ 2>/dev/null` ]; then
-  useradd -m @@PRODUCT_EXEC@@
+  useradd @@PRODUCT_EXEC@@
 fi
 
+echo "in post - RPM_INSTALL_PREFIX0 = $RPM_INSTALL_PREFIX0"
 # create home dir if it does not exist (maybe it has been deleted upon uninstall)
 if [ ! -d "$RPM_INSTALL_PREFIX0" ]; then
-  mkdir -p $RPM_INSTALL_PREFIX0
+  echo "mkdir -p $RPM_INSTALL_PREFIX0"
+  mkdir -p "$RPM_INSTALL_PREFIX0"
   chown @@PRODUCT_BASE@@:@@PRODUCT_BASE@@ $RPM_INSTALL_PREFIX0
 fi
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -21,7 +21,7 @@
 
   
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="CBG-364" />
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" />
 
   
   <!-- Sync Gateway Accel-->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -21,7 +21,7 @@
 
   
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase"/>
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="CBG-364" />
 
   
   <!-- Sync Gateway Accel-->

--- a/service/sync_gateway_service_install.sh
+++ b/service/sync_gateway_service_install.sh
@@ -83,6 +83,8 @@ pre_install_actions() {
     exit 1
   fi
 
+  setup_output_dirs
+
   # Check that the runtime base directory exists
   if [ ! -d "$RUNBASE_TEMPLATE_VAR" ]; then
     echo "The runtime base directory does not exist \"$RUNBASE_TEMPLATE_VAR\"." >/dev/stderr
@@ -118,8 +120,6 @@ pre_install_actions() {
     cp $SRCCFGDIR/$SRCCFG $CONFIG_TEMPLATE_VAR
     chown ${RUNAS_TEMPLATE_VAR}:${RUNAS_TEMPLATE_VAR} ${CONFIG_TEMPLATE_VAR}
   fi
-
-  setup_output_dirs
 }
 
 #


### PR DESCRIPTION
- Reverted change to add `--create-home` to useradd commands in RPM scripts
  - `--create-home` in useradd causes selinux issues [CBG-364](https://issues.couchbase.com/browse/CBG-364), as useradd doesn't have permission to create directories in `/home`.
  - This now reduces the RPM install scripts to be dealing purely with putting files into `/opt/couchbase-sync-gateway`. The following install script is left to deal with getting required files and directories into `/home/sync_gateway`
- The `/home/sync_gateway` directory is now created from `sync_gateway_service_install.sh` by moving `setup_output_dirs` up before the directory checks.