### PR TITLE
MB-34045 Update support upload URL

### DIFF
--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -33,7 +33,7 @@ const (
 	sgStopped uint32 = iota
 	sgRunning
 
-	defaultSGUploadHost = "https://s3.amazonaws.com/cb-customers"
+	defaultSGUploadHost = "https://uploads.couchbase.com"
 )
 
 type sgCollect struct {

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -135,7 +135,7 @@ func TestSgcollectOptionsArgs(t *testing.T) {
 		{
 			// Check that the default upload host is set
 			options:      &sgCollectOptions{Upload: true, Customer: "alice"},
-			expectedArgs: []string{"--upload-host", "https://s3.amazonaws.com/cb-customers", "--customer", "alice"},
+			expectedArgs: []string{"--upload-host", defaultSGUploadHost, "--customer", "alice"},
 		},
 		{
 			options:      &sgCollectOptions{Upload: true, Customer: "alice", UploadHost: "example.org/custom-s3-bucket-url"},

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -90,7 +90,7 @@ def create_option_parser():
                       help=optparse.SUPPRESS_HELP)
     parser.add_option("--upload-host", dest="upload_host",
                       help="if specified, gathers diagnotics and uploads it to the specified host,"
-                           " e.g 'https://s3.amazonaws.com/cb-customers'")
+                           " e.g 'https://uploads.couchbase.com'")
     parser.add_option("--customer", dest="upload_customer",
                       help="used in conjunction with '--upload-host' and '--ticket', "
                            "specifies the customer name for the upload")


### PR DESCRIPTION
Provides a more generic URL for sgcollect uploads. The old URL still works, but is being deprecated by Amazon.

/cc @JFlath 