### PR TITLE
Make assertStatus use testify's require.Equal method for clearer output

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -22,6 +21,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
 )
 
@@ -603,11 +603,11 @@ func requestByUser(method, resource, body, username string) *http.Request {
 }
 
 func assertStatus(t *testing.T, response *TestResponse, expectedStatus int) {
-	if response.Code != expectedStatus {
-		debug.PrintStack()
-		t.Fatalf("Response status %d (expected %d) for %s <%s> : %s",
-			response.Code, expectedStatus, response.Req.Method, response.Req.URL, response.Body)
-	}
+	require.Equalf(t, expectedStatus, response.Code,
+		"Response status %d %q (expected %d %q)\nfor %s <%s> : %s",
+		response.Code, http.StatusText(response.Code),
+		expectedStatus, http.StatusText(expectedStatus),
+		response.Req.Method, response.Req.URL, response.Body)
 }
 
 func NewSlowResponseRecorder(responseDelay time.Duration, responseRecorder *httptest.ResponseRecorder) *SlowResponseRecorder {


### PR DESCRIPTION
## Before
```
goroutine 35 [running]:
runtime/debug.Stack(0x30, 0x4a2f8a0, 0xc000019c18)
	/Users/benbrooks/dev/go/go1.13rc1/src/runtime/debug/stack.go:24 +0x9d
runtime/debug.PrintStack()
	/Users/benbrooks/dev/go/go1.13rc1/src/runtime/debug/stack.go:16 +0x22
github.com/couchbase/sync_gateway/rest.assertStatus(0xc0001fc300, 0xc0001752d0, 0x190)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:607 +0x5e
github.com/couchbase/sync_gateway/rest.TestConflictWithInvalidAttachment(0xc0001fc300)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/rest/api_test.go:3923 +0xc35
testing.tRunner(0xc0001fc300, 0x4ac8b38)
	/Users/benbrooks/dev/go/go1.13rc1/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/Users/benbrooks/dev/go/go1.13rc1/src/testing/testing.go:960 +0x350
--- FAIL: TestConflictWithInvalidAttachment (0.01s)
    utilities_testing.go:608: Response status 201 (expected 400) for PUT <http://localhost/db/doc1?new_edits=false> : {"id":"doc1","ok":true,"rev":"3-foo3"}
```

## After
```
--- FAIL: TestConflictWithInvalidAttachment (0.01s)
    require.go:232:
        	Error Trace:	utilities_testing.go:606
        	            				api_test.go:3923
        	Error:      	Not equal:
        	            	expected: 400
        	            	actual  : 201
        	Test:       	TestConflictWithInvalidAttachment
        	Messages:   	Response status 201 "Created" (expected 400 "Bad Request")
        	            	for PUT <http://localhost/db/doc1?new_edits=false> : {"id":"doc1","ok":true,"rev":"3-foo3"}
```