### PR TITLE
Bump Go version to 1.12.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'sync-gateway-pipeline-builder' }
 
     environment {
-        GO_VERSION = 'go1.12.9'
+        GO_VERSION = 'go1.12.10'
         GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/godeps"

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.12.9",
+            "go_version": "1.12.10",
             "start_build": 1
         },
         "manifest/1.4.0.xml": {


### PR DESCRIPTION
Version contains only a fix for [CVE-2019-16276](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16276) (https://github.com/golang/go/issues/34540)

https://github.com/golang/go/compare/go1.12.9...go1.12.10

https://groups.google.com/forum/#!msg/golang-announce/cszieYyuL9Q/g4Z7pKaqAgAJ