### PR TITLE
CBG-436 Tune syncrunner pool size to account for sequence allocation batching

### DIFF
--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -35,7 +35,8 @@ type ChannelMapper struct {
 type AccessMap map[string]base.Set
 
 // Number of SyncRunner tasks (and Otto contexts) to cache
-const kTaskCacheSize = 4
+// Should be larger than sequence_allocator.maxBatchSize, to avoid pool overflow under some load scenarios (CBG-436)
+const kTaskCacheSize = 16
 
 func NewChannelMapper(fnSource string) *ChannelMapper {
 	return &ChannelMapper{


### PR DESCRIPTION
Toy build testing shows improvement vs 2.6.0-113.  Throughput results:

|Channels|2.6.0-113|Toy build|
|---|---|---|
|35K|5744|7672|
|200K|3538|5705|
|400K|3945|5477|
|600K|4100| 6350|