### PR TITLE
CBG-486 Remove view dependency for heartbeat processing

### DIFF
--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -24,6 +25,7 @@ type Heartbeater interface {
 type HeartbeatChecker interface {
 	StartCheckingHeartbeats(staleThresholdMs int, handler HeartbeatsStoppedHandler) error
 	StopCheckingHeartbeats()
+	GetNodeList() []string
 }
 
 // A HeartbeatSender sends heartbeats
@@ -39,6 +41,17 @@ type HeartbeatsStoppedHandler interface {
 	StaleHeartBeatDetected(nodeUuid string)
 }
 
+// HeartbeatNodeSetHandler defines the interface to manage the list of nodes
+// participating in heartbeat processing.  This list is used by CouchbaseHeartbeater
+// instances to determine which heartbeat docs are monitored.
+// CouchbaseHeartbeater has an internal implementation (DocumentBackedNodeListHandler), but
+// accepts custom implementations.
+type HeartbeatNodeSetHandler interface {
+	AddNode(nodeID string) error
+	RemoveNode(nodeID string) error
+	GetNodes() ([]string, error)
+}
+
 type heartbeatMeta struct {
 	Type     string `json:"type"`
 	NodeUUID string `json:"node_uuid"`
@@ -52,6 +65,7 @@ type heartbeatTimeout struct {
 type couchbaseHeartBeater struct {
 	bucket               Bucket
 	nodeUuid             string
+	heartbeatHandler     HeartbeatNodeSetHandler
 	keyPrefix            string
 	heartbeatSendCloser  chan struct{} // break out of heartbeat sender goroutine
 	heartbeatCheckCloser chan struct{} // break out of heartbeat checker goroutine
@@ -66,17 +80,23 @@ type couchbaseHeartBeater struct {
 // and the nodeUuid, which is an opaque identifier for the "thing" that is using this
 // library.  You can think of nodeUuid as a generic token, so put whatever you want there
 // as long as it is unique to the node where this is running.  (eg, an ip address could work)
-func NewCouchbaseHeartbeater(bucket Bucket, keyPrefix, nodeUuid string) (*couchbaseHeartBeater, error) {
+func NewCouchbaseHeartbeater(bucket Bucket, keyPrefix, nodeUuid string, handler HeartbeatNodeSetHandler) (heartbeater *couchbaseHeartBeater, err error) {
 
-	heartbeater := &couchbaseHeartBeater{
+	heartbeater = &couchbaseHeartBeater{
 		bucket:               bucket,
 		nodeUuid:             nodeUuid,
+		heartbeatHandler:     handler,
 		keyPrefix:            keyPrefix,
 		heartbeatSendCloser:  make(chan struct{}),
 		heartbeatCheckCloser: make(chan struct{}),
 	}
 
-	return heartbeater, nil
+	// If custom handler not specified, default to document-based handler
+	if handler == nil {
+		heartbeater.heartbeatHandler, err = NewDocumentBackedNodeListHandler(bucket, keyPrefix)
+	}
+
+	return heartbeater, err
 
 }
 
@@ -84,6 +104,11 @@ func NewCouchbaseHeartbeater(bucket Bucket, keyPrefix, nodeUuid string) (*couchb
 // This method will BLOCK until the first heartbeat is sent, and the rest
 // will happen asynchronously.
 func (h *couchbaseHeartBeater) StartSendingHeartbeats(intervalSeconds int) error {
+
+	err := h.heartbeatHandler.AddNode(h.nodeUuid)
+	if err != nil {
+		return err
+	}
 
 	// send the first heartbeat in the current goroutine and return
 	// an error if it fails
@@ -140,10 +165,6 @@ func (h *couchbaseHeartBeater) StopSendingHeartbeats() {
 // will be called back in that case (and passed the opaque node uuid)
 func (h *couchbaseHeartBeater) StartCheckingHeartbeats(staleThresholdMs int, handler HeartbeatsStoppedHandler) error {
 
-	if err := h.addHeartbeatCheckView(); err != nil {
-		return err
-	}
-
 	ticker := time.NewTicker(time.Duration(staleThresholdMs) * time.Millisecond)
 
 	go func() {
@@ -170,24 +191,28 @@ func (h *couchbaseHeartBeater) StopCheckingHeartbeats() {
 	close(h.heartbeatCheckCloser)
 }
 
+func (h *couchbaseHeartBeater) GetNodeList() ([]string, error) {
+	return h.heartbeatHandler.GetNodes()
+}
+
 func (h *couchbaseHeartBeater) checkStaleHeartbeats(staleThresholdMs int, handler HeartbeatsStoppedHandler) error {
 
 	// query view to get all heartbeat docs
-	heartbeatDocs, err := h.viewQueryHeartbeatDocs()
+	heartbeatDocs, err := h.heartbeatHandler.GetNodes()
 	if err != nil {
 		return err
 	}
 
-	for _, heartbeatDoc := range heartbeatDocs {
-		if heartbeatDoc.NodeUUID == h.nodeUuid {
+	for _, heartbeatDocID := range heartbeatDocs {
+		if heartbeatDocID == h.nodeUuid {
 			// that's us, and we don't care about ourselves
 			continue
 		}
-		if heartbeatDoc.NodeUUID == "" {
+		if heartbeatDocID == "" {
 			continue
 		}
 
-		timeoutDocId := h.heartbeatTimeoutDocId(heartbeatDoc.NodeUUID)
+		timeoutDocId := heartbeatTimeoutDocId(heartbeatDocID, h.keyPrefix)
 		heartbeatTimeoutDoc := heartbeatTimeout{}
 		_, err := h.bucket.Get(timeoutDocId, &heartbeatTimeoutDoc)
 		if err != nil {
@@ -198,15 +223,11 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats(staleThresholdMs int, handle
 
 			// doc not found, which means the heartbeat doc expired.
 			// call back the handler.
-			handler.StaleHeartBeatDetected(heartbeatDoc.NodeUUID)
+			handler.StaleHeartBeatDetected(heartbeatDocID)
 
 			// delete the heartbeat doc itself so we don't have unwanted
 			// repeated callbacks to the stale heartbeat handler
-			docId := h.heartbeatDocId(heartbeatDoc.NodeUUID)
-			if err := h.bucket.Delete(docId); err != nil {
-				Infof(KeyImport, "Failed to delete heartbeat doc: %v err: %v", docId, err)
-			}
-
+			h.heartbeatHandler.RemoveNode(heartbeatDocID)
 		}
 
 	}
@@ -214,50 +235,16 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats(staleThresholdMs int, handle
 	return nil
 }
 
-func (h *couchbaseHeartBeater) heartbeatTimeoutDocId(nodeUuid string) string {
-	return fmt.Sprintf("%vheartbeat_timeout:%v", h.keyPrefix, nodeUuid)
+func heartbeatTimeoutDocId(nodeUuid, keyPrefix string) string {
+	return fmt.Sprintf("%vheartbeat_timeout:%v", keyPrefix, nodeUuid)
 }
 
-func (h *couchbaseHeartBeater) heartbeatDocId(nodeUuid string) string {
-	return fmt.Sprintf("%vheartbeat:%v", h.keyPrefix, nodeUuid)
-}
-
-func (h *couchbaseHeartBeater) viewQueryHeartbeatDocs() ([]heartbeatMeta, error) {
-
-	viewRes := struct {
-		Rows []struct {
-			Id    string
-			Value string
-		}
-		Errors []sgbucket.ViewError
-	}{}
-
-	err := h.bucket.ViewCustom("cbgt", "heartbeats",
-		map[string]interface{}{
-			"stale": false,
-		}, &viewRes)
-	if err != nil {
-		return nil, err
-	}
-
-	heartbeats := []heartbeatMeta{}
-	for _, row := range viewRes.Rows {
-		heartbeat := heartbeatMeta{
-			Type:     docTypeHeartbeat,
-			NodeUUID: row.Value,
-		}
-		heartbeats = append(heartbeats, heartbeat)
-	}
-
-	return heartbeats, nil
-
+func heartbeatDocId(nodeUuid, keyPrefix string) string {
+	return fmt.Sprintf("%vheartbeat:%v", keyPrefix, nodeUuid)
 }
 
 func (h *couchbaseHeartBeater) sendHeartbeat(intervalSeconds int) error {
 
-	if err := h.upsertHeartbeatDoc(); err != nil {
-		return err
-	}
 	if err := h.upsertHeartbeatTimeoutDoc(intervalSeconds); err != nil {
 		return err
 	}
@@ -271,7 +258,7 @@ func (h *couchbaseHeartBeater) upsertHeartbeatDoc() error {
 		Type:     docTypeHeartbeat,
 		NodeUUID: h.nodeUuid,
 	}
-	docId := h.heartbeatDocId(h.nodeUuid)
+	docId := heartbeatDocId(h.nodeUuid, h.keyPrefix)
 
 	if err := h.bucket.Set(docId, 0, heartbeatDoc); err != nil {
 		return err
@@ -287,7 +274,7 @@ func (h *couchbaseHeartBeater) upsertHeartbeatTimeoutDoc(intervalSeconds int) er
 		NodeUUID: h.nodeUuid,
 	}
 
-	docId := h.heartbeatTimeoutDocId(h.nodeUuid)
+	docId := heartbeatTimeoutDocId(h.nodeUuid, h.keyPrefix)
 
 	// make the expire time double the interval time, to ensure there is
 	// always a heartbeat timeout document present under normal operation
@@ -300,7 +287,157 @@ func (h *couchbaseHeartBeater) upsertHeartbeatTimeoutDoc(intervalSeconds int) er
 
 }
 
-func (h *couchbaseHeartBeater) addHeartbeatCheckView() error {
+// documentBackedNodeListHandler tracks nodes in a single node list document
+type documentBackedNodeListHandler struct {
+	nodeListKey string     // key for the tracking document
+	bucket      Bucket     // bucket used for document storage
+	nodeIDs     []string   // Set of nodes from the latest retrieval
+	cas         uint64     // CAS from latest retrieval of tracking document
+	lock        sync.Mutex // lock for nodes access
+}
+
+func NewDocumentBackedNodeListHandler(bucket Bucket, keyPrefix string) (*documentBackedNodeListHandler, error) {
+
+	handler := &documentBackedNodeListHandler{
+		nodeListKey: keyPrefix + "HeartbeatNodeList",
+		bucket:      bucket,
+	}
+	return handler, nil
+}
+
+// Adds the node to the tracking document
+func (dh *documentBackedNodeListHandler) AddNode(nodeID string) error {
+	return dh.updateNodeList(nodeID, false)
+}
+
+// Removes the node to the tracking document
+func (dh *documentBackedNodeListHandler) RemoveNode(nodeID string) error {
+	return dh.updateNodeList(nodeID, true)
+}
+
+func (dh *documentBackedNodeListHandler) GetNodes() ([]string, error) {
+	dh.lock.Lock()
+	err := dh.loadNodeIDs()
+	dh.lock.Unlock()
+	return dh.nodeIDs, err
+}
+
+// Adds or removes a nodeID from the node list document
+func (dh *documentBackedNodeListHandler) updateNodeList(nodeID string, remove bool) error {
+
+	dh.lock.Lock()
+	defer dh.lock.Unlock()
+
+	// Retry loop handles CAS failure
+	for {
+		// Reload the node set if it hasn't been initialized (or has been marked out of date by previous CAS write failure)
+		if dh.cas == 0 {
+			if err := dh.loadNodeIDs(); err != nil {
+				return err
+			}
+		}
+
+		// Check whether nodeID already exists in the set
+		nodeIndex := -1
+		for index, existingNodeID := range dh.nodeIDs {
+			if existingNodeID == nodeID {
+				nodeIndex = index
+			}
+		}
+
+		if remove { // RemoveNode handling
+			if nodeIndex == -1 {
+				return nil // NodeID isn't part of set, doesn't need to be removed
+			}
+			dh.nodeIDs = append(dh.nodeIDs[:nodeIndex], dh.nodeIDs[nodeIndex+1:]...)
+		} else { // AddNode handling
+			if nodeIndex > -1 {
+				return nil // NodeID is already part of set, doesn't need to be added
+			}
+			dh.nodeIDs = append(dh.nodeIDs, nodeID)
+		}
+
+		casOut, err := dh.bucket.WriteCas(dh.nodeListKey, 0, 0, dh.cas, dh.nodeIDs, 0)
+
+		if err == nil { // Successful update
+			dh.cas = casOut
+			return nil
+		}
+
+		if !IsCasMismatch(err) { // Unexpected error
+			return err
+		}
+
+		// CAS mismatch - reset cas to trigger reload and try again
+		dh.cas = 0
+	}
+
+}
+
+func (dh *documentBackedNodeListHandler) loadNodeIDs() (err error) {
+
+	dh.cas, err = dh.bucket.Get(dh.nodeListKey, &dh.nodeIDs)
+	if err != nil {
+		dh.cas = 0
+		dh.nodeIDs = []string{}
+		if !IsKeyNotFoundError(dh.bucket, err) {
+			return err
+		}
+	}
+	return nil
+
+}
+
+// viewBackedNodeListHandler tracks nodes as individual documents, and uses a view query to
+// identify the full set of documents
+// TODO: Currently being used to validate pluggable node handlers.  Can be removed to when this functionality
+//       has test coverage with a cbgt-based handler
+type viewBackedNodeListHandler struct {
+	keyPrefix string
+	bucket    Bucket
+}
+
+func NewViewBackedNodeListHandler(bucket Bucket, keyPrefix string) (*viewBackedNodeListHandler, error) {
+
+	handler := &viewBackedNodeListHandler{
+		keyPrefix: keyPrefix,
+		bucket:    bucket,
+	}
+	err := handler.addHeartbeatCheckView(bucket)
+	return handler, err
+}
+
+// Writes the heartbeat doc used to register the node
+func (vh *viewBackedNodeListHandler) AddNode(nodeID string) error {
+
+	heartbeatDoc := heartbeatMeta{
+		Type:     docTypeHeartbeat,
+		NodeUUID: nodeID,
+	}
+	docId := heartbeatDocId(nodeID, vh.keyPrefix)
+
+	if err := vh.bucket.Set(docId, 0, heartbeatDoc); err != nil {
+		return err
+	}
+	return nil
+
+}
+
+// Deletes the heartbeat doc used to register the node
+func (vh *viewBackedNodeListHandler) RemoveNode(nodeID string) error {
+	docId := heartbeatDocId(nodeID, vh.keyPrefix)
+	if err := vh.bucket.Delete(docId); err != nil {
+		Infof(KeyImport, "Failed to delete heartbeat doc: %v err: %v", docId, err)
+	}
+	return nil
+}
+
+// Issues a view query to identify the node set
+func (vh *viewBackedNodeListHandler) GetNodes() ([]string, error) {
+	return vh.viewQueryHeartbeatDocs()
+}
+
+func (vh *viewBackedNodeListHandler) addHeartbeatCheckView(bucket Bucket) error {
 
 	heartbeatsMap := `function (doc, meta) { if (doc.type == 'heartbeat') { emit(meta.id, doc.node_uuid); }}`
 
@@ -310,5 +447,32 @@ func (h *couchbaseHeartBeater) addHeartbeatCheckView() error {
 		},
 	}
 
-	return h.bucket.PutDDoc("cbgt", designDoc)
+	return vh.bucket.PutDDoc("cbgt", designDoc)
+}
+
+func (vh *viewBackedNodeListHandler) viewQueryHeartbeatDocs() ([]string, error) {
+
+	viewRes := struct {
+		Rows []struct {
+			Id    string
+			Value string
+		}
+		Errors []sgbucket.ViewError
+	}{}
+
+	err := vh.bucket.ViewCustom("cbgt", "heartbeats",
+		map[string]interface{}{
+			"stale": false,
+		}, &viewRes)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeIDs := []string{}
+	for _, row := range viewRes.Rows {
+		nodeIDs = append(nodeIDs, row.Value)
+	}
+
+	return nodeIDs, nil
+
 }

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestHeartbeatStoppedHandler struct {
@@ -21,7 +22,7 @@ func (th *TestHeartbeatStoppedHandler) StaleHeartBeatDetected(nodeUuid string) {
 // TestNewCouchbaseHeartbeater simulates three nodes.  The minimum time window for failed node
 // detection is 2 seconds, based on Couchbase Server's minimum document expiry TTL of
 // one second, so retry polling is required.
-func TestNewCouchbaseHeartbeater(t *testing.T) {
+func TestCouchbaseHeartbeater(t *testing.T) {
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test won't work under walrus - no expiry, required for heartbeats")
@@ -35,11 +36,11 @@ func TestNewCouchbaseHeartbeater(t *testing.T) {
 	defer testBucket.Close()
 
 	// Create three heartbeaters (representing three nodes)
-	node1, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node1")
+	node1, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node1", nil)
 	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node2")
+	node2, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node2", nil)
 	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node3")
+	node3, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node3", nil)
 	assert.NoError(t, err)
 
 	assert.NoError(t, node1.StartSendingHeartbeats(1))
@@ -74,6 +75,90 @@ func TestNewCouchbaseHeartbeater(t *testing.T) {
 	// Validate that at least one node detected the stopped node 1
 	assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
 		fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
+
+	// Validate current node list
+	activeNodes, err := node2.GetNodeList()
+	require.NoError(t, err, "Error getting node list")
+	assert.Equal(t, 2, len(activeNodes))
+	assert.NotContains(t, activeNodes, "node1")
+	assert.Contains(t, activeNodes, "node2")
+	assert.Contains(t, activeNodes, "node3")
+
+	// Stop heartbeaters
+	node2.Stop()
+	node3.Stop()
+
+}
+
+// TestCouchbaseHeartbeaterUsingViews tests the same functionality as TestCouchbaseHeartbeater,
+// but using ViewBackedNodeListHandlers.
+func TestCouchbaseHeartbeaterUsingViews(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus - no expiry, required for heartbeats")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping heartbeattest in short mode")
+	}
+
+	testBucket := GetTestBucket(t)
+	defer testBucket.Close()
+
+	// Create three heartbeaters (representing three nodes)
+	viewBackedHandler1, err := NewViewBackedNodeListHandler(testBucket, "hbtest")
+	assert.NoError(t, err)
+	node1, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node1", viewBackedHandler1)
+	assert.NoError(t, err)
+	viewBackedHandler2, err := NewViewBackedNodeListHandler(testBucket, "hbtest")
+	assert.NoError(t, err)
+	node2, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node2", viewBackedHandler2)
+	assert.NoError(t, err)
+	viewBackedHandler3, err := NewViewBackedNodeListHandler(testBucket, "hbtest")
+	assert.NoError(t, err)
+	node3, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node3", viewBackedHandler3)
+	assert.NoError(t, err)
+
+	assert.NoError(t, node1.StartSendingHeartbeats(1))
+	assert.NoError(t, node2.StartSendingHeartbeats(1))
+	assert.NoError(t, node3.StartSendingHeartbeats(1))
+
+	heartbeatStoppedHandler1 := &TestHeartbeatStoppedHandler{handlerID: "handler1"}
+	heartbeatStoppedHandler2 := &TestHeartbeatStoppedHandler{handlerID: "handler2"}
+	heartbeatStoppedHandler3 := &TestHeartbeatStoppedHandler{handlerID: "handler3"}
+
+	assert.NoError(t, node1.StartCheckingHeartbeats(1000, heartbeatStoppedHandler1))
+	assert.NoError(t, node2.StartCheckingHeartbeats(1000, heartbeatStoppedHandler2))
+	assert.NoError(t, node3.StartCheckingHeartbeats(1000, heartbeatStoppedHandler3))
+
+	// Wait for node1 to start running (and persist initial heartbeat docs) before stopping
+	retryUntilFunc := func() bool {
+		return node1.checkCount > 0 && node1.sendCount > 0
+	}
+	testRetryUntilTrue(t, retryUntilFunc)
+	assert.True(t, node1.checkCount > 0)
+	assert.True(t, node1.sendCount > 0)
+
+	// Stop node 1
+	node1.Stop()
+
+	// Wait for another node to detect node1 has stopped sending heartbeats
+	retryUntilFunc = func() bool {
+		return heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1
+	}
+	testRetryUntilTrue(t, retryUntilFunc)
+
+	// Validate that at least one node detected the stopped node 1
+	assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
+		fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
+
+	// Validate current node list
+	activeNodes, err := node2.GetNodeList()
+	require.NoError(t, err, "Error getting node list")
+	assert.Equal(t, 2, len(activeNodes))
+	assert.NotContains(t, activeNodes, "node1")
+	assert.Contains(t, activeNodes, "node2")
+	assert.Contains(t, activeNodes, "node3")
 
 	// Stop heartbeaters
 	node2.Stop()

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -22,7 +22,7 @@ func (th *TestHeartbeatStoppedHandler) StaleHeartBeatDetected(nodeUuid string) {
 // TestNewCouchbaseHeartbeater simulates three nodes.  The minimum time window for failed node
 // detection is 2 seconds, based on Couchbase Server's minimum document expiry TTL of
 // one second, so retry polling is required.
-func TestCouchbaseHeartbeater(t *testing.T) {
+func TestCouchbaseHeartbeaters(t *testing.T) {
 
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test won't work under walrus - no expiry, required for heartbeats")
@@ -32,136 +32,91 @@ func TestCouchbaseHeartbeater(t *testing.T) {
 		t.Skip("Skipping heartbeattest in short mode")
 	}
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	keyprefix := "hbtest"
 
-	// Create three heartbeaters (representing three nodes)
-	node1, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node1", nil)
-	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node2", nil)
-	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node3", nil)
-	assert.NoError(t, err)
-
-	assert.NoError(t, node1.StartSendingHeartbeats(1))
-	assert.NoError(t, node2.StartSendingHeartbeats(1))
-	assert.NoError(t, node3.StartSendingHeartbeats(1))
-
-	heartbeatStoppedHandler1 := &TestHeartbeatStoppedHandler{handlerID: "handler1"}
-	heartbeatStoppedHandler2 := &TestHeartbeatStoppedHandler{handlerID: "handler2"}
-	heartbeatStoppedHandler3 := &TestHeartbeatStoppedHandler{handlerID: "handler3"}
-
-	assert.NoError(t, node1.StartCheckingHeartbeats(1000, heartbeatStoppedHandler1))
-	assert.NoError(t, node2.StartCheckingHeartbeats(1000, heartbeatStoppedHandler2))
-	assert.NoError(t, node3.StartCheckingHeartbeats(1000, heartbeatStoppedHandler3))
-
-	// Wait for node1 to start running (and persist initial heartbeat docs) before stopping
-	retryUntilFunc := func() bool {
-		return node1.checkCount > 0 && node1.sendCount > 0
+	heartbeaters := []struct {
+		name                      string
+		nodeSetHandlerConstructor func(bucket Bucket) HeartbeatNodeSetHandler
+	}{
+		{
+			"documentBackedNodeListHandler",
+			func(bucket Bucket) HeartbeatNodeSetHandler {
+				handler, _ := NewDocumentBackedNodeListHandler(bucket, keyprefix)
+				return handler
+			},
+		},
+		{
+			"viewBackedNodeListHandler",
+			func(bucket Bucket) HeartbeatNodeSetHandler {
+				handler, _ := NewViewBackedNodeListHandler(bucket, keyprefix)
+				return handler
+			},
+		},
 	}
-	testRetryUntilTrue(t, retryUntilFunc)
-	assert.True(t, node1.checkCount > 0)
-	assert.True(t, node1.sendCount > 0)
+	for _, h := range heartbeaters {
+		t.Run(h.name, func(tt *testing.T) {
+			testBucket := GetTestBucket(t)
+			defer testBucket.Close()
 
-	// Stop node 1
-	node1.Stop()
+			// Create three heartbeaters (representing three nodes)
+			handler1 := h.nodeSetHandlerConstructor(testBucket)
+			assert.NotNil(tt, handler1)
+			node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", handler1)
+			assert.NoError(tt, err)
+			handler2 := h.nodeSetHandlerConstructor(testBucket)
+			assert.NotNil(tt, handler2)
+			node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", handler2)
+			assert.NoError(tt, err)
+			handler3 := h.nodeSetHandlerConstructor(testBucket)
+			assert.NotNil(tt, handler3)
+			node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", handler3)
+			assert.NoError(tt, err)
 
-	// Wait for another node to detect node1 has stopped sending heartbeats
-	retryUntilFunc = func() bool {
-		return heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1
+			assert.NoError(t, node1.StartSendingHeartbeats(1))
+			assert.NoError(t, node2.StartSendingHeartbeats(1))
+			assert.NoError(t, node3.StartSendingHeartbeats(1))
+
+			heartbeatStoppedHandler1 := &TestHeartbeatStoppedHandler{handlerID: "handler1"}
+			heartbeatStoppedHandler2 := &TestHeartbeatStoppedHandler{handlerID: "handler2"}
+			heartbeatStoppedHandler3 := &TestHeartbeatStoppedHandler{handlerID: "handler3"}
+
+			assert.NoError(t, node1.StartCheckingHeartbeats(1000, heartbeatStoppedHandler1))
+			assert.NoError(t, node2.StartCheckingHeartbeats(1000, heartbeatStoppedHandler2))
+			assert.NoError(t, node3.StartCheckingHeartbeats(1000, heartbeatStoppedHandler3))
+
+			// Wait for node1 to start running (and persist initial heartbeat docs) before stopping
+			retryUntilFunc := func() bool {
+				return node1.checkCount > 0 && node1.sendCount > 0
+			}
+			testRetryUntilTrue(t, retryUntilFunc)
+			assert.True(t, node1.checkCount > 0)
+			assert.True(t, node1.sendCount > 0)
+
+			// Stop node 1
+			node1.Stop()
+
+			// Wait for another node to detect node1 has stopped sending heartbeats
+			retryUntilFunc = func() bool {
+				return heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1
+			}
+			testRetryUntilTrue(t, retryUntilFunc)
+
+			// Validate that at least one node detected the stopped node 1
+			assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
+				fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
+
+			// Validate current node list
+			activeNodes, err := node2.GetNodeList()
+			require.NoError(t, err, "Error getting node list")
+			assert.Equal(t, 2, len(activeNodes))
+			assert.NotContains(t, activeNodes, "node1")
+			assert.Contains(t, activeNodes, "node2")
+			assert.Contains(t, activeNodes, "node3")
+
+			// Stop heartbeaters
+			node2.Stop()
+			node3.Stop()
+		})
 	}
-	testRetryUntilTrue(t, retryUntilFunc)
-
-	// Validate that at least one node detected the stopped node 1
-	assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
-		fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
-
-	// Validate current node list
-	activeNodes, err := node2.GetNodeList()
-	require.NoError(t, err, "Error getting node list")
-	assert.Equal(t, 2, len(activeNodes))
-	assert.NotContains(t, activeNodes, "node1")
-	assert.Contains(t, activeNodes, "node2")
-	assert.Contains(t, activeNodes, "node3")
-
-	// Stop heartbeaters
-	node2.Stop()
-	node3.Stop()
-
-}
-
-// TestCouchbaseHeartbeaterUsingViews tests the same functionality as TestCouchbaseHeartbeater,
-// but using ViewBackedNodeListHandlers.
-func TestCouchbaseHeartbeaterUsingViews(t *testing.T) {
-
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test won't work under walrus - no expiry, required for heartbeats")
-	}
-
-	if testing.Short() {
-		t.Skip("Skipping heartbeattest in short mode")
-	}
-
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-
-	// Create three heartbeaters (representing three nodes)
-	viewBackedHandler1, err := NewViewBackedNodeListHandler(testBucket, "hbtest")
-	assert.NoError(t, err)
-	node1, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node1", viewBackedHandler1)
-	assert.NoError(t, err)
-	viewBackedHandler2, err := NewViewBackedNodeListHandler(testBucket, "hbtest")
-	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node2", viewBackedHandler2)
-	assert.NoError(t, err)
-	viewBackedHandler3, err := NewViewBackedNodeListHandler(testBucket, "hbtest")
-	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, "hbtest", "node3", viewBackedHandler3)
-	assert.NoError(t, err)
-
-	assert.NoError(t, node1.StartSendingHeartbeats(1))
-	assert.NoError(t, node2.StartSendingHeartbeats(1))
-	assert.NoError(t, node3.StartSendingHeartbeats(1))
-
-	heartbeatStoppedHandler1 := &TestHeartbeatStoppedHandler{handlerID: "handler1"}
-	heartbeatStoppedHandler2 := &TestHeartbeatStoppedHandler{handlerID: "handler2"}
-	heartbeatStoppedHandler3 := &TestHeartbeatStoppedHandler{handlerID: "handler3"}
-
-	assert.NoError(t, node1.StartCheckingHeartbeats(1000, heartbeatStoppedHandler1))
-	assert.NoError(t, node2.StartCheckingHeartbeats(1000, heartbeatStoppedHandler2))
-	assert.NoError(t, node3.StartCheckingHeartbeats(1000, heartbeatStoppedHandler3))
-
-	// Wait for node1 to start running (and persist initial heartbeat docs) before stopping
-	retryUntilFunc := func() bool {
-		return node1.checkCount > 0 && node1.sendCount > 0
-	}
-	testRetryUntilTrue(t, retryUntilFunc)
-	assert.True(t, node1.checkCount > 0)
-	assert.True(t, node1.sendCount > 0)
-
-	// Stop node 1
-	node1.Stop()
-
-	// Wait for another node to detect node1 has stopped sending heartbeats
-	retryUntilFunc = func() bool {
-		return heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1
-	}
-	testRetryUntilTrue(t, retryUntilFunc)
-
-	// Validate that at least one node detected the stopped node 1
-	assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
-		fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
-
-	// Validate current node list
-	activeNodes, err := node2.GetNodeList()
-	require.NoError(t, err, "Error getting node list")
-	assert.Equal(t, 2, len(activeNodes))
-	assert.NotContains(t, activeNodes, "node1")
-	assert.Contains(t, activeNodes, "node2")
-	assert.Contains(t, activeNodes, "node3")
-
-	// Stop heartbeaters
-	node2.Stop()
-	node3.Stop()
 
 }


### PR DESCRIPTION
Abstracts interaction with the full set of nodes to a HeartbeatNodeSetHandler, and switches CouchbaseHeartbeater to use a document-backed handler by default.

View-based handler is left in place for test coverage of custom handler support, can be removed when a cbgt-based handler is implemented.