### PR TITLE
CBG-375 - Add roundtrip parameter to block PUT and POST until sequence cached

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -70,7 +70,7 @@ const (
 
 	// Until the sporadic integration tests failures in SG #3570 are fixed, should be GTE n1ql query timeout
 	// to make it easier to identify root cause of test failures.
-	DefaultWaitForSequenceTesting = time.Second * 30
+	DefaultWaitForSequence = time.Second * 30
 
 	// Default the max number of idle connections per host to a relatively high number to avoid
 	// excessive socket churn caused by opening short-lived connections and closing them after, which can cause

--- a/base/error.go
+++ b/base/error.go
@@ -130,6 +130,8 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		}
 	case *json.SyntaxError, *json.UnmarshalTypeError:
 		return http.StatusBadRequest, fmt.Sprintf("Invalid JSON: \"%v\"", unwrappedErr)
+	case *RetryTimeoutError:
+		return http.StatusGatewayTimeout, unwrappedErr.Error()
 	}
 	return http.StatusInternalServerError, fmt.Sprintf("Internal error: %v", unwrappedErr)
 }

--- a/base/util.go
+++ b/base/util.go
@@ -11,6 +11,7 @@ package base
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/binary"
@@ -445,6 +446,16 @@ func RetryLoopTimeout(description string, worker RetryWorker, sleeper RetrySleep
 			return fmt.Errorf("Invocation timeout after waiting %v for worker to complete", timeoutPerInvocation), nil
 		}
 
+	}
+}
+
+// SleeperFuncCtx wraps the given RetrySleeper with a context, so it can be cancelled, or have a deadline.
+func SleeperFuncCtx(sleeperFunc RetrySleeper, ctx context.Context) RetrySleeper {
+	return func(retryCount int) (bool, int) {
+		if err := ctx.Err(); err != nil {
+			return false, -1
+		}
+		return sleeperFunc(retryCount)
 	}
 }
 

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -56,7 +56,7 @@ type DocAttachment struct {
 // Given a CouchDB document body about to be stored in the database, goes through the _attachments
 // dict, finds attachments with inline bodies, copies the bodies into the Couchbase db, and replaces
 // the bodies with the 'digest' attributes which are the keys to retrieving them.
-func (db *Database) storeAttachments(doc *document, body Body, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
+func (db *Database) storeAttachments(doc *Document, body Body, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
 	var parentAttachments map[string]interface{}
 	newAttachmentData := make(AttachmentData, 0)
 	atts := GetBodyAttachments(body)
@@ -125,7 +125,7 @@ func (db *Database) storeAttachments(doc *document, body Body, generation int, p
 // Attempts to retrieve ancestor attachments for a document.  First attempts to find and use a non-pruned ancestor.
 // If no non-pruned ancestor is available, checks whether the currently active doc has a common ancestor with the new revision.
 // If it does, can use the attachments on the active revision with revpos earlier than that common ancestor.
-func (db *Database) retrieveAncestorAttachments(doc *document, parentRev string, docHistory []string) map[string]interface{} {
+func (db *Database) retrieveAncestorAttachments(doc *Document, parentRev string, docHistory []string) map[string]interface{} {
 
 	var parentAttachments map[string]interface{}
 	// Attempt to find a non-pruned parent or ancestor

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -52,7 +52,7 @@ func TestAttachments(t *testing.T) {
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
 	var body Body
 	json.Unmarshal([]byte(rev1input), &body)
-	revid, err := db.Put("doc1", unjson(rev1input))
+	revid, _, err := db.Put("doc1", unjson(rev1input))
 	rev1id := revid
 	assert.NoError(t, err, "Couldn't create document")
 
@@ -67,7 +67,7 @@ func TestAttachments(t *testing.T) {
 	var body2 Body
 	json.Unmarshal([]byte(rev2str), &body2)
 	body2[BodyRev] = revid
-	revid, err = db.Put("doc1", body2)
+	revid, _, err = db.Put("doc1", body2)
 	assert.NoError(t, err, "Couldn't update document")
 	assert.Equal(t, "2-08b42c51334c0469bd060e6d9e6d797b", revid)
 
@@ -88,7 +88,7 @@ func TestAttachments(t *testing.T) {
 	var body3 Body
 	json.Unmarshal([]byte(rev3str), &body3)
 	body3[BodyRev] = revid
-	revid, err = db.Put("doc1", body3)
+	revid, _, err = db.Put("doc1", body3)
 	assert.NoError(t, err, "Couldn't update document")
 	assert.Equal(t, "3-252b9fa1f306930bffc07e7d75b77faf", revid)
 
@@ -105,7 +105,7 @@ func TestAttachments(t *testing.T) {
 	var body2B Body
 	err = json.Unmarshal([]byte(rev2Bstr), &body2B)
 	assert.NoError(t, err, "bad JSON")
-	err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id}, false)
+	_, err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id}, false)
 	assert.NoError(t, err, "Couldn't update document")
 }
 
@@ -128,7 +128,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 	docBody := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	var body Body
 	json.Unmarshal([]byte(docBody), &body)
-	_, err = db.Put("doc1", unjson(docBody))
+	_, _, err = db.Put("doc1", unjson(docBody))
 	log.Printf("Got error on put doc:%v", err)
 	db.Bucket.Dump()
 
@@ -154,7 +154,7 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	// Test creating & updating a document:
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
-	_, err = db.Put("doc1", unjson(rev1input))
+	_, _, err = db.Put("doc1", unjson(rev1input))
 	assert.NoError(t, err, "Couldn't create document")
 
 	initCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"testing"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -58,17 +57,14 @@ type ChangeIndex interface {
 	// Remove purges the given doc IDs and returns the number of items removed
 	Remove(docIDs []string, startTime time.Time) (count int)
 
-	// Utility functions for unit testing
-	waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration, tb testing.TB)
-
 	// Handling specific to change_cache.go's sequence handling.  Ideally should refactor usage in changes.go to push
 	// down into internal change_cache.go handling, but it's non-trivial refactoring
 	getOldestSkippedSequence() uint64
 	getChannelCache() ChannelCache
 
-	// Unit test support
-	waitForSequence(sequence uint64, maxWaitTime time.Duration, tb testing.TB)
-	waitForSequenceWithMissing(sequence uint64, maxWaitTime time.Duration, tb testing.TB)
+	// waitFor
+	waitForSequence(sequence uint64, maxWaitTime time.Duration) error
+	waitForSequenceNotSkipped(sequence uint64, maxWaitTime time.Duration) error
 }
 
 // Index type

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -62,7 +62,7 @@ type ChangeIndex interface {
 	getOldestSkippedSequence() uint64
 	getChannelCache() ChannelCache
 
-	// waitFor
+	// These methods should block up until maxWaitTime, or until the given sequence has been received by the change cache.
 	waitForSequence(sequence uint64, maxWaitTime time.Duration) error
 	waitForSequenceNotSkipped(sequence uint64, maxWaitTime time.Duration) error
 }

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -63,8 +64,8 @@ type ChangeIndex interface {
 	getChannelCache() ChannelCache
 
 	// These methods should block up until maxWaitTime, or until the given sequence has been received by the change cache.
-	waitForSequence(sequence uint64, maxWaitTime time.Duration) error
-	waitForSequenceNotSkipped(sequence uint64, maxWaitTime time.Duration) error
+	waitForSequence(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error
+	waitForSequenceNotSkipped(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error
 }
 
 // Index type

--- a/db/changes.go
+++ b/db/changes.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
-	"testing"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -779,26 +778,23 @@ func (db *Database) GetChangeLog(channelName string, afterSeq uint64) (entries [
 	return db.changeCache.getChannelCache().GetCachedChanges(channelName)
 }
 
-// TEST ONLY.  Wait until the change-cache has caught up with the latest writes to the database.
-func (context *DatabaseContext) WaitForSequence(sequence uint64, tb testing.TB) (err error) {
+// WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
+func (context *DatabaseContext) WaitForSequence(sequence uint64) (err error) {
 	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", sequence)
-	context.changeCache.waitForSequenceID(SequenceID{Seq: sequence}, base.DefaultWaitForSequenceTesting, tb)
-	return
+	return context.changeCache.waitForSequence(sequence, base.DefaultWaitForSequence)
 }
 
-// TEST ONLY.  Wait until the change-cache has caught up with the latest writes to the database.
-func (context *DatabaseContext) WaitForSequenceWithMissing(sequence uint64, tb testing.TB) (err error) {
+// WaitForSequenceNotSkipped blocks until the given sequence has been received by the change cache without being skipped.
+func (context *DatabaseContext) WaitForSequenceNotSkipped(sequence uint64) (err error) {
 	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", sequence)
-	context.changeCache.waitForSequenceWithMissing(sequence, base.DefaultWaitForSequenceTesting, tb)
-	return
+	return context.changeCache.waitForSequenceNotSkipped(sequence, base.DefaultWaitForSequence)
 }
 
-// TEST ONLY.  Wait until the change-cache has caught up with the latest writes to the database.
-func (context *DatabaseContext) WaitForPendingChanges(tb testing.TB) (err error) {
+// WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
+func (context *DatabaseContext) WaitForPendingChanges() (err error) {
 	lastSequence, err := context.LastSequence()
 	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", lastSequence)
-	context.changeCache.waitForSequenceID(SequenceID{Seq: lastSequence}, base.DefaultWaitForSequenceTesting, tb)
-	return
+	return context.changeCache.waitForSequence(lastSequence, base.DefaultWaitForSequence)
 }
 
 // Late Sequence Feed

--- a/db/changes.go
+++ b/db/changes.go
@@ -111,7 +111,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 
 	} else if includeConflicts {
 		// Load doc metadata only
-		doc := &document{}
+		doc := &Document{}
 		var err error
 		doc.SyncData, err = db.GetDocSyncData(entry.ID)
 		if err != nil {
@@ -138,7 +138,7 @@ func (db *Database) AddDocToChangeEntryUsingRevCache(entry *ChangeEntry, revID s
 }
 
 // Adds a document body and/or its conflicts to a ChangeEntry
-func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *document, options ChangesOptions) {
+func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Document, options ChangesOptions) {
 
 	includeConflicts := options.Conflicts && entry.branched
 
@@ -779,22 +779,22 @@ func (db *Database) GetChangeLog(channelName string, afterSeq uint64) (entries [
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received or skipped by the change cache.
-func (context *DatabaseContext) WaitForSequence(sequence uint64) (err error) {
+func (dbc *DatabaseContext) WaitForSequence(ctx context.Context, sequence uint64) (err error) {
 	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return context.changeCache.waitForSequence(sequence, base.DefaultWaitForSequence)
+	return dbc.changeCache.waitForSequence(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForSequenceNotSkipped blocks until the given sequence has been received by the change cache without being skipped.
-func (context *DatabaseContext) WaitForSequenceNotSkipped(sequence uint64) (err error) {
+func (dbc *DatabaseContext) WaitForSequenceNotSkipped(ctx context.Context, sequence uint64) (err error) {
 	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", sequence)
-	return context.changeCache.waitForSequenceNotSkipped(sequence, base.DefaultWaitForSequence)
+	return dbc.changeCache.waitForSequenceNotSkipped(ctx, sequence, base.DefaultWaitForSequence)
 }
 
 // WaitForPendingChanges blocks until the change-cache has caught up with the latest writes to the database.
-func (context *DatabaseContext) WaitForPendingChanges() (err error) {
-	lastSequence, err := context.LastSequence()
+func (dbc *DatabaseContext) WaitForPendingChanges(ctx context.Context) (err error) {
+	lastSequence, err := dbc.LastSequence()
 	base.Debugf(base.KeyChanges, "Waiting for sequence: %d", lastSequence)
-	return context.changeCache.waitForSequence(lastSequence, base.DefaultWaitForSequence)
+	return dbc.changeCache.waitForSequence(ctx, lastSequence, base.DefaultWaitForSequence)
 }
 
 // Late Sequence Feed

--- a/db/crud.go
+++ b/db/crud.go
@@ -721,7 +721,7 @@ func (db *Database) PutRoundTrip(docid string, body Body, roundTrip bool) (newRe
 	}
 
 	if roundTrip {
-		if err := db.WaitForSequence(doc.Sequence); err != nil {
+		if err := db.WaitForSequenceNotSkipped(doc.Sequence); err != nil {
 			return "", err
 		}
 	}
@@ -835,7 +835,7 @@ func (db *Database) PutExistingRevRoundTrip(docid string, body Body, docHistory 
 	}
 
 	if roundTrip {
-		if err := db.WaitForSequence(doc.Sequence); err != nil {
+		if err := db.WaitForSequenceNotSkipped(doc.Sequence); err != nil {
 			return err
 		}
 	}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -63,7 +63,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -73,7 +74,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -89,7 +91,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
@@ -130,7 +133,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	assert.NoError(t, err, "add 3-b (tombstone)")
 
 	// Retrieve tombstone
 	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
@@ -163,7 +167,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}, false), "add 2-c")
+	_, err = db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}, false)
+	assert.NoError(t, err, "add 2-c")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-c")
@@ -182,7 +187,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}, false), "add 3-c (large tombstone)")
+	_, err = db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}, false)
+	assert.NoError(t, err, "add 3-c (large tombstone)")
 
 	// Validate the tombstone is not stored inline (due to small size)
 	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
@@ -207,7 +213,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}, false), "add 3-a")
+	_, err = db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "add 3-a")
 
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
@@ -229,7 +236,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -239,7 +247,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -255,7 +264,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
@@ -297,7 +307,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	assert.NoError(t, err, "add 3-b (tombstone)")
 
 	// Retrieve tombstone
 	db.FlushRevisionCacheForTest()
@@ -327,12 +338,18 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}, false), "add 3-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}, false), "add 4-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}, false), "add 5-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}, false), "add 6-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}, false), "add 7-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}, false), "add 8-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "add 3-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}, false)
+	assert.NoError(t, err, "add 4-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}, false)
+	assert.NoError(t, err, "add 5-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}, false)
+	assert.NoError(t, err, "add 6-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}, false)
+	assert.NoError(t, err, "add 7-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}, false)
+	assert.NoError(t, err, "add 8-a")
 
 	// Verify that 3-b is still present at this point
 	db.FlushRevisionCacheForTest()
@@ -340,7 +357,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}, false), "add 9-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}, false)
+	assert.NoError(t, err, "add 9-a")
 
 	// Verify that 3-b has been pruned
 	log.Printf("Attempt to retrieve 3-b, expect pruned")
@@ -367,7 +385,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -375,7 +394,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "version": "2a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -392,7 +412,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "version": "3a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false), "add 3-a")
+	_, err = db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 3-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 3-a...")
@@ -408,7 +429,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "version": "2b", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify still rev 3-a")
@@ -430,7 +452,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "version": "6a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false), "add 6-a")
+	_, err = db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	assert.NoError(t, err, "add 6-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 6-a...")
@@ -452,7 +475,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "version": "3b", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false), "add 3-b")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-b")
 
 	// Same again and again
 	// Add child to non-winning revision w/ inline body
