### PR TITLE
CBG-561 - Add retry handling to GetIndexMeta

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2698,14 +2698,13 @@ func (bucket *CouchbaseBucketGoCB) releaseViewOp() {
 	<-bucket.viewOps
 }
 
+// AsGoCBBucket tries to return the given bucket as a GoCBBucket.
 func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
-
-	if gocbBucket, ok := bucket.(*CouchbaseBucketGoCB); ok {
-		return gocbBucket, true
-	}
 
 	var underlyingBucket Bucket
 	switch typedBucket := bucket.(type) {
+	case *CouchbaseBucketGoCB:
+		return typedBucket, true
 	case *LoggingBucket:
 		underlyingBucket = typedBucket.GetUnderlyingBucket()
 	case *LeakyBucket:

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2712,6 +2712,9 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 		underlyingBucket = typedBucket.GetUnderlyingBucket()
 	case TestBucket:
 		underlyingBucket = typedBucket.Bucket
+	default:
+		// bail out for unrecognised/unsupported buckets
+		return nil, false
 	}
 
 	return AsGoCBBucket(underlyingBucket)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2700,20 +2700,21 @@ func (bucket *CouchbaseBucketGoCB) releaseViewOp() {
 
 func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 
-	switch typedBucket := bucket.(type) {
-	case *CouchbaseBucketGoCB:
-		return typedBucket, true
-	case *LoggingBucket:
-		gocbBucket, ok := typedBucket.GetUnderlyingBucket().(*CouchbaseBucketGoCB)
-		return gocbBucket, ok
-	case TestBucket:
-		gocbBucket, ok := typedBucket.Bucket.(*CouchbaseBucketGoCB)
-		return gocbBucket, ok
-	case *LeakyBucket:
-		return AsGoCBBucket(typedBucket.GetUnderlyingBucket())
-	default:
-		return nil, false
+	if gocbBucket, ok := bucket.(*CouchbaseBucketGoCB); ok {
+		return gocbBucket, true
 	}
+
+	var underlyingBucket Bucket
+	switch typedBucket := bucket.(type) {
+	case *LoggingBucket:
+		underlyingBucket = typedBucket.GetUnderlyingBucket()
+	case *LeakyBucket:
+		underlyingBucket = typedBucket.GetUnderlyingBucket()
+	case TestBucket:
+		underlyingBucket = typedBucket.Bucket
+	}
+
+	return AsGoCBBucket(underlyingBucket)
 }
 
 // Get one of the management endpoints.  It will be a string such as http://couchbase

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -248,7 +248,7 @@ func (bucket *CouchbaseBucketGoCB) WaitForIndexOnline(indexName string) error {
 	}
 
 	// Kick off retry loop
-	description := fmt.Sprintf("GetIndexMeta for index %s", indexName)
+	description := fmt.Sprintf("WaitForIndexOnline for index %s", indexName)
 	err, _ := RetryLoop(description, worker, CreateMaxDoublingSleeperFunc(25, 100, 15000))
 
 	return err
@@ -258,10 +258,9 @@ func (bucket *CouchbaseBucketGoCB) WaitForIndexOnline(indexName string) error {
 func (bucket *CouchbaseBucketGoCB) waitForBucketExistence(indexName string, shouldExist bool) error {
 
 	worker := func() (shouldRetry bool, err error, value interface{}) {
-		exists, _, getMetaErr := bucket.GetIndexMeta(indexName)
-		if getMetaErr != nil {
-			return false, getMetaErr, nil
-		}
+		// GetIndexMeta has its own error retry handling,
+		// but keep the retry logic up here for checking if the index exists.
+		exists, _, _ := bucket.GetIndexMeta(indexName)
 		// If it's in the desired state, we're done
 		if exists == shouldExist {
 			return false, nil, nil
@@ -271,13 +270,44 @@ func (bucket *CouchbaseBucketGoCB) waitForBucketExistence(indexName string, shou
 	}
 
 	// Kick off retry loop
-	description := fmt.Sprintf("GetIndexMeta for index %s", indexName)
+	description := fmt.Sprintf("waitForBucketExistence for index %s", indexName)
 	err, _ := RetryLoop(description, worker, CreateMaxDoublingSleeperFunc(25, 100, 15000))
 
 	return err
 }
 
+type getIndexMetaRetryValues struct {
+	exists bool
+	meta   *gocb.IndexInfo
+}
+
 func (bucket *CouchbaseBucketGoCB) GetIndexMeta(indexName string) (exists bool, meta *gocb.IndexInfo, err error) {
+
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		exists, meta, err := bucket.getIndexMetaWithoutRetry(indexName)
+		if err != nil {
+			// retry
+			return true, err, nil
+		}
+		return false, nil, getIndexMetaRetryValues{
+			exists: exists,
+			meta:   meta,
+		}
+	}
+
+	// Kick off retry loop
+	description := fmt.Sprintf("GetIndexMeta for index %s", indexName)
+	err, val := RetryLoop(description, worker, CreateMaxDoublingSleeperFunc(25, 100, 15000))
+
+	valTyped, ok := val.(getIndexMetaRetryValues)
+	if !ok {
+		return false, nil, fmt.Errorf("Expected GetIndexMeta retry value to be getIndexMetaRetryValues but got %T", val)
+	}
+
+	return valTyped.exists, valTyped.meta, err
+}
+
+func (bucket *CouchbaseBucketGoCB) getIndexMetaWithoutRetry(indexName string) (exists bool, meta *gocb.IndexInfo, err error) {
 	statement := fmt.Sprintf("SELECT state from system:indexes WHERE indexes.name = '%s' AND indexes.keyspace_id = '%s'", indexName, bucket.GetName())
 	n1qlQuery := gocb.NewN1qlQuery(statement)
 	results, err := bucket.ExecuteN1qlQuery(n1qlQuery, nil)

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -24,7 +24,7 @@ func TestN1qlQuery(t *testing.T) {
 
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	bucket, ok := AsGoCBBucket(testBucket)
 	if !ok {
 		t.Fatalf("Requires gocb bucket")
 	}


### PR DESCRIPTION
- Improved `AsGoCBBucket()` to recurse on all bucket types (to support `TestBucket->LoggingBucket->GoCBBucket`)
- Add retry handling to `GetIndexMeta()`