### PR TITLE
CBG-569 - Store unmarshalled body from MutableBody

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1209,7 +1209,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		return
 	}
 
-	syncFnBody := newDoc.GetMutableBody()
+	syncFnBody := newDoc.GetDeepMutableBody()
 
 	// TODO: seems a bit late to do this. Could we move it earlier?
 	err = validateNewBody(syncFnBody)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -918,7 +918,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 		deltaSrcRev, err := db.GetRev("doc1", "1-a", false, nil)
 		assert.NoError(b, err)
 
-		deltaSrcBody, err := deltaSrcRev.MutableBody()
+		deltaSrcBody, err := deltaSrcRev.DeepMutableBody()
 		assert.NoError(b, err)
 
 		// Stamp attachments so we can patch them

--- a/db/document.go
+++ b/db/document.go
@@ -254,7 +254,7 @@ func (doc *Document) Body() Body {
 	return doc._body
 }
 
-func (doc *Document) GetMutableBody() Body {
+func (doc *Document) GetDeepMutableBody() Body {
 	// we can avoid a deep copy by just unmarshalling raw bytes, if available
 	if doc._rawBody != nil {
 		var b Body

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -120,7 +120,7 @@ func (rev *DocumentRevision) MutableBody() (b Body, err error) {
 	}
 
 	// store a copy of the unmarshalled body for next time we need it
-	// We need to copy it now, because the caller may modify the returned bodby between now and the next copy.
+	// We need to copy it now, because the caller may modify the returned body between now and the next copy.
 	rev._shallowCopyBody = b.Copy(BodyShallowCopy)
 
 	return b, nil

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -903,7 +903,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 			return base.HTTPErrorf(http.StatusNotFound, "Can't fetch doc for deltaSrc=%s %v", deltaSrcRevID, err)
 		}
 
-		deltaSrcBody, err := deltaSrcRev.MutableBody()
+		deltaSrcBody, err := deltaSrcRev.DeepMutableBody()
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "Unable to marshal mutable body for deltaSrc=%s %v", deltaSrcRevID, err)
 		}


### PR DESCRIPTION
- When calling MutableBody - store the unmarshalled body so we can do a shallow copy next time MutableBody is called.
- Switch to DeepMutableCopy for delta sync cases where a shallow copy isn't sufficient.