@@ -470,11 +494,13 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "version": "3c", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false), "add 3-c")
+	_, err = db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-c")
 
 	log.Printf("Create rev 3-d")
 	rev3d_body := Body{"key1": "value2", "version": "3d", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false), "add 3-d")
+	_, err = db.PutExistingRev("doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-d")
 
 	// Create new winning revision on 'b' branch.  Triggers movement of 6-a to inline storage.  Force cas retry, check document contents
 	//    1-a
@@ -492,7 +518,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	//     7-b
 	log.Printf("Create rev 7-b")
 	rev7b_body := Body{"key1": "value2", "version": "7b", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false), "add 7-b")
+	_, err = db.PutExistingRev("doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
+	assert.NoError(t, err, "add 7-b")
 
 }
 
@@ -513,7 +540,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -521,7 +549,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "v": "2a"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -537,7 +566,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "v": "3a"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false), "add 3-a")
+	_, err = db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 3-a")
 
 	// Create rev 2-b
 	//    1-a
@@ -547,7 +577,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "v": "2b"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify still rev 3-a")
@@ -569,7 +600,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "v": "6a"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false), "add 6-a")
+	_, err = db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	assert.NoError(t, err, "add 6-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 6-a...")
@@ -592,7 +624,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "v": "3b"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false), "add 3-b")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-b")
 
 	// Same again
 	// Add child to non-winning revision w/ inline body.
@@ -611,7 +644,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false), "add 3-c")
+	_, err = db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-c")
 
 }
 
@@ -626,7 +660,8 @@ func TestLargeSequence(t *testing.T) {
 
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
-	assert.NoError(t, db.PutExistingRev("largeSeqDoc", body, []string{"1-a"}, false), "add largeSeqDoc")
+	_, err := db.PutExistingRev("largeSeqDoc", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add largeSeqDoc")
 
 	syncData, err := db.GetDocSyncData("largeSeqDoc")
 	assert.NoError(t, err, "Error retrieving document sync data")
@@ -701,5 +736,6 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Attempt to create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false), "add 3-c")
+	_, err := db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-c")
 }

--- a/db/database.go
+++ b/db/database.go
@@ -1030,7 +1030,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 		key := realDocID(docid)
 
 		docCount++
