### PR TITLE
CBG-564 Uptake TLS support in cbgt/cbdatasource

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -181,6 +181,15 @@ func (b BucketSpec) GetViewQueryTimeoutMs() uint64 {
 	return uint64(*b.ViewQueryTimeoutSecs * 1000)
 }
 
+func (b BucketSpec) TLSConfig() *tls.Config {
+	tlsConfig, err := TLSConfigForX509(b.Certpath, b.Keypath, b.CACertPath)
+	if err != nil {
+		Errorf(KeyAll, "Error creating tlsConfig for DCP processing: %v", err)
+		return nil
+	}
+	return tlsConfig
+}
+
 // TLSConnect method is passed to cbdatasource, to be used when creating a TLS-enabled memcached connection.
 // Establishes a connection, then wraps w/ gomemcached Client for use by cbdatasource.
 // Will include client cert (x.509) authentication when specified in the BucketSpec.

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2281,15 +2281,9 @@ func (bucket *CouchbaseBucketGoCB) StartTapFeed(args sgbucket.FeedArguments, dbS
 
 func (bucket *CouchbaseBucketGoCB) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 
-	// TODO: Include feed type or an unsupported flag to support
-	//  legacy cbdatasource-based feed?  Depends on stablility/risk of cbgt feed
-	// TODO: Use cbgt exclusively when x.509 support is finalized
-	// Use non-cbgt cbdatasource feed when x.509 cert is present
-	if bucket.spec.Certpath != "" {
-		return StartDCPFeed(bucket, bucket.spec, args, callback, dbStats)
-	} else {
-		return StartCbgtDCPFeed(bucket, bucket.spec, args, callback, dbStats)
-	}
+	// TODO: Evaluate whether to use cbgt for non-sharded caching feed, as a way to push concurrency upstream
+	return StartDCPFeed(bucket, bucket.spec, args, callback, dbStats)
+
 }
 
 func (bucket *CouchbaseBucketGoCB) StartShardedDCPFeed(dbName string) (*CbgtContext, error) {

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/couchbase/cbgt"
+	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/pkg/errors"
 	pkgerrors "github.com/pkg/errors"
 )
@@ -111,6 +112,14 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 	indexParams := `{"name": "` + dbName + `"}`
 
 	indexName := dbName + "_import"
+
+	// Register bucketDataSource callback for new index if we need to configure TLS
+	if spec.IsTLS() {
+		cbgt.RegisterBucketDataSourceOptionsCallback(indexName, manager.UUID(), func(options *cbdatasource.BucketDataSourceOptions) *cbdatasource.BucketDataSourceOptions {
+			options.TLSConfig = spec.TLSConfig
+			return options
+		})
+	}
 
 	_, previousIndexUUID, err := getCBGTIndexUUID(manager, indexName)
 	indexType := CBGTIndexTypeSyncGatewayImport + dbName

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f1b8a89d740738af8cc69efa090b99d34579cd31"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="f83e63d76bc41c5b61e022db2d5463f776dc545f"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="7204b8f19bb8a873d817519821c2eca24a982f22"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="d5dc4f6170174357adee38c22e81721d1918b09e" />
   <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="d5dc4f6170174357adee38c22e81721d1918b09e" />
@@ -102,7 +102,7 @@
 
   <project name="testify" path="godeps/src/github.com/stretchr/testify" remote="couchbasedeps" revision="04af85275a5c7ac09d16bb3b9b2e751ed45154e5"/>
 
-  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="6ec6ff92f71473f61dc77cfa253f61e399eb1382"/>
+  <project name="cbgt" path="godeps/src/github.com/couchbase/cbgt" remote="couchbase" revision="439bf6fbbb47569e5a79fa3c2698ac797643259f"/>
 
   <project name="blance" path="godeps/src/github.com/couchbase/blance" remote="couchbase" revision="5cd1345cca3ed72f1e63d41d622fcda73e63fea8" />
 


### PR DESCRIPTION
Leverages new callback to customize bucketdatasource options when using cbgt and Manager.  For non-cbgt case (caching feed), have switched back to receiver-based processing pending further analysis of potential concurrency benefits of using cbgt for concurrency.

- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/1385/
- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-master/1386/