### PR TITLE
2.6.1 Preserve attachment metadata on CAS retry

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -45,6 +45,10 @@ type LeakyBucketConfig struct {
 	// Returns a partial error the first time ViewCustom is called
 	FirstTimeViewCustomPartialError bool
 	PostQueryCallback               func(ddoc, viewName string, params map[string]interface{}) // Issues callback after issuing query when bucket.ViewQuery is called
+
+	// WriteUpdateCallback issues additional callback in WriteUpdate after standard callback completes, but prior to document write.  Allows
+	// tests to trigger CAS retry handling by modifying the underlying document in a WriteUpdateCallback implementation.
+	WriteUpdateCallback func(key string)
 }
 
 func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
@@ -114,6 +118,14 @@ func (b *LeakyBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc)
 	return b.bucket.Update(k, exp, callback)
 }
 func (b *LeakyBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
+	if b.config.WriteUpdateCallback != nil {
+		wrapperCallback := func(current []byte) (updated []byte, opt sgbucket.WriteOptions, expiry *uint32, err error) {
+			updated, opt, expiry, err = callback(current)
+			b.config.WriteUpdateCallback(k)
+			return updated, opt, expiry, err
+		}
+		return b.bucket.WriteUpdate(k, exp, wrapperCallback)
+	}
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
 func (b *LeakyBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
@@ -191,6 +203,14 @@ func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas 
 }
 
 func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+	if b.config.WriteUpdateCallback != nil {
+		wrapperCallback := func(current []byte, xattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+			updated, updatedXattr, deletedDoc, expiry, err = callback(current, xattr, cas)
+			b.config.WriteUpdateCallback(k)
+			return updated, updatedXattr, deletedDoc, expiry, err
+		}
+		return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, wrapperCallback)
+	}
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }
 

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -247,3 +247,124 @@ func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 	assert.NoError(t, countErr, "Couldn't retrieve document_gets expvar")
 	assert.Equal(t, initCount, getCount)
 }
+
+func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
+
+	var db *Database
+	var enableCallback bool
+	var rev1ID string
+
+	writeUpdateCallback := func(key string) {
+		if enableCallback {
+			enableCallback = false
+			log.Printf("Creating rev 2 for key %s", key)
+			var rev2Body Body
+			rev2Data := `{"prop1":"value2", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
+			require.NoError(t, json.Unmarshal([]byte(rev2Data), &rev2Body))
+			err := db.PutExistingRev("doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			//log.Printf("rev2Doc attachments %+v", rev2Doc.Attachments)
+			require.NoError(t, err)
+
+			log.Printf("Done creating rev 2 for key %s", key)
+		}
+	}
+
+	// Use leaky bucket to inject callback in query invocation
+	queryCallbackConfig := base.LeakyBucketConfig{
+		WriteUpdateCallback: writeUpdateCallback,
+	}
+
+	db = setupTestLeakyDBWithCacheOptions(t, CacheOptions{}, queryCallbackConfig)
+	defer tearDownTestDB(t, db)
+
+	// Test creating & updating a document:
+
+	// 1. Create a document with no attachment
+	rev1Json := `{"prop1":"value1"}`
+	rev1ID, err := db.Put("doc1", unjson(rev1Json))
+	assert.NoError(t, err, "Couldn't create document")
+
+	// 2. Create rev 2 with new attachment - done in callback
+	enableCallback = true
+
+	// 3. Create rev 3 with new attachment to same attachment
+	log.Printf("starting create of rev 3")
+	var rev3Body Body
+	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"revpos":2,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+	require.NoError(t, json.Unmarshal([]byte(rev3Data), &rev3Body))
+	err = db.PutExistingRev("doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	require.NoError(t, err)
+
+	log.Printf("rev 3 done")
+
+	// 4. Get the document, check attachments
+	finalDoc, err := db.Get("doc1")
+	attachments := GetBodyAttachments(finalDoc)
+	assert.True(t, attachments != nil, "_attachments should be present in GET response")
+	attachment, attachmentOk := attachments["hello.txt"].(map[string]interface{})
+	assert.True(t, attachmentOk, "hello.txt attachment should be present in GET response")
+	_, digestOk := attachment["digest"]
+	assert.True(t, digestOk, "digest should be set for attachment hello.txt in GET response")
+
+}
+
+func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
+
+	var db *Database
+	var enableCallback bool
+	var rev1ID string
+
+	writeUpdateCallback := func(key string) {
+		if enableCallback {
+			enableCallback = false
+			log.Printf("Creating rev 2 for key %s", key)
+			var rev2Body Body
+			rev2Data := `{"prop1":"value2"}`
+			require.NoError(t, json.Unmarshal([]byte(rev2Data), &rev2Body))
+			err := db.PutExistingRev("doc1", rev2Body, []string{"2-abc", rev1ID}, true)
+			require.NoError(t, err)
+
+			log.Printf("Done creating rev 2 for key %s", key)
+		}
+	}
+
+	// Use leaky bucket to inject callback in query invocation
+	queryCallbackConfig := base.LeakyBucketConfig{
+		WriteUpdateCallback: writeUpdateCallback,
+	}
+
+	db = setupTestLeakyDBWithCacheOptions(t, CacheOptions{}, queryCallbackConfig)
+	defer tearDownTestDB(t, db)
+
+	// Test creating & updating a document:
+
+	// 1. Create a document with no attachment
+	rev1Json := `{"prop1":"value1"}`
+	rev1ID, err := db.Put("doc1", unjson(rev1Json))
+	assert.NoError(t, err, "Couldn't create document")
+
+	// 2. Create rev 2 with no attachment
+	enableCallback = true
+
+	// 3. Create rev 3 with new attachment
+	log.Printf("starting create of rev 3")
+	var rev3Body Body
+	rev3Data := `{"prop1":"value3", "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
+	require.NoError(t, json.Unmarshal([]byte(rev3Data), &rev3Body))
+	err = db.PutExistingRev("doc1", rev3Body, []string{"3-abc", "2-abc", rev1ID}, true)
+	require.NoError(t, err)
+
+	log.Printf("rev 3 done")
+
+	// 4. Get the document, check attachments
+	finalDoc, err := db.Get("doc1")
+	log.Printf("get doc attachments: %v", finalDoc)
+
+	attachments := GetBodyAttachments(finalDoc)
+	assert.True(t, attachments != nil, "_attachments should be present in GET response")
+	attachment, attachmentOk := attachments["hello.txt"].(map[string]interface{})
+	assert.True(t, attachmentOk, "hello.txt attachment should be present in GET response")
+	_, digestOk := attachment["digest"]
+	assert.True(t, digestOk, "digest should be set for attachment hello.txt in GET response")
+
+}

--- a/db/crud.go
+++ b/db/crud.go
@@ -853,7 +853,6 @@ func (db *Database) PutExistingRev(docid string, body Body, docHistory []string,
 			delete(body, BodyAttachments)
 		}
 
-
 		body[BodyRev] = newRev
 		return body, newAttachments, nil, nil
 	})


### PR DESCRIPTION
In certain CAS retry scenarios, attachment metadata was being removed from sync metadata.