### PR TITLE
Append "+" to log keys for Trace level logging

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -550,7 +550,7 @@ func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey L
 	if logKey > KeyNone && logKey != KeyAll {
 		logKeyName := logKey.String()
 		// Append "+" to logKeys at debug level (for backwards compatibility)
-		if logLevel == LevelDebug {
+		if logLevel >= LevelDebug {
 			logKeyName += "+"
 		}
 		logKeyPrefix = logKeyName + ": "


### PR DESCRIPTION
Debug level log keys are suffixed with "+" due to older logging behaviour, and I think it makes sense to do the same for trace level.