### PR TITLE
Bump json-iterator-go commit to master branch

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -107,7 +107,7 @@
   <project groups="notdefault,cb_sg_enterprise" name="go-fleecedelta" path="godeps/src/github.com/couchbaselabs/go-fleecedelta" remote="couchbaselabs_private" revision="68cf89ddc17d5fed0c1424083439585bec964590"/>
   <project groups="notdefault,cb_sg_enterprise" name="go-diff" path="godeps/src/github.com/sergi/go-diff" remote="couchbasedeps" revision="da645544ed44df016359bd4c0e3dc60ee3a0da43"/>
 
-  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="27518f6661eba504be5a7a9a9f6d9460d892ade3"/>
+  <project groups="notdefault,cb_sg_enterprise" name="json-iterator-go" path="godeps/src/github.com/json-iterator/go" remote="couchbasedeps" revision="819acad769e54806c920726ac93537ba4e2c22ad"/>
   <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="modern-go" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
   <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="modern-go" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
   <!-- Enterprise edition dependencies -->


### PR DESCRIPTION
The patch in `bbrks/fix_nil_map_encoding` got merged upstream sooner than anticipated.

I've updated the master branch in `couchbasedeps` so now we can come off our patched branch.