### PR TITLE
TLS client certificate support for CBL

### DIFF
--- a/auth/client_cert.go
+++ b/auth/client_cert.go
@@ -1,0 +1,141 @@
+//  Copyright (c) 2019 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package auth
+
+import (
+	"crypto/x509"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// A pattern for extracting usernames from X.509 certificates. Found in the config file.
+// The behavior is compatible with Couchbase Server's client cert configuration
+// <https://docs.google.com/document/d/1sC_He6DZdiZBw63jIvOdwqD_2uGAkELzSA1BqxGuNCA/>
+// extended with an optional regular-expression mode that's more powerful.
+type ClientCertNamePattern struct {
+	Path       string  `json:"path,omitempty"`       // Identifies which field of the cert to look in
+	Prefix     *string `json:"prefix,omitempty"`     // Optional prefix to skip before the username
+	Delimiters *string `json:"delimiters,omitempty"` // Optional delimiter to end the username at
+	Regex      *string `json:"regex,omitempty"`      // Optional regex to match; the 1st submatch (group) is the username
+
+	regex *regexp.Regexp
+}
+
+// Looks up a User from a client X.509 certificate, based on the rules in the patterns.
+func (auth *Authenticator) GetUserByCertificate(clientCert x509.Certificate, patterns []ClientCertNamePattern) (User, error) {
+	for _, pattern := range patterns {
+		if username := pattern.Match(clientCert); username != nil {
+			user, err := auth.GetUser(*username)
+			if user == nil && err == nil {
+				err = fmt.Errorf("Unknown username '%s' in X.509 client certificate", *username)
+			}
+			return user, err
+		}
+	}
+	return nil, fmt.Errorf("No username found in X.509 client certificate")
+}
+
+// Checks whether the pattern parameters are correct.
+func (pat *ClientCertNamePattern) Validate() error {
+	if pat.Path != "subject.cn" && pat.Path != "san.uri" && pat.Path != "san.email" && pat.Path != "san.dns" {
+		return fmt.Errorf(`unknown "path" value "%s"`, pat.Path)
+	}
+	if pat.Prefix != nil || pat.Delimiters != nil {
+		if pat.Regex != nil {
+			return fmt.Errorf(`"regex" cannot be combined with "prefix" or "delimiters"`)
+		}
+		return nil
+	} else if pat.Regex != nil {
+		// as a side effect, this compiles the Regexp
+		var err error
+		pat.regex, err = regexp.Compile(*pat.Regex)
+		if pat.regex == nil {
+			return err
+		}
+		return nil
+	} else {
+		return nil
+	}
+}
+
+// Given a cert and a pattern, return a matching username or nil
+func (pat *ClientCertNamePattern) Match(cert x509.Certificate) *string {
+	for _, name := range pat.findNames(cert) {
+		if username := pat.match(name); username != nil {
+			return username
+		}
+	}
+	return nil
+}
+
+// Get the name(s) from the cert based on my Path property:
+func (pat *ClientCertNamePattern) findNames(cert x509.Certificate) []string {
+	switch pat.Path {
+	case "subject.cn":
+		return []string{cert.Subject.CommonName}
+	case "san.uri":
+		names := make([]string, len(cert.URIs))
+		for i, uri := range cert.URIs {
+			names[i] = uri.String()
+		}
+		return names
+	case "san.email":
+		return cert.EmailAddresses
+	case "san.dns":
+		return cert.DNSNames
+	default:
+		return nil
+	}
+}
+
+// Match a name
+func (pat *ClientCertNamePattern) match(name string) *string {
+	if pat.Regex != nil {
+		return pat.matchByRegex(name)
+	} else {
+		return pat.matchByPrefix(name)
+	}
+}
+
+// Use .Prefix and/or .Delimiters to match a name
+func (pat *ClientCertNamePattern) matchByPrefix(name string) *string {
+	if pat.Prefix != nil {
+		if suffix := strings.TrimPrefix(name, *pat.Prefix); suffix != name {
+			name = suffix
+		} else {
+			return nil // Prefix must be matched
+		}
+	}
+	if pat.Delimiters != nil {
+		if end := strings.IndexAny(name, *pat.Delimiters); end >= 0 {
+			name = name[0:end]
+		}
+		// Delimiters don't need to be matched
+	}
+	if len(name) == 0 {
+		return nil
+	}
+	return &name
+}
+
+// Use .Regex to match a name
+func (pat *ClientCertNamePattern) matchByRegex(name string) *string {
+	if pat.regex == nil {
+		pat.regex = regexp.MustCompile(*pat.Regex) // (usually this happens during Validate)
+	}
+	m := pat.regex.FindStringSubmatchIndex(name)
+	if len(m) >= 4 && m[2] >= 0 && m[3] > m[2] {
+		// Return the first submatch, i.e. '(...)' group in the RE
+		username := name[m[2]:m[3]]
+		return &username
+	}
+	return nil
+}

--- a/auth/client_cert_test.go
+++ b/auth/client_cert_test.go
@@ -1,0 +1,164 @@
+//  Copyright (c) 2019 Couchbase, Inc.
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+package auth
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func pattern(t *testing.T, jsn string) *ClientCertNamePattern {
+	var pat *ClientCertNamePattern
+	err := json.Unmarshal([]byte(jsn), &pat)
+	if err != nil {
+		t.Errorf("INVALID JSON: %v", err)
+	}
+	assert.True(t, err == nil)
+	assert.NotNil(t, pat)
+	return pat
+}
+
+func TestValidate(t *testing.T) {
+	assert.NoError(t, pattern(t, `{"path":"san.dns", "prefix":"www.", "delimiters":". "}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"san.dns", "prefix":"www."}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"san.dns", "delimiters":". "}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"subject.cn", "regex":"^([-\\w]+)@couchbase\\.com$"}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"san.email", "regex":"^([-\\w]+)@couchbase\\.com$"}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"san.uri", "delimiters":". "}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"san.email", "delimiters":". "}`).Validate())
+	assert.NoError(t, pattern(t, `{"path":"subject.cn"}`).Validate())
+
+	assert.Error(t, pattern(t, `{"path":"mxptlk", "prefix":"www."}`).Validate())
+	assert.Error(t, pattern(t, `{"path":"subject.cn", "regex":"^([-\\w"}`).Validate())
+	assert.Error(t, pattern(t, `{"path":"subject.cn", "prefix":"www.", "regex":"^([-\\w]+)@couchbase\\.com$"}`).Validate())
+	assert.Error(t, pattern(t, `{"path":"subject.cn", "delimiters":". ", "regex":"^([-\\w]+)@couchbase\\.com$"}`).Validate())
+	assert.Error(t, pattern(t, `{"path":"subject.cn", "prefix":"www.", "delimiters":". ", "regex":"^([-\\w]+)@couchbase\\.com$"}`).Validate())
+}
+
+func TestPrefixMatch(t *testing.T) {
+	pat := pattern(t, `{"path":"san.dns", "prefix":"www."}`)
+	assert.Equal(t, *pat.match("www.foo.couchbase.com"), "foo.couchbase.com")
+	assert.Equal(t, *pat.match("www.foo"), "foo")
+	assert.Equal(t, *pat.match("www.foo "), "foo ")
+
+	assert.Nil(t, pat.match("mmm.foo.couchbase.com"))
+	assert.Nil(t, pat.match("www."))
+	assert.Nil(t, pat.match(""))
+}
+
+func TestPrefixDelimiterMatch(t *testing.T) {
+	pat := pattern(t, `{"path":"san.dns", "prefix":"www.", "delimiters":". "}`)
+	assert.Equal(t, *pat.match("www.foo.couchbase.com"), "foo")
+	assert.Equal(t, *pat.match("www.foo couchbase.com"), "foo")
+	assert.Equal(t, *pat.match("www.foo."), "foo")
+	assert.Equal(t, *pat.match("www.foo "), "foo")
+	assert.Equal(t, *pat.match("www.foo"), "foo")
+
+	assert.Nil(t, pat.match("mmm.foo.couchbase.com"))
+	assert.Nil(t, pat.match("foo.couchbase.com"))
+	assert.Nil(t, pat.match("www."))
+	assert.Nil(t, pat.match("www.."))
+	assert.Nil(t, pat.match("www "))
+	assert.Nil(t, pat.match("www ."))
+	assert.Nil(t, pat.match(""))
+}
+
+func TestDelimiterMatch(t *testing.T) {
+	pat := pattern(t, `{"path":"san.dns", "delimiters":". "}`)
+	assert.Equal(t, *pat.match("foo.couchbase.com"), "foo")
+	assert.Equal(t, *pat.match("foo couchbase.com"), "foo")
+	assert.Equal(t, *pat.match("foo."), "foo")
+	assert.Equal(t, *pat.match("foo "), "foo")
+	assert.Equal(t, *pat.match("foo"), "foo")
+
+	assert.Nil(t, pat.match(".couchbase.com"))
+	assert.Nil(t, pat.match(" foo.couchbase.com"))
+	assert.Nil(t, pat.match(""))
+}
+
+func TestRegexMatch(t *testing.T) {
+	// Note that this regex must match the entire string (since it uses `^...$`)
+	pat := pattern(t, `{"path":"san.email", "regex":"^([-\\w]+)@couchbase\\.com$"}`)
+	assert.Equal(t, *pat.match("foo@couchbase.com"), "foo")
+	assert.Equal(t, *pat.match("foo-bar@couchbase.com"), "foo-bar")
+	assert.Equal(t, *pat.match("f@couchbase.com"), "f")
+	assert.Equal(t, *pat.match("aLengthierNameThanFoo@couchbase.com"), "aLengthierNameThanFoo")
+
+	assert.Nil(t, pat.match("@couchbase.com"))
+	assert.Nil(t, pat.match("føø@couchbase.com"))
+	assert.Nil(t, pat.match("foo@@couchbase.com"))
+	assert.Nil(t, pat.match("foo@couchbase.com "))
+	assert.Nil(t, pat.match(" foo@couchbase.com"))
+	assert.Nil(t, pat.match(" foo@couchbase.com "))
+
+	// Now the regex is not anchored to the ends of the string:
+	pat = pattern(t, `{"path":"san.email", "regex":"([-\\w]+)@couchbase\\.com"}`)
+	assert.Equal(t, *pat.match("foo@couchbase.com"), "foo")
+	assert.Equal(t, *pat.match("foo-bar@couchbase.com"), "foo-bar")
+	assert.Equal(t, *pat.match("f@couchbase.com"), "f")
+	assert.Equal(t, *pat.match("aLengthierNameThanFoo@couchbase.com"), "aLengthierNameThanFoo")
+
+	assert.Equal(t, *pat.match("foo@couchbase.com "), "foo")
+	assert.Equal(t, *pat.match(" foo@couchbase.com"), "foo")
+	assert.Equal(t, *pat.match(" foo@couchbase.com "), "foo")
+	assert.Equal(t, *pat.match("Nathan Foo <foo@couchbase.com>"), "foo")
+	assert.Equal(t, *pat.match("snäfoo@couchbase.community.xxx"), "foo")
+
+	assert.Nil(t, pat.match("x @couchbase.com"))
+	assert.Nil(t, pat.match("føø@couchbase.com"))
+	assert.Nil(t, pat.match("foo@@couchbase.com"))
+}
+
+func TestCertPatternMatch(t *testing.T) {
+	// This is not a real certificate, but it has all the fields that the code we're testing uses
+	url1, _ := url.Parse("https://baz.couchbase.com/wow.html")
+	url2, _ := url.Parse("wss://www.zab.couchbase.com/wow.html")
+	cert := x509.Certificate{
+		Subject:        pkix.Name{CommonName: "Martha McGill"},
+		EmailAddresses: []string{"foo@couchbase.com"},
+		DNSNames:       []string{"bar.couchbase.com", "www.example.com"},
+		URIs:           []*url.URL{url1, url2},
+	}
+
+	pat := pattern(t, `{"path":"san.dns", "prefix":"www.", "delimiters":". "}`)
+	assert.Equal(t, *pat.Match(cert), "example")
+	pat = pattern(t, `{"path":"san.uri", "prefix":"https://", "delimiters":"."}`)
+	assert.Equal(t, *pat.Match(cert), "baz")
+	pat = pattern(t, `{"path":"san.uri", "regex":"^wss?://(?:www\\.)?(\\w+).couchbase\\.com"}`)
+	assert.Equal(t, *pat.Match(cert), "zab")
+	pat = pattern(t, `{"path":"subject.cn", "delimiters":" "}`)
+	assert.Equal(t, *pat.Match(cert), "Martha")
+	pat = pattern(t, `{"path":"subject.cn"}`)
+	assert.Equal(t, *pat.Match(cert), "Martha McGill")
+	pat = pattern(t, `{"path":"san.email", "regex":"([-\\w]+)@couchbase\\.com"}`)
+	assert.Equal(t, *pat.Match(cert), "foo")
+
+	pat = pattern(t, `{"path":"san.uri", "prefix":"www.", "delimiters":". "}`)
+	assert.Nil(t, pat.Match(cert))
+}
+
+func TestCertPatternMatchNilAttributes(t *testing.T) {
+	// Make sure nil fields in the cert don't cause panics
+	cert := x509.Certificate{}
+
+	pat := pattern(t, `{"path":"san.dns", "prefix":"www.", "delimiters":". "}`)
+	assert.Nil(t, pat.Match(cert))
+	pat = pattern(t, `{"path":"san.uri", "prefix":"https://", "delimiters":"."}`)
+	assert.Nil(t, pat.Match(cert))
+	pat = pattern(t, `{"path":"subject.cn", "delimiters":" "}`)
+	assert.Nil(t, pat.Match(cert))
+	pat = pattern(t, `{"path":"san.email", "regex":"([-\\w]+)@couchbase\\.com"}`)
+	assert.Nil(t, pat.Match(cert))
+}

--- a/base/error.go
+++ b/base/error.go
@@ -41,6 +41,7 @@ var (
 	ErrNotFound              = &sgError{"Not Found"}
 	ErrUpdateCancel          = &sgError{"Cancel update"}
 	ErrImportCancelledPurged = &sgError{"Import Cancelled Due to Purge"}
+	ErrInvalidCertificate    = &sgError{"Error reading X.509 certificate(s) from file"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.


### PR DESCRIPTION
If enabled via `unsupported.SSLClientCerts` config, TLS client certs
will be used for authentication. If a client cert contains an email
address (in the Subject Alternative Name or as the Common Name),
and if there's a user with that email address, a request is authenti-
cated as that user. Otherwise authentication proceeds normally.

If `unsupported.SSLClientCerts` is present, it must be an object
containing a key `CA_cert` whose value is the path to a PEM or DER
file containing the CA certificate used to validate client certs.
It may also have a key `required` whose value is a boolean; if
false, client certs are optional.

CBG-570