### PR TITLE
Retain raw body when calling UnmarshalWithXattr and DocUnmarshalAll

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -927,11 +927,10 @@ func (doc *Document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 		if unmarshalErr != nil {
 			return pkgerrors.WithStack(base.RedactErrorf("Failed to UnmarshalWithXattr() doc with id: %s (DocUnmarshalAll/Sync).  Error: %v", base.UD(doc.ID), unmarshalErr))
 		}
+		doc._rawBody = data
 		// Unmarshal body if requested and present
 		if unmarshalLevel == DocUnmarshalAll && len(data) > 0 {
 			return doc._body.Unmarshal(data)
-		} else {
-			doc._rawBody = data
 		}
 
 	case DocUnmarshalNoHistory:


### PR DESCRIPTION
- Previously we were throwing away the raw body bytes as soon as we were done unmarshalling.
- Prevents additional marshalling work to get raw bytes back to store in the revcache.