### PR TITLE
Prevent panic on timeout scenario in BlipTester.WaitForNumChang…

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1088,7 +1088,8 @@ func (bt *BlipTester) WaitForNumChanges(numChangesExpected int) (changes [][]int
 		base.CreateDoublingSleeperFunc(10, 10),
 	)
 
-	return rawChanges.([][]interface{})
+	changes, _ = rawChanges.([][]interface{})
+	return changes
 
 }
 


### PR DESCRIPTION
When rawChanges is `nil` from a timeout scenario, this type assertion for `[][]interface{}` paniced. We should just return `nil` instead.