### PR TITLE
Log warning for GetIndexMeta errors inside retry loop

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -290,7 +290,7 @@ func (bucket *CouchbaseBucketGoCB) GetIndexMeta(indexName string) (exists bool, 
 		exists, meta, err := bucket.getIndexMetaWithoutRetry(indexName)
 		if err != nil {
 			// retry
-			Warnf("GetIndexMeta error: %s", err)
+			Warnf("Error from GetIndexMeta: %v will retry", err)
 			return true, err, nil
 		}
 		return false, nil, getIndexMetaRetryValues{

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -290,6 +290,7 @@ func (bucket *CouchbaseBucketGoCB) GetIndexMeta(indexName string) (exists bool, 
 		exists, meta, err := bucket.getIndexMetaWithoutRetry(indexName)
 		if err != nil {
 			// retry
+			Warnf("GetIndexMeta error: %s", err)
 			return true, err, nil
 		}
 		return false, nil, getIndexMetaRetryValues{


### PR DESCRIPTION
Warns for each error seen in the `GetIndexMeta` retry loop, before finally logging the last error as an error.

## Before

```
2019-11-20T14:09:37.060Z [DBG] RetryLoop retrying GetIndexMeta for index sg_allDocs_x1 after 200 ms.
2019-11-20 14:09:37.265587 I | protocol error: received *http2.GoAwayFrame before a SETTINGS frame
2019-11-20T14:09:37.265Z [DBG] RetryLoop retrying GetIndexMeta for index sg_allDocs_x1 after 400 ms.
2019-11-20 14:09:37.670928 I | protocol error: received *http2.GoAwayFrame before a SETTINGS frame
2019-11-20T14:09:37.670Z [DBG] RetryLoop retrying GetIndexMeta for index sg_allDocs_x1 after 800 ms.
2019-11-20 14:09:38.476519 I | protocol error: received *http2.GoAwayFrame before a SETTINGS frame
...
2019-11-20T14:12:33.853Z [WRN] RetryLoop for GetIndexMeta for index sg_access_x1 giving up after 25 attempts -- base.RetryLoop() at util.go:373
2019-11-20T14:12:33.853Z [ERR] Error opening database db1: Unable to install index access: Post https://two.cbs.dev.bbrks.me:18093/query/service: connection error: PROTOCOL_ERROR -- rest.RunServer() at config.go:1020
```

## After

```
2019-11-20T14:09:37.060Z [DBG] RetryLoop retrying GetIndexMeta for index sg_allDocs_x1 after 200 ms.
2019-11-20 14:09:37.265587 I | protocol error: received *http2.GoAwayFrame before a SETTINGS frame
2019-11-20T14:09:37.265Z [WRN] GetIndexMeta error: Post https://one.cbs.dev.bbrks.me:18093/query/service: connection error: PROTOCOL_ERROR -- base.(*CouchbaseBucketGoCB).GetIndexMeta.func1() at bucket_n1ql.go:293
2019-11-20T14:09:37.265Z [DBG] RetryLoop retrying GetIndexMeta for index sg_allDocs_x1 after 400 ms.
2019-11-20 14:09:37.670928 I | protocol error: received *http2.GoAwayFrame before a SETTINGS frame
2019-11-20T14:09:37.670Z [WRN] GetIndexMeta error: Post https://two.cbs.dev.bbrks.me:18093/query/service: connection error: PROTOCOL_ERROR -- base.(*CouchbaseBucketGoCB).GetIndexMeta.func1() at bucket_n1ql.go:293
2019-11-20T14:09:37.670Z [DBG] RetryLoop retrying GetIndexMeta for index sg_allDocs_x1 after 800 ms.
2019-11-20 14:09:38.476519 I | protocol error: received *http2.GoAwayFrame before a SETTINGS frame
2019-11-20T14:09:38.476Z [WRN] GetIndexMeta error: Post https://two.cbs.dev.bbrks.me:18093/query/service: connection error: PROTOCOL_ERROR -- base.(*CouchbaseBucketGoCB).GetIndexMeta.func1() at bucket_n1ql.go:293
...
2019-11-20T14:12:33.853Z [WRN] RetryLoop for GetIndexMeta for index sg_access_x1 giving up after 25 attempts -- base.RetryLoop() at util.go:373
2019-11-20T14:12:33.853Z [ERR] Error opening database db1: Unable to install index access: Post https://two.cbs.dev.bbrks.me:18093/query/service: connection error: PROTOCOL_ERROR -- rest.RunServer() at config.go:1020
```