### PR TITLE
Skip long-running tests when using -short

### DIFF
--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -384,6 +384,10 @@ func InitWebhookTest() (*httptest.Server, *WebhookRequest) {
 
 func TestWebhookBasic(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
 	url := ts.URL
@@ -520,6 +524,10 @@ func TestWebhookBasic(t *testing.T) {
 // function is expecting an old doc revision.
 func TestWebhookOldDoc(t *testing.T) {
 
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
 	url := ts.URL
@@ -649,6 +657,10 @@ func TestWebhookOldDoc(t *testing.T) {
 }
 
 func TestWebhookTimeout(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyEvents)()
 	ts, wr := InitWebhookTest()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -481,6 +481,11 @@ func TestCORSOrigin(t *testing.T) {
 }
 
 func TestCORSLoginOriginOnSessionPost(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/login_test.go
+++ b/rest/login_test.go
@@ -48,6 +48,11 @@ func TestVerifyFacebook(t *testing.T) {
 // This test exists because there have been problems with builds of Go being unable to make HTTPS
 // connections due to the TLS package missing the Cgo bits needed to load system root certs.
 func TestVerifyHTTPSSupport(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	resp, err := http.Get("https://google.com")
 	if err != nil {
 		// Skip test if dial tcp fails with no such host.


### PR DESCRIPTION
Shaves around 1 minute 30 off the webhook tests under `-short` and a couple of 1sec+ tests elsewhere.