### PR TITLE
Fixes race introduced in PR #4260

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -332,7 +332,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, CacheOptions{}, queryCallbackConfig)
+	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer tearDownTestDB(t, db)
 
 	// Test creating & updating a document:
@@ -391,7 +391,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, CacheOptions{}, queryCallbackConfig)
+	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer tearDownTestDB(t, db)
 
 	// Test creating & updating a document:


### PR DESCRIPTION
Missed this during review of #4260 and can't repro the race locally, but it was caught on the build server.

Creating a leaky bucket with empty CacheOptions struct resulted in zero value for skipped sequence handling vars, causing racy handling of changes in the clean skipped sequence queue task.

```
==================
WARNING: DATA RACE
Write at 0x00c000434010 by goroutine 43:
  github.com/couchbase/sync_gateway/db.(*DatabaseContext).Close()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/database.go:521 +0x195
  github.com/couchbase/sync_gateway/db.tearDownTestDB()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/database_test.go:182 +0x4b
  github.com/couchbase/sync_gateway/db.TestAttachmentCASRetryAfterNewAttachment()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/attachment_test.go:367 +0xa72
  testing.tRunner()
      /usr/local/go/1.12.10/go/src/testing/testing.go:865 +0x163

Previous read at 0x00c000434010 by goroutine 47:
  github.com/couchbase/sync_gateway/db.(*DatabaseContext).getChangesForSequences()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/changes_view.go:180 +0x59
  github.com/couchbase/sync_gateway/db.(*changeCache).CleanSkippedSequenceQueue()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/change_cache.go:284 +0x52a
  github.com/couchbase/sync_gateway/db.(*changeCache).CleanSkippedSequenceQueue-fm()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/change_cache.go:252 +0x55
  github.com/couchbase/sync_gateway/db.NewBackgroundTask.func1()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/utils.go:21 +0x223

Goroutine 43 (running) created at:
  testing.(*T).Run()
      /usr/local/go/1.12.10/go/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/go/1.12.10/go/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/go/1.12.10/go/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/go/1.12.10/go/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/go/1.12.10/go/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:404 +0x222

Goroutine 47 (running) created at:
  github.com/couchbase/sync_gateway/db.NewBackgroundTask()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/utils.go:16 +0x183
  github.com/couchbase/sync_gateway/db.(*changeCache).Init()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/change_cache.go:156 +0x92c
  github.com/couchbase/sync_gateway/db.NewDatabaseContext()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/database.go:271 +0xb2e
  github.com/couchbase/sync_gateway/db.setupTestLeakyDBWithCacheOptions()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/database_test.go:160 +0x1d5
  github.com/couchbase/sync_gateway/db.TestAttachmentCASRetryAfterNewAttachment()
      /home/couchbase/jenkins/workspace/sgw-unix-build@2/2.7.0/enterprise/godeps/src/github.com/couchbase/sync_gateway/db/attachment_test.go:335 +0x315
  testing.tRunner()
      /usr/local/go/1.12.10/go/src/testing/testing.go:865 +0x163
==================
```