### PR TITLE
More integration test fixes for new AutoImport default

### DIFF
--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -243,9 +243,6 @@ func TestXattrResurrectViaSG(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
-		DatabaseConfig: &DbConfig{
-			AutoImport: false,
-		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -241,8 +241,12 @@ func TestXattrResurrectViaSG(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
-		function(doc, oldDoc) { channel(doc.channels) }`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -286,8 +290,12 @@ func TestXattrResurrectViaSDK(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
-		function(doc, oldDoc) { channel(doc.channels) }`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -347,8 +355,12 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
-		function(doc, oldDoc) { channel(doc.channels) }`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -392,8 +404,12 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	rtConfig := RestTesterConfig{SyncFn: `
-		function(doc, oldDoc) { channel(doc.channels) }`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -453,8 +469,9 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	for _, entry := range results {
 		log.Printf("Got view result: %v", entry)
 	}
-	goassert.Equals(t, len(results), 2)
-	assert.True(t, strings.HasPrefix(results[0].RevID, "2-") && strings.HasPrefix(results[1].RevID, "2-"), "Unexpected revisions in view results post-delete")
+	require.Len(t, results, 2)
+	assert.True(t, strings.HasPrefix(results[0].RevID, "2-"), "Unexpected revisions in view results post-delete")
+	assert.True(t, strings.HasPrefix(results[1].RevID, "2-"), "Unexpected revisions in view results post-delete")
 }
 
 func TestXattrImportFilterOptIn(t *testing.T) {
@@ -465,6 +482,7 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
+			AutoImport:   false,
 			ImportFilter: &importFilter,
 		},
 	}
@@ -747,6 +765,9 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -793,6 +814,9 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -859,6 +883,9 @@ func TestMigrateTombstone(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -925,6 +952,9 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -998,6 +1028,9 @@ func TestCheckForUpgradeOnRead(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -1074,6 +1107,9 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -1486,6 +1522,7 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
+			AutoImport:   false,
 			ImportFilter: &importFilter,
 		},
 	}
@@ -1531,8 +1568,12 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 // Test to write a binary document to the bucket, ensure it's not imported.
 func TestImportBinaryDoc(t *testing.T) {
 
-	rtConfig := RestTesterConfig{SyncFn: `
-		function(doc, oldDoc) { channel(doc.channels) }`}
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -1561,6 +1602,7 @@ func TestImportRevisionCopy(t *testing.T) {
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportBackupOldRev: true,
+			AutoImport:         false,
 		},
 	}
 	rt := NewRestTester(t, &rtConfig)
@@ -1617,6 +1659,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
 			ImportBackupOldRev: true,
+			AutoImport:         false,
 		},
 	}
 	rt := NewRestTester(t, &rtConfig)
@@ -1676,6 +1719,9 @@ func TestImportRevisionCopyDisabled(t *testing.T) {
 	// ImportBackupOldRev not set in config, defaults to false
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -1793,6 +1839,9 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+		},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()


### PR DESCRIPTION
All tests explicitly relying on on-demand import handling switched to `AutoImport: false` in `rest/import_test.go`

- [x] xattrs=true http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1406/
- [x] xattrs=false http://uberjenkins.sc.couchbase.com/view/Build/job/sync-gateway-integration-master/1410/