### PR TITLE
CBG-454 - Merge dev (mercury) into master (cobalt)

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -26,9 +26,9 @@ import (
 	"github.com/couchbase/gomemcached"
 	memcached "github.com/couchbase/gomemcached/client"
 	sgbucket "github.com/couchbase/sg-bucket"
-	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 const (

--- a/base/constants.go
+++ b/base/constants.go
@@ -70,7 +70,7 @@ const (
 
 	// Until the sporadic integration tests failures in SG #3570 are fixed, should be GTE n1ql query timeout
 	// to make it easier to identify root cause of test failures.
-	DefaultWaitForSequenceTesting = time.Second * 30
+	DefaultWaitForSequence = time.Second * 30
 
 	// Default the max number of idle connections per host to a relatively high number to avoid
 	// excessive socket churn caused by opening short-lived connections and closing them after, which can cause

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -25,12 +25,6 @@ import (
 	pkgerrors "github.com/pkg/errors"
 )
 
-var dcpExpvars *expvar.Map
-
-func init() {
-	dcpExpvars = expvar.NewMap("syncGateway_dcp")
-}
-
 // Memcached binary protocol datatype bit flags (https://github.com/couchbase/memcached/blob/master/docs/BinaryProtocol.md#data-types),
 // used in MCRequest.DataType
 const (
@@ -85,6 +79,7 @@ type Receiver interface {
 // cbdatasource BucketDataSource.  See go-couchbase/cbdatasource for
 // additional details
 type DCPReceiver struct {
+	dbStatsExpvars         *expvar.Map
 	m                      sync.Mutex
 	bucket                 Bucket                         // For metadata persistence/retrieval
 	maxVbNo                uint16                         // Number of vbuckets being used for this feed
@@ -96,12 +91,14 @@ type DCPReceiver struct {
 	lastCheckpointTime     []time.Time                    // Time of last checkpoint persistence, per vbucket.  Used to manage checkpoint persistence volume
 	notify                 sgbucket.BucketNotifyFn        // Function to callback when we lose our dcp feed
 	callback               sgbucket.FeedEventCallbackFunc // Function to callback for mutation processing
-	backfill               backfillStatus                 // Backfill state and stats
+	backfill               *backfillStatus                // Backfill state and stats
 }
 
-func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool) Receiver {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map) Receiver {
+	newBackfillStatus := backfillStatus{}
 
 	r := &DCPReceiver{
+		dbStatsExpvars:         dbStats,
 		bucket:                 bucket,
 		maxVbNo:                maxVbNo,
 		persistCheckpoints:     persistCheckpoints,
@@ -111,6 +108,7 @@ func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxV
 		updatesSinceCheckpoint: make([]uint64, maxVbNo),
 		callback:               callback,
 		lastCheckpointTime:     make([]time.Time, maxVbNo),
+		backfill:               &newBackfillStatus,
 	}
 
 	if LogDebugEnabled(KeyDCP) {
@@ -279,10 +277,7 @@ func (r *DCPReceiver) GetMetaData(vbucketId uint16) (
 // it's called, logs warning and does a hard reset on metadata for the vbucket
 func (r *DCPReceiver) Rollback(vbucketId uint16, rollbackSeq uint64) error {
 	Warnf(KeyAll, "DCP Rollback request.  Expected RollbackEx call - resetting vbucket %d to 0.", vbucketId)
-
-	// TODO: move to per-db stats, or if that's too difficult due to package dependencies, then at least under Global stats
-	dcpExpvars.Add("rollback_count", 1)
-
+	r.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	r.updateSeq(vbucketId, 0, false)
 	r.SetMetaData(vbucketId, nil)
 
@@ -292,9 +287,7 @@ func (r *DCPReceiver) Rollback(vbucketId uint16, rollbackSeq uint64) error {
 // RollbackEx includes the vbucketUUID needed to reset the metadata correctly
 func (r *DCPReceiver) RollbackEx(vbucketId uint16, vbucketUUID uint64, rollbackSeq uint64) error {
 	Warnf(KeyAll, "DCP RollbackEx request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x.", vbucketId, rollbackSeq)
-
-	dcpExpvars.Add("rollback_count", 1)
-
+	r.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	r.updateSeq(vbucketId, rollbackSeq, false)
 	r.SetMetaData(vbucketId, makeVbucketMetadataForSequence(vbucketUUID, rollbackSeq))
 	return nil
@@ -467,7 +460,7 @@ func (r *DCPReceiver) initFeed(backfillType uint64) error {
 		// For resume case, load previously persisted checkpoints from bucket
 		r.initMetadata(r.maxVbNo)
 		// Track backfill (from persisted checkpoints to current high seqno)
-		r.backfill.init(r.seqs, highSeqnos, r.maxVbNo)
+		r.backfill.init(r.seqs, highSeqnos, r.maxVbNo, r)
 		Debugf(KeyDCP, "Initializing DCP feed based on persisted checkpoints")
 	default:
 		// Otherwise, start feed from zero
@@ -475,7 +468,7 @@ func (r *DCPReceiver) initFeed(backfillType uint64) error {
 		vbuuids := make(map[uint16]uint64, r.maxVbNo)
 		r.SeedSeqnos(vbuuids, startSeqnos)
 		// Track backfill (from zero to current high seqno)
-		r.backfill.init(r.seqs, highSeqnos, r.maxVbNo)
+		r.backfill.init(r.seqs, highSeqnos, r.maxVbNo, r)
 		Debugf(KeyDCP, "Initializing DCP feed to start from zero")
 	}
 	return nil
@@ -562,7 +555,7 @@ func (nph NoPasswordAuthHandler) GetCredentials() (username string, password str
 
 // This starts a cbdatasource powered DCP Feed using an entirely separate connection to Couchbase Server than anything the existing
 // bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
-func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
+func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 
 	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
 	// reusing the bucket connection we've already established.
@@ -589,7 +582,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		persistCheckpoints = true
 	}
 
-	dcpReceiver := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints)
+	dcpReceiver := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats)
 	dcpReceiver.SetBucketNotifyFn(args.Notify)
 
 	// Initialize the feed based on the backfill type
@@ -696,13 +689,15 @@ type backfillStatus struct {
 	snapStart         []uint64  // Start sequence of current backfill snapshot
 	snapEnd           []uint64  // End sequence of current backfill snapshot
 	lastPersistTime   time.Time // The last time backfill stats were emitted (log, expvar)
+	dcpReceiver       *DCPReceiver
 }
 
-func (b *backfillStatus) init(start []uint64, end map[uint16]uint64, maxVbNo uint16) {
+func (b *backfillStatus) init(start []uint64, end map[uint16]uint64, maxVbNo uint16, dcpReceiver *DCPReceiver) {
 	b.vbActive = make([]bool, maxVbNo)
 	b.snapStart = make([]uint64, maxVbNo)
 	b.snapEnd = make([]uint64, maxVbNo)
 	b.endSeqs = make([]uint64, maxVbNo)
+	b.dcpReceiver = dcpReceiver
 
 	// Calculate total sequences in backfill
 	b.expectedSequences = 0
@@ -722,8 +717,8 @@ func (b *backfillStatus) init(start []uint64, end map[uint16]uint64, maxVbNo uin
 	completedVar := &expvar.Int{}
 	totalVar.Set(int64(b.expectedSequences))
 	completedVar.Set(0)
-	dcpExpvars.Set("backfill_expected", totalVar)
-	dcpExpvars.Set("backfill_completed", completedVar)
+	b.dcpReceiver.dbStatsExpvars.Set("dcp_backfill_expected", totalVar)
+	b.dcpReceiver.dbStatsExpvars.Set("dcp_backfill_completed", completedVar)
 
 }
 
@@ -759,7 +754,7 @@ func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, cur
 	b.receivedSequences += backfillDelta
 
 	// NOTE: this is a legacy stat, but cannot be removed b/c there are unit tests that depend on these stats
-	dcpExpvars.Add("backfill_completed", int64(backfillDelta))
+	b.dcpReceiver.dbStatsExpvars.Add("dcp_backfill_completed", int64(backfillDelta))
 
 	// Check if it's time to persist and log backfill progress
 	if time.Since(b.lastPersistTime) > kBackfillPersistInterval {

--- a/base/error.go
+++ b/base/error.go
@@ -130,6 +130,8 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 		}
 	case *json.SyntaxError, *json.UnmarshalTypeError:
 		return http.StatusBadRequest, fmt.Sprintf("Invalid JSON: \"%v\"", unwrappedErr)
+	case *RetryTimeoutError:
+		return http.StatusGatewayTimeout, unwrappedErr.Error()
 	}
 	return http.StatusInternalServerError, fmt.Sprintf("Internal error: %v", unwrappedErr)
 }

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"expvar"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -177,16 +178,16 @@ func (b *LoggingBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
-func (b *LoggingBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
+func (b *LoggingBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 	start := time.Now()
 	defer func() { Tracef(KeyBucket, "StartTapFeed(...) [%v]", time.Since(start)) }()
-	return b.bucket.StartTapFeed(args)
+	return b.bucket.StartTapFeed(args, dbStats)
 }
 
-func (b *LoggingBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
+func (b *LoggingBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 	start := time.Now()
 	defer func() { Tracef(KeyBucket, "StartDcpFeed(...) [%v]", time.Since(start)) }()
-	return b.bucket.StartDCPFeed(args, callback)
+	return b.bucket.StartDCPFeed(args, callback, dbStats)
 }
 
 func (b *LoggingBucket) Close() {

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"sync/atomic"
 
@@ -235,12 +236,12 @@ func (b *StatsBucket) Refresh() error {
 	return b.bucket.Refresh()
 }
 
-func (b *StatsBucket) StartTapFeed(args sgbucket.FeedArguments) (sgbucket.MutationFeed, error) {
-	return b.bucket.StartTapFeed(args)
+func (b *StatsBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
+	return b.bucket.StartTapFeed(args, dbStats)
 }
 
-func (b *StatsBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc) error {
-	return b.bucket.StartDCPFeed(args, callback)
+func (b *StatsBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
+	return b.bucket.StartDCPFeed(args, callback, dbStats)
 }
 
 func (b *StatsBucket) Close() {

--- a/base/util.go
+++ b/base/util.go
@@ -12,6 +12,7 @@ package base
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -1134,4 +1135,11 @@ func (ab *AtomicBool) Set(flag bool) {
 
 func (ab *AtomicBool) IsTrue() bool {
 	return atomic.LoadInt32(&ab.value) == 1
+}
+
+func Sha1HashString(str string, salt string) string {
+	h := sha1.New()
+	h.Write([]byte(salt + str))
+	hashedKey := h.Sum(nil)
+	return fmt.Sprintf("%x", hashedKey)
 }

--- a/base/util.go
+++ b/base/util.go
@@ -34,9 +34,9 @@ import (
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/gomemcached"
-	"github.com/couchbaselabs/gocbconnstr"
 	"github.com/gorilla/mux"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 const (

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -56,7 +56,7 @@ type DocAttachment struct {
 // Given a CouchDB document body about to be stored in the database, goes through the _attachments
 // dict, finds attachments with inline bodies, copies the bodies into the Couchbase db, and replaces
 // the bodies with the 'digest' attributes which are the keys to retrieving them.
-func (db *Database) storeAttachments(doc *document, body Body, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
+func (db *Database) storeAttachments(doc *Document, body Body, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
 	var parentAttachments map[string]interface{}
 	newAttachmentData := make(AttachmentData, 0)
 	atts := GetBodyAttachments(body)
@@ -125,7 +125,7 @@ func (db *Database) storeAttachments(doc *document, body Body, generation int, p
 // Attempts to retrieve ancestor attachments for a document.  First attempts to find and use a non-pruned ancestor.
 // If no non-pruned ancestor is available, checks whether the currently active doc has a common ancestor with the new revision.
 // If it does, can use the attachments on the active revision with revpos earlier than that common ancestor.
-func (db *Database) retrieveAncestorAttachments(doc *document, parentRev string, docHistory []string) map[string]interface{} {
+func (db *Database) retrieveAncestorAttachments(doc *Document, parentRev string, docHistory []string) map[string]interface{} {
 
 	var parentAttachments map[string]interface{}
 	// Attempt to find a non-pruned parent or ancestor

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -66,7 +66,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev1Body Body
 	rev1Data := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	require.NoError(t, json.Unmarshal([]byte(rev1Data), &rev1Body))
-	rev1ID, err := db.Put(docID, rev1Body)
+	rev1ID, _, err := db.Put(docID, rev1Body)
 	require.NoError(t, err)
 	assert.Equal(t, "1-6e5a9ed9e2e8637d495ac5dd2fa90479", rev1ID)
 
@@ -84,7 +84,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
 	require.NoError(t, json.Unmarshal([]byte(rev2Data), &rev2Body))
-	err = db.PutExistingRev(docID, rev2Body, []string{"2-abc", rev1ID}, true)
+	_, err = db.PutExistingRev(docID, rev2Body, []string{"2-abc", rev1ID}, true)
 	require.NoError(t, err)
 	rev2ID := "2-abc"
 
@@ -123,7 +123,7 @@ func TestAttachments(t *testing.T) {
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
 	var body Body
 	json.Unmarshal([]byte(rev1input), &body)
-	revid, err := db.Put("doc1", unjson(rev1input))
+	revid, _, err := db.Put("doc1", unjson(rev1input))
 	rev1id := revid
 	assert.NoError(t, err, "Couldn't create document")
 
@@ -138,7 +138,7 @@ func TestAttachments(t *testing.T) {
 	var body2 Body
 	json.Unmarshal([]byte(rev2str), &body2)
 	body2[BodyRev] = revid
-	revid, err = db.Put("doc1", body2)
+	revid, _, err = db.Put("doc1", body2)
 	assert.NoError(t, err, "Couldn't update document")
 	assert.Equal(t, "2-08b42c51334c0469bd060e6d9e6d797b", revid)
 
@@ -159,7 +159,7 @@ func TestAttachments(t *testing.T) {
 	var body3 Body
 	json.Unmarshal([]byte(rev3str), &body3)
 	body3[BodyRev] = revid
-	revid, err = db.Put("doc1", body3)
+	revid, _, err = db.Put("doc1", body3)
 	assert.NoError(t, err, "Couldn't update document")
 	assert.Equal(t, "3-252b9fa1f306930bffc07e7d75b77faf", revid)
 
@@ -176,7 +176,7 @@ func TestAttachments(t *testing.T) {
 	var body2B Body
 	err = json.Unmarshal([]byte(rev2Bstr), &body2B)
 	assert.NoError(t, err, "bad JSON")
-	err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id}, false)
+	_, err = db.PutExistingRev("doc1", body2B, []string{"2-f000", rev1id}, false)
 	assert.NoError(t, err, "Couldn't update document")
 }
 
@@ -199,7 +199,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 	docBody := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	var body Body
 	json.Unmarshal([]byte(docBody), &body)
-	_, err = db.Put("doc1", unjson(docBody))
+	_, _, err = db.Put("doc1", unjson(docBody))
 	log.Printf("Got error on put doc:%v", err)
 	db.Bucket.Dump()
 
@@ -225,7 +225,7 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	// Test creating & updating a document:
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
-	_, err = db.Put("doc1", unjson(rev1input))
+	_, _, err = db.Put("doc1", unjson(rev1input))
 	assert.NoError(t, err, "Couldn't create document")
 
 	initCount, countErr := base.GetExpvarAsInt("syncGateway_db", "document_gets")

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -419,7 +419,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		migratedDoc, _ := c.context.checkForUpgrade(docID, DocUnmarshalNoHistory)
 		if migratedDoc != nil && migratedDoc.Cas == event.Cas {
 			base.Infof(base.KeyCache, "Found mobile xattr on doc %q without _sync property - caching, assuming upgrade in progress.", base.UD(docID))
-			syncData = &migratedDoc.syncData
+			syncData = &migratedDoc.SyncData
 		} else {
 			base.Warnf(base.KeyAll, "changeCache: Doc %q does not have valid sync data.", base.UD(docID))
 			return

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -614,7 +614,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "PBS"}, 6)
 
 	// Test that retrieval isn't blocked by skipped sequences
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 6}, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 6, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 	changes, err := db.GetChanges(base.SetOf("*"), ChangesOptions{Since: SequenceID{Seq: 0}})
 	assert.NoError(t, err, "Couldn't GetChanges")
@@ -629,7 +629,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 	// Validate insert to various cache states
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "TBS"}, 3)
 	WriteDirect(db, []string{"CBS"}, 7)
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 7}, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 7, base.DefaultWaitForSequence))
 	// verify insert at start (PBS)
 	pbsCache := db.changeCache.getChannelCache().getSingleChannelCache("PBS").(*singleChannelCacheImpl)
 	goassert.True(t, verifyCacheSequences(pbsCache, []uint64{3, 5, 6}))
@@ -698,14 +698,14 @@ func TestContinuousChangesBackfill(t *testing.T) {
 	// Write some more docs
 	WriteDirect(db, []string{"CBS"}, 3)
 	WriteDirect(db, []string{"PBS"}, 12)
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 12}, base.DefaultWaitForSequenceTesting, t)
+	db.changeCache.waitForSequence(context.TODO(), 12, base.DefaultWaitForSequence)
 
 	// Test multiple backfill in single changes loop iteration
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "CBS"}, 4)
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "CBS"}, 7)
 	WriteDirect(db, []string{"ABC", "PBS"}, 8)
 	WriteDirect(db, []string{"ABC", "PBS"}, 13)
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 13}, base.DefaultWaitForSequenceTesting, t)
+	db.changeCache.waitForSequence(context.TODO(), 13, base.DefaultWaitForSequence)
 	time.Sleep(50 * time.Millisecond)
 
 	// We can't guarantee how compound sequences will be generated in a multi-core test - will
@@ -783,7 +783,7 @@ func TestLowSequenceHandling(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "PBS"}, 5)
 	WriteDirect(db, []string{"ABC", "PBS"}, 6)
 
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 6}, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 6, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 
 	// Start changes feed
@@ -848,7 +848,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 	WriteDirect(db, []string{"PBS"}, 5)
 	WriteDirect(db, []string{"ABC", "PBS"}, 6)
 
-	db.changeCache.waitForSequence(6, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 6, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 
 	// Start changes feed
@@ -905,7 +905,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	WriteDirect(db, []string{"PBS"}, 5)
 	WriteDirect(db, []string{"ABC", "PBS"}, 6)
 
-	db.changeCache.waitForSequence(6, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 6, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 
 	// Start changes feed
@@ -921,7 +921,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	var changes = make([]*ChangeEntry, 0, 50)
 
 	// Validate the initial sequences arrive as expected
-	err = appendFromFeed(&changes, feed, 3, base.DefaultWaitForSequenceTesting)
+	err = appendFromFeed(&changes, feed, 3, base.DefaultWaitForSequence)
 	goassert.True(t, err == nil)
 	goassert.Equals(t, len(changes), 3)
 	goassert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6"}))
@@ -937,9 +937,9 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 	assert.NoError(t, err, "UpdatePrincipal failed")
 
 	WriteDirect(db, []string{"PBS"}, 9)
-	db.changeCache.waitForSequence(9, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 9, base.DefaultWaitForSequence))
 
-	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequenceTesting)
+	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequence)
 	assert.NoError(t, err, "Expected more changes to be sent on feed, but never received")
 	goassert.Equals(t, len(changes), 7)
 	goassert.True(t, verifyChangesFullSequences(changes, []string{"1", "2", "2::6", "2:8:5", "2:8:6", "2::8", "2::9"}))
@@ -1001,15 +1001,15 @@ func TestChannelQueryCancellation(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	// Write a handful of docs/sequences to the bucket
-	_, err := db.Put("key1", Body{"channels": "ABC"})
+	_, _, err := db.Put("key1", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
-	_, err = db.Put("key2", Body{"channels": "ABC"})
+	_, _, err = db.Put("key2", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
-	_, err = db.Put("key3", Body{"channels": "ABC"})
+	_, _, err = db.Put("key3", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
-	_, err = db.Put("key4", Body{"channels": "ABC"})
+	_, _, err = db.Put("key4", Body{"channels": "ABC"})
 	assert.NoError(t, err, "Put failed with error: %v", err)
-	db.changeCache.waitForSequence(4, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 4, base.DefaultWaitForSequence))
 
 	// Flush the cache, to ensure view query on subsequent changes requests
 	db.FlushChannelCache()
@@ -1108,7 +1108,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "PBS"}, 5)
 	WriteDirect(db, []string{"ABC", "PBS"}, 6)
 
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 6}, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 6, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 
 	// Start changes feed
@@ -1125,7 +1125,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	// Array to read changes from feed to support assertions
 	var changes = make([]*ChangeEntry, 0, 50)
 
-	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequenceTesting)
+	err = appendFromFeed(&changes, feed, 4, base.DefaultWaitForSequence)
 
 	// Validate the initial sequences arrive as expected
 	goassert.True(t, err == nil)
@@ -1139,9 +1139,9 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	WriteDirect(db, []string{"ABC", "NBC", "PBS", "TBS"}, 3)
 	WriteDirect(db, []string{"ABC", "PBS"}, 4)
 
-	db.changeCache.waitForSequenceWithMissing(4, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequenceNotSkipped(context.TODO(), 4, base.DefaultWaitForSequence))
 
-	err = appendFromFeed(&changes, feed, 2, base.DefaultWaitForSequenceTesting)
+	err = appendFromFeed(&changes, feed, 2, base.DefaultWaitForSequence)
 	goassert.True(t, err == nil)
 	goassert.Equals(t, len(changes), 6)
 	goassert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4}))
@@ -1149,8 +1149,8 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 	WriteDirect(db, []string{"ABC"}, 7)
 	WriteDirect(db, []string{"ABC", "NBC"}, 8)
 	WriteDirect(db, []string{"ABC", "PBS"}, 9)
-	db.changeCache.waitForSequence(9, base.DefaultWaitForSequenceTesting, t)
-	appendFromFeed(&changes, feed, 5, base.DefaultWaitForSequenceTesting)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 9, base.DefaultWaitForSequence))
+	appendFromFeed(&changes, feed, 5, base.DefaultWaitForSequence)
 	goassert.True(t, verifyChangesSequencesIgnoreOrder(changes, []uint64{1, 2, 5, 6, 3, 4, 7, 8, 9}))
 
 }
@@ -1198,7 +1198,7 @@ func TestChannelRace(t *testing.T) {
 	WriteDirect(db, []string{"Even"}, 2)
 	WriteDirect(db, []string{"Odd"}, 3)
 
-	db.changeCache.waitForSequence(3, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 3, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 
 	// Start changes feed
@@ -1322,7 +1322,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 	assert.NoError(t, cleanErr, "CleanSkippedSequenceQueue returned error")
 
 	// Validate expected entries
-	db.changeCache.waitForSequenceID(SequenceID{Seq: 15}, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 15, base.DefaultWaitForSequence))
 	entries, err := db.changeCache.GetChanges("ABC", ChangesOptions{Since: SequenceID{Seq: 2}})
 	assert.NoError(t, err, "Get Changes returned error")
 	goassert.Equals(t, len(entries), 6)
@@ -1413,7 +1413,7 @@ func TestChannelCacheSize(t *testing.T) {
 	}
 
 	// Validate that retrieval returns expected sequences
-	db.changeCache.waitForSequence(750, base.DefaultWaitForSequenceTesting, t)
+	require.NoError(t, db.changeCache.waitForSequence(context.TODO(), 750, base.DefaultWaitForSequence))
 	db.user, _ = authenticator.GetUser("naomi")
 	changes, err := db.GetChanges(base.SetOf("ABC"), ChangesOptions{Since: SequenceID{Seq: 0}})
 	assert.NoError(t, err, "Couldn't GetChanges")
@@ -1539,7 +1539,7 @@ func verifySequencesInFeed(feed <-chan (*ChangeEntry), sequences []uint64) ([]*C
 	var changes = make([]*ChangeEntry, 0, 50)
 	for {
 		// Attempt to read at one entry from feed
-		err := appendFromFeed(&changes, feed, 1, base.DefaultWaitForSequenceTesting)
+		err := appendFromFeed(&changes, feed, 1, base.DefaultWaitForSequence)
 		if err != nil {
 			return nil, err
 		}
@@ -1648,7 +1648,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 
 	// Create doc1 w/ unused sequences 1, actual sequence 3.
 	doc1Id := "doc1Id"
-	doc1 := document{
+	doc1 := Document{
 		ID: doc1Id,
 	}
 	doc1.SyncData = SyncData{
@@ -1663,7 +1663,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 
 	// Create doc2 w/ sequence 2, channel ABC
 	doc2Id := "doc2Id"
-	doc2 := document{
+	doc2 := Document{
 		ID: doc2Id,
 	}
 	channelMap := channels.ChannelMap{
@@ -1723,7 +1723,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 		channels := []string{"islands"}
 		body := Body{"serialnumber": int64(i), "channels": channels}
 		docID := fmt.Sprintf("loadCache-ch-%d", i)
-		_, err := db.Put(docID, body)
+		_, _, err := db.Put(docID, body)
 		assert.NoError(t, err, "Couldn't create document")
 		docCount++
 	}
@@ -1739,7 +1739,7 @@ func TestInitializeEmptyCache(t *testing.T) {
 		channels := []string{"zero"}
 		body := Body{"serialnumber": int64(i), "channels": channels}
 		docID := fmt.Sprintf("loadCache-z-%d", i)
-		_, err := db.Put(docID, body)
+		_, _, err := db.Put(docID, body)
 		assert.NoError(t, err, "Couldn't create document")
 		docCount++
 	}
@@ -1785,7 +1785,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 			channels := []string{"zero"}
 			body := Body{"serialnumber": int64(i), "channels": channels}
 			docID := fmt.Sprintf("loadCache-%d", i)
-			_, err := db.Put(docID, body)
+			_, _, err := db.Put(docID, body)
 			assert.NoError(t, err, "Couldn't create document")
 			if i < inProgressCount {
 				writesInProgress.Done()
@@ -1836,7 +1836,7 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 
 	// Write a document to channel zero
 	body := Body{"channels": []string{"zero"}}
-	_, err := db.Put("inactiveCacheNotify", body)
+	_, _, err := db.Put("inactiveCacheNotify", body)
 	assert.NoError(t, err)
 
 	// Wait for notify to arrive

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -510,7 +510,7 @@ func WriteDirectWithKey(db *Database, key string, channelArray []string, sequenc
 		chanMap[channel] = nil
 	}
 
-	syncData := &syncData{
+	syncData := &SyncData{
 		CurrentRev: rev,
 		Sequence:   sequence,
 		Channels:   chanMap,
@@ -540,7 +540,7 @@ func WriteDirectWithChannelGrant(db *Database, channelArray []string, sequence u
 	channelTimedSet := channels.AtSequence(base.SetFromArray(channelGrantArray), sequence)
 	accessMap[username] = channelTimedSet
 
-	syncData := &syncData{
+	syncData := &SyncData{
 		CurrentRev: rev,
 		Sequence:   sequence,
 		Channels:   chanMap,
@@ -1651,7 +1651,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	doc1 := document{
 		ID: doc1Id,
 	}
-	doc1.syncData = syncData{
+	doc1.SyncData = SyncData{
 		UnusedSequences: []uint64{
 			1,
 		},
@@ -1669,7 +1669,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	channelMap := channels.ChannelMap{
 		"ABC": nil,
 	}
-	doc2.syncData = syncData{
+	doc2.SyncData = SyncData{
 		CurrentRev: "1-cde",
 		Sequence:   2,
 		Channels:   channelMap,

--- a/db/change_index.go
+++ b/db/change_index.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"testing"
+	"context"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -58,17 +58,14 @@ type ChangeIndex interface {
 	// Remove purges the given doc IDs and returns the number of items removed
 	Remove(docIDs []string, startTime time.Time) (count int)
 
-	// Utility functions for unit testing
-	waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration, tb testing.TB)
-
 	// Handling specific to change_cache.go's sequence handling.  Ideally should refactor usage in changes.go to push
 	// down into internal change_cache.go handling, but it's non-trivial refactoring
 	getOldestSkippedSequence() uint64
 	getChannelCache() ChannelCache
 
-	// Unit test support
-	waitForSequence(sequence uint64, maxWaitTime time.Duration, tb testing.TB)
-	waitForSequenceWithMissing(sequence uint64, maxWaitTime time.Duration, tb testing.TB)
+	// These methods should block up until maxWaitTime, or until the given sequence has been received by the change cache.
+	waitForSequence(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error
+	waitForSequenceNotSkipped(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error
 }
 
 // Index type

--- a/db/changes.go
+++ b/db/changes.go
@@ -114,7 +114,7 @@ func (db *Database) addDocToChangeEntry(entry *ChangeEntry, options ChangesOptio
 		// Load doc metadata only
 		doc := &document{}
 		var err error
-		doc.syncData, err = db.GetDocSyncData(entry.ID)
+		doc.SyncData, err = db.GetDocSyncData(entry.ID)
 		if err != nil {
 			base.WarnfCtx(db.Ctx, base.KeyAll, "Changes feed: error getting doc sync data %q: %v", base.UD(entry.ID), err)
 			return

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Unit test for bug #314
@@ -45,7 +46,8 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _ := db.Put("doc1", Body{"channels": []string{"ABC", "PBS"}})
+	revid, _, err := db.Put("doc1", Body{"channels": []string{"ABC", "PBS"}})
+	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
 	// Modify user to have access to both channels (sequence 2):
@@ -82,7 +84,8 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
 
 	// Add a new doc (sequence 3):
-	revid, _ = db.Put("doc2", Body{"channels": []string{"PBS"}})
+	revid, _, err = db.Put("doc2", Body{"channels": []string{"PBS"}})
+	require.NoError(t, err)
 
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 2 (the user doc) and isn't stuck waiting for it.
@@ -149,7 +152,8 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _ := db.Put("alpha", Body{"channels": []string{"A", "B"}})
+	revid, _, err := db.Put("alpha", Body{"channels": []string{"A", "B"}})
+	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
 	if changeCache, ok := db.changeCache.(*kvChangeIndex); ok {
@@ -237,7 +241,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
 	// Create a doc on two channels (sequence 1):
-	revid, _ := db.Put("alpha", Body{"channels": []string{"A", "B"}})
+	revid, _, err := db.Put("alpha", Body{"channels": []string{"A", "B"}})
+	require.NoError(t, err)
 	cacheWaiter.AddAndWait(1)
 
 	if changeCache, ok := db.changeCache.(*kvChangeIndex); ok {
@@ -331,21 +336,21 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 		// Create the parent rev
 		docid := base.CreateUUID()
 		docBody := createDoc(numKeys, valSizeBytes)
-		revId, err := db.Put(docid, docBody)
+		revId, _, err := db.Put(docid, docBody)
 		if err != nil {
 			b.Fatalf("Error creating doc: %v", err)
 		}
 
 		// Create child rev 1
 		docBody["child"] = "A"
-		err = db.PutExistingRev(docid, docBody, []string{"2-A", revId}, false)
+		_, err = db.PutExistingRev(docid, docBody, []string{"2-A", revId}, false)
 		if err != nil {
 			b.Fatalf("Error creating child1 rev: %v", err)
 		}
 
 		// Create child rev 2
 		docBody["child"] = "B"
-		err = db.PutExistingRev(docid, docBody, []string{"2-B", revId}, false)
+		_, err = db.PutExistingRev(docid, docBody, []string{"2-B", revId}, false)
 		if err != nil {
 			b.Fatalf("Error creating child2 rev: %v", err)
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -46,7 +46,7 @@ func realDocID(docid string) string {
 }
 
 // Lowest-level method that reads a document from the bucket
-func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *document, err error) {
+func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, base.HTTPErrorf(400, "Invalid doc ID")
@@ -98,7 +98,7 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 	return doc, nil
 }
 
-func (db *DatabaseContext) GetDocWithXattr(key string, unmarshalLevel DocumentUnmarshalLevel) (doc *document, rawBucketDoc *sgbucket.BucketDocument, err error) {
+func (db *DatabaseContext) GetDocWithXattr(key string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, rawBucketDoc *sgbucket.BucketDocument, err error) {
 	rawBucketDoc = &sgbucket.BucketDocument{}
 	var getErr error
 	rawBucketDoc.Cas, getErr = db.Bucket.GetWithXattr(key, base.SyncXattrName, &rawBucketDoc.Body, &rawBucketDoc.Xattr)
@@ -176,7 +176,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 
 // OnDemandImportForGet.  Attempts to import the doc based on the provided id, contents and cas.  ImportDocRaw does cas retry handling
 // if the document gets updated after the initial retrieval attempt that triggered this.
-func (db *DatabaseContext) OnDemandImportForGet(docid string, rawDoc []byte, rawXattr []byte, cas uint64) (docOut *document, err error) {
+func (db *DatabaseContext) OnDemandImportForGet(docid string, rawDoc []byte, rawXattr []byte, cas uint64) (docOut *Document, err error) {
 	isDelete := rawDoc == nil
 	importDb := Database{DatabaseContext: db, user: nil}
 	var importErr error
@@ -420,7 +420,7 @@ func (db *Database) authorizeUserForChannels(docID, revID string, channels base.
 
 // Returns the body of the active revision of a document, as well as the document's current channels
 // and the user/roles it grants channel access to.
-func (db *Database) GetDocAndActiveRev(docid string) (populatedDoc *document, body Body, err error) {
+func (db *Database) GetDocAndActiveRev(docid string) (populatedDoc *Document, body Body, err error) {
 	populatedDoc, err = db.GetDocument(docid, DocUnmarshalAll)
 	if populatedDoc == nil {
 		return
@@ -461,7 +461,7 @@ func (db *Database) AuthorizeDocID(docid, revid string) error {
 }
 
 // Returns an HTTP 403 error if the User is not allowed to access any of this revision's channels.
-func (db *Database) authorizeDoc(doc *document, revid string) error {
+func (db *Database) authorizeDoc(doc *Document, revid string) error {
 	user := db.user
 	if doc == nil || user == nil {
 		return nil // A nil User means access control is disabled
@@ -480,7 +480,7 @@ func (db *Database) authorizeDoc(doc *document, revid string) error {
 
 // Gets a revision of a document. If it's obsolete it will be loaded from the database if possible.
 // This method adds the magic _id, _rev and _attachments properties.
-func (db *DatabaseContext) getRevision(doc *document, revid string) (Body, error) {
+func (db *DatabaseContext) getRevision(doc *Document, revid string) (Body, error) {
 	var body Body
 	if body = doc.getRevisionBody(revid, db.RevisionBodyLoader); body == nil {
 		// No inline body, so look for separate doc:
@@ -505,7 +505,7 @@ func (db *DatabaseContext) getRevision(doc *document, revid string) (Body, error
 // Gets a revision of a document as raw JSON.
 // If it's obsolete it will be loaded from the database if possible.
 // Does not add _id or _rev properties.
-func (db *Database) getRevisionBodyJSON(doc *document, revid string) ([]byte, error) {
+func (db *Database) getRevisionBodyJSON(doc *Document, revid string) ([]byte, error) {
 	if body := doc.getRevisionBodyJSON(revid, db.RevisionBodyLoader); body != nil {
 		return body, nil
 	} else if !doc.History.contains(revid) {
@@ -517,7 +517,7 @@ func (db *Database) getRevisionBodyJSON(doc *document, revid string) ([]byte, er
 
 // Gets the body of a revision's nearest ancestor, as raw JSON (without _id or _rev.)
 // If no ancestor has any JSON, returns nil but no error.
-func (db *Database) getAncestorJSON(doc *document, revid string) ([]byte, error) {
+func (db *Database) getAncestorJSON(doc *Document, revid string) ([]byte, error) {
 	for {
 		if revid = doc.History.getParent(revid); revid == "" {
 			return nil, nil
@@ -530,7 +530,7 @@ func (db *Database) getAncestorJSON(doc *document, revid string) ([]byte, error)
 }
 
 // Returns the body of a revision given a document struct. Checks user access.
-func (db *Database) getRevFromDoc(doc *document, revid string, listRevisions bool) (Body, error) {
+func (db *Database) getRevFromDoc(doc *Document, revid string, listRevisions bool) (Body, error) {
 	var body Body
 	if err := db.authorizeDoc(doc, revid); err != nil {
 		// As a special case, you don't need channel access to see a deletion revision,
@@ -572,7 +572,7 @@ func (db *Database) getRevFromDoc(doc *document, revid string, listRevisions boo
 }
 
 // Returns the body of the asked-for revision or the most recent available ancestor.
-func (db *Database) getAvailableRev(doc *document, revid string) (Body, error) {
+func (db *Database) getAvailableRev(doc *Document, revid string) (Body, error) {
 	for ; revid != ""; revid = doc.History[revid].Parent {
 		if body, _ := db.getRevision(doc, revid); body != nil {
 			return body, nil
@@ -582,7 +582,7 @@ func (db *Database) getAvailableRev(doc *document, revid string) (Body, error) {
 }
 
 // Moves a revision's ancestor's body out of the document object and into a separate db doc.
-func (db *Database) backupAncestorRevs(doc *document, newRevId string, newBody Body) {
+func (db *Database) backupAncestorRevs(doc *Document, newRevId string, newBody Body) {
 	// Find an ancestor that still has JSON in the document:
 	var json []byte
 	ancestorRevId := newRevId
@@ -611,7 +611,7 @@ func (db *Database) backupAncestorRevs(doc *document, newRevId string, newBody B
 
 // Initializes the gateway-specific "_sync_" metadata of a new document.
 // Used when importing an existing Couchbase doc that hasn't been seen by the gateway before.
-func (db *Database) initializeSyncData(doc *document) (err error) {
+func (db *Database) initializeSyncData(doc *Document) (err error) {
 	body := doc.Body()
 	doc.CurrentRev, err = createRevID(1, "", body)
 	if err != nil {
@@ -629,7 +629,7 @@ func (db *Database) initializeSyncData(doc *document) (err error) {
 	return
 }
 
-func (db *Database) OnDemandImportForWrite(docid string, doc *document, body Body) error {
+func (db *Database) OnDemandImportForWrite(docid string, doc *Document, body Body) error {
 
 	// Check whether the doc requiring import is an SDK delete
 	isDelete := false
@@ -659,24 +659,24 @@ func (db *Database) OnDemandImportForWrite(docid string, doc *document, body Bod
 
 // Updates or creates a document.
 // The new body's BodyRev property must match the current revision's, if any.
-func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
+func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document, err error) {
 	// Get the revision ID to match, and the new generation number:
 	matchRev, _ := body[BodyRev].(string)
 	generation, _ := ParseRevID(matchRev)
 	if generation < 0 {
-		return "", base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
+		return "", nil, base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 	generation++
 	deleted, _ := body[BodyDeleted].(bool)
 
 	expiry, err := body.extractExpiry()
 	if err != nil {
-		return "", base.HTTPErrorf(http.StatusBadRequest, "Invalid expiry: %v", err)
+		return "", nil, base.HTTPErrorf(http.StatusBadRequest, "Invalid expiry: %v", err)
 	}
 
 	allowImport := db.UseXattrs()
 
-	return db.updateDoc(docid, allowImport, expiry, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(docid, allowImport, expiry, nil, func(doc *Document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 
 		var isSgWrite bool
 		var crc32Match bool
@@ -738,6 +738,8 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 
 		return body, newAttachments, nil, nil
 	})
+
+	return newRevID, doc, err
 }
 
 // Adds an existing revision to a document along with its history (list of rev IDs.)
@@ -752,21 +754,21 @@ func (db *Database) Put(docid string, body Body) (newRevID string, err error) {
 //
 // and the new revision being added is "3-cde", then docHistory passed in should be ["2-bcd", "1-abc"].
 //
-func (db *Database) PutExistingRev(docid string, body Body, docHistory []string, noConflicts bool) error {
+func (db *Database) PutExistingRev(docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, err error) {
 	newRev := docHistory[0]
 	generation, _ := ParseRevID(newRev)
 	if generation < 0 {
-		return base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
+		return nil, base.HTTPErrorf(http.StatusBadRequest, "Invalid revision ID")
 	}
 	deleted, _ := body[BodyDeleted].(bool)
 
 	expiry, err := body.extractExpiry()
 	if err != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "Invalid expiry: %v", err)
+		return nil, base.HTTPErrorf(http.StatusBadRequest, "Invalid expiry: %v", err)
 	}
 
 	allowImport := db.UseXattrs()
-	_, err = db.updateDoc(docid, allowImport, expiry, func(doc *document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(docid, allowImport, expiry, nil, func(doc *Document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -836,7 +838,8 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 		body[BodyRev] = newRev
 		return body, newAttachments, nil, nil
 	})
-	return err
+
+	return doc, err
 }
 
 // IsIllegalConflict returns true if the given operation is forbidden due to conflicts.
@@ -848,7 +851,7 @@ Truth table for AllowConflicts and noConflicts combinations:
                        AllowConflicts=true     AllowConflicts=false
    noConflicts=true    continue checks         continue checks
    noConflicts=false   return false            continue checks */
-func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted, noConflicts bool) bool {
+func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted, noConflicts bool) bool {
 
 	if db.AllowConflicts() && !noConflicts {
 		return false
@@ -879,15 +882,8 @@ func (db *Database) IsIllegalConflict(doc *document, parentRevID string, deleted
 	return true
 }
 
-// Common subroutine of Put and PutExistingRev: a shell that loads the document, lets the caller
-// make changes to it in a callback and supply a new body, then saves the body and document.
-func (db *Database) updateDoc(docid string, allowImport bool, expiry uint32, callback updateAndReturnDocCallback) (newRevID string, err error) {
-	_, newRevID, err = db.updateAndReturnDoc(docid, allowImport, expiry, nil, callback)
-	return newRevID, err
-}
-
 // Function type for the callback passed into updateAndReturnDoc
-type updateAndReturnDocCallback func(*document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error)
+type updateAndReturnDocCallback func(*Document) (resultBody Body, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error)
 
 // Calling updateAndReturnDoc directly allows callers to:
 //   1. Receive the updated document body in the response
@@ -898,14 +894,14 @@ func (db *Database) updateAndReturnDoc(
 	allowImport bool,
 	expiry uint32,
 	existingDoc *sgbucket.BucketDocument, // If existing is present, passes these to WriteUpdateWithXattr to allow bypass of initial GET
-	callback updateAndReturnDocCallback) (docOut *document, newRevID string, err error) {
+	callback updateAndReturnDocCallback) (docOut *Document, newRevID string, err error) {
 	key := realDocID(docid)
 	if key == "" {
 		return nil, "", base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
 	// Added annotation to the following variable declarations for reference during future refactoring of documentUpdateFunc into a standalone function
-	var doc *document                                // Passed to documentUpdateFunc as pointer, may be possible to define in documentUpdateFunc
+	var doc *Document                                // Passed to documentUpdateFunc as pointer, may be possible to define in documentUpdateFunc
 	var body Body                                    // Could be returned by documentUpdateFunc
 	var storedBody Body                              // Persisted revision body, used to update rev cache
 	var changedPrincipals, changedRoleUsers []string // Could be returned by documentUpdateFunc
@@ -914,7 +910,7 @@ func (db *Database) updateAndReturnDoc(
 	var oldBodyJSON string                           // Could be returned by documentUpdateFunc.  Stores previous revision body for use by DocumentChangeEvent
 
 	// documentUpdateFunc applies the changes to the document.  Called by either WriteUpdate or WriteUpdateWithXATTR below.
-	documentUpdateFunc := func(doc *document, docExists bool, importAllowed bool) (updatedDoc *document, writeOpts sgbucket.WriteOptions, shadowerEcho bool, updatedExpiry *uint32, err error) {
+	documentUpdateFunc := func(doc *Document, docExists bool, importAllowed bool) (updatedDoc *Document, writeOpts sgbucket.WriteOptions, shadowerEcho bool, updatedExpiry *uint32, err error) {
 
 		var newAttachments AttachmentData
 		// Be careful: this block can be invoked multiple times if there are races!
@@ -1400,9 +1396,9 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 }
 
 // Creates a new document, assigning it a random doc ID.
-func (db *Database) Post(body Body) (string, string, error) {
+func (db *Database) Post(body Body) (string, string, *Document, error) {
 	if body[BodyRev] != nil {
-		return "", "", base.HTTPErrorf(http.StatusNotFound, "No previous revision to replace")
+		return "", "", nil, base.HTTPErrorf(http.StatusNotFound, "No previous revision to replace")
 	}
 
 	// If there's an incoming _id property, use that as the doc ID.
@@ -1411,17 +1407,18 @@ func (db *Database) Post(body Body) (string, string, error) {
 		docid = base.CreateUUID()
 	}
 
-	rev, err := db.Put(docid, body)
+	rev, doc, err := db.Put(docid, body)
 	if err != nil {
 		docid = ""
 	}
-	return docid, rev, err
+	return docid, rev, doc, err
 }
 
 // Deletes a document, by adding a new revision whose _deleted property is true.
 func (db *Database) DeleteDoc(docid string, revid string) (string, error) {
 	body := Body{BodyDeleted: true, BodyRev: revid}
-	return db.Put(docid, body)
+	newRevID, _, err := db.Put(docid, body)
+	return newRevID, err
 }
 
 // Purges a document from the bucket (no tombstone)
@@ -1437,7 +1434,7 @@ func (db *Database) Purge(key string) error {
 
 // Calls the JS sync function to assign the doc to channels, grant users
 // access to channels, and reject invalid documents.
-func (db *Database) getChannelsAndAccess(doc *document, body Body, revID string) (
+func (db *Database) getChannelsAndAccess(doc *Document, body Body, revID string) (
 	result base.Set,
 	access channels.AccessMap,
 	roles channels.AccessMap,
@@ -1660,7 +1657,7 @@ func (context *DatabaseContext) ComputeVbSequenceRolesForUser(user auth.User) (c
 }
 
 // Checks whether a document has a mobile xattr.  Used when running in non-xattr mode to support no downtime upgrade.
-func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*document, *sgbucket.BucketDocument) {
+func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*Document, *sgbucket.BucketDocument) {
 	// If we are using xattrs or Couchbase Server doesn't support them, an upgrade isn't going to be in progress
 	if context.UseXattrs() || !context.Bucket.IsSupported(sgbucket.BucketFeatureXattrs) {
 		return nil, nil

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -63,7 +63,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -73,7 +74,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -89,7 +91,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
@@ -130,7 +133,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3b_body := Body{}
 	rev3b_body["version"] = "3b"
 	rev3b_body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	assert.NoError(t, err, "add 3-b (tombstone)")
 
 	// Retrieve tombstone
 	rev3bGet, err := db.GetRev("doc1", "3-b", false, nil)
@@ -163,7 +167,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev2c_body := Body{}
 	rev2c_body["key1"] = prop_1000_bytes
 	rev2c_body["version"] = "2c"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}, false), "add 2-c")
+	_, err = db.PutExistingRev("doc1", rev2c_body, []string{"2-c", "1-a"}, false)
+	assert.NoError(t, err, "add 2-c")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-c")
@@ -182,7 +187,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3c_body["version"] = "3c"
 	rev3c_body["key1"] = prop_1000_bytes
 	rev3c_body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}, false), "add 3-c (large tombstone)")
+	_, err = db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-c"}, false)
+	assert.NoError(t, err, "add 3-c (large tombstone)")
 
 	// Validate the tombstone is not stored inline (due to small size)
 	log.Printf("Verify raw revtree w/ tombstone 3-c in key map")
@@ -207,7 +213,8 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	rev3a_body := Body{}
 	rev3a_body["key1"] = prop_1000_bytes
 	rev3a_body["version"] = "3a"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}, false), "add 3-a")
+	_, err = db.PutExistingRev("doc1", rev2c_body, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "add 3-a")
 
 	revTree, err = getRevTreeList(db.Bucket, "doc1", db.UseXattrs())
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
@@ -229,7 +236,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	// Create rev 2-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a"}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -239,7 +247,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2a_body := Body{}
 	rev2a_body["key1"] = prop_1000_bytes
 	rev2a_body["version"] = "2a"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -255,7 +264,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev2b_body := Body{}
 	rev2b_body["key1"] = prop_1000_bytes
 	rev2b_body["version"] = "2b"
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify rev 2-b")
@@ -297,7 +307,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	rev3b_body["version"] = "3b"
 	rev3b_body["key1"] = prop_1000_bytes
 	rev3b_body[BodyDeleted] = true
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false), "add 3-b (tombstone)")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b"}, false)
+	assert.NoError(t, err, "add 3-b (tombstone)")
 
 	// Retrieve tombstone
 	db.FlushRevisionCacheForTest()
@@ -327,12 +338,18 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	activeRevBody := Body{}
 	activeRevBody["version"] = "...a"
 	activeRevBody["key1"] = prop_1000_bytes
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}, false), "add 3-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}, false), "add 4-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}, false), "add 5-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}, false), "add 6-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}, false), "add 7-a")
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}, false), "add 8-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "add 3-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"4-a", "3-a"}, false)
+	assert.NoError(t, err, "add 4-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"5-a", "4-a"}, false)
+	assert.NoError(t, err, "add 5-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"6-a", "5-a"}, false)
+	assert.NoError(t, err, "add 6-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"7-a", "6-a"}, false)
+	assert.NoError(t, err, "add 7-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"8-a", "7-a"}, false)
+	assert.NoError(t, err, "add 8-a")
 
 	// Verify that 3-b is still present at this point
 	db.FlushRevisionCacheForTest()
@@ -340,7 +357,8 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	assert.NoError(t, err, "Rev 3-b should still exist")
 
 	// Add one more rev that triggers pruning since gen(9-3) > revsLimit
-	assert.NoError(t, db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}, false), "add 9-a")
+	_, err = db.PutExistingRev("doc1", activeRevBody, []string{"9-a", "8-a"}, false)
+	assert.NoError(t, err, "add 9-a")
 
 	// Verify that 3-b has been pruned
 	log.Printf("Attempt to retrieve 3-b, expect pruned")
@@ -367,7 +385,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "version": "1a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -375,7 +394,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "version": "2a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -392,7 +412,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "version": "3a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false), "add 3-a")
+	_, err = db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 3-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 3-a...")
@@ -408,7 +429,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "version": "2b", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify still rev 3-a")
@@ -430,7 +452,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "version": "6a", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false), "add 6-a")
+	_, err = db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	assert.NoError(t, err, "add 6-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 6-a...")
@@ -452,7 +475,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "version": "3b", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false), "add 3-b")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-b")
 
 	// Same again and again
 	// Add child to non-winning revision w/ inline body
@@ -470,11 +494,13 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "version": "3c", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false), "add 3-c")
+	_, err = db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-c")
 
 	log.Printf("Create rev 3-d")
 	rev3d_body := Body{"key1": "value2", "version": "3d", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false), "add 3-d")
+	_, err = db.PutExistingRev("doc1", rev3d_body, []string{"3-d", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-d")
 
 	// Create new winning revision on 'b' branch.  Triggers movement of 6-a to inline storage.  Force cas retry, check document contents
 	//    1-a
@@ -492,7 +518,8 @@ func TestOldRevisionStorage(t *testing.T) {
 	//     7-b
 	log.Printf("Create rev 7-b")
 	rev7b_body := Body{"key1": "value2", "version": "7b", "large": prop_1000_bytes}
-	assert.NoError(t, db.PutExistingRev("doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false), "add 7-b")
+	_, err = db.PutExistingRev("doc1", rev7b_body, []string{"7-b", "6-b", "5-b", "4-b", "3-b"}, false)
+	assert.NoError(t, err, "add 7-b")
 
 }
 
@@ -513,7 +540,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// Create rev 1-a
 	log.Printf("Create rev 1-a")
 	body := Body{"key1": "value1", "v": "1a"}
-	assert.NoError(t, db.PutExistingRev("doc1", body, []string{"1-a"}, false), "add 1-a")
+	_, err := db.PutExistingRev("doc1", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add 1-a")
 
 	// Create rev 2-a
 	// 1-a
@@ -521,7 +549,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 2-a
 	log.Printf("Create rev 2-a")
 	rev2a_body := Body{"key1": "value2", "v": "2a"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false), "add 2-a")
+	_, err = db.PutExistingRev("doc1", rev2a_body, []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 2-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 2-a...")
@@ -537,7 +566,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 3-a")
 	rev3a_body := Body{"key1": "value2", "v": "3a"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false), "add 3-a")
+	_, err = db.PutExistingRev("doc1", rev3a_body, []string{"3-a", "2-a", "1-a"}, false)
+	assert.NoError(t, err, "add 3-a")
 
 	// Create rev 2-b
 	//    1-a
@@ -547,7 +577,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 3-a
 	log.Printf("Create rev 2-b")
 	rev2b_body := Body{"key1": "value2", "v": "2b"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false), "add 2-b")
+	_, err = db.PutExistingRev("doc1", rev2b_body, []string{"2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 2-b")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc, verify still rev 3-a")
@@ -569,7 +600,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 6-a")
 	rev6a_body := Body{"key1": "value2", "v": "6a"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false), "add 6-a")
+	_, err = db.PutExistingRev("doc1", rev6a_body, []string{"6-a", "5-a", "4-a", "3-a"}, false)
+	assert.NoError(t, err, "add 6-a")
 
 	// Retrieve the document:
 	log.Printf("Retrieve doc 6-a...")
@@ -592,7 +624,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 	// 6-a
 	log.Printf("Create rev 3-b")
 	rev3b_body := Body{"key1": "value2", "v": "3b"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false), "add 3-b")
+	_, err = db.PutExistingRev("doc1", rev3b_body, []string{"3-b", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-b")
 
 	// Same again
 	// Add child to non-winning revision w/ inline body.
@@ -611,7 +644,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 
 	log.Printf("Create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false), "add 3-c")
+	_, err = db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-c")
 
 }
 
@@ -626,7 +660,8 @@ func TestLargeSequence(t *testing.T) {
 
 	// Write a doc via SG
 	body := Body{"key1": "largeSeqTest"}
-	assert.NoError(t, db.PutExistingRev("largeSeqDoc", body, []string{"1-a"}, false), "add largeSeqDoc")
+	_, err := db.PutExistingRev("largeSeqDoc", body, []string{"1-a"}, false)
+	assert.NoError(t, err, "add largeSeqDoc")
 
 	syncData, err := db.GetDocSyncData("largeSeqDoc")
 	assert.NoError(t, err, "Error retrieving document sync data")
@@ -701,5 +736,6 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	// 6-a
 	log.Printf("Attempt to create rev 3-c")
 	rev3c_body := Body{"key1": "value2", "v": "3c"}
-	assert.NoError(t, db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false), "add 3-c")
+	_, err := db.PutExistingRev("doc1", rev3c_body, []string{"3-c", "2-b", "1-a"}, false)
+	assert.NoError(t, err, "add 3-c")
 }

--- a/db/database.go
+++ b/db/database.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb"
-	"github.com/couchbase/sg-bucket"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -356,7 +356,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 			// TODO: invoke the same callback function from there as well, to pick up the auto-online handling
 
-		})
+		}, dbContext.DbStats.statsDatabaseMap)
 
 		// Check if there is an error starting the DCP feed
 		if err != nil {
@@ -582,8 +582,7 @@ func (context *DatabaseContext) RestartListener() error {
 	if context.UseXattrs() && context.autoImport {
 		feedMode = sgbucket.FeedResume
 	}
-
-	if err := context.mutationListener.Start(context.Bucket, context.Options.TrackDocs, feedMode, nil); err != nil {
+	if err := context.mutationListener.Start(context.Bucket, context.Options.TrackDocs, feedMode, nil, context.DbStats.statsDatabaseMap); err != nil {
 		return err
 	}
 	return nil

--- a/db/database.go
+++ b/db/database.go
@@ -1030,7 +1030,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 		key := realDocID(docid)
 
 		docCount++
-		documentUpdateFunc := func(doc *document) (updatedDoc *document, shouldUpdate bool, updatedExpiry *uint32, err error) {
+		documentUpdateFunc := func(doc *Document) (updatedDoc *Document, shouldUpdate bool, updatedExpiry *uint32, err error) {
 			imported := false
 			if !doc.HasValidSyncData(db.writeSequences()) {
 				// This is a document not known to the sync gateway. Ignore it:

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -323,7 +323,7 @@ func TestGetDeleted(t *testing.T) {
 	// Get the raw doc and make sure the sync data has the current revision
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
 	assert.NoError(t, err, "Err getting doc")
-	goassert.Equals(t, doc.syncData.CurrentRev, rev2id)
+	goassert.Equals(t, doc.SyncData.CurrentRev, rev2id)
 
 	// Try again but with a user who doesn't have access to this revision (see #179)
 	authenticator := auth.NewAuthenticator(db.Bucket, db)
@@ -1548,7 +1548,7 @@ func TestConcurrentImport(t *testing.T) {
 			doc, err := db.GetDocument("directWrite", DocUnmarshalAll)
 			assert.True(t, doc != nil)
 			assert.NoError(t, err, "Document retrieval error")
-			assert.Equal(t, "1-36fa688dc2a2c39a952ddce46ab53d12", doc.syncData.CurrentRev)
+			assert.Equal(t, "1-36fa688dc2a2c39a952ddce46ab53d12", doc.SyncData.CurrentRev)
 		}()
 	}
 	wg.Wait()

--- a/db/document.go
+++ b/db/document.go
@@ -45,7 +45,7 @@ type UserAccessMap map[string]channels.TimedSet
 type AttachmentsMeta map[string]interface{} // AttachmentsMeta metadata as included in sync metadata
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
-type syncData struct {
+type SyncData struct {
 	CurrentRev      string              `json:"rev"`
 	NewestRev       string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
 	Flags           uint8               `json:"flags,omitempty"`
@@ -76,12 +76,79 @@ type syncData struct {
 	removedRevisionBodyKeys map[string]string // keys of non-winning revisions that have been removed (and so may require deletion), indexed by revID
 }
 
+func (sd *SyncData) HashRedact(salt string) SyncData {
+
+	// Creating a new SyncData with the redacted info. We copy all the information which stays the same and create new
+	// items for the redacted data. The data to be redacted is populated below.
+	syncData := SyncData{
+		CurrentRev:      sd.CurrentRev,
+		NewestRev:       sd.NewestRev,
+		Flags:           sd.Flags,
+		Sequence:        sd.Sequence,
+		UnusedSequences: sd.UnusedSequences,
+		RecentSequences: sd.RecentSequences,
+		History:         RevTree{},
+		Channels:        channels.ChannelMap{},
+		Access:          UserAccessMap{},
+		RoleAccess:      UserAccessMap{},
+		Expiry:          sd.Expiry,
+		Cas:             sd.Cas,
+		Crc32c:          sd.Crc32c,
+		TombstonedAt:    sd.TombstonedAt,
+		Attachments:     AttachmentsMeta{},
+	}
+
+	// Populate and redact channels
+	for k, v := range sd.Channels {
+		syncData.Channels[base.Sha1HashString(k, salt)] = v
+	}
+
+	// Populate and redact history. This is done as it also includes channel names
+	for k, v := range sd.History {
+		revInfo := *v
+
+		if revInfo.Channels != nil {
+			revInfo.Channels = base.Set{}
+			for existingChanKey := range v.Channels {
+				revInfo.Channels.Add(base.Sha1HashString(existingChanKey, salt))
+			}
+		}
+
+		syncData.History.addRevision(k, revInfo)
+	}
+
+	// Populate and redact user access
+	for k, v := range sd.Access {
+		accessTimerSet := map[string]channels.VbSequence{}
+		for channelName, vbStats := range v {
+			accessTimerSet[base.Sha1HashString(channelName, salt)] = vbStats
+		}
+		syncData.Access[base.Sha1HashString(k, salt)] = accessTimerSet
+	}
+
+	// Populate and redact user role access
+	for k, v := range sd.RoleAccess {
+		accessTimerSet := map[string]channels.VbSequence{}
+		for channelName, vbStats := range v {
+			accessTimerSet[base.Sha1HashString(channelName, salt)] = vbStats
+		}
+		syncData.RoleAccess[base.Sha1HashString(k, salt)] = accessTimerSet
+	}
+
+	// Populate and redact attachment names
+	for k, v := range sd.Attachments {
+		syncData.Attachments[base.Sha1HashString(k, salt)] = v
+	}
+
+	return syncData
+}
+
 // A document as stored in Couchbase. Contains the body of the current revision plus metadata.
-// In its JSON form, the body's properties are at top-level while the syncData is in a special
+// In its JSON form, the body's properties are at top-level while the SyncData is in a special
 // "_sync" property.
 // Document doesn't do any locking - document instances aren't intended to be shared across multiple goroutines.
 type document struct {
-	syncData        // Sync metadata
+	SyncData        // Sync metadata
 	_body    Body   // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
 	rawBody  []byte // Raw document body, as retrieved from the bucket
 	ID       string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
@@ -99,7 +166,7 @@ type casOnlySyncData struct {
 
 // Returns a new empty document.
 func newDocument(docid string) *document {
-	return &document{ID: docid, syncData: syncData{History: make(RevTree)}}
+	return &document{ID: docid, SyncData: SyncData{History: make(RevTree)}}
 }
 
 // Accessors for document properties.  To support lazy unmarshalling of document contents, all access should be done through accessors
@@ -165,10 +232,10 @@ func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas
 
 // Unmarshals just a document's sync metadata from JSON data.
 // (This is somewhat faster, if all you need is the sync data without the doc body.)
-func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*syncData, error) {
+func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*SyncData, error) {
 	var root documentRoot
 	if needHistory {
-		root.SyncData = &syncData{History: make(RevTree)}
+		root.SyncData = &SyncData{History: make(RevTree)}
 	}
 	if err := json.Unmarshal(data, &root); err != nil {
 		return nil, err
@@ -185,7 +252,7 @@ func UnmarshalDocumentSyncData(data []byte, needHistory bool) (*syncData, error)
 // Returns the raw body, in case it's needed for import.
 
 // TODO: Using a pool of unmarshal workers may help prevent memory spikes under load
-func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory bool) (result *syncData, rawBody []byte, rawXattr []byte, err error) {
+func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory bool) (result *SyncData, rawBody []byte, rawXattr []byte, err error) {
 
 	var body []byte
 
@@ -198,9 +265,9 @@ func UnmarshalDocumentSyncDataFromFeed(data []byte, dataType uint8, needHistory 
 			return nil, nil, nil, err
 		}
 
-		// If the sync xattr is present, use that to build syncData
+		// If the sync xattr is present, use that to build SyncData
 		if syncXattr != nil && len(syncXattr) > 0 {
-			result = &syncData{}
+			result = &SyncData{}
 			if needHistory {
 				result.History = make(RevTree)
 			}
@@ -284,14 +351,14 @@ func parseXattrStreamData(xattrName string, data []byte) (body []byte, xattr []b
 	return body, xattr, nil
 }
 
-func (doc *syncData) HasValidSyncData(requireSequence bool) bool {
+func (doc *SyncData) HasValidSyncData(requireSequence bool) bool {
 
 	valid := doc != nil && doc.CurrentRev != "" && (doc.Sequence > 0 || !requireSequence)
 	return valid
 }
 
 // Converts the string hex encoding that's stored in the sync metadata to a uint64 cas value
-func (s *syncData) GetSyncCas() uint64 {
+func (s *SyncData) GetSyncCas() uint64 {
 
 	if s.Cas == "" {
 		return 0
@@ -300,8 +367,8 @@ func (s *syncData) GetSyncCas() uint64 {
 	return base.HexCasToUint64(s.Cas)
 }
 
-// syncData.IsSGWrite - used during feed-based import
-func (s *syncData) IsSGWrite(cas uint64, rawBody []byte) (isSGWrite bool, crc32Match bool) {
+// SyncData.IsSGWrite - used during feed-based import
+func (s *SyncData) IsSGWrite(cas uint64, rawBody []byte) (isSGWrite bool, crc32Match bool) {
 
 	// If cas matches, it was a SG write
 	if cas == s.GetSyncCas() {
@@ -316,16 +383,16 @@ func (s *syncData) IsSGWrite(cas uint64, rawBody []byte) (isSGWrite bool, crc32M
 	return false, false
 }
 
-// doc.IsSGWrite - used during on-demand import.  Doesn't invoke syncData.IsSGWrite so that we
+// doc.IsSGWrite - used during on-demand import.  Doesn't invoke SyncData.IsSGWrite so that we
 // can complete the inexpensive cas check before the (potential) doc marshalling.
 func (doc *document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool) {
 
-	// If the raw body is available, use syncData.IsSGWrite
+	// If the raw body is available, use SyncData.IsSGWrite
 	if rawBody != nil && len(rawBody) > 0 {
 
-		isSgWriteFeed, crc32MatchFeed := doc.syncData.IsSGWrite(doc.Cas, rawBody)
+		isSgWriteFeed, crc32MatchFeed := doc.SyncData.IsSGWrite(doc.Cas, rawBody)
 		if !isSgWriteFeed {
-			base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.syncData.Cas)
+			base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
 		}
 
 		return isSgWriteFeed, crc32MatchFeed
@@ -333,7 +400,7 @@ func (doc *document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool)
 	}
 
 	// If raw body isn't available, first do the inexpensive cas check
-	if doc.Cas == doc.syncData.GetSyncCas() {
+	if doc.Cas == doc.SyncData.GetSyncCas() {
 		return true, false
 	}
 
@@ -343,11 +410,11 @@ func (doc *document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool)
 		base.Warnf(base.KeyAll, "Unable to marshal doc body during SG write check for doc %s.  Error: %v", base.UD(doc.ID), err)
 		return false, false
 	}
-	if base.Crc32cHashString(docBody) == doc.syncData.Crc32c {
+	if base.Crc32cHashString(docBody) == doc.SyncData.Crc32c {
 		return true, true
 	}
 
-	base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.syncData.Cas)
+	base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
 	return false, false
 }
 
@@ -685,21 +752,21 @@ func (accessMap *UserAccessMap) updateAccess(doc *document, newAccess channels.A
 //////// MARSHALING ////////
 
 type documentRoot struct {
-	SyncData *syncData `json:"_sync"`
+	SyncData *SyncData `json:"_sync"`
 }
 
 func (doc *document) UnmarshalJSON(data []byte) error {
 	if doc.ID == "" {
 		panic("Doc was unmarshaled without ID set")
 	}
-	root := documentRoot{SyncData: &syncData{History: make(RevTree)}}
+	root := documentRoot{SyncData: &SyncData{History: make(RevTree)}}
 	err := json.Unmarshal([]byte(data), &root)
 	if err != nil {
 		return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalJSON() doc with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
 
 	if root.SyncData != nil {
-		doc.syncData = *root.SyncData
+		doc.SyncData = *root.SyncData
 	}
 
 	if err := doc._body.Unmarshal(data); err != nil {
@@ -715,7 +782,7 @@ func (doc *document) MarshalJSON() ([]byte, error) {
 	if body == nil {
 		body = Body{}
 	}
-	body[base.SyncXattrName] = &doc.syncData
+	body[base.SyncXattrName] = &doc.SyncData
 	data, err := json.Marshal(body)
 	delete(body, base.SyncXattrName)
 	if err != nil {
@@ -737,8 +804,8 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 	switch unmarshalLevel {
 	case DocUnmarshalAll, DocUnmarshalSync:
 		// Unmarshal full document and/or sync metadata
-		doc.syncData = syncData{History: make(RevTree)}
-		unmarshalErr := json.Unmarshal(xdata, &doc.syncData)
+		doc.SyncData = SyncData{History: make(RevTree)}
+		unmarshalErr := json.Unmarshal(xdata, &doc.SyncData)
 		if unmarshalErr != nil {
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
@@ -751,8 +818,8 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 
 	case DocUnmarshalNoHistory:
 		// Unmarshal sync metadata only, excluding history
-		doc.syncData = syncData{}
-		unmarshalErr := json.Unmarshal(xdata, &doc.syncData)
+		doc.SyncData = SyncData{}
+		unmarshalErr := json.Unmarshal(xdata, &doc.SyncData)
 		if unmarshalErr != nil {
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalNoHistory).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
@@ -764,7 +831,7 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 		if unmarshalErr != nil {
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalRev).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
-		doc.syncData = syncData{
+		doc.SyncData = SyncData{
 			CurrentRev: revOnlyMeta.CurrentRev,
 			Cas:        revOnlyMeta.Cas,
 		}
@@ -776,7 +843,7 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 		if unmarshalErr != nil {
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalCAS).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
-		doc.syncData = syncData{
+		doc.SyncData = SyncData{
 			Cas: casOnlyMeta.Cas,
 		}
 		doc.rawBody = data
@@ -804,9 +871,9 @@ func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 		}
 	}
 
-	xdata, err = json.Marshal(doc.syncData)
+	xdata, err = json.Marshal(doc.SyncData)
 	if err != nil {
-		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc syncData with id: %s.  Error: %v", base.UD(doc.ID), err))
+		return nil, nil, pkgerrors.WithStack(base.RedactErrorf("Failed to MarshalWithXattr() doc SyncData with id: %s.  Error: %v", base.UD(doc.ID), err))
 	}
 
 	return data, xdata, nil

--- a/db/document.go
+++ b/db/document.go
@@ -147,7 +147,7 @@ func (sd *SyncData) HashRedact(salt string) SyncData {
 // In its JSON form, the body's properties are at top-level while the SyncData is in a special
 // "_sync" property.
 // Document doesn't do any locking - document instances aren't intended to be shared across multiple goroutines.
-type document struct {
+type Document struct {
 	SyncData        // Sync metadata
 	_body    Body   // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
 	rawBody  []byte // Raw document body, as retrieved from the bucket
@@ -165,12 +165,12 @@ type casOnlySyncData struct {
 }
 
 // Returns a new empty document.
-func newDocument(docid string) *document {
-	return &document{ID: docid, SyncData: SyncData{History: make(RevTree)}}
+func NewDocument(docid string) *Document {
+	return &Document{ID: docid, SyncData: SyncData{History: make(RevTree)}}
 }
 
 // Accessors for document properties.  To support lazy unmarshalling of document contents, all access should be done through accessors
-func (doc *document) Body() Body {
+func (doc *Document) Body() Body {
 	if doc._body == nil && doc.rawBody != nil {
 		err := doc._body.Unmarshal(doc.rawBody)
 		if err != nil {
@@ -182,13 +182,13 @@ func (doc *document) Body() Body {
 	return doc._body
 }
 
-func (doc *document) RemoveBody() {
+func (doc *Document) RemoveBody() {
 	doc._body = nil
 	doc.rawBody = nil
 }
 
 // TODO: review whether this can just return raw body when available
-func (doc *document) MarshalBody() ([]byte, error) {
+func (doc *Document) MarshalBody() ([]byte, error) {
 	marshalled, err := json.Marshal(doc.Body())
 	if err != nil {
 		return []byte{}, pkgerrors.Wrapf(err, "Error marshalling JSON")
@@ -198,8 +198,8 @@ func (doc *document) MarshalBody() ([]byte, error) {
 
 // Unmarshals a document from JSON data. The doc ID isn't in the data and must be given.  Uses decode to ensure
 // UseNumber handling is applied to numbers in the body.
-func unmarshalDocument(docid string, data []byte) (*document, error) {
-	doc := newDocument(docid)
+func unmarshalDocument(docid string, data []byte) (*Document, error) {
+	doc := NewDocument(docid)
 	if len(data) > 0 {
 		decoder := json.NewDecoder(bytes.NewReader(data))
 		decoder.UseNumber()
@@ -214,13 +214,13 @@ func unmarshalDocument(docid string, data []byte) (*document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *document, err error) {
+func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 
 	if xattrData == nil || len(xattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
 	} else {
-		doc = newDocument(docid)
+		doc = NewDocument(docid)
 		err = doc.UnmarshalWithXattr(data, xattrData, unmarshalLevel)
 	}
 	if err != nil {
@@ -385,7 +385,7 @@ func (s *SyncData) IsSGWrite(cas uint64, rawBody []byte) (isSGWrite bool, crc32M
 
 // doc.IsSGWrite - used during on-demand import.  Doesn't invoke SyncData.IsSGWrite so that we
 // can complete the inexpensive cas check before the (potential) doc marshalling.
-func (doc *document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool) {
+func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool) {
 
 	// If the raw body is available, use SyncData.IsSGWrite
 	if rawBody != nil && len(rawBody) > 0 {
@@ -418,11 +418,11 @@ func (doc *document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool)
 	return false, false
 }
 
-func (doc *document) hasFlag(flag uint8) bool {
+func (doc *Document) hasFlag(flag uint8) bool {
 	return doc.Flags&flag != 0
 }
 
-func (doc *document) setFlag(flag uint8, state bool) {
+func (doc *Document) setFlag(flag uint8, state bool) {
 	if state {
 		doc.Flags |= flag
 	} else {
@@ -430,7 +430,7 @@ func (doc *document) setFlag(flag uint8, state bool) {
 	}
 }
 
-func (doc *document) newestRevID() string {
+func (doc *Document) newestRevID() string {
 	if doc.NewestRev != "" {
 		return doc.NewestRev
 	}
@@ -446,7 +446,7 @@ func (db *DatabaseContext) RevisionBodyLoader(key string) ([]byte, error) {
 }
 
 // Fetches the body of a revision as a map, or nil if it's not available.
-func (doc *document) getRevisionBody(revid string, loader RevLoaderFunc) Body {
+func (doc *Document) getRevisionBody(revid string, loader RevLoaderFunc) Body {
 	var body Body
 	if revid == doc.CurrentRev {
 		body = doc.Body()
@@ -458,7 +458,7 @@ func (doc *document) getRevisionBody(revid string, loader RevLoaderFunc) Body {
 
 // Retrieves a non-winning revision body.  If not already loaded in the document (either because inline,
 // or was previously requested), loader function is used to retrieve from the bucket.
-func (doc *document) getNonWinningRevisionBody(revid string, loader RevLoaderFunc) Body {
+func (doc *Document) getNonWinningRevisionBody(revid string, loader RevLoaderFunc) Body {
 	var body Body
 	bodyBytes, found := doc.History.getRevisionBody(revid, loader)
 	if !found || len(bodyBytes) == 0 {
@@ -473,7 +473,7 @@ func (doc *document) getNonWinningRevisionBody(revid string, loader RevLoaderFun
 }
 
 // Fetches the body of a revision as JSON, or nil if it's not available.
-func (doc *document) getRevisionBodyJSON(revid string, loader RevLoaderFunc) []byte {
+func (doc *Document) getRevisionBodyJSON(revid string, loader RevLoaderFunc) []byte {
 	var bodyJSON []byte
 	if revid == doc.CurrentRev {
 		var marshalErr error
@@ -487,7 +487,7 @@ func (doc *document) getRevisionBodyJSON(revid string, loader RevLoaderFunc) []b
 	return bodyJSON
 }
 
-func (doc *document) removeRevisionBody(revID string) {
+func (doc *Document) removeRevisionBody(revID string) {
 	removedBodyKey := doc.History.removeRevisionBody(revID)
 	if removedBodyKey != "" {
 		if doc.removedRevisionBodyKeys == nil {
@@ -498,14 +498,14 @@ func (doc *document) removeRevisionBody(revID string) {
 }
 
 // makeBodyActive moves a previously non-winning revision body from the rev tree to the document body
-func (doc *document) promoteNonWinningRevisionBody(revid string, loader RevLoaderFunc) {
+func (doc *Document) promoteNonWinningRevisionBody(revid string, loader RevLoaderFunc) {
 	// If the new revision is not current, transfer the current revision's
 	// body to the top level doc._body:
 	doc._body = doc.getNonWinningRevisionBody(revid, loader)
 	doc.removeRevisionBody(revid)
 }
 
-func (doc *document) pruneRevisions(maxDepth uint32, keepRev string) int {
+func (doc *Document) pruneRevisions(maxDepth uint32, keepRev string) int {
 	numPruned, prunedTombstoneBodyKeys := doc.History.pruneRevisions(maxDepth, keepRev)
 	for revID, bodyKey := range prunedTombstoneBodyKeys {
 		if doc.removedRevisionBodyKeys == nil {
@@ -517,7 +517,7 @@ func (doc *document) pruneRevisions(maxDepth uint32, keepRev string) int {
 }
 
 // Adds a revision body (as Body) to a document.  Removes special properties first.
-func (doc *document) setRevisionBody(revid string, body Body, storeInline bool) (revisionBody Body) {
+func (doc *Document) setRevisionBody(revid string, body Body, storeInline bool) (revisionBody Body) {
 	strippedBody := stripSpecialProperties(body)
 	if revid == doc.CurrentRev {
 		doc._body = strippedBody
@@ -532,7 +532,7 @@ func (doc *document) setRevisionBody(revid string, body Body, storeInline bool) 
 }
 
 // Adds a revision body (as []byte) to a document.  Flags for external storage when appropriate
-func (doc *document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool) {
+func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool) {
 	revBodyKey := ""
 	if !storeInline && len(body) > MaximumInlineBodySize {
 		revBodyKey = generateRevBodyKey(doc.ID, revid)
@@ -543,7 +543,7 @@ func (doc *document) setNonWinningRevisionBody(revid string, body []byte, storeI
 
 // persistModifiedRevisionBodies writes new non-inline revisions to the bucket.
 // Should be invoked BEFORE the document is successfully committed.
-func (doc *document) persistModifiedRevisionBodies(bucket base.Bucket) error {
+func (doc *Document) persistModifiedRevisionBodies(bucket base.Bucket) error {
 
 	for _, revID := range doc.addedRevisionBodies {
 		// if this rev is also in the delete set, skip add/delete
@@ -574,7 +574,7 @@ func (doc *document) persistModifiedRevisionBodies(bucket base.Bucket) error {
 
 // deleteRemovedRevisionBodies deletes obsolete non-inline revisions from the bucket.
 // Should be invoked AFTER the document is successfully committed.
-func (doc *document) deleteRemovedRevisionBodies(bucket base.Bucket) {
+func (doc *Document) deleteRemovedRevisionBodies(bucket base.Bucket) {
 
 	for _, revBodyKey := range doc.removedRevisionBodyKeys {
 		deleteErr := bucket.Delete(revBodyKey)
@@ -585,13 +585,13 @@ func (doc *document) deleteRemovedRevisionBodies(bucket base.Bucket) {
 	doc.removedRevisionBodyKeys = map[string]string{}
 }
 
-func (doc *document) persistRevisionBody(bucket base.Bucket, key string, body []byte) error {
+func (doc *Document) persistRevisionBody(bucket base.Bucket, key string, body []byte) error {
 	_, err := bucket.AddRaw(key, 0, body)
 	return err
 }
 
 // Move any large revision bodies to external document storage
-func (doc *document) migrateRevisionBodies(bucket base.Bucket) error {
+func (doc *Document) migrateRevisionBodies(bucket base.Bucket) error {
 
 	for _, revID := range doc.History.GetLeaves() {
 		revInfo, err := doc.History.getInfo(revID)
@@ -623,7 +623,7 @@ func generateRevDigest(docid, revid string) string {
 }
 
 // Updates the expiry for a document
-func (doc *document) UpdateExpiry(expiry uint32) {
+func (doc *Document) UpdateExpiry(expiry uint32) {
 
 	if expiry == 0 {
 		doc.Expiry = nil
@@ -637,7 +637,7 @@ func (doc *document) UpdateExpiry(expiry uint32) {
 
 // Updates the Channels property of a document object with current & past channels.
 // Returns the set of channels that have changed (document joined or left in this revision)
-func (doc *document) updateChannels(newChannels base.Set) (changedChannels base.Set, err error) {
+func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.Set, err error) {
 	var changed []string
 	oldChannels := doc.Channels
 	if oldChannels == nil {
@@ -673,7 +673,7 @@ func (doc *document) updateChannels(newChannels base.Set) (changedChannels base.
 
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
-func (doc *document) IsChannelRemoval(revID string) (body Body, history Revisions, channels base.Set, isRemoval bool, err error) {
+func (doc *Document) IsChannelRemoval(revID string) (body Body, history Revisions, channels base.Set, isRemoval bool, err error) {
 
 	channels = make(base.Set)
 
@@ -719,7 +719,7 @@ func (doc *document) IsChannelRemoval(revID string) (body Body, history Revision
 
 // Updates a document's channel/role UserAccessMap with new access settings from an AccessMap.
 // Returns an array of the user/role names whose access has changed as a result.
-func (accessMap *UserAccessMap) updateAccess(doc *document, newAccess channels.AccessMap) (changedUsers []string) {
+func (accessMap *UserAccessMap) updateAccess(doc *Document, newAccess channels.AccessMap) (changedUsers []string) {
 	// Update users already appearing in doc.Access:
 	for name, access := range *accessMap {
 		if access.UpdateAtSequence(newAccess[name], doc.Sequence) {
@@ -755,7 +755,7 @@ type documentRoot struct {
 	SyncData *SyncData `json:"_sync"`
 }
 
-func (doc *document) UnmarshalJSON(data []byte) error {
+func (doc *Document) UnmarshalJSON(data []byte) error {
 	if doc.ID == "" {
 		panic("Doc was unmarshaled without ID set")
 	}
@@ -777,7 +777,7 @@ func (doc *document) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (doc *document) MarshalJSON() ([]byte, error) {
+func (doc *Document) MarshalJSON() ([]byte, error) {
 	body := doc._body
 	if body == nil {
 		body = Body{}
@@ -795,7 +795,7 @@ func (doc *document) MarshalJSON() ([]byte, error) {
 // (unmarshalLevel) specifies how much of the provided document/xattr needs to be initially unmarshalled.  If
 // unmarshalLevel is anything less than the full document + metadata, the raw data is retained for subsequent
 // lazy unmarshalling as needed.
-func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLevel DocumentUnmarshalLevel) error {
+func (doc *Document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLevel DocumentUnmarshalLevel) error {
 	if doc.ID == "" {
 		base.Warnf(base.KeyAll, "Attempted to unmarshal document without ID set")
 		return errors.New("Document was unmarshalled without ID set")
@@ -857,7 +857,7 @@ func (doc *document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 	return nil
 }
 
-func (doc *document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
+func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 
 	body := doc._body
 	// If body is non-empty and non-deleted, unmarshal and return

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -155,7 +155,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				doc := newDocument("testDocID")
+				doc := NewDocument("testDocID")
 				docReader := bytes.NewReader(doc1k_body)
 				b.StartTimer()
 				var err error

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -224,7 +224,7 @@ func TestParseXattr(t *testing.T) {
 }
 
 func TestParseDocumentCas(t *testing.T) {
-	syncData := &syncData{}
+	syncData := &SyncData{}
 	syncData.Cas = "0x00002ade734fb714"
 
 	casInt := syncData.GetSyncCas()

--- a/db/import.go
+++ b/db/import.go
@@ -235,7 +235,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		docOut = alreadyImportedDoc
 	case nil:
 		db.DbStats.SharedBucketImport().Add(base.StatKeyImportCount, 1)
-		db.DbStats.SharedBucketImport().Set(base.StatKeyImportHighSeq, base.ExpvarInt64Val(int64(docOut.syncData.Sequence)))
+		db.DbStats.SharedBucketImport().Set(base.StatKeyImportHighSeq, base.ExpvarInt64Val(int64(docOut.SyncData.Sequence)))
 		db.DbStats.SharedBucketImport().Add(base.StatKeyImportProcessingTime, time.Since(importStartTime).Nanoseconds())
 		base.Debugf(base.KeyImport, "Imported %s (delete=%v) as rev %s", base.UD(docid), isDelete, newRev)
 	case base.ErrImportCancelled:

--- a/db/kv_change_index.go
+++ b/db/kv_change_index.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -19,7 +20,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -198,14 +198,13 @@ func (k *kvChangeIndex) Remove(docIDs []string, startTime time.Time) int {
 }
 
 // TODO: refactor waitForSequence to accept either vbNo or clock
-func (k *kvChangeIndex) waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration, tb testing.TB) {
-	k.waitForSequence(sequence.Seq, maxWaitTime, tb)
+func (k *kvChangeIndex) waitForSequence(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error {
+	// no-op
+	return nil
 }
-func (k *kvChangeIndex) waitForSequence(sequence uint64, maxWaitTime time.Duration, tb testing.TB) {
-	return
-}
-func (k *kvChangeIndex) waitForSequenceWithMissing(sequence uint64, maxWaitTime time.Duration, tb testing.TB) {
-	k.waitForSequence(sequence, maxWaitTime, tb)
+func (k *kvChangeIndex) waitForSequenceNotSkipped(ctx context.Context, sequence uint64, maxWaitTime time.Duration) error {
+	// no-op
+	return nil
 }
 
 // If set to false, DocChanged() becomes a no-op.

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -23,11 +23,11 @@ func TestQueryChannelsStatsView(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	_, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
+	_, _, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc1")
-	_, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc2")
-	_, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
@@ -69,11 +69,11 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	_, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
+	_, _, err := db.Put("queryTestDoc1", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc1")
-	_, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc2", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc2")
-	_, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
+	_, _, err = db.Put("queryTestDoc3", Body{"channels": []string{"ABC"}})
 	assert.NoError(t, err, "Put queryDoc3")
 
 	// Check expvar prior to test
@@ -114,7 +114,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 	// Add docs without channel assignment (will only be assigned to the star channel)
 	for i := 1; i <= 10; i++ {
 		//_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"channels": []string{"ABC"}})
-		_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 
@@ -158,7 +158,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 
 	// Add some docs in different channels, to validate query handling when non-star channel docs are present
 	for i := 1; i <= 10; i++ {
-		_, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 	// Issue channels query
@@ -198,7 +198,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 	// Add docs without channel assignment (will only be assigned to the star channel)
 	for i := 1; i <= 10; i++ {
 		//_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"channels": []string{"ABC"}})
-		_, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDoc%d", i), Body{"nochannels": true})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 
@@ -243,7 +243,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 	// Add some docs in different channels, to validate query handling when non-star channel docs are present
 	for i := 1; i <= 10; i++ {
-		_, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
+		_, _, err := db.Put(fmt.Sprintf("queryTestDocChanneled%d", i), Body{"channels": []string{fmt.Sprintf("ABC%d", i)}})
 		assert.NoError(t, err, "Put queryDoc")
 	}
 	// Issue channels query
@@ -328,7 +328,7 @@ func TestAllDocsQuery(t *testing.T) {
 
 	// Add docs with channel assignment
 	for i := 1; i <= 10; i++ {
-		_, err := db.Put(fmt.Sprintf("allDocsTest%d", i), Body{"channels": []string{"ABC"}})
+		_, _, err := db.Put(fmt.Sprintf("allDocsTest%d", i), Body{"channels": []string{"ABC"}})
 		assert.NoError(t, err, "Put allDocsTest doc")
 	}
 
@@ -394,7 +394,7 @@ func TestAccessQuery(t *testing.T) {
 }`)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
-		_, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
+		_, _, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
 		assert.NoError(t, err, "Put accessTest doc")
 	}
 
@@ -445,7 +445,7 @@ func TestRoleAccessQuery(t *testing.T) {
 }`)
 	// Add docs with access grants assignment
 	for i := 1; i <= 5; i++ {
-		_, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
+		_, _, err := db.Put(fmt.Sprintf("accessTest%d", i), Body{"accessUser": "user1", "accessChannel": fmt.Sprintf("channel%d", i)})
 		assert.NoError(t, err, "Put accessTest doc")
 	}
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -25,7 +25,7 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 
 	// Add harmless docs
 	for i := 0; i < base.DefaultViewQueryPageSize+1; i++ {
-		testSyncData := syncData{}
+		testSyncData := SyncData{}
 		bucket.Add(fmt.Sprintf("foo-%d", i), 0, map[string]interface{}{"foo": "bar", "_sync": testSyncData})
 		numDocsAdded++
 	}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -39,7 +39,7 @@ func (rc *BypassRevisionCache) GetActive(docID string, copyType BodyCopyType) (d
 	}
 
 	docRev.RevID = doc.CurrentRev
-	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.syncData.CurrentRev)
+	docRev.Body, docRev.History, docRev.Channels, docRev.Attachments, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -74,8 +74,8 @@ func DefaultRevisionCacheOptions() *RevisionCacheOptions {
 
 // RevisionCacheBackingStore is the inteface required to be passed into a RevisionCache constructor to provide a backing store for loading documents.
 type RevisionCacheBackingStore interface {
-	GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *document, err error)
-	getRevision(doc *document, revid string) (Body, error)
+	GetDocument(docid string, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error)
+	getRevision(doc *Document, revid string) (Body, error)
 }
 
 // Revision information as returned by the rev cache
@@ -118,7 +118,7 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
 func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
-	var doc *document
+	var doc *Document
 	if doc, err = backingStore.GetDocument(id.DocID, DocUnmarshalAll); doc == nil {
 		return body, history, channels, attachments, expiry, err
 	}
@@ -127,7 +127,7 @@ func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev) (body B
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *document, revid string) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
+func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Document, revid string) (body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, expiry *time.Time, err error) {
 
 	if body, err = backingStore.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -254,7 +254,7 @@ func (value *revCacheValue) _asDocumentRevision(copyType BodyCopyType) (Document
 
 // Retrieves the body etc. out of a revCacheValue.  If they aren't already present, loads into the cache value using
 // the provided document.
-func (value *revCacheValue) loadForDoc(backingStore RevisionCacheBackingStore, doc *document, copyType BodyCopyType) (docRev DocumentRevision, cacheHit bool, err error) {
+func (value *revCacheValue) loadForDoc(backingStore RevisionCacheBackingStore, doc *Document, copyType BodyCopyType) (docRev DocumentRevision, cacheHit bool, err error) {
 
 	value.lock.RLock()
 	if value.body != nil || value.err != nil {

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -916,7 +916,7 @@ func addPruneAndGet(revTree RevTree, revID string, parentRevID string, revBody [
 
 }
 
-func getHistoryWithTimeout(rawDoc *document, revId string, timeout time.Duration) (history []string, err error) {
+func getHistoryWithTimeout(rawDoc *Document, revId string, timeout time.Duration) (history []string, err error) {
 
 	historyChannel := make(chan []string)
 	errChannel := make(chan error)

--- a/db/shadower.go
+++ b/db/shadower.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"expvar"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -25,11 +26,11 @@ type Shadower struct {
 }
 
 // Creates a new Shadower.
-func NewShadower(context *DatabaseContext, bucket base.Bucket, docIDPattern *regexp.Regexp) (*Shadower, error) {
+func NewShadower(context *DatabaseContext, bucket base.Bucket, docIDPattern *regexp.Regexp, dbStats *expvar.Map) (*Shadower, error) {
 
 	tapFeed, err := bucket.StartTapFeed(sgbucket.FeedArguments{Backfill: 0, Notify: func(bucket string, err error) {
 		context.TakeDbOffline("Lost shadower TAP Feed")
-	}})
+	}}, dbStats)
 	if err != nil {
 		return nil, err
 	}

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -54,7 +54,7 @@ func TestShadowerPull(t *testing.T) {
 	db := setupTestDBForShadowing(t)
 	defer tearDownTestDB(t, db)
 
-	shadower, err := NewShadower(db.DatabaseContext, bucket, nil)
+	shadower, err := NewShadower(db.DatabaseContext, bucket, nil, db.DbStats.statsDatabaseMap)
 	assert.NoError(t, err, "NewShadower")
 	defer shadower.Stop()
 
@@ -117,7 +117,7 @@ func TestShadowerPullWithNotifications(t *testing.T) {
 
 	defer tearDownTestDB(t, db)
 
-	shadower, err := NewShadower(db.DatabaseContext, bucket, nil)
+	shadower, err := NewShadower(db.DatabaseContext, bucket, nil, db.DbStats.statsDatabaseMap)
 	assert.NoError(t, err, "NewShadower")
 	defer shadower.Stop()
 
@@ -173,7 +173,7 @@ func TestShadowerPush(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	var err error
-	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
+	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil, db.DbStats.statsDatabaseMap)
 	assert.NoError(t, err, "NewShadower")
 
 	key1rev1, _, err := db.Put("key1", Body{"aaa": "bbb"})
@@ -223,7 +223,7 @@ func TestShadowerPushEchoCancellation(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	var err error
-	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
+	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil, db.DbStats.statsDatabaseMap)
 	assert.NoError(t, err, "NewShadower")
 
 	// Push an existing doc revision (the way a client's push replicator would)
@@ -257,7 +257,7 @@ func TestShadowerPullRevisionWithMissingParentRev(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	var err error
-	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
+	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil, db.DbStats.statsDatabaseMap)
 	assert.NoError(t, err, "NewShadower")
 
 	// Push an existing doc revision (the way a client's push replicator would)
@@ -319,7 +319,7 @@ func TestShadowerPattern(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	pattern, _ := regexp.Compile(`key\d+`)
-	shadower, err := NewShadower(db.DatabaseContext, bucket, pattern)
+	shadower, err := NewShadower(db.DatabaseContext, bucket, pattern, db.DbStats.statsDatabaseMap)
 	assert.NoError(t, err, "NewShadower")
 	defer shadower.Stop()
 

--- a/db/shadower_test.go
+++ b/db/shadower_test.go
@@ -59,7 +59,7 @@ func TestShadowerPull(t *testing.T) {
 	defer shadower.Stop()
 
 	t.Logf("Waiting for shadower to catch up...")
-	var doc1, doc2 *document
+	var doc1, doc2 *Document
 	waitFor(t, func() bool {
 		seq, _ := db.LastSequence()
 		return seq >= 2
@@ -176,9 +176,9 @@ func TestShadowerPush(t *testing.T) {
 	db.Shadower, err = NewShadower(db.DatabaseContext, bucket, nil)
 	assert.NoError(t, err, "NewShadower")
 
-	key1rev1, err := db.Put("key1", Body{"aaa": "bbb"})
+	key1rev1, _, err := db.Put("key1", Body{"aaa": "bbb"})
 	assert.NoError(t, err, "Put")
-	_, err = db.Put("key2", Body{"ccc": "ddd"})
+	_, _, err = db.Put("key2", Body{"ccc": "ddd"})
 	assert.NoError(t, err, "Put")
 
 	t.Log("Waiting for shadower to catch up...")

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -74,52 +74,6 @@ func ResultsEmpty(results gocb.QueryResults) (resultsEmpty bool) {
 
 }
 
-// FOR TESTS ONLY: Blocks until the given sequence has been received.
-func (c *changeCache) waitForSequenceID(sequence SequenceID, maxWaitTime time.Duration, tb testing.TB) {
-	c.waitForSequence(sequence.Seq, maxWaitTime, tb)
-}
-
-// FOR TESTS ONLY
-func (c *changeCache) waitForSequence(sequence uint64, maxWaitTime time.Duration, tb testing.TB) {
-
-	startTime := time.Now()
-
-	for {
-
-		if time.Since(startTime) >= maxWaitTime {
-			tb.Fatalf("changeCache: Sequence %d did not show up after waiting %v", sequence, time.Since(startTime))
-		}
-
-		if c.getNextSequence() >= sequence+1 {
-			base.Infof(base.KeyAll, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
-// FOR TESTS ONLY: Blocks until the given sequence has been received.
-func (c *changeCache) waitForSequenceWithMissing(sequence uint64, maxWaitTime time.Duration, tb testing.TB) {
-
-	startTime := time.Now()
-
-	for {
-
-		if time.Since(startTime) >= maxWaitTime {
-			tb.Fatalf("changeCache: Sequence %d did not show up after waiting %v", sequence, time.Since(startTime))
-		}
-
-		if c.getNextSequence() >= sequence+1 {
-			foundInMissing := c.skippedSeqs.Contains(sequence)
-			if !foundInMissing {
-				base.Infof(base.KeyAll, "waitForSequence(%d) took %v", sequence, time.Since(startTime))
-				return
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
 func (db *DatabaseContext) CacheCompactActive() bool {
 	channelCache := db.changeCache.getChannelCache()
 	compactingCache, ok := channelCache.(*channelCacheImpl)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -55,8 +55,6 @@
 
   <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="5905fd813f0ec718a59374725efaab4993560436"/>
 
-  <project name="gocbconnstr" path="godeps/src/github.com/couchbaselabs/gocbconnstr" remote="couchbaselabs" revision="3c902e3ed6c25b53d53f6a9d26cc4f7a85c0fcf8"/>
-
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 
   <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="3c902e3ed6c25b53d53f6a9d26cc4f7a85c0fcf8"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -47,7 +47,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="62e1e281e9578eed39ca7f894cabae1faa07afc3"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f1b8a89d740738af8cc69efa090b99d34579cd31"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="4fab5d18974b2155cd9986ecf8e0f1b898da38df"/>
 
@@ -61,7 +61,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="31ebef88356e413477d9787df3946a2c9631d551"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e3767aa427bf68885260f46d406627edd7982774"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1669,6 +1669,17 @@ func TestDocumentChangeReplicate(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close() // Close RestTester, which closes ServerContext, which stops all replications
 
+	mockClient := NewMockClient()
+	fakeConfigURL := "http://myhost:4985"
+	mockClient.RespondToGET(fakeConfigURL+"/db", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/db2", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/db3", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/db4", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/mysourcedb", MakeResponse(200, nil, ``))
+	mockClient.RespondToGET(fakeConfigURL+"/mytargetdb", MakeResponse(200, nil, ``))
+	sc := rt.ServerContext()
+	sc.HTTPClient = mockClient.Client
+
 	//Initiate synchronous one shot replication
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db", "target":"http://myhost:4985/db"}`), 500)
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3905,7 +3905,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevID2, `{"channels": ["B"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	//Changes call
 	request, _ := http.NewRequest("GET", "/db/_changes", nil)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -945,7 +945,8 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 
 	// Finally, save the revision (with the new attachments inline)
 	bh.db.DbStats.CblReplicationPush().Add(base.StatKeyDocPushCount, 1)
-	return bh.db.PutExistingRev(docID, body, history, noConflicts)
+	_, err := bh.db.PutExistingRev(docID, body, history, noConflicts)
+	return err
 }
 
 //////// ATTACHMENTS:

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -492,9 +492,9 @@ func (h *handler) handleBulkDocs() error {
 		var revid string
 		if newEdits {
 			if docid != "" {
-				revid, err = h.db.Put(docid, doc)
+				revid, _, err = h.db.Put(docid, doc)
 			} else {
-				docid, revid, err = h.db.Post(doc)
+				docid, revid, _, err = h.db.Post(doc)
 			}
 		} else {
 			revisions := db.ParseRevisions(doc)
@@ -502,7 +502,7 @@ func (h *handler) handleBulkDocs() error {
 				err = base.HTTPErrorf(http.StatusBadRequest, "Bad _revisions")
 			} else {
 				revid = revisions[0]
-				err = h.db.PutExistingRev(docid, doc, revisions, false)
+				_, err = h.db.PutExistingRev(docid, doc, revisions, false)
 			}
 		}
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -11,6 +11,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -222,7 +223,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/alpha", `{"channel":"zero"}`))
 
 	// Check the _changes feed:
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 	var changes struct {
 		Results []db.ChangeEntry
 	}
@@ -685,7 +686,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 2)
 	WriteDirect(testDb, []string{"PBS"}, 5)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	testDb.WaitForSequenceWithMissing(6, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 6))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -710,7 +711,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a missing doc - low sequence should move to 3
 	WriteDirect(testDb, []string{"PBS"}, 3)
-	testDb.WaitForSequence(3, t)
+	require.NoError(t, rt.WaitForSequence(3))
 
 	// WaitForSequence doesn't wait for low sequence to be updated on each channel - additional delay to ensure
 	// low is updated before making the next changes request.
@@ -724,7 +725,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
 	WriteDirect(testDb, []string{"PBS"}, 7)
-	testDb.WaitForSequenceWithMissing(7, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 7))
 
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -777,7 +778,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	testDb.WaitForSequenceWithMissing(5, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -797,7 +798,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	testDb.WaitForSequenceWithMissing(10, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -811,7 +812,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	testDb.WaitForSequenceWithMissing(12, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -825,7 +826,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	WriteDirect(testDb, []string{"PBS"}, 13)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	testDb.WaitForSequence(13, t)
+	require.NoError(t, rt.WaitForSequence(13))
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
@@ -907,7 +908,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	testDb.WaitForSequenceWithMissing(5, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -927,7 +928,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	testDb.WaitForSequenceWithMissing(10, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -941,7 +942,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	testDb.WaitForSequenceWithMissing(12, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -955,7 +956,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
 	WriteDirect(testDb, []string{"PBS"}, 13)
 	WriteDirect(testDb, []string{"PBS"}, 6)
-	testDb.WaitForSequence(13, t)
+	require.NoError(t, rt.WaitForSequence(13))
 
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
 	log.Printf("sending changes JSON: %s", changesJSON)
@@ -1042,7 +1043,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 3)
 	WriteDirect(testDb, []string{"PBS"}, 4)
 	WriteDirect(testDb, []string{"PBS"}, 5)
-	testDb.WaitForSequenceWithMissing(5, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 5))
 
 	// Check the _changes feed:
 	var changes struct {
@@ -1062,7 +1063,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	WriteDirect(testDb, []string{"PBS"}, 8)
 	WriteDirect(testDb, []string{"PBS"}, 9)
 	WriteDirect(testDb, []string{"PBS"}, 10)
-	testDb.WaitForSequenceWithMissing(10, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 10))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON := fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1076,7 +1077,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	// Write a few more docs
 	WriteDirect(testDb, []string{"PBS"}, 11)
 	WriteDirect(testDb, []string{"PBS"}, 12)
-	testDb.WaitForSequenceWithMissing(12, t)
+	require.NoError(t, testDb.WaitForSequenceNotSkipped(context.TODO(), 12))
 
 	// Send another changes request with the last_seq received from the last changes ("5")
 	changesJSON = fmt.Sprintf(`{"since":"%s"}`, changes.Last_Seq)
@@ -1104,7 +1105,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	}()
 
 	// Wait for longpoll to get into wait mode
-	rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Write the skipped doc, wait for longpoll to return
 	WriteDirect(testDb, []string{"PBS"}, 6)
@@ -1169,13 +1170,13 @@ func _testConcurrentDelete(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 
 	// Wait for writes to be processed and indexed
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 }
 
@@ -1208,13 +1209,13 @@ func _testConcurrentPutAsDelete(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Write another doc, to validate sequences restart
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 }
 
 func _testConcurrentUpdate(t *testing.T) {
@@ -1246,13 +1247,13 @@ func _testConcurrentUpdate(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Write another doc, to validate sequences restart
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 }
 
 func _testConcurrentNewEditsFalseDelete(t *testing.T) {
@@ -1286,12 +1287,12 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 	wg.Wait()
 
 	// WaitForPendingChanges waits up to 2 seconds for all allocated sequences to be cached, panics on timeout
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	// Write another doc, to see where sequences are at
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 }
 
@@ -2924,7 +2925,7 @@ func TestChangesIncludeConflicts(t *testing.T) {
 	}
 
 	// Get changes
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?style=all_docs", "")
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
@@ -2964,7 +2965,7 @@ func TestChangesLargeSequences(t *testing.T) {
 	}
 
 	// Get changes
-	rt.ServerContext().Database("db").WaitForPendingChanges(t)
+	require.NoError(t, rt.WaitForPendingChanges())
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
 	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -106,7 +106,7 @@ func TestDocumentNumbers(t *testing.T) {
 			}
 
 			// Check channel assignment
-			getRawResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", test.name), "")
+			getRawResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s?redact=false", test.name), "")
 			var rawResponse RawResponse
 			json.Unmarshal(getRawResponse.Body.Bytes(), &rawResponse)
 			log.Printf("raw response: %s", getRawResponse.Body.Bytes())

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1748,9 +1748,9 @@ func TestDcpBackfill(t *testing.T) {
 
 	backfillComplete := false
 	var expectedBackfill, completedBackfill int
-	for i := 0; i < 10; i++ {
-		expectedBackfill, _ = base.GetExpvarAsInt("syncGateway_dcp", "backfill_expected")
-		completedBackfill, _ = base.GetExpvarAsInt("syncGateway_dcp", "backfill_completed")
+	for i := 0; i < 20; i++ {
+		expectedBackfill, _ := strconv.Atoi(newRt.GetDatabase().DbStats.StatsDatabase().Get("dcp_backfill_expected").String())
+		completedBackfill, _ := strconv.Atoi(newRt.GetDatabase().DbStats.StatsDatabase().Get("dcp_backfill_completed").String())
 		if expectedBackfill > 0 && completedBackfill >= expectedBackfill {
 			log.Printf("backfill complete: %d/%d", completedBackfill, expectedBackfill)
 			backfillComplete = true

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -73,7 +73,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	assert.NoError(t, err, "Unable to insert doc TestImportDelete")
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
-	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
+	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
@@ -92,7 +92,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	assert.NoError(t, err, "Unable to update doc TestImportDelete")
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
-	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
+	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
 	goassert.Equals(t, response.Code, 200)
 	var rawUpdateResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
@@ -110,7 +110,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	err = bucket.Delete(key)
 	assert.NoError(t, err, "Unable to delete doc TestImportDelete")
 
-	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete", "")
+	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
 	goassert.Equals(t, response.Code, 200)
 	var rawDeleteResponse RawResponse
 	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
@@ -301,7 +301,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	assert.NoError(t, err, "Unable to insert doc TestResurrectViaSDK")
 
 	// Attempt to get the document via Sync Gateway, to trigger import.  On import of a create, oldDoc should be nil.
-	rawPath := fmt.Sprintf("/db/_raw/%s", key)
+	rawPath := fmt.Sprintf("/db/_raw/%s?redact=false", key)
 	response := rt.SendAdminRequest("GET", rawPath, "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
@@ -966,7 +966,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 
 	// Get raw to retrieve metadata, and validate bodies have been moved to xattr
-	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
+	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key+"?redact=false", "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
 	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -895,7 +895,7 @@ func (sc *ServerContext) startShadowing(dbcontext *db.DatabaseContext, shadow *S
 			"Unable to connect to shadow bucket: %s", err)
 		return err
 	}
-	shadower, err := db.NewShadower(dbcontext, bucket, pattern)
+	shadower, err := db.NewShadower(dbcontext, bucket, pattern, dbcontext.DbStats.StatsDatabase())
 	if err != nil {
 		bucket.Close()
 		return err

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -276,7 +276,7 @@ func (rt *RestTester) WaitForSequence(seq uint64) error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForSequence(seq, rt.tb)
+	return database.WaitForSequence(context.TODO(), seq)
 }
 
 func (rt *RestTester) WaitForPendingChanges() error {
@@ -284,7 +284,7 @@ func (rt *RestTester) WaitForPendingChanges() error {
 	if database == nil {
 		return fmt.Errorf("No database found")
 	}
-	return database.WaitForPendingChanges(rt.tb)
+	return database.WaitForPendingChanges(context.TODO())
 }
 
 func (rt *RestTester) SetAdminParty(partyTime bool) {

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -231,13 +231,16 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt):
         R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'               # Windows (Post-2.1) sync gateway
     ]
     # Try to find user-specified log path
-    config_url = "{0}/_config".format(sg_url)
-    try:
-        response = urllib2.urlopen(config_url)
-    except urllib2.URLError:
-        config_str = ""
+    if sg_url:
+        config_url = "{0}/_config".format(sg_url)
+        try:
+            response = urllib2.urlopen(config_url)
+        except urllib2.URLError:
+            config_str = ""
+        else:
+            config_str = str(response.read())
     else:
-        config_str = str(response.read())
+        config_str = ""
 
     # Find log file path from old style top level config
     guessed_log_path = extract_element_from_config('LogFilePath', config_str)
@@ -428,11 +431,12 @@ def get_paths_from_expvars(sg_url):
     sg_config_path = None
 
     # get content and parse into json
-    try:
-        response = urllib2.urlopen(expvar_url(sg_url))
-        data = json.load(response)
-    except urllib2.URLError as e:
-        print("WARNING: Unable to connect to Sync Gateway: {0}".format(e))
+    if sg_url:
+        try:
+            response = urllib2.urlopen(expvar_url(sg_url))
+            data = json.load(response)
+        except urllib2.URLError as e:
+            print("WARNING: Unable to connect to Sync Gateway: {0}".format(e))
 
     if data is not None and "cmdline" in data:
         cmdline_args = data["cmdline"]
@@ -571,11 +575,34 @@ def main():
     if options.watch_stdin:
         setup_stdin_watcher()
 
-    # Get the sg url the user passed in, or use the default
     sg_url = options.sync_gateway_url
-    if sg_url is None:
-        sg_url = "http://127.0.0.1:4985"
-    print("Using Sync Gateway URL: {0}".format(sg_url))
+
+    if not sg_url or "://" not in sg_url:
+        if not sg_url:
+            root_url = "127.0.0.1:4985"
+        else:
+            root_url = sg_url
+        sg_url_http = "http://" + root_url
+        print("Trying Sync Gateway URL: {0}".format(sg_url_http))
+
+        try:
+            response = urllib2.urlopen(sg_url_http)
+            json.load(response)
+        except Exception, e:
+            print("Failed to communicate with: {} {}".format(sg_url_http, e))
+            sg_url_https = "https://" + root_url
+            print("Trying Sync Gateway URL: {0}".format(sg_url_https))
+            try:
+                response = urllib2.urlopen(sg_url_https)
+                json.load(response)
+            except Exception, e:
+                print("Failed to communicate with Sync Gateway using url {}. "
+                      "Check that Sync Gateway is running and reachable. "
+                      "Will attempt to continue anyway.".format(e))
+            else:
+                sg_url = sg_url_https
+        else:
+            sg_url = sg_url_http
 
     # Build path to zip directory, make sure it exists
     zip_filename = args[0]


### PR DESCRIPTION
Resolved a couple of test-only conflicts in the `dev-copy` branch:

```diff
diff --cc db/change_cache_test.go
index 650ec899,696cd6d5..00000000
--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@@ -1744,8 -1743,8 +1744,13 @@@ func TestInitializeEmptyCache(t *testin
                docCount++
        }

++<<<<<<< HEAD
 +      cacheWaiter.Add(docCount)
 +      cacheWaiter.Wait()
++=======
+       // Wait for writes to complete, then getChanges again
+       db.changeCache.waitForSequence(context.TODO(), uint64(docCount), base.DefaultWaitForSequence)
++>>>>>>> dev

        changes, err = db.GetChanges(channels.SetOf(t, "zero"), ChangesOptions{})
        assert.NoError(t, err, "Couldn't GetChanges")
@@@ -1803,8 -1803,9 +1808,14 @@@ func TestInitializeCacheUnderLoad(t *te
                lastSeq = changes[len(changes)-1].Seq
        }

++<<<<<<< HEAD
 +      // Wait for all writes to be cached, then getChanges again
 +      cacheWaiter.Wait()
++=======
+       // Wait for writes to complete, then getChanges again
+       writesDone.Wait()
+       require.NoError(t, db.changeCache.waitForSequence(context.TODO(), uint64(docCount), base.DefaultWaitForSequence))
++>>>>>>> dev

        changes, err = db.GetChanges(channels.SetOf(t, "zero"), ChangesOptions{Since: lastSeq})
        assert.NoError(t, err, "Couldn't GetChanges")
diff --cc rest/api_test.go
index 59bd6d61,60fadd2c..00000000
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@@ -2301,7 -2288,7 +2301,11 @@@ func TestChannelAccessChanges(t *testin

        // Must wait for sequence to arrive in cache, since the cache processor will be paused when UpdateSyncFun() is called
        // below, which could lead to a data race if the cache processor is paused while it's processing a change
++<<<<<<< HEAD
 +      rt.MustWaitForDoc("epsilon", t)
++=======
+       require.NoError(t, rt.WaitForSequence(10))
++>>>>>>> dev

        // Finally, throw a wrench in the works by changing the sync fn. Note that normally this wouldn't
        // be changed while the database is in use (only when it's re-opened) but for testing purposes
```