-		documentUpdateFunc := func(doc *document) (updatedDoc *document, shouldUpdate bool, updatedExpiry *uint32, err error) {
+		documentUpdateFunc := func(doc *Document) (updatedDoc *Document, shouldUpdate bool, updatedExpiry *uint32, err error) {
 			imported := false
 			if !doc.HasValidSyncData(db.writeSequences()) {
 				// This is a document not known to the sync gateway. Ignore it:

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -10,6 +10,7 @@
 package db
 
 import (
+	"context"
 	"expvar"
 	"fmt"
 	"log"
@@ -214,7 +215,7 @@ func TestDatabase(t *testing.T) {
 	// Test creating & updating a document:
 	log.Printf("Create rev 1...")
 	body := Body{"key1": "value1", "key2": 1234}
-	rev1id, err := db.Put("doc1", body)
+	rev1id, _, err := db.Put("doc1", body)
 	assert.NoError(t, err, "Couldn't create document")
 	goassert.Equals(t, rev1id, body[BodyRev])
 	goassert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
@@ -222,7 +223,7 @@ func TestDatabase(t *testing.T) {
 	log.Printf("Create rev 2...")
 	body["key1"] = "new value"
 	body["key2"] = int64(4321)
-	rev2id, err := db.Put("doc1", body)
+	rev2id, _, err := db.Put("doc1", body)
 	body[BodyId] = "doc1"
 	assert.NoError(t, err, "Couldn't update document")
 	goassert.Equals(t, rev2id, body[BodyRev])
@@ -285,7 +286,7 @@ func TestDatabase(t *testing.T) {
 	body["key2"] = int64(4444)
 	history := []string{"4-four", "3-three", "2-488724414d0ed6b398d6d2aeb228d797",
 		"1-cb0c9a22be0e5a1b01084ec019defa81"}
-	err = db.PutExistingRev("doc1", body, history, false)
+	_, err = db.PutExistingRev("doc1", body, history, false)
 	assert.NoError(t, err, "PutExistingRev failed")
 
 	// Retrieve the document:
@@ -303,7 +304,7 @@ func TestGetDeleted(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	body := Body{"key1": 1234}
-	rev1id, err := db.Put("doc1", body)
+	rev1id, _, err := db.Put("doc1", body)
 	assert.NoError(t, err, "Put")
 
 	rev2id, err := db.DeleteDoc("doc1", rev1id)
@@ -347,7 +348,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 		"key1":     1234,
 		"channels": []string{"ABC"},
 	}
-	rev1id, err := db.Put("doc1", rev1body)
+	rev1id, _, err := db.Put("doc1", rev1body)
 	assert.NoError(t, err, "Put")
 
 	rev2body := Body{
@@ -355,7 +356,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 		"channels": []string{"NBC"},
 		BodyRev:    rev1id,
 	}
-	rev2id, err := db.Put("doc1", rev2body)
+	rev2id, _, err := db.Put("doc1", rev2body)
 	assert.NoError(t, err, "Put Rev 2")
 
 	// Add another revision, so that rev 2 is obsolete
@@ -364,7 +365,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 		"channels": []string{"NBC"},
 		BodyRev:    rev2id,
 	}
-	_, err = db.Put("doc1", rev3body)
+	_, _, err = db.Put("doc1", rev3body)
 	assert.NoError(t, err, "Put Rev 3")
 
 	// Get the deleted doc with its history; equivalent to GET with ?revs=true, while still resident in the rev cache
@@ -432,7 +433,7 @@ func TestGetRemoved(t *testing.T) {
 		"key1":     1234,
 		"channels": []string{"ABC"},
 	}
-	rev1id, err := db.Put("doc1", rev1body)
+	rev1id, _, err := db.Put("doc1", rev1body)
 	assert.NoError(t, err, "Put")
 
 	rev2body := Body{
@@ -440,7 +441,7 @@ func TestGetRemoved(t *testing.T) {
 		"channels": []string{"NBC"},
 		BodyRev:    rev1id,
 	}
-	rev2id, err := db.Put("doc1", rev2body)
+	rev2id, _, err := db.Put("doc1", rev2body)
 	assert.NoError(t, err, "Put Rev 2")
 
 	// Add another revision, so that rev 2 is obsolete
@@ -449,7 +450,7 @@ func TestGetRemoved(t *testing.T) {
 		"channels": []string{"NBC"},
 		BodyRev:    rev2id,
 	}
-	_, err = db.Put("doc1", rev3body)
+	_, _, err = db.Put("doc1", rev3body)
 	assert.NoError(t, err, "Put Rev 3")
 
 	// Get the deleted doc with its history; equivalent to GET with ?revs=true, while still resident in the rev cache
@@ -508,7 +509,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		"key1":     1234,
 		"channels": []string{"ABC"},
 	}
-	rev1id, err := db.Put("doc1", rev1body)
+	rev1id, _, err := db.Put("doc1", rev1body)
 	assert.NoError(t, err, "Put")
 
 	rev2body := Body{
@@ -516,7 +517,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		BodyDeleted: true,
 		BodyRev:     rev1id,
 	}
-	rev2id, err := db.Put("doc1", rev2body)
+	rev2id, _, err := db.Put("doc1", rev2body)
 	assert.NoError(t, err, "Put Rev 2")
 
 	// Add another revision, so that rev 2 is obsolete
@@ -525,7 +526,7 @@ func TestGetRemovedAndDeleted(t *testing.T) {
 		"channels": []string{"NBC"},
 		BodyRev:    rev2id,
 	}
-	_, err = db.Put("doc1", rev3body)
+	_, _, err = db.Put("doc1", rev3body)
 	assert.NoError(t, err, "Put Rev 3")
 
 	// Get the deleted doc with its history; equivalent to GET with ?revs=true, while still resident in the rev cache
@@ -622,7 +623,7 @@ func TestAllDocsOnly(t *testing.T) {
 		}
 		body := Body{"serialnumber": int64(i), "channels": channels}
 		ids[i].DocID = fmt.Sprintf("alldoc-%02d", i)
-		revid, err := db.Put(ids[i].DocID, body)
+		revid, _, err := db.Put(ids[i].DocID, body)
 		ids[i].RevID = revid
 		ids[i].Sequence = uint64(i + 1)
 		ids[i].Channels = channels
@@ -653,7 +654,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Inspect the channel log to confirm that it's only got the last 50 sequences.
 	// There are 101 sequences overall, so the 1st one it has should be #52.
-	db.changeCache.waitForSequence(101, base.DefaultWaitForSequence)
+	db.changeCache.waitForSequence(context.TODO(), 101, base.DefaultWaitForSequence)
 	changeLog := db.GetChangeLog("all", 0)
 	assert.Equal(t, 50, len(changeLog))
 	assert.Equal(t, 52, int(changeLog[0].Sequence))
@@ -739,16 +740,19 @@ func TestRepeatedConflict(t *testing.T) {
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create two conflicting changes:
 	body["n"] = 2
 	body["channels"] = []string{"all", "2b"}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	body["n"] = 3
 	body["channels"] = []string{"all", "2a"}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Get the _rev that was set in the body by PutExistingRev() and make assertions on it
 	rev, ok := body[BodyRev]
@@ -787,7 +791,8 @@ func TestConflicts(t *testing.T) {
 
 	// Create rev 1 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Wait for rev to be cached
 	cacheWaiter.AddAndWait(1)
@@ -798,10 +803,12 @@ func TestConflicts(t *testing.T) {
 	// Create two conflicting changes:
 	body["n"] = 2
 	body["channels"] = []string{"all", "2b"}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 	body["n"] = 3
 	body["channels"] = []string{"all", "2a"}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	cacheWaiter.Add(2)
 
@@ -924,55 +931,60 @@ func TestNoConflictsMode(t *testing.T) {
 
 	// Create revs 1 and 2 of "doc":
 	body := Body{"n": 1, "channels": []string{"all", "1"}}
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 	body["n"] = 2
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Try to create a conflict branching from rev 1:
-	err := db.PutExistingRev("doc", body, []string{"2-b", "1-a"}, false)
+	_, err = db.PutExistingRev("doc", body, []string{"2-b", "1-a"}, false)
 	assertHTTPError(t, err, 409)
 
 	// Try to create a conflict with no common ancestor:
-	err = db.PutExistingRev("doc", body, []string{"2-c", "1-c"}, false)
+	_, err = db.PutExistingRev("doc", body, []string{"2-c", "1-c"}, false)
 	assertHTTPError(t, err, 409)
 
 	// Try to create a conflict with a longer history:
-	err = db.PutExistingRev("doc", body, []string{"4-d", "3-d", "2-d", "1-a"}, false)
+	_, err = db.PutExistingRev("doc", body, []string{"4-d", "3-d", "2-d", "1-a"}, false)
 	assertHTTPError(t, err, 409)
 
 	// Try to create a conflict with no history:
-	err = db.PutExistingRev("doc", body, []string{"1-e"}, false)
+	_, err = db.PutExistingRev("doc", body, []string{"1-e"}, false)
 	assertHTTPError(t, err, 409)
 
 	// Create a non-conflict with a longer history, ending in a deletion:
 	body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"4-a", "3-a", "2-a", "1-a"}, false), "add 4-a")
+	_, err = db.PutExistingRev("doc", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 4-a")
 	delete(body, BodyDeleted)
 
 	// Create a non-conflict with no history (re-creating the document, but with an invalid rev):
-	err = db.PutExistingRev("doc", body, []string{"1-f"}, false)
+	_, err = db.PutExistingRev("doc", body, []string{"1-f"}, false)
 	assertHTTPError(t, err, 409)
 
 	// Resurrect the tombstoned document with a valid history
-	assert.NoError(t, db.PutExistingRev("doc", body, []string{"5-f", "4-a"}, false), "add 5-f")
+	_, err = db.PutExistingRev("doc", body, []string{"5-f", "4-a"}, false)
+	assert.NoError(t, err, "add 5-f")
 	delete(body, BodyDeleted)
 
 	// Create a new document with a longer history:
-	assert.NoError(t, db.PutExistingRev("COD", body, []string{"4-a", "3-a", "2-a", "1-a"}, false), "add COD")
+	_, err = db.PutExistingRev("COD", body, []string{"4-a", "3-a", "2-a", "1-a"}, false)
+	assert.NoError(t, err, "add COD")
 	delete(body, BodyDeleted)
 
 	// Now use Put instead of PutExistingRev:
 
 	// Successfully add a new revision:
-	_, err = db.Put("doc", Body{BodyRev: "5-f", "foo": -1})
+	_, _, err = db.Put("doc", Body{BodyRev: "5-f", "foo": -1})
 	assert.NoError(t, err, "Put rev after 1-f")
 
 	// Try to create a conflict:
-	_, err = db.Put("doc", Body{BodyRev: "3-a", "foo": 7})
+	_, _, err = db.Put("doc", Body{BodyRev: "3-a", "foo": 7})
 	assertHTTPError(t, err, 409)
 
 	// Conflict with no ancestry:
-	_, err = db.Put("doc", Body{"foo": 7})
+	_, _, err = db.Put("doc", Body{"foo": 7})
 	assertHTTPError(t, err, 409)
 }
 
@@ -985,19 +997,28 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	// Create documents with multiple non-deleted branches
 	log.Printf("Creating docs")
 	body := Body{"n": 1}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"1-a"}, false), "add 1-a")
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
+	_, err = db.PutExistingRev("doc2", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
+	_, err = db.PutExistingRev("doc3", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create two conflicting changes:
 	body["n"] = 2
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"2-b", "1-a"}, false), "add 2-b")
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"2-b", "1-a"}, false), "add 2-b")
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
+	_, err = db.PutExistingRev("doc2", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
+	_, err = db.PutExistingRev("doc3", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 	body["n"] = 3
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"2-a", "1-a"}, false), "add 2-a")
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"2-a", "1-a"}, false), "add 2-a")
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
+	_, err = db.PutExistingRev("doc2", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
+	_, err = db.PutExistingRev("doc3", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Set AllowConflicts to false
 	db.Options.AllowConflicts = base.BoolPtr(false)
@@ -1005,12 +1026,12 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	body[BodyDeleted] = true
 
 	// Attempt to tombstone a non-leaf node of a conflicted document
-	err := db.PutExistingRev("doc1", body, []string{"2-c", "1-a"}, false)
+	_, err = db.PutExistingRev("doc1", body, []string{"2-c", "1-a"}, false)
 	assert.True(t, err != nil, "expected error tombstoning non-leaf")
 
 	// Tombstone the non-winning branch of a conflicted document
 	body[BodyRev] = "2-a"
-	tombstoneRev, putErr := db.Put("doc1", body)
+	tombstoneRev, _, putErr := db.Put("doc1", body)
 	assert.NoError(t, putErr, "tombstone 2-a")
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
@@ -1018,12 +1039,12 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 
 	// Attempt to add a tombstone rev w/ the previous tombstone as parent
 	body[BodyRev] = tombstoneRev
-	_, putErr = db.Put("doc1", body)
+	_, _, putErr = db.Put("doc1", body)
 	assert.True(t, putErr != nil, "Expect error tombstoning a tombstone")
 
 	// Tombstone the winning branch of a conflicted document
 	body[BodyRev] = "2-b"
-	_, putErr = db.Put("doc2", body)
+	_, _, putErr = db.Put("doc2", body)
 	assert.NoError(t, putErr, "tombstone 2-b")
 	doc, err = db.GetDocument("doc2", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
@@ -1032,7 +1053,7 @@ func TestAllowConflictsFalseTombstoneExistingConflict(t *testing.T) {
 	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
 	db.RevsLimit = uint32(1)
 	body[BodyRev] = "2-a"
-	_, putErr = db.Put("doc3", body)
+	_, _, putErr = db.Put("doc3", body)
 	assert.NoError(t, putErr, "tombstone 2-a w/ revslimit=1")
 	doc, err = db.GetDocument("doc3", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
@@ -1051,19 +1072,28 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 	// Create documents with multiple non-deleted branches
 	log.Printf("Creating docs")
 	body := Body{"n": 1}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"1-a"}, false), "add 1-a")
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
+	_, err = db.PutExistingRev("doc2", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
+	_, err = db.PutExistingRev("doc3", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create two conflicting changes:
 	body["n"] = 2
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"2-b", "1-a"}, false), "add 2-b")
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"2-b", "1-a"}, false), "add 2-b")
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
+	_, err = db.PutExistingRev("doc2", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
+	_, err = db.PutExistingRev("doc3", body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 	body["n"] = 3
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"2-a", "1-a"}, false), "add 2-a")
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"2-a", "1-a"}, false), "add 2-a")
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
+	_, err = db.PutExistingRev("doc2", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
+	_, err = db.PutExistingRev("doc3", body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Set AllowConflicts to false
 	db.Options.AllowConflicts = base.BoolPtr(false)
@@ -1071,24 +1101,27 @@ func TestAllowConflictsFalseTombstoneExistingConflictNewEditsFalse(t *testing.T)
 	body[BodyDeleted] = true
 
 	// Attempt to tombstone a non-leaf node of a conflicted document
-	err := db.PutExistingRev("doc1", body, []string{"2-c", "1-a"}, false)
+	_, err = db.PutExistingRev("doc1", body, []string{"2-c", "1-a"}, false)
 	assert.True(t, err != nil, "expected error tombstoning non-leaf")
 
 	// Tombstone the non-winning branch of a conflicted document
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"3-a", "2-a"}, false), "add 3-a (tombstone)")
+	_, err = db.PutExistingRev("doc1", body, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "add 3-a (tombstone)")
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
 	goassert.Equals(t, doc.CurrentRev, "2-b")
 
 	// Tombstone the winning branch of a conflicted document
