### PR TITLE
CBG-489 Support multi-node sharding for import

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2292,6 +2292,10 @@ func (bucket *CouchbaseBucketGoCB) StartDCPFeed(args sgbucket.FeedArguments, cal
 	}
 }
 
+func (bucket *CouchbaseBucketGoCB) StartShardedDCPFeed(dbName string) (*CbgtContext, error) {
+	return StartShardedDCPFeed(dbName, bucket, bucket.spec)
+}
+
 func (bucket *CouchbaseBucketGoCB) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -35,7 +35,7 @@ func init() {
 	for i := 0; i < len(vbucketIdStrings); i++ {
 		vbucketIdStrings[i] = fmt.Sprintf("%d", i)
 	}
-	feedType = cbgtFeedType_gocb
+	feedType = cbgtFeedType_cbdatasource
 	cbgt.DCPFeedPrefix = "sg:"
 }
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -35,7 +35,7 @@ func init() {
 	for i := 0; i < len(vbucketIdStrings); i++ {
 		vbucketIdStrings[i] = fmt.Sprintf("%d", i)
 	}
-	feedType = cbgtFeedType_cbdatasource
+	feedType = cbgtFeedType_gocb
 	cbgt.DCPFeedPrefix = "sg:"
 }
 
@@ -193,8 +193,8 @@ func (d *DCPDest) Query(pindex *cbgt.PIndex, req []byte, w io.Writer,
 	return nil
 }
 
+// Stats would allow SG to return SG-specific stats to cbgt's stats reporting - not currently used.
 func (d *DCPDest) Stats(io.Writer) error {
-	WarnfCtx(d.loggingCtx, KeyAll, "Dest.Stats being invoked by cbgt - not supported by Sync Gateway")
 	return nil
 }
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -68,7 +68,7 @@ func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo 
 }
 
 func (d *DCPDest) Close() error {
-	// TODO: Do we have any cleanup we should be doing on close?
+	DebugfCtx(d.loggingCtx, KeyDCP, "Closing DCPDest for %s", d.feedID)
 	return nil
 }
 
@@ -301,13 +301,11 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 		return pkgerrors.WithStack(RedactErrorf("Error instantiating gocb DCP Feed.  Feed:%s URL:%s, bucket:%s.  Error: %v", feedName, UD(serverURL), MD(spec.BucketName), err))
 	}
 
-	InfofCtx(loggingCtx, KeyDCP, "DCP feed starting with name %s", feedName)
-
 	if err = feed.Start(); err != nil {
 		return pkgerrors.WithStack(RedactErrorf("Error starting gocb DCP Feed.  Feed:%s URLs:%s, bucket:%s.  Error: %v", feedName, UD(serverURL), MD(spec.BucketName), err))
 	}
 
