### PR TITLE
Add Stringer method for ChangesOptions logging

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -351,7 +351,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 		to = fmt.Sprintf("  (to %s)", db.user.Name())
 	}
 
-	base.InfofCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %+v) ... %s", base.UD(chans), options, base.UD(to))
+	base.InfofCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed(channels: %s, options: %s) ... %s", base.UD(chans), options, base.UD(to))
 	output := make(chan *ChangeEntry, 50)
 
 	go func() {
@@ -978,4 +978,19 @@ func createChangesEntry(docid string, db *Database, options ChangesOptions) *Cha
 	}
 
 	return row
+}
+
+func (options ChangesOptions) String() string {
+	return fmt.Sprintf(
+		`{Since: %s, Limit: %d, Conflicts: %t, IncludeDocs: %t, Wait: %t, Continuous: %t, HeartbeatMs: %d, TimeoutMs: %d, ActiveOnly: %t}`,
+		options.Since,
+		options.Limit,
+		options.Conflicts,
+		options.IncludeDocs,
+		options.Wait,
+		options.Continuous,
+		options.HeartbeatMs,
+		options.TimeoutMs,
+		options.ActiveOnly,
+	)
 }


### PR DESCRIPTION
Excludes Terminator and Ctx from options logging

## Before

```
2019-11-12T18:56:52.660Z [INF] Changes: c:#002 MultiChangesFeed(channels: {*}, options: {Since:0 Limit:0 Conflicts:false IncludeDocs:false Wait:false Continuous:false Terminator:0xc0000422a0 HeartbeatMs:0 TimeoutMs:300000 ActiveOnly:false Ctx:<nil>}) ...
```

## After

```
2019-11-12T18:54:55.311Z [INF] Changes: c:#008 MultiChangesFeed(channels: {*}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 300000, ActiveOnly: false}) ...
```