### PR TITLE
CBG-483 Independent feeds for import, caching

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -118,6 +118,8 @@ const (
 	StatKeyDcpReceivedTime         = "dcp_received_time"
 	StatKeyDcpCachingCount         = "dcp_caching_count"
 	StatKeyDcpCachingTime          = "dcp_caching_time"
+	StatKeyCachingDcpStats         = "cache_feed"
+	StatKeyImportDcpStats          = "import_feed"
 
 	// StatsDeltaSync
 	StatKeyDeltasRequested           = "deltas_requested"

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -395,15 +395,11 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 
 	// If using xattrs and this isn't an SG write, we shouldn't attempt to cache.
 	if c.context.UseXattrs() {
-		var isSGWrite bool
-		if syncData != nil {
-			var crc32Match bool
-			isSGWrite, crc32Match = syncData.IsSGWrite(event.Cas, rawBody)
-			if crc32Match {
-				c.context.DbStats.StatsDatabase().Add(base.StatKeyCrc32cMatchCount, 1)
-			}
+		if syncData == nil {
+			return
 		}
-		if syncData == nil || !isSGWrite {
+		isSGWrite, _ := syncData.IsSGWrite(event.Cas, rawBody)
+		if !isSGWrite {
 			return
 		}
 	}

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -171,6 +171,8 @@ func initEmptyStatsMap(key string, d *DatabaseStats) *expvar.Map {
 		result.Set(base.StatKeyDcpCachingTime, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyDcpReceivedCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyDcpReceivedTime, base.ExpvarIntVal(0))
+		result.Set(base.StatKeyCachingDcpStats, new(expvar.Map).Init())
+		result.Set(base.StatKeyImportDcpStats, new(expvar.Map).Init())
 		d.statsDatabaseMap = result
 	case base.StatsGroupKeyDeltaSync:
 		result.Set(base.StatKeyDeltasRequested, base.ExpvarIntVal(0))

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"expvar"
+	"strings"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// importListener manages the import DCP feed.  ProcessFeedEvent is triggered for each feed events,
+// and invokes ImportFeedEvent for any event that's eligible for import handling.
+type importListener struct {
+	bucketName string      // Used for logging
+	terminator chan bool   // Signal to cause cbdatasource bucketdatasource.Close() to be called, which removes dcp receiver
+	database   Database    // Admin database instance to be used for import
+	stats      *expvar.Map // Database stats group
+}
+
+func NewImportListener() *importListener {
+
+	importListener := &importListener{
+		terminator: make(chan bool),
+	}
+	return importListener
+}
+
+// StartImportFeed starts an import DCP feed.  Always starts the feed based on previous checkpoints (Backfill:FeedResume).
+// Writes DCP stats into the StatKeyImportDcpStats map
+func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *DatabaseStats, dbContext *DatabaseContext) error {
+
+	base.Infof(base.KeyDCP, "Attempting to start import DCP feed...")
+
+	il.bucketName = bucket.GetName()
+	il.database = Database{DatabaseContext: dbContext, user: nil}
+	il.stats = dbStats.statsDatabaseMap
+	feedArgs := sgbucket.FeedArguments{
+		ID:         base.DCPImportFeedID,
+		Backfill:   sgbucket.FeedResume,
+		Terminator: il.terminator,
+	}
+
+	importFeedStatsMap, ok := dbContext.DbStats.statsDatabaseMap.Get(base.StatKeyImportDcpStats).(*expvar.Map)
+	if !ok {
+		base.Infof(base.KeyDCP, "Import feed stats map not initialized - will not be tracked")
+	}
+
+	// Start DCP mutation feed
+	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
+
+	return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap)
+}
+
+// ProcessFeedEvent is invoked for each mutate or delete event seen on the server's mutation feed.  It may be
+// executed concurrently for multiple events from different vbuckets.  Filters out
+// internal documents based on key, then checks sync metadata to determine whether document needs to be imported
+func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPersistCheckpoint bool) {
+
+	shouldPersistCheckpoint = true
+
+	// Ignore non-mutation/deletion events
+	if event.Opcode != sgbucket.FeedOpMutation && event.Opcode != sgbucket.FeedOpDeletion {
+		return shouldPersistCheckpoint
+	}
+	key := string(event.Key)
+
+	// Ignore internal documents
+	if strings.HasPrefix(key, base.SyncPrefix) {
+		if strings.HasPrefix(key, base.DCPCheckpointPrefix) {
+			shouldPersistCheckpoint = false
+		}
+		return shouldPersistCheckpoint
+	}
+
+	// If this is a delete and there are no xattrs (no existing SG revision), we shouldn't import
+	if event.Opcode == sgbucket.FeedOpDeletion && len(event.Value) == 0 {
+		base.Debugf(base.KeyImport, "Ignoring delete mutation for %s - no existing Sync Gateway metadata.", base.UD(event.Key))
+		return shouldPersistCheckpoint
+	}
+
+	// If this is a binary document we can ignore, but update checkpoint to avoid reprocessing upon restart
+	if event.DataType == base.MemcachedDataTypeRaw {
+		return shouldPersistCheckpoint
+	}
+
+	il.ImportFeedEvent(event)
+	return shouldPersistCheckpoint
+}
+
+func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
+
+	// Unmarshal the doc metadata to determine if this mutation requires import:
+	syncData, rawBody, rawXattr, err := UnmarshalDocumentSyncDataFromFeed(event.Value, event.DataType, false)
+	if err != nil {
+		base.Debugf(base.KeyCache, "Unable to unmarshal sync metadata for feed document %q.  Will not be included in channel cache.  Error: %v", base.UD(event.Key), err)
+		if err == base.ErrEmptyMetadata {
+			base.Warnf(base.KeyAll, "Unexpected empty metadata when processing feed event.  docid: %s opcode: %v datatype:%v", base.UD(event.Key), event.Opcode, event.DataType)
+		}
+		return
+	}
+
+	var isSGWrite bool
+	var crc32Match bool
+	if syncData != nil {
+		isSGWrite, crc32Match = syncData.IsSGWrite(event.Cas, rawBody)
+		if crc32Match {
+			il.stats.Add(base.StatKeyCrc32cMatchCount, 1)
+		}
+	}
+
+	// If syncData is nil, or if this was not an SG write, attempt to import
+	if syncData == nil || !isSGWrite {
+		isDelete := event.Opcode == sgbucket.FeedOpDeletion
+		if isDelete {
+			rawBody = nil
+		}
+		docID := string(event.Key)
+		_, err := il.database.ImportDocRaw(docID, rawBody, rawXattr, isDelete, event.Cas, &event.Expiry, ImportFromFeed)
+		if err != nil {
+			if err == base.ErrImportCasFailure {
+				base.Debugf(base.KeyImport, "Not importing mutation - document %s has been subsequently updated and will be imported based on that mutation.", base.UD(docID))
+			} else if err == base.ErrImportCancelledFilter {
+				// No logging required - filter info already logged during importDoc
+			} else {
+				base.Debugf(base.KeyImport, "Did not import doc %q - external update will not be accessible via Sync Gateway.  Reason: %v", base.UD(docID), err)
+			}
+		}
+	}
+}
+
+func (il *importListener) Stop() {
+	close(il.terminator)
+}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,7 +45,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="0bee044932a86c40e25a01f9f46cc62374e7f3af"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="de3a040899d6acf57077599b2ea15b3677f56864"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,7 +45,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e3767aa427bf68885260f46d406627edd7982774"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="0bee044932a86c40e25a01f9f46cc62374e7f3af"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"log"
 	"net/http"
@@ -1749,8 +1750,10 @@ func TestDcpBackfill(t *testing.T) {
 	backfillComplete := false
 	var expectedBackfill, completedBackfill int
 	for i := 0; i < 20; i++ {
-		expectedBackfill, _ := strconv.Atoi(newRt.GetDatabase().DbStats.StatsDatabase().Get("dcp_backfill_expected").String())
-		completedBackfill, _ := strconv.Atoi(newRt.GetDatabase().DbStats.StatsDatabase().Get("dcp_backfill_completed").String())
+		importFeedStats, ok := newRt.GetDatabase().DbStats.StatsDatabase().Get(base.StatKeyImportDcpStats).(*expvar.Map)
+		assert.True(t, ok)
+		expectedBackfill, _ := strconv.Atoi(importFeedStats.Get("dcp_backfill_expected").String())
+		completedBackfill, _ := strconv.Atoi(importFeedStats.Get("dcp_backfill_completed").String())
 		if expectedBackfill > 0 && completedBackfill >= expectedBackfill {
 			log.Printf("backfill complete: %d/%d", completedBackfill, expectedBackfill)
 			backfillComplete = true


### PR DESCRIPTION
Use distinct DCP feeds for import and caching.  Prerequisite for sharded import processing.  Adds an import_listener to manage the import feed, and moves feed-based import logic there from DocChanged.

Adds separate feed name prefix (SGI) for the import feed - caching feed uses the previous name (SG).  Added this prefix to DCP logging for additional context.

Required a fix during feed initialization - we were previously mutating cbdatasource.DefaultBucketDataSourceOptions, which resulted in feed name collisions when starting multiple feeds.

Depends on https://github.com/couchbase/sg-bucket/pull/48

- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/1253/