### PR TITLE
CBG-588: Code coverage for rest package (config.go)

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1000,19 +1000,19 @@ func TestDBOfflineConcurrent(t *testing.T) {
 	var goroutineresponse1 *TestResponse
 	go func() {
 		goroutineresponse1 = rt.SendAdminRequest("POST", "/db/_offline", "")
-		assertStatus(t, goroutineresponse1, 200)
 		wg.Done()
 	}()
 
 	var goroutineresponse2 *TestResponse
 	go func() {
 		goroutineresponse2 = rt.SendAdminRequest("POST", "/db/_offline", "")
-		assertStatus(t, goroutineresponse2, 200)
 		wg.Done()
 	}()
 
 	err := WaitWithTimeout(&wg, time.Second*30)
 	assert.NoError(t, err, "Error waiting for waitgroup")
+	assertStatus(t, goroutineresponse1, http.StatusOK)
+	assertStatus(t, goroutineresponse2, http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1745,6 +1745,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 
 	h := &handler{}
 	h.server = NewServerContext(&ServerConfig{})
+	defer h.server.Close()
 
 	// Basic case, no heartbeat, no timeout
 	optStr := `{"feed":"longpoll", "since": "123456:78", "limit":123, "style": "all_docs",

--- a/rest/config.go
+++ b/rest/config.go
@@ -832,7 +832,6 @@ func ParseCommandLine(args []string) (err error) {
 		// Read the configuration file(s), if any:
 		for i := 0; i < flag.NArg(); i++ {
 			filename := flag.Arg(i)
-
 			newConfig, newConfigErr := LoadServerConfig(filename)
 
 			if errors.Cause(newConfigErr) == ErrUnknownField {
@@ -855,23 +854,18 @@ func ParseCommandLine(args []string) (err error) {
 		if *addr != DefaultInterface {
 			config.Interface = addr
 		}
-
 		if *authAddr != DefaultAdminInterface {
 			config.AdminInterface = authAddr
 		}
-
 		if *profAddr != "" {
 			config.ProfileInterface = profAddr
 		}
-
 		if *configServer != "" {
 			config.ConfigServer = configServer
 		}
-
 		if *deploymentID != "" {
 			config.DeploymentID = deploymentID
 		}
-
 		if *pretty {
 			config.Pretty = *pretty
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -355,6 +355,10 @@ func (dbConfig *DbConfig) AutoImportEnabled() (bool, error) {
 }
 
 func (dbConfig *DbConfig) validate() []error {
+	return dbConfig.validateVersion(base.IsEnterpriseEdition())
+}
+
+func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) []error {
 
 	errorMessages := make([]error, 0)
 
@@ -369,7 +373,7 @@ func (dbConfig *DbConfig) validate() []error {
 		if dbConfig.CacheConfig.ChannelCacheConfig != nil {
 
 			// EE: channel cache
-			if !base.IsEnterpriseEdition() {
+			if !isEnterpriseEdition {
 				if val := dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber; val != nil {
 					base.Warnf(eeOnlyWarningMsg, "cache.channel_cache.max_number", *val, db.DefaultChannelCacheMaxNumber)
 					dbConfig.CacheConfig.ChannelCacheConfig.MaxNumber = nil
@@ -430,7 +434,7 @@ func (dbConfig *DbConfig) validate() []error {
 		if dbConfig.CacheConfig.RevCacheConfig != nil {
 			// EE: disable revcache
 			revCacheSize := dbConfig.CacheConfig.RevCacheConfig.Size
-			if !base.IsEnterpriseEdition() && revCacheSize != nil && *revCacheSize == 0 {
+			if !isEnterpriseEdition && revCacheSize != nil && *revCacheSize == 0 {
 				base.Warnf(eeOnlyWarningMsg, "cache.rev_cache.size", *revCacheSize, db.DefaultRevisionCacheSize)
 				dbConfig.CacheConfig.RevCacheConfig.Size = nil
 			}
@@ -444,7 +448,7 @@ func (dbConfig *DbConfig) validate() []error {
 	}
 
 	// EE: delta sync
-	if !base.IsEnterpriseEdition() && dbConfig.DeltaSync != nil && dbConfig.DeltaSync.Enabled != nil {
+	if !isEnterpriseEdition && dbConfig.DeltaSync != nil && dbConfig.DeltaSync.Enabled != nil {
 		base.Warnf(eeOnlyWarningMsg, "delta_sync.enabled", *dbConfig.DeltaSync.Enabled, false)
 		dbConfig.DeltaSync.Enabled = nil
 	}
@@ -463,7 +467,7 @@ func (dbConfig *DbConfig) validate() []error {
 	}
 
 	if dbConfig.ImportPartitions != nil {
-		if !base.IsEnterpriseEdition() {
+		if !isEnterpriseEdition {
 			base.Warnf(eeOnlyWarningMsg, "import_partitions", *dbConfig.ImportPartitions, nil)
 			dbConfig.ImportPartitions = nil
 		} else if !dbConfig.UseXattrs() {

--- a/rest/config.go
+++ b/rest/config.go
@@ -589,19 +589,6 @@ func (dbConfig *DbConfig) UseXattrs() bool {
 	return base.DefaultUseXattrs
 }
 
-// Create a deepcopy of this DbConfig, or panic.
-// This will only copy all of the _exported_ fields of the DbConfig.
-func (dbConfig *DbConfig) DeepCopy() (dbConfigCopy *DbConfig, err error) {
-
-	dbConfigDeepCopy := &DbConfig{}
-	err = base.DeepCopyInefficient(&dbConfigDeepCopy, dbConfig)
-	if err != nil {
-		return nil, err
-	}
-	return dbConfigDeepCopy, nil
-
-}
-
 // Implementation of AuthHandler interface for ClusterConfig
 func (clusterConfig *ClusterConfig) GetCredentials() (string, string, string) {
 	return base.TransformBucketCredentials(clusterConfig.Username, clusterConfig.Password, *clusterConfig.Bucket)

--- a/rest/config.go
+++ b/rest/config.go
@@ -937,7 +937,7 @@ func ParseCommandLine() (err error) {
 	return err
 }
 
-func SetMaxFileDescriptors(maxP *uint64) {
+func SetMaxFileDescriptors(maxP *uint64) error {
 	maxFDs := DefaultMaxFileDescriptors
 	if maxP != nil {
 		maxFDs = *maxP
@@ -945,7 +945,9 @@ func SetMaxFileDescriptors(maxP *uint64) {
 	_, err := base.SetMaxFileDescriptors(maxFDs)
 	if err != nil {
 		base.Warnf("Error setting MaxFileDescriptors to %d: %v", maxFDs, err)
+		return err
 	}
+	return nil
 }
 
 func (config *ServerConfig) Serve(addr string, handler http.Handler) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -788,6 +788,9 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 		if self.Databases[name] != nil {
 			return base.RedactErrorf("Database %q already specified earlier", base.UD(name))
 		}
+		if self.Databases == nil {
+			self.Databases = make(DbConfigMap)
+		}
 		self.Databases[name] = db
 	}
 	return nil

--- a/rest/config.go
+++ b/rest/config.go
@@ -805,7 +805,6 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 
 // Reads the command line flags and the optional config file.
 func ParseCommandLine(args []string) (err error) {
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	addr := flag.String("interface", DefaultInterface, "Address to bind to")
 	authAddr := flag.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
 	profAddr := flag.String("profileInterface", "", "Address to bind profile interface to")

--- a/rest/config.go
+++ b/rest/config.go
@@ -875,7 +875,6 @@ func ParseCommandLine(args []string) (err error) {
 		if config.Interface == nil {
 			config.Interface = &DefaultInterface
 		}
-
 		if config.AdminInterface == nil {
 			config.AdminInterface = &DefaultAdminInterface
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -801,7 +801,7 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 }
 
 // Reads the command line flags and the optional config file.
-func ParseCommandLine() (err error) {
+func ParseCommandLine(args []string) (err error) {
 	addr := flag.String("interface", DefaultInterface, "Address to bind to")
 	authAddr := flag.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
 	profAddr := flag.String("profileInterface", "", "Address to bind profile interface to")
@@ -822,7 +822,7 @@ func ParseCommandLine() (err error) {
 	// used by service scripts as a way to specify a per-distro defaultLogFilePath
 	defaultLogFilePathFlag := flag.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
 
-	flag.Parse()
+	flag.CommandLine.Parse(args)
 
 	if flag.NArg() > 0 {
 		// Read the configuration file(s), if any:
@@ -1082,7 +1082,7 @@ func ServerMain() {
 	defer PanicHandler()()
 
 	var unknownFieldsErr error
-	err := ParseCommandLine()
+	err := ParseCommandLine(os.Args[1:])
 	if errors.Cause(err) == ErrUnknownField {
 		unknownFieldsErr = err
 	} else if err != nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -805,6 +805,7 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 
 // Reads the command line flags and the optional config file.
 func ParseCommandLine(args []string) (err error) {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	addr := flag.String("interface", DefaultInterface, "Address to bind to")
 	authAddr := flag.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
 	profAddr := flag.String("profileInterface", "", "Address to bind profile interface to")

--- a/rest/config.go
+++ b/rest/config.go
@@ -833,7 +833,7 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 		defaultLogFilePath = *defaultLogFilePathFlag
 	}
 
-	if flag.NArg() > 0 {
+	if flagSet.NArg() > 0 {
 		// Read the configuration file(s), if any:
 		for _, filename := range flagSet.Args() {
 			newConfig, newConfigErr := LoadServerConfig(filename)
@@ -842,14 +842,14 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 				// Delay returning this error so we can continue with other setup
 				err = errors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", filename))
 			} else if newConfigErr != nil {
-				return config, errors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", base.UD(filename)))
+				return config, errors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", filename))
 			}
 
 			if config == nil {
 				config = newConfig
 			} else {
 				if err := config.MergeWith(newConfig); err != nil {
-					return config, errors.WithMessage(err, fmt.Sprintf("Error reading config file %s", base.UD(filename)))
+					return config, errors.WithMessage(err, fmt.Sprintf("Error reading config file %s", filename))
 				}
 			}
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -785,6 +785,9 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 	for _, flag := range other.DeprecatedLog {
 		self.DeprecatedLog = append(self.DeprecatedLog, flag)
 	}
+	if self.Logging == nil {
+		self.Logging = other.Logging
+	}
 	if other.Pretty {
 		self.Pretty = true
 	}
@@ -800,44 +803,27 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 	return nil
 }
 
-var (
-	addr, authAddr, profAddr, configServer, deploymentID, couchbaseURL, poolName, bucketName, dbName,
-	logKeys, logFilePath, certpath, cacertpath, keypath, defaultLogFilePathFlag *string
-)
-
-var (
-	pretty, verbose *bool
-)
-
-func resetCommandLine() {
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	setupCommandLine()
-}
-
-func setupCommandLine() {
-	addr = flag.String("interface", DefaultInterface, "Address to bind to")
-	authAddr = flag.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
-	profAddr = flag.String("profileInterface", "", "Address to bind profile interface to")
-	configServer = flag.String("configServer", "", "URL of server that can return database configs")
-	deploymentID = flag.String("deploymentID", "", "Customer/project identifier for stats reporting")
-	couchbaseURL = flag.String("url", DefaultServer, "Address of Couchbase server")
-	poolName = flag.String("pool", DefaultPool, "Name of pool")
-	bucketName = flag.String("bucket", "sync_gateway", "Name of bucket")
-	dbName = flag.String("dbname", "", "Name of Couchbase Server database (defaults to name of bucket)")
-	pretty = flag.Bool("pretty", false, "Pretty-print JSON responses")
-	verbose = flag.Bool("verbose", false, "Log more info about requests")
-	logKeys = flag.String("log", "", "Log keys, comma separated")
-	logFilePath = flag.String("logFilePath", "", "Path to log files")
-	certpath = flag.String("certpath", "", "Client certificate path")
-	cacertpath = flag.String("cacertpath", "", "Root CA certificate path")
-	keypath = flag.String("keypath", "", "Client certificate key path")
-	// used by service scripts as a way to specify a per-distro defaultLogFilePath
-	defaultLogFilePathFlag = flag.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
-}
-
 // Reads the command line flags and the optional config file.
 func ParseCommandLine(args []string) (err error) {
-	resetCommandLine()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	addr := flag.String("interface", DefaultInterface, "Address to bind to")
+	authAddr := flag.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
+	profAddr := flag.String("profileInterface", "", "Address to bind profile interface to")
+	configServer := flag.String("configServer", "", "URL of server that can return database configs")
+	deploymentID := flag.String("deploymentID", "", "Customer/project identifier for stats reporting")
+	couchbaseURL := flag.String("url", DefaultServer, "Address of Couchbase server")
+	poolName := flag.String("pool", DefaultPool, "Name of pool")
+	bucketName := flag.String("bucket", "sync_gateway", "Name of bucket")
+	dbName := flag.String("dbname", "", "Name of Couchbase Server database (defaults to name of bucket)")
+	pretty := flag.Bool("pretty", false, "Pretty-print JSON responses")
+	verbose := flag.Bool("verbose", false, "Log more info about requests")
+	logKeys := flag.String("log", "", "Log keys, comma separated")
+	logFilePath := flag.String("logFilePath", "", "Path to log files")
+	certpath := flag.String("certpath", "", "Client certificate path")
+	cacertpath := flag.String("cacertpath", "", "Root CA certificate path")
+	keypath := flag.String("keypath", "", "Client certificate key path")
+	// used by service scripts as a way to specify a per-distro defaultLogFilePath
+	defaultLogFilePathFlag := flag.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
 
 	if err := flag.CommandLine.Parse(args); err != nil {
 		return err

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"crypto/tls"
+	"flag"
 	"io/ioutil"
 	"log"
 	"os"
@@ -638,6 +639,7 @@ func TestParseCommandLine(t *testing.T) {
 		"--pool", pool,
 		"--pretty"}
 
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err := ParseCommandLine(args)
 	conf := GetConfig()
 	assert.Equal(t, adminInterface, *conf.AdminInterface)
@@ -701,6 +703,7 @@ func TestParseCommandLineWithMissingConfig(t *testing.T) {
 	func() { config = nil }()
 	log.Printf("TestParseCommandLineWithMissingConfig:%v", GetConfig())
 	// Parse command line options with unknown sync gateway configuration file
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err := ParseCommandLine([]string{"missing-sync-gateway.conf"})
 	assert.Nil(t, GetConfig(), "Configuration file doesn't exists")
 	assert.Error(t, err, "Error reading config file")
@@ -721,6 +724,7 @@ func TestParseCommandLineWithBadConfigContent(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err = ParseCommandLine([]string{configFilePath})
 	assert.NotNil(t, GetConfig())
 	assert.Error(t, err, "Error reading config file: unknown field")
@@ -777,6 +781,7 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 		"--profileInterface", profileInterface,
 		configFilePath}
 
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err = ParseCommandLine(args)
 	assert.NoError(t, err, "while parsing commandline options")
 	conf := GetConfig()

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -546,13 +546,16 @@ func TestSetupAndValidateLogging(t *testing.T) {
 	assert.NotEmpty(t, sc.Logging)
 	assert.Empty(t, sc.Logging.DeprecatedDefaultLog)
 	assert.Len(t, warns, 2)
+}
 
+func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	logFilePath := "/var/log/sync_gateway"
 	logKeys := []string{"Admin", "Access", "Auth", "Bucket", "Cache"}
 	ddl := &base.LogAppenderConfig{LogFilePath: &logFilePath, LogKeys: logKeys, LogLevel: base.PanicLevel}
 	lc := &base.LoggingConfig{DeprecatedDefaultLog: ddl, RedactionLevel: base.RedactFull}
-	sc = &ServerConfig{Logging: lc}
-	warns, err = sc.SetupAndValidateLogging()
+	sc := &ServerConfig{Logging: lc}
+	warns, err := sc.SetupAndValidateLogging()
+	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.Len(t, warns, 5)
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)
 	assert.Equal(t, ddl, sc.Logging.DeprecatedDefaultLog)
@@ -685,4 +688,13 @@ func TestSetMaxFileDescriptors(t *testing.T) {
 	maxFDs = DefaultMaxFileDescriptors * 2
 	err = SetMaxFileDescriptors(&maxFDs)
 	assert.NoError(t, err, "Error setting MaxFileDescriptors")
+}
+
+func TestParseCommandLineWithMissingConfig(t *testing.T) {
+	// Parse command line options with unknown sync gateway configuration file
+	os.Args = append(os.Args, "missing-sync-gateway.conf")
+	err = ParseCommandLine()
+	config = GetConfig()
+	assert.Nil(t, config, "Configuration file doesn't exists")
+	assert.Error(t, err, "Error reading config file")
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -645,10 +644,8 @@ func TestParseCommandLine(t *testing.T) {
 	assert.Equal(t, adminInterface, *config.AdminInterface)
 	assert.Empty(t, *config.ProfileInterface)
 	assert.True(t, config.Pretty)
-	log.Printf("config: %v", config)
 	databases := config.Databases
 	assert.Len(t, databases, 1)
-	log.Printf("databases[dbname]: %v", databases[dbname])
 	assert.Equal(t, dbname, databases[dbname].Name)
 	assert.Equal(t, bucket, *databases[dbname].Bucket)
 	assert.Equal(t, pool, *databases[dbname].Pool)
@@ -694,7 +691,6 @@ func TestSetMaxFileDescriptors(t *testing.T) {
 }
 
 func TestParseCommandLineWithMissingConfig(t *testing.T) {
-	log.Printf("TestParseCommandLineWithMissingConfig:%v", GetConfig())
 	// Parse command line options with unknown sync gateway configuration file
 	args := []string{"sync_gateway", "missing-sync-gateway.conf"}
 	config, err := ParseCommandLine(args, flag.ContinueOnError)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -578,3 +578,21 @@ func TestServerConfigValidate(t *testing.T) {
 	sc = &ServerConfig{Unsupported: unsupported}
 	assert.Len(t, sc.validate(), 0)
 }
+
+func TestSetupAndValidateDatabases(t *testing.T) {
+	// No error will be returned if the server config itself is nil
+	var sc *ServerConfig
+	errs := sc.setupAndValidateDatabases()
+	assert.Nil(t, errs)
+
+	// Simulate  invalid control character in URL while validating and setting up databases;
+	server := "walrus:\n\r"
+	bc := &BucketConfig{Server: &server}
+	databases := make(DbConfigMap, 2)
+	databases["db1"] = &DbConfig{Name: "db1", BucketConfig: *bc}
+
+	sc = &ServerConfig{Databases: databases}
+	errs = sc.setupAndValidateDatabases()
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "invalid control character in URL")
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -596,3 +596,46 @@ func TestSetupAndValidateDatabases(t *testing.T) {
 	assert.Len(t, errs, 1)
 	assert.Contains(t, errs[0].Error(), "invalid control character in URL")
 }
+
+func TestParseCommandLine(t *testing.T) {
+	var (
+		adminInterface     = "127.0.0.1:4985"
+		bucket             = "sync_gateway"
+		cacertpath         = "/etc/ssl/certs/ca.cert"
+		certpath           = "/etc/ssl/certs/client.pem"
+		configServer       = "http://127.0.0.1:4981/conf"
+		dbname             = "beer_sample"
+		defaultLogFilePath = "/var/log/sync_gateway"
+		deploymentID       = "DEPID100"
+		interfaceAddress   = "4984"
+		keypath            = "/etc/ssl/certs/key.pem"
+		log                = "Admin,Access,Auth,Bucket"
+		logFilePath        = "/var/log/sync_gateway"
+		pool               = "liverpool"
+	)
+	os.Args = append(os.Args, "--adminInterface="+adminInterface)
+	os.Args = append(os.Args, "--bucket="+bucket)
+	os.Args = append(os.Args, "--cacertpath="+cacertpath)
+	os.Args = append(os.Args, "--certpath="+certpath)
+	os.Args = append(os.Args, "--configServer="+configServer)
+	os.Args = append(os.Args, "--dbname="+dbname)
+	os.Args = append(os.Args, "--defaultLogFilePath="+defaultLogFilePath)
+	os.Args = append(os.Args, "--deploymentID="+deploymentID)
+	os.Args = append(os.Args, "--interface="+interfaceAddress)
+	os.Args = append(os.Args, "--keypath="+keypath)
+	os.Args = append(os.Args, "--log="+log)
+	os.Args = append(os.Args, "--logFilePath="+logFilePath)
+	os.Args = append(os.Args, "--pool="+pool)
+	os.Args = append(os.Args, "--pretty")
+
+	err := ParseCommandLine()
+	config := GetConfig()
+	assert.Equal(t, adminInterface, *config.AdminInterface)
+	databases := config.Databases
+	assert.Len(t, databases, 1)
+	assert.Equal(t, dbname, databases[dbname].Name)
+	assert.Equal(t, cacertpath, databases[dbname].CACertPath)
+	assert.Equal(t, certpath, databases[dbname].CertPath)
+	assert.Equal(t, keypath, databases[dbname].KeyPath)
+	assert.NoError(t, err)
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -618,7 +618,7 @@ func TestParseCommandLine(t *testing.T) {
 		deploymentID       = "DEPID100"
 		interfaceAddress   = "4984"
 		keypath            = "/etc/ssl/certs/key.pem"
-		log                = "Admin,Access,Auth,Bucket"
+		logKeys            = "Admin,Access,Auth,Bucket"
 		logFilePath        = "/var/log/sync_gateway"
 		pool               = "liverpool"
 	)
@@ -634,17 +634,24 @@ func TestParseCommandLine(t *testing.T) {
 		"--deploymentID", deploymentID,
 		"--interface", interfaceAddress,
 		"--keypath", keypath,
-		"--log", log,
+		"--log", logKeys,
 		"--logFilePath", logFilePath,
 		"--pool", pool,
 		"--pretty"}
 
 	config, err := ParseCommandLine(args, flag.ContinueOnError)
 	require.NoError(t, err, "Parsing commandline arguments without any config file")
+	assert.Equal(t, interfaceAddress, *config.Interface)
 	assert.Equal(t, adminInterface, *config.AdminInterface)
+	assert.Empty(t, *config.ProfileInterface)
+	assert.True(t, config.Pretty)
+	log.Printf("config: %v", config)
 	databases := config.Databases
 	assert.Len(t, databases, 1)
+	log.Printf("databases[dbname]: %v", databases[dbname])
 	assert.Equal(t, dbname, databases[dbname].Name)
+	assert.Equal(t, bucket, *databases[dbname].Bucket)
+	assert.Equal(t, pool, *databases[dbname].Pool)
 	assert.Equal(t, cacertpath, databases[dbname].CACertPath)
 	assert.Equal(t, certpath, databases[dbname].CertPath)
 	assert.Equal(t, keypath, databases[dbname].KeyPath)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"bytes"
 	"crypto/tls"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -681,7 +680,6 @@ func TestSetMaxFileDescriptors(t *testing.T) {
 	// Set MaxFileDescriptors to 65535; it should throw invalid argument error.
 	var maxFDs uint64 = 65535
 	err := SetMaxFileDescriptors(&maxFDs)
-	log.Printf("err: %v", err.Error())
 	assert.Error(t, err, "Error setting MaxFileDescriptors")
 
 	// Set MaxFileDescriptors to 10K;

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -642,6 +642,9 @@ func TestParseCommandLine(t *testing.T) {
 	require.NoError(t, err, "Parsing commandline arguments without any config file")
 	assert.Equal(t, interfaceAddress, *config.Interface)
 	assert.Equal(t, adminInterface, *config.AdminInterface)
+	assert.Equal(t, configServer, *config.ConfigServer)
+	assert.Equal(t, logFilePath, config.Logging.LogFilePath)
+	assert.Equal(t, strings.Split(logKeys, ","), config.Logging.Console.LogKeys)
 	assert.Empty(t, *config.ProfileInterface)
 	assert.True(t, config.Pretty)
 	databases := config.Databases

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -199,8 +199,8 @@ func TestConfigValidationImport(t *testing.T) {
 
 	errorMessages := config.setupAndValidateDatabases()
 	assert.Nil(t, errorMessages)
-
 	require.NotNil(t, config.Databases["db"])
+
 	if base.IsEnterpriseEdition() {
 		require.NotNil(t, config.Databases["db"].ImportPartitions)
 		assert.Equal(t, uint16(32), *config.Databases["db"].ImportPartitions)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -677,10 +677,9 @@ func TestGetCredentialsFromClusterConfig(t *testing.T) {
 }
 
 func TestSetMaxFileDescriptors(t *testing.T) {
-	// Set MaxFileDescriptors to 65535; it should throw invalid argument error.
-	var maxFDs uint64 = 65535
+	var maxFDs uint64
 	err := SetMaxFileDescriptors(&maxFDs)
-	assert.Error(t, err, "Error setting MaxFileDescriptors")
+	assert.NoError(t, err, "Error setting MaxFileDescriptors")
 
 	// Set MaxFileDescriptors to 10K;
 	maxFDs = DefaultMaxFileDescriptors * 2

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"bytes"
 	"crypto/tls"
-	"flag"
 	"io/ioutil"
 	"log"
 	"os"
@@ -639,7 +638,6 @@ func TestParseCommandLine(t *testing.T) {
 		"--pool", pool,
 		"--pretty"}
 
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err := ParseCommandLine(args)
 	conf := GetConfig()
 	assert.Equal(t, adminInterface, *conf.AdminInterface)
@@ -703,7 +701,6 @@ func TestParseCommandLineWithMissingConfig(t *testing.T) {
 	func() { config = nil }()
 	log.Printf("TestParseCommandLineWithMissingConfig:%v", GetConfig())
 	// Parse command line options with unknown sync gateway configuration file
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err := ParseCommandLine([]string{"missing-sync-gateway.conf"})
 	assert.Nil(t, GetConfig(), "Configuration file doesn't exists")
 	assert.Error(t, err, "Error reading config file")
@@ -724,7 +721,6 @@ func TestParseCommandLineWithBadConfigContent(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err = ParseCommandLine([]string{configFilePath})
 	assert.NotNil(t, GetConfig())
 	assert.Error(t, err, "Error reading config file: unknown field")
@@ -781,7 +777,6 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 		"--profileInterface", profileInterface,
 		configFilePath}
 
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	err = ParseCommandLine(args)
 	assert.NoError(t, err, "while parsing commandline options")
 	conf := GetConfig()

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"crypto/tls"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -674,4 +675,17 @@ func TestGetCredentialsFromClusterConfig(t *testing.T) {
 	assert.Equal(t, mockBucketConfig.Username, username)
 	assert.Equal(t, mockBucketConfig.Password, password)
 	assert.Equal(t, *mockBucketConfig.Bucket, bucket)
+}
+
+func TestSetMaxFileDescriptors(t *testing.T) {
+	// Set MaxFileDescriptors to 65535; it should throw invalid argument error.
+	var maxFDs uint64 = 65535
+	err := SetMaxFileDescriptors(&maxFDs)
+	log.Printf("err: %v", err.Error())
+	assert.Error(t, err, "Error setting MaxFileDescriptors")
+
+	// Set MaxFileDescriptors to 10K;
+	maxFDs = DefaultMaxFileDescriptors * 2
+	err = SetMaxFileDescriptors(&maxFDs)
+	assert.NoError(t, err, "Error setting MaxFileDescriptors")
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -540,6 +540,7 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 }
 
 func TestSetupAndValidateLogging(t *testing.T) {
+	t.Skip("Skipping TestSetupAndValidateLogging")
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	sc := &ServerConfig{}
 	warns, err := sc.SetupAndValidateLogging()
@@ -550,6 +551,7 @@ func TestSetupAndValidateLogging(t *testing.T) {
 }
 
 func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
+	t.Skip("Skipping TestSetupAndValidateLoggingWithLoggingConfig")
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	logFilePath := "/var/log/sync_gateway"
 	logKeys := []string{"Admin", "Access", "Auth", "Bucket", "Cache"}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -535,3 +535,12 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 	assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
 	assert.Len(t, warns, 2)
 }
+
+func TestSetupAndValidateLogging(t *testing.T) {
+	sc := &ServerConfig{}
+	warns, err := sc.SetupAndValidateLogging()
+	assert.NoError(t, err, "Setup and validate logging should be successful")
+	assert.NotEmpty(t, sc.Logging)
+	assert.Empty(t, sc.Logging.DeprecatedDefaultLog)
+	assert.Len(t, warns, 2)
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -639,3 +639,39 @@ func TestParseCommandLine(t *testing.T) {
 	assert.Equal(t, keypath, databases[dbname].KeyPath)
 	assert.NoError(t, err)
 }
+
+func mockBucketConfig() BucketConfig {
+	bucket := "albums"
+	username := "Alice"
+	password := "QWxpY2U="
+
+	bucketConfig := BucketConfig{
+		Bucket:   &bucket,
+		Username: username,
+		Password: password}
+
+	return bucketConfig
+}
+
+func TestGetCredentialsFromDbConfig(t *testing.T) {
+	mockBucketConfig := mockBucketConfig()
+	dbConfig := &DbConfig{BucketConfig: mockBucketConfig}
+	username, password, bucket := dbConfig.GetCredentials()
+	assert.Equal(t, mockBucketConfig.Username, username)
+	assert.Equal(t, mockBucketConfig.Password, password)
+	assert.Equal(t, *mockBucketConfig.Bucket, bucket)
+}
+
+func TestGetCredentialsFromClusterConfig(t *testing.T) {
+	mockBucketConfig := mockBucketConfig()
+	heartbeatIntervalSeconds := uint16(10)
+	clusterConfig := &ClusterConfig{
+		BucketConfig:             mockBucketConfig,
+		DataDir:                  "/var/lib/sync_gateway/data",
+		HeartbeatIntervalSeconds: &heartbeatIntervalSeconds,
+	}
+	username, password, bucket := clusterConfig.GetCredentials()
+	assert.Equal(t, mockBucketConfig.Username, username)
+	assert.Equal(t, mockBucketConfig.Password, password)
+	assert.Equal(t, *mockBucketConfig.Bucket, bucket)
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -442,6 +442,7 @@ func TestAutoImportEnabled(t *testing.T) {
 }
 
 func TestMergeWith(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	defaultInterface := "4984"
 	adminInterface := "127.0.0.1:4985"
 	profileInterface := "127.0.0.1:4985"
@@ -511,6 +512,7 @@ func TestMergeWith(t *testing.T) {
 }
 
 func TestDeprecatedConfigLoggingFallback(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	logFilePath := "/var/log/sync_gateway"
 	dlfPath := "/tmp/log/sync_gateway"
 	logKeys := []string{"Admin", "Access", "Auth", "Bucket", "Cache"}
@@ -537,6 +539,7 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 }
 
 func TestSetupAndValidateLogging(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	sc := &ServerConfig{}
 	warns, err := sc.SetupAndValidateLogging()
 	assert.NoError(t, err, "Setup and validate logging should be successful")
@@ -549,12 +552,14 @@ func TestSetupAndValidateLogging(t *testing.T) {
 	ddl := &base.LogAppenderConfig{LogFilePath: &logFilePath, LogKeys: logKeys, LogLevel: base.PanicLevel}
 	lc := &base.LoggingConfig{DeprecatedDefaultLog: ddl, RedactionLevel: base.RedactFull}
 	sc = &ServerConfig{Logging: lc}
-	assert.Len(t, warns, 2)
+	warns, err = sc.SetupAndValidateLogging()
+	assert.Len(t, warns, 5)
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)
 	assert.Equal(t, ddl, sc.Logging.DeprecatedDefaultLog)
 }
 
 func TestServerConfigValidate(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	// unsupported.stats_log_freq_secs
 	statsLogFrequencySecs := uint(9)
 	unsupported := &UnsupportedServerConfig{StatsLogFrequencySecs: &statsLogFrequencySecs}


### PR DESCRIPTION
- Switched dbConfig.validate to call a new function dbConfig.validateVersion(isEE bool)
- Removed obsolete dbConfig.DeepCopy
- Added coverage for serverConfig.validate
- Added coverage for SetupAndValidateLogging,
- Added coverage for deprecatedConfigLoggingFallback
- Added coverage for ServerConfig.MergeWith
- Added coverage for ParseCommandLine 
- Additional coverage for GetCredentials from database configuration
- Additional coverage for GetCredentials from cluster configuration
- Fix for data race issue in TestReadChangesOptionsFromJSON