-	assert.NoError(t, db.PutExistingRev("doc2", body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
+	_, err = db.PutExistingRev("doc2", body, []string{"3-b", "2-b"}, false)
+	assert.NoError(t, err, "add 3-b (tombstone)")
 	doc, err = db.GetDocument("doc2", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
 	goassert.Equals(t, doc.CurrentRev, "2-a")
 
 	// Set revs_limit=1, then tombstone non-winning branch of a conflicted document.  Validate retrieval still works.
 	db.RevsLimit = uint32(1)
-	assert.NoError(t, db.PutExistingRev("doc3", body, []string{"3-a", "2-a"}, false), "add 3-a (tombstone)")
+	_, err = db.PutExistingRev("doc3", body, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "add 3-a (tombstone)")
 	doc, err = db.GetDocument("doc3", DocUnmarshalAll)
 	assert.NoError(t, err, "Retrieve doc post-tombstone")
 	goassert.Equals(t, doc.CurrentRev, "2-b")
@@ -1111,7 +1144,7 @@ func TestSyncFnOnPush(t *testing.T) {
 
 	// Create first revision:
 	body := Body{"key1": "value1", "key2": 1234, "channels": []string{"public"}}
-	rev1id, err := db.Put("doc1", body)
+	rev1id, _, err := db.Put("doc1", body)
 	assert.NoError(t, err, "Couldn't create document")
 
 	// Add several revisions at once to a doc, as on a push:
@@ -1122,7 +1155,7 @@ func TestSyncFnOnPush(t *testing.T) {
 	body["channels"] = "clibup"
 	history := []string{"4-four", "3-three", "2-488724414d0ed6b398d6d2aeb228d797",
 		rev1id}
-	err = db.PutExistingRev("doc1", body, history, false)
+	_, err = db.PutExistingRev("doc1", body, history, false)
 	assert.NoError(t, err, "PutExistingRev failed")
 
 	// Check that the doc has the correct channel (test for issue #300)
@@ -1143,7 +1176,7 @@ func TestInvalidChannel(t *testing.T) {
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	body := Body{"channels": []string{"bad,name"}}
-	_, err := db.Put("doc", body)
+	_, _, err := db.Put("doc", body)
 	assertHTTPError(t, err, 500)
 }
 
@@ -1157,27 +1190,27 @@ func TestAccessFunctionValidation(t *testing.T) {
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc){access(doc.users,doc.userChannels);}`)
 
 	body := Body{"users": []string{"username"}, "userChannels": []string{"BBC1"}}
-	_, err = db.Put("doc1", body)
+	_, _, err = db.Put("doc1", body)
 	assert.NoError(t, err, "")
 
 	body = Body{"users": []string{"role:rolename"}, "userChannels": []string{"BBC1"}}
-	_, err = db.Put("doc2", body)
+	_, _, err = db.Put("doc2", body)
 	assert.NoError(t, err, "")
 
 	body = Body{"users": []string{"bad username"}, "userChannels": []string{"BBC1"}}
-	_, err = db.Put("doc3", body)
+	_, _, err = db.Put("doc3", body)
 	assertHTTPError(t, err, 500)
 
 	body = Body{"users": []string{"role:bad rolename"}, "userChannels": []string{"BBC1"}}
-	_, err = db.Put("doc4", body)
+	_, _, err = db.Put("doc4", body)
 	assertHTTPError(t, err, 500)
 
 	body = Body{"users": []string{"roll:over"}, "userChannels": []string{"BBC1"}}
-	_, err = db.Put("doc5", body)
+	_, _, err = db.Put("doc5", body)
 	assertHTTPError(t, err, 500)
 
 	body = Body{"users": []string{"username"}, "userChannels": []string{"bad,name"}}
-	_, err = db.Put("doc6", body)
+	_, _, err = db.Put("doc6", body)
 	assertHTTPError(t, err, 500)
 }
 
@@ -1197,11 +1230,11 @@ func TestAccessFunctionDb(t *testing.T) {
 	assert.NoError(t, authenticator.Save(user), "Save")
 
 	body := Body{"users": []string{"naomi"}, "userChannels": []string{"Hulu"}}
-	_, err = db.Put("doc1", body)
+	_, _, err = db.Put("doc1", body)
 	assert.NoError(t, err, "")
 
 	body = Body{"users": []string{"role:animefan"}, "userChannels": []string{"CrunchyRoll"}}
-	_, err = db.Put("doc2", body)
+	_, _, err = db.Put("doc2", body)
 	assert.NoError(t, err, "")
 
 	// Create the role _after_ creating the documents, to make sure the previously-indexed access
@@ -1243,7 +1276,7 @@ func TestAccessFunctionWithVbuckets(t *testing.T) {
 	assert.NoError(t, authenticator.Save(user), "Save")
 
 	body := Body{"users": []string{"bernard"}, "userChannels": []string{"ABC"}}
-	_, err = db.Put("doc1", body)
+	_, _, err = db.Put("doc1", body)
 	assert.NoError(t, err, "")
 	time.Sleep(100 * time.Millisecond)
 
@@ -1253,7 +1286,7 @@ func TestAccessFunctionWithVbuckets(t *testing.T) {
 	goassert.DeepEquals(t, user.Channels(), expected)
 
 	body = Body{"users": []string{"bernard"}, "userChannels": []string{"NBC"}}
-	_, err = db.Put("doc2", body)
+	_, _, err = db.Put("doc2", body)
 	assert.NoError(t, err, "")
 	time.Sleep(100 * time.Millisecond)
 
@@ -1264,7 +1297,7 @@ func TestAccessFunctionWithVbuckets(t *testing.T) {
 
 	// Have another doc assign a new channel, and one of the previously present channels
 	body = Body{"users": []string{"bernard"}, "userChannels": []string{"ABC", "PBS"}}
-	_, err = db.Put("doc3", body)
+	_, _, err = db.Put("doc3", body)
 	assert.NoError(t, err, "")
 	time.Sleep(100 * time.Millisecond)
 
@@ -1330,7 +1363,7 @@ func TestPostWithExistingId(t *testing.T) {
 	customDocId := "customIdValue"
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
-	docid, rev1id, err := db.Post(body)
+	docid, rev1id, _, err := db.Post(body)
 	goassert.True(t, rev1id != "")
 	goassert.True(t, docid == customDocId)
 	assert.NoError(t, err, "Couldn't create document")
@@ -1343,7 +1376,7 @@ func TestPostWithExistingId(t *testing.T) {
 	// Test that standard UUID creation still works:
 	log.Printf("Create document with existing id...")
 	body = Body{"notAnId": customDocId, "key1": "value1", "key2": "existing"}
-	docid, rev1id, err = db.Post(body)
+	docid, rev1id, _, err = db.Post(body)
 	goassert.True(t, rev1id != "")
 	goassert.True(t, docid != customDocId)
 	assert.NoError(t, err, "Couldn't create document")
@@ -1366,7 +1399,7 @@ func TestPutWithUserSpecialProperty(t *testing.T) {
 	customDocId := "customIdValue"
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "_key2": "existing"}
-	docid, rev1id, err := db.Post(body)
+	docid, rev1id, _, err := db.Post(body)
 	goassert.True(t, rev1id == "")
 	goassert.True(t, docid == "")
 	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
@@ -1383,7 +1416,7 @@ func TestWithNullPropertyKey(t *testing.T) {
 	customDocId := "customIdValue"
 	log.Printf("Create document with empty property key")
 	body := Body{BodyId: customDocId, "": "value1"}
-	docid, rev1id, _ := db.Post(body)
+	docid, rev1id, _, _ := db.Post(body)
 	goassert.True(t, rev1id != "")
 	goassert.True(t, docid != "")
 }
@@ -1399,7 +1432,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	customDocId := "customIdValue"
 	log.Printf("Create document with existing id...")
 	body := Body{BodyId: customDocId, "key1": "value1", "key2": "existing"}
-	docid, rev1id, err := db.Post(body)
+	docid, rev1id, _, err := db.Post(body)
 	goassert.True(t, rev1id != "")
 	goassert.True(t, docid == customDocId)
 	assert.NoError(t, err, "Couldn't create document")
@@ -1413,7 +1446,7 @@ func TestPostWithUserSpecialProperty(t *testing.T) {
 	//document
 	log.Printf("Update document with existing id...")
 	body = Body{BodyId: customDocId, BodyRev: rev1id, "_special": "value", "key1": "value1", "key2": "existing"}
-	_, err = db.Put(docid, body)
+	_, _, err = db.Put(docid, body)
 	goassert.True(t, err.Error() == "400 user defined top level properties beginning with '_' are not allowed in document body")
 
 	// Test retrieval gets rev1
@@ -1434,7 +1467,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 
 	// Validate recent sequence is written
 	body := Body{"val": "one"}
-	revid, err := db.Put("doc1", body)
+	revid, _, err := db.Put("doc1", body)
 	seqTracker++
 
 	expectedRecent := make([]uint64, 0)
@@ -1446,7 +1479,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 
 	// Add up to kMaxRecentSequences revisions - validate they are retained when total is less than max
 	for i := 1; i < kMaxRecentSequences; i++ {
-		revid, err = db.Put("doc1", body)
+		revid, _, err = db.Put("doc1", body)
 		seqTracker++
 		expectedRecent = append(expectedRecent, seqTracker)
 	}
@@ -1458,10 +1491,10 @@ func TestRecentSequenceHistory(t *testing.T) {
 	// Recent sequence pruning only prunes entries older than what's been seen over DCP
 	// (to ensure it's not pruning something that may still be coalesced).  Because of this, test waits
 	// for caching before attempting to trigger pruning.
-	db.changeCache.waitForSequence(seqTracker, base.DefaultWaitForSequence)
+	db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence)
 
 	// Add another sequence to validate pruning when past max (20)
-	revid, err = db.Put("doc1", body)
+	revid, _, err = db.Put("doc1", body)
 	seqTracker++
 	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
 	goassert.True(t, err == nil)
@@ -1471,14 +1504,14 @@ func TestRecentSequenceHistory(t *testing.T) {
 	// Ensure pruning works when sequences aren't sequential
 	doc2Body := Body{"val": "two"}
 	for i := 0; i < kMaxRecentSequences; i++ {
-		revid, err = db.Put("doc1", body)
+		revid, _, err = db.Put("doc1", body)
 		seqTracker++
-		revid, err = db.Put("doc2", doc2Body)
+		revid, _, err = db.Put("doc2", doc2Body)
 		seqTracker++
 	}
 
-	db.changeCache.waitForSequence(seqTracker, base.DefaultWaitForSequence) //
-	revid, err = db.Put("doc1", body)
+	db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence) //
+	revid, _, err = db.Put("doc1", body)
 	seqTracker++
 	doc, err = db.GetDocument("doc1", DocUnmarshalAll)
 	goassert.True(t, err == nil)
@@ -1496,7 +1529,7 @@ func TestChannelView(t *testing.T) {
 	// Create doc
 	log.Printf("Create doc 1...")
 	body := Body{"key1": "value1", "key2": 1234}
-	rev1id, err := db.Put("doc1", body)
+	rev1id, _, err := db.Put("doc1", body)
 	assert.NoError(t, err, "Couldn't create document")
 	goassert.Equals(t, rev1id, body[BodyRev])
 	goassert.Equals(t, rev1id, "1-cb0c9a22be0e5a1b01084ec019defa81")
@@ -1570,7 +1603,7 @@ func TestViewCustom(t *testing.T) {
 
 	// add some docs
 	docId := base.CreateUUID()
-	_, err := db.Put(docId, Body{"val": "one"})
+	_, _, err := db.Put(docId, Body{"val": "one"})
 	if err != nil {
 		log.Printf("error putting doc: %v", err)
 	}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -653,7 +653,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Inspect the channel log to confirm that it's only got the last 50 sequences.
 	// There are 101 sequences overall, so the 1st one it has should be #52.
-	db.changeCache.waitForSequence(101, base.DefaultWaitForSequenceTesting, t)
+	db.changeCache.waitForSequence(101, base.DefaultWaitForSequence)
 	changeLog := db.GetChangeLog("all", 0)
 	assert.Equal(t, 50, len(changeLog))
 	assert.Equal(t, 52, int(changeLog[0].Sequence))
@@ -1458,7 +1458,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 	// Recent sequence pruning only prunes entries older than what's been seen over DCP
 	// (to ensure it's not pruning something that may still be coalesced).  Because of this, test waits
 	// for caching before attempting to trigger pruning.
-	db.changeCache.waitForSequence(seqTracker, base.DefaultWaitForSequenceTesting, t)
+	db.changeCache.waitForSequence(seqTracker, base.DefaultWaitForSequence)
 
 	// Add another sequence to validate pruning when past max (20)
 	revid, err = db.Put("doc1", body)
@@ -1477,7 +1477,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 		seqTracker++
 	}
 
-	db.changeCache.waitForSequence(seqTracker, base.DefaultWaitForSequenceTesting, t) //
+	db.changeCache.waitForSequence(seqTracker, base.DefaultWaitForSequence) //
 	revid, err = db.Put("doc1", body)
 	seqTracker++
 	doc, err = db.GetDocument("doc1", DocUnmarshalAll)

--- a/db/document.go
+++ b/db/document.go
@@ -165,7 +165,7 @@ type casOnlySyncData struct {
 }
 
 // Returns a new empty document.
-func newDocument(docid string) *Document {
+func NewDocument(docid string) *Document {
 	return &Document{ID: docid, SyncData: SyncData{History: make(RevTree)}}
 }
 

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -155,7 +155,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				doc := newDocument("testDocID")
+				doc := NewDocument("testDocID")
 				docReader := bytes.NewReader(doc1k_body)
 				b.StartTimer()
 				var err error

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -19,7 +19,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -198,14 +197,13 @@ func (k *kvChangeIndex) Remove(docIDs []string, startTime time.Time) int {
 }
 
 // TODO: refactor waitForSequence to accept either vbNo or clock
-func (k *kvChangeIndex) waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration, tb testing.TB) {
-	k.waitForSequence(sequence.Seq, maxWaitTime, tb)
+func (k *kvChangeIndex) waitForSequence(sequence uint64, maxWaitTime time.Duration) error {
+	// no-op
+	return nil
 }
-func (k *kvChangeIndex) waitForSequence(sequence uint64, maxWaitTime time.Duration, tb testing.TB) {
-	return
-}
-func (k *kvChangeIndex) waitForSequenceWithMissing(sequence uint64, maxWaitTime time.Duration, tb testing.TB) {
-	k.waitForSequence(sequence, maxWaitTime, tb)
+func (k *kvChangeIndex) waitForSequenceNotSkipped(sequence uint64, maxWaitTime time.Duration) error {
+	// no-op
+	return nil
 }
 
 // If set to false, DocChanged() becomes a no-op.

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -197,11 +198,11 @@ func (k *kvChangeIndex) Remove(docIDs []string, startTime time.Time) int {
 }
 
 // TODO: refactor waitForSequence to accept either vbNo or clock
-func (k *kvChangeIndex) waitForSequence(sequence uint64, maxWaitTime time.Duration) error {
+func (k *kvChangeIndex) waitForSequence(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error {
 	// no-op
 	return nil
 }
-func (k *kvChangeIndex) waitForSequenceNotSkipped(sequence uint64, maxWaitTime time.Duration) error {
+func (k *kvChangeIndex) waitForSequenceNotSkipped(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error {
 	// no-op
 	return nil
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -23,11 +23,11 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	_, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
+	_, _, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc1")
-	_, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc2")
-	_, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
@@ -69,11 +69,11 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	_, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
+	_, _, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc1")
-	_, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc2")
-	_, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
@@ -114,7 +114,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	// Add docs without channel assignment (will only be assigned to the star channel)
 	for i := 1; i <= 10; i++ {
 		//_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"channels": []string{"ABC"}})
-		_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 
@@ -158,7 +158,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 
 	// Add some docs in different channels, to validate query handling when non-star channel docs are present
 	for i := 1; i <= 10; i++ {
-		_, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 	// Issue channels query
@@ -198,7 +198,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	// Add docs without channel assignment (will only be assigned to the star channel)
 	for i := 1; i <= 10; i++ {
 		//_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"channels": []string{"ABC"}})
-		_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 
@@ -243,7 +243,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 	// Add some docs in different channels, to validate query handling when non-star channel docs are present
 	for i := 1; i <= 10; i++ {
-		_, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 	// Issue channels query
@@ -328,7 +328,7 @@ func TestAllDocsQuery(t *testing.T) {
 
 	// Add docs with channel assignment
 	for i := 1; i <= 10; i++ {
-		_, err := db.Put(fmt.Sprintf("allDocsTest%d", i), Body{"channels": []string{"ABC"}})
+		_, _, err := db.Put(fmt.Sprintf("allDocsTest%d", i), Body{"channels": []string{"ABC"}})
 		assert.NoError(t, err, "Put allDocsTest doc")
 	}
 
@@ -394,7 +394,7 @@ func TestAccessQuery(t *testing.T) {
 }`)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
-		_, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
+		_, _, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
 		assert.NoError(t, err, "Put accessTest doc")
 	}
 
@@ -445,7 +445,7 @@ func TestRoleAccessQuery(t *testing.T) {
 }`)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
-		_, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
+		_, _, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
 		assert.NoError(t, err, "Put accessTest doc")
 	}
 

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -74,8 +74,8 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 
 // RevisionCacheBackingStore is the inteface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
-	GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *document, err error)
-	getRevision(doc *document, revid string) (Body, error)
+	GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
+	getRevision(doc *Document, revid string) (Body, error)
 }
 
 // Revision information as returned by the rev cache
@@ -114,7 +114,7 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
 func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
-	var doc *document
+	var doc *Document
 	if doc, err = backingStore.GetDocument(id.DocID, DocUnmarshalAll); doc == nil {
 		return body, history, channels, attachments, expiry, err
 	}
@@ -123,7 +123,7 @@ func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev) (body B
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *document, revid string) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
+func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Document, revid string) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
 
 	if body, err = backingStore.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -254,7 +254,7 @@ func (value *revCacheValue) _asDocumentRevision(copyType BodyCopyType) (Document
 
 // Retrieves the body etc. out of a revCacheValue.  If they aren't already present, loads into the cache value using
 // the provided document.
-func (value *revCacheValue) loadForDoc(backingStore RevisionCacheBackingStore, doc *document, copyType BodyCopyType) (docRev DocumentRevision, cacheHit bool, err error) {
+func (value *revCacheValue) loadForDoc(backingStore RevisionCacheBackingStore, doc *Document, copyType BodyCopyType) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	value.lock.RLock()
 	if value.body != nil || value.err != nil {

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -916,7 +916,7 @@ func addPruneAndGet(revTree RevTree, revID string, parentRevID string, revBody [
 
 }
 
-func getHistoryWithTimeout(rawDoc *document, revId string, timeout time.Duration) (history []string, err error) {
+func getHistoryWithTimeout(rawDoc *Document, revId string, timeout time.Duration) (history []string, err error) {
 
 	historyChannel := make(chan []string)
 	errChannel := make(chan error)

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -107,7 +107,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid expiry: %v", err)
 	}
 
-	_, err = db.updateDoc(key, false, expiry, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
+	_, _, err = db.updateAndReturnDoc(key, false, expiry, nil, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		if doc.UpstreamCAS != nil && *doc.UpstreamCAS == cas {
 			return nil, nil, nil, base.ErrUpdateCancel // we already have this doc revision

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -107,7 +107,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid expiry: %v", err)
 	}
 
-	_, _, err = db.updateAndReturnDoc(key, false, expiry, nil, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
+	_, _, err = db.updateAndReturnDoc(key, false, expiry, nil, func(doc *Document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 		if doc.UpstreamCAS != nil && *doc.UpstreamCAS == cas {
 			return nil, nil, nil, base.ErrUpdateCancel // we already have this doc revision
@@ -155,7 +155,7 @@ func (s *Shadower) pullDocument(key string, value []byte, isDeletion bool, cas u
 }
 
 // Saves a new local revision to the external bucket.
-func (s *Shadower) PushRevision(doc *document) {
+func (s *Shadower) PushRevision(doc *Document) {
 	defer func() { atomic.AddUint64(&s.pushCount, 1) }()
 	if !s.docIDMatches(doc.ID) {
 		return

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -59,7 +59,7 @@ func TestShadowerPull(t *testing.T) {
 	defer shadower.Stop()
 
 	t.Logf("Waiting for shadower to catch up...")
-	var doc1, doc2 *document
+	var doc1, doc2 *Document
 	waitFor(t, func() bool {
 		seq, _ := db.LastSequence()
 		return seq >= 2
@@ -176,9 +176,9 @@ func TestShadowerPush(t *testing.T) {
 	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
 	assert.NoError(t, err, "NewShadower")
 
-	key1rev1, err := db.Put("key1", Body{"aaa": "bbb"})
+	key1rev1, _, err := db.Put("key1", Body{"aaa": "bbb"})
 	assert.NoError(t, err, "Put")
-	_, err = db.Put("key2", Body{"ccc": "ddd"})
+	_, _, err = db.Put("key2", Body{"ccc": "ddd"})
 	assert.NoError(t, err, "Put")
 
 	t.Log("Waiting for shadower to catch up...")

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -89,7 +89,7 @@ func (c *changeCache) waitForSequence(sequence uint64, maxWaitTime time.Duration
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), startTime.Add(maxWaitTime))
-	sleeper := base.SleeperFuncCtx(base.CreateMaxDoublingSleeperFunc(300, 1, 100), ctx)
+	sleeper := base.SleeperFuncCtx(base.CreateMaxDoublingSleeperFunc(math.MaxInt64, 1, 100), ctx)
 	err, _ := base.RetryLoop(fmt.Sprintf("waitForSequence(%d)", sequence), worker, sleeper)
 	cancel()
 	return err
@@ -112,7 +112,7 @@ func (c *changeCache) waitForSequenceNotSkipped(sequence uint64, maxWaitTime tim
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), startTime.Add(maxWaitTime))
-	sleeper := base.SleeperFuncCtx(base.CreateMaxDoublingSleeperFunc(300, 1, 100), ctx)
+	sleeper := base.SleeperFuncCtx(base.CreateMaxDoublingSleeperFunc(math.MaxInt64, 1, 100), ctx)
 	err, _ := base.RetryLoop(fmt.Sprintf("waitForSequenceNotSkipped(%d)", sequence), worker, sleeper)
 	cancel()
 	return err

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -81,7 +81,7 @@ func (c *changeCache) waitForSequence(sequence uint64, maxWaitTime time.Duration
 
 	worker := func() (bool, error, interface{}) {
 		if c.getNextSequence() >= sequence+1 {
-			base.Infof(base.KeyAll, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
+			base.Debugf(base.KeyCache, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
 			return false, nil, nil
 		}
 		// retry
@@ -103,7 +103,7 @@ func (c *changeCache) waitForSequenceNotSkipped(sequence uint64, maxWaitTime tim
 		if c.getNextSequence() >= sequence+1 {
 			foundInMissing := c.skippedSeqs.Contains(sequence)
 			if !foundInMissing {
-				base.Infof(base.KeyAll, "waitForSequenceNotSkipped(%d) took %v", sequence, time.Since(startTime))
+				base.Debugf(base.KeyCache, "waitForSequenceNotSkipped(%d) took %v", sequence, time.Since(startTime))
 				return false, nil, nil
 			}
 		}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -21,7 +21,7 @@
 
   
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="CBG-375"/>
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" />
 
   
   <!-- Sync Gateway Accel-->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -21,7 +21,7 @@
 
   
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" />
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="CBG-375"/>
 
   
   <!-- Sync Gateway Accel-->

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2288,7 +2288,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Must wait for sequence to arrive in cache, since the cache processor will be paused when UpdateSyncFun() is called
 	// below, which could lead to a data race if the cache processor is paused while it's processing a change
-	rt.ServerContext().Database("db").WaitForSequence(uint64(10), t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForSequence(uint64(10)))
 
 	// Finally, throw a wrench in the works by changing the sync fn. Note that normally this wouldn't
 	// be changed while the database is in use (only when it's re-opened) but for testing purposes
@@ -3892,7 +3892,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevID2, `{"channels": ["B"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	//Changes call
 	request, _ := http.NewRequest("GET", "/db/_changes", nil)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2288,7 +2288,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Must wait for sequence to arrive in cache, since the cache processor will be paused when UpdateSyncFun() is called
 	// below, which could lead to a data race if the cache processor is paused while it's processing a change
-	require.NoError(t, rt.ServerContext().Database("db").WaitForSequence(uint64(10)))
+	require.NoError(t, rt.WaitForSequence(10))
 
 	// Finally, throw a wrench in the works by changing the sync fn. Note that normally this wouldn't
 	// be changed while the database is in use (only when it's re-opened) but for testing purposes
@@ -3892,7 +3892,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevID2, `{"channels": ["B"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
-	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	//Changes call
 	request, _ := http.NewRequest("GET", "/db/_changes", nil)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -931,7 +931,8 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 
 	// Finally, save the revision (with the new attachments inline)
 	bh.db.DbStats.CblReplicationPush().Add(base.StatKeyDocPushCount, 1)
-	return bh.db.PutExistingRev(docID, body, history, noConflicts)
+	_, err := bh.db.PutExistingRev(docID, body, history, noConflicts)
+	return err
 }
 
 //////// ATTACHMENTS:

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -492,9 +492,9 @@ func (h *handler) handleBulkDocs() error {
 		var revid string
 		if newEdits {
 			if docid != "" {
-				revid, err = h.db.Put(docid, doc)
+				revid, _, err = h.db.Put(docid, doc)
 			} else {
-				docid, revid, err = h.db.Post(doc)
+				docid, revid, _, err = h.db.Post(doc)
 			}
 		} else {
 			revisions := db.ParseRevisions(doc)
@@ -502,7 +502,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				err = h.db.PutExistingRev(docid, doc, revisions, false)
+				_, err = h.db.PutExistingRev(docid, doc, revisions, false)
 			}
 		}
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1104,7 +1104,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	}()
 
 	// Wait for longpoll to get into wait mode
-	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1))
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Write the skipped doc, wait for longpoll to return
 	WriteDirect(testDb, []string{"PBS"}, 6)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -222,7 +222,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/alpha", `{"channel":"zero"}`))
 
 	// Check the _changes feed:
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 	var changes struct {
 		Results []db.ChangeEntry
 	}
@@ -685,7 +685,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 2)
 	WriteDirect(testDb, []string{"PBS"}, 5)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	testDb.WaitForSequenceWithMissing(6, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(6))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -710,7 +710,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a missing doc - low sequence should move to 3
 	WriteDirect(testDb, []string{"PBS"}, 3)
-	testDb.WaitForSequence(3, t)
+	require.NoError(t, testDb.WaitForSequence(3))
 
 	// WaitForSequence doesn't wait for low sequence to be updated on each channel - additional delay to ensure
 	// low is updated before making the next changes request.
@@ -724,7 +724,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
 	WriteDirect(testDb, []string{"PBS"}, 7)
-	testDb.WaitForSequenceWithMissing(7, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(7))
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -777,7 +777,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	testDb.WaitForSequenceWithMissing(5, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -797,7 +797,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	testDb.WaitForSequenceWithMissing(10, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -811,7 +811,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	testDb.WaitForSequenceWithMissing(12, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -825,7 +825,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	WriteDirect(testDb, []string{"PBS"}, 13)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	testDb.WaitForSequence(13, t)
+	require.NoError(t, testDb.WaitForSequence(13))
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
@@ -907,7 +907,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	testDb.WaitForSequenceWithMissing(5, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -927,7 +927,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	testDb.WaitForSequenceWithMissing(10, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -941,7 +941,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	testDb.WaitForSequenceWithMissing(12, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -955,7 +955,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	WriteDirect(testDb, []string{"PBS"}, 13)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	testDb.WaitForSequence(13, t)
+	require.NoError(t, testDb.WaitForSequence(13))
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
@@ -1042,7 +1042,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	testDb.WaitForSequenceWithMissing(5, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1062,7 +1062,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	testDb.WaitForSequenceWithMissing(10, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1076,7 +1076,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	testDb.WaitForSequenceWithMissing(12, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1104,7 +1104,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	}()
 
 	// Wait for longpoll to get into wait mode
-	rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1))
 
 	// Write the skipped doc, wait for longpoll to return
 	WriteDirect(testDb, []string{"PBS"}, 6)
@@ -1169,13 +1169,13 @@ func _testConcurrentDelete(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 
 	// Wait for writes to be processed and indexed
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 }
 
@@ -1208,13 +1208,13 @@ func _testConcurrentPutAsDelete(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	// Write another doc, to validate sequences restart
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 }
 
 func _testConcurrentUpdate(t *testing.T) {
@@ -1246,13 +1246,13 @@ func _testConcurrentUpdate(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	// Write another doc, to validate sequences restart
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 }
 
 func _testConcurrentNewEditsFalseDelete(t *testing.T) {
@@ -1286,12 +1286,12 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	// Write another doc, to see where sequences are at
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 }
 
@@ -2924,7 +2924,7 @@ func TestChangesIncludeConflicts(t *testing.T) {
 	}
 
 	// Get changes
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?style=all_docs", "")
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
@@ -2964,7 +2964,7 @@ func TestChangesLargeSequences(t *testing.T) {
 	}
 
 	// Get changes
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.ServerContext().Database("db").WaitForPendingChanges())
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -248,7 +248,7 @@ func (h *handler) handlePutAttachment() error {
 	attachments[attachmentName] = attachment
 	body[db.BodyAttachments] = attachments
 
-	newRev, err := h.db.Put(docid, body)
+	newRev, _, err := h.db.Put(docid, body)
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,9 @@ func (h *handler) handlePutDoc() error {
 	if body == nil {
 		return base.ErrEmptyDocument
 	}
+
 	var newRev string
+	var doc *db.Document
 	var ok bool
 
 	roundTrip := h.getBoolQuery("roundtrip")
@@ -286,7 +288,7 @@ func (h *handler) handlePutDoc() error {
 		} else if ifMatch := h.rq.Header.Get("If-Match"); ifMatch != "" {
 			body[db.BodyRev] = ifMatch
 		}
-		newRev, err = h.db.PutRoundTrip(docid, body, roundTrip)
+		newRev, doc, err = h.db.Put(docid, body)
 		if err != nil {
 			return err
 		}
@@ -297,7 +299,7 @@ func (h *handler) handlePutDoc() error {
 		if revisions == nil {
 			return base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 		}
-		err = h.db.PutExistingRevRoundTrip(docid, body, revisions, false, roundTrip)
+		doc, err = h.db.PutExistingRev(docid, body, revisions, false)
 		if err != nil {
 			return err
 		}
@@ -308,6 +310,13 @@ func (h *handler) handlePutDoc() error {
 		}
 
 	}
+
+	if doc != nil && roundTrip {
+		if err := h.db.WaitForSequenceNotSkipped(h.rq.Context(), doc.Sequence); err != nil {
+			return err
+		}
+	}
+
 	h.writeJSONStatus(http.StatusCreated, db.Body{"ok": true, "id": docid, "rev": newRev})
 	return nil
 }
@@ -319,10 +328,19 @@ func (h *handler) handlePostDoc() error {
 	if err != nil {
 		return err
 	}
-	docid, newRev, err := h.db.PostRoundTrip(body, roundTrip)
+
+	docid, newRev, doc, err := h.db.Post(body)
 	if err != nil {
 		return err
 	}
+
+	if doc != nil && roundTrip {
+		err := h.db.WaitForSequenceNotSkipped(h.rq.Context(), doc.Sequence)
+		if err != nil {
+			return err
+		}
+	}
+
 	h.setHeader("Location", docid)
 	h.setHeader("Etag", strconv.Quote(newRev))
 	h.writeJSON(db.Body{"ok": true, "id": docid, "rev": newRev})

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -276,7 +276,7 @@ func (rt *RestTester) WaitForSequence(seq uint64) error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForSequence(seq)
+	return database.WaitForSequence(context.TODO(), seq)
 }
 
 func (rt *RestTester) WaitForPendingChanges() error {
@@ -284,7 +284,7 @@ func (rt *RestTester) WaitForPendingChanges() error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForPendingChanges()
+	return database.WaitForPendingChanges(context.TODO())
 }
 
 func (rt *RestTester) SetAdminParty(partyTime bool) {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -276,7 +276,7 @@ func (rt *RestTester) WaitForSequence(seq uint64) error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForSequence(seq, rt.tb)
+	return database.WaitForSequence(seq)
 }
 
 func (rt *RestTester) WaitForPendingChanges() error {
@@ -284,7 +284,7 @@ func (rt *RestTester) WaitForPendingChanges() error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForPendingChanges(rt.tb)
+	return database.WaitForPendingChanges()
 }
 
 func (rt *RestTester) SetAdminParty(partyTime bool) {


### PR DESCRIPTION
## Functional Additions
- Added boolean query parameter `roundtrip` to `PUT /db/{doc}` and `POST /db/{doc}`
  - When set to true, the request will block until the written doc sequence is received by the change cache.

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1175/
- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1176/

---

## Log Examples

### Working
```
2019-07-01T14:34:24.669+01:00 [INF] HTTP:  #001: PUT /db/mydoc1?roundtrip=true (as ADMIN)
2019-07-01T14:34:24.670+01:00 [DBG] CRUD+: c:#001 Invoking sync on doc "mydoc1" rev 1-ca9ad22802b66f662ff171f226211d5c
2019-07-01T14:34:24.670+01:00 [DBG] CRUD+: Backed up revision body "mydoc1"/"" (1 bytes, ttl:300)
2019-07-01T14:34:24.672+01:00 [DBG] CRUD+: c:#001 Saving doc (seq: #6533, id: mydoc1 rev: 1-ca9ad22802b66f662ff171f226211d5c)
2019-07-01T14:34:24.673+01:00 [DBG] CRUD+: c:#001 Stored doc "mydoc1" / "1-ca9ad22802b66f662ff171f226211d5c" as #6533
2019-07-01T14:34:24.673+01:00 [DBG] Changes+: Waiting for sequence: 6533
2019-07-01T14:34:24.673+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6533) after 1 ms.
2019-07-01T14:34:24.674+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6533) after 2 ms.
2019-07-01T14:34:24.676+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6533) after 4 ms.
2019-07-01T14:34:24.681+01:00 [DBG] DCP+: Received #6533 after   8ms ("mydoc1" / "1-ca9ad22802b66f662ff171f226211d5c")
2019-07-01T14:34:24.681+01:00 [DBG] DCP+:  #6533 ==> channels {*}
2019-07-01T14:34:24.681+01:00 [DBG] Changes+: Notifying that "sgw" changed (keys="{*}") count=2
2019-07-01T14:34:24.681+01:00 [DBG] Cache: waitForSequenceNotSkipped(6533) took 8.0096ms
2019-07-01T14:34:24.681+01:00 [INF] HTTP+: #001:     --> 201   (12.0 ms)
```

### Timeout
```
2019-07-01T15:27:26.536+01:00 [INF] HTTP:  #001: PUT /db/mydoc7?roundtrip=true (as ADMIN)
2019-07-01T15:27:26.536+01:00 [DBG] CRUD+: c:#001 Invoking sync on doc "mydoc7" rev 1-ca9ad22802b66f662ff171f226211d5c
2019-07-01T15:27:26.537+01:00 [DBG] CRUD+: Backed up revision body "mydoc7"/"" (1 bytes, ttl:300)
2019-07-01T15:27:26.538+01:00 [DBG] CRUD+: c:#001 Saving doc (seq: #6539, id: mydoc7 rev: 1-ca9ad22802b66f662ff171f226211d5c)
2019-07-01T15:27:26.539+01:00 [DBG] CRUD+: c:#001 Stored doc "mydoc7" / "1-ca9ad22802b66f662ff171f226211d5c" as #6539
2019-07-01T15:27:26.539+01:00 [DBG] Changes+: Waiting for sequence: 6549
2019-07-01T15:27:26.539+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6549) after 1 ms.
2019-07-01T15:27:26.540+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6549) after 2 ms.
2019-07-01T15:27:26.542+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6549) after 4 ms.

