### PR TITLE
CBG-474: Write Benchmark for GetRev and Patching

### DIFF
--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -4,12 +4,11 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type treeDoc struct {
@@ -743,6 +742,8 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 }
 
 func BenchmarkDatabaseGet1xRev(b *testing.B) {
+	defer base.DisableTestLogging()()
+
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()
 	defer tearDownTestDB(b, db)
@@ -765,20 +766,17 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc1", "", false, nil)
-			require.NoError(b, err)
+			db.Get1xRevBody("doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc2", "", false, nil)
-			require.NoError(b, err)
+			db.Get1xRevBody("doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc3", "", false, nil)
-			require.NoError(b, err)
+			db.Get1xRevBody("doc3", "", false, nil)
 		}
 	})
 
@@ -792,25 +790,24 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc1", "1-a", false, nil)
-			require.NoError(b, err)
+			db.Get1xRevBody("doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc2", "1-a", false, nil)
-			require.NoError(b, err)
+			db.Get1xRevBody("doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc3", "1-a", false, nil)
-			require.NoError(b, err)
+			db.Get1xRevBody("doc3", "1-a", false, nil)
 		}
 	})
 }
 
 func BenchmarkDatabaseGetRev(b *testing.B) {
+	defer base.DisableTestLogging()()
+
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()
 	defer tearDownTestDB(b, db)
@@ -833,20 +830,17 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc1", "", false, nil)
-			require.NoError(b, err)
+			db.GetRev("doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc2", "", false, nil)
-			require.NoError(b, err)
+			db.GetRev("doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc3", "", false, nil)
-			require.NoError(b, err)
+			db.GetRev("doc3", "", false, nil)
 		}
 	})
 
@@ -860,26 +854,24 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc1", "1-a", false, nil)
-			require.NoError(b, err)
+			db.GetRev("doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc2", "1-a", false, nil)
-			require.NoError(b, err)
+			db.GetRev("doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc3", "1-a", false, nil)
-			require.NoError(b, err)
+			db.GetRev("doc3", "1-a", false, nil)
 		}
 	})
 }
 
 // Replicates delta patching work carried out by handleRev
 func BenchmarkHandleRevDelta(b *testing.B) {
+	defer base.DisableTestLogging()()
 
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()


### PR DESCRIPTION
## CE

```
$ go test -run=- -bench='^(BenchmarkDatabaseGetRev|BenchmarkDatabaseGet1xRev|BenchmarkHandleRevDelta)$' ./db
goos: darwin
goarch: amd64
pkg: github.com/couchbase/sync_gateway/db
BenchmarkDatabaseGet1xRev/ShortLatest-12         	   78906	     15142 ns/op
BenchmarkDatabaseGet1xRev/LongLatest-12          	       7	 152653688 ns/op
BenchmarkDatabaseGet1xRev/ShortWithAttachmentsLatest-12         	   58544	     20149 ns/op
BenchmarkDatabaseGet1xRev/ShortOld-12                           	  681219	      1676 ns/op
BenchmarkDatabaseGet1xRev/LongOld-12                            	      27	  40618103 ns/op
BenchmarkDatabaseGet1xRev/ShortWithAttachmentsOld-12            	  538816	      2076 ns/op
BenchmarkDatabaseGetRev/ShortLatest-12                          	   87907	     13299 ns/op
BenchmarkDatabaseGetRev/LongLatest-12                           	      10	 104407308 ns/op
BenchmarkDatabaseGetRev/ShortWithAttachmentsLatest-12           	   64166	     18350 ns/op
BenchmarkDatabaseGetRev/ShortOld-12                             	 8651296	       137 ns/op
BenchmarkDatabaseGetRev/LongOld-12                              	 8340261	       139 ns/op
BenchmarkDatabaseGetRev/ShortWithAttachmentsOld-12              	 2165895	       551 ns/op
BenchmarkHandleRevDelta/SmallDiff-12                            	  430972	      2782 ns/op
BenchmarkHandleRevDelta/Huge_Diff-12                            	  368932	      2967 ns/op
PASS
ok  	github.com/couchbase/sync_gateway/db	20.155s
```

## EE

```
$ go test -tags cb_sg_enterprise -run=- -bench='^(BenchmarkDatabaseGetRev|BenchmarkDatabaseGet1xRev|BenchmarkHandleRevDelta)$' ./db
goos: darwin
goarch: amd64
pkg: github.com/couchbase/sync_gateway/db
BenchmarkDatabaseGet1xRev/ShortLatest-12         	  107313	     10304 ns/op
BenchmarkDatabaseGet1xRev/LongLatest-12          	      10	 101034339 ns/op
BenchmarkDatabaseGet1xRev/ShortWithAttachmentsLatest-12         	   83574	     14287 ns/op
BenchmarkDatabaseGet1xRev/ShortOld-12                           	 1086657	      1101 ns/op
BenchmarkDatabaseGet1xRev/LongOld-12                            	      46	  24441562 ns/op
BenchmarkDatabaseGet1xRev/ShortWithAttachmentsOld-12            	  775402	      1525 ns/op
BenchmarkDatabaseGetRev/ShortLatest-12                          	  117724	      9409 ns/op
BenchmarkDatabaseGetRev/LongLatest-12                           	      13	  81226986 ns/op
BenchmarkDatabaseGetRev/ShortWithAttachmentsLatest-12           	   89473	     13505 ns/op
BenchmarkDatabaseGetRev/ShortOld-12                             	 8861264	       140 ns/op
BenchmarkDatabaseGetRev/LongOld-12                              	 8271513	       141 ns/op
BenchmarkDatabaseGetRev/ShortWithAttachmentsOld-12              	 2207628	       548 ns/op
BenchmarkHandleRevDelta/SmallDiff-12                            	  469882	      2529 ns/op
BenchmarkHandleRevDelta/Huge_Diff-12                            	  473072	      2518 ns/op
PASS
ok  	github.com/couchbase/sync_gateway/db	20.197s
```