### PR TITLE
Use atomics for for heartbeater flags/counts to prevent data races

### DIFF
--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -74,8 +74,8 @@ type couchbaseHeartBeater struct {
 	heartbeatCheckCloser chan struct{} // break out of heartbeat checker goroutine
 	sendCount            int           // Monitoring stat - number of heartbeats sent
 	checkCount           int           // Monitoring stat - number of checks issued
-	sendActive           bool          // Monitoring state of send goroutine
-	checkActive          bool          // Monitoring state of check goroutine
+	sendActive           AtomicBool    // Monitoring state of send goroutine
+	checkActive          AtomicBool    // Monitoring state of check goroutine
 }
 
 // Create a new CouchbaseHeartbeater, passing in an authenticated bucket connection,
@@ -122,8 +122,8 @@ func (h *couchbaseHeartBeater) StartSendingHeartbeats(intervalSeconds int) error
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 
 	go func() {
-		defer func() { h.sendActive = false }()
-		h.sendActive = true
+		defer func() { h.sendActive.Set(false) }()
+		h.sendActive.Set(true)
 		for {
 			select {
 			case _ = <-h.heartbeatSendCloser:
@@ -147,7 +147,7 @@ func (h *couchbaseHeartBeater) Stop() {
 
 	maxWaitTimeMs := 1000
 	waitTimeMs := 0
-	for h.sendActive || h.checkActive {
+	for h.sendActive.IsTrue() || h.checkActive.IsTrue() {
 		waitTimeMs += 10
 		if waitTimeMs > maxWaitTimeMs {
 			Warnf("couchbaseHeartBeater didn't complete Stop() within expected elapsed time")
@@ -175,8 +175,8 @@ func (h *couchbaseHeartBeater) StartCheckingHeartbeats(staleThresholdMs int, han
 	ticker := time.NewTicker(time.Duration(staleThresholdMs) * time.Millisecond)
 
 	go func() {
-		defer func() { h.checkActive = false }()
-		h.checkActive = true
+		defer func() { h.checkActive.Set(false) }()
+		h.checkActive.Set(true)
 		for {
 			select {
 			case _ = <-h.heartbeatCheckCloser:

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -3,6 +3,7 @@ package base
 import (
 	"fmt"
 	"log"
+	"sync/atomic"
 	"testing"
 
 	"github.com/couchbase/cbgt"
@@ -13,12 +14,12 @@ import (
 
 type TestHeartbeatStoppedHandler struct {
 	handlerID        string
-	staleDetectCount int
+	staleDetectCount uint32
 }
 
 func (th *TestHeartbeatStoppedHandler) StaleHeartBeatDetected(nodeUuid string) {
 	log.Printf("Handler %s detected stale heartbeat for %v, will be removed", th.handlerID, nodeUuid)
-	th.staleDetectCount++
+	atomic.AddUint32(&th.staleDetectCount, 1)
 }
 
 // TestNewCouchbaseHeartbeater simulates three nodes.  The minimum time window for failed node
@@ -99,13 +100,16 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 
 			// Wait for another node to detect node1 has stopped sending heartbeats
 			retryUntilFunc = func() bool {
-				return heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1
+				return atomic.LoadUint32(&heartbeatStoppedHandler2.staleDetectCount) >= 1 ||
+					atomic.LoadUint32(&heartbeatStoppedHandler3.staleDetectCount) >= 1
 			}
 			testRetryUntilTrue(t, retryUntilFunc)
 
 			// Validate that at least one node detected the stopped node 1
-			assert.True(t, heartbeatStoppedHandler2.staleDetectCount >= 1 || heartbeatStoppedHandler3.staleDetectCount >= 1,
-				fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", heartbeatStoppedHandler2.staleDetectCount, heartbeatStoppedHandler3.staleDetectCount))
+			h2staleDetectCount := atomic.LoadUint32(&heartbeatStoppedHandler2.staleDetectCount)
+			h3staleDetectCount := atomic.LoadUint32(&heartbeatStoppedHandler3.staleDetectCount)
+			assert.True(t, h2staleDetectCount >= 1 || h3staleDetectCount >= 1,
+				fmt.Sprintf("Expected stale detection counts (1) not found in either handler2 (%d) or handler3 (%d)", h2staleDetectCount, h3staleDetectCount))
 
 			// Validate current node list
 			activeNodes, err := handler2.GetNodes()


### PR DESCRIPTION
Prevents data race on the active flags for checking if the heartbeater has stopped or not, and the `staleDetectCount` counter on the `TestHeartbeatStoppedHandler`.

http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/30
```
==================
WARNING: DATA RACE
Read at 0x00c0000f2140 by goroutine 9:
  github.com/couchbase/sync_gateway/base.(*couchbaseHeartBeater).Stop()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat.go:150 +0xac
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters.func3()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:98 +0x11fd
  testing.tRunner()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:865 +0x163

Previous write at 0x00c0000f2140 by goroutine 64:
  github.com/couchbase/sync_gateway/base.(*couchbaseHeartBeater).StartSendingHeartbeats.func1()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat.go:126 +0x83

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:916 +0x65a
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:59 +0x3dd
  testing.tRunner()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:865 +0x163

Goroutine 64 (running) created at:
  github.com/couchbase/sync_gateway/base.(*couchbaseHeartBeater).StartSendingHeartbeats()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat.go:124 +0x15c
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters.func3()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:77 +0xd44
  testing.tRunner()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:865 +0x163
==================
```

http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/31
```
==================
WARNING: DATA RACE
Write at 0x00c0001823b0 by goroutine 68:
  github.com/couchbase/sync_gateway/base.(*TestHeartbeatStoppedHandler).StaleHeartBeatDetected()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:21 +0x117
  github.com/couchbase/sync_gateway/base.(*couchbaseHeartBeater).checkStaleHeartbeats()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat.go:230 +0x3d7
  github.com/couchbase/sync_gateway/base.(*couchbaseHeartBeater).StartCheckingHeartbeats.func1()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat.go:187 +0x1b1

Previous read at 0x00c0001823b0 by goroutine 9:
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters.func3.2()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:102 +0x59
  github.com/couchbase/sync_gateway/base.testRetryUntilTrueCustom()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/util_testing.go:629 +0x73
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters.func3()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/util_testing.go:623 +0x1274
  testing.tRunner()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:865 +0x163

Goroutine 68 (running) created at:
  github.com/couchbase/sync_gateway/base.(*couchbaseHeartBeater).StartCheckingHeartbeats()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat.go:177 +0x11b
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters.func3()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:86 +0x1030
  testing.tRunner()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:865 +0x163

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:916 +0x65a
  github.com/couchbase/sync_gateway/base.TestCouchbaseHeartbeaters()
      /var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/heartbeat_test.go:59 +0x3dd
  testing.tRunner()
      /root/.gvm/gos/go1.12.10/src/testing/testing.go:865 +0x163
==================
```