...

2019-07-01T15:27:56.412+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6549) after 100 ms.
2019-07-01T15:27:56.512+01:00 [DBG] RetryLoop retrying waitForSequenceNotSkipped(6549) after 100 ms.
2019-07-01T15:27:56.612+01:00 [WRN] RetryLoop for waitForSequenceNotSkipped(6549) giving up after 305 attempts -- base.RetryLoop() at util.go:374
2019-07-01T15:27:56.613+01:00 [ERR] c:#001 RetryLoop for waitForSequenceNotSkipped(6549) giving up after 305 attempts -- rest.(*handler).writeError() at handler.go:692
2019-07-01T15:27:56.613+01:00 [INF] HTTP: #001:     --> 504 RetryLoop for waitForSequenceNotSkipped(6549) giving up after 305 attempts  (30077.8 ms)
```

---

## Code Changes
### Added
- Added `db.PutRoundTrip` and `db.PutExistingRevRoundTrip`
- Added `SleeperFuncCtx(RetrySleeper, context.Context)` which wraps any existing RetrySleeper func with a context that can be used for cancellation or have a deadline/timeout

### Removed
- Removed duplicate `WaitForSequenceID` functions that were unnecessary wrappers of `WaitForSequence`
- Removed unused `RetryTimeout` and related code
- Removed old/unused `IsFilePathWritable` logging util