### PR TITLE
Improve HTTP error logging

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -128,9 +128,6 @@ func (h *handler) invoke(method handlerMethod) error {
 	}
 
 	h.logRequestLine()
-	if base.EnableLogHTTPBodies {
-		h.logRequestBody()
-	}
 
 	switch h.rq.Header.Get("Content-Encoding") {
 	case "":
@@ -142,6 +139,10 @@ func (h *handler) invoke(method handlerMethod) error {
 		h.rq.Header.Del("Content-Encoding") // to prevent double decoding later on
 	default:
 		return base.HTTPErrorf(http.StatusUnsupportedMediaType, "Unsupported Content-Encoding; use gzip")
+	}
+
+	if base.EnableLogHTTPBodies {
+		h.logRequestBody()
 	}
 
 	h.setHeader("Server", base.VersionString)


### PR DESCRIPTION
- Log request earlier, to avoid duplication, and missing log
- Include serial number in `writeError` error logging

## Before
```
2019-07-24T14:56:34.296+01:00 [INF] HTTP:  #001: POST /db/_offline (as ADMIN)
2019-07-24T14:56:34.296+01:00 [INF] HTTP+: #001:     --> 200   (0.1 ms)
2019-07-24T14:56:35.514+01:00 [ERR] 503 DB is currently under maintenance -- rest.(*handler).writeError() at handler.go:694
2019-07-24T14:56:35.514+01:00 [INF] HTTP: #002:     --> 503 DB is currently under maintenance  (0.1 ms)
```

## After
```
2019-07-24T15:06:43.294+01:00 [INF] HTTP:  #001: POST /db/_offline (as ADMIN)
2019-07-24T15:06:43.294+01:00 [INF] HTTP+: #001:     --> 200   (0.1 ms)
2019-07-24T15:06:44.752+01:00 [INF] HTTP:  #002: PUT /db/mydoc2 (as ADMIN)
2019-07-24T15:06:44.752+01:00 [ERR] HTTP: #002: 503 DB is currently under maintenance -- rest.(*handler).writeError() at handler.go:691
2019-07-24T15:06:44.752+01:00 [INF] HTTP: #002:     --> 503 DB is currently under maintenance  (0.1 ms)
```