### PR TITLE
Fix TestViewQueryWithXattrAndNonXattr

### DIFF
--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -47,15 +47,19 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
-		function(doc, oldDoc) {
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) {
 			if (oldDoc == null) {
 				channel("oldDocNil")
 			} 
 			if (doc._deleted) {
 				channel("docDeleted")
 			}
-		}`}
+		}`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -550,6 +550,9 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -604,6 +607,9 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -1344,8 +1350,10 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 		t.Run(fmt.Sprintf("%s", testCase.name), func(t *testing.T) {
 
 			rtConfig := RestTesterConfig{
-				SyncFn:         `function(doc, oldDoc) { channel(doc.channels) }`,
-				DatabaseConfig: &DbConfig{},
+				SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+				DatabaseConfig: &DbConfig{
+					AutoImport: false,
+				},
 			}
 			rt := NewRestTester(t, &rtConfig)
 			defer rt.Close()
@@ -1429,6 +1437,9 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 
 			rtConfig := RestTesterConfig{
 				SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+				DatabaseConfig: &DbConfig{
+					AutoImport: false,
+				},
 			}
 			rt := NewRestTester(t, &rtConfig)
 			defer rt.Close()

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -515,6 +515,7 @@ func TestImportFilterLogging(t *testing.T) {
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportFilter: &importFilter,
+			AutoImport:   false,
 		},
 	}
 	rt := NewRestTester(t, &rtConfig)

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -685,7 +685,8 @@ func TestViewQueryWithXattrAndNonXattr(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foodoc/_view/foobarview")
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(result.Rows))
+	assert.Equal(t, 3, len(result.Rows))
 	assert.Contains(t, "doc1", result.Rows[0].ID)
 	assert.Contains(t, "doc2", result.Rows[1].ID)
+	assert.Contains(t, "doc3", result.Rows[2].ID)
 }


### PR DESCRIPTION
Looks like this test was broken as a result of setting the default auto import to true as part of: https://github.com/couchbase/sync_gateway/pull/4303

- [ ] Looks like TestOnDemandMigrateWithExpiry has issue too. Specifically triggerOnDemandViaWrite - I expect this has the same cause 

These are integration tests