### PR TITLE
CBG-554 - Insert attachments into CE body when sending BLIP revisions

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -750,9 +750,9 @@ func (bh *blipHandler) sendRevision(sender *blip.Sender, docID, revID string, se
 		return bh.sendNoRev(sender, docID, revID, err)
 	}
 
-	// Still need to stamp _attachments into BLIP messages, so do that below
 	var bodyBytes []byte
 	if base.IsEnterpriseEdition() {
+		// Still need to stamp _attachments into BLIP messages
 		if len(rev.Attachments) > 0 {
 			bodyBytes, err = base.InjectJSONProperties(rev.BodyBytes, base.KVPair{Key: db.BodyAttachments, Val: rev.Attachments})
 			if err != nil {
@@ -766,7 +766,12 @@ func (bh *blipHandler) sendRevision(sender *blip.Sender, docID, revID string, se
 		if err != nil {
 			return bh.sendNoRev(sender, docID, revID, err)
 		}
-		body[db.BodyAttachments] = rev.Attachments
+
+		// Still need to stamp _attachments into BLIP messages
+		if len(rev.Attachments) > 0 {
+			body[db.BodyAttachments] = rev.Attachments
+		}
+
 		bodyBytes, err = base.JSONMarshalCanonical(body)
 		if err != nil {
 			return bh.sendNoRev(sender, docID, revID, err)


### PR DESCRIPTION
Testing already covered by `TestPutAttachmentViaBlipGetViaBlip` (for both CE/EE)