### PR TITLE
CBG-463 - Remove retry timeout on write operations

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -781,7 +781,6 @@ func createBatchesKeys(batchSize uint, keys []string) [][]string {
 // on the next call.  Only useful for unit tests.
 var doSingleFakeRecoverableGOCBError = false
 
-
 // Recoverable errors or timeouts trigger retry for gocb read operations
 func isRecoverableReadError(err error) bool {
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -135,15 +135,15 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 	}
 
 	keyPrefix := "TestAddRawTimeout"
-	largeDoc := make([]byte,1000000)
+	largeDoc := make([]byte, 1000000)
 	rand.Read(largeDoc)
 
 	var wg sync.WaitGroup
-	for i:=0; i<100; i++ {
+	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			key := fmt.Sprintf("%s_%d", keyPrefix,i)
+			key := fmt.Sprintf("%s_%d", keyPrefix, i)
 			added, err := bucket.AddRaw(key, 0, largeDoc)
 			if err != nil {
 				if pkgerrors.Cause(err) != gocb.ErrTimeout {
@@ -158,7 +158,6 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 	wg.Wait()
 
 }
-
 
 func TestBulkGetRaw(t *testing.T) {
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -14,8 +14,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -116,6 +119,46 @@ func TestAddRaw(t *testing.T) {
 	}
 
 }
+
+// TestAddRawTimeout attempts to fill up the gocbpipeline by writing large documents concurrently with a small timeout,
+// to verify that timeout errors are returned, and the operation isn't retried (which would return a cas error).
+//   (see CBG-463)
+func TestAddRawTimeoutRetry(t *testing.T) {
+
+	testBucket := GetTestBucket(t)
+	defer testBucket.Close()
+	bucket := testBucket.Bucket
+
+	gocbBucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if ok {
+		gocbBucket.Bucket.SetOperationTimeout(100 * time.Millisecond)
+	}
+
+	keyPrefix := "TestAddRawTimeout"
+	largeDoc := make([]byte,1000000)
+	rand.Read(largeDoc)
+
+	var wg sync.WaitGroup
+	for i:=0; i<100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("%s_%d", keyPrefix,i)
+			added, err := bucket.AddRaw(key, 0, largeDoc)
+			if err != nil {
+				if pkgerrors.Cause(err) != gocb.ErrTimeout {
+					t.Errorf("Unexpected error calling AddRaw(): %v", err)
+				}
+			} else {
+				assert.True(t, added, fmt.Sprintf("AddRaw returned added=false, expected true for key %v", key))
+			}
+		}(i)
+
+	}
+	wg.Wait()
+
+}
+
 
 func TestBulkGetRaw(t *testing.T) {
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -68,7 +68,7 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params interface{}, c
 		}
 
 		// Timeout error - return named error
-		if isGoCBTimeoutError(queryErr) {
+		if isGoCBQueryTimeoutError(queryErr) {
 			return queryResults, ErrViewTimeoutError
 		}
 


### PR DESCRIPTION
A gocb timeout on a write operation leaves the write in the pipeline, where it will usually eventually succeed.  Retrying will result in additional pipeline bloat, and eventual CAS errors.