### PR TITLE
GetChanges logging fix

### DIFF
--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -359,10 +359,10 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 	// Use the cache, and return if it fulfilled the entire request:
 	cacheValidFrom, resultFromCache := c.GetCachedChanges(options)
 	numFromCache := len(resultFromCache)
-	if numFromCache > 0 || resultFromCache == nil {
+	if numFromCache > 0 {
 		base.InfofCtx(options.Ctx, base.KeyCache, "GetCachedChanges(%q, %s) --> %d changes valid from #%d",
 			base.UD(c.channelName), options.Since.String(), numFromCache, cacheValidFrom)
-	} else if resultFromCache == nil {
+	} else {
 		base.InfofCtx(options.Ctx, base.KeyCache, "GetCachedChanges(%q, %s) --> nothing cached",
 			base.UD(c.channelName), options.Since.String())
 	}


### PR DESCRIPTION
In channelCache.GetChanges was failing to output info logging in the case where resultFromCache was empty but non-nil.

As previously written, the 'nothing cached' log line was unreachable.  This was resulting in unexpected info logging output
when c.GetCachedChanges returned a non-nil empty slice.  In particular, a changes request that queried two channels -  one
that was empty and anotherl that had no results for the requested range - would log "0 changes valid from' for the former, and log nothing
for the latter, which gave the impression the second channel wasn't being queried.