### PR TITLE
Exit early when storing old doc revision if no body is available

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -950,7 +950,7 @@ func (doc *Document) updateWinningRevAndSetDocFlags() {
 }
 
 func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCurrentRev string, newRevID string, newDoc *Document) {
-	if doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" {
+	if doc.HasBody() && doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" {
 		// Store the doc's previous body into the revision tree:
 		oldBodyJson, marshalErr := doc.BodyBytes()
 		if marshalErr != nil {

--- a/db/document.go
+++ b/db/document.go
@@ -269,6 +269,11 @@ func (doc *Document) RemoveBody() {
 	doc._rawBody = nil
 }
 
+// HasBody returns true if the given document has either an unmarshalled body, or raw bytes available.
+func (doc *Document) HasBody() bool {
+	return doc._body != nil || doc._rawBody != nil
+}
+
 func (doc *Document) BodyBytes() ([]byte, error) {
 	var caller string
 	if base.ConsoleLogLevel().Enabled(base.LevelTrace) {


### PR DESCRIPTION
Prevents an empty body warning and avoids additional work when importing an SDK-written document, due to no revision body being available.

- [x] http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1382/