### PR TITLE
Optmistically store unmarshalled body in revcache

### DIFF
--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -25,7 +25,7 @@ func (rc *BypassRevisionCache) Get(docID, revID string) (docRev DocumentRevision
 		RevID: revID,
 	}
 
-	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoader(rc.backingStore, IDAndRev{DocID: docID, RevID: revID})
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoader(rc.backingStore, IDAndRev{DocID: docID, RevID: revID})
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -46,7 +46,7 @@ func (rc *BypassRevisionCache) GetActive(docID string) (docRev DocumentRevision,
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev.History, docRev.Channels, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}


### PR DESCRIPTION
- [x] Based on top of #4357 for toy build perf testing

If we call `revCacheLoaderForDocument` with the current revision, and we already have an unmarshalled body on the doc, store in the revcache, and use it for populating `DocumentRevision._shallowBodyCopy`