### PR TITLE
CBG-493 - Tidy BLIP code

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -161,7 +161,7 @@ func (h *handler) handleBLIPSync() error {
 	server.Handler = func(conn *websocket.Conn) {
 		h.logStatus(101, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol%s", blipContext.ID, h.formattedEffectiveUserName()))
 		defer func() {
-			conn.Close() // in case it wasn't closed already
+			_ = conn.Close() // in case it wasn't closed already
 			ctx.Logf(base.LevelInfo, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())
 		}()
 		defaultHandler(conn)
@@ -264,7 +264,8 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 	response.Properties[getCheckpointResponseRev] = value[db.BodyRev].(string)
 	delete(value, db.BodyRev)
 	delete(value, db.BodyId)
-	response.SetJSONBody(value)
+	// TODO: Marshaling here when we could use raw bytes all the way from the bucket
+	_ = response.SetJSONBody(value)
 	return nil
 }
 

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -325,36 +325,11 @@ func (rm *revMessage) setRev(rev string) {
 	rm.Properties[revMessageRev] = rev
 }
 
-func (rm *revMessage) setDeleted(deleted bool) {
-	if deleted {
-		rm.Properties[revMessageDeleted] = "1"
-	} else {
-		delete(rm.Properties, revMessageDeleted)
-	}
-}
-
 // setProperties will add the given properties to the blip message, overwriting any that already exist.
 func (rm *revMessage) setProperties(properties blip.Properties) {
 	for k, v := range properties {
 		rm.Properties[k] = v
 	}
-}
-
-func (rm *revMessage) setHistory(history []string) {
-	if len(history) > 0 {
-		rm.Properties[revMessageHistory] = strings.Join(history, ",")
-	} else {
-		delete(rm.Properties, revMessageHistory)
-	}
-}
-
-func (rm *revMessage) setSequence(seq db.SequenceID) error {
-	seqJSON, marshalErr := json.Marshal(seq)
-	if marshalErr != nil {
-		return marshalErr
-	}
-	rm.Properties[revMessageSequence] = string(seqJSON)
-	return nil
 }
 
 func (rm *revMessage) String() string {


### PR DESCRIPTION
- [x] Merge #4220 first and change base branch in PR

## Changes:
- Pull BLIP message properties up into helper function instead of parameters
- Tidy up BLIP regexp init
- Rename BLIP things to be more consistent with Go's HTTP package (handlerFunc, etc.)
- Explicitly ignore a couple of errors
- Minor tidy up