### PR TITLE
CBG-413: Improve handling of invalid replicator source/target

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -156,19 +156,19 @@ func (h *handler) handleReplicate() error {
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 	if response.StatusCode >= 400 {
 		return base.HTTPErrorf(response.StatusCode, "Unable to start replication target db not reachable")
 	}
-	response.Body.Close()
 
 	response, err = h.server.HTTPClient.Get(params.GetSourceDbUrl())
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 	if response.StatusCode >= 400 {
 		return base.HTTPErrorf(response.StatusCode, "Unable to start replication source db not reachable")
 	}
-	response.Body.Close()
 
 	replication, err := h.server.replicator.Replicate(params, cancel)
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -153,40 +153,44 @@ func (h *handler) handleReplicate() error {
 		return err
 	}
 
-	response, err := h.server.HTTPClient.Get(params.GetTargetDbUrl())
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-	if response.StatusCode >= 400 {
-		b, err := ioutil.ReadAll(response.Body)
+	if !cancel {
+		response, err := h.server.HTTPClient.Get(params.GetTargetDbUrl())
 		if err != nil {
 			return err
 		}
-		var body db.Body
-		err = json.Unmarshal(b, &body)
-		if err != nil {
-			return err
+		defer response.Body.Close()
+		if response.StatusCode >= 400 {
+			b, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+			var body db.Body
+			err = json.Unmarshal(b, &body)
+			if err != nil {
+				return err
+			}
+			return base.HTTPErrorf(response.StatusCode, "Unable to start replication to target db: %s", body["reason"])
 		}
-		return base.HTTPErrorf(response.StatusCode, "Unable to start replication to target db: %s", body["reason"])
-	}
 
-	response, err = h.server.HTTPClient.Get(params.GetSourceDbUrl())
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-	if response.StatusCode >= 400 {
-		b, err := ioutil.ReadAll(response.Body)
+		response, err = h.server.HTTPClient.Get(params.GetSourceDbUrl())
 		if err != nil {
 			return err
 		}
-		var body db.Body
-		err = json.Unmarshal(b, &body)
-		if err != nil {
-			return err
+		defer response.Body.Close()
+		if response.StatusCode >= 400 {
+			b, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+			var body db.Body
+			err = json.Unmarshal(b, &body)
+			if err != nil {
+				return err
+			}
+			return base.HTTPErrorf(response.StatusCode, "Unable to start replication from source db: %s", body["reason"])
 		}
-		return base.HTTPErrorf(response.StatusCode, "Unable to start replication from source db: %s", body["reason"])
 	}
 
 	replication, err := h.server.replicator.Replicate(params, cancel)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -153,6 +153,39 @@ func (h *handler) handleReplicate() error {
 		return err
 	}
 
+	client := &http.Client{}
+	targetRequest, err := http.NewRequest("GET", params.GetTargetDbUrl(), nil)
+
+	if err != nil {
+		return err
+	}
+
+	sourceRequest, err := http.NewRequest("GET", params.GetSourceDbUrl(), nil)
+
+	if err != nil {
+		return err
+	}
+
+	response, err := client.Do(targetRequest)
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return base.HTTPErrorf(response.StatusCode, "Unable to start replication target db not reachable")
+	}
+
+	response, err = client.Do(sourceRequest)
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return base.HTTPErrorf(response.StatusCode, "Unable to start replication source db not reachable")
+	}
+
 	replication, err := h.server.replicator.Replicate(params, cancel)
 
 	if err == nil {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1669,6 +1669,17 @@ func TestDocumentChangeReplicate(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close() // Close RestTester, which closes ServerContext, which stops all replications
 
+	mockClient := NewMockClient()
+	fakeConfigURL := "http://myhost:4985"
+	mockClient.RespondToGET(fakeConfigURL+"/db", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/db2", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/db3", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/db4", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/mysourcedb", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/mytargetdb", MakeResponse(200, nil, ``))
+	sc := rt.ServerContext()
+	sc.HTTPClient = mockClient.Client
+
 	//Initiate synchronous one shot replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db", "target":"http://myhost:4985/db"}`), 500)
 


### PR DESCRIPTION
Example response:
```
{
    "error": "Unauthorized",
    "reason": "Unable to start replication to target db: Invalid login"
}
```
```
{
    "error": "not_found",
    "reason": "Unable to start replication from source db: no such database \"test2\""
}
```