### PR TITLE
CBG-448: Additional channel cache unit tests

### DIFF
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1872,8 +1872,8 @@ func TestMaxChannelCacheConfig(t *testing.T) {
 			},
 		}
 		db, testBucket := setupTestDBWithCacheOptions(t, options)
+		assert.Equal(t, val, db.DatabaseContext.Options.CacheOptions.MaxNumChannels)
 		testBucket.Close()
 		tearDownTestDB(t, db)
-		assert.Equal(t, val, db.DatabaseContext.Options.CacheOptions.MaxNumChannels)
 	}
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1861,3 +1861,19 @@ func logChangesResponse(changes []*ChangeEntry) {
 	}
 
 }
+
+func TestMaxChannelCacheConfig(t *testing.T) {
+	channelCacheMaxChannels := []int{10, 50000, 100000}
+
+	for _, val := range channelCacheMaxChannels {
+		options := CacheOptions{
+			ChannelCacheOptions: ChannelCacheOptions{
+				MaxNumChannels: val,
+			},
+		}
+		db, testBucket := setupTestDBWithCacheOptions(t, options)
+		testBucket.Close()
+		tearDownTestDB(t, db)
+		assert.Equal(t, val, db.DatabaseContext.Options.CacheOptions.MaxNumChannels)
+	}
+}


### PR DESCRIPTION
- test setting num_channels to something higher than the default, verifying it works as expected
- test verifying EE vs CE for channel cache config

---

- First is covered by newly added `TestMaxChannelCacheConfig`
- Second is already covered by `TestConfigValidationCache`