### PR TITLE
Remove last PUT /_logging from tests - use SetUpTestLogging instead

### DIFF
--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -136,7 +136,7 @@ func TestXattrSGTombstone(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create doc through SG
 	key := "TestXattrSGTombstone"
@@ -181,7 +181,7 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	rt.SendAdminRequest("PUT", "/_logging", `{"ImportCas":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	// 1. SG Write
 	key := "TestCasFailureImport"
@@ -244,7 +244,7 @@ func TestXattrResurrectViaSG(t *testing.T) {
 
 	rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create and import doc
 	key := "TestResurrectViaSG"
@@ -289,7 +289,7 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	// 1. Create and import doc
 	key := "TestResurrectViaSDK"
@@ -350,7 +350,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create and import doc
 	key := "TestDoubleDelete"
@@ -395,7 +395,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	// 1. Create and import docs
 	key := "SG_delete"
@@ -468,7 +468,7 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create two docs via the SDK, one matching filter
 	mobileKey := "TestImportFilterValid"
@@ -555,7 +555,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportMultiActorUpdate"
@@ -609,7 +609,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportMultiActorUpdate"
@@ -669,7 +669,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// Create doc via the SDK
 	mobileKey := "TestImportMultiActorFeed"
@@ -741,7 +741,7 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportLargeNumbers"
@@ -787,7 +787,7 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateLargeInlineRevisions"
@@ -853,7 +853,7 @@ func TestMigrateTombstone(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateTombstone"
@@ -919,7 +919,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateWithExternalRevisions"
@@ -992,7 +992,7 @@ func TestCheckForUpgradeOnRead(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1068,7 +1068,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true, "Cache+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD|base.KeyCache)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1150,7 +1150,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true, "Cache+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD|base.KeyCache)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1210,7 +1210,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create docs via the SDK with expiry set
 	mobileKey := "TestXattrImportPreservesExpiry"
@@ -1268,7 +1268,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestFeedBasedMigrateWithExpiry"
@@ -1351,7 +1351,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			defer rt.Close()
 			bucket := rt.Bucket()
 
-			rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 			key := fmt.Sprintf("TestXattrOnDemandImportPreservesExpiry-%d", i)
 
@@ -1434,7 +1434,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			defer rt.Close()
 			bucket := rt.Bucket()
 
-			rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 			// Create via the SDK with sync metadata intact
 			expirySeconds := time.Second * 30
@@ -1480,7 +1480,7 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create doc via SG
 	sgWriteKey := "TestImportFilterSGWrite"
@@ -1524,7 +1524,7 @@ func TestImportBinaryDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true, "Cache+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD|base.KeyCache)()
 
 	// 1. Write a binary doc through the SDK
 	rawBytes := []byte("some bytes")
@@ -1551,7 +1551,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	key := "TestImportRevisionCopy"
 	docBody := make(map[string]interface{})
@@ -1611,7 +1611,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	}
 
 	bucket := rt.Bucket()
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	key := "TestImportRevisionCopy"
 	docBody := make(map[string]interface{})
@@ -1669,7 +1669,7 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	}
 
 	bucket := rt.Bucket()
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	key := "TestImportRevisionCopy"
 	docBody := make(map[string]interface{})
@@ -1782,7 +1782,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	rt.SendAdminRequest("PUT", "/_logging", `{"Import+":true, "CRUD+":true}`)
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestTombstoneUpdate"


### PR DESCRIPTION
These last set of `PUT /_logging` from tests weren't caught when we added `SetUpTestLogging` - so switched them over.