### PR TITLE
CBG-580 - Enforce property ordering from writeJSONStatus

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -603,7 +603,7 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 		return
 	}
 
-	jsonOut, err := base.JSONMarshal(value)
+	jsonOut, err := base.JSONMarshalCanonical(value)
 	if err != nil {
 		base.Warnf("Couldn't serialize JSON for %v : %s", base.UD(value), err)
 		h.writeStatus(http.StatusInternalServerError, "JSON serialization failed")
@@ -753,7 +753,7 @@ func (h *handler) writeStatus(status int, message string) {
 	h.setHeader("Content-Type", "application/json")
 	h.response.WriteHeader(status)
 	h.setStatus(status, message)
-	jsonOut, _ := base.JSONMarshal(db.Body{"error": errorStr, "reason": message})
+	jsonOut, _ := base.JSONMarshalCanonical(db.Body{"error": errorStr, "reason": message})
 	h.response.Write(jsonOut)
 }
 


### PR DESCRIPTION
This enforces orering of properties for the repsonses to CRUD operations using `writeJSONStatus`.

There's a future enhancement we could make to build ordered raw bytes manually in quite a few places where we don't need to marshal anything other than simple types.
Notably in:
- `writeStatus` for `base.JSONMarshalCanonical(db.Body{"error": errorStr, "reason": message})`
- `handlePutDoc`, `handleDeleteDoc`, etc. for `h.writeJSONStatus(http.StatusCreated, db.Body{"ok": true, "id": docid, "rev": newRev})`