### PR TITLE
CBG-610 handle panics 

### DIFF
--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -122,7 +122,7 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats(intervalSeconds int) error
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 
 	go func() {
-		defer FatalPanicHandler()()
+		defer FatalPanicHandler()
 		defer func() { h.sendActive.Set(false) }()
 		h.sendActive.Set(true)
 		for {
@@ -176,7 +176,7 @@ func (h *couchbaseHeartBeater) StartCheckingHeartbeats(staleThresholdMs int, han
 	ticker := time.NewTicker(time.Duration(staleThresholdMs) * time.Millisecond)
 
 	go func() {
-		defer FatalPanicHandler()()
+		defer FatalPanicHandler()
 		defer func() { h.checkActive.Set(false) }()
 		h.checkActive.Set(true)
 		for {
@@ -555,7 +555,7 @@ func (ch *cbgtNodeListHandler) subscribeNodeChanges() error {
 	cfgEvents := make(chan cbgt.CfgEvent)
 	ch.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
 	go func() {
-		defer FatalPanicHandler()()
+		defer FatalPanicHandler()
 		for {
 			select {
 			case <-cfgEvents:

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -122,6 +122,7 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats(intervalSeconds int) error
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 
 	go func() {
+		defer FatalPanicHandler()()
 		defer func() { h.sendActive.Set(false) }()
 		h.sendActive.Set(true)
 		for {
@@ -175,6 +176,7 @@ func (h *couchbaseHeartBeater) StartCheckingHeartbeats(staleThresholdMs int, han
 	ticker := time.NewTicker(time.Duration(staleThresholdMs) * time.Millisecond)
 
 	go func() {
+		defer FatalPanicHandler()()
 		defer func() { h.checkActive.Set(false) }()
 		h.checkActive.Set(true)
 		for {
@@ -553,6 +555,7 @@ func (ch *cbgtNodeListHandler) subscribeNodeChanges() error {
 	cfgEvents := make(chan cbgt.CfgEvent)
 	ch.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
 	go func() {
+		defer FatalPanicHandler()()
 		for {
 			select {
 			case <-cfgEvents:

--- a/base/util.go
+++ b/base/util.go
@@ -1204,11 +1204,9 @@ type JSONEncoderI interface {
 	SetEscapeHTML(on bool)
 }
 
-func FatalPanicHandler() (panicHandler func()) {
-	return func() {
-		// Log any panics using the built-in loggers so that the stacktraces end up in SG log files before exiting.
-		if r := recover(); r != nil {
-			Fatalf("Handling panic: %v\n%v", r, string(debug.Stack()))
-		}
+func FatalPanicHandler() {
+	// Log any panics using the built-in loggers so that the stacktraces end up in SG log files before exiting.
+	if r := recover(); r != nil {
+		Fatalf("Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
 	}
 }

--- a/base/util.go
+++ b/base/util.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -1201,4 +1202,13 @@ type JSONEncoderI interface {
 	Encode(v interface{}) error
 	SetIndent(prefix, indent string)
 	SetEscapeHTML(on bool)
+}
+
+func FatalPanicHandler() (panicHandler func()) {
+	return func() {
+		// Log any panics using the built-in loggers so that the stacktraces end up in SG log files before exiting.
+		if r := recover(); r != nil {
+			Fatalf("Handling panic: %v\n%v", r, string(debug.Stack()))
+		}
+	}
 }

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1128,3 +1128,34 @@ func BenchmarkInjectJSONProperties_Multiple(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkPanicRecover(b *testing.B) {
+	b.Run("recover panic", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			func() {
+				defer func() {
+					_ = recover()
+				}()
+				panic("test")
+			}()
+		}
+	})
+
+	b.Run("recover no panic", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			func() {
+				defer func() {
+					_ = recover()
+				}()
+			}()
+		}
+	})
+
+	b.Run("noop no panic", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			func() {
+				defer func() {}()
+			}()
+		}
+	})
+}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -68,9 +68,8 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 			return err
 		}
 		go func() {
-			defer func() {
-				listener.notifyStopping()
-			}()
+			defer base.FatalPanicHandler()
+			defer listener.notifyStopping()
 			for event := range listener.tapFeed.Events() {
 				event.TimeReceived = time.Now()
 				listener.ProcessFeedEvent(event)

--- a/db/changes.go
+++ b/db/changes.go
@@ -170,10 +170,10 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 
 // Creates a Go-channel of all the changes made on a channel.
 // Does NOT handle the Wait option. Does NOT check authorization.
-func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options ChangesOptions, currentCachedSequence uint64, to string) (<-chan *ChangeEntry, error) {
+func (db *Database) changesFeed(changesFeedOutput chan *ChangeEntry, singleChannelCache SingleChannelCache, options ChangesOptions, currentCachedSequence uint64, to string) (<-chan *ChangeEntry, error) {
 	// TODO: pass db.Ctx down to changeCache?
 	log, err := singleChannelCache.GetChanges(options)
-	base.DebugfCtx(db.Ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %s", len(log), base.UD(singleChannelCache.ChannelName()))
+	base.DebugfCtx(db.Ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %q", len(log), base.UD(singleChannelCache.ChannelName()))
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,15 @@ func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options C
 
 	feed := make(chan *ChangeEntry, 1)
 	go func() {
-		defer close(feed)
+		defer func() {
+			if panicked := recover(); panicked != nil {
+				base.WarnfCtx(db.Ctx, "[%s] Unexpected panic getting changes from channel %q - terminating changes feed: \n %s", panicked, base.UD(singleChannelCache.ChannelName()), debug.Stack())
+				close(changesFeedOutput)
+				return
+			}
+			close(feed)
+		}()
+
 		// Now write each log entry to the 'feed' channel in turn:
 		for _, logEntry := range log {
 			if !options.Conflicts && (logEntry.Flags&channels.Hidden) != 0 {
@@ -540,7 +548,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy}
 				}
 
-				feed, err := db.changesFeed(singleChannelCache, chanOpts, currentCachedSequence, to)
+				feed, err := db.changesFeed(output, singleChannelCache, chanOpts, currentCachedSequence, to)
 				if err != nil {
 					base.WarnfCtx(db.Ctx, "MultiChangesFeed got error reading changes feed %q: %v", base.UD(name), err)
 					change := makeErrorEntry("Error reading changes feed - terminating changes feed")

--- a/db/changes.go
+++ b/db/changes.go
@@ -187,14 +187,8 @@ func (db *Database) changesFeed(changesFeedOutput chan *ChangeEntry, singleChann
 
 	feed := make(chan *ChangeEntry, 1)
 	go func() {
-		defer func() {
-			if panicked := recover(); panicked != nil {
-				base.WarnfCtx(db.Ctx, "[%s] Unexpected panic getting changes from channel %q - terminating changes feed: \n %s", panicked, base.UD(singleChannelCache.ChannelName()), debug.Stack())
-				close(changesFeedOutput)
-				return
-			}
-			close(feed)
-		}()
+		defer base.FatalPanicHandler()
+		defer close(feed)
 
 		// Now write each log entry to the 'feed' channel in turn:
 		for _, logEntry := range log {

--- a/db/changes.go
+++ b/db/changes.go
@@ -170,7 +170,7 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 
 // Creates a Go-channel of all the changes made on a channel.
 // Does NOT handle the Wait option. Does NOT check authorization.
-func (db *Database) changesFeed(changesFeedOutput chan *ChangeEntry, singleChannelCache SingleChannelCache, options ChangesOptions, currentCachedSequence uint64, to string) (<-chan *ChangeEntry, error) {
+func (db *Database) changesFeed(singleChannelCache SingleChannelCache, options ChangesOptions, currentCachedSequence uint64, to string) (<-chan *ChangeEntry, error) {
 	// TODO: pass db.Ctx down to changeCache?
 	log, err := singleChannelCache.GetChanges(options)
 	base.DebugfCtx(db.Ctx, base.KeyChanges, "[changesFeed] Found %d changes for channel %q", len(log), base.UD(singleChannelCache.ChannelName()))
@@ -542,7 +542,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					chanOpts.Since = SequenceID{Seq: options.Since.TriggeredBy}
 				}
 
-				feed, err := db.changesFeed(output, singleChannelCache, chanOpts, currentCachedSequence, to)
+				feed, err := db.changesFeed(singleChannelCache, chanOpts, currentCachedSequence, to)
 				if err != nil {
 					base.WarnfCtx(db.Ctx, "MultiChangesFeed got error reading changes feed %q: %v", base.UD(name), err)
 					change := makeErrorEntry("Error reading changes feed - terminating changes feed")

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -69,7 +69,10 @@ func newSequenceAllocator(bucket base.Bucket, dbStatsMap *expvar.Map) (*sequence
 
 	// The reserveNotify channel manages communication between the releaseSequenceMonitor goroutine and _reserveSequenceRange invocations.
 	s.reserveNotify = make(chan struct{}, 1)
-	go s.releaseSequenceMonitor()
+	go func() {
+		defer base.FatalPanicHandler()()
+		s.releaseSequenceMonitor()
+	}()
 	_, err := s.lastSequence() // just reads latest sequence from bucket
 	return s, err
 }

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -70,7 +70,7 @@ func newSequenceAllocator(bucket base.Bucket, dbStatsMap *expvar.Map) (*sequence
 	// The reserveNotify channel manages communication between the releaseSequenceMonitor goroutine and _reserveSequenceRange invocations.
 	s.reserveNotify = make(chan struct{}, 1)
 	go func() {
-		defer base.FatalPanicHandler()()
+		defer base.FatalPanicHandler()
 		s.releaseSequenceMonitor()
 	}()
 	_, err := s.lastSequence() // just reads latest sequence from bucket

--- a/db/utils.go
+++ b/db/utils.go
@@ -14,7 +14,7 @@ type BackgroundTaskFunc func(ctx context.Context) error
 func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, interval time.Duration, c chan bool) {
 	base.Infof(base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
-		defer base.FatalPanicHandler()()
+		defer base.FatalPanicHandler()
 		for {
 			select {
 			case <-time.After(interval):

--- a/db/utils.go
+++ b/db/utils.go
@@ -14,6 +14,7 @@ type BackgroundTaskFunc func(ctx context.Context) error
 func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, interval time.Duration, c chan bool) {
 	base.Infof(base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
+		defer base.FatalPanicHandler()()
 		for {
 			select {
 			case <-time.After(interval):

--- a/rest/config.go
+++ b/rest/config.go
@@ -1081,7 +1081,7 @@ func RegisterSignalHandler() {
 // It parses command-line flags, reads the optional configuration file, then starts the server.
 func ServerMain() {
 	RegisterSignalHandler()
-	defer base.FatalPanicHandler()()
+	defer base.FatalPanicHandler()
 
 	var unknownFieldsErr error
 	err := ParseCommandLine()

--- a/rest/config.go
+++ b/rest/config.go
@@ -23,7 +23,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -1078,21 +1077,11 @@ func RegisterSignalHandler() {
 	}()
 }
 
-func PanicHandler() (panicHandler func()) {
-	return func() {
-		// Recover from any panics to allow for graceful shutdown.
-		if r := recover(); r != nil {
-			base.Fatalf("Handling panic: %v\n%v", r, string(debug.Stack()))
-		}
-	}
-
-}
-
 // Main entry point for a simple server; you can have your main() function just call this.
 // It parses command-line flags, reads the optional configuration file, then starts the server.
 func ServerMain() {
 	RegisterSignalHandler()
-	defer PanicHandler()()
+	defer base.FatalPanicHandler()()
 
 	var unknownFieldsErr error
 	err := ParseCommandLine()


### PR DESCRIPTION
Moved panic handler that logs the panic as an error and exits process to `FatalPanicHandler`.

Added `FatalPanicHandler`:
- heartbeater goroutines
- TAP mutation feed event loop
- `newSequenceAllocator`
- `NewBackgroundTask`
- Changes feed single-channel goroutine

Added non-fatal panic handling:
- Rotated Log File deletion (logs a warning and continues trying to clean up next time)