### PR TITLE
Add InjectJSONProperty utility functions

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1063,6 +1063,8 @@ func Sha1HashString(str string, salt string) string {
 // This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
 // usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
 func InjectJSONProperty(b []byte, key string, val interface{}) (new []byte, err error) {
+	b = bytes.TrimSpace(b)
+
 	bIsJSONObject, bIsEmpty := isJSONObject(b)
 	if !bIsJSONObject {
 		return nil, errors.New("b is not a JSON object")
@@ -1081,6 +1083,8 @@ func InjectJSONProperty(b []byte, key string, val interface{}) (new []byte, err 
 // This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
 // usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
 func InjectJSONPropertyFromBytes(b []byte, key string, val []byte) (new []byte, err error) {
+	b = bytes.TrimSpace(b)
+
 	bIsJSONObject, bIsEmpty := isJSONObject(b)
 	if !bIsJSONObject {
 		return nil, errors.New("b is not a JSON object")

--- a/base/util.go
+++ b/base/util.go
@@ -1059,6 +1059,9 @@ func Sha1HashString(str string, salt string) string {
 }
 
 // InjectJSONProperty takes the given JSON byte slice, marshals val, and inserts under the given key, and returns the result.
+//
+// This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
+// usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
 func InjectJSONProperty(b []byte, key string, val interface{}) (new []byte, err error) {
 	bIsJSONObject, bIsEmpty := isJSONObject(b)
 	if !bIsJSONObject {
@@ -1074,6 +1077,9 @@ func InjectJSONProperty(b []byte, key string, val interface{}) (new []byte, err 
 }
 
 // InjectJSONPropertyFromBytes takes the given JSON byte slice, and inserts val under the given key, and returns the result.
+//
+// This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
+// usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
 func InjectJSONPropertyFromBytes(b []byte, key string, val []byte) (new []byte, err error) {
 	bIsJSONObject, bIsEmpty := isJSONObject(b)
 	if !bIsJSONObject {
@@ -1095,7 +1101,7 @@ func isJSONObject(b []byte) (isJSONObject, isEmpty bool) {
 	return true, len(b) == 2
 }
 
-// injectJSONPropertyFromBytes injects val under the given key into b, assuming b is a JSON object.
+// injectJSONPropertyFromBytes injects val under the given key into b.
 func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, key string, val []byte) (newJSON []byte) {
 
 	// the overhead of wrapping key in quotes, a colon, and a comma if body is not empty
@@ -1119,8 +1125,8 @@ func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, key string, val []byte
 	offset += copy(newJSON[offset:], `"`+key+`":`)
 	offset += copy(newJSON[offset:], val)
 
-	// copy the last closing brace of b
-	_ = copy(newJSON[offset:], b[len(b)-1:])
+	// closing brace
+	_ = copy(newJSON[offset:], "}")
 
 	return newJSON
 }

--- a/base/util.go
+++ b/base/util.go
@@ -1058,31 +1058,17 @@ func Sha1HashString(str string, salt string) string {
 	return fmt.Sprintf("%x", hashedKey)
 }
 
-// InjectJSONProperty takes the given JSON byte slice, marshals val, and inserts under the given key, and returns the result.
-//
-// This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
-// usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
-func InjectJSONProperty(b []byte, key string, val interface{}) (new []byte, err error) {
-	b = bytes.TrimSpace(b)
-
-	bIsJSONObject, bIsEmpty := isJSONObject(b)
-	if !bIsJSONObject {
-		return nil, errors.New("b is not a JSON object")
-	}
-
-	valBytes, err := json.Marshal(val)
-	if err != nil {
-		return nil, err
-	}
-
-	return injectJSONPropertyFromBytes(b, bIsEmpty, key, valBytes), nil
+// KVPair represents a single KV pair to be used in InjectJSONProperties
+type KVPair struct {
+	Key string
+	Val interface{}
 }
 
-// InjectJSONPropertyFromBytes takes the given JSON byte slice, and inserts val under the given key, and returns the result.
+// InjectJSONProperties takes the given JSON byte slice, and for each KV pair, marshals the value and inserts into b under the given key.
 //
 // This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
 // usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
-func InjectJSONPropertyFromBytes(b []byte, key string, val []byte) (new []byte, err error) {
+func InjectJSONProperties(b []byte, kvPairs ...KVPair) (new []byte, err error) {
 	b = bytes.TrimSpace(b)
 
 	bIsJSONObject, bIsEmpty := isJSONObject(b)
@@ -1090,7 +1076,45 @@ func InjectJSONPropertyFromBytes(b []byte, key string, val []byte) (new []byte, 
 		return nil, errors.New("b is not a JSON object")
 	}
 
-	return injectJSONPropertyFromBytes(b, bIsEmpty, key, val), nil
+	if len(kvPairs) < 1 {
+		return nil, errors.New("kvPairs was empty")
+	}
+
+	kvPairsBytes := make([]KVPairBytes, len(kvPairs))
+	for i, kv := range kvPairs {
+		valBytes, err := json.Marshal(kv.Val)
+		if err != nil {
+			return nil, err
+		}
+		kvPairsBytes[i] = KVPairBytes{Key: kv.Key, Val: valBytes}
+	}
+
+	return injectJSONPropertyFromBytes(b, bIsEmpty, kvPairsBytes), nil
+}
+
+// KVPairBytes represents a single KV pair to be used in InjectJSONPropertiesFromBytes
+type KVPairBytes struct {
+	Key string
+	Val []byte
+}
+
+// InjectJSONPropertiesFromBytes takes the given JSON byte slice, and for each KV pair, inserts into b under the given key.
+//
+// This has the potential to create duplicate keys, which whilst adhering to the spec, are ambiguous with how they get read...
+// usually "last key wins" - although there is no standardized way of handling JSON with non-unique keys.
+func InjectJSONPropertiesFromBytes(b []byte, kvPairs ...KVPairBytes) (new []byte, err error) {
+	b = bytes.TrimSpace(b)
+
+	bIsJSONObject, bIsEmpty := isJSONObject(b)
+	if !bIsJSONObject {
+		return nil, errors.New("b is not a JSON object")
+	}
+
+	if len(kvPairs) < 1 {
+		return nil, errors.New("kvPairs was empty")
+	}
+
+	return injectJSONPropertyFromBytes(b, bIsEmpty, kvPairs), nil
 }
 
 // isJSONObject checks if the given bytes are a JSON object,
@@ -1106,28 +1130,33 @@ func isJSONObject(b []byte) (isJSONObject, isEmpty bool) {
 }
 
 // injectJSONPropertyFromBytes injects val under the given key into b.
-func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, key string, val []byte) (newJSON []byte) {
+func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, kvPairs []KVPairBytes) (newJSON []byte) {
 
-	// the overhead of wrapping key in quotes, a colon, and a comma if body is not empty
-	jsonOverhead := 4
+	newJSONLength := len(b)
+	for _, kv := range kvPairs {
+		newJSONLength += len(kv.Key) + len(kv.Val) + 4 // json overhead for comma, quoted key, and colon
+	}
 	if bIsEmpty {
-		jsonOverhead = 3
+		// Take off the length of a comma when the starting body is empty
+		newJSONLength--
 	}
 
 	// Create the new byte slice with the required capacity
-	newJSON = make([]byte, len(b)+len(val)+len(key)+jsonOverhead)
+	newJSON = make([]byte, newJSONLength)
 
 	// copy almost all of b, except the last closing brace
 	offset := copy(newJSON, b[0:len(b)-1])
 
-	// if the body isn't empty, append a comma before we insert our property
-	if !bIsEmpty {
-		offset += copy(newJSON[offset:], ",")
-	}
+	for i, kv := range kvPairs {
+		// if the body isn't empty, or we're not on our first value, prepend a comma before our property
+		if i > 0 || !bIsEmpty {
+			offset += copy(newJSON[offset:], ",")
+		}
 
-	// inject valBytes as the last property
-	offset += copy(newJSON[offset:], `"`+key+`":`)
-	offset += copy(newJSON[offset:], val)
+		// inject valBytes as the last property
+		offset += copy(newJSON[offset:], `"`+kv.Key+`":`)
+		offset += copy(newJSON[offset:], kv.Val)
+	}
 
 	// closing brace
 	_ = copy(newJSON[offset:], "}")

--- a/base/util.go
+++ b/base/util.go
@@ -1088,7 +1088,7 @@ func InjectJSONPropertyFromBytes(b []byte, key string, val []byte) (new []byte, 
 func isJSONObject(b []byte) (isJSONObject, isEmpty bool) {
 
 	// Check if the byte slice starts with { and ends with }
-	if b[0] != 0x7b || b[len(b)-1] != 0x7d {
+	if len(b) < 2 || b[0] != 0x7b || b[len(b)-1] != 0x7d {
 		return false, false
 	}
 

--- a/base/util.go
+++ b/base/util.go
@@ -1096,7 +1096,7 @@ func isJSONObject(b []byte) (isJSONObject, isEmpty bool) {
 }
 
 // injectJSONPropertyFromBytes injects val under the given key into b, assuming b is a JSON object.
-func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, key string, val []byte) (new []byte) {
+func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, key string, val []byte) (newJSON []byte) {
 
 	// the overhead of wrapping key in quotes, a colon, and a comma if body is not empty
 	jsonOverhead := 4
@@ -1105,22 +1105,22 @@ func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, key string, val []byte
 	}
 
 	// Create the new byte slice with the required capacity
-	new = make([]byte, 0, len(b)+len(val)+len(key)+jsonOverhead)
+	newJSON = make([]byte, len(b)+len(val)+len(key)+jsonOverhead)
 
 	// copy almost all of b, except the last closing brace
-	new = append(new, b[0:len(b)-1]...)
+	offset := copy(newJSON, b[0:len(b)-1])
 
 	// if the body isn't empty, append a comma before we insert our property
 	if !bIsEmpty {
-		new = append(new, []byte(",")...)
+		offset += copy(newJSON[offset:], ",")
 	}
 
 	// inject valBytes as the last property
-	new = append(new, []byte(`"`+key+`":`)...)
-	new = append(new, val...)
+	offset += copy(newJSON[offset:], `"`+key+`":`)
+	offset += copy(newJSON[offset:], val)
 
 	// copy the last closing brace of b
-	new = append(new, b[len(b)-1:]...)
+	_ = copy(newJSON[offset:], b[len(b)-1:])
 
-	return new
+	return newJSON
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -765,3 +765,30 @@ func BenchmarkInjectJSONPropertyFromBytes(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkInjectJSONProperty(b *testing.B) {
+	newValKey := "newval"
+	newVal := 123
+
+	tests := []struct {
+		input string
+	}{
+		{
+			input: `null`,
+		},
+		{
+			input: "{}",
+		},
+		{
+			input: `{"key":"val"}`,
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.input, func(bb *testing.B) {
+			for i := 0; i < bb.N; i++ {
+				_, _ = InjectJSONProperty([]byte(test.input), newValKey, newVal)
+			}
+		})
+	}
+}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -649,6 +649,10 @@ func TestInjectJSONProperty(t *testing.T) {
 		expectedErr    string
 	}{
 		{
+			input:       ``,
+			expectedErr: `not a JSON object`,
+		},
+		{
 			input:       `null`,
 			expectedErr: `not a JSON object`,
 		},
@@ -698,6 +702,10 @@ func TestInjectJSONPropertyFromBytes(t *testing.T) {
 		expectedOutput string
 		expectedErr    string
 	}{
+		{
+			input:       ``,
+			expectedErr: `not a JSON object`,
+		},
 		{
 			input:       `null`,
 			expectedErr: `not a JSON object`,

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 )
@@ -672,11 +674,10 @@ func TestInjectJSONProperty(t *testing.T) {
 		t.Run(test.input, func(tt *testing.T) {
 			output, err := InjectJSONProperty([]byte(test.input), newValKey, newVal)
 			if test.expectedErr != "" {
-				assert.Errorf(tt, err, test.expectedErr, "expected error did not match")
+				require.Errorf(tt, err, test.expectedErr, "expected error did not match")
 				return
 			} else {
-				assert.NoError(tt, err, "unexpected error")
-				return
+				require.NoError(tt, err, "unexpected error")
 			}
 
 			assert.Equal(tt, test.expectedOutput, string(output))
@@ -723,11 +724,10 @@ func TestInjectJSONPropertyFromBytes(t *testing.T) {
 		t.Run(test.input, func(tt *testing.T) {
 			output, err := InjectJSONPropertyFromBytes([]byte(test.input), newValKey, newValBytes)
 			if test.expectedErr != "" {
-				assert.Errorf(tt, err, test.expectedErr, "expected error did not match")
+				require.Errorf(tt, err, test.expectedErr, "expected error did not match")
 				return
 			} else {
-				assert.NoError(tt, err, "unexpected error")
-				return
+				require.NoError(tt, err, "unexpected error")
 			}
 
 			assert.Equal(tt, test.expectedOutput, string(output))

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -672,6 +672,10 @@ func TestInjectJSONProperty(t *testing.T) {
 			input:          `{"newval":"old"}`,
 			expectedOutput: `{"newval":"old","newval":123}`,
 		},
+		{
+			input:          `    {"key":"val"}  `,
+			expectedOutput: `{"key":"val","newval":123}`,
+		},
 	}
 
 	for _, test := range tests {
@@ -725,6 +729,10 @@ func TestInjectJSONPropertyFromBytes(t *testing.T) {
 		{
 			input:          `{"newval":"old"}`,
 			expectedOutput: `{"newval":"old","newval":{"abc":123,"nums":["one","two","three"],"test":true}}`,
+		},
+		{
+			input:          `    {"key":"val"}  `,
+			expectedOutput: `{"key":"val","newval":{"abc":123,"nums":["one","two","three"],"test":true}}`,
 		},
 	}
 


### PR DESCRIPTION
Allows cheap injection of a value under a given key into a byte slice containing a marshalled JSON object.

```
16:13 $ go test -run=xxx -bench=BenchmarkInjectJSONProperties -benchmem -v ./base
goos: darwin
goarch: amd64
pkg: github.com/couchbase/sync_gateway/base
BenchmarkInjectJSONPropertiesFromBytes/null-12                    30000000     44.0 ns/op     16 B/op    1 allocs/op
BenchmarkInjectJSONPropertiesFromBytes/{}-12                      10000000    154   ns/op     96 B/op    1 allocs/op
BenchmarkInjectJSONPropertiesFromBytes/{"key":"val"}-12           10000000    165   ns/op    112 B/op    1 allocs/op
BenchmarkInjectJSONPropertiesFromBytes_Multiple/null-12           30000000     44.3 ns/op     16 B/op    1 allocs/op
BenchmarkInjectJSONPropertiesFromBytes_Multiple/{}-12             20000000     87.1 ns/op     64 B/op    1 allocs/op
BenchmarkInjectJSONPropertiesFromBytes_Multiple/{"key":"val"}-12  20000000     94.4 ns/op     80 B/op    1 allocs/op
BenchmarkInjectJSONProperties/null-12                             30000000     43.3 ns/op     16 B/op    1 allocs/op
BenchmarkInjectJSONProperties/{}-12                                5000000    300   ns/op     72 B/op    3 allocs/op
BenchmarkInjectJSONProperties/{"key":"val"}-12                     5000000    311   ns/op     88 B/op    3 allocs/op
BenchmarkInjectJSONProperties_Multiple/null-12                    30000000     42.8 ns/op     16 B/op    1 allocs/op
BenchmarkInjectJSONProperties_Multiple/{}-12                       2000000    724   ns/op    200 B/op    5 allocs/op
BenchmarkInjectJSONProperties_Multiple/{"key":"val"}-12            2000000    730   ns/op    216 B/op    5 allocs/op
PASS
ok      github.com/couchbase/sync_gateway/base    20.896s
```