### PR TITLE
Switch cbgt feed to cbdatasource, additional diagnostics

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -135,6 +135,7 @@ const (
 	StatKeyImportErrorCount     = "import_error_count"
 	StatKeyImportProcessingTime = "import_processing_time"
 	StatKeyImportHighSeq        = "import_high_seq"
+	StatKeyImportPartitions     = "import_partitions"
 
 	// StatsCBLReplicationPush
 	StatKeyDocPushCount        = "doc_push_count"

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -118,9 +118,9 @@ func ClogCallback(level, format string, v ...interface{}) string {
 		// TODO: cbgt currently logs a lot of what we'd consider debug as INFO,
 		//    (i.e. diagnostic information that's not actionable by users), so
 		//    routing to Info pending potential enhancements on cbgt side.
-		Debugf(KeyDCP, format, v...)
+		Infof(KeyDCP, format, v...)
 	case "DEBU":
-		Tracef(KeyDCP, format, v...)
+		Debugf(KeyDCP, format, v...)
 	case "TRAC":
 		Tracef(KeyDCP, format, v...)
 	}

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -188,6 +188,7 @@ func initEmptyStatsMap(key string, d *DatabaseStats) *expvar.Map {
 		result.Set(base.StatKeyImportErrorCount, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyImportProcessingTime, base.ExpvarIntVal(0))
 		result.Set(base.StatKeyImportHighSeq, base.ExpvarUInt64Val(0))
+		result.Set(base.StatKeyImportPartitions, base.ExpvarIntVal(0))
 		d.sharedBucketImportMap = result
 	case base.StatsGroupKeyCblReplicationPush:
 		result.Set(base.StatKeyDocPushCount, base.ExpvarIntVal(0))

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -67,6 +67,6 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 		return nil, errors.New("Import feed stats map not initialized")
 	}
 
-	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap, base.DCPImportFeedID)
+	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap, base.DCPImportFeedID, base.DestShardedFeed)
 	return importDest, nil
 }

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -21,7 +21,7 @@
 
   
   <!-- Sync Gateway -->
-  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase" />
+  <project name="sync_gateway" path="godeps/src/github.com/couchbase/sync_gateway" remote="couchbase"/>
   
   <!-- Dependencies for Sync Gateway (and possibly Sync Gateway Accel too) -->
 


### PR DESCRIPTION
Revert feed type to cbdatasource until gocb-based feed is stabilized.

Adds "import_partitions" expvar to monitor partition distribution without extensive log parsing, and restores info-level logging for cbgt as an additional diagnostic tool.