-	InfofCtx(loggingCtx, KeyDCP, "DCP feed started successfully with name %s", feedName)
+	InfofCtx(loggingCtx, KeyDCP, "Caching DCP feed started successfully: %s", feedName)
 
 	// Close the feed if feed terminator is closed
 	if args.Terminator != nil {

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -1,0 +1,269 @@
+package base
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	"github.com/couchbase/cbgt"
+	"github.com/pkg/errors"
+)
+
+const CBGTIndexTypeSyncGatewayImport = "syncGateway-import"
+
+// The two "handles" we have for CBGT are the manager and Cfg objects.
+// This struct makes it easy to pass them around together as a unit.
+type CbgtContext struct {
+	Manager *cbgt.Manager
+	Cfg     cbgt.Cfg
+}
+
+func StartShardedDCPFeed(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContext, error) {
+
+	cbgtContext, err := initCBGTManager(dbName, bucket, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	//TODO: start heartbeater
+
+	cbgtContext.StartManager(dbName, bucket, spec)
+
+	return cbgtContext, nil
+
+}
+
+// cbgtFeedParams builds feed params for dest-based feed.  cbgt expects marshalled json, as string.
+func cbgtFeedParams(spec BucketSpec) (string, error) {
+	feedParams := cbgt.NewDCPFeedParams()
+
+	// check for basic auth
+	if spec.Certpath == "" && spec.Auth != nil {
+		username, password, _ := spec.Auth.GetCredentials()
+		feedParams.AuthUser = username
+		feedParams.AuthPassword = password
+	}
+
+	if spec.UseXattrs {
+		// TODO: This is always being set in NewGocbDCPFeed, review whether we actually need ability to run w/ false
+		feedParams.IncludeXAttrs = true
+	}
+
+	paramBytes, err := JSONMarshal(feedParams)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
+}
+
+// Create database-specific instance of CBGT Index.
+func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec BucketSpec) error {
+
+	// sourceType is based on cbgt.source_gocouchbase non-public constant.
+	// TODO: Request that cbgt make this and source_gocb public.
+
+	sourceType := "gocb"
+	if feedType == cbgtFeedType_cbdatasource {
+		sourceType = "couchbase"
+	}
+
+	bucketUUID, err := bucket.UUID()
+	if err != nil {
+		return err
+	}
+
+	sourceParams, err := cbgtFeedParams(spec)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Review uniqueness requirements for index definition, to determine if it should include 'import'
+	indexName := dbName + "_import"
+
+	// IndexParams are metadata that get passed back to us when ImportPIndex is created.  ImportPIndex is server context
+	// scoped, so only needs dbName, but needs to be JSON.
+
+	// TODO: Turn into proper struct
+	indexParams := `{"name": "` + dbName + `"}`
+
+	// TODO: MaxPartitionsPerPIndex could be configurable
+	// TODO: what if this is inconsistent between SG nodes?
+	planParams := cbgt.PlanParams{
+		MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
+		NumReplicas:            0,  // No replicas required for SG sharded feed
+	}
+
+	// TODO: The manager
+	exists, previousIndexUUID, err := getCBGTIndexUUID(manager, indexName)
+	if exists {
+		log.Printf("Hey, this index already exists.  Another node must have registered it with the same cfgCB")
+	}
+
+	err = manager.CreateIndex(
+		sourceType,                     // sourceType
+		bucket.GetName(),               // sourceName
+		bucketUUID,                     // sourceUUID
+		sourceParams,                   // sourceParams
+		CBGTIndexTypeSyncGatewayImport, // indexType
+		indexName,                      // indexName
+		indexParams,                    // indexParams
+		planParams,                     // planParams
+		previousIndexUUID,              // prevIndexUUID
+	)
+	return err
+
+}
+
+// Check if this CBGT index already exists.
+// TODO: The manager goes and looks up the index from the config.
+func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (exists bool, previousUUID string, err error) {
+
+	_, indexDefsMap, err := manager.GetIndexDefs(true)
+	if err != nil {
+		return false, "", errors.Wrapf(err, "Error calling CBGT GetIndexDefs() on index: %s", indexName)
+	}
+
+	indexDef, ok := indexDefsMap[indexName]
+	if ok {
+		return true, indexDef.UUID, nil
+	} else {
+		return false, "", nil
+	}
+}
+
+// createCBGTManager creates a new manager for a given bucket and bucketSpec
+// Inline comments below provide additional detail on how cbgt uses each manager
+// parameter, and the implications for SG
+func initCBGTManager(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContext, error) {
+
+	// uuid: Unique identifier for the node. Used to identify the node in the config
+	// TODO: review whether SG actually needs UUID state across restarts, in order
+	//       to minimize config churn
+	uuid := cbgt.NewUUID()
+
+	// cfg: Implementation of cbgt.Cfg interface.  Responsible for configuration management
+	//      Sync Gateway uses bucket-based config management
+
+	// TODO: Replace CfgMem with CfgCB
+	//cfgCB := cbgt.NewCfgMem()
+
+	options := map[string]interface{}{
+		"keyPrefix": SyncPrefix,
+	}
+
+	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+	if errConvertServerSpec != nil {
+		return nil, errConvertServerSpec
+	}
+
+	// TODO: Until we switch to a gocb-backed CfgCB, need to manage credentials in URL
+	basicAuthUrls, err := ServerUrlsWithAuth(urls, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	cfgCB, err := cbgt.NewCfgCBEx(
+		strings.Join(basicAuthUrls, ";"),
+		spec.BucketName,
+		options,
+	)
+	if err != nil {
+		log.Printf("Hey there's an error initializing the cfgCB: %v", err)
+		return nil, err
+	}
+
+	// tags: Every node participating in sharded DCP has feed, janitor, pindex and planner roles
+	//   	"feed": runs dcp feed
+	//   	"janitor": maintains feed instances, attempts to match to plan
+	//   	"pindex": handles DCP events
+	//   	"planner": assigns partitions to nodes
+	// TODO: Every participating node acts as planner, which means every node is going to be trying to
+	//       reassign partitions (vbuckets) to nodes when a cfg change is detected.  cbft doesn't do this -
+	//       it leverages ns-server to identify a master node.
+	//       Assumption is that cbgt handles multi-planner collisions gracefully, and that SG
+	//       doesn't need to set up master election.  Could revisit in future, as this functionality is
+	//       required for sg-replicate HA anyway
+	tags := []string{"feed", "janitor", "pindex", "planner"}
+
+	// weight: Allows for weighted distribution of vbuckets across participating nodes.  Not
+	//         used by Sync Gateway
+	weight := 1
+
+	// container: Used by cbgt to determine node hierarchy.  Not needed by Sync Gateway
+	container := ""
+
+	// extras: Can be used to pass Sync Gateway specific node information to callbacks.  Not
+	//         currently needed by Sync Gateway.
+	extras := ""
+
+	// bindHttp: Used for REST binding (not needed by Sync Gateway), but also as a unique identifier
+	//           in some circumstances.  See below for additional information.
+	// 		(from accel): use the uuid as the bindHttp so that we don't have to make the user
+	// 		configure this, since we're just using for uniqueness and not for REST API
+	// 		More info here:
+	//   		https://github.com/couchbaselabs/cbgt/issues/1
+	//   		https://github.com/couchbaselabs/cbgt/issues/25
+	bindHttp := uuid
+
+	// serverURL: Passing gocb connect string.
+	serverURL, err := spec.GetGoCBConnString()
+	if err != nil {
+		return nil, err
+	}
+
+	// dataDir: file system location for files persisted by cbgt.  Needs to be unique
+	// per database
+
+	dataDir := os.TempDir() + "sg_" + dbName
+	// TODO: Would really not have to persist here
+	// Create the db-scoped path
+	err = os.MkdirAll(dataDir, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	// eventHandlers: SG doesn't currently do any processing on manager events:
+	//   - OnRegisterPIndex
+	//   - OnUnregisterPIndex
+	//   - OnFeedError
+	var eventHandlers cbgt.ManagerEventHandlers
+
+	// Creates a new cbgt manager.  NewManagerEx is available if we need to specify advanced options,
+	// but isn't needed today.
+	mgr := cbgt.NewManager(
+		cbgt.VERSION, // cbgt metadata version
+		cfgCB,
+		uuid,
+		tags,
+		container,
+		weight,
+		extras,
+		bindHttp,
+		dataDir,
+		serverURL,
+		eventHandlers)
+
+	cbgtContext := &CbgtContext{
+		Manager: mgr,
+		Cfg:     cfgCB,
+	}
+	return cbgtContext, nil
+}
+
+func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec) (err error) {
+	// TODO: always wanted?
+	// Start the manager.  Will retrieve config, and janitor will start feeds on this node.
+
+	registerType := "wanted"
+	if err := c.Manager.Start(registerType); err != nil {
+		log.Printf("Manager start failed with error: %v", err)
+		return err
+	}
+	// Add the index definition for this feed to the cbgt cfg, in case it's not already present.
+	err = createCBGTIndex(c.Manager, dbName, bucket, spec)
+	if err != nil {
+		return err
+	}
+	c.Manager.Kick("NewIndexesCreated")
+	return nil
+}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -192,9 +192,19 @@ func initCBGTManager(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContex
 	bindHttp := uuid
 
 	// serverURL: Passing gocb connect string.
-	serverURL, err := spec.GetGoCBConnString()
-	if err != nil {
-		return nil, err
+	var serverURL string
+	if feedType == cbgtFeedType_cbdatasource {
+		// cbdatasource expects server URL in http format
+		serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+		if errConvertServerSpec != nil {
+			return nil, errConvertServerSpec
+		}
+		serverURL = strings.Join(serverURLs, ";")
+	} else {
+		serverURL, err = spec.GetGoCBConnString()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// dataDir: file system location for files persisted by cbgt.  Needs to be unique

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -10,7 +10,7 @@ import (
 	pkgerrors "github.com/pkg/errors"
 )
 
-const CBGTIndexTypeSyncGatewayImport = "syncGateway-import"
+const CBGTIndexTypeSyncGatewayImport = "syncGateway-import-"
 
 // CbgtContext holds the two handles we have for CBGT-related functionality.
 type CbgtContext struct {
@@ -106,16 +106,17 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 	indexName := dbName + "_import"
 
 	_, previousIndexUUID, err := getCBGTIndexUUID(manager, indexName)
+	indexType := CBGTIndexTypeSyncGatewayImport + dbName
 	err = manager.CreateIndex(
-		sourceType,                     // sourceType
-		bucket.GetName(),               // sourceName
-		bucketUUID,                     // sourceUUID
-		sourceParams,                   // sourceParams
-		CBGTIndexTypeSyncGatewayImport, // indexType
-		indexName,                      // indexName
-		indexParams,                    // indexParams
-		planParams,                     // planParams
-		previousIndexUUID,              // prevIndexUUID
+		sourceType,        // sourceType
+		bucket.GetName(),  // sourceName
+		bucketUUID,        // sourceUUID
+		sourceParams,      // sourceParams
+		indexType,         // indexType
+		indexName,         // indexName
+		indexParams,       // indexParams
+		planParams,        // planParams
+		previousIndexUUID, // prevIndexUUID
 	)
 	manager.Kick("NewIndexesCreated")
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"log"
 	"os"
 	"strings"
 
@@ -237,22 +236,12 @@ func initCBGTManager(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContex
 
 // StartManager registers this node with cbgt, and the janitor will start feeds on this node.
 func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec) (err error) {
-	// TODO: Unclear on the functional difference between registering the manager as 'wanted' vs 'known'.
 
+	// TODO: Clarify the functional difference between registering the manager as 'wanted' vs 'known'.
 	registerType := cbgt.NODE_DEFS_WANTED
 	if err := c.Manager.Start(registerType); err != nil {
 		Errorf(KeyDCP, "cbgt Manager start failed: %v", err)
 		return err
-	}
-
-	wanted, err := c.Manager.GetNodeDefs(cbgt.NODE_DEFS_WANTED, true)
-	for key, def := range wanted.NodeDefs {
-		log.Printf("Wanted nodedef [%s]: %+v", key, def)
-	}
-
-	known, err := c.Manager.GetNodeDefs(cbgt.NODE_DEFS_KNOWN, true)
-	for key, def := range known.NodeDefs {
-		log.Printf("Known nodedef [%s]: %+v", key, def)
 	}
 
 	// Add the index definition for this feed to the cbgt cfg, in case it's not already present.

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/couchbase/cbgt"
@@ -152,7 +153,7 @@ func initCBGTManager(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContex
 
 	cfgCB, err := initCfgCB(bucket, spec)
 	if err != nil {
-		Warnf(KeyDCP, "Error initializing cfg for import sharding: %v", err)
+		Warnf(KeyAll, "Error initializing cfg for import sharding: %v", err)
 		return nil, err
 	}
 
@@ -198,7 +199,7 @@ func initCBGTManager(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContex
 	// dataDir: file system location for files persisted by cbgt.  Needs to be unique
 	// per database
 
-	dataDir := os.TempDir() + "sg_" + dbName
+	dataDir := filepath.Join(os.TempDir(), "sg_"+dbName)
 	// TODO: Would really not have to persist here
 	// Create the db-scoped path
 	err = os.MkdirAll(dataDir, 0700)
@@ -332,6 +333,6 @@ func (h HeartbeatStoppedHandler) StaleHeartBeatDetected(nodeUUID string) {
 	Debugf(KeyDCP, "StaleHeartBeatDetected for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(h.Cfg, h.Manager.Version(), []string{nodeUUID})
 	if err != nil {
-		Warnf(KeyDCP, "base.Warning: attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
+		Warnf(KeyAll, "base.Warning: attempt to unregister %v from CBGT got error: %v", nodeUUID, err)
 	}
 }

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -576,8 +576,10 @@ func (ch *cbgtNodeListHandler) reloadNodes() error {
 	}
 
 	nodeUUIDs := make([]string, 0)
-	for _, nodeDef := range nodeSet.NodeDefs {
-		nodeUUIDs = append(nodeUUIDs, nodeDef.UUID)
+	if nodeSet != nil {
+		for _, nodeDef := range nodeSet.NodeDefs {
+			nodeUUIDs = append(nodeUUIDs, nodeDef.UUID)
+		}
 	}
 
 	ch.lock.Lock()

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -558,7 +558,7 @@ func (ch *cbgtNodeListHandler) subscribeNodeChanges() error {
 			case <-cfgEvents:
 				err := ch.reloadNodes()
 				if err != nil {
-					Warnf(KeyDCP, "Error while reloading heartbeat node definitions: %v", err)
+					Warnf(KeyAll, "Error while reloading heartbeat node definitions: %v", err)
 				}
 			case <-ch.terminator:
 				return

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -168,6 +168,10 @@ func (h *couchbaseHeartBeater) StopSendingHeartbeats() {
 // will be called back in that case (and passed the opaque node uuid)
 func (h *couchbaseHeartBeater) StartCheckingHeartbeats(staleThresholdMs int, handler HeartbeatsStoppedHandler) error {
 
+	if err := h.checkStaleHeartbeats(staleThresholdMs, handler); err != nil {
+		Warnf(KeyImport, "Error checking for stale heartbeats: %v", err)
+	}
+
 	ticker := time.NewTicker(time.Duration(staleThresholdMs) * time.Millisecond)
 
 	go func() {

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -144,9 +144,6 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats(intervalSeconds int) error
 func (h *couchbaseHeartBeater) Stop() {
 	h.StopSendingHeartbeats()
 	h.StopCheckingHeartbeats()
-	if h.heartbeatHandler != nil {
-		h.heartbeatHandler.Stop()
-	}
 
 	maxWaitTimeMs := 1000
 	waitTimeMs := 0

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"testing"
 
+	"github.com/couchbase/cbgt"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,4 +121,107 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 		})
 	}
 
+}
+
+// TestNewCouchbaseHeartbeater simulates three nodes.  The minimum time window for failed node
+// detection is 2 seconds, based on Couchbase Server's minimum document expiry TTL of
+// one second, so retry polling is required.
+func TestCBGTManagerHeartbeater(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("This test won't work under walrus - no expiry, required for heartbeats")
+	}
+
+	if testing.Short() {
+		t.Skip("Skipping heartbeattest in short mode")
+	}
+
+	keyprefix := "hbtest"
+
+	testBucket := GetTestBucket(t)
+	defer testBucket.Close()
+
+	// Initialize cfgCB
+	cfgCB, err := initCfgCB(testBucket.Bucket, testBucket.BucketSpec)
+
+	// Simulate the three nodes self-registering into the cfg
+	nodeDefs := cbgt.NewNodeDefs("1.0.0")
+	nodeDefs.NodeDefs["node1"] = &cbgt.NodeDef{UUID: "node1"}
+	nodeDefs.NodeDefs["node2"] = &cbgt.NodeDef{UUID: "node2"}
+	nodeDefs.NodeDefs["node3"] = &cbgt.NodeDef{UUID: "node3"}
+	cbgt.CfgSetNodeDefs(cfgCB, cbgt.NODE_DEFS_KNOWN, nodeDefs, 0)
+
+	// Create three heartbeaters (representing three nodes)
+	handler1, err := NewCBGTNodeListHandler(cfgCB)
+	assert.NoError(t, err)
+	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", handler1)
+	assert.NoError(t, err)
+	handler2, err := NewCBGTNodeListHandler(cfgCB)
+	assert.NoError(t, err)
+	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", handler2)
+	assert.NoError(t, err)
+	handler3, err := NewCBGTNodeListHandler(cfgCB)
+	assert.NoError(t, err)
+	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", handler3)
+	assert.NoError(t, err)
+
+	assert.NoError(t, node1.StartSendingHeartbeats(1))
+	assert.NoError(t, node2.StartSendingHeartbeats(1))
+	assert.NoError(t, node3.StartSendingHeartbeats(1))
+
+	heartbeatStoppedHandler1 := &TestCfgHeartbeatStoppedHandler{handlerID: "handler1", cfg: cfgCB}
+	heartbeatStoppedHandler2 := &TestCfgHeartbeatStoppedHandler{handlerID: "handler2", cfg: cfgCB}
+	heartbeatStoppedHandler3 := &TestCfgHeartbeatStoppedHandler{handlerID: "handler3", cfg: cfgCB}
+
+	assert.NoError(t, node1.StartCheckingHeartbeats(1000, heartbeatStoppedHandler1))
+	assert.NoError(t, node2.StartCheckingHeartbeats(1000, heartbeatStoppedHandler2))
+	assert.NoError(t, node3.StartCheckingHeartbeats(1000, heartbeatStoppedHandler3))
+
+	// Wait for node1 to start running (and persist initial heartbeat docs) before stopping
+	retryUntilFunc := func() bool {
+		return node1.checkCount > 0 && node1.sendCount > 0
+	}
+	testRetryUntilTrue(t, retryUntilFunc)
+	assert.True(t, node1.checkCount > 0)
+	assert.True(t, node1.sendCount > 0)
+
+	// Stop node 1
+	node1.Stop()
+
+	// Wait for another node to detect node1 has stopped sending heartbeats
+	retryUntilFunc = func() bool {
+		return heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1
+	}
+	testRetryUntilTrue(t, retryUntilFunc)
+
+	// Validate that at least one node detected the stopped node 1
+	assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
+		fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
+
+	// Validate current node list
+	activeNodes, err := node2.GetNodeList()
+	require.NoError(t, err, "Error getting node list")
+	assert.Equal(t, 2, len(activeNodes))
+	assert.NotContains(t, activeNodes, "node1")
+	assert.Contains(t, activeNodes, "node2")
+	assert.Contains(t, activeNodes, "node3")
+
+	// Stop heartbeaters
+	node2.Stop()
+	node3.Stop()
+}
+
+type TestCfgHeartbeatStoppedHandler struct {
+	handlerID        string
+	cfg              cbgt.Cfg
+	staleDetectCount int
+}
+
+func (tch *TestCfgHeartbeatStoppedHandler) StaleHeartBeatDetected(nodeUUID string) {
+	log.Printf("Handler %s detected stale heartbeat for %v, will be removed from config", tch.handlerID, nodeUUID)
+	err := cbgt.UnregisterNodes(tch.cfg, "1.0.0", []string{nodeUUID})
+	if err != nil {
+		log.Printf("Error removing node %s from config: %v", nodeUUID, err)
+	}
+	tch.staleDetectCount++
 }

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -108,7 +108,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 				fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
 
 			// Validate current node list
-			activeNodes, err := node2.GetNodeList()
+			activeNodes, err := handler2.GetNodes()
 			require.NoError(t, err, "Error getting node list")
 			assert.Equal(t, 2, len(activeNodes))
 			assert.NotContains(t, activeNodes, "node1")
@@ -199,7 +199,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 		fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
 
 	// Validate current node list
-	activeNodes, err := node2.GetNodeList()
+	activeNodes, err := handler2.GetNodes()
 	require.NoError(t, err, "Error getting node list")
 	assert.Equal(t, 2, len(activeNodes))
 	assert.NotContains(t, activeNodes, "node1")

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -111,13 +111,16 @@ func ClogCallback(level, format string, v ...interface{}) string {
 		Errorf(KeyDCP, format, v...)
 	case "WARN":
 		// TODO: cbgt currently logs a lot of what we'd consider info as WARN,
-		// (i.e. diagnostic information that's not actionable by users), so
-		// routing to Info pending potential enhancements on cbgt side.
+		//    (i.e. diagnostic information that's not actionable by users), so
+		//    routing to Info pending potential enhancements on cbgt side.
 		Infof(KeyDCP, format, v...)
 	case "INFO":
-		Infof(KeyDCP, format, v...)
-	case "DEBU":
+		// TODO: cbgt currently logs a lot of what we'd consider debug as INFO,
+		//    (i.e. diagnostic information that's not actionable by users), so
+		//    routing to Info pending potential enhancements on cbgt side.
 		Debugf(KeyDCP, format, v...)
+	case "DEBU":
+		Tracef(KeyDCP, format, v...)
 	case "TRAC":
 		Tracef(KeyDCP, format, v...)
 	}

--- a/base/util.go
+++ b/base/util.go
@@ -735,6 +735,24 @@ func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string) (httpUrls []strin
 
 }
 
+// Add auth credentials to the given urls, since CBGT cannot take auth handlers in certain API calls yet
+func ServerUrlsWithAuth(urls []string, spec BucketSpec) (urlsWithAuth []string, err error) {
+	for _, url := range urls {
+		username, password, bucketName := spec.Auth.GetCredentials()
+		urlWithAuth, err := CouchbaseUrlWithAuth(
+			url,
+			username,
+			password,
+			bucketName,
+		)
+		if err != nil {
+			return urlsWithAuth, err
+		}
+		urlsWithAuth = append(urlsWithAuth, urlWithAuth)
+	}
+	return urlsWithAuth, nil
+}
+
 // Special case for couchbaseUri strings that contain a single host with http:// or https:// schemes,
 // possibly containing embedded basic auth.  Needed since gocbconnstr.Parse() will remove embedded
 // basic auth from URLS.

--- a/base/util.go
+++ b/base/util.go
@@ -737,8 +737,9 @@ func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string) (httpUrls []strin
 
 // Add auth credentials to the given urls, since CBGT cannot take auth handlers in certain API calls yet
 func ServerUrlsWithAuth(urls []string, spec BucketSpec) (urlsWithAuth []string, err error) {
-	for _, url := range urls {
-		username, password, bucketName := spec.Auth.GetCredentials()
+	urlsWithAuth = make([]string, len(urls))
+	username, password, bucketName := spec.Auth.GetCredentials()
+	for i, url := range urls {
 		urlWithAuth, err := CouchbaseUrlWithAuth(
 			url,
 			username,
@@ -748,7 +749,7 @@ func ServerUrlsWithAuth(urls []string, spec BucketSpec) (urlsWithAuth []string, 
 		if err != nil {
 			return urlsWithAuth, err
 		}
-		urlsWithAuth = append(urlsWithAuth, urlWithAuth)
+		urlsWithAuth[i] = urlWithAuth
 	}
 	return urlsWithAuth, nil
 }

--- a/db/database.go
+++ b/db/database.go
@@ -77,7 +77,7 @@ type DatabaseContext struct {
 	BucketSpec         base.BucketSpec          // The BucketSpec
 	BucketLock         sync.RWMutex             // Control Access to the underlying bucket object
 	mutationListener   changeListener           // Caching feed listener
-	importListener     *importListener          // Import feed listener
+	ImportListener     *importListener          // Import feed listener
 	sequences          *sequenceAllocator       // Source of new sequence numbers
 	ChannelMapper      *channels.ChannelMapper  // Runs JS 'sync' function
 	StartTime          time.Time                // Timestamp when context was instantiated
@@ -282,8 +282,8 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	// If this is an xattr import node, start import feed
 	if dbContext.UseXattrs() && dbContext.autoImport {
-		dbContext.importListener = NewImportListener()
-		if importFeedErr := dbContext.importListener.StartImportFeed(bucket, dbContext.DbStats, dbContext); importFeedErr != nil {
+		dbContext.ImportListener = NewImportListener()
+		if importFeedErr := dbContext.ImportListener.StartImportFeed(bucket, dbContext.DbStats, dbContext); importFeedErr != nil {
 			return nil, importFeedErr
 		}
 	}
@@ -468,7 +468,7 @@ func (context *DatabaseContext) Close() {
 	context.sequences.Stop()
 	context.mutationListener.Stop()
 	context.changeCache.Stop()
-	context.importListener.Stop()
+	context.ImportListener.Stop()
 	context.Bucket.Close()
 	context.Bucket = nil
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -25,9 +25,6 @@ func NewImportListener() *importListener {
 		terminator: make(chan bool),
 	}
 
-	// Register cbgt PIndex to support sharded import.
-	importListener.RegisterImportPindexImpl()
-
 	return importListener
 }
 
@@ -50,6 +47,9 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *DatabaseS
 	if !ok {
 		return errors.New("Import feed stats map not initialized")
 	}
+
+	// Register cbgt PIndex to support sharded import.
+	il.RegisterImportPindexImpl()
 
 	// Start DCP mutation feed
 	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -143,6 +143,9 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 
 func (il *importListener) Stop() {
 	if il != nil {
+		if il.cbgtContext != nil && il.cbgtContext.Heartbeater != nil {
+			il.cbgtContext.Heartbeater.Stop()
+		}
 		close(il.terminator)
 	}
 }

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -143,8 +143,11 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 
 func (il *importListener) Stop() {
 	if il != nil {
-		if il.cbgtContext != nil && il.cbgtContext.Heartbeater != nil {
-			il.cbgtContext.Heartbeater.Stop()
+		if il.cbgtContext != nil {
+			il.cbgtContext.Manager.Stop()
+			if il.cbgtContext.Heartbeater != nil {
+				il.cbgtContext.Heartbeater.Stop()
+			}
 		}
 		close(il.terminator)
 	}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -144,10 +144,18 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 func (il *importListener) Stop() {
 	if il != nil {
 		if il.cbgtContext != nil {
-			il.cbgtContext.Manager.Stop()
 			if il.cbgtContext.Heartbeater != nil {
 				il.cbgtContext.Heartbeater.Stop()
 			}
+
+			// Close open PIndexes before stopping the manager.
+			_, pindexes := il.cbgtContext.Manager.CurrentMaps()
+			for _, pIndex := range pindexes {
+				il.cbgtContext.Manager.ClosePIndex(pIndex)
+			}
+			// ClosePIndex calls are synchronous, so can stop manager once they've completed
+			il.cbgtContext.Manager.Stop()
+
 		}
 		close(il.terminator)
 	}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -144,6 +144,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 func (il *importListener) Stop() {
 	if il != nil {
 		if il.cbgtContext != nil {
+
 			if il.cbgtContext.Heartbeater != nil {
 				il.cbgtContext.Heartbeater.Stop()
 			}
@@ -156,6 +157,7 @@ func (il *importListener) Stop() {
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed
 			il.cbgtContext.Manager.Stop()
 
+			// TODO: Shut down the cfg (when cfg supports)
 		}
 		close(il.terminator)
 	}

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -1,0 +1,67 @@
+package db
+
+import (
+	"expvar"
+	"os"
+
+	"github.com/couchbase/cbgt"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/pkg/errors"
+)
+
+// init registers the PIndex type definition.  This is invoked by cbgt when a Pindex (collection of
+// vbuckets) is assigned to this node.
+func (il *importListener) RegisterImportPindexImpl() {
+	cbgt.RegisterPIndexImplType(base.CBGTIndexTypeSyncGatewayImport,
+		&cbgt.PIndexImplType{
+			New:  il.NewImportPIndexImpl,
+			Open: il.OpenImportPIndexImpl,
+			Description: "general/syncGateway-import " +
+				" - import processing for shared bucket access",
+		})
+}
+
+// NewImportPIndexImpl is called when the node is first added to the cbgt cfg.  On a node restart,
+// OpenImportPindexImpl is called, and indexParams aren't included.
+func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+
+	// TODO: Would really rather not require any file persistence here
+	// https://issues.couchbase.com/browse/MB-36085
+
+	// Create the pindex-specific path
+	err := os.MkdirAll(path, 0700)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	importDest, err := il.NewImportDest()
+	return nil, importDest, err
+}
+
+func (il *importListener) OpenImportPIndexImpl(indexType, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+	importDest, err := il.NewImportDest()
+	return nil, importDest, err
+}
+
+func (il *importListener) OpenImportPIndexImplUsing(indexType, path, indexParams string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+	return il.OpenImportPIndexImpl(indexType, path, restart)
+}
+
+// Returns a cbgt.Dest targeting the importListener's ProcessFeedEvent
+func (il *importListener) NewImportDest() (cbgt.Dest, error) {
+	callback := il.ProcessFeedEvent
+	bucket := il.database.Bucket
+
+	maxVbNo, err := bucket.GetMaxVbno()
+	if err != nil {
+		return nil, err
+	}
+
+	importFeedStatsMap, ok := il.database.DbStats.StatsDatabase().Get(base.StatKeyImportDcpStats).(*expvar.Map)
+	if !ok {
+		return nil, errors.New("Import feed stats map not initialized")
+	}
+
+	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap, base.DCPImportFeedID)
+	return importDest, nil
+}

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -40,7 +40,7 @@ func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path strin
 
 	importDest, err := il.NewImportDest()
 	if err != nil {
-		base.Errorf(base.KeyDCP, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
+		base.Errorf(base.KeyAll, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
 	}
 	return nil, importDest, err
 }
@@ -50,7 +50,7 @@ func (il *importListener) OpenImportPIndexImpl(indexType, path string, restart f
 	base.Infof(base.KeyDCP, "OpenImportPindexImpl - indexType %s, path %s", indexType, path)
 	importDest, err := il.NewImportDest()
 	if err != nil {
-		base.Errorf(base.KeyDCP, "Error creating NewImportDest during OpenImportPIndexImpl: %v", err)
+		base.Errorf(base.KeyAll, "Error creating NewImportDest during OpenImportPIndexImpl: %v", err)
 	}
 	return nil, importDest, err
 }

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -12,10 +12,13 @@ import (
 // init registers the PIndex type definition.  This is invoked by cbgt when a Pindex (collection of
 // vbuckets) is assigned to this node.
 func (il *importListener) RegisterImportPindexImpl() {
+
+	base.Infof(base.KeyDCP, "Registering PindexImplType for %s", base.CBGTIndexTypeSyncGatewayImport)
 	cbgt.RegisterPIndexImplType(base.CBGTIndexTypeSyncGatewayImport,
 		&cbgt.PIndexImplType{
-			New:  il.NewImportPIndexImpl,
-			Open: il.OpenImportPIndexImpl,
+			New:       il.NewImportPIndexImpl,
+			Open:      il.OpenImportPIndexImpl,
+			OpenUsing: il.OpenImportPIndexImplUsing,
 			Description: "general/syncGateway-import " +
 				" - import processing for shared bucket access",
 		})
@@ -27,6 +30,7 @@ func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path strin
 
 	// TODO: Would really rather not require any file persistence here
 	// https://issues.couchbase.com/browse/MB-36085
+	base.Infof(base.KeyDCP, "NewImportPindexImpl - indexType %s, path %s", indexType, path)
 
 	// Create the pindex-specific path
 	err := os.MkdirAll(path, 0700)
@@ -35,15 +39,24 @@ func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path strin
 	}
 
 	importDest, err := il.NewImportDest()
+	if err != nil {
+		base.Errorf(base.KeyDCP, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
+	}
 	return nil, importDest, err
 }
 
 func (il *importListener) OpenImportPIndexImpl(indexType, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+
+	base.Infof(base.KeyDCP, "OpenImportPindexImpl - indexType %s, path %s", indexType, path)
 	importDest, err := il.NewImportDest()
+	if err != nil {
+		base.Errorf(base.KeyDCP, "Error creating NewImportDest during OpenImportPIndexImpl: %v", err)
+	}
 	return nil, importDest, err
 }
 
 func (il *importListener) OpenImportPIndexImplUsing(indexType, path, indexParams string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
+	base.Infof(base.KeyDCP, "OpenImportPindexImplUsing - indexType %s, path %s", indexType, path)
 	return il.OpenImportPIndexImpl(indexType, path, restart)
 }
 

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -32,8 +32,6 @@ func (il *importListener) RegisterImportPindexImpl() {
 // OpenImportPindexImpl is called, and indexParams aren't included.
 func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
 
-	base.Infof(base.KeyDCP, "NewImportPindexImpl - indexType %s, path %s, params %v", indexType, path, indexParams)
-
 	importDest, err := il.NewImportDest()
 	if err != nil {
 		base.Errorf(base.KeyAll, "Error creating NewImportDest during NewImportPIndexImpl: %v", err)
@@ -43,7 +41,6 @@ func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path strin
 
 func (il *importListener) OpenImportPIndexImpl(indexType, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
 
-	base.Infof(base.KeyDCP, "OpenImportPindexImpl - indexType %s, path %s", indexType, path)
 	importDest, err := il.NewImportDest()
 	if err != nil {
 		base.Errorf(base.KeyAll, "Error creating NewImportDest during OpenImportPIndexImpl: %v", err)
@@ -52,7 +49,6 @@ func (il *importListener) OpenImportPIndexImpl(indexType, path string, restart f
 }
 
 func (il *importListener) OpenImportPIndexImplUsing(indexType, path, indexParams string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
-	base.Infof(base.KeyDCP, "OpenImportPindexImplUsing - indexType %s, path %s, params %v", indexType, path, indexParams)
 	return il.OpenImportPIndexImpl(indexType, path, restart)
 }
 

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"expvar"
-	"os"
 
 	"github.com/couchbase/cbgt"
 	"github.com/couchbase/sync_gateway/base"
@@ -33,15 +32,7 @@ func (il *importListener) RegisterImportPindexImpl() {
 // OpenImportPindexImpl is called, and indexParams aren't included.
 func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
 
-	// TODO: Would really rather not require any file persistence here
-	// https://issues.couchbase.com/browse/MB-36085
 	base.Infof(base.KeyDCP, "NewImportPindexImpl - indexType %s, path %s, params %v", indexType, path, indexParams)
-
-	// Create the pindex-specific path
-	err := os.MkdirAll(path, 0700)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	importDest, err := il.NewImportDest()
 	if err != nil {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -102,7 +102,7 @@
 
   <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="849f3ee6820277b918c0c9702776f85c705485bd"/>
+  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="6ec6ff92f71473f61dc77cfa253f61e399eb1382"/>
 
   <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -102,7 +102,7 @@
 
   <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="46a999e3db7c1edcaeb4e2bee9281167198b7bdd"/>
+  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="849f3ee6820277b918c0c9702776f85c705485bd"/>
 
   <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1713,6 +1713,8 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 // Test DCP backfill stats
 func TestDcpBackfill(t *testing.T) {
 
+	t.Skip("Test disabled pending CBG-560")
+
 	SkipImportTestsIfNotEnabled(t)
 
 	rt := NewRestTester(t, nil)


### PR DESCRIPTION
Adds sharded DCP support using CBGT.   CBGT manager is initialized and started on import listener creation, and a pindex definition is registered using importListener scoped functions for New/Open/OpenUsing.  On PIndex creation, importListener returns the Dest associated with that listener to route DCP events to that importListener’s ProcessFeedEvent.