### PR TITLE
Jenkinsfile: Allow goveralls to fail silently in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,7 @@ pipeline {
                                     // Publish CE coverage to coveralls.io
                                     // Replace covermode values with set just for coveralls to reduce the variability in reports.
                                     sh 'awk \'NR==1{print "mode: set";next} $NF>0{$NF=1} {print}\' cover_ce.out > cover_ce_coveralls.out'
-                                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN}"
+                                    sh "goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=${COVERALLS_TOKEN} || true"
                                 }
                             }
                         }


### PR DESCRIPTION
Prevents third-party service outage from causing build failure.

```
+ goveralls -coverprofile=cover_ce_coveralls.out -service=uberjenkins -repotoken=****
Bad response status from coveralls: 503
<h2>This website is under heavy load (queue full)</h2><p>We're sorry, too many people are accessing this website at the same time. We're working on this problem. Please try again later.</p>
script returned exit code 1
```