### PR TITLE
CBG-520 Add mutex for validFrom handling

### DIFF
--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -303,7 +303,6 @@ func (c *channelCacheImpl) addChannelCache(channelName string) (*singleChannelCa
 	c.validFromLock.Lock()
 
 	// Everything after the current high sequence will be added to the cache via the feed
-	// TODO: Deadlock between validFromLock and seqLock?
 	validFrom := c.GetHighCacheSequence() + 1
 
 	singleChannelCache := newChannelCacheWithOptions(c.queryHandler, channelName, validFrom, c.options, c.statsMap)


### PR DESCRIPTION
Avoids race between addToCache and adding channels to the cache that can result in invalid validFrom values for newly initialized caches.