### PR TITLE
Fix logging command line flags for default config

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -830,6 +830,10 @@ func ParseCommandLine() (err error) {
 
 	flag.Parse()
 
+	if defaultLogFilePathFlag != nil {
+		defaultLogFilePath = *defaultLogFilePathFlag
+	}
+
 	if flag.NArg() > 0 {
 		// Read the configuration file(s), if any:
 		for i := 0; i < flag.NArg(); i++ {
@@ -887,10 +891,6 @@ func ParseCommandLine() (err error) {
 
 		if *logKeys != "" {
 			config.Logging.Console.LogKeys = strings.Split(*logKeys, ",")
-		}
-
-		if defaultLogFilePathFlag != nil {
-			defaultLogFilePath = *defaultLogFilePathFlag
 		}
 
 		// Log HTTP Responses if verbose is enabled.

--- a/rest/config.go
+++ b/rest/config.go
@@ -918,7 +918,12 @@ func ParseCommandLine() (err error) {
 			AdminInterface:   authAddr,
 			ProfileInterface: profAddr,
 			Pretty:           *pretty,
-			Logging:          &base.LoggingConfig{LogFilePath: *logFilePath},
+			Logging: &base.LoggingConfig{
+				Console: base.ConsoleLoggerConfig{
+					LogKeys: strings.Split(*logKeys, ","),
+				},
+				LogFilePath: *logFilePath,
+			},
 			Databases: map[string]*DbConfig{
 				*dbName: {
 					Name: *dbName,

--- a/rest/config.go
+++ b/rest/config.go
@@ -920,7 +920,9 @@ func ParseCommandLine() (err error) {
 			Pretty:           *pretty,
 			Logging: &base.LoggingConfig{
 				Console: base.ConsoleLoggerConfig{
-					LogKeys: strings.Split(*logKeys, ","),
+					// Enable the logger only when log keys have explicitly been set on the command line
+					FileLoggerConfig: base.FileLoggerConfig{Enabled: base.BoolPtr(*logKeys != "")},
+					LogKeys:          strings.Split(*logKeys, ","),
 				},
 				LogFilePath: *logFilePath,
 			},

--- a/rest/config.go
+++ b/rest/config.go
@@ -918,6 +918,7 @@ func ParseCommandLine() (err error) {
 			AdminInterface:   authAddr,
 			ProfileInterface: profAddr,
 			Pretty:           *pretty,
+			Logging:          &base.LoggingConfig{LogFilePath: *logFilePath},
 			Databases: map[string]*DbConfig{
 				*dbName: {
 					Name: *dbName,

--- a/rest/config.go
+++ b/rest/config.go
@@ -918,6 +918,7 @@ func ParseCommandLine() (err error) {
 			AdminInterface:   authAddr,
 			ProfileInterface: profAddr,
 			Pretty:           *pretty,
+			ConfigServer:     configServer,
 			Logging: &base.LoggingConfig{
 				Console: base.ConsoleLoggerConfig{
 					// Enable the logger only when log keys have explicitly been set on the command line


### PR DESCRIPTION
As @sarathkumarsivan found - we weren't correctly handling the logging flags when no config file was specified.