### PR TITLE
CBG-597 Initialize metadata for sharded DCP feed

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -211,6 +211,20 @@ func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStar
 
 }
 
+func (c *DCPCommon) InitVbMeta(vbNo uint16) {
+	metadata, snapStart, _, err := c.loadCheckpoint(vbNo)
+	c.m.Lock()
+	if err != nil {
+		WarnfCtx(c.loggingCtx, "Unexpected error attempting to load DCP checkpoint for vbucket %d.  Will restart DCP for that vbucket from zero.  Error: %v", vbNo, err)
+		c.meta[vbNo] = []byte{}
+		c.seqs[vbNo] = 0
+	} else {
+		c.meta[vbNo] = metadata
+		c.seqs[vbNo] = snapStart
+	}
+	c.m.Unlock()
+}
+
 func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 	c.m.Lock()
 	defer c.m.Unlock()


### PR DESCRIPTION
Needs to be initialized on-demand per vbucket, as each DCPDest only processes a subset of vbuckets.

- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/24/
	- Failed only on `TestQuerySequencesStatsView` which is a known issue (CBG-594)