### PR TITLE
CBG-549: SGCollect collects stderr and stdout Linux

### DIFF
--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -161,6 +161,6 @@ type systemLoggerError struct {
 }
 
 func (n systemLoggerError) Write(b []byte) (int, error) {
-	n.systemLogger.Error(string(b))
+	n.systemLogger.Info(string(b))
 	return len(b), nil
 }

--- a/service/sg-windows/sg-service/sg-service.go
+++ b/service/sg-windows/sg-service/sg-service.go
@@ -15,6 +15,7 @@ const installLocation = "C:\\Program Files\\Couchbase\\Sync Gateway\\"
 const defaultLogFilePath = installLocation + "var\\lib\\couchbase\\logs"
 
 var logger service.Logger
+var infoLogger systemLoggerError
 
 type program struct {
 	ExePath     string
@@ -40,7 +41,11 @@ func (p *program) startup() error {
 		p.SyncGateway = exec.Command(p.ExePath, "--defaultLogFilePath", defaultLogFilePath)
 	}
 
+	p.SyncGateway.Stdout = infoLogger
+	p.SyncGateway.Stderr = infoLogger
+
 	err := p.SyncGateway.Start()
+
 	if err != nil {
 		logger.Errorf("Failed to start Sync Gateway due to error %v", err)
 		return err
@@ -105,6 +110,15 @@ func main() {
 		log.Fatal(err)
 	}
 
+	systemLogger, err := s.SystemLogger(nil)
+	if err != nil {
+		log.Fatalf("Unable to setup system logger: %v", err)
+	}
+
+	infoLogger = systemLoggerError{
+		systemLogger: systemLogger,
+	}
+
 	switch {
 	case os.Args[1] == "install":
 		logger.Info("Installing Sync Gateway")
@@ -140,4 +154,13 @@ func main() {
 		logger.Error(err)
 	}
 	logger.Infof("Exiting Sync Gateway service.")
+}
+
+type systemLoggerError struct {
+	systemLogger service.Logger
+}
+
+func (n systemLoggerError) Write(b []byte) (int, error) {
+	n.systemLogger.Error(string(b))
+	return len(b), nil
 }

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -645,6 +645,8 @@ def make_os_tasks(processes):
         UnixTask("Processor status", "mpstat 1 10"),
         UnixTask("System log", "cat /var/adm/messages"),
         LinuxTask("Raw /proc/uptime", "cat /proc/uptime"),
+        LinuxTask("Systemd journal", "journalctl 2>&1 | gzip -c",
+                  log_file="systemd_journal.gz", no_header=True),
         LinuxTask("All logs", "tar cz /var/log/syslog* /var/log/dmesg /var/log/messages* /var/log/daemon* /var/log/debug* /var/log/kern.log* 2>/dev/null",
                   log_file="syslog.tar.gz", no_header=True),
         LinuxTask("Relevant proc data", "echo %(programs)s | "

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -542,6 +542,24 @@ def make_event_log_task():
                        "/FORMAT:list" % locals())
 
 
+def make_event_log_task_sg_info():
+    from datetime import datetime, timedelta
+
+    # I found that wmic ntevent can be extremely slow; so limiting the output
+    # to approximately last month
+    limit = datetime.today() - timedelta(days=31)
+    limit = limit.strftime('%Y%m%d000000.000000-000')
+
+    return WindowsTask("SG Event log",
+                       "wmic ntevent where "
+                       "\""
+                       "SourceName='SyncGateway' and "
+                       "TimeGenerated>'%(limit)s'"
+                       "\" "
+                       "get TimeGenerated,LogFile,SourceName,EventType,Message "
+                       "/FORMAT:list" % locals())
+
+
 def make_os_tasks(processes):
     programs = " ".join(processes)
 
@@ -665,6 +683,7 @@ def make_os_tasks(processes):
         LinuxTask("Full raw netstat", "cat /proc/net/netstat"),
         LinuxTask("CPU throttling info", "echo /sys/devices/system/cpu/cpu*/thermal_throttle/* | xargs -n1 -- sh -c 'echo $1; cat $1' --"),
         make_event_log_task(),
+        make_event_log_task_sg_info(),
         ]
 
     return _tasks


### PR DESCRIPTION
This should allow stderr and stdout errors to be collected on Linux systems.
Should also allow these to collected on Windows systems via event logging and collecting event logs.

Tested on:
- [X] Ubuntu 18.04
- [x] Centos 7.7
- [x] Windows 10 (following commit 2 & 3)