### PR TITLE
CBG-568 - Fix missing _deleted properties in webhook and _raw doc bodies

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1447,7 +1447,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 		}
 		db.revisionCache.Put(documentRevision)
 		if db.EventMgr.HasHandlerForEvent(DocumentChange) {
-			webhookJSON, err := doc.MarshalBodyForWebhook()
+			webhookJSON, err := doc.BodyWithSpecialProperties()
 			if err != nil {
 				base.Warnf(base.KeyAll, "Error marshalling doc with id %s and revid %s for webhook post: %v", base.UD(docid), base.UD(newRevID), err)
 			} else {

--- a/db/document.go
+++ b/db/document.go
@@ -194,6 +194,10 @@ func (doc *Document) MarshalBodyAndSync() (retBytes []byte, err error) {
 	}
 }
 
+func (doc *Document) IsDeleted() bool {
+	return doc.hasFlag(channels.Deleted)
+}
+
 func (doc *Document) BodyWithSpecialProperties() ([]byte, error) {
 	bodyBytes, err := doc.BodyBytes()
 	if err != nil {
@@ -205,7 +209,7 @@ func (doc *Document) BodyWithSpecialProperties() ([]byte, error) {
 		{Key: BodyRev, Val: doc.CurrentRev},
 	}
 
-	if doc.hasFlag(channels.Deleted) {
+	if doc.IsDeleted() {
 		kvPairs = append(kvPairs, base.KVPair{Key: BodyDeleted, Val: true})
 	}
 

--- a/db/document.go
+++ b/db/document.go
@@ -194,22 +194,26 @@ func (doc *Document) MarshalBodyAndSync() (retBytes []byte, err error) {
 	}
 }
 
-func (doc *Document) MarshalBodyForWebhook() (retBytes []byte, err error) {
+func (doc *Document) BodyWithSpecialProperties() ([]byte, error) {
 	bodyBytes, err := doc.BodyBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	kvpairs := []base.KVPair{
+	kvPairs := []base.KVPair{
 		{Key: BodyId, Val: doc.ID},
 		{Key: BodyRev, Val: doc.CurrentRev},
 	}
 
 	if doc.hasFlag(channels.Deleted) {
-		kvpairs = append(kvpairs, base.KVPair{Key: BodyDeleted, Val: true})
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyDeleted, Val: true})
 	}
 
-	bodyBytes, err = base.InjectJSONProperties(bodyBytes, kvpairs...)
+	if doc.hasFlag(channels.Removed) {
+		kvPairs = append(kvPairs, base.KVPair{Key: BodyRemoved, Val: true})
+	}
+
+	bodyBytes, err = base.InjectJSONProperties(bodyBytes, kvPairs...)
 	if err != nil {
 		return nil, err
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -41,6 +41,8 @@ const (
 const (
 	// RemovedRedactedDocument is returned by SG when a given document has been dropped out of a channel
 	RemovedRedactedDocument = `{"` + BodyRemoved + `":true}`
+	// DeletedDocument is returned by SG when a given document has been deleted
+	DeletedDocument = `{"` + BodyDeleted + `":true}`
 )
 
 // Maps what users have access to what channels or roles, and when they got that access.

--- a/db/document.go
+++ b/db/document.go
@@ -200,11 +200,16 @@ func (doc *Document) MarshalBodyForWebhook() (retBytes []byte, err error) {
 		return nil, err
 	}
 
-	bodyBytes, err = base.InjectJSONProperties(
-		bodyBytes,
-		base.KVPair{Key: BodyId, Val: doc.ID},
-		base.KVPair{Key: BodyRev, Val: doc.CurrentRev},
-	)
+	kvpairs := []base.KVPair{
+		{Key: BodyId, Val: doc.ID},
+		{Key: BodyRev, Val: doc.CurrentRev},
+	}
+
+	if doc.hasFlag(channels.Deleted) {
+		kvpairs = append(kvpairs, base.KVPair{Key: BodyDeleted, Val: true})
+	}
+
+	bodyBytes, err = base.InjectJSONProperties(bodyBytes, kvpairs...)
 	if err != nil {
 		return nil, err
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -215,10 +215,6 @@ func (doc *Document) BodyWithSpecialProperties() ([]byte, error) {
 		kvPairs = append(kvPairs, base.KVPair{Key: BodyDeleted, Val: true})
 	}
 
-	if doc.hasFlag(channels.Removed) {
-		kvPairs = append(kvPairs, base.KVPair{Key: BodyRemoved, Val: true})
-	}
-
 	bodyBytes, err = base.InjectJSONProperties(bodyBytes, kvPairs...)
 	if err != nil {
 		return nil, err

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -372,14 +372,15 @@ func (h *handler) handleGetRawDoc() error {
 	}
 
 	doc, err := h.db.GetDocument(docid, db.DocUnmarshalSync)
-
 	if err != nil {
 		return err
 	}
 
 	response := map[string]interface{}{}
 
+	// if we found a doc, and we need the body, copy the full thing
 	if docBody := doc.Body(); docBody != nil && includeDoc {
+		// TODO: special properties are gone
 		response = docBody.Copy(db.BodyDeepCopy)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -378,13 +378,13 @@ func (h *handler) handleGetRawDoc() error {
 
 	var rawBytes []byte
 	if includeDoc {
-		docRawBodyBytes, err := doc.BodyWithSpecialProperties()
-		if err != nil {
-			return err
-		}
-		if len(docRawBodyBytes) <= len(base.EmptyDocument) {
+		if doc.IsDeleted() {
 			rawBytes = []byte(`{"_deleted":true}`)
 		} else {
+			docRawBodyBytes, err := doc.BodyBytes()
+			if err != nil {
+				return err
+			}
 			rawBytes = docRawBodyBytes
 		}
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -379,7 +379,7 @@ func (h *handler) handleGetRawDoc() error {
 	var rawBytes []byte
 	if includeDoc {
 		if doc.IsDeleted() {
-			rawBytes = []byte(`{"_deleted":true}`)
+			rawBytes = []byte(db.DeletedDocument)
 		} else {
 			docRawBodyBytes, err := doc.BodyBytes()
 			if err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -376,7 +376,7 @@ func (h *handler) handleGetRawDoc() error {
 		return err
 	}
 
-	var rawBytes []byte
+	rawBytes := []byte(base.EmptyDocument)
 	if includeDoc {
 		if doc.IsDeleted() {
 			rawBytes = []byte(db.DeletedDocument)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1725,6 +1725,7 @@ func TestRawRedaction(t *testing.T) {
 	err = base.JSONUnmarshal(res.Body.Bytes(), &body)
 	assert.NoError(t, err)
 	syncData = body["_sync"]
+	require.NotNil(t, syncData)
 	assert.NotEqual(t, map[string]interface{}{"achannel": nil}, syncData.(map[string]interface{})["channels"])
 	assert.NotEqual(t, []interface{}([]interface{}{[]interface{}{"achannel"}}), syncData.(map[string]interface{})["history"].(map[string]interface{})["channels"])
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1758,8 +1758,8 @@ func TestRawTombstone(t *testing.T) {
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-	assert.Contains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.Contains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"_deleted":true`)
 
@@ -1770,8 +1770,8 @@ func TestRawTombstone(t *testing.T) {
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_raw/"+docID, ``)
 	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
-	assert.Contains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
-	assert.Contains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
+	assert.NotContains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"_deleted":true`)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1757,14 +1757,21 @@ func TestRawTombstone(t *testing.T) {
 	revID := respRevID(t, resp)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_raw/"+docID, ``)
+	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+	assert.Contains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
+	assert.Contains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"_deleted":true`)
 
 	// Delete the doc
 	resp = rt.SendAdminRequest(http.MethodDelete, "/db/"+docID+"?rev="+revID, ``)
 	assertStatus(t, resp, http.StatusOK)
+	revID = respRevID(t, resp)
 
 	resp = rt.SendAdminRequest(http.MethodGet, "/db/_raw/"+docID, ``)
+	assert.Equal(t, "application/json", resp.Header().Get("Content-Type"))
+	assert.Contains(t, string(resp.BodyBytes()), `"_id":"`+docID+`"`)
+	assert.Contains(t, string(resp.BodyBytes()), `"_rev":"`+revID+`"`)
 	assert.NotContains(t, string(resp.BodyBytes()), `"foo":"bar"`)
 	assert.Contains(t, string(resp.BodyBytes()), `"_deleted":true`)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4309,9 +4309,6 @@ func TestDeletedPutReplicator2(t *testing.T) {
 }
 
 func TestWebhookDelete(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Test doesn't work with Walrus")
-	}
 
 	wg := sync.WaitGroup{}
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4308,7 +4308,7 @@ func TestDeletedPutReplicator2(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 }
 
-func TestWebhookDelete(t *testing.T) {
+func TestWebhookSpecialProperties(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 
@@ -4321,6 +4321,8 @@ func TestWebhookDelete(t *testing.T) {
 
 		var body db.Body
 		err = base.JSONUnmarshal(out, &body)
+		require.Contains(t, body, db.BodyId)
+		require.Contains(t, body, db.BodyRev)
 		require.Contains(t, body, db.BodyDeleted)
 		assert.True(t, body[db.BodyDeleted].(bool))
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -584,7 +584,8 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 		json.Indent(&buffer, jsonOut, "", "  ")
 		jsonOut = append(buffer.Bytes(), '\n')
 	}
-	h.writeRawJSONStatus(status, jsonOut)
+
+	h._writeRawJSONStatus(status, jsonOut)
 }
 
 // writeRawJSONStatus writes the given byte slice as a JSON response.
@@ -595,7 +596,10 @@ func (h *handler) writeRawJSONStatus(status int, b []byte) {
 		h.writeStatus(http.StatusNotAcceptable, "only application/json available")
 		return
 	}
+	h._writeRawJSONStatus(status, b)
+}
 
+func (h *handler) _writeRawJSONStatus(status int, b []byte) {
 	h.setHeader("Content-Type", "application/json")
 	if h.rq.Method != "HEAD" {
 		if len(b) < 1000 {


### PR DESCRIPTION
## Tests
- Add test `TestRawTombstone` that verifies a tombstoned doc shows `"_deleted":true` in the raw doc body (but not `_id`, `_rev`, etc.)
- Add test `TestWebhookSpecialProperties` that verifies webhook bodies contain special properties `_id`, `_rev`, and `_deleted`

Verified above running clean as unit/integrations on both `2.6.0` and this branch.

## Fixes
- Add missing flag check when stamping properties into webhook bodies
- Add check for `doc.IsDeleted` from `handleGetRawDoc`

## Misc.
- Add `h.writeRawJSON` to write raw bytes as JSON as a response

## Test helpers
- Add test helper `respRevID()` to get a rev ID from a response to a write
- Add test helper `resp.BodyBytes()` to take a copy of a test response body that can be re-used (unlike the body buffer previously) (used in `respRevID()`)