### PR TITLE
CBG-531: Fixed webhook filter function

### DIFF
--- a/db/event.go
+++ b/db/event.go
@@ -147,7 +147,7 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 	switch event := event.(type) {
 
 	case *DocumentChangeEvent:
-		result, err = ef.Call(event.DocBytes, sgbucket.JSONString(event.OldDoc))
+		result, err = ef.Call(sgbucket.JSONString(event.DocBytes), sgbucket.JSONString(event.OldDoc))
 	case *DBStateChangeEvent:
 		result, err = ef.Call(event.Doc)
 	}


### PR DESCRIPTION
This issue should've been caught by `TestWebhookBasic` however it was disabled due to the fact it required a live http server. This test will be re-enabled after CBG-517 and CBG-519. 
I have tested using `TestWebhookBasic` and this fix does work.