### PR TITLE
Tidy up SpecialProperties utils

### DIFF
--- a/db/revision.go
+++ b/db/revision.go
@@ -427,16 +427,16 @@ func compareRevIDs(id1, id2 string) int {
 
 // stripSpecialProperties returns a copy of the given body with all underscore-prefixed keys removed, except _attachments and _deleted.
 func stripSpecialProperties(b Body) Body {
-	return stripSpecialPropertiesExcept(b, []string{BodyAttachments, BodyDeleted})
+	return stripSpecialPropertiesExcept(b, BodyAttachments, BodyDeleted)
 }
 
 // stripAllSpecialProperties returns a copy of the given body with all underscore-prefixed keys removed.
 func stripAllSpecialProperties(b Body) Body {
-	return stripSpecialPropertiesExcept(b, nil)
+	return stripSpecialPropertiesExcept(b)
 }
 
 // stripSpecialPropertiesExcept returns a copy of the given body with all underscore-prefixed keys removed, except those given.
-func stripSpecialPropertiesExcept(b Body, exceptions []string) Body {
+func stripSpecialPropertiesExcept(b Body, exceptions ...string) Body {
 	// Assume no properties removed for the initial capacity to reduce allocs on large docs.
 	stripped := make(Body, len(b))
 	for k, v := range b {

--- a/db/revision.go
+++ b/db/revision.go
@@ -453,11 +453,13 @@ func stripSpecialPropertiesExcept(b Body, exceptions []string) Body {
 func containsUserSpecialProperties(b Body) bool {
 	for k := range b {
 		if k != "" && k[0] == '_' &&
-			k != BodyId &&
-			k != BodyRev &&
-			k != BodyDeleted &&
-			k != BodyAttachments &&
-			k != BodyRevisions {
+			!base.ContainsString([]string{
+				BodyId,
+				BodyRev,
+				BodyDeleted,
+				BodyAttachments,
+				BodyRevisions,
+			}, k) {
 			// body contains special property that isn't one of the above... must be user's
 			return true
 		}

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -84,3 +84,61 @@ func TestParseRevisionsToAncestor(t *testing.T) {
 	shortRevisions := Revisions{RevisionsStart: 3, RevisionsIds: []string{"three"}}
 	assert.Equal(t, []string(nil), shortRevisions.parseAncestorRevisions("2-two"))
 }
+
+func BenchmarkStripSpecialProperties(b *testing.B) {
+	tests := []struct {
+		name string
+		body Body
+	}{
+		{
+			"no special",
+			Body{
+				"asdf":  "qwerty",
+				"one":   1,
+				"two":   2,
+				"three": 3,
+				"four":  4,
+				"five":  5,
+				"six":   6,
+				"seven": 7,
+				"eight": 8,
+				"nine":  9,
+				"ten":   10,
+				"a":     true,
+				"b":     true,
+				"c":     true,
+			},
+		},
+		{
+			"special",
+			Body{
+				"asdf":  "qwerty",
+				"one":   1,
+				"two":   2,
+				"three": 3,
+				"four":  4,
+				"five":  5,
+				"six":   6,
+				"seven": 7,
+				"eight": 8,
+				"nine":  9,
+				"ten":   10,
+				"a":     true,
+				"b":     true,
+				"c":     true,
+				BodyId:  "1234",
+				BodyRev: "1-abc",
+			},
+		},
+	}
+
+	for _, t := range tests {
+		b.Run(t.name, func(bb *testing.B) {
+			bb.ReportAllocs()
+			for i := 0; i < bb.N; i++ {
+				stripSpecialProperties(t.body)
+			}
+		})
+	}
+
+}

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -85,60 +85,46 @@ func TestParseRevisionsToAncestor(t *testing.T) {
 	assert.Equal(t, []string(nil), shortRevisions.parseAncestorRevisions("2-two"))
 }
 
-func BenchmarkStripSpecialProperties(b *testing.B) {
+func BenchmarkSpecialProperties(b *testing.B) {
+	noSpecialBody := Body{
+		"asdf": "qwerty", "a": true, "b": true, "c": true,
+		"one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+		"six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+	}
+
+	specialBody := noSpecialBody.Copy(BodyShallowCopy)
+	specialBody[BodyId] = "abc123"
+	specialBody[BodyRev] = "1-abc"
+
 	tests := []struct {
 		name string
 		body Body
 	}{
 		{
 			"no special",
-			Body{
-				"asdf":  "qwerty",
-				"one":   1,
-				"two":   2,
-				"three": 3,
-				"four":  4,
-				"five":  5,
-				"six":   6,
-				"seven": 7,
-				"eight": 8,
-				"nine":  9,
-				"ten":   10,
-				"a":     true,
-				"b":     true,
-				"c":     true,
-			},
+			noSpecialBody,
 		},
 		{
 			"special",
-			Body{
-				"asdf":  "qwerty",
-				"one":   1,
-				"two":   2,
-				"three": 3,
-				"four":  4,
-				"five":  5,
-				"six":   6,
-				"seven": 7,
-				"eight": 8,
-				"nine":  9,
-				"ten":   10,
-				"a":     true,
-				"b":     true,
-				"c":     true,
-				BodyId:  "1234",
-				BodyRev: "1-abc",
-			},
+			specialBody,
 		},
 	}
 
 	for _, t := range tests {
-		b.Run(t.name, func(bb *testing.B) {
-			bb.ReportAllocs()
+		b.Run(t.name+"-stripSpecialProperties", func(bb *testing.B) {
 			for i := 0; i < bb.N; i++ {
 				stripSpecialProperties(t.body)
 			}
 		})
+		b.Run(t.name+"-stripAllSpecialProperties", func(bb *testing.B) {
+			for i := 0; i < bb.N; i++ {
+				stripAllSpecialProperties(t.body)
+			}
+		})
+		b.Run(t.name+"-containsUserSpecialProperties", func(bb *testing.B) {
+			for i := 0; i < bb.N; i++ {
+				containsUserSpecialProperties(t.body)
+			}
+		})
 	}
-
 }

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -94,7 +94,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 
 func (db *Database) PutSpecial(doctype string, docid string, body Body) (string, error) {
 	matchRev, _ := body[BodyRev].(string)
-	body = stripSpecialSpecialProperties(body)
+	body = stripAllSpecialProperties(body)
 	return db.putSpecial(doctype, docid, matchRev, body)
 }
 
@@ -105,14 +105,4 @@ func (db *Database) DeleteSpecial(doctype string, docid string, revid string) er
 
 func (db *Database) realSpecialDocID(doctype string, docid string) string {
 	return base.SyncPrefix + doctype + ":" + docid
-}
-
-func stripSpecialSpecialProperties(body Body) Body {
-	stripped := Body{}
-	for key, value := range body {
-		if key == "" || key[0] != '_' {
-			stripped[key] = value
-		}
-	}
-	return stripped
 }


### PR DESCRIPTION
- Renamed `stripSpecialSpecialProperties` -> `stripAllSpecialProperties`
- Reformatted ifs for clarity
- Pre-allocate new body capacity based on maximum possible size (no stripped properties)
```
21:20 $ go test -run=- -bench='BenchmarkStripSpecialProperties' -benchmem -count=3 ./db > old.txt
21:22 $ go test -run=- -bench='BenchmarkStripSpecialProperties' -benchmem -count=3 ./db > new.txt
21:23 $ benchcmp -best old.txt new.txt
benchmark                                         old ns/op     new ns/op     delta
BenchmarkStripSpecialProperties/no_special-12     1657          903           -45.50%
BenchmarkStripSpecialProperties/special-12        1689          944           -44.11%

benchmark                                         old allocs     new allocs     delta
BenchmarkStripSpecialProperties/no_special-12     4              2              -50.00%
BenchmarkStripSpecialProperties/special-12        4              2              -50.00%

benchmark                                         old bytes     new bytes     delta
BenchmarkStripSpecialProperties/no_special-12     2143          1202          -43.91%
BenchmarkStripSpecialProperties/special-12        2143          1202          -43.91%
```