### PR TITLE
CBG-424 - Stamp _attachments into delta+xattr body backup

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func unjson(j string) Body {
@@ -32,6 +33,76 @@ func unjson(j string) Body {
 func tojson(obj interface{}) string {
 	j, _ := json.Marshal(obj)
 	return string(j)
+}
+
+func TestBackupOldRevisionWithAttachments(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+
+	deltasEnabled := base.IsEnterpriseEdition()
+	xattrsEnabled := base.TestUseXattrs()
+
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+	bucket := testBucket.Bucket
+
+	context, err := NewDatabaseContext(
+		"db",
+		bucket,
+		false,
+		DatabaseContextOptions{
+			EnableXattr: xattrsEnabled,
+			DeltaSyncOptions: DeltaSyncOptions{
+				Enabled:          deltasEnabled,
+				RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
+			},
+		},
+	)
+	assert.NoError(t, err, "Couldn't create context for database 'db'")
+	defer context.Close()
+	db, err := CreateDatabase(context)
+	assert.NoError(t, err, "Couldn't create database 'db'")
+
+	docID := "doc1"
+	var rev1Body Body
+	rev1Data := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
+	require.NoError(t, json.Unmarshal([]byte(rev1Data), &rev1Body))
+	rev1ID, err := db.Put(docID, rev1Body)
+	require.NoError(t, err)
+	assert.Equal(t, "1-6e5a9ed9e2e8637d495ac5dd2fa90479", rev1ID)
+
+	rev1OldBody, err := db.getOldRevisionJSON(docID, rev1ID)
+	if deltasEnabled && xattrsEnabled {
+		require.NoError(t, err)
+		assert.Contains(t, string(rev1OldBody), "hello.txt")
+	} else {
+		// current revs aren't backed up unless both xattrs and deltas are enabled
+		require.Error(t, err)
+		assert.Equal(t, "404 missing", err.Error())
+	}
+
+	// create rev 2 and check backups for both revs
+	var rev2Body Body
+	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
+	require.NoError(t, json.Unmarshal([]byte(rev2Data), &rev2Body))
+	err = db.PutExistingRev(docID, rev2Body, []string{"2-abc", rev1ID}, true)
+	require.NoError(t, err)
+	rev2ID := "2-abc"
+
+	// now in any case - we'll have rev 1 backed up
+	rev1OldBody, err = db.getOldRevisionJSON(docID, rev1ID)
+	require.NoError(t, err)
+	assert.Contains(t, string(rev1OldBody), "hello.txt")
+
+	// and rev 2 should be present only for the xattrs and deltas case
+	rev2OldBody, err := db.getOldRevisionJSON(docID, rev2ID)
+	if deltasEnabled && xattrsEnabled {
+		require.NoError(t, err)
+		assert.Contains(t, string(rev2OldBody), "hello.txt")
+	} else {
+		// current revs aren't backed up unless both xattrs and deltas are enabled
+		require.Error(t, err)
+		assert.Equal(t, "404 missing", err.Error())
+	}
 }
 
 func TestAttachments(t *testing.T) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -561,7 +561,7 @@ func (db *Database) backupAncestorRevs(doc *document, newRevId string, newBody B
 	for {
 		if ancestorRevId = doc.History.getParent(ancestorRevId); ancestorRevId == "" {
 			// No ancestors with JSON found.  Check if we need to back up current rev for delta sync, then return
-			db.backupRevisionJSON(doc.ID, newRevId, "", newBody, nil)
+			db.backupRevisionJSON(doc.ID, newRevId, "", newBody, nil, doc.Attachments)
 			return
 		} else if json = doc.getRevisionBodyJSON(ancestorRevId, db.RevisionBodyLoader); json != nil {
 			break
@@ -569,7 +569,7 @@ func (db *Database) backupAncestorRevs(doc *document, newRevId string, newBody B
 	}
 
 	// Back up the revision JSON as a separate doc in the bucket:
-	db.backupRevisionJSON(doc.ID, newRevId, ancestorRevId, newBody, json)
+	db.backupRevisionJSON(doc.ID, newRevId, ancestorRevId, newBody, json, doc.Attachments)
 
 	// Nil out the ancestor rev's body in the document struct:
 	if ancestorRevId == doc.CurrentRev {

--- a/db/revision.go
+++ b/db/revision.go
@@ -233,30 +233,74 @@ func (db *DatabaseContext) getOldRevisionJSON(docid string, revid string) ([]byt
 //      - new revision stored (as duplicate), with expiry rev_max_age_seconds
 //   delta=true && shared_bucket_access=false
 //      - old revision stored, with expiry rev_max_age_seconds
-// Ignores
 func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody Body, oldBody []byte, newAtts AttachmentsMeta) {
 
+	// Without delta sync, store the old rev for in-flight replication purposes
 	if !db.DeltaSyncEnabled() || db.Options.DeltaSyncOptions.RevMaxAgeSeconds == 0 {
 		_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.OldRevExpirySeconds)
 		return
 	}
 
-	if db.UseXattrs() {
-		newBodyCopy := newBody.ShallowCopy()
-		newBodyCopy[BodyAttachments] = newAtts
+	// Otherwise, store the revs for delta generation purposes, with a longer expiry
 
-		newBodyBytes, marshalErr := json.Marshal(newBodyCopy)
-		if marshalErr != nil {
-			base.Warnf(base.KeyAll, "Unable to marshal new revision body during backupRevisionJSON: doc=%q rev=%q err=%v ", base.UD(docId), newRevId, marshalErr)
+	// Special handling for Xattrs so that SG still has revisions that were updated by an SDK write
+	if db.UseXattrs() {
+		// Backup the current revision
+		newBodyBytes, err := bodyBytesFromBodyAttachmentsMeta(newBody, newAtts)
+		if err != nil {
+			base.Warnf(base.KeyAll, "Unable to marshal new revision body during backupRevisionJSON: doc=%q rev=%q err=%v ", base.UD(docId), newRevId, err)
 			return
 		}
 		_ = db.setOldRevisionJSON(docId, newRevId, newBodyBytes, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
 
 		// Refresh the expiry on the previous revision backup
 		_ = db.refreshPreviousRevisionBackup(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
-	} else {
-		_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+		return
 	}
+
+	// Non-xattr only need to store the previous revision, as all writes come through SG
+	_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+}
+
+// We need to include attachments in body when we store a backup
+// but don't want it in there when it gets put in the revcache... but we also don't want the cost of copying doc body
+// so this function marshals body with atts included, and then removes it again
+func bodyBytesFromBodyAttachmentsMeta(body Body, atts AttachmentsMeta) ([]byte, error) {
+	if len(atts) == 0 {
+		return json.Marshal(body)
+	}
+
+	origAtts, haveOrigAtts := body[BodyAttachments]
+	if haveOrigAtts {
+		origAttsMeta, _ := origAtts.(AttachmentsMeta)
+		if len(origAttsMeta) > 0 {
+			// Found existing _attachments, need to merge and restore original when done
+			attsCopy := make(AttachmentsMeta, len(origAttsMeta)+len(atts))
+			for k, v := range origAttsMeta {
+				attsCopy[k] = v
+			}
+			for k, v := range atts {
+				attsCopy[k] = v
+			}
+			body[BodyAttachments] = attsCopy
+		} else {
+			body[BodyAttachments] = atts
+			haveOrigAtts = false
+		}
+	} else {
+		body[BodyAttachments] = atts
+	}
+
+	newBodyBytes, err := json.Marshal(body)
+
+	if haveOrigAtts {
+		// Restore original attachments field
+		body[BodyAttachments] = origAtts
+	} else {
+		delete(body, BodyAttachments)
+	}
+
+	return newBodyBytes, err
 }
 
 func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte, expiry uint32) error {


### PR DESCRIPTION
When running with both xattrs and delta sync, the current revision backup does not contain _attachments, unlike previous revision body backups. Need to stamp them in when backing up the current rev.

## Integration Tests
- [x] [EE + Xattr - sync-gateway-integration-master/1180](http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1180/)
- [ ] [EE + No Xattr - sync-gateway-integration-master/1184](http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1184/)
- [x] [CE + Xattr - sync-gateway-integration-master/1182](http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1182/)
- [ ] [CE + No Xattr - sync-gateway-integration-master/1185](http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1185/)