### PR TITLE
CBG-432 - Backport CBG-342 to 2.5.1

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1723,9 +1723,14 @@ func (bucket *CouchbaseBucketGoCB) Incr(k string, amt, def uint64, exp uint32) (
 	if amt == 0 {
 		var result uint64
 		_, err := bucket.Get(k, &result)
-		if err != nil {
+		if bucket.IsKeyNotFoundError(err) {
+			// Return Incr value as zero
 			return uint64(0), nil
+		} else if err != nil {
+			// Got an error when trying to fetch the value
+			return 0, err
 		}
+		// Got a non-zero value to return
 		return result, nil
 	}
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -18,7 +18,7 @@ type LeakyBucket struct {
 // The config object that controls the LeakyBucket behavior
 type LeakyBucketConfig struct {
 
-	// Incr() fails 3 times before finally succeeding
+	// Incr() fails N times before finally succeeding
 	IncrTemporaryFailCount uint16
 
 	// Emulate TAP/DCP feed de-dupliation behavior, such that within a


### PR DESCRIPTION
Check for explicit KeyNotFound in gocb Incr's amt=0 handling (#4095)

* CBG-342 Check for explicit KeyNotFoundError in gocbbucket.Incr
  * Prevents Incr from reporting incorrect zero value under cases where the
Get fails for other unexpected reasons (like persistent network timeouts)

* Add test to cover amt=0 in Incr for gocb bucket
* Use existing test bucket pattern for TestIncrAmtZero
* Make TestIncrAmtZero run on all bucket types - change def param to expected SG usage