### PR TITLE
CBG-434 Constrain sequence allocator batch size

### DIFF
--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -27,7 +27,7 @@ const (
 	defaultReleaseSequenceWait = 1500 * time.Millisecond
 
 	// Maximum batch size
-	maxBatchSize = 100000
+	maxBatchSize = 10
 
 	// Factor by which to grow the sequence batch size
 	sequenceBatchMultiplier = 2


### PR DESCRIPTION
Batched sequence allocation reduces the number of kv operations per Sync Gateway write.  However, aggressive sequence batching can result in higher latency in deployments with multiple SG nodes.  When m nodes allocate sequence batches of size n concurrently, the next documents written from the cluster will have a sequence gap of up to `n(m-1)`.  This typically doesn't result in skipped sequences -  allocated sequences are released before they would be skipped - but can result in significant increases in latency during DCP processing/sequence buffering when n is large.  There are write scaling enhancements planned for Cobalt that will optimize this buffering - until those are available, limiting the maximum batch size to 10 provides the optimal throughput when considering both single-node and multi-node SG deployments.  


Test | Batch Size | Build | Nodes | Throughput | vs. 2.5.0
-- | -- | -- | -- | -- | --
1 node | 1 | 2.5.0-271 | 1 | 4865 | 100.00%
1 node | Unlimited | 2.6.0-104 | 1 | 7966 | 163.74%
1 node | 1 | 2.6.0-63 (toy) | 1 | 4233 | 87.01%
1 node | 10 | 2.6.0-61 (toy) | 1 | 7530 | 154.78%
1 node | 20 | 2.6.0-64 (toy) | 1 | 7591 | 156.03%
4 node | 1 | 2.5.0-271 | 4 | 12941 | 100.00%
4 node | Unlimited | 2.6.0-104 | 4 | 6449 | 49.83%
4 node | 1 | 2.6.0-63 (toy) | 4 | 13498 | 104.30%
4 node | 10 | 2.6.0-61 (toy) | 4 | 12307 | 95.10%
4 node | 20 | 2.6.0-64 (toy) | 4 | 11809 | 91.25%



 