### PR TITLE
CBG-527: Code coverage for attachment.go

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -101,7 +101,7 @@ func (db *Database) storeAttachments(doc *Document, newAttachmentsMeta Attachmen
 	return newAttachmentData, nil
 }
 
-// Attempts to retrieve ancestor attachments for a document.  First attempts to find and use a non-pruned ancestor.
+// Attempts to retrieve ancestor attachments for a document. First attempts to find and use a non-pruned ancestor.
 // If no non-pruned ancestor is available, checks whether the currently active doc has a common ancestor with the new revision.
 // If it does, can use the attachments on the active revision with revpos earlier than that common ancestor.
 func (db *Database) retrieveAncestorAttachments(doc *Document, parentRev string, docHistory []string) map[string]interface{} {

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -621,7 +621,7 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 	revText := `{"_attachments": {"att3b.txt": {"stub":true,"revpos":2,"digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`
 	revBody[BodyRev] = docHistory[1]
 	assert.NoError(t, base.JSONUnmarshal([]byte(revText), &revBody))
-	doc, err = db.PutExistingRevWithBody("doc1", revBody, []string{"2-517786bf", docHistory[1]}, true)
+	doc, err = db.PutExistingRevWithBody("doc1", revBody, []string{"2-517786bf", docHistory[1]}, false)
 	assert.NoError(t, err, "Couldn't update document")
 	log.Printf("revId: %v, doc: %v, docHistory: %v", revId, doc, docHistory)
 }


### PR DESCRIPTION
- Added coverage for decode attachment error.
- Added coverage to generate Proof of attachment