### PR TITLE
Improve warning from encodeRevisions when the revision list has a gap

### DIFF
--- a/db/revtree.go
+++ b/db/revtree.go
@@ -767,7 +767,7 @@ func encodeRevisions(revs []string) Revisions {
 		if i == 0 {
 			start = gen
 		} else if gen != start-i {
-			base.Warnf("encodeRevisions found weird history %v", revs)
+			base.Warnf("Found gap in revision list. Expecting gen %v but got %v in %v", start-i, gen, revs)
 		}
 	}
 	return Revisions{RevisionsStart: start, RevisionsIds: ids}

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -717,7 +717,12 @@ func TestParseRevisions(t *testing.T) {
 
 func TestEncodeRevisions(t *testing.T) {
 	encoded := encodeRevisions([]string{"5-huey", "4-dewey", "3-louie"})
-	goassert.DeepEquals(t, encoded, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}})
+	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "dewey", "louie"}}, encoded)
+}
+
+func TestEncodeRevisionsGap(t *testing.T) {
+	encoded := encodeRevisions([]string{"5-huey", "3-louie"})
+	assert.Equal(t, Revisions{RevisionsStart: 5, RevisionsIds: []string{"huey", "louie"}}, encoded)
 }
 
 func TestTrimEncodedRevisionsToAncestor(t *testing.T) {


### PR DESCRIPTION
Reduces guesswork in figuring out what this warning means:

## Before
```
2019-11-11T10:23:14.545Z [WRN] encodeRevisions found weird history [5-huey 3-louie] -- db.encodeRevisions() at revtree.go:770
```

## After

```
2019-11-11T10:22:27.439Z [WRN] Found gap in revision list. Expecting gen 4 but got 3 in [5-huey 3-louie] -- db.encodeRevisions() at revtree.go:770
```