### PR TITLE
Check clients can take JSON before writing raw bytes to them

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -533,7 +533,7 @@ func (h *handler) handleSGCollectStatus() error {
 		status = "running"
 	}
 
-	h.writeBytesAsJSONResponse(http.StatusOK, []byte(`{"status":"`+status+`"}`))
+	h.writeRawJSONStatus(http.StatusOK, []byte(`{"status":"`+status+`"}`))
 	return nil
 }
 
@@ -543,7 +543,7 @@ func (h *handler) handleSGCollectCancel() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Error stopping sgcollect_info: %v", err)
 	}
 
-	h.writeBytesAsJSONResponse(http.StatusOK, []byte(`{"status":"cancelled"}`))
+	h.writeRawJSONStatus(http.StatusOK, []byte(`{"status":"cancelled"}`))
 	return nil
 }
 
@@ -568,7 +568,7 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 
-	h.writeBytesAsJSONResponse(http.StatusOK, []byte(`{"status":"started"}`))
+	h.writeRawJSONStatus(http.StatusOK, []byte(`{"status":"started"}`))
 
 	return nil
 }

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -296,7 +296,7 @@ func (h *handler) handlePutAttachment() error {
 	}
 	h.setHeader("Etag", strconv.Quote(newRev))
 
-	h.writeBytesAsJSONResponse(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
+	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
 	return nil
 }
 
@@ -357,7 +357,7 @@ func (h *handler) handlePutDoc() error {
 		}
 	}
 
-	h.writeBytesAsJSONResponse(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
+	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
 	return nil
 }
 
@@ -431,7 +431,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		}
 	}
 
-	h.writeBytesAsJSONResponse(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+rev+`"}`))
+	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+rev+`"}`))
 	return nil
 }
 
@@ -470,7 +470,7 @@ func (h *handler) handleDeleteDoc() error {
 	}
 	newRev, err := h.db.DeleteDoc(docid, revid)
 	if err == nil {
-		h.writeBytesAsJSONResponse(http.StatusOK, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
+		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
 	}
 	return err
 }
@@ -500,7 +500,7 @@ func (h *handler) handlePutLocalDoc() error {
 		var revid string
 		revid, err = h.db.PutSpecial("local", docid, body)
 		if err == nil {
-			h.writeBytesAsJSONResponse(http.StatusCreated, []byte(`{"id":"_local/`+docid+`","ok":true,"rev":"`+revid+`"}`))
+			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"_local/`+docid+`","ok":true,"rev":"`+revid+`"}`))
 		}
 	}
 	return err

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -569,9 +569,9 @@ func (h *handler) disableResponseCompression() {
 }
 
 // Do not call from HTTP handlers. Use h.writeRawJSON/h.writeRawJSONStatus instead.
-// writeBytesAsJSONResponse takes the given bytes and always writes the response as JSON,
+// writeRawJSONWithoutClientVerification takes the given bytes and always writes the response as JSON,
 // without checking that the client can accept it.
-func (h *handler) writeBytesAsJSONResponse(status int, b []byte) {
+func (h *handler) writeRawJSONWithoutClientVerification(status int, b []byte) {
 	h.setHeader("Content-Type", "application/json")
 	if h.rq.Method != "HEAD" {
 		if len(b) < minCompressibleJSONSize {
@@ -615,7 +615,7 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 		jsonOut = append(buffer.Bytes(), '\n')
 	}
 
-	h.writeBytesAsJSONResponse(status, jsonOut)
+	h.writeRawJSONWithoutClientVerification(status, jsonOut)
 }
 
 // writeRawJSON writes the given bytes as a JSON response with a 200 OK status.
@@ -632,7 +632,7 @@ func (h *handler) writeRawJSONStatus(status int, b []byte) {
 		return
 	}
 
-	h.writeBytesAsJSONResponse(status, b)
+	h.writeRawJSONWithoutClientVerification(status, b)
 }
 
 // writeRawJSON writes the given bytes as a plaintext response with a 200 OK status.


### PR DESCRIPTION
These handlers were using the "internal" method of writing raw JSON, without first checking that the client can accept it.

Switched to the version including the check, and renamed the internal method to be more explicit about the skipped check.