### PR TITLE
CBG-571: Code coverage and obsolete code cleanup [crud.go]

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1823,7 +1823,7 @@ func (db *Database) RevDiff(docid string, revids []string) (missing, possible []
 	// Convert possibleSet to an array (possible)
 	if len(possibleSet) > 0 {
 		possible = make([]string, 0, len(possibleSet))
-		for revid := range possibleSet {
+		for revid, _ := range possibleSet {
 			possible = append(possible, revid)
 		}
 	}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"log"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
@@ -969,18 +970,18 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the very first revision of the document with attachment; let's call this as rev 1-a
-	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}},"version":"1-a"}`
+	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
 	doc, rev, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	ancestor := rev // Ancestor revision
 
 	// Create the second revision of the document with attachment reference;
-	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}},"version":"2-a"}`
+	payload = `{"sku":"6213101","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
 	doc, rev, err = db.PutExistingRevWithBody("camera", unjson(payload), []string{"2-a", "1-a"}, false)
 	parent := rev // Immediate ancestor or parent revision
 	assert.NoError(t, err, "Couldn't create document")
 
-	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}},"version":"3-a"}`
+	payload = `{"sku":"6213102","_attachments":{"camera.txt":{"stub":true,"revpos":1}}}`
 	doc, rev, err = db.PutExistingRevWithBody("camera", unjson(payload), []string{"3-a", "2-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
@@ -1012,11 +1013,11 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	db, err := CreateDatabase(context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
-	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}},"version":"1-a"}`
+	payload := `{"sku":"6213100","_attachments":{"camera.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
 	doc1, rev1, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
-	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}},"version":"2-a"}`
+	payload = `{"sku":"6213101","_attachments":{"lens.txt":{"data":"Q2Fub24gRU9TIDVEIE1hcmsgSVY="}}}`
 	doc2, rev2, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"2-a", "1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 
@@ -1028,7 +1029,6 @@ func TestGet1xRevAndChannels(t *testing.T) {
 
 	var response = Body{}
 	assert.NoError(t, response.Unmarshal(bodyBytes))
-	log.Printf("body:%v", response)
 
 	// Get the 1x revision from document with list revision enabled
 	bodyBytes, removed, err = db.get1xRevFromDoc(doc1, rev1, true)
@@ -1049,9 +1049,7 @@ func TestGet1xRevAndChannels(t *testing.T) {
 	assert.False(t, removed)
 	assert.NoError(t, err, "It should not throw any error")
 	assert.NotNil(t, bodyBytes, "Document body bytes should be received")
-
 	assert.NoError(t, response.Unmarshal(bodyBytes))
-	log.Printf("body:%v", response)
 }
 
 func TestGet1xRevFromDoc(t *testing.T) {
@@ -1066,83 +1064,78 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the first revision of the document
-	payload := `{"model":"1483C002SKU","sku":"5578523","name":"Canon EOS 5D Mark IV","price":"$2,499.99","version":"1a"}`
-	doc1, rev1, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"1-a"}, false)
+	docId := "356779a9a1696714480f57fa3fb66d4c"
+	payload := `{"city":"Los Angeles"}`
+	doc, rev1, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
-	assert.NotEmpty(t, doc1, "Document shouldn't be empty")
+	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
 
-	// Create the second revision of the document
-	payload = `{"model":"1483C002SKU","sku":"5578523","name":"Canon EOS 5D Mark IV","price":"$2,499.99","version":"2a"}`
-	doc2, rev2, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"2-a", "1-a"}, false)
-	assert.NoError(t, err, "Couldn't create document")
-	assert.NotEmpty(t, doc2, "Document shouldn't be empty")
-	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")
-
-	// Get the 1x revision from second doc.
-	bodyBytes, removed, err := db.get1xRevFromDoc(doc2, rev2, true)
+	// Get the 1x revision with rev1
+	bodyBytes, removed, err := db.get1xRevFromDoc(doc, rev1, true)
 	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
 	assert.False(t, removed, "This shouldn't be a removed document")
 	var response = Body{}
 	assert.NoError(t, response.Unmarshal(bodyBytes))
-	assert.Equal(t, "camera", response[BodyId])
-	assert.Equal(t, "2-a", response[BodyRev])
-	assert.Equal(t, "1483C002SKU", response["model"])
-	assert.Equal(t, "Canon EOS 5D Mark IV", response["name"])
-	assert.Equal(t, "$2,499.99", response["price"])
-	assert.Equal(t, "5578523", response["sku"])
-	assert.Equal(t, "2a", response["version"])
+	assert.Equal(t, docId, response[BodyId])
+	assert.Equal(t, "1-a", response[BodyRev])
+	assert.Equal(t, "Los Angeles", response["city"])
 
-	// Get 1x revision from doc with unknown revision id; it simulates the error scenario.
+	// Create the second revision of the document
+	payload = `{"city":"Hollywood"}`
+	doc, rev2, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"2-a", "1-a"}, false)
+	assert.NoError(t, err, "Couldn't create document")
+	assert.NotEmpty(t, doc, "Document shouldn't be empty")
+	assert.Equal(t, "2-a", rev2, "Provided input revision ID should be returned")
+
+	// Get the 1x revision with rev2
+	bodyBytes, removed, err = db.get1xRevFromDoc(doc, rev2, true)
+	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
+	assert.False(t, removed, "This shouldn't be a removed document")
+	assert.NoError(t, response.Unmarshal(bodyBytes))
+	assert.Equal(t, docId, response[BodyId])
+	assert.Equal(t, "2-a", response[BodyRev])
+	assert.Equal(t, "Hollywood", response["city"])
+
+	// Get body bytes from doc with unknown revision id; it simulates the error scenario.
 	// A 404 missing error should be thrown when trying get the body bytes of the document
 	// which doesn't exists in the database. The revision "3-a" doesn't exists in database.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc2, "3-a", true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(doc, "3-a", true)
 	assert.Error(t, err, "It should throw 404 missing error")
 	assert.Contains(t, err.Error(), "404 missing")
 	assert.Empty(t, bodyBytes, "Provided revision doesn't exists")
 	assert.False(t, removed, "This shouldn't be a removed revision")
 	assert.Error(t, response.Unmarshal(bodyBytes), "Unexpected empty JSON input to body.Unmarshal")
 
-	// Create the third revision of the document
-	payload = `{"model":"1483C002SKU","sku":"5578523","name":"Canon EOS 5D Mark IV","price":"$2,499.99","version":"3a"}`
-	doc3, rev3, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"3-a", "2-a"}, false)
-	assert.NoError(t, err, "Couldn't create document")
-	assert.NotEmpty(t, doc3, "Document shouldn't be empty")
-	assert.Equal(t, "3-a", rev3, "Provided input revision ID should be returned")
-
-	// Get the 1x revision from third doc.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc3, rev3, true)
-	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
-	assert.False(t, removed, "This shouldn't be a removed document")
-	assert.NoError(t, response.Unmarshal(bodyBytes))
-	assert.Equal(t, "camera", response[BodyId])
-	assert.Equal(t, "3-a", response[BodyRev])
-	assert.Equal(t, "1483C002SKU", response["model"])
-	assert.Equal(t, "Canon EOS 5D Mark IV", response["name"])
-	assert.Equal(t, "$2,499.99", response["price"])
-	assert.Equal(t, "5578523", response["sku"])
-	assert.Equal(t, "3a", response["version"])
-
-	// Create the fourth revision by deleting the third revision
-	rev4, err := db.DeleteDoc("camera", rev3)
+	// Deletes a document, by adding a new revision whose _deleted property is true.
+	body := Body{BodyDeleted: true, BodyRev: rev2}
+	rev3, doc, err := db.Put(docId, body)
 	assert.NoError(t, err, "Document should be deleted")
-	assert.NotEmpty(t, rev4, "Document revision shouldn't be empty")
+	assert.NotEmpty(t, rev3, "Document revision shouldn't be empty")
 
 	// Get the document body bytes with the deleted revision, list revisions enabled.
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc3, rev3, true)
+	bodyBytes, removed, err = db.get1xRevFromDoc(doc, rev3, true)
 	assert.NotEmpty(t, bodyBytes, "Document body bytes should be returned")
 	assert.False(t, removed, "This shouldn't be a removed document")
 	assert.NoError(t, response.Unmarshal(bodyBytes))
-	assert.Equal(t, "camera", response[BodyId])
-	assert.Equal(t, "3-a", response[BodyRev])
-	assert.Equal(t, "1483C002SKU", response["model"])
-	assert.Equal(t, "Canon EOS 5D Mark IV", response["name"])
-	assert.Equal(t, "$2,499.99", response["price"])
-	assert.Equal(t, "5578523", response["sku"])
-	assert.Equal(t, "3a", response["version"])
+	assert.Equal(t, docId, response[BodyId])
+	assert.Equal(t, rev3, response[BodyRev])
+	assert.Equal(t, "Hollywood", response["city"])
+
+	// If the provided revision ID is blank and the current revision is already deleted
+	// when checking document revision history, it should throw 404 deleted error.
+	bodyBytes, removed, err = db.get1xRevFromDoc(doc, "", true)
+	assert.Error(t, err, "404 deleted")
+	assert.Contains(t, err.Error(), "404 deleted")
+	assert.Empty(t, bodyBytes, "Document body bytes should be empty")
+	assert.False(t, removed, "This shouldn't be a removed document")
+	assert.Error(t, response.Unmarshal(bodyBytes), "Unexpected empty JSON input to body.Unmarshal")
 }
 
 func TestCheckForUpgrade(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with xattrs enabled")
+	}
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
@@ -1154,13 +1147,32 @@ func TestCheckForUpgrade(t *testing.T) {
 	assert.NoError(t, err, "Couldn't create database 'db'")
 
 	// Create the first revision of the document
-	payload := `{"model":"1483C002SKU","sku":"5578523","name":"Canon EOS 5D Mark IV","price":"$2,499.99","version":"1a"}`
-	doc, rev1, err := db.PutExistingRevWithBody("camera", unjson(payload), []string{"1-a"}, false)
+	docId := "356779a9a1696714480f57fa3fb66d4c"
+	payload := `{"city":"Los Angeles"}`
+	doc, rev1, err := db.PutExistingRevWithBody(docId, unjson(payload), []string{"1-a"}, false)
 	assert.NoError(t, err, "Couldn't create document")
 	assert.NotEmpty(t, doc, "Document shouldn't be empty")
 	assert.Equal(t, "1-a", rev1, "Provided input revision ID should be returned")
 
-	doc, buc := db.checkForUpgrade("camera", DocUnmarshalAll)
-	assert.Nil(t, doc)
-	assert.Nil(t, buc)
+	// Check scenario where xattrs is being used already;
+	context.Options.EnableXattr = false
+	doc, buc := db.checkForUpgrade(docId, DocUnmarshalAll)
+	assert.Nil(t, doc, "An upgrade isn't going to be in progress")
+	assert.Nil(t, buc, "An upgrade isn't going to be in progress")
+
+	// Simulate scenario where Couchbase server support Xattrs and it not being used already
+	// but it's enabled.
+	context.Options.EnableXattr = true
+	bodyBytes := rawDocWithSyncMeta()
+	body := Body{}
+	err = body.Unmarshal(bodyBytes)
+	assert.NoError(t, err)
+
+	syncMetaExpiry := time.Now().Add(time.Second * 30)
+	_, err = testBucket.Bucket.Add(docId, uint32(syncMetaExpiry.Unix()), bodyBytes)
+	assert.NoError(t, err)
+
+	doc, buc = db.checkForUpgrade(docId, DocUnmarshalAll)
+	assert.NotEmpty(t, doc)
+	assert.NotEmpty(t, doc)
 }


### PR DESCRIPTION
- Removed AuthorizeDocID; obsolete.
- Removed ComputeVbSequenceChannelsForPrincipal; obsolete.
- Removed ComputeVbSequenceRolesForUser; obsolete.
- Additional coverage for deleted and listRevisions handling for get1xRevFromDoc.
- Additional coverage for the use of parentAttachmentsStruct in getAvailableRevAttachments.
- Additional coverage for checkForUpgrade.