### PR TITLE
CBG-577 Update config handling for import sharding

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2286,8 +2286,8 @@ func (bucket *CouchbaseBucketGoCB) StartDCPFeed(args sgbucket.FeedArguments, cal
 
 }
 
-func (bucket *CouchbaseBucketGoCB) StartShardedDCPFeed(dbName string) (*CbgtContext, error) {
-	return StartShardedDCPFeed(dbName, bucket, bucket.spec)
+func (bucket *CouchbaseBucketGoCB) StartShardedDCPFeed(dbName string, numPartitions uint16) (*CbgtContext, error) {
+	return StartShardedDCPFeed(dbName, bucket, bucket.spec, numPartitions)
 }
 
 func (bucket *CouchbaseBucketGoCB) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {

--- a/base/constants.go
+++ b/base/constants.go
@@ -50,7 +50,7 @@ const (
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"
 
-	DefaultAutoImport = false // Whether Sync Gateway should auto-import docs, if not specified in the config
+	DefaultAutoImport = true // Whether Sync Gateway should auto-import docs, if not specified in the config
 
 	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config

--- a/db/database.go
+++ b/db/database.go
@@ -156,8 +156,9 @@ type WarningThresholds struct {
 
 // Options associated with the import of documents not written by Sync Gateway
 type ImportOptions struct {
-	ImportFilter *ImportFilterFunction // Opt-in filter for document import
-	BackupOldRev bool                  // Create temporary backup of old revision body when available
+	ImportFilter     *ImportFilterFunction // Opt-in filter for document import
+	BackupOldRev     bool                  // Create temporary backup of old revision body when available
+	ImportPartitions uint16                // Number of partitions for import
 }
 
 // Represents a simulated CouchDB database. A new instance is created for each HTTP request,

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -60,7 +60,7 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *DatabaseS
 		// Non-gocb bucket, start a non-sharded feed
 		return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap)
 	} else {
-		il.cbgtContext, err = gocbBucket.StartShardedDCPFeed(dbContext.Name)
+		il.cbgtContext, err = gocbBucket.StartShardedDCPFeed(dbContext.Name, il.database.Options.ImportOptions.ImportPartitions)
 		return err
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -353,6 +353,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 	importOptions.BackupOldRev = config.ImportBackupOldRev
 
+	if config.ImportPartitions == nil {
+		importOptions.ImportPartitions = base.DefaultImportPartitions
+	} else {
+		importOptions.ImportPartitions = *config.ImportPartitions
+	}
+
 	// Check for deprecated cache options. If new are set they will take priority but will still log warnings
 	warnings := config.deprecatedConfigCacheFallback()
 	for _, warnLog := range warnings {


### PR DESCRIPTION
Adds import_partitions config setting, used to set the number of partitions for the import feed, and enables import_docs by default when enable_shared_bucket_access is true.