### PR TITLE
CBG-581 Write simple responses as alphabetically ordered JSON in raw bytes

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -39,7 +39,7 @@ func (h *handler) handleRoot() error {
 
 	admin := ""
 	if h.privs == adminPrivs {
-		admin = `"ADMIN":true`
+		admin = `"ADMIN":true,`
 	}
 
 	r := []byte(`{` +

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -451,7 +451,7 @@ func (h *handler) handlePostDoc() error {
 
 	h.setHeader("Location", docid)
 	h.setHeader("Etag", strconv.Quote(newRev))
-	h.writeJSON(db.Body{"ok": true, "id": docid, "rev": newRev})
+	h.writeRawJSON([]byte(`{"id":"` + docid + `","ok":true,"rev":"` + newRev + `"}`))
 	return nil
 }
 


### PR DESCRIPTION
These raw byte responses weren't covered in #4334 

The only one that may be useful in real-world use-cases is the `handlePostDoc` response.