### PR TITLE
Bump go-couchbase and gomemcached (prereq for cbgt)

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f1b8a89d740738af8cc69efa090b99d34579cd31"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="4fab5d18974b2155cd9986ecf8e0f1b898da38df"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="f83e63d76bc41c5b61e022db2d5463f776dc545f"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="d46732ea85f0ca44f82842ca2996bd2a21995172"/>
 
@@ -43,7 +43,7 @@
 
   <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="3c902e3ed6c25b53d53f6a9d26cc4f7a85c0fcf8"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="0da75df145308b9a4e6704d762ca9d9b77752efc"/>
+  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
   <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="de3a040899d6acf57077599b2ea15b3677f56864"/>
 


### PR DESCRIPTION
Switching to cbgt requires updating pinned commits for go-couchbase and gomemcached.  Making this change first to be able to differentiate between performance differences associated with this uptake, versus switching to cbgt-based feeds.

Integration test is clean:
http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/1267/
