### PR TITLE
CBG-478 - Find and replace existing stdlib json usages

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -10,7 +10,6 @@
 package auth
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
@@ -108,8 +107,8 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 		}
 
 		princ = factory()
-		if err := json.Unmarshal(currentValue, princ); err != nil {
-			return nil, nil, pkgerrors.WithStack(base.RedactErrorf("json.Unmarshal() error for doc ID: %s in getPrincipal().  Error: %v", base.UD(docID), err))
+		if err := base.JSONUnmarshal(currentValue, princ); err != nil {
+			return nil, nil, pkgerrors.WithStack(base.RedactErrorf("base.JSONUnmarshal() error for doc ID: %s in getPrincipal().  Error: %v", base.UD(docID), err))
 		}
 		changed := false
 		if princ.Channels() == nil {
@@ -132,9 +131,9 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 
 		if changed {
 			// Save the updated doc:
-			updatedBytes, marshalErr := json.Marshal(princ)
+			updatedBytes, marshalErr := base.JSONMarshal(princ)
 			if marshalErr != nil {
-				marshalErr = pkgerrors.WithStack(base.RedactErrorf("json.Unmarshal() error for doc ID: %s in getPrincipal(). Error: %v", base.UD(docID), marshalErr))
+				marshalErr = pkgerrors.WithStack(base.RedactErrorf("base.JSONUnmarshal() error for doc ID: %s in getPrincipal(). Error: %v", base.UD(docID), marshalErr))
 			}
 			return updatedBytes, nil, marshalErr
 		} else {
@@ -569,7 +568,7 @@ func (auth *Authenticator) updateVbucketSequences(docID string, factory func() P
 			return nil, nil, base.ErrUpdateCancel
 		}
 		princ := factory()
-		if err := json.Unmarshal(currentValue, princ); err != nil {
+		if err := base.JSONUnmarshal(currentValue, princ); err != nil {
 			return nil, nil, err
 		}
 		channelsChanged := false
@@ -610,7 +609,7 @@ func (auth *Authenticator) updateVbucketSequences(docID string, factory func() P
 
 		if channelsChanged || rolesChanged {
 			// Save the updated principal doc.
-			updatedBytes, marshalErr := json.Marshal(princ)
+			updatedBytes, marshalErr := base.JSONMarshal(princ)
 			return updatedBytes, nil, marshalErr
 		} else {
 			// No entries found requiring update, so cancel update.

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -10,7 +10,6 @@
 package auth
 
 import (
-	"encoding/json"
 	"errors"
 	"log"
 	"sync"
@@ -123,12 +122,12 @@ func TestSerializeUser(t *testing.T) {
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	user, _ := auth.NewUser("me", "letmein", ch.SetOf(t, "me", "public"))
 	require.NoError(t, user.SetEmail("foo@example.com"))
-	encoded, _ := json.Marshal(user)
+	encoded, _ := base.JSONMarshal(user)
 	assert.True(t, encoded != nil)
 	log.Printf("Marshaled User as: %s", encoded)
 
 	resu := &userImpl{}
-	err := json.Unmarshal(encoded, resu)
+	err := base.JSONUnmarshal(encoded, resu)
 	assert.True(t, err == nil)
 	goassert.DeepEquals(t, resu.Name(), user.Name())
 	goassert.DeepEquals(t, resu.Email(), user.Email())
@@ -143,11 +142,11 @@ func TestSerializeRole(t *testing.T) {
 	defer gTestBucket.Close()
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
 	role, _ := auth.NewRole("froods", ch.SetOf(t, "hoopy", "public"))
-	encoded, _ := json.Marshal(role)
+	encoded, _ := base.JSONMarshal(role)
 	assert.True(t, encoded != nil)
 	log.Printf("Marshaled Role as: %s", encoded)
 	elor := &roleImpl{}
-	err := json.Unmarshal(encoded, elor)
+	err := base.JSONUnmarshal(encoded, elor)
 
 	assert.True(t, err == nil)
 	goassert.DeepEquals(t, elor.Name(), role.Name())

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -334,13 +334,14 @@ func TestRebuildRoleChannels(t *testing.T) {
 	defer gTestBucket.Close()
 	computer := mockComputer{roleChannels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
-	role, _ := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
-	err := auth.InvalidateChannels(role)
+	role, err := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
+	assert.NoError(t, err)
+	err = auth.InvalidateChannels(role)
 	assert.Equal(t, nil, err)
 
 	role2, err := auth.GetRole("testRole")
 	assert.Equal(t, nil, err)
-	goassert.DeepEquals(t, role2.Channels(), ch.AtSequence(ch.SetOf(t, "explicit1", "derived1", "derived2", "!"), 1))
+	assert.Equal(t, ch.AtSequence(ch.SetOf(t, "explicit1", "derived1", "derived2", "!"), 1), role2.Channels())
 }
 
 func TestRebuildChannelsError(t *testing.T) {
@@ -350,14 +351,14 @@ func TestRebuildChannelsError(t *testing.T) {
 	computer := mockComputer{}
 	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
 	role, err := auth.NewRole("testRole2", ch.SetOf(t, "explicit1"))
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	assert.Equal(t, nil, auth.InvalidateChannels(role))
 
 	computer.err = errors.New("I'm sorry, Dave.")
 
 	role2, err := auth.GetRole("testRole2")
-	assert.Equal(t, nil, role2)
-	goassert.DeepEquals(t, err, computer.err)
+	assert.Nil(t, role2)
+	assert.Equal(t, computer.err, err)
 }
 
 func TestRebuildUserRoles(t *testing.T) {

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -10,7 +10,6 @@
 package auth
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -234,7 +233,7 @@ func (op *OIDCProvider) FetchCustomProviderConfig(discoveryURL string) (*oidc.Pr
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if err := json.NewDecoder(resp.Body).Decode(&customConfig); err != nil {
+	if err := base.JSONDecoder(resp.Body).Decode(&customConfig); err != nil {
 		base.Debugf(base.KeyAuth, "Error parsing body %s: %v", base.UD(discoveryURL), err)
 		return nil, err
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -11,7 +11,6 @@ package auth
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -319,11 +318,11 @@ func (user *userImpl) GetAddedChannels(channels ch.TimedSet) base.Set {
 
 func (user *userImpl) MarshalJSON() ([]byte, error) {
 	var err error
-	data, err := json.Marshal(user.roleImpl)
+	data, err := base.JSONMarshal(user.roleImpl)
 	if err != nil {
 		return nil, err
 	}
-	userData, err := json.Marshal(user.userImplBody)
+	userData, err := base.JSONMarshal(user.userImplBody)
 	if err != nil {
 		return nil, err
 	}
@@ -337,9 +336,9 @@ func (user *userImpl) MarshalJSON() ([]byte, error) {
 }
 
 func (user *userImpl) UnmarshalJSON(data []byte) error {
-	if err := json.Unmarshal(data, &user.userImplBody); err != nil {
+	if err := base.JSONUnmarshal(data, &user.userImplBody); err != nil {
 		return err
-	} else if err := json.Unmarshal(data, &user.roleImpl); err != nil {
+	} else if err := base.JSONUnmarshal(data, &user.roleImpl); err != nil {
 		return err
 	}
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -234,7 +234,7 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (int, error
 		return 0, err
 	}
 
-	if err := json.Unmarshal(respBytes, &purgeResponse); err != nil {
+	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
 		return 0, err
 	}
 
@@ -260,7 +260,7 @@ func (bucket *CouchbaseBucketGoCB) GetServerUUID() (uuid string, err error) {
 		ServerUUID string `json:"uuid"`
 	}
 
-	if err := json.Unmarshal(respBytes, &responseJson); err != nil {
+	if err := JSONUnmarshal(respBytes, &responseJson); err != nil {
 		return "", err
 	}
 
@@ -286,7 +286,7 @@ func (bucket *CouchbaseBucketGoCB) GetMaxTTL() (int, error) {
 		return -1, err
 	}
 
-	if err := json.Unmarshal(respBytes, &bucketResponseWithMaxTTL); err != nil {
+	if err := JSONUnmarshal(respBytes, &bucketResponseWithMaxTTL); err != nil {
 		return -1, err
 	}
 
@@ -1873,13 +1873,13 @@ func (bucket *CouchbaseBucketGoCB) GetDDoc(docname string, into interface{}) err
 		// marshal/unmarshal round trip
 
 		// Serialize DesignDocument into []byte
-		designDocBytes, err := json.Marshal(designDocPointer)
+		designDocBytes, err := JSONMarshal(designDocPointer)
 		if err != nil {
 			return err
 		}
 
 		// Deserialize []byte into "into" empty interface
-		if err := json.Unmarshal(designDocBytes, into); err != nil {
+		if err := JSONUnmarshal(designDocBytes, into); err != nil {
 			return err
 		}
 
@@ -1955,7 +1955,7 @@ func (bucket *CouchbaseBucketGoCB) putDDocForTombstones(ddoc *gocb.DesignDocumen
 		DesignDocument:         ddoc,
 		IndexXattrOnTombstones: true,
 	}
-	data, err := json.Marshal(&xattrEnabledDesignDoc)
+	data, err := JSONMarshal(&xattrEnabledDesignDoc)
 	if err != nil {
 		return err
 	}
@@ -2181,13 +2181,13 @@ func (bucket *CouchbaseBucketGoCB) ViewCustom(ddoc, name string, params map[stri
 	}
 
 	// serialize the whole thing to a []byte
-	viewResponseBytes, err := json.Marshal(viewResponse)
+	viewResponseBytes, err := JSONMarshal(viewResponse)
 	if err != nil {
 		return err
 	}
 
 	// unmarshal into vres
-	if err := json.Unmarshal(viewResponseBytes, vres); err != nil {
+	if err := JSONUnmarshal(viewResponseBytes, vres); err != nil {
 		return err
 	}
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2418,7 +2418,7 @@ func (bucket *CouchbaseBucketGoCB) BucketItemCount() (itemCount int, err error) 
 	}
 
 	respJson := map[string]interface{}{}
-	decoder := json.NewDecoder(resp.Body)
+	decoder := JSONDecoder(resp.Body)
 	if err := decoder.Decode(&respJson); err != nil {
 		return -1, err
 	}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -11,7 +11,6 @@ package base
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -641,7 +640,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
 
-	valBytes, marshalErr := json.Marshal(val)
+	valBytes, marshalErr := JSONMarshal(val)
 	assert.NoError(t, marshalErr, "Error marshalling document body")
 
 	xattrVal := make(map[string]interface{})
@@ -848,12 +847,12 @@ func TestXattrWriteCasRaw(t *testing.T) {
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
-	valRaw, _ := json.Marshal(val)
+	valRaw, _ := JSONMarshal(val)
 
 	xattrVal := make(map[string]interface{})
 	xattrVal["seq"] = float64(123)
 	xattrVal["rev"] = "1-1234"
-	xattrValRaw, _ := json.Marshal(xattrVal)
+	xattrValRaw, _ := JSONMarshal(xattrVal)
 
 	var existsVal map[string]interface{}
 	_, err := bucket.Get(key, existsVal)
@@ -1094,7 +1093,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 		var xattrMap map[string]interface{}
 		// Marshal the doc
 		if len(doc) > 0 {
-			err = json.Unmarshal(doc, &docMap)
+			err = JSONUnmarshal(doc, &docMap)
 			if err != nil {
 				return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming doc")
 			}
@@ -1105,7 +1104,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 		// Marshal the xattr
 		if len(xattr) > 0 {
-			err = json.Unmarshal(xattr, &xattrMap)
+			err = JSONUnmarshal(xattr, &xattrMap)
 			if err != nil {
 				return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming xattr")
 			}
@@ -1130,8 +1129,8 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 			xattrMap["seq"] = float64(1)
 		}
 
-		updatedDoc, _ = json.Marshal(docMap)
-		updatedXattr, _ = json.Marshal(xattrMap)
+		updatedDoc, _ = JSONMarshal(docMap)
+		updatedXattr, _ = JSONMarshal(xattrMap)
 		return updatedDoc, updatedXattr, false, nil, nil
 	}
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -100,7 +99,7 @@ func (bucket *CouchbaseBucketGoCB) ExplainQuery(statement string, params interfa
 	}
 
 	firstRow := explainResults.NextBytes()
-	unmarshalErr := json.Unmarshal(firstRow, &plan)
+	unmarshalErr := JSONUnmarshal(firstRow, &plan)
 	return plan, unmarshalErr
 }
 
@@ -209,7 +208,7 @@ func (bucket *CouchbaseBucketGoCB) CreatePrimaryIndex(indexName string, options 
 func (bucket *CouchbaseBucketGoCB) createIndex(indexName string, createStatement string, options *N1qlIndexOptions) error {
 
 	if options != nil {
-		withClause, marshalErr := json.Marshal(options)
+		withClause, marshalErr := JSONMarshal(options)
 		if marshalErr != nil {
 			return marshalErr
 		}

--- a/base/dcp_feed.go
+++ b/base/dcp_feed.go
@@ -12,7 +12,6 @@ package base
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"sync"
@@ -363,7 +362,7 @@ func makeVbucketMetadata(vbucketUUID uint64, sequence uint64, snapStart uint64, 
 		SnapEnd:     snapEnd,
 		FailOverLog: failOver,
 	}
-	metadataBytes, err := json.Marshal(metadata)
+	metadataBytes, err := JSONMarshal(metadata)
 	if err == nil {
 		return metadataBytes
 	} else {
@@ -405,7 +404,7 @@ func (r *DCPReceiver) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotSt
 	}
 
 	var snapshotMetadata cbdatasource.VBucketMetaData
-	unmarshalErr := json.Unmarshal(rawValue, &snapshotMetadata)
+	unmarshalErr := JSONUnmarshal(rawValue, &snapshotMetadata)
 	if unmarshalErr != nil {
 		return []byte{}, 0, 0, err
 	}

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"encoding/json"
 	"sync"
 	"time"
 
@@ -404,7 +403,7 @@ func (dh *documentBackedNodeListHandler) loadNodeIDs() error {
 	}
 
 	// Update the in-memory list and cas
-	if unmarshalErr := json.Unmarshal(docBytes, &dh.nodeIDs); unmarshalErr != nil {
+	if unmarshalErr := JSONUnmarshal(docBytes, &dh.nodeIDs); unmarshalErr != nil {
 		return unmarshalErr
 	}
 	dh.cas = cas

--- a/base/set.go
+++ b/base/set.go
@@ -10,7 +10,6 @@
 package base
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -126,12 +125,12 @@ func (set Set) MarshalJSON() ([]byte, error) {
 	}
 	list := set.ToArray()
 	sort.Strings(list) // sort the array so it's written in a consistent order; helps testability
-	return json.Marshal(list)
+	return JSONMarshal(list)
 }
 
 func (setPtr *Set) UnmarshalJSON(data []byte) error {
 	var names []string
-	if err := json.Unmarshal(data, &names); err != nil {
+	if err := JSONUnmarshal(data, &names); err != nil {
 		return err
 	}
 	if names == nil {

--- a/base/set_test.go
+++ b/base/set_test.go
@@ -10,7 +10,6 @@
 package base
 
 import (
-	"encoding/json"
 	"sort"
 	"testing"
 
@@ -86,17 +85,17 @@ func TestSetMarshal(t *testing.T) {
 	var str struct {
 		Channels Set
 	}
-	bytes, err := json.Marshal(str)
+	bytes, err := JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = SetOf()
-	bytes, err = json.Marshal(str)
+	bytes, err = JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":[]}`)
 
 	str.Channels = SetOf("a", "b")
-	bytes, err = json.Marshal(str)
+	bytes, err = JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":["a","b"]}`)
 }
@@ -123,15 +122,15 @@ func TestSetUnmarshal(t *testing.T) {
 	var str struct {
 		Channels Set
 	}
-	err := json.Unmarshal([]byte(`{"channels":null}`), &str)
+	err := JSONUnmarshal([]byte(`{"channels":null}`), &str)
 	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels, Set(nil))
 
-	err = json.Unmarshal([]byte(`{"channels":[]}`), &str)
+	err = JSONUnmarshal([]byte(`{"channels":[]}`), &str)
 	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels, SetOf())
 
-	err = json.Unmarshal([]byte(`{"channels":["foo"]}`), &str)
+	err = JSONUnmarshal([]byte(`{"channels":["foo"]}`), &str)
 	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels.ToArray(), []string{"foo"})
 

--- a/base/sg_transcoding.go
+++ b/base/sg_transcoding.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"encoding/json"
 	"github.com/couchbase/gocb"
 
 	"gopkg.in/couchbase/gocbcore.v7"
@@ -44,7 +43,7 @@ func (t SGTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
 		// calls back into this
 		return t.Encode(*value.(*interface{}))
 	default:
-		bytes, err = json.Marshal(value)
+		bytes, err = JSONMarshal(value)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/base/stats_bucket.go
+++ b/base/stats_bucket.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"sync/atomic"
@@ -89,7 +88,7 @@ func (b *StatsBucket) Get(k string, rv interface{}) (uint64, error) {
 	cas, err := b.bucket.Get(k, rv)
 	if vBytes, ok := rv.([]byte); ok {
 		defer b.docRead(1, len(vBytes))
-	} else if marshalledJSON, marshalErr := json.Marshal(rv); marshalErr == nil {
+	} else if marshalledJSON, marshalErr := JSONMarshal(rv); marshalErr == nil {
 		defer b.docRead(1, len(marshalledJSON))
 	} else {
 		defer b.docRead(1, -1)
@@ -193,7 +192,7 @@ func (b *StatsBucket) GetWithXattr(k string, xattr string, rv interface{}, xv in
 	cas, err = b.bucket.GetWithXattr(k, xattr, rv, xv)
 	if vBytes, ok := rv.([]byte); ok {
 		defer b.docRead(1, len(vBytes))
-	} else if marshalledJSON, marshalErr := json.Marshal(rv); marshalErr == nil {
+	} else if marshalledJSON, marshalErr := JSONMarshal(rv); marshalErr == nil {
 		defer b.docRead(1, len(marshalledJSON))
 	} else {
 		defer b.docRead(1, -1)

--- a/base/util.go
+++ b/base/util.go
@@ -110,7 +110,7 @@ func FixJSONNumbers(value interface{}) interface{} {
 // "thing" -> "thing"
 func ConvertJSONString(s string) string {
 	var jsonString string
-	err := json.Unmarshal([]byte(s), &jsonString)
+	err := JSONUnmarshal([]byte(s), &jsonString)
 	if err != nil {
 		return s
 	} else {
@@ -1039,7 +1039,7 @@ func InjectJSONProperties(b []byte, kvPairs ...KVPair) (new []byte, err error) {
 
 	kvPairsBytes := make([]KVPairBytes, len(kvPairs))
 	for i, kv := range kvPairs {
-		valBytes, err := json.Marshal(kv.Val)
+		valBytes, err := JSONMarshal(kv.Val)
 		if err != nil {
 			return nil, err
 		}

--- a/base/util_ce.go
+++ b/base/util_ce.go
@@ -31,6 +31,12 @@ func JSONMarshal(v interface{}) ([]byte, error) {
 	return json.Marshal(v)
 }
 
+// JSONMarshalCanonical returns the canonical JSON encoding of v.
+// Mostly notably: Ordered properties, in order to generate deterministic Rev IDs.
+func JSONMarshalCanonical(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
 // JSONDecoder returns a new JSON decoder implementing the JSONDecoderI interface
 func JSONDecoder(r io.Reader) JSONDecoderI {
 	return json.NewDecoder(r)

--- a/base/util_ee.go
+++ b/base/util_ee.go
@@ -19,8 +19,6 @@ func init() {
 	fleecedelta.StringDiffTimeout = time.Millisecond // Aggressive string diff timeout
 }
 
-var jsonIterConfig = jsoniter.ConfigCompatibleWithStandardLibrary
-
 // Diff will return the fleece delta between old and new.
 func Diff(old, new map[string]interface{}) (delta []byte, err error) {
 	return fleecedelta.DiffJSON(old, new)
@@ -34,7 +32,7 @@ func Patch(old *map[string]interface{}, delta map[string]interface{}) (err error
 // JSONUnmarshal parses the JSON-encoded data and stores the result in the value pointed to by v.
 func JSONUnmarshal(data []byte, v interface{}) (err error) {
 	if !UseStdlibJSON {
-		err = jsonIterConfig.Unmarshal(data, v)
+		err = jsoniter.Unmarshal(data, v)
 		if err != nil {
 			err = &JSONIterError{E: err}
 		}
@@ -47,7 +45,20 @@ func JSONUnmarshal(data []byte, v interface{}) (err error) {
 // JSONMarshal returns the JSON encoding of v.
 func JSONMarshal(v interface{}) (b []byte, err error) {
 	if !UseStdlibJSON {
-		b, err = jsonIterConfig.Marshal(v)
+		b, err = jsoniter.Marshal(v)
+		if err != nil {
+			err = &JSONIterError{E: err}
+		}
+	} else {
+		b, err = json.Marshal(v)
+	}
+	return b, err
+}
+
+// JSONMarshalCanonical returns the stdlib-compatible JSON encoding of v.
+func JSONMarshalCanonical(v interface{}) (b []byte, err error) {
+	if !UseStdlibJSON {
+		b, err = jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(v)
 		if err != nil {
 			err = &JSONIterError{E: err}
 		}
@@ -60,7 +71,7 @@ func JSONMarshal(v interface{}) (b []byte, err error) {
 // JSONDecoder returns a new JSON decoder implementing the JSONDecoderI interface
 func JSONDecoder(r io.Reader) JSONDecoderI {
 	if !UseStdlibJSON {
-		return jsonIterConfig.NewDecoder(r)
+		return jsoniter.NewDecoder(r)
 	} else {
 		return json.NewDecoder(r)
 	}
@@ -69,7 +80,7 @@ func JSONDecoder(r io.Reader) JSONDecoderI {
 // JSONEncoder returns a new JSON encoder implementing the JSONEncoderI interface
 func JSONEncoder(w io.Writer) JSONEncoderI {
 	if !UseStdlibJSON {
-		return jsonIterConfig.NewEncoder(w)
+		return jsoniter.NewEncoder(w)
 	} else {
 		return json.NewEncoder(w)
 	}

--- a/base/util_ee.go
+++ b/base/util_ee.go
@@ -55,7 +55,8 @@ func JSONMarshal(v interface{}) (b []byte, err error) {
 	return b, err
 }
 
-// JSONMarshalCanonical returns the stdlib-compatible JSON encoding of v.
+// JSONMarshalCanonical returns the canonical JSON encoding of v.
+// Mostly notably: Ordered properties, in order to generate deterministic Rev IDs.
 func JSONMarshalCanonical(v interface{}) (b []byte, err error) {
 	if !UseStdlibJSON {
 		b, err = jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(v)

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -10,7 +10,6 @@
 package base
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -668,7 +667,7 @@ func TestInjectJSONProperties(t *testing.T) {
 			assert.Equal(tt, test.expectedOutput, string(output))
 
 			var m map[string]interface{}
-			err = json.Unmarshal(output, &m)
+			err = JSONUnmarshal(output, &m)
 			assert.NoError(tt, err, "produced invalid JSON")
 		})
 	}
@@ -738,7 +737,7 @@ func TestInjectJSONProperties_Multiple(t *testing.T) {
 			assert.Equal(tt, test.expectedOutput, string(output))
 
 			var m map[string]interface{}
-			err = json.Unmarshal(output, &m)
+			err = JSONUnmarshal(output, &m)
 			assert.NoError(tt, err, "produced invalid JSON")
 		})
 	}
@@ -798,7 +797,7 @@ func TestInjectJSONPropertiesFromBytes(t *testing.T) {
 			assert.Equal(tt, test.expectedOutput, string(output))
 
 			var m map[string]interface{}
-			err = json.Unmarshal(output, &m)
+			err = JSONUnmarshal(output, &m)
 			assert.NoError(tt, err, "produced invalid JSON")
 		})
 	}
@@ -868,7 +867,7 @@ func TestInjectJSONPropertiesFromBytes_Multiple(t *testing.T) {
 			assert.Equal(tt, test.expectedOutput, string(output))
 
 			var m map[string]interface{}
-			err = json.Unmarshal(output, &m)
+			err = JSONUnmarshal(output, &m)
 			assert.NoError(tt, err, "produced invalid JSON")
 		})
 	}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -2,7 +2,6 @@ package base
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -587,7 +586,7 @@ func DeepCopyInefficient(dst interface{}, src interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Unable to marshal src: %s", err)
 	}
-	d := json.NewDecoder(bytes.NewBuffer(b))
+	d := JSONDecoder(bytes.NewBuffer(b))
 	d.UseNumber()
 	err = d.Decode(dst)
 	if err != nil {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -583,7 +583,7 @@ func DeepCopyInefficient(dst interface{}, src interface{}) error {
 	if src == nil {
 		return fmt.Errorf("src cannot be nil")
 	}
-	b, err := json.Marshal(src)
+	b, err := JSONMarshal(src)
 	if err != nil {
 		return fmt.Errorf("Unable to marshal src: %s", err)
 	}

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -10,7 +10,6 @@
 package channels
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -26,7 +25,7 @@ func init() {
 
 func parse(jsonStr string) map[string]interface{} {
 	var parsed map[string]interface{}
-	json.Unmarshal([]byte(jsonStr), &parsed)
+	base.JSONUnmarshal([]byte(jsonStr), &parsed)
 	return parsed
 }
 

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -10,7 +10,6 @@
 package channels
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -258,11 +257,11 @@ func (set TimedSet) CompareKeys(other TimedSet) ChangedKeys {
 func (setPtr *TimedSet) UnmarshalJSON(data []byte) error {
 
 	var normalForm map[string]VbSequence
-	if err := json.Unmarshal(data, &normalForm); err != nil {
+	if err := base.JSONUnmarshal(data, &normalForm); err != nil {
 		var sequenceOnlyForm map[string]uint64
-		if err := json.Unmarshal(data, &sequenceOnlyForm); err != nil {
+		if err := base.JSONUnmarshal(data, &sequenceOnlyForm); err != nil {
 			var altForm []string
-			if err2 := json.Unmarshal(data, &altForm); err2 == nil {
+			if err2 := base.JSONUnmarshal(data, &altForm); err2 == nil {
 				set, err := SetFromArray(altForm, KeepStar)
 				if err == nil {
 					*setPtr = AtSequence(set, 0)
@@ -294,11 +293,11 @@ func (set TimedSet) MarshalJSON() ([]byte, error) {
 		// Marshals entries as "ABC":{"vb":5,"seq":1} or "CBS":{"seq":1}, depending on whether VbSequence.VbNo is nil
 		var plainMap map[string]VbSequence
 		plainMap = set
-		return json.Marshal(plainMap)
+		return base.JSONMarshal(plainMap)
 	} else {
 		// Sequence-only form.
 		// Marshals entries as "ABC":1, "CBS":1  - backwards compatibility when vbuckets aren't present.
-		return json.Marshal(set.SequenceOnlySet())
+		return base.JSONMarshal(set.SequenceOnlySet())
 	}
 }
 

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -11,6 +11,7 @@ package channels
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -24,17 +25,24 @@ func TestTimedSetMarshal(t *testing.T) {
 	}
 	bytes, err := base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
-	goassert.Equals(t, string(bytes), `{"Channels":null}`)
+	assert.Equal(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = TimedSet{}
 	bytes, err = base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":{}}`)
 
+	str.Channels = AtSequence(SetOf(t, "a"), 17)
+	bytes, err = base.JSONMarshal(str)
+	assert.NoError(t, err, "Marshal")
+	goassert.Equals(t, string(bytes), `{"Channels":{"a":17}}`)
+
 	str.Channels = AtSequence(SetOf(t, "a", "b"), 17)
 	bytes, err = base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
-	goassert.Equals(t, string(bytes), `{"Channels":{"a":17,"b":17}}`)
+	// Ordering of JSON keys can vary - so just check each channel is present with the correct sequence
+	assert.True(t, strings.Contains(string(bytes), `"a":17`))
+	assert.True(t, strings.Contains(string(bytes), `"b":17`))
 }
 
 func TestTimedSetUnmarshal(t *testing.T) {

--- a/channels/timed_set_test.go
+++ b/channels/timed_set_test.go
@@ -10,7 +10,6 @@
 package channels
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -23,17 +22,17 @@ func TestTimedSetMarshal(t *testing.T) {
 	var str struct {
 		Channels TimedSet
 	}
-	bytes, err := json.Marshal(str)
+	bytes, err := base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":null}`)
 
 	str.Channels = TimedSet{}
-	bytes, err = json.Marshal(str)
+	bytes, err = base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":{}}`)
 
 	str.Channels = AtSequence(SetOf(t, "a", "b"), 17)
-	bytes, err = json.Marshal(str)
+	bytes, err = base.JSONMarshal(str)
 	assert.NoError(t, err, "Marshal")
 	goassert.Equals(t, string(bytes), `{"Channels":{"a":17,"b":17}}`)
 }
@@ -42,28 +41,28 @@ func TestTimedSetUnmarshal(t *testing.T) {
 	var str struct {
 		Channels TimedSet
 	}
-	err := json.Unmarshal([]byte(`{"channels":null}`), &str)
+	err := base.JSONUnmarshal([]byte(`{"channels":null}`), &str)
 	assert.NoError(t, err, "Unmarshal")
 	goassert.DeepEquals(t, str.Channels, TimedSet(nil))
 
-	err = json.Unmarshal([]byte(`{"channels":{}}`), &str)
+	err = base.JSONUnmarshal([]byte(`{"channels":{}}`), &str)
 	assert.NoError(t, err, "Unmarshal empty")
 	goassert.DeepEquals(t, str.Channels, TimedSet{})
 
-	err = json.Unmarshal([]byte(`{"channels":{"a":17,"b":17}}`), &str)
+	err = base.JSONUnmarshal([]byte(`{"channels":{"a":17,"b":17}}`), &str)
 	assert.NoError(t, err, "Unmarshal sequence only")
 	goassert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(17), "b": NewVbSimpleSequence(17)})
 
 	// Now try unmarshaling the alternative array form:
-	err = json.Unmarshal([]byte(`{"channels":[]}`), &str)
+	err = base.JSONUnmarshal([]byte(`{"channels":[]}`), &str)
 	assert.NoError(t, err, "Unmarshal empty array")
 	goassert.DeepEquals(t, str.Channels, TimedSet{})
 
-	err = json.Unmarshal([]byte(`{"channels":["a","b"]}`), &str)
+	err = base.JSONUnmarshal([]byte(`{"channels":["a","b"]}`), &str)
 	assert.NoError(t, err, "Unmarshal populated array")
 	goassert.DeepEquals(t, str.Channels, TimedSet{"a": NewVbSimpleSequence(0), "b": NewVbSimpleSequence(0)})
 
-	err = json.Unmarshal([]byte(`{"channels":{"a":{"seq":17, "vb":21},"b":{"seq":23, "vb":25}}}`), &str)
+	err = base.JSONUnmarshal([]byte(`{"channels":{"a":{"seq":17, "vb":21},"b":{"seq":23, "vb":25}}}`), &str)
 	assert.NoError(t, err, "Unmarshal sequence and vbucket only")
 	goassert.Equals(t, fmt.Sprintf("%s", str.Channels), fmt.Sprintf("%s", TimedSet{"a": NewVbSequence(21, 17), "b": NewVbSequence(25, 23)}))
 }

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -16,7 +16,6 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -232,7 +231,7 @@ func ReadJSONFromMIME(headers http.Header, input io.Reader, into interface{}) er
 		return base.HTTPErrorf(http.StatusUnsupportedMediaType, "Unsupported Content-Encoding; use gzip")
 	}
 
-	decoder := json.NewDecoder(input)
+	decoder := base.JSONDecoder(input)
 	decoder.UseNumber()
 	if err := decoder.Decode(into); err != nil {
 		base.Warnf(base.KeyAll, "Couldn't parse JSON in HTTP request: %v", err)

--- a/db/attachment.go
+++ b/db/attachment.go
@@ -248,7 +248,7 @@ type attInfo struct {
 }
 
 func writeJSONPart(writer *multipart.Writer, contentType string, body Body, compressed bool) (err error) {
-	bytes, err := json.Marshal(body)
+	bytes, err := base.JSONMarshal(body)
 	if err != nil {
 		return err
 	}

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -10,7 +10,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
@@ -23,7 +22,7 @@ import (
 
 func unjson(j string) Body {
 	var body Body
-	err := json.Unmarshal([]byte(j), &body)
+	err := base.JSONUnmarshal([]byte(j), &body)
 	if err != nil {
 		panic(fmt.Sprintf("Invalid JSON: %v", err))
 	}
@@ -31,7 +30,7 @@ func unjson(j string) Body {
 }
 
 func tojson(obj interface{}) string {
-	j, _ := json.Marshal(obj)
+	j, _ := base.JSONMarshal(obj)
 	return string(j)
 }
 
@@ -65,7 +64,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	docID := "doc1"
 	var rev1Body Body
 	rev1Data := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
-	require.NoError(t, json.Unmarshal([]byte(rev1Data), &rev1Body))
+	require.NoError(t, base.JSONUnmarshal([]byte(rev1Data), &rev1Body))
 	rev1ID, _, err := db.Put(docID, rev1Body)
 	require.NoError(t, err)
 	assert.Equal(t, "1-12ff9ce1dd501524378fe092ce9aee8f", rev1ID)
@@ -83,7 +82,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	// create rev 2 and check backups for both revs
 	var rev2Body Body
 	rev2Data := `{"test": true, "updated": true, "_attachments": {"hello.txt": {"stub": true, "revpos": 1}}}`
-	require.NoError(t, json.Unmarshal([]byte(rev2Data), &rev2Body))
+	require.NoError(t, base.JSONUnmarshal([]byte(rev2Data), &rev2Body))
 	_, err = db.PutExistingRevWithBody(docID, rev2Body, []string{"2-abc", rev1ID}, true)
 	require.NoError(t, err)
 	rev2ID := "2-abc"
@@ -122,7 +121,7 @@ func TestAttachments(t *testing.T) {
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},
                                     "bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
 	var body Body
-	json.Unmarshal([]byte(rev1input), &body)
+	base.JSONUnmarshal([]byte(rev1input), &body)
 	revid, _, err := db.Put("doc1", unjson(rev1input))
 	rev1id := revid
 	assert.NoError(t, err, "Couldn't create document")
@@ -136,7 +135,7 @@ func TestAttachments(t *testing.T) {
 	log.Printf("Create rev 2...")
 	rev2str := `{"_attachments": {"hello.txt": {"stub":true, "revpos":1}, "bye.txt": {"data": "YnllLXlh"}}}`
 	var body2 Body
-	json.Unmarshal([]byte(rev2str), &body2)
+	base.JSONUnmarshal([]byte(rev2str), &body2)
 	body2[BodyRev] = revid
 	revid, _, err = db.Put("doc1", body2)
 	assert.NoError(t, err, "Couldn't update document")
@@ -157,7 +156,7 @@ func TestAttachments(t *testing.T) {
 	log.Printf("Create rev 3...")
 	rev3str := `{"_attachments": {"bye.txt": {"stub":true,"revpos":2}}}`
 	var body3 Body
-	json.Unmarshal([]byte(rev3str), &body3)
+	base.JSONUnmarshal([]byte(rev3str), &body3)
 	body3[BodyRev] = revid
 	revid, _, err = db.Put("doc1", body3)
 	assert.NoError(t, err, "Couldn't update document")
@@ -174,7 +173,7 @@ func TestAttachments(t *testing.T) {
 	assert.NoError(t, err, "Couldn't compact old revision")
 	rev2Bstr := `{"_attachments": {"bye.txt": {"stub":true,"revpos":1,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}, "_rev": "2-f000"}`
 	var body2B Body
-	err = json.Unmarshal([]byte(rev2Bstr), &body2B)
+	err = base.JSONUnmarshal([]byte(rev2Bstr), &body2B)
 	assert.NoError(t, err, "bad JSON")
 	_, err = db.PutExistingRevWithBody("doc1", body2B, []string{"2-f000", rev1id}, false)
 	assert.NoError(t, err, "Couldn't update document")
@@ -198,7 +197,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 
 	docBody := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	var body Body
-	json.Unmarshal([]byte(docBody), &body)
+	base.JSONUnmarshal([]byte(docBody), &body)
 	_, _, err = db.Put("doc1", unjson(docBody))
 	log.Printf("Got error on put doc:%v", err)
 	db.Bucket.Dump()

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"container/list"
 	"context"
-	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
@@ -525,7 +524,7 @@ func (c *changeCache) Remove(docIDs []string, startTime time.Time) (count int) {
 // Principals unmarshalled during caching don't need to instantiate a real principal - we're just using name and seq from the document
 func (c *changeCache) unmarshalCachePrincipal(docJSON []byte) (cachePrincipal, error) {
 	var principal cachePrincipal
-	err := json.Unmarshal(docJSON, &principal)
+	err := base.JSONUnmarshal(docJSON, &principal)
 	return principal, err
 }
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -11,7 +11,6 @@ package db
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
@@ -166,7 +165,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	//Unmarshall into nested maps
 	var x map[string]interface{}
-	json.Unmarshal(rv, &x)
+	base.JSONUnmarshal(rv, &x)
 	goassert.True(t, err == nil)
 
 	sync := x[base.SyncXattrName].(map[string]interface{})
@@ -184,7 +183,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	history["channels"] = []base.Set{base.SetOf("A", "B"), base.SetOf("B"), base.SetOf("B")}
 
 	//Marshall back to JSON
-	b, err := json.Marshal(x)
+	b, err := base.JSONMarshal(x)
 
 	// Update raw document in the bucket
 	db.Bucket.SetRaw("alpha", 0, b)
@@ -253,7 +252,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	//Unmarshall into nested maps
 	var x map[string]interface{}
-	json.Unmarshal(rv, &x)
+	base.JSONUnmarshal(rv, &x)
 
 	goassert.True(t, err == nil)
 
@@ -268,7 +267,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	history["channels"] = []base.Set{base.SetOf("A", "B"), base.SetOf("A", "B"), base.SetOf("A", "B")}
 
 	//Marshall back to JSON
-	b, err := json.Marshal(x)
+	b, err := base.JSONMarshal(x)
 
 	// Update raw document in the bucket
 	db.Bucket.SetRaw("alpha", 0, b)

--- a/db/crud.go
+++ b/db/crud.go
@@ -10,7 +10,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -165,7 +164,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 		docRoot := documentRoot{
 			SyncData: &SyncData{History: make(RevTree)},
 		}
-		if err := json.Unmarshal(rawDocBytes, &docRoot); err != nil {
+		if err := base.JSONUnmarshal(rawDocBytes, &docRoot); err != nil {
 			return emptySyncData, err
 		}
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"log"
 	"testing"
 
@@ -30,7 +29,7 @@ func getRevTreeList(bucket base.Bucket, key string, useXattrs bool) (revTreeList
 		}
 
 		var treeMeta treeMeta
-		err := json.Unmarshal(rawXattr, &treeMeta)
+		err := base.JSONUnmarshal(rawXattr, &treeMeta)
 		if err != nil {
 			return revTreeList{}, err
 		}
@@ -42,7 +41,7 @@ func getRevTreeList(bucket base.Bucket, key string, useXattrs bool) (revTreeList
 			return revTreeList{}, err
 		}
 		var doc treeDoc
-		err = json.Unmarshal(rawDoc, &doc)
+		err = base.JSONUnmarshal(rawDoc, &doc)
 		return doc.Meta.RevTree, err
 	}
 
@@ -114,7 +113,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 	var revisionBody Body
 	rawRevision, _, err := db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assert.NoError(t, err, "Couldn't get raw backup revision")
-	json.Unmarshal(rawRevision, &revisionBody)
+	base.JSONUnmarshal(rawRevision, &revisionBody)
 	goassert.Equals(t, revisionBody["version"], rev2a_body["version"])
 	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 
@@ -287,7 +286,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	var revisionBody Body
 	rawRevision, _, err := db.Bucket.GetRaw("_sync:rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assert.NoError(t, err, "Couldn't get raw backup revision")
-	json.Unmarshal(rawRevision, &revisionBody)
+	base.JSONUnmarshal(rawRevision, &revisionBody)
 	goassert.Equals(t, revisionBody["version"], rev2a_body["version"])
 	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 

--- a/db/database.go
+++ b/db/database.go
@@ -11,7 +11,6 @@ package db
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
@@ -932,14 +931,14 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 	_, err = context.Bucket.Update(base.SyncDataKey, 0, func(currentValue []byte) ([]byte, *uint32, error) {
 		// The first time opening a new db, currentValue will be nil. Don't treat this as a change.
 		if currentValue != nil {
-			parseErr := json.Unmarshal(currentValue, &syncData)
+			parseErr := base.JSONUnmarshal(currentValue, &syncData)
 			if parseErr != nil || syncData.Sync != syncFun {
 				changed = true
 			}
 		}
 		if changed || currentValue == nil {
 			syncData.Sync = syncFun
-			bytes, err := json.Marshal(syncData)
+			bytes, err := base.JSONMarshal(syncData)
 			return bytes, nil, err
 		} else {
 			return nil, nil, base.ErrUpdateCancel // value unchanged, no need to save
@@ -1073,7 +1072,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 					if updatedExpiry != nil {
 						updatedDoc.UpdateExpiry(*updatedExpiry)
 					}
-					updatedBytes, marshalErr := json.Marshal(updatedDoc)
+					updatedBytes, marshalErr := base.JSONMarshal(updatedDoc)
 					return updatedBytes, updatedExpiry, marshalErr
 				} else {
 					return nil, nil, base.ErrUpdateCancel

--- a/db/document.go
+++ b/db/document.go
@@ -14,7 +14,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -228,7 +227,7 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	doc := NewDocument(docid)
 	if len(data) > 0 {
-		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder := base.JSONDecoder(bytes.NewReader(data))
 		decoder.UseNumber()
 		if err := decoder.Decode(doc); err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error unmarshalling doc.")

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -3,7 +3,6 @@ package db
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/json"
 	"log"
 	"testing"
 
@@ -160,8 +159,8 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 				b.StartTimer()
 				var err error
 				if bm.useDecode {
-					//decoder := json.NewDecoder(bytes.NewReader(doc1k_body))
-					decoder := json.NewDecoder(docReader)
+					//decoder := base.JSONDecoder(bytes.NewReader(doc1k_body))
+					decoder := base.JSONDecoder(docReader)
 					if bm.fixJSONNumbers {
 						decoder.UseNumber()
 					}

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -167,7 +167,7 @@ func BenchmarkUnmarshalBody(b *testing.B) {
 					}
 					err = decoder.Decode(&doc._body)
 				} else {
-					err = json.Unmarshal(doc1k_body, &doc._body)
+					err = base.JSONUnmarshal(doc1k_body, &doc._body)
 					if bm.fixJSONNumbers {
 						doc.Body().FixJSONNumbers()
 					}

--- a/db/event.go
+++ b/db/event.go
@@ -103,7 +103,7 @@ func newJsEventTask(funcSource string) (sgbucket.JSServerTask, error) {
 				stringResult = nativeValue
 				eventTask.responseType = StringResponse
 			case interface{}:
-				resultBytes, marshErr := json.Marshal(nativeValue)
+				resultBytes, marshErr := base.JSONMarshal(nativeValue)
 				if marshErr != nil {
 					err = marshErr
 				} else {

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -88,7 +87,7 @@ func (wh *Webhook) HandleEvent(event Event) {
 	switch event := event.(type) {
 	case *DocumentChangeEvent:
 		// for DocumentChangeEvent, post document body
-		jsonOut, err := json.Marshal(event.Doc)
+		jsonOut, err := base.JSONMarshal(event.Doc)
 		if err != nil {
 			base.Warnf(base.KeyAll, "Error marshalling doc for webhook post: %v", err)
 			return
@@ -104,7 +103,7 @@ func (wh *Webhook) HandleEvent(event Event) {
 		//	"reason":"DB started from config”,
 		//	“state”:"online"
 		//}
-		jsonOut, err := json.Marshal(event.Doc)
+		jsonOut, err := base.JSONMarshal(event.Doc)
 		if err != nil {
 			base.Warnf(base.KeyAll, "Error marshalling doc for webhook post")
 			return

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -308,7 +307,7 @@ func InitWebhookTest() (*int, *float64, *[][]byte) {
 			if len(body) > 0 {
 				payloads = append(payloads, body)
 				var payload map[string]interface{}
-				json.Unmarshal(body, &payload)
+				base.JSONUnmarshal(body, &payload)
 				floatValue, ok := payload["value"].(float64)
 				if ok {
 					sum = sum + floatValue
@@ -494,7 +493,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, _ := eventForTest(-i)
-		oldBodyBytes, _ := json.Marshal(oldBody)
+		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, channels := eventForTest(i)
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
@@ -517,7 +516,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, _ := eventForTest(-i)
-		oldBodyBytes, _ := json.Marshal(oldBody)
+		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, channels := eventForTest(i)
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
@@ -540,7 +539,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, _ := eventForTest(-i)
-		oldBodyBytes, _ := json.Marshal(oldBody)
+		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, channels := eventForTest(i)
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
@@ -568,7 +567,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	for i := 10; i < 20; i++ {
 		body, channels := eventForTest(i)
 		oldBody, _ := eventForTest(-i)
-		oldBodyBytes, _ := json.Marshal(oldBody)
+		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		em.RaiseDocumentChangeEvent(body, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)

--- a/db/import.go
+++ b/db/import.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -336,7 +335,7 @@ func (db *Database) backupPreImportRevision(docid, revid string) error {
 		return nil
 	}
 
-	bodyJson, marshalErr := json.Marshal(stripSpecialProperties(previousRev.Body))
+	bodyJson, marshalErr := base.JSONMarshal(stripSpecialProperties(previousRev.Body))
 	if marshalErr != nil {
 		return fmt.Errorf("Marshal error: %v", marshalErr)
 	}

--- a/db/repair_bucket.go
+++ b/db/repair_bucket.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -346,7 +345,7 @@ func RepairJobRevTreeCycles(docId string, originalCBDoc []byte) (transformedCBDo
 		return nil, false, err
 	}
 
-	transformedCBDoc, errMarshal := json.Marshal(doc)
+	transformedCBDoc, errMarshal := base.JSONMarshal(doc)
 	if errMarshal != nil {
 		return nil, false, errMarshal
 	}

--- a/db/revision.go
+++ b/db/revision.go
@@ -280,7 +280,7 @@ func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody
 // so this function marshals body with atts included, and then removes it again
 func bodyBytesFromBodyAttachmentsMeta(body Body, atts AttachmentsMeta) ([]byte, error) {
 	if len(atts) == 0 {
-		return json.Marshal(body)
+		return base.JSONMarshal(body)
 	}
 
 	origAtts, haveOrigAtts := body[BodyAttachments]
@@ -304,7 +304,7 @@ func bodyBytesFromBodyAttachmentsMeta(body Body, atts AttachmentsMeta) ([]byte, 
 		body[BodyAttachments] = atts
 	}
 
-	newBodyBytes, err := json.Marshal(body)
+	newBodyBytes, err := base.JSONMarshal(body)
 
 	if haveOrigAtts {
 		// Restore original attachments field
@@ -469,7 +469,7 @@ func containsUserSpecialProperties(b Body) bool {
 
 // canonicalEncoding returns the canonical version of body as bytes
 func canonicalEncoding(body Body) ([]byte, error) {
-	return json.Marshal(body) // FIXME: Use canonical JSON encoder
+	return base.JSONMarshal(body) // FIXME: Use canonical JSON encoder
 }
 
 func GetStringArrayProperty(body map[string]interface{}, property string) ([]string, error) {

--- a/db/revision.go
+++ b/db/revision.go
@@ -367,7 +367,7 @@ func createRevID(generation int, parentRevID string, body Body) (string, error) 
 	digester := md5.New()
 	digester.Write([]byte{byte(len(parentRevID))})
 	digester.Write([]byte(parentRevID))
-	encoding, err := canonicalEncoding(stripSpecialProperties(body))
+	encoding, err := base.JSONMarshalCanonical(stripSpecialProperties(body))
 	if err != nil {
 		return "", err
 	}
@@ -464,11 +464,6 @@ func containsUserSpecialProperties(b Body) bool {
 		}
 	}
 	return false
-}
-
-// canonicalEncoding returns the canonical version of body as bytes
-func canonicalEncoding(body Body) ([]byte, error) {
-	return base.JSONMarshal(body) // FIXME: Use canonical JSON encoder
 }
 
 func GetStringArrayProperty(body map[string]interface{}, property string) ([]string, error) {

--- a/db/revision.go
+++ b/db/revision.go
@@ -12,7 +12,6 @@ package db
 import (
 	"bytes"
 	"crypto/md5"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -60,7 +59,7 @@ func (b *Body) Unmarshal(data []byte) error {
 	}
 
 	// Use decoder for unmarshalling to preserve large numbers
-	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder := base.JSONDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	if err := decoder.Decode(b); err != nil {
 		return err

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -1,11 +1,11 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,7 +56,7 @@ func TestBodyUnmarshal(t *testing.T) {
 
 			// Unmarshal using json.Unmarshal for comparison below
 			var jsonUnmarshalBody Body
-			unmarshalErr := json.Unmarshal(test.inputBytes, &jsonUnmarshalBody)
+			unmarshalErr := base.JSONUnmarshal(test.inputBytes, &jsonUnmarshalBody)
 
 			if unmarshalErr != nil {
 				// If json.Unmarshal returns error for input, body.Unmarshal should do the same

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -11,7 +11,6 @@ package db
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -104,7 +103,7 @@ func (tree RevTree) MarshalJSON() ([]byte, error) {
 
 	}
 
-	return json.Marshal(rep)
+	return base.JSONMarshal(rep)
 }
 
 func (tree RevTree) UnmarshalJSON(inputjson []byte) (err error) {
@@ -114,7 +113,7 @@ func (tree RevTree) UnmarshalJSON(inputjson []byte) (err error) {
 		return nil
 	}
 	var rep revTreeList
-	err = json.Unmarshal(inputjson, &rep)
+	err = base.JSONUnmarshal(inputjson, &rep)
 	if err != nil {
 		return
 	}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -215,7 +215,7 @@ func TestRevTreeUnmarshalRevChannelCountMismatch(t *testing.T) {
 	const testJSON = `{"revs": ["3-three", "2-two", "1-one"], "parents": [1, 2, -1], "bodymap": {"0":"{}"}, "channels": [null, ["ABC", "CBS"]]}`
 	gotmap := RevTree{}
 	err := base.JSONUnmarshal([]byte(testJSON), &gotmap)
-	goassert.Equals(t, err.Error(), "revtreelist data is invalid, revs/parents/channels counts are inconsistent")
+	assert.Errorf(t, err, "revtreelist data is invalid, revs/parents/channels counts are inconsistent")
 }
 
 func TestRevTreeMarshal(t *testing.T) {

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -10,7 +10,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -97,7 +96,7 @@ func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs 
 		}`
 
 	revTree := RevTree{}
-	if err := json.Unmarshal([]byte(testJSON), &revTree); err != nil {
+	if err := base.JSONUnmarshal([]byte(testJSON), &revTree); err != nil {
 		panic(fmt.Sprintf("Error: %v", err))
 	}
 
@@ -172,7 +171,7 @@ func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs 
 
 func testUnmarshal(t *testing.T, jsonString string) RevTree {
 	gotmap := RevTree{}
-	assert.NoError(t, json.Unmarshal([]byte(jsonString), &gotmap), "Couldn't parse RevTree from JSON")
+	assert.NoError(t, base.JSONUnmarshal([]byte(jsonString), &gotmap), "Couldn't parse RevTree from JSON")
 	goassert.DeepEquals(t, gotmap, testmap)
 	return gotmap
 }
@@ -215,12 +214,12 @@ func TestRevTreeUnmarshal(t *testing.T) {
 func TestRevTreeUnmarshalRevChannelCountMismatch(t *testing.T) {
 	const testJSON = `{"revs": ["3-three", "2-two", "1-one"], "parents": [1, 2, -1], "bodymap": {"0":"{}"}, "channels": [null, ["ABC", "CBS"]]}`
 	gotmap := RevTree{}
-	err := json.Unmarshal([]byte(testJSON), &gotmap)
+	err := base.JSONUnmarshal([]byte(testJSON), &gotmap)
 	goassert.Equals(t, err.Error(), "revtreelist data is invalid, revs/parents/channels counts are inconsistent")
 }
 
 func TestRevTreeMarshal(t *testing.T) {
-	bytes, err := json.Marshal(testmap)
+	bytes, err := base.JSONMarshal(testmap)
 	assert.NoError(t, err, "Couldn't write RevTree to JSON")
 	fmt.Printf("Marshaled RevTree as %s\n", string(bytes))
 	testUnmarshal(t, string(bytes))
@@ -976,7 +975,7 @@ func addRevs(revTree RevTree, startingParentRevId string, numRevs int, revDigest
 
 	docSizeBytes := 1024 * 5
 	body := createBodyContentAsMapWithSize(docSizeBytes)
-	bodyBytes, err := json.Marshal(body)
+	bodyBytes, err := base.JSONMarshal(body)
 	if err != nil {
 		panic(fmt.Sprintf("Error: %v", err))
 	}

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -123,7 +122,7 @@ func (s *SequenceID) UnmarshalJSON(data []byte) error {
 
 func (s *SequenceID) unmarshalIntSequence(data []byte) error {
 	var raw string
-	err := json.Unmarshal(data, &raw)
+	err := base.JSONUnmarshal(data, &raw)
 	if err != nil {
 		*s, err = parseIntegerSequenceID(string(data))
 	} else {

--- a/db/sequence_id_test.go
+++ b/db/sequence_id_test.go
@@ -1,9 +1,9 @@
 package db
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 )
@@ -46,12 +46,12 @@ func TestParseSequenceID(t *testing.T) {
 func TestMarshalSequenceID(t *testing.T) {
 	s := SequenceID{Seq: 1234}
 	goassert.Equals(t, s.String(), "1234")
-	asJson, err := json.Marshal(s)
+	asJson, err := base.JSONMarshal(s)
 	assert.NoError(t, err, "Marshal failed")
 	goassert.Equals(t, string(asJson), "1234")
 
 	var s2 SequenceID
-	err = json.Unmarshal(asJson, &s2)
+	err = base.JSONUnmarshal(asJson, &s2)
 	assert.NoError(t, err, "Unmarshal failed")
 	goassert.Equals(t, s2, s)
 }
@@ -98,12 +98,12 @@ func TestSequenceIDUnmarshalJSON(t *testing.T) {
 func TestMarshalTriggeredSequenceID(t *testing.T) {
 	s := SequenceID{TriggeredBy: 5678, Seq: 1234}
 	goassert.Equals(t, s.String(), "5678:1234")
-	asJson, err := json.Marshal(s)
+	asJson, err := base.JSONMarshal(s)
 	assert.NoError(t, err, "Marshal failed")
 	goassert.Equals(t, string(asJson), "\"5678:1234\"")
 
 	var s2 SequenceID
-	err = json.Unmarshal(asJson, &s2)
+	err = base.JSONUnmarshal(asJson, &s2)
 	assert.NoError(t, err, "Unmarshal failed")
 	goassert.Equals(t, s2, s)
 }

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -10,7 +10,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -81,7 +80,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 			}
 			revid = fmt.Sprintf("0-%d", generation+1)
 			body[BodyRev] = revid
-			bodyBytes, marshalErr := json.Marshal(body)
+			bodyBytes, marshalErr := base.JSONMarshal(body)
 			return bodyBytes, nil, marshalErr
 		} else {
 			// Deleting:

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -7,8 +7,6 @@
 
   <remote fetch="https://github.com/tleyden/" name="tleyden"/>
 
-  <remote fetch="https://github.com/modern-go/" name="modern-go"/>
-
   <remote fetch="ssh://git@github.com/couchbaselabs/" name="couchbaselabs_private" />
   
   <default remote="couchbase" revision="master"/>
@@ -108,8 +106,8 @@
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
   <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="27518f6661eba504be5a7a9a9f6d9460d892ade3"/>
-  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="modern-go" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
-  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="modern-go" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
+  <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
+  <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
   <!-- Enterprise edition dependencies -->
 
   <!-- gozip tools -->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -105,9 +105,7 @@
   <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <!-- json-iterator-go currently branched with non-upstreamed patch applied -->
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="028e2ef2bd976bae587f7323f47bf34c5559a4b9"/>
-  <!-- required by json-iterator-go -->
+  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
   <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
   <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
   <!-- Enterprise edition dependencies -->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -105,7 +105,9 @@
   <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="27518f6661eba504be5a7a9a9f6d9460d892ade3"/>
+  <!-- json-iterator-go currently branched with non-upstreamed patch applied -->
+  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="028e2ef2bd976bae587f7323f47bf34c5559a4b9"/>
+  <!-- required by json-iterator-go -->
   <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
   <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
   <!-- Enterprise edition dependencies -->

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -73,7 +72,7 @@ func (h *handler) handleDbOnline() error {
 
 	input.Delay = kDefaultDBOnlineDelay
 
-	json.Unmarshal(body, &input)
+	base.JSONUnmarshal(body, &input)
 
 	base.Infof(base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 
@@ -166,7 +165,7 @@ func (h *handler) handleReplicate() error {
 			}
 			fmt.Println(string(b))
 			var body db.Body
-			err = json.Unmarshal(b, &body)
+			err = base.JSONUnmarshal(b, &body)
 			if err != nil {
 				return err
 			}
@@ -185,7 +184,7 @@ func (h *handler) handleReplicate() error {
 			}
 			fmt.Println(string(b))
 			var body db.Body
-			err = json.Unmarshal(b, &body)
+			err = base.JSONUnmarshal(b, &body)
 			if err != nil {
 				return err
 			}
@@ -221,7 +220,7 @@ type ReplicationConfig struct {
 func (h *handler) readReplicationParametersFromJSON(jsonData []byte) (params sgreplicate.ReplicationParameters, cancel bool, localdb bool, err error) {
 
 	var in ReplicationConfig
-	if err = json.Unmarshal(jsonData, &in); err != nil {
+	if err = base.JSONUnmarshal(jsonData, &in); err != nil {
 		return params, false, localdb, err
 	}
 
@@ -500,11 +499,11 @@ func (h *handler) handleSetLogging() error {
 	}
 
 	var keys map[string]bool
-	if err := json.Unmarshal(body, &keys); err != nil {
+	if err := base.JSONUnmarshal(body, &keys); err != nil {
 
 		// return a better error if a user is setting log level inside the body
 		var logLevel map[string]string
-		if err := json.Unmarshal(body, &logLevel); err == nil {
+		if err := base.JSONUnmarshal(body, &logLevel); err == nil {
 			if _, ok := logLevel["logLevel"]; ok {
 				return base.HTTPErrorf(http.StatusBadRequest, "Can't set log level in body, please use \"logLevel\" query parameter instead.")
 			}
@@ -548,7 +547,7 @@ func (h *handler) handleSGCollect() error {
 	}
 
 	var params sgCollectOptions
-	if err = json.Unmarshal(body, &params); err != nil {
+	if err = base.JSONUnmarshal(body, &params); err != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to parse request body: %v", err)
 	}
 
@@ -599,7 +598,7 @@ func marshalPrincipal(princ auth.Principal) ([]byte, error) {
 	} else {
 		info.Channels = princ.Channels().AsSet()
 	}
-	return json.Marshal(info)
+	return base.JSONMarshal(info)
 }
 
 // Handles PUT and POST for a user or a role.
@@ -609,7 +608,7 @@ func (h *handler) updatePrincipal(name string, isUser bool) error {
 	body, _ := h.readBody()
 	var newInfo db.PrincipalConfig
 	var err error
-	if err = json.Unmarshal(body, &newInfo); err != nil {
+	if err = base.JSONUnmarshal(body, &newInfo); err != nil {
 		return err
 	}
 
@@ -725,7 +724,7 @@ func (h *handler) getUsers() error {
 	if err != nil {
 		return err
 	}
-	bytes, err := json.Marshal(users)
+	bytes, err := base.JSONMarshal(users)
 	h.response.Write(bytes)
 	return err
 }
@@ -735,7 +734,7 @@ func (h *handler) getRoles() error {
 	if err != nil {
 		return err
 	}
-	bytes, err := json.Marshal(roles)
+	bytes, err := base.JSONMarshal(roles)
 	h.response.Write(bytes)
 	return err
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1744,9 +1744,7 @@ func TestRawRedaction(t *testing.T) {
 	// Test include doc false doesn't return doc
 	body = map[string]interface{}{}
 	res = rt.SendAdminRequest("GET", "/db/_raw/testdoc?include_doc=false", ``)
-	err = base.JSONUnmarshal(res.Body.Bytes(), &body)
-	assert.NoError(t, err)
-	assert.Equal(t, "bar", body["foo"])
+	assert.NotContains(t, res.Body.String(), "foo")
 
 	// Test doc is returned by default
 	body = map[string]interface{}{}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -153,7 +155,7 @@ func TestUserAPI(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
 	assertStatus(t, response, 200)
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body["admin_roles"], []interface{}{"hipster"})
 	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "bar", "fedoras", "fixies", "foo"})
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -258,7 +257,7 @@ func (h *handler) handleProfiling() error {
 		return err
 	}
 	if len(body) > 0 {
-		if err = json.Unmarshal(body, &params); err != nil {
+		if err = base.JSONUnmarshal(body, &params); err != nil {
 			return err
 		}
 	}
@@ -300,7 +299,7 @@ func (h *handler) handleHeapProfiling() error {
 	if err != nil {
 		return err
 	}
-	if err = json.Unmarshal(body, &params); err != nil {
+	if err = base.JSONUnmarshal(body, &params); err != nil {
 		return err
 	}
 

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -66,7 +65,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
 	response := rt.SendAdminRequest("PUT", "/db/doc1k", doc1k_putDoc)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revid := body["rev"].(string)
 
 	// Create user
@@ -126,7 +125,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 		// revid will be the same for all docs
 		if i == 0 {
 			var body db.Body
-			json.Unmarshal(response.Body.Bytes(), &body)
+			base.JSONUnmarshal(response.Body.Bytes(), &body)
 			revid = body["rev"].(string)
 		}
 	}
@@ -194,7 +193,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 	}
 
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revid := body["rev"].(string)
 	_, rev1_digest := db.ParseRevID(revid)
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc1k?rev=%s", revid), doc1k_putDoc)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -13,7 +13,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1547,7 +1546,7 @@ func TestResponseEncoding(t *testing.T) {
 	assert.Equal(t, "gzip", response.Header().Get("Content-Encoding"))
 	unzip, err := gzip.NewReader(response.Body)
 	assert.NoError(t, err)
-	unjson := json.NewDecoder(unzip)
+	unjson := base.JSONDecoder(unzip)
 	var body db.Body
 	assert.Equal(t, nil, unjson.Decode(&body))
 	assert.Equal(t, str, body["long"])

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1365,10 +1365,19 @@ func TestOpenRevs(t *testing.T) {
 	}
 	response = rt.SendRequestWithHeaders("GET", `/db/or1?open_revs=["12-abc","10-ten"]`, "", reqHeaders)
 	assertStatus(t, response, 200)
-	goassert.Equals(t, response.Body.String(), `[
-{"ok":{"_id":"or1","_rev":"12-abc","n":1}}
-,{"missing":"10-ten"}
-]`)
+
+	var respBody []map[string]interface{}
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
+
+	assert.Len(t, respBody, 2)
+
+	ok := respBody[0]["ok"].(map[string]interface{})
+	assert.NotNil(t, ok)
+	assert.Equal(t, "or1", ok[db.BodyId])
+	assert.Equal(t, "12-abc", ok[db.BodyRev])
+	assert.Equal(t, float64(1), ok["n"])
+
+	assert.Equal(t, "10-ten", respBody[1]["missing"])
 }
 
 // Attempts to get a varying number of revisions on a per-doc basis.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -56,7 +56,7 @@ func TestRoot(t *testing.T) {
 	response := rt.SendRequest("GET", "/", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["couchdb"], "Welcome")
 
 	response = rt.SendRequest("HEAD", "/", "")
@@ -77,7 +77,7 @@ func TestDBRoot(t *testing.T) {
 	response := rt.SendRequest("GET", "/db/", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	err := json.Unmarshal(response.Body.Bytes(), &body)
+	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.NoError(t, err)
 
 	goassert.Equals(t, body["db_name"], "db")
@@ -94,7 +94,7 @@ func (rt *RestTester) createDoc(t *testing.T, docid string) string {
 	response := rt.SendRequest("PUT", "/db/"+docid, `{"prop":true}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revid := body["rev"].(string)
 	if revid == "" {
@@ -122,7 +122,7 @@ func TestDocEtag(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revid := body["rev"].(string)
 	if revid == "" {
@@ -141,7 +141,7 @@ func TestDocEtag(t *testing.T) {
 	//Validate Etag returned when updating doc
 	response = rt.SendRequest("PUT", "/db/doc?rev="+revid, `{"prop":false}`)
 	revid = body["rev"].(string)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revid = body["rev"].(string)
 	if revid == "" {
@@ -161,7 +161,7 @@ func TestDocEtag(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -192,7 +192,7 @@ func TestDocAttachment(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revid := body["rev"].(string)
 
 	attachmentBody := "this is the body of attachment"
@@ -243,13 +243,13 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revid := body["rev"].(string)
 
 	//Put new revision removing document from users channel set
 	response = rt.Send(requestByUser("PUT", "/db/doc?rev="+revid, `{"prop":true}`, "user1"))
 	assertStatus(t, response, 201)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revid = body["rev"].(string)
 
 	attachmentBody := "this is the body of attachment"
@@ -281,7 +281,7 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revid := body["rev"].(string)
 
 	//Put new revision with null body
@@ -348,7 +348,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 
@@ -380,7 +380,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/AC%2FDC/attachpath%2Fattachment.txt?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment = body["rev"].(string)
 
@@ -412,7 +412,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/AC%2BDC%2BGC2/attachpath%2Fattachment.txt?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment = body["rev"].(string)
 
@@ -546,7 +546,7 @@ func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
 	assertStatus(t, response, 404)
 
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["reason"], "no session")
 }
 
@@ -566,7 +566,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 	assertStatus(t, response, 400)
 
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["reason"], "No CORS")
 }
 
@@ -582,7 +582,7 @@ func TestNoCORSOriginOnSessionDelete(t *testing.T) {
 	assertStatus(t, response, 400)
 
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["reason"], "No CORS")
 }
 
@@ -615,7 +615,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -643,7 +643,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	body = db.Body{}
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterUpdateAttachment := body["rev"].(string)
 	if revIdAfterUpdateAttachment == "" {
@@ -657,7 +657,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	body = db.Body{}
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterUpdateAttachmentAgain := body["rev"].(string)
 	if revIdAfterUpdateAttachmentAgain == "" {
@@ -679,7 +679,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc1/attach2?rev="+revIdAfterUpdateAttachmentAgain, attachmentBody)
 	assertStatus(t, response, 201)
 	body = db.Body{}
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterSecondAttachment := body["rev"].(string)
 	if revIdAfterSecondAttachment == "" {
@@ -697,7 +697,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequest("GET", "/db/doc1", "")
 	assertStatus(t, response, 200)
 	body = db.Body{}
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	bodyAttachments, ok := body["_attachments"].(map[string]interface{})
 	if !ok {
 		t.Errorf("Attachments must be map")
@@ -735,7 +735,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -752,7 +752,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	body = db.Body{}
 	response = rt.SendRequest("GET", "/db/notexistyet", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	// body should only have 3 top-level entries _id, _rev, _attachments
 	goassert.True(t, len(body) == 3)
 }
@@ -765,7 +765,7 @@ func TestBulkDocs(t *testing.T) {
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 	var docs []interface{}
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	goassert.Equals(t, len(docs), 3)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-50133ddd8e49efad34ad9ecae4cb9907", "id": "bulk1"})
@@ -782,7 +782,7 @@ func TestBulkDocs(t *testing.T) {
 	// update all documents
 	input = `{"docs": [{"_id": "bulk1", "_rev" : "1-50133ddd8e49efad34ad9ecae4cb9907", "n": 10}, {"_id": "bulk2", "_rev":"1-035168c88bd4b80fb098a8da72f881ce", "n": 20}, {"_id": "_local/bulk3","_rev":"0-1","n": 30}]}`
 	response = rt.SendRequest("POST", "/db/_bulk_docs", input)
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	goassert.Equals(t, len(docs), 3)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "2-7e384b16e63ee3218349ee568f156d6f", "id": "bulk1"})
@@ -800,7 +800,7 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 	var docs []map[string]string
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	log.Printf("response: %s", response.Body.Bytes())
 	assertStatus(t, response, 201)
 	goassert.Equals(t, len(docs), 2)
@@ -1211,7 +1211,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	var docs []interface{}
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	goassert.Equals(t, len(docs), 2)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-afbcffa8a4641a0f4dd94d3fc9593e74", "id": "bulk1"})
@@ -1264,7 +1264,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	var docs []interface{}
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	goassert.Equals(t, len(docs), 2)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-17424d2a21bf113768dfdbcd344741ac", "id": "bulk1"})
@@ -1285,7 +1285,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 	var docs []interface{}
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	goassert.Equals(t, len(docs), 2)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "12-abc", "id": "bdne1"})
@@ -1299,7 +1299,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
             ]}`
 	response = rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
-	json.Unmarshal(response.Body.Bytes(), &docs)
+	base.JSONUnmarshal(response.Body.Bytes(), &docs)
 	goassert.Equals(t, len(docs), 1)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "14-jkl", "id": "bdne1"})
@@ -1331,7 +1331,7 @@ func TestRevsDiff(t *testing.T) {
 	response = rt.SendRequest("POST", "/db/_revs_diff", input)
 	assertStatus(t, response, 200)
 	var diffResponse RevsDiffResponse
-	json.Unmarshal(response.Body.Bytes(), &diffResponse)
+	base.JSONUnmarshal(response.Body.Bytes(), &diffResponse)
 	sort.Strings(diffResponse["rd1"]["possible_ancestors"])
 	goassert.DeepEquals(t, diffResponse, RevsDiffResponse{
 		"rd1": RevDiffResponse{"missing": []string{"13-def", "12-xyz"},
@@ -1383,17 +1383,17 @@ func TestBulkGetPerDocRevsLimit(t *testing.T) {
 
 		response := rt.SendRequest("PUT", fmt.Sprintf("/db/%v", k), fmt.Sprintf(`{"val":"1-%s"}`, k))
 		assertStatus(t, response, 201)
-		json.Unmarshal(response.Body.Bytes(), &body)
+		base.JSONUnmarshal(response.Body.Bytes(), &body)
 		rev := body["rev"].(string)
 
 		response = rt.SendRequest("PUT", fmt.Sprintf("/db/%v?rev=%s", k, rev), fmt.Sprintf(`{"val":"2-%s"}`, k))
 		assertStatus(t, response, 201)
-		json.Unmarshal(response.Body.Bytes(), &body)
+		base.JSONUnmarshal(response.Body.Bytes(), &body)
 		rev = body["rev"].(string)
 
 		response = rt.SendRequest("PUT", fmt.Sprintf("/db/%v?rev=%s", k, rev), fmt.Sprintf(`{"val":"3-%s"}`, k))
 		assertStatus(t, response, 201)
-		json.Unmarshal(response.Body.Bytes(), &body)
+		base.JSONUnmarshal(response.Body.Bytes(), &body)
 		rev = body["rev"].(string)
 
 		docs[k] = rev
@@ -1454,7 +1454,7 @@ readerLoop:
 		log.Printf("multipart part: %+v", string(partBytes))
 
 		partJSON := map[string]interface{}{}
-		err = json.Unmarshal(partBytes, &partJSON)
+		err = base.JSONUnmarshal(partBytes, &partJSON)
 		assert.NoError(t, err, "Unexpected error")
 
 		var exp int
@@ -1595,7 +1595,7 @@ func TestInvalidSession(t *testing.T) {
 	assertStatus(t, response, 401)
 
 	var body db.Body
-	err := json.Unmarshal(response.Body.Bytes(), &body)
+	err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Session Invalid", body["reason"])
@@ -1772,7 +1772,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
@@ -1789,7 +1789,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
@@ -1802,7 +1802,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
@@ -1815,7 +1815,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc5")
@@ -1828,7 +1828,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
@@ -1841,7 +1841,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
@@ -1854,7 +1854,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
@@ -1869,7 +1869,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
@@ -1889,7 +1889,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
@@ -1910,7 +1910,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
@@ -1922,7 +1922,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 5)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -1954,7 +1954,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/alpha", `{"owner":"alice"}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	alphaRevID := body["rev"].(string)
 
@@ -1971,7 +1971,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	changes := changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 1)
@@ -2045,7 +2045,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	// Look at alice's _changes feed:
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.NoError(t, err)
 	assert.Equal(t, "d1", changes.Results[0].ID)
@@ -2053,7 +2053,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	// The complete _changes feed for zegpold contains docs a1 and g1:
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "g1", changes.Results[0].ID)
@@ -2068,7 +2068,7 @@ func TestChannelAccessChanges(t *testing.T) {
 		"", "zegpold"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "a1", changes.Results[0].ID)
 
@@ -2138,7 +2138,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/alpha", `{"owner":"bernard", "channel":"PBS"}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -2151,7 +2151,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 1)
 	if len(changes.Results) > 0 {
@@ -2168,7 +2168,7 @@ func TestAccessOnTombstone(t *testing.T) {
 	// Check user access again:
 	changes.Results = nil
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	goassert.Equals(t, len(changes.Results), 1)
 	if len(changes.Results) > 0 {
 		goassert.Equals(t, changes.Results[0].ID, "alpha")
@@ -2300,14 +2300,14 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_role/role1", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, "role1", body["name"])
 
 	//Put document to trigger sync function
 	response = rt.Send(request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
 	assertStatus(t, response, 201)
 	body = nil
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 
 	// POST the new user the GET and verify that it shows the assigned role
@@ -2316,7 +2316,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_user/user1", "")
 	assertStatus(t, response, 200)
 	body = nil
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, "user1", body["name"])
 	goassert.DeepEquals(t, body["roles"], []interface{}{"role1"})
 	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "chan1"})
@@ -2366,7 +2366,7 @@ func TestRoleAccessChanges(t *testing.T) {
 		`{"user":"alice","role":["role:hipster","role:bogus"]}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 	fashionRevID := body["rev"].(string)
 
@@ -2414,7 +2414,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	cacheWaiter.Wait()
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("1st _changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	require.Equal(t, 3, len(changes.Results))
 	assert.Equal(t, "_user/alice", changes.Results[0].ID)
 	assert.Equal(t, "g1", changes.Results[1].ID)
@@ -2422,7 +2422,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("2nd _changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	require.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
 	assert.Equal(t, "b1", changes.Results[1].ID)
@@ -2459,7 +2459,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	changes.Results = nil
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("3rd _changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	log.Printf("changes: %+v", changes.Results)
 	require.Equal(t, len(changes.Results), 3)
 	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
@@ -2471,7 +2471,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%v", lastSeqPreGrant), "", "zegpold"))
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	require.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "g1", changes.Results[0].ID)
 }
@@ -2510,7 +2510,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/doc1", `{"foo":"bar", "channels":["ch1"]}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	doc1RevID := body["rev"].(string)
 
@@ -2519,7 +2519,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -2531,7 +2531,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -2547,7 +2547,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -2560,7 +2560,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -2585,7 +2585,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	response := rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -2601,7 +2601,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	response = rt.SendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId), "", reqHeaders)
 	goassert.Equals(t, response.Code, 200)
 	//validate attachment has data property
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	log.Printf("response body revid1 = %s", body)
 	attachments := body["_attachments"].(map[string]interface{})
 	attach1 := attachments["attach1"].(map[string]interface{})
@@ -2611,7 +2611,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment)
 	response = rt.SendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment), "", reqHeaders)
 	goassert.Equals(t, response.Code, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	log.Printf("response body revid1 = %s", body)
 	attachments = body["_attachments"].(map[string]interface{})
 	attach1 = attachments["attach1"].(map[string]interface{})
@@ -2726,7 +2726,7 @@ func TestOldDocHandling(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/testOldDocId", `{"foo":"bar"}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	alphaRevID := body["rev"].(string)
 
@@ -2806,7 +2806,7 @@ func TestStarAccess(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -2821,7 +2821,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 3)
 	since := changes.Results[0].Seq
@@ -2831,7 +2831,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes for single channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=books", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 1)
 	since = changes.Results[0].Seq
@@ -2841,7 +2841,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes for ! channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
@@ -2851,7 +2851,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes for unauthorized channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=gifts", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 0)
 
@@ -2877,7 +2877,7 @@ func TestStarAccess(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 6)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc1")
@@ -2886,7 +2886,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 6)
 	since = changes.Results[0].Seq
@@ -2896,7 +2896,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes for ! channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "fran"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
@@ -2923,7 +2923,7 @@ func TestStarAccess(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_all_docs?channels=true", "", "manny"))
 	assertStatus(t, response, 200)
 	log.Printf("Response = %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &allDocsResult)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 2)
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
@@ -2931,7 +2931,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
@@ -2941,7 +2941,7 @@ func TestStarAccess(t *testing.T) {
 	// GET /db/_changes for ! channel
 	response = rt.Send(requestByUser("GET", "/db/_changes?filter=sync_gateway/bychannel&channels=!", "", "manny"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(changes.Results), 2)
 	since = changes.Results[0].Seq
@@ -3032,7 +3032,7 @@ func TestEventConfigValidationSuccess(t *testing.T) {
       			   }`
 
 	var dbConfig DbConfig
-	err := json.Unmarshal([]byte(configJSON), &dbConfig)
+	err := base.JSONUnmarshal([]byte(configJSON), &dbConfig)
 	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&dbConfig)
@@ -3067,7 +3067,7 @@ func TestEventConfigValidationInvalid(t *testing.T) {
       			   }`
 
 	var dbConfig DbConfig
-	err := json.Unmarshal([]byte(configJSON), &dbConfig)
+	err := base.JSONUnmarshal([]byte(configJSON), &dbConfig)
 	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&dbConfig)
@@ -3096,20 +3096,20 @@ func TestBulkGetRevPruning(t *testing.T) {
 	// Do a write
 	response := rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`)
 	assertStatus(t, response, 201)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId := body["rev"]
 
 	// Update 10 times
 	for i := 0; i < 20; i++ {
 		str := fmt.Sprintf(`{"_rev":%q}`, revId)
 		response = rt.Send(request("PUT", "/db/doc1", str))
-		json.Unmarshal(response.Body.Bytes(), &body)
+		base.JSONUnmarshal(response.Body.Bytes(), &body)
 		revId = body["rev"]
 	}
 
 	// Get latest rev id
 	response = rt.SendRequest("GET", "/db/doc1", "")
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId = body[db.BodyRev]
 
 	// Spin up several goroutines to all try to do a _bulk_get on the latest revision.
@@ -3158,7 +3158,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	resource := fmt.Sprintf("/db/%v", docIdDoc1)
 	response := rt.SendRequest("PUT", resource, `{"prop":true}`)
 	assertStatus(t, response, 201)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revidDoc1 := body["rev"].(string)
 
 	// Add another doc
@@ -3241,7 +3241,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 
 	// Get latest rev id
 	response = rt.SendRequest("GET", resource, "")
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId := body[db.BodyRev]
 
 	// Do a bulk_get to get the doc -- this was causing a panic prior to the fix for #2528
@@ -3305,7 +3305,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 		log.Printf("multipart part: %+v", string(partBytes))
 
 		partJson := map[string]interface{}{}
-		err = json.Unmarshal(partBytes, &partJson)
+		err = base.JSONUnmarshal(partBytes, &partJson)
 		assert.NoError(t, err, "Unexpected error")
 
 		// Assert expectations for the doc with attachment errors
@@ -3348,7 +3348,7 @@ func TestDocExpiry(t *testing.T) {
 	// Validate that exp isn't returned on the standard GET, bulk get
 	response = rt.SendRequest("GET", "/db/expNumericTTL", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	_, ok := body["_exp"]
 	goassert.Equals(t, ok, false)
 
@@ -3366,7 +3366,7 @@ func TestDocExpiry(t *testing.T) {
 	body = nil
 	response = rt.SendRequest("GET", "/db/expNumericTTL?show_exp=true", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
 
@@ -3376,7 +3376,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/expNumericUnix?show_exp=true", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	log.Printf("numeric unix response: %s", response.Body.Bytes())
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
@@ -3386,7 +3386,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/expNumericString?show_exp=true", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
 
@@ -3395,7 +3395,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 400)
 	response = rt.SendRequest("GET", "/db/expBadString?show_exp=true", "")
 	assertStatus(t, response, 404)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, false)
 
@@ -3404,7 +3404,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/expDateString?show_exp=true", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
 
@@ -3413,7 +3413,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 400)
 	response = rt.SendRequest("GET", "/db/expBadDateString?show_exp=true", "")
 	assertStatus(t, response, 404)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, false)
 
@@ -3431,7 +3431,7 @@ func TestDocSyncFunctionExpiry(t *testing.T) {
 
 	response = rt.SendRequest("GET", "/db/expNumericTTL?show_exp=true", "")
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	value, ok := body["_exp"]
 	goassert.Equals(t, ok, true)
 	log.Printf("value: %v", value)
@@ -3477,7 +3477,7 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	log.Printf("Response: %s", response.Body)
 
 	bulkDocsResponse := []map[string]interface{}{}
-	err := json.Unmarshal(response.Body.Bytes(), &bulkDocsResponse)
+	err := base.JSONUnmarshal(response.Body.Bytes(), &bulkDocsResponse)
 	assert.NoError(t, err, "Unexpected error")
 	log.Printf("bulkDocsResponse: %+v", bulkDocsResponse)
 	for _, bulkDocResponse := range bulkDocsResponse {
@@ -3543,7 +3543,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 		changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		log.Printf("_changes looks like: %s", changesResponse.Body.Bytes())
-		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		// Checkthat the changes loop isn't returning an empty result immediately (the previous bug) - should
 		// be waiting until entry 'sherlock', created below, appears.
 		goassert.True(t, len(changes.Results) > 0)
@@ -3570,7 +3570,7 @@ func TestUnsupportedConfig(t *testing.T) {
       			   }`
 
 	var testProviderOnlyConfig DbConfig
-	err := json.Unmarshal([]byte(testProviderOnlyJSON), &testProviderOnlyConfig)
+	err := base.JSONUnmarshal([]byte(testProviderOnlyJSON), &testProviderOnlyConfig)
 	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&testProviderOnlyConfig)
@@ -3587,7 +3587,7 @@ func TestUnsupportedConfig(t *testing.T) {
       			   }`
 
 	var viewsOnlyConfig DbConfig
-	err = json.Unmarshal([]byte(viewsOnlyJSON), &viewsOnlyConfig)
+	err = base.JSONUnmarshal([]byte(viewsOnlyJSON), &viewsOnlyConfig)
 	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&viewsOnlyConfig)
@@ -3608,7 +3608,7 @@ func TestUnsupportedConfig(t *testing.T) {
       			   }`
 
 	var viewsAndTestConfig DbConfig
-	err = json.Unmarshal([]byte(viewsAndTestJSON), &viewsAndTestConfig)
+	err = base.JSONUnmarshal([]byte(viewsAndTestJSON), &viewsAndTestConfig)
 	goassert.True(t, err == nil)
 
 	_, err = sc.AddDatabaseFromConfig(&viewsAndTestConfig)
@@ -3668,13 +3668,13 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc1", `{"channels": ["A"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevID := body["rev"].(string)
 
 	//Delete Doc
 	response = rt.SendRequest("DELETE", "/db/doc1?rev="+docRevID, "")
 	assert.Equal(t, http.StatusOK, response.Code)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevID2 := body["rev"].(string)
 
 	//Update / Revive Doc
@@ -3690,7 +3690,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 
 	var changesResponse = make(map[string]interface{})
-	json.Unmarshal(response.Body.Bytes(), &changesResponse)
+	base.JSONUnmarshal(response.Body.Bytes(), &changesResponse)
 	assert.NotContains(t, changesResponse["results"].([]interface{})[1], "deleted")
 }
 
@@ -3744,14 +3744,14 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	response := rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+docrevId, attachmentBody, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docrevId2 := body["rev"].(string)
 
 	//Update Doc
 	rev3Input := `{"_attachments":{"attach1":{"content-type": "content/type", "digest":"sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 2, "stub": true}}, "_id": "doc1", "_rev": "` + docrevId2 + `", "prop":true}`
 	response = rt.SendRequest("PUT", "/db/doc1", rev3Input)
 	assertStatus(t, response, http.StatusCreated)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docrevId3 := body["rev"].(string)
 
 	//Get Existing Doc & Update rev
@@ -3762,7 +3762,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	//Get Existing Doc to Modify
 	response = rt.SendRequest("GET", "/db/doc1?revs=true", "")
 	assertStatus(t, response, http.StatusOK)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 
 	//Modify Doc
 	parentRevList := [3]string{"foo3", "foo2", docRevDigest}
@@ -3773,7 +3773,7 @@ func TestConflictWithInvalidAttachment(t *testing.T) {
 	delete(body["_attachments"].(map[string]interface{})["attach1"].(map[string]interface{}), "digest")
 
 	//Prepare changed doc
-	temp, err := json.Marshal(body)
+	temp, err := base.JSONMarshal(body)
 	assert.NoError(t, err)
 	newBody := string(temp)
 
@@ -3797,14 +3797,14 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev2)
 	assertStatus(t, response, http.StatusCreated)
 
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevId2 := body["rev"].(string)
 	assert.Equal(t, "2-two", docRevId2)
 
 	reqBodyRev2a := `{"_rev": "2-two", "_revisions": {"ids": ["twoa", "` + docRevDigest + `"], "start": 2}}`
 	response = rt.SendRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev2a)
 	assertStatus(t, response, http.StatusCreated)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevId2a := body["rev"].(string)
 	assert.Equal(t, "2-twoa", docRevId2a)
 
@@ -3818,28 +3818,28 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	rev3Attachment := `aGVsbG8gd29ybGQ=` //hello.txt
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev=2-two", rev3Attachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevId3 := body["rev"].(string)
 
 	//Put attachment on doc1 conflicting rev 2a
 	rev3aAttachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` //bye.txt
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1a?rev=2-twoa", rev3aAttachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevId3a := body["rev"].(string)
 
 	//Perform small update on doc3
 	rev4Body := `{"_id": "doc1", "_attachments": {"attach1": {"content_type": "content/type", "digest": "sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 3, "stub":true}}}`
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevId3, rev4Body)
 	assertStatus(t, response, http.StatusCreated)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevId4 := body["rev"].(string)
 
 	//Perform small update on doc3a
 	rev4aBody := `{"_id": "doc1", "_attachments": {"attach1a": {"content_type": "content/type", "digest": "sha1-rdfKyt3ssqPHnWBUxl/xauXXcUs=", "length": 28, "revpos": 3, "stub": true}}}`
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevId3a, rev4aBody)
 	assertStatus(t, response, http.StatusCreated)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	docRevId4a := body["rev"].(string)
 
 	//Ensure the two attachments are different
@@ -3849,8 +3849,8 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	var body1 db.Body
 	var body2 db.Body
 
-	json.Unmarshal(response1.Body.Bytes(), &body1)
-	json.Unmarshal(response2.Body.Bytes(), &body2)
+	base.JSONUnmarshal(response1.Body.Bytes(), &body1)
+	base.JSONUnmarshal(response2.Body.Bytes(), &body2)
 
 	assert.NotEqual(t, body1["_attachments"], body2["_attachments"])
 
@@ -3877,7 +3877,7 @@ func TestNumAccessErrors(t *testing.T) {
 	responseBody := make(map[string]interface{})
 	response = rt.SendAdminRequest("GET", "/_expvar", "")
 
-	json.Unmarshal(response.Body.Bytes(), &responseBody)
+	base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	numAccessErrors := responseBody["syncgateway"].(map[string]interface{})["per_db"].(map[string]interface{})["db"].(map[string]interface{})["security"].(map[string]interface{})["num_access_errors"]
 	assert.Equal(t, float64(1), numAccessErrors)
 }
@@ -3910,13 +3910,13 @@ func TestChanCacheActiveRevsStat(t *testing.T) {
 
 	responseBody := make(map[string]interface{})
 	response := rt.SendRequest("PUT", "/db/testdoc", `{"value":"a value", "channels":["a"]}`)
-	err := json.Unmarshal(response.Body.Bytes(), &responseBody)
+	err := base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	assert.NoError(t, err)
 	rev1 := fmt.Sprint(responseBody["rev"])
 	assertStatus(t, response, http.StatusCreated)
 
 	response = rt.SendRequest("PUT", "/db/testdoc2", `{"value":"a value", "channels":["a"]}`)
-	err = json.Unmarshal(response.Body.Bytes(), &responseBody)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	assert.NoError(t, err)
 	rev2 := fmt.Sprint(responseBody["rev"])
 	assertStatus(t, response, http.StatusCreated)

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -15,7 +15,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -64,7 +63,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 		}
 		changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 		changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		goassert.Equals(t, len(changes.Results), 3)
 	}()
 
@@ -131,7 +130,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 					 "channels":"ABC,PBS"}`
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))
-	err := json.Unmarshal(changesResponse.Body.Bytes(), &initialChanges)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &initialChanges)
 	assert.NoError(t, err, "Unexpected error unmarshalling initialChanges")
 	lastSeq := initialChanges.Last_Seq.String()
 	goassert.Equals(t, lastSeq, "1")
@@ -149,7 +148,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		}
 		sinceLastJSON := fmt.Sprintf(changesJSON, lastSeq)
 		changesResponse := it.Send(requestByUser("POST", "/db/_changes", sinceLastJSON, "bernard"))
-		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		goassert.Equals(t, len(changes.Results), 1)
 	}()
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -51,7 +50,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	goassert.Equals(t, changesResponse.SerialNumber(), changesRequest.SerialNumber())
 	body, err := changesResponse.Body()
 	assert.NoError(t, err, "Error reading changes response body")
-	err = json.Unmarshal(body, &changeList)
+	err = base.JSONUnmarshal(body, &changeList)
 	assert.NoError(t, err, "Error unmarshalling response body")
 	goassert.Equals(t, len(changeList), 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow := changeList[0]
@@ -80,7 +79,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 	goassert.Equals(t, changesResponse2.SerialNumber(), changesRequest2.SerialNumber())
 	body2, err := changesResponse2.Body()
 	assert.NoError(t, err, "Error reading changes response body")
-	err = json.Unmarshal(body2, &changeList2)
+	err = base.JSONUnmarshal(body2, &changeList2)
 	assert.NoError(t, err, "Error unmarshalling response body")
 	goassert.Equals(t, len(changeList2), 1) // Should be 1 row, corresponding to the single doc that was queried in changes
 	changeRow2 := changeList2[0]
@@ -101,7 +100,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
-			err = json.Unmarshal(body, &changeListReceived)
+			err = base.JSONUnmarshal(body, &changeListReceived)
 			assert.NoError(t, err, "Error unmarshalling changes received")
 			goassert.Equals(t, len(changeListReceived), 1)
 			change := changeListReceived[0] // [1,"foo","1-abc"]
@@ -116,7 +115,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
 			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
@@ -173,7 +172,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
-			err = json.Unmarshal(body, &changeListReceived)
+			err = base.JSONUnmarshal(body, &changeListReceived)
 			assert.NoError(t, err, "Error unmarshalling changes received")
 
 			for _, change := range changeListReceived {
@@ -206,7 +205,7 @@ func TestContinuousChangesSubscription(t *testing.T) {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
 			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
@@ -292,7 +291,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
-			err = json.Unmarshal(body, &changeListReceived)
+			err = base.JSONUnmarshal(body, &changeListReceived)
 			assert.NoError(t, err, "Error unmarshalling changes received")
 
 			for _, change := range changeListReceived {
@@ -329,7 +328,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
 			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
@@ -457,7 +456,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 
 			// Expected changes body: [[1,"foo","1-abc"]]
 			changeListReceived := [][]interface{}{}
-			err = json.Unmarshal(body, &changeListReceived)
+			err = base.JSONUnmarshal(body, &changeListReceived)
 			assert.NoError(t, err, "Error unmarshalling changes received")
 
 			for _, change := range changeListReceived {
@@ -504,7 +503,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
 			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
@@ -545,7 +544,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 	subChangesRequest.SetCompressed(false)
 
 	body := subChangesBody{DocIDs: docIDsExpected}
-	bodyBytes, err := json.Marshal(body)
+	bodyBytes, err := base.JSONMarshal(body)
 	assert.NoError(t, err, "Error marshalling subChanges body.")
 
 	subChangesRequest.SetBody(bodyBytes)
@@ -613,7 +612,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 	assert.NoError(t, err, "Error getting changes response body")
 
 	var changeList [][]interface{}
-	err = json.Unmarshal(body, &changeList)
+	err = base.JSONUnmarshal(body, &changeList)
 	assert.NoError(t, err, "Error getting changes response body")
 
 	// The common case of an empty array response tells the sender to send all of the proposed revisions,
@@ -711,7 +710,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	response := bt.restTester.SendAdminRequest("GET", "/db/sendAndGetRev?rev=1-abc", "")
 	assertStatus(t, response, 200)
 	var responseBody RestDocument
-	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
 	_, ok := responseBody[db.BodyDeleted]
 	goassert.False(t, ok)
 
@@ -726,7 +725,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	response = bt.restTester.SendAdminRequest("GET", "/db/sendAndGetRev?rev=2-bcd", "")
 	assertStatus(t, response, 200)
 	responseBody = RestDocument{}
-	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody), "Error unmarshalling GET doc response")
 	deletedValue, deletedOK := responseBody[db.BodyDeleted].(bool)
 	goassert.True(t, deletedOK)
 	goassert.True(t, deletedValue)
@@ -828,7 +827,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/_local/checkpoint%252Ftestclient", "")
 	assertStatus(t, response, 200)
 	var responseBody map[string]interface{}
-	err = json.Unmarshal(response.Body.Bytes(), &responseBody)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	goassert.Equals(t, responseBody["client_seq"], "1000")
 
 	// Attempt to update the checkpoint with previous rev
@@ -1501,7 +1500,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
 			assert.NoError(t, err, "Error marshalling response")
 			response.SetBody(emptyResponseValBytes)
 		}
@@ -2061,7 +2060,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 		// Validate that generation of a delta didn't mutate the revision body in the revision cache
 		docRev, cacheErr := rt.GetDatabase().GetRevisionCacheForTest().Get("doc1", "1-0335a345b6ffed05707ccc4cbc1b67f4", db.BodyShallowCopy)
 		assert.NoError(t, cacheErr)
-		marshalledBody, _ := json.Marshal(docRev.Body)
+		marshalledBody, _ := base.JSONMarshal(docRev.Body)
 		assert.Equal(t, []byte(`{"_id":"doc1","_rev":"1-0335a345b6ffed05707ccc4cbc1b67f4","greetings":[{"hello":"world!"},{"hi":"alice"}]}`), marshalledBody)
 
 	} else {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2131,7 +2131,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/doc1?rev="+newRev, "")
 	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Equal(t, `{"_id":"doc1","_rev":"2-abcxyz","greetings":[{"hello":"world!"},{"hi":"alice"},{"howdy":"bob"}]}`, resp.Body.String())
+	assert.Contains(t, resp.Body.String(), `{"howdy":"bob"}`)
 }
 
 // TestBlipDeltaSyncNewAttachmentPull tests that adding a new attachment in SG and replicated via delta sync adds the attachment

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"sync"
@@ -72,7 +71,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 
 		if string(body) != "null" {
 			var changesReqs [][]interface{}
-			err = json.Unmarshal(body, &changesReqs)
+			err = base.JSONUnmarshal(body, &changesReqs)
 			if err != nil {
 				panic(err)
 			}
@@ -124,7 +123,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 			response.Properties["deltas"] = "true"
 		}
 
-		b, err := json.Marshal(knownRevs)
+		b, err := base.JSONMarshal(knownRevs)
 		if err != nil {
 			panic(err)
 		}
@@ -260,7 +259,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		}
 
 		if bodyJSON != nil {
-			body, err = json.Marshal(bodyJSON)
+			body, err = base.JSONMarshal(bodyJSON)
 			if err != nil {
 				panic(err)
 			}
@@ -481,7 +480,7 @@ func (btc *BlipTesterClient) PushRev(docID, parentRev string, body []byte) (revI
 	// Inline attachment processing
 	if bytes.Contains(body, []byte(db.BodyAttachments)) {
 		var newDocJSON map[string]interface{}
-		if err = json.Unmarshal(body, &newDocJSON); err != nil {
+		if err = base.JSONUnmarshal(body, &newDocJSON); err != nil {
 			return "", err
 		}
 		if attachments, ok := newDocJSON[db.BodyAttachments]; ok {
@@ -521,7 +520,7 @@ func (btc *BlipTesterClient) PushRev(docID, parentRev string, body []byte) (revI
 					newDocJSON[db.BodyAttachments] = attachmentMap
 				}
 			}
-			if body, err = json.Marshal(newDocJSON); err != nil {
+			if body, err = base.JSONMarshal(newDocJSON); err != nil {
 				return "", err
 			}
 		}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -786,7 +786,7 @@ func blipRevMessageProperties(revisionHistory []string, deleted bool, seq db.Seq
 	properties := make(blip.Properties)
 
 	// TODO: Assert? db.SequenceID.MarshalJSON can never error
-	seqJSON, _ := json.Marshal(seq)
+	seqJSON, _ := base.JSONMarshal(seq)
 	properties[revMessageSequence] = string(seqJSON)
 
 	if len(revisionHistory) > 0 {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -592,7 +592,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}
 	output := bytes.NewBuffer(make([]byte, 0, 100*len(changeList)))
 	output.Write([]byte("["))
-	jsonOutput := json.NewEncoder(output)
+	jsonOutput := base.JSONEncoder(output)
 	nWritten := 0
 
 	// Include changes messages w/ proposeChanges stats, although CBL should only be using proposeChanges

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -2,7 +2,6 @@ package rest
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -137,7 +136,7 @@ func readDocIDsFromRequest(rq *blip.Message) (docIDs []string, err error) {
 	// If there's a non-empty body, unmarshal to get the docIDs
 	if len(rawBody) > 0 {
 		var body subChangesBody
-		unmarshalErr := json.Unmarshal(rawBody, &body)
+		unmarshalErr := base.JSONUnmarshal(rawBody, &body)
 		if unmarshalErr != nil {
 			return nil, err
 		} else {

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"html"
@@ -244,8 +243,8 @@ func (h *handler) handleDump() error {
 		title, title)))
 	h.response.Write([]byte("\t<tr><th>Key</th><th>Value</th><th>ID</th></tr>\n"))
 	for _, row := range result.Rows {
-		key, _ := json.Marshal(row.Key)
-		value, _ := json.Marshal(row.Value)
+		key, _ := base.JSONMarshal(row.Key)
+		value, _ := base.JSONMarshal(row.Value)
 		h.response.Write([]byte(fmt.Sprintf("\t<tr><td>%s</td><td>%s</td><td><em>%s</em></td>",
 			html.EscapeString(string(key)), html.EscapeString(string(value)), html.EscapeString(row.ID))))
 		h.response.Write([]byte("</tr>\n"))
@@ -273,7 +272,7 @@ func (h *handler) handleRepair() error {
 	}
 
 	repairBucketParams := db.RepairBucketParams{}
-	if err := json.Unmarshal(body, &repairBucketParams); err != nil {
+	if err := base.JSONUnmarshal(body, &repairBucketParams); err != nil {
 		return pkgerrors.Wrapf(err, "Error unmarshalling %v into RepairJobParams.", string(body))
 	}
 
@@ -286,7 +285,7 @@ func (h *handler) handleRepair() error {
 		return err
 	}
 
-	resultMarshalled, err := json.Marshal(repairBucketResult)
+	resultMarshalled, err := base.JSONMarshal(repairBucketResult)
 	if err != nil {
 		return pkgerrors.Wrapf(err, "Error marshalling repairBucketResult: %+v", repairBucketResult)
 	}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -12,7 +12,6 @@ package rest
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -379,7 +378,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 			base.InfofCtx(h.db.Ctx, base.KeyChanges, "simple changes cannot get Close Notifier from ResponseWriter")
 		}
 
-		encoder := json.NewEncoder(h.response)
+		encoder := base.JSONEncoder(h.response)
 	loop:
 		for {
 			select {

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -119,7 +119,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 		docidsParam := h.getQuery("doc_ids")
 		if docidsParam != "" {
 			var querydocidKeys []string
-			err := json.Unmarshal([]byte(docidsParam), &querydocidKeys)
+			err := base.JSONUnmarshal([]byte(docidsParam), &querydocidKeys)
 			if err == nil {
 				if len(querydocidKeys) > 0 {
 					docIdsArray = querydocidKeys
@@ -187,7 +187,7 @@ func (h *handler) handleChanges() error {
 		docidsParam := h.getQuery("doc_ids")
 		if docidsParam != "" {
 			var docidKeys []string
-			err := json.Unmarshal([]byte(docidsParam), &docidKeys)
+			err := base.JSONUnmarshal([]byte(docidsParam), &docidKeys)
 			if err == nil {
 				if len(docidKeys) > 0 {
 					docIdsArray = docidKeys
@@ -630,7 +630,7 @@ func (h *handler) sendContinuousChangesByHTTP(inChannels base.Set, options db.Ch
 		var err error
 		if changes != nil {
 			for _, change := range changes {
-				data, _ := json.Marshal(change)
+				data, _ := base.JSONMarshal(change)
 				if _, err = h.response.Write(data); err != nil {
 					break
 				}
@@ -692,10 +692,10 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 		_, forceClose = h.generateContinuousChanges(inChannels, wsoptions, func(changes []*db.ChangeEntry) error {
 			var data []byte
 			if changes != nil {
-				data, _ = json.Marshal(changes)
+				data, _ = base.JSONMarshal(changes)
 			} else if !caughtUp {
 				caughtUp = true
-				data, _ = json.Marshal([]*db.ChangeEntry{})
+				data, _ = base.JSONMarshal([]*db.ChangeEntry{})
 			} else {
 				data = []byte{}
 			}
@@ -746,7 +746,7 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 		input.Since = h.db.CreateZeroSinceValue()
 	}
 
-	if err = json.Unmarshal(jsonData, &input); err != nil {
+	if err = base.JSONUnmarshal(jsonData, &input); err != nil {
 		return
 	}
 	feed = input.Feed

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -134,7 +134,7 @@ func TestReproduce2383(t *testing.T) {
 
 	changes.Results = nil
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 
 	// In the first changes request since cache flush, we're forcing a nil cache with no error. Thereforce we'd expect to see zero results.
@@ -145,7 +145,7 @@ func TestReproduce2383(t *testing.T) {
 
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 
 	// Now we should expect 3 results, as the invalid cache was not persisted.
@@ -164,7 +164,7 @@ func TestReproduce2383(t *testing.T) {
 
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes?filter=sync_gateway/bychannel&channels=PBS", "{}", "ben"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 
 	assert.Equal(t, 4, len(changes.Results))
@@ -199,7 +199,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 1, len(changes.Results))
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -216,7 +216,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 		"", "alice"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 1, len(changes.Results))
 
 	assert.Equal(t, "alpha", changes.Results[0].ID)
@@ -229,7 +229,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	assert.Equal(t, 200, response.Code)
 	log.Printf("Deletion looks like: %s", response.Body.Bytes())
 	var docBody db.Body
-	json.Unmarshal(response.Body.Bytes(), &docBody)
+	base.JSONUnmarshal(response.Body.Bytes(), &docBody)
 	goassert.DeepEquals(t, docBody, db.Body{db.BodyId: "alpha", db.BodyRev: rev2, db.BodyDeleted: true})
 
 	// Access without deletion revID shouldn't be allowed (since doc is not in Alice's channels):
@@ -280,7 +280,7 @@ func postChanges(t *testing.T, it *indexTester) {
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 3, len(changes.Results))
 
@@ -326,7 +326,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 		changesJSON := `{"style":"all_docs", "timeout":6000, "feed":"longpoll", "limit":50, "since":"0"}`
 		changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		// Validate that the user receives backfill plus the new doc
-		err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
 
 		if len(changes.Results) != 3 {
@@ -387,7 +387,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 	changesJSON := `{"heartbeat":50, "feed":"normal", "limit":1, "since":"3"}`
 	changesResponse := it.SendAdminRequest("POST", "/db/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
 
-	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 4, len(changes.Results))
 
@@ -399,7 +399,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 	changesJSON = `{"feed":"longpoll"}`
 	changesResponse = it.SendAdminRequest("POST", "/db/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
 
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &filteredChanges)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &filteredChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 1, len(filteredChanges.Results))
 }
@@ -433,7 +433,7 @@ func postChangesSince(t *testing.T, it *indexTester) {
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
-	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
@@ -451,7 +451,7 @@ func postChangesSince(t *testing.T, it *indexTester) {
 
 	changesJSON = fmt.Sprintf(`{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"%s"}`, changes.Last_Seq)
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 3, len(changes.Results))
@@ -499,7 +499,7 @@ func postChangesChannelFilter(t *testing.T, it *indexTester) {
 	changesJSON := `{"filter":"sync_gateway/bychannel", "channels":"PBS"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 4, len(changes.Results))
 
@@ -514,7 +514,7 @@ func postChangesChannelFilter(t *testing.T, it *indexTester) {
 	assertStatus(t, response, 201)
 	cacheWaiter.AddAndWait(4)
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	for _, result := range changes.Results {
 		log.Printf("changes result:%+v", result)
@@ -570,7 +570,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	assertStatus(t, changesResponse, 200)
 
 	log.Printf("Response:%+v", changesResponse.Body)
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 1, len(changes.Results))
 
@@ -586,7 +586,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	assertStatus(t, changesResponse, 200)
 
 	log.Printf("Response:%+v", changesResponse.Body)
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -606,7 +606,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 		"", "bernard"))
 	assertStatus(t, changesResponse, 200)
 	log.Printf("Response:%+v", changesResponse.Body)
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
@@ -665,7 +665,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	require.Equal(t, 4, len(changes.Results))
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -676,7 +676,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 0, len(changes.Results))
 
 	// Send a missing doc - low sequence should move to 3
@@ -690,7 +690,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	// Send another changes request with the same since ("2::6") to ensure we see data once there are changes
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 3, len(changes.Results))
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
@@ -702,7 +702,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 1, len(changes.Results))
 
 }
@@ -757,7 +757,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 5, len(changes.Results)) // Includes user doc
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -775,7 +775,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 4, len(changes.Results))
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
@@ -789,7 +789,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
@@ -802,7 +802,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 4 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 
 	// Valid results here under race conditions should be:
 	//    receive sequences 6-13, last seq 13
@@ -887,7 +887,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	}
 	response := rt.SendAdminRequest("GET", "/db/_changes", "")
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 5, len(changes.Results))
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -905,7 +905,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 4, len(changes.Results))
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
@@ -919,7 +919,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
@@ -932,7 +932,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
 	log.Printf("_changes 4 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 
 	// Valid results here under race conditions should be:
 	//    receive sequences 6-13, last seq 13
@@ -1022,7 +1022,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 5, len(changes.Results)) // Includes user doc
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
@@ -1040,7 +1040,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 4, len(changes.Results))
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
@@ -1054,7 +1054,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	log.Printf("sending changes JSON: %s", changesJSON)
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &changes)
+	base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
@@ -1068,7 +1068,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		log.Printf("starting longpoll changes w/ JSON: %s", longpollChangesJSON)
 		longPollResponse := rt.Send(requestByUser("POST", "/db/_changes", longpollChangesJSON, "bernard"))
 		log.Printf("longpoll changes looks like: %s", longPollResponse.Body.Bytes())
-		json.Unmarshal(longPollResponse.Body.Bytes(), &changes)
+		base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes)
 		// Expect to get 6 through 12
 		assert.Equal(t, 7, len(changes.Results))
 		assert.Equal(t, "12", changes.Last_Seq)
@@ -1123,7 +1123,7 @@ func _testConcurrentDelete(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 	revId := body["rev"].(string)
 
@@ -1162,7 +1162,7 @@ func _testConcurrentPutAsDelete(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 	revId := body["rev"].(string)
 
@@ -1200,7 +1200,7 @@ func _testConcurrentUpdate(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 	revId := body["rev"].(string)
 
@@ -1238,7 +1238,7 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channel":"PBS"}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 	revId := body["rev"].(string)
 	revIdHash := strings.TrimPrefix(revId, "1-")
@@ -1327,7 +1327,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user1", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err := json.Unmarshal(response.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "doc4", changes.Results[1].ID)
@@ -1338,7 +1338,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user2", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 3, len(changes.Results))
 	assert.Equal(t, "docD", changes.Results[2].ID)
@@ -1349,7 +1349,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(changes.Results))
 	assert.Equal(t, "docD", changes.Results[3].ID)
@@ -1360,7 +1360,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user4", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 0, len(changes.Results))
 
@@ -1370,7 +1370,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 5, len(changes.Results))
 
@@ -1380,7 +1380,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 2, len(changes.Results))
 
@@ -1389,7 +1389,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 3, len(changes.Results))
 
@@ -1398,7 +1398,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(changes.Results))
 
@@ -1406,7 +1406,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "docA"]}`
 	response = rt.SendAdminRequest("POST", "/db/_changes", body)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(changes.Results))
 
@@ -1416,7 +1416,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 3, len(changes.Results))
 	assert.Equal(t, "docD", changes.Results[2].ID)
@@ -1427,7 +1427,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "doc4", changes.Results[0].ID)
@@ -1438,7 +1438,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(changes.Results))
 	assert.Equal(t, "docD", changes.Results[3].ID)
@@ -1453,7 +1453,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 4, len(changes.Results))
 	assert.Equal(t, "docC", changes.Results[3].ID)
@@ -1471,7 +1471,7 @@ func updateTestDoc(rt *RestTester, docid string, revid string, body string) (new
 	}
 
 	var responseBody db.Body
-	json.Unmarshal(response.Body.Bytes(), &responseBody)
+	base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
 	return responseBody["rev"].(string), nil
 }
 
@@ -1581,7 +1581,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	var changes struct {
 		Results []*json.RawMessage
 	}
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, len(expectedResults), len(changes.Results))
 
@@ -1599,7 +1599,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	var postFlushChanges struct {
 		Results []*json.RawMessage
 	}
-	err = json.Unmarshal(postFlushChangesResponse.Body.Bytes(), &postFlushChanges)
+	err = base.JSONUnmarshal(postFlushChangesResponse.Body.Bytes(), &postFlushChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, len(expectedResults), len(postFlushChanges.Results))
 
@@ -1624,7 +1624,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 	var allDocsChanges struct {
 		Results []*json.RawMessage
 	}
-	err = json.Unmarshal(styleAllDocsChangesResponse.Body.Bytes(), &allDocsChanges)
+	err = base.JSONUnmarshal(styleAllDocsChangesResponse.Body.Bytes(), &allDocsChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, len(expectedStyleAllDocs), len(allDocsChanges.Results))
 	for index, result := range allDocsChanges.Results {
@@ -1639,7 +1639,7 @@ func TestChangesIncludeDocs(t *testing.T) {
 		Results []*json.RawMessage
 	}
 
-	err = json.Unmarshal(combinedChangesResponse.Body.Bytes(), &combinedChanges)
+	err = base.JSONUnmarshal(combinedChangesResponse.Body.Bytes(), &combinedChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, len(expectedResults), len(combinedChanges.Results))
 	for index, result := range combinedChanges.Results {
@@ -1659,17 +1659,17 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	// Put several documents
 	var body db.Body
 	response := it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/activeDoc", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
@@ -1694,7 +1694,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	// Pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 
@@ -1715,7 +1715,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1729,7 +1729,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 3, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1742,7 +1742,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	// Active only, GET
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 3, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1801,7 +1801,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	changes.Results = nil
 	changesJSON := `{"since":0, "limit":50}`
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1814,7 +1814,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1872,7 +1872,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changes.Results = nil
 	changesJSON := `{"since":0, "limit":5}`
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1885,7 +1885,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	// Issue another since=0, limit 5 changes request.  Validate that there is another a view-based backfill
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1899,7 +1899,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changes.Results = nil
 	changesJSON = `{"since":20, "limit":5}`
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 3, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1913,7 +1913,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changes.Results = nil
 	changesJSON = `{"since":20, "limit":5}`
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 3, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1969,7 +1969,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	changesJSON := `{"since":15, "limit":50}`
 	changes.Results = nil
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1983,7 +1983,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	changes.Results = nil
 	changesJSON = `{"since":0, "limit":50}`
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -1996,7 +1996,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2068,7 +2068,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	changesJSON := `{"since":15, "limit":50}`
 	changes.Results = nil
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 6, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2082,7 +2082,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	changes.Results = nil
 	changesJSON = `{"since":15, "limit":50}`
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 6, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2142,7 +2142,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	changesJSON := `{"since":0, "limit":50}`
 	changes.Results = nil
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2154,7 +2154,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2214,7 +2214,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	changesJSON := `{"since":0, "limit":50}`
 	changes.Results = nil
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for index, entry := range changes.Results {
@@ -2228,7 +2228,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for index, entry := range changes.Results {
@@ -2269,7 +2269,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/doc1", `{"channels":["PBS"]}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	assert.Equal(t, true, body["ok"])
 	revId := body["rev"].(string)
 
@@ -2326,7 +2326,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	changesJSON := `{"since":0, "limit":50}`
 	changes.Results = nil
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 2, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2340,7 +2340,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	// Issue another since=0 changes request - cache SHOULD only have a single rev for doc1
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 2, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2373,18 +2373,18 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Put several documents
 	var body db.Body
 	response := it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
@@ -2410,7 +2410,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 
@@ -2443,7 +2443,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2457,7 +2457,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2472,7 +2472,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2485,7 +2485,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Active only with Limit, GET
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2499,7 +2499,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2531,18 +2531,18 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Put several documents
 	var body db.Body
 	response := it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = it.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
@@ -2569,7 +2569,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Get pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 
@@ -2602,7 +2602,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2619,7 +2619,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2635,7 +2635,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2650,7 +2650,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	testDb.FlushChannelCache()
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2665,7 +2665,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2680,7 +2680,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	testDb.FlushChannelCache()
 	changes.Results = nil
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2695,7 +2695,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 		Last_Seq interface{}
 	}
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &updatedChanges)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &updatedChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(updatedChanges.Results))
 
@@ -2731,18 +2731,18 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	// Put several documents
 	var body db.Body
 	response := rt.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 	response = rt.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
@@ -2767,7 +2767,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	// Get pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 
@@ -2800,7 +2800,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 10, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2814,7 +2814,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2829,7 +2829,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2842,7 +2842,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	// Active only with Limit, GET
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 5, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2856,7 +2856,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 8, len(changes.Results))
 	for _, entry := range changes.Results {
@@ -2898,7 +2898,7 @@ func TestChangesIncludeConflicts(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?style=all_docs", "")
-	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("changes response: %s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 1, len(changes.Results))
@@ -2938,7 +2938,7 @@ func TestChangesLargeSequences(t *testing.T) {
 	require.NoError(t, rt.WaitForPendingChanges())
 
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
-	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, uint64(9223372036854775808), changes.Results[0].Seq.Seq)
@@ -2946,13 +2946,13 @@ func TestChangesLargeSequences(t *testing.T) {
 
 	// Validate incoming since value isn't being truncated
 	changesResponse = rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775808", "")
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 0, len(changes.Results))
 
 	// Validate incoming since value isn't being truncated
 	changesResponse = rt.SendAdminRequest("POST", "/db/_changes", `{"since":9223372036854775808}`)
-	err = json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	assert.Equal(t, 0, len(changes.Results))
 
@@ -2996,7 +2996,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	// Get as admin
 	changes.Results = nil
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?include_docs=true", "")
-	err := json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("admin response: %s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	// Expect three docs, no user docs
@@ -3005,7 +3005,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	// Get as user
 	changes.Results = nil
 	userChangesResponse := rt.Send(requestByUser("GET", "/db/_changes?include_docs=true", "", "includeDocsUser"))
-	err = json.Unmarshal(userChangesResponse.Body.Bytes(), &changes)
+	err = base.JSONUnmarshal(userChangesResponse.Body.Bytes(), &changes)
 	log.Printf("userChangesResponse: %s", userChangesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	// Expect three docs and the authenticated user's user doc
@@ -3058,7 +3058,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 		longpollChangesJSON := `{"since":0, "feed":"longpoll"}`
 		longPollResponse := rt.Send(requestByUser("POST", "/db/_changes", longpollChangesJSON, "bernard"))
 		log.Printf("longpoll changes response looks like: %s", longPollResponse.Body.Bytes())
-		json.Unmarshal(longPollResponse.Body.Bytes(), &changes)
+		base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes)
 		// Expect to get 4 docs plus user doc
 		assert.Equal(t, 5, len(changes.Results))
 	}()
@@ -3111,7 +3111,7 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 			channelName := fmt.Sprintf("chan_%d", i)
 			changesURL := fmt.Sprintf(changesURLPattern, channelName)
 			changesResponse := rt.SendAdminRequest("GET", changesURL, "")
-			json.Unmarshal(changesResponse.Body.Bytes(), &changes)
+			base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 			// Expect to get 1 doc
 			assert.Equal(t, 1, len(changes.Results))
 		}(i)
@@ -3140,7 +3140,7 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 	// Write a single doc to all 100 channels, ensure everyone gets it
 	channelDocBody := make(map[string]interface{})
 	channelDocBody["channels"] = channelSet
-	bodyBytes, err := json.Marshal(channelDocBody)
+	bodyBytes, err := base.JSONMarshal(channelDocBody)
 	assert.NoError(t, err, "Marshal error for 100 channel doc")
 
 	putResponse := rt.SendAdminRequest("PUT", "/db/100ChannelDoc", string(bodyBytes))
@@ -3177,7 +3177,7 @@ func TestTombstoneCompaction(t *testing.T) {
 			response := rt.SendAdminRequest("POST", "/db/", `{"foo":"bar"}`)
 			assert.Equal(t, 200, response.Code)
 			var body db.Body
-			err := json.Unmarshal(response.Body.Bytes(), &body)
+			err := base.JSONUnmarshal(response.Body.Bytes(), &body)
 			assert.NoError(t, err)
 			revId := body["rev"].(string)
 			docId := body["id"].(string)

--- a/rest/config.go
+++ b/rest/config.go
@@ -636,7 +636,7 @@ func decodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
 	d := base.JSONDecoder(bytes.NewBuffer(b))
 	d.DisallowUnknownFields()
 	err = d.Decode(config)
-	if err != nil && strings.HasPrefix(err.Error(), "json: unknown field") {
+	if err != nil && strings.Contains(err.Error(), "unknown field") {
 		// Special handling for unknown field errors
 		// json.Decode continues to decode the full data into the struct
 		// so it's safe to use even after this error

--- a/rest/config.go
+++ b/rest/config.go
@@ -12,7 +12,6 @@ package rest
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -634,7 +633,7 @@ func decodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
 
 	b = base.ConvertBackQuotedStrings(b)
 
-	d := json.NewDecoder(bytes.NewBuffer(b))
+	d := base.JSONDecoder(bytes.NewBuffer(b))
 	d.DisallowUnknownFields()
 	err = d.Decode(config)
 	if err != nil && strings.HasPrefix(err.Error(), "json: unknown field") {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -64,7 +64,10 @@ func TestReadServerConfig(t *testing.T) {
 			if test.err == "" {
 				assert.NoError(tt, err, "unexpected error for test config")
 			} else {
-				if test.errEE != "" && !base.UseStdlibJSON.IsTrue() {
+				if test.errEE != "" &&
+					base.IsEnterpriseEdition() &&
+					!base.UseStdlibJSON {
+					// jsoniter-specific error handling
 					assert.NotNil(tt, err)
 					assert.Contains(tt, err.Error(), test.errEE)
 					return

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"mime/multipart"
@@ -103,7 +102,7 @@ func (h *handler) handleGetDoc() error {
 			revids = doc.History.GetLeaves()
 		} else {
 			// open_revs=["id1", "id2", ...]
-			err := json.Unmarshal([]byte(openRevs), &revids)
+			err := base.JSONUnmarshal([]byte(openRevs), &revids)
 			if err != nil {
 				return base.HTTPErrorf(http.StatusBadRequest, "bad open_revs")
 			}

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -1,12 +1,12 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -108,7 +108,7 @@ func TestDocumentNumbers(t *testing.T) {
 			// Check channel assignment
 			getRawResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s?redact=false", test.name), "")
 			var rawResponse RawResponse
-			json.Unmarshal(getRawResponse.Body.Bytes(), &rawResponse)
+			base.JSONUnmarshal(getRawResponse.Body.Bytes(), &rawResponse)
 			log.Printf("raw response: %s", getRawResponse.Body.Bytes())
 			assert.Equal(ts, 1, len(rawResponse.Sync.Channels))
 			assert.True(ts, HasActiveChannel(rawResponse.Sync.Channels, test.expectedFormatChannel), fmt.Sprintf("Expected channel %s was not found in document channels (%s)", test.expectedFormatChannel, test.name))

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/url"
 
@@ -69,7 +68,7 @@ func verifyFacebook(fbUrl, accessToken string) (*FacebookResponse, error) {
 			"Facebook verification server status %d", res.StatusCode)
 	}
 
-	decoder := json.NewDecoder(res.Body)
+	decoder := base.JSONDecoder(res.Body)
 
 	var response FacebookResponse
 	err = decoder.Decode(&response)

--- a/rest/google.go
+++ b/rest/google.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -55,7 +54,7 @@ func verifyGoogle(idToken string, allowedAppID []string) (*GoogleResponse, error
 	}
 	defer res.Body.Close()
 
-	decoder := json.NewDecoder(res.Body)
+	decoder := base.JSONDecoder(res.Body)
 
 	var response GoogleResponse
 	err = decoder.Decode(&response)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -426,7 +426,7 @@ func (h *handler) getIntQuery(query string, defaultValue uint64) (value uint64) 
 func (h *handler) getJSONQuery(query string) (value interface{}, err error) {
 	valueJSON := h.getQuery(query)
 	if valueJSON != "" {
-		err = json.Unmarshal([]byte(valueJSON), &value)
+		err = base.JSONUnmarshal([]byte(valueJSON), &value)
 	}
 	return
 }
@@ -435,7 +435,7 @@ func (h *handler) getJSONStringArrayQuery(param string) ([]string, error) {
 	var strings []string
 	value := h.getQuery(param)
 	if value != "" {
-		if err := json.Unmarshal([]byte(value), &strings); err != nil {
+		if err := base.JSONUnmarshal([]byte(value), &strings); err != nil {
 			return nil, base.HTTPErrorf(http.StatusBadRequest, "%s URL param is not a JSON string array", param)
 		}
 	}
@@ -573,7 +573,7 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 		return
 	}
 
-	jsonOut, err := json.Marshal(value)
+	jsonOut, err := base.JSONMarshal(value)
 	if err != nil {
 		base.Warnf(base.KeyAll, "Couldn't serialize JSON for %v : %s", base.UD(value), err)
 		h.writeStatus(http.StatusInternalServerError, "JSON serialization failed")
@@ -721,7 +721,7 @@ func (h *handler) writeStatus(status int, message string) {
 	h.setHeader("Content-Type", "application/json")
 	h.response.WriteHeader(status)
 	h.setStatus(status, message)
-	jsonOut, _ := json.Marshal(db.Body{"error": errorStr, "reason": message})
+	jsonOut, _ := base.JSONMarshal(db.Body{"error": errorStr, "reason": message})
 	h.response.Write(jsonOut)
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -627,7 +627,7 @@ func (h *handler) writeTextStatus(status int, value []byte) {
 }
 
 func (h *handler) addJSON(value interface{}) error {
-	encoder := json.NewEncoder(h.response)
+	encoder := base.JSONEncoder(h.response)
 	err := encoder.Encode(value)
 	if err != nil {
 		clientConnectionError := strings.Contains(err.Error(), "write: broken pipe")

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"log"
@@ -77,7 +76,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 	assert.True(t, rawInsertResponse.Sync.Channels != nil, "Expected channels not returned for SDK insert")
 	log.Printf("insert channels: %+v", rawInsertResponse.Sync.Channels)
@@ -96,7 +95,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
 	goassert.Equals(t, response.Code, 200)
 	var rawUpdateResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 
 	// If delta sync is enabled, old doc may be available based on the backup used for delta generation, if it hasn't already
@@ -114,7 +113,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_raw/TestImportDelete?redact=false", "")
 	goassert.Equals(t, response.Code, 200)
 	var rawDeleteResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawDeleteResponse)
 	log.Printf("Post-delete: %s", response.Body.Bytes())
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 	assert.True(t, rawUpdateResponse.Sync.Channels != nil, "Expected channels not returned for SDK update")
@@ -149,7 +148,7 @@ func TestXattrSGTombstone(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -157,7 +156,7 @@ func TestXattrSGTombstone(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
@@ -194,7 +193,7 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["rev"], "1-111c27be37c17f18ae8fe9faa3bb4e0e")
 	revId := body["rev"].(string)
 
@@ -257,7 +256,7 @@ func TestXattrResurrectViaSG(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -265,14 +264,14 @@ func TestXattrResurrectViaSG(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
 	// 3. Recreate the doc through the SG (with different data)
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", key, revId), `{"channels":"ABC"}`)
 	goassert.Equals(t, response.Code, 201)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	goassert.Equals(t, body["rev"], "3-70c113f08c6622cd87af68f4f60d12e3")
 
@@ -306,7 +305,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	response := rt.SendAdminRequest("GET", rawPath, "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 
 	// 2. Delete the doc through the SDK
@@ -316,7 +315,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	response = rt.SendAdminRequest("GET", rawPath, "")
 	goassert.Equals(t, response.Code, 200)
 	var rawDeleteResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawDeleteResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawDeleteResponse)
 	log.Printf("Post-delete: %s", response.Body.Bytes())
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 
@@ -332,7 +331,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 	response = rt.SendAdminRequest("GET", rawPath, "")
 	goassert.Equals(t, response.Code, 200)
 	var rawUpdateResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawUpdateResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 	_, ok := rawUpdateResponse.Sync.Channels["HBO"]
 	assert.True(t, ok, "Didn't find expected channel (HBO) on resurrected doc")
@@ -363,7 +362,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -379,7 +378,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 409)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
@@ -408,7 +407,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -420,7 +419,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", sdk_key), `{"channels":"ABC"}`)
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 
 	// 2. Delete SDK_delete through the SDK
@@ -437,7 +436,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
@@ -570,7 +569,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -591,7 +590,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	goassert.Equals(t, response.Code, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	goassert.Equals(t, newRevId, revId)
@@ -624,7 +623,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -646,7 +645,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	// rev should have generation 2.
 	putResponse := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", mobileKey, revId), `{"updated":true}`)
 	goassert.Equals(t, putResponse.Code, 201)
-	json.Unmarshal(putResponse.Body.Bytes(), &body)
+	base.JSONUnmarshal(putResponse.Body.Bytes(), &body)
 	log.Printf("Put response details: %s", putResponse.Body.Bytes())
 	newRevId, ok := body["rev"].(string)
 	assert.True(t, ok, "Unable to cast rev to string")
@@ -684,7 +683,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -722,7 +721,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	// Get the doc again, validate rev hasn't changed
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	goassert.Equals(t, response.Code, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	goassert.Equals(t, newRevId, revId)
@@ -836,7 +835,7 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
-	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)
+	err = base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc)
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 3)
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 0)
 
@@ -902,7 +901,7 @@ func TestMigrateTombstone(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
-	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)
+	err = base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc)
 	goassert.Equals(t, doc.Meta.CurrentRev, "2-6b1e1af9190829c1ceab6f1c8fb9fa3f")
 	goassert.Equals(t, doc.Meta.Sequence, uint64(5))
 
@@ -970,7 +969,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key+"?redact=false", "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
-	err = json.Unmarshal(rawResponse.Body.Bytes(), &doc)
+	err = base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc)
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 1)
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 2)
 }
@@ -1318,7 +1317,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 	}
 	triggerOnDemandViaWrite := func(rt *RestTester, key string) {
 		mobileBody["foo"] = "bar"
-		mobileBodyMarshalled, err := json.Marshal(mobileBody)
+		mobileBodyMarshalled, err := base.JSONMarshal(mobileBody)
 		assert.NoError(t, err, "Error marshalling body")
 		rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), string(mobileBodyMarshalled))
 	}
@@ -1567,7 +1566,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 	rev1id := rawInsertResponse.Sync.Rev
 
@@ -1581,7 +1580,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	// 4. Trigger import of update via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	goassert.Equals(t, response.Code, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 
 	// 5. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
@@ -1627,7 +1626,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 	rev1id := rawInsertResponse.Sync.Rev
 
@@ -1645,7 +1644,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	// 5. Trigger import of update via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	goassert.Equals(t, response.Code, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 
 	// 6. Attempt to retrieve previous revision body.  Should return missing, as rev wasn't in rev cache when import occurred.
@@ -1685,7 +1684,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	response := rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	goassert.Equals(t, response.Code, 200)
 	var rawInsertResponse RawResponse
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 	rev1id := rawInsertResponse.Sync.Rev
 
@@ -1699,7 +1698,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	// 4. Trigger import of update via SG retrieval
 	response = rt.SendAdminRequest("GET", fmt.Sprintf("/db/_raw/%s", key), "")
 	goassert.Equals(t, response.Code, 200)
-	err = json.Unmarshal(response.Body.Bytes(), &rawInsertResponse)
+	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
 	assert.NoError(t, err, "Unable to unmarshal raw response")
 
 	// 5. Flush the rev cache (simulates attempted retrieval by a different SG node, since testing framework isn't great
@@ -1795,7 +1794,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -1820,7 +1819,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	goassert.Equals(t, response.Code, 200)
-	json.Unmarshal(response.Body.Bytes(), &body)
+	base.JSONUnmarshal(response.Body.Bytes(), &body)
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	goassert.Equals(t, newRevId, revId)
@@ -1828,7 +1827,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 
 func assertDocProperty(t *testing.T, getDocResponse *TestResponse, propertyName string, expectedPropertyValue interface{}) {
 	var responseBody map[string]interface{}
-	err := json.Unmarshal(getDocResponse.Body.Bytes(), &responseBody)
+	err := base.JSONUnmarshal(getDocResponse.Body.Bytes(), &responseBody)
 	assert.NoError(t, err, "Error unmarshalling document response")
 	value, ok := responseBody[propertyName]
 	assert.True(t, ok, fmt.Sprintf("Expected property %s not found in response %s", propertyName, getDocResponse.Body.Bytes()))

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -13,7 +13,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -120,7 +119,7 @@ func (h *handler) handleOidcProviderConfiguration() error {
 		ClaimsSupported:                   []string{"email", "sub", "exp", "iat", "iss", "aud", "nickname"},
 	}
 
-	if bytes, err := json.Marshal(config); err == nil {
+	if bytes, err := base.JSONMarshal(config); err == nil {
 		h.response.Write(bytes)
 	}
 
@@ -464,7 +463,7 @@ func writeTokenResponse(h *handler, subject string, issuerUrl string, tokenttl t
 		IdToken:      idToken.Encode(),
 	}
 
-	if bytes, err := json.Marshal(tokenResponse); err == nil {
+	if bytes, err := base.JSONMarshal(tokenResponse); err == nil {
 		h.response.Write(bytes)
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -697,12 +697,12 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 			}
 		}
 
-		eventHandlersJSON, err := json.Marshal(eventHandlersMap)
+		eventHandlersJSON, err := base.JSONMarshal(eventHandlersMap)
 		if err != nil {
-			return pkgerrors.Wrapf(err, "Error calling json.Marshal() in initEventHandlers")
+			return pkgerrors.Wrapf(err, "Error calling base.JSONMarshal() in initEventHandlers")
 		}
-		if err := json.Unmarshal(eventHandlersJSON, eventHandlers); err != nil {
-			return pkgerrors.Wrapf(err, "Error calling json.Unmarshal() in initEventHandlers")
+		if err := base.JSONUnmarshal(eventHandlersJSON, eventHandlers); err != nil {
+			return pkgerrors.Wrapf(err, "Error calling base.JSONUnmarshal() in initEventHandlers")
 		}
 
 		// Process document commit event handlers
@@ -928,7 +928,7 @@ func (sc *ServerContext) logStats() error {
 		RFC3339:            currentTime.Format(time.RFC3339),
 	}
 
-	marshalled, err := json.Marshal(wrapper)
+	marshalled, err := base.JSONMarshal(wrapper)
 	if err != nil {
 		return err
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -376,7 +375,7 @@ func (rt *RestTester) CreateWaitForChangesRetryWorker(numChangesExpected int, ch
 		} else {
 			response = rt.Send(requestByUser("GET", changesUrl, "", username))
 		}
-		err = json.Unmarshal(response.Body.Bytes(), &changes)
+		err = base.JSONUnmarshal(response.Body.Bytes(), &changes)
 		if err != nil {
 			return false, err, nil
 		}
@@ -457,7 +456,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 			return false, fmt.Errorf("Got response code: %d from view call.  Expected 200.", response.Code), sgbucket.ViewResult{}
 		}
 		var result sgbucket.ViewResult
-		json.Unmarshal(response.Body.Bytes(), &result)
+		base.JSONUnmarshal(response.Body.Bytes(), &result)
 
 		if len(result.Rows) >= numResultsExpected {
 			// Got enough results, break out of retry loop
@@ -518,7 +517,7 @@ func (rt *RestTester) WaitForDBOnline() (err error) {
 
 		response := rt.SendAdminRequest("GET", "/db/", "")
 		var body db.Body
-		json.Unmarshal(response.Body.Bytes(), &body)
+		base.JSONUnmarshal(response.Body.Bytes(), &body)
 
 		if body["state"].(string) == "Online" {
 			return
@@ -565,7 +564,7 @@ func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 	}
 
 	var rawResponse RawResponse
-	json.Unmarshal(response.Body.Bytes(), &rawResponse)
+	base.JSONUnmarshal(response.Body.Bytes(), &rawResponse)
 	return rawResponse.Sync.Sequence
 }
 
@@ -580,7 +579,7 @@ func (r TestResponse) DumpBody() {
 
 func (r TestResponse) GetRestDocument() RestDocument {
 	restDoc := NewRestDocument()
-	err := json.Unmarshal(r.Body.Bytes(), restDoc)
+	err := base.JSONUnmarshal(r.Body.Bytes(), restDoc)
 	if err != nil {
 		panic(fmt.Sprintf("Error parsing body into RestDocument.  Body: %s.  Err: %v", string(r.Body.Bytes()), err))
 	}
@@ -755,7 +754,7 @@ func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, err
 		}
 
 		// serialize admin channels to json array
-		adminChannelsJson, err := json.Marshal(adminChannels)
+		adminChannelsJson, err := base.JSONMarshal(adminChannels)
 		if err != nil {
 			return nil, err
 		}
@@ -934,7 +933,7 @@ func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resul
 			// unmarshal into json array
 			changesBatch := [][]interface{}{}
 
-			if err := json.Unmarshal(body, &changesBatch); err != nil {
+			if err := base.JSONUnmarshal(body, &changesBatch); err != nil {
 				panic(fmt.Sprintf("Error unmarshalling changes. Body: %vs.  Error: %v", string(body), err))
 			}
 
@@ -946,7 +945,7 @@ func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resul
 			}
 
 			response := request.Response()
-			responseValBytes, err := json.Marshal(responseVal)
+			responseValBytes, err := base.JSONMarshal(responseVal)
 			log.Printf("responseValBytes: %s", responseValBytes)
 			if err != nil {
 				panic(fmt.Sprintf("Error marshalling response: %v", err))
@@ -962,7 +961,7 @@ func (bt *BlipTester) GetDocAtRev(requestedDocID, requestedDocRev string) (resul
 		defer revsFinishedWg.Done()
 		body, err := request.Body()
 		var doc RestDocument
-		err = json.Unmarshal(body, &doc)
+		err = base.JSONUnmarshal(body, &doc)
 		if err != nil {
 			panic(fmt.Sprintf("Unexpected err: %v", err))
 		}
@@ -1028,7 +1027,7 @@ func (bt *BlipTester) SendRevWithAttachment(input SendRevWithAttachmentInput) (s
 		input.attachmentName: &myAttachment,
 	})
 
-	docBody, err := json.Marshal(doc)
+	docBody, err := base.JSONMarshal(doc)
 	if err != nil {
 		panic(fmt.Sprintf("Error marshalling doc.  Error: %v", err))
 	}
@@ -1113,7 +1112,7 @@ func (bt *BlipTester) GetChanges() (changes [][]interface{}) {
 		// unmarshal into json array
 		changesBatch := [][]interface{}{}
 
-		if err := json.Unmarshal(body, &changesBatch); err != nil {
+		if err := base.JSONUnmarshal(body, &changesBatch); err != nil {
 			panic(fmt.Sprintf("Error unmarshalling changes. Body: %vs.  Error: %v", string(body), err))
 		}
 
@@ -1195,7 +1194,7 @@ func (bt *BlipTester) PullDocs() (docs map[string]RestDocument) {
 			// unmarshal into json array
 			changesBatch := [][]interface{}{}
 
-			if err := json.Unmarshal(body, &changesBatch); err != nil {
+			if err := base.JSONUnmarshal(body, &changesBatch); err != nil {
 				panic(fmt.Sprintf("Error unmarshalling changes. Body: %vs.  Error: %v", string(body), err))
 			}
 
@@ -1207,7 +1206,7 @@ func (bt *BlipTester) PullDocs() (docs map[string]RestDocument) {
 			}
 
 			response := request.Response()
-			responseValBytes, err := json.Marshal(responseVal)
+			responseValBytes, err := base.JSONMarshal(responseVal)
 			log.Printf("responseValBytes: %s", responseValBytes)
 			if err != nil {
 				panic(fmt.Sprintf("Error marshalling response: %v", err))
@@ -1223,7 +1222,7 @@ func (bt *BlipTester) PullDocs() (docs map[string]RestDocument) {
 		defer revsFinishedWg.Done()
 		body, err := request.Body()
 		var doc RestDocument
-		err = json.Unmarshal(body, &doc)
+		err = base.JSONUnmarshal(body, &doc)
 		if err != nil {
 			panic(fmt.Sprintf("Unexpected err: %v", err))
 		}
@@ -1306,7 +1305,7 @@ func (bt *BlipTester) SubscribeToChanges(continuous bool, changes chan<- *blip.M
 			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
 			response := request.Response()
 			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := json.Marshal(emptyResponseVal)
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
 			if err != nil {
 				panic(fmt.Sprintf("Error marshalling response: %v", err))
 			}
@@ -1447,12 +1446,12 @@ func (d RestDocument) GetAttachments() (db.AttachmentMap, error) {
 		for attachmentName, attachmentVal := range rawAttachmentsMap {
 
 			// marshal attachmentVal into a byte array, then unmarshal into a DocAttachment
-			attachmentValMarshalled, err := json.Marshal(attachmentVal)
+			attachmentValMarshalled, err := base.JSONMarshal(attachmentVal)
 			if err != nil {
 				return db.AttachmentMap{}, err
 			}
 			docAttachment := db.DocAttachment{}
-			if err := json.Unmarshal(attachmentValMarshalled, &docAttachment); err != nil {
+			if err := base.JSONUnmarshal(attachmentValMarshalled, &docAttachment); err != nil {
 				return db.AttachmentMap{}, err
 			}
 

--- a/rest/utilities_testing_test.go
+++ b/rest/utilities_testing_test.go
@@ -1,10 +1,10 @@
 package rest
 
 import (
-	"encoding/json"
 	"log"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ func TestDocumentUnmarshal(t *testing.T) {
 `
 
 	doc := RestDocument{}
-	err := json.Unmarshal([]byte(jsonContent), &doc)
+	err := base.JSONUnmarshal([]byte(jsonContent), &doc)
 	if err != nil {
 		log.Printf("Error: %v", err)
 	}

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -2,12 +2,11 @@ package rest
 
 import (
 	"crypto/sha1"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/couchbase/sg-bucket"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 )
@@ -93,7 +92,7 @@ func (h *handler) handleView() error {
 	for _, name := range []string{"startkey", "endkey", "key", "keys"} {
 		if rawVal := h.getQuery(name); "" != rawVal {
 			var val interface{}
-			if err := json.Unmarshal([]byte(rawVal), &val); err != nil {
+			if err := base.JSONUnmarshal([]byte(rawVal), &val); err != nil {
 				return err
 			}
 			opts[name] = val

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -73,7 +72,7 @@ func TestViewQuery(t *testing.T) {
 	// TODO: update the query to use stale=false and remove the wait
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
 	assert.NoError(t, err, "Got unexpected error")
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"})
 	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: "ten"})
@@ -220,21 +219,21 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_design/foo/_view/by_age", ``)
 	assertStatus(t, response, 200)
 	var result sgbucket.ViewResult
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)})
 	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)})
 
 	response = rt.SendAdminRequest("GET", "/db/_design/foo/_view/by_fname", ``)
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)})
 	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)})
 
 	response = rt.SendAdminRequest("GET", "/db/_design/foo/_view/by_lname", ``)
 	assertStatus(t, response, 200)
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 2)
 	goassert.DeepEquals(t, result.Rows[0], &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)})
 	goassert.DeepEquals(t, result.Rows[1], &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)})
@@ -343,7 +342,7 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	// // test group=true
 	// response = rt.sendAdminRequest("GET", "/db/_design/foo/_view/bar?reduce=true&group=true", ``)
 	// assertStatus(t, response, 200)
-	// json.Unmarshal(response.Body.Bytes(), &result)
+	// base.JSONUnmarshal(response.Body.Bytes(), &result)
 	// // we should get 2 rows with the reduce result
 	// goassert.Equals(t, len(result.Rows), 2)
 	// row = result.Rows[0]
@@ -444,7 +443,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	assertStatus(t, response, 200) // Query string was parsed properly
 
 	var result sgbucket.ViewResult
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 1)
 
 	// Ensure that query for non-existent keys returns no rows
@@ -452,7 +451,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 	assertStatus(t, response, 200) // Query string was parsed properly
 
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 0)
 
 }
@@ -482,7 +481,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 	assertStatus(t, response, 200)
 	var result sgbucket.ViewResult
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 1)
 
 	// Ensure that a query for non-existent key returns no rows
@@ -490,7 +489,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 	assertStatus(t, response, 200)
 
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 0)
 }
 
@@ -519,7 +518,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 	assertStatus(t, response, 200)
 	var result sgbucket.ViewResult
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 1)
 
 	// Ensure that a query for non-existent key returns no rows
@@ -528,7 +527,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	response = rt.SendAdminRequest("GET", viewUrlPath, ``)
 	assertStatus(t, response, 200)
 
-	json.Unmarshal(response.Body.Bytes(), &result)
+	base.JSONUnmarshal(response.Body.Bytes(), &result)
 	goassert.Equals(t, len(result.Rows), 0)
 }
 
@@ -591,7 +590,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	var postUpgradeResponse PostUpgradeResponse
 	response := rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
 	assertStatus(t, response, 200)
-	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, true)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
 
@@ -599,7 +598,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
 	assertStatus(t, response, 200)
-	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, false)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 2)
 
@@ -607,7 +606,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade?preview=true", "")
 	assertStatus(t, response, 200)
-	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, true)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
 
@@ -615,7 +614,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	postUpgradeResponse = PostUpgradeResponse{}
 	response = rt.SendAdminRequest("POST", "/_post_upgrade", "")
 	assertStatus(t, response, 200)
-	assert.NoError(t, json.Unmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	goassert.Equals(t, postUpgradeResponse.Preview, false)
 	goassert.Equals(t, len(postUpgradeResponse.Result["db"].RemovedDDocs), 0)
 


### PR DESCRIPTION
- Use the new wrappers added in #4239 
- Fixed some tests that expected hardcoded errors from stdlib json

## TODO
- [x] Change base branch once #4239 is merged
- [x] handle canonical marshal
- [x] update manifest
- [x] pull in fix https://github.com/json-iterator/go/pull/406
- [x] update tests that still check for hardcoded JSON bytes to remove property order requirements

## Tests
after latest json-iter upstream updates (2019-09-23)
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration-master/1282/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration-master/1283/