### PR TITLE
2.6.1 Setup builds

### DIFF
--- a/manifest/2.6/2.6.0.xml
+++ b/manifest/2.6/2.6.0.xml
@@ -13,15 +13,15 @@
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
-    <project name="build" path="cbbuild" remote="couchbase">
-        <annotation name="VERSION" value="2.6.1"     keep="true"/>
+    <project name="build" path="cbbuild" revision="b2139268084eab6e8225819ebee1ebe4175348e0" remote="couchbase">
+        <annotation name="VERSION" value="2.6.0"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>
     </project>
 
 
     <!-- Sync Gateway -->
-    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="release/2.6.1"/>
+    <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" revision="b4c828d5d167140d75ab4c4f7402602f65f74464"/>
 
 
     <!-- Sync Gateway Accel-->

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -130,12 +130,20 @@
             "start_build": 270
         },
         "manifest/2.6.xml": {
+            "release": "2.6.1",
+            "release_name": "Couchbase Sync Gateway 2.6.1",
+            "production": true,
+            "interval": 120,
+            "go_version": "1.11.5",
+            "start_build": 1
+        },
+        "manifest/2.6/2.6.0.xml": {
             "release": "2.6.0",
             "release_name": "Couchbase Sync Gateway 2.6.0",
             "production": true,
             "interval": 120,
             "go_version": "1.11.5",
-            "start_build": 128
+            "start_build": 138
         },
         "manifest/dev.xml": {
             "release": "dev",


### PR DESCRIPTION
Switch 2.6.xml to specify 2.6.1, and added 2.6/2.6.0.xml with pinned commits for SG and build (based on [release build manifest](https://github.com/couchbase/build-manifests/commit/245f733ef1c268e13cfe05c98d09202b1a2ef434#diff-ecd0efcce6021d126ccaa6aa5a4fcdc1)). 