### PR TITLE
CBG-506: Clean up unhandled errors

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,13 +11,13 @@ package auth
 
 import (
 	"fmt"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
-	"golang.org/x/crypto/bcrypt"
 )
 
 /** Manages user authentication for a database. */

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -395,7 +395,7 @@ func (auth *Authenticator) Delete(p Principal) error {
 	if user, ok := p.(User); ok {
 		if user.Email() != "" {
 			if err := auth.bucket.Delete(docIDForUserEmail(user.Email())); err != nil {
-				base.Debugf(base.KeyAuth, "Error deleting document ID for user email %s. Error: %v", user.Email(), err)
+				base.Debugf(base.KeyAuth, "Error deleting document ID for user email %s. Error: %v", base.UD(user.Email()), err)
 			}
 		}
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,13 +12,12 @@ package auth
 import (
 	"fmt"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
 )
 
 /** Manages user authentication for a database. */
@@ -395,7 +394,9 @@ func (auth *Authenticator) casUpdatePrincipal(p Principal, callback casUpdatePri
 func (auth *Authenticator) Delete(p Principal) error {
 	if user, ok := p.(User); ok {
 		if user.Email() != "" {
-			auth.bucket.Delete(docIDForUserEmail(user.Email()))
+			if err := auth.bucket.Delete(docIDForUserEmail(user.Email())); err != nil {
+				return err
+			}
 		}
 	}
 	return auth.bucket.Delete(p.DocID())

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -395,7 +395,7 @@ func (auth *Authenticator) Delete(p Principal) error {
 	if user, ok := p.(User); ok {
 		if user.Email() != "" {
 			if err := auth.bucket.Delete(docIDForUserEmail(user.Email())); err != nil {
-				return err
+				base.Debugf(base.KeyAuth, "Error deleting document ID for user email %s. Error: %v", user.Email(), err)
 			}
 		}
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,12 +12,12 @@ package auth
 import (
 	"fmt"
 
-	"golang.org/x/crypto/bcrypt"
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
 )
 
 /** Manages user authentication for a database. */
@@ -157,7 +157,7 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 	channels := princ.ExplicitChannels().Copy()
 
 	// Changes for vbucket sequence management.  We can't determine relative ordering of sequences
-	// across vbuckets.  To avoid redundant channel backfills during changes processing, we maintain
+	// across vbuckets. To avoid redundant channel backfills during changes processing, we maintain
 	// the previous vb/seq for a channel in PreviousChannels.  If that channel is still present during
 	// this rebuild, we reuse the vb/seq from PreviousChannels (using UpdateIfPresent).  If PreviousChannels
 	// is nil, reverts to normal sequence handling.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,13 +11,13 @@ package auth
 
 import (
 	"fmt"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
 )
 
 /** Manages user authentication for a database. */

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -12,12 +12,12 @@ package auth
 import (
 	"fmt"
 
+	"golang.org/x/crypto/bcrypt"
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/couchbase/sync_gateway/base"
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
-	"golang.org/x/crypto/bcrypt"
 )
 
 /** Manages user authentication for a database. */

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -485,7 +485,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 	email := "foo@bar.org"
 
 	// Modify the bcrypt cost to test rehashPassword properly below
-	_ = SetBcryptCost(5)
+	require.Error(t, SetBcryptCost(5))
 
 	// Create user
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
@@ -502,7 +502,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 		t.Errorf("Error retrieving user: %v", getErr)
 	}
 
-	_ = SetBcryptCost(bcryptDefaultCost)
+	require.NoError(t, SetBcryptCost(bcryptDefaultCost))
 	// Reset bcryptCostChanged state after test runs
 	defer func() {
 		bcryptCostChanged = false

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -485,7 +485,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 	email := "foo@bar.org"
 
 	// Modify the bcrypt cost to test rehashPassword properly below
-	SetBcryptCost(5)
+	_ = SetBcryptCost(5)
 
 	// Create user
 	auth := NewAuthenticator(gTestBucket.Bucket, nil)
@@ -502,7 +502,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 		t.Errorf("Error retrieving user: %v", getErr)
 	}
 
-	SetBcryptCost(bcryptDefaultCost)
+	_ = SetBcryptCost(bcryptDefaultCost)
 	// Reset bcryptCostChanged state after test runs
 	defer func() {
 		bcryptCostChanged = false

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -232,7 +232,11 @@ func (op *OIDCProvider) FetchCustomProviderConfig(discoveryURL string) (*oidc.Pr
 		base.Debugf(base.KeyAuth, "Error invoking calling discovery URL %s: %v", base.UD(discoveryURL), err)
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			base.Debugf(base.KeyAuth, "Error while closing response body from discovery URL %s: %v", base.UD(discoveryURL), err)
+		}
+	}()
 	if err := base.JSONDecoder(resp.Body).Decode(&customConfig); err != nil {
 		base.Debugf(base.KeyAuth, "Error parsing body %s: %v", base.UD(discoveryURL), err)
 		return nil, err

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -232,11 +232,7 @@ func (op *OIDCProvider) FetchCustomProviderConfig(discoveryURL string) (*oidc.Pr
 		base.Debugf(base.KeyAuth, "Error invoking calling discovery URL %s: %v", base.UD(discoveryURL), err)
 		return nil, err
 	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			base.Debugf(base.KeyAuth, "Error while closing response body from discovery URL %s: %v", base.UD(discoveryURL), err)
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 	if err := base.JSONDecoder(resp.Body).Decode(&customConfig); err != nil {
 		base.Debugf(base.KeyAuth, "Error parsing body %s: %v", base.UD(discoveryURL), err)
 		return nil, err

--- a/auth/session.go
+++ b/auth/session.go
@@ -118,7 +118,10 @@ func (auth Authenticator) DeleteSessionForCookie(rq *http.Request) *http.Cookie 
 	if cookie == nil {
 		return nil
 	}
-	auth.bucket.Delete(DocIDForSession(cookie.Value))
+
+	if err := auth.bucket.Delete(DocIDForSession(cookie.Value)); err != nil {
+		base.Debugf(base.KeyAuth, "Error while deleting session for cookie %s", base.UD(cookie.Value))
+	}
 
 	newCookie := *cookie
 	newCookie.Value = ""

--- a/auth/session.go
+++ b/auth/session.go
@@ -120,7 +120,7 @@ func (auth Authenticator) DeleteSessionForCookie(rq *http.Request) *http.Cookie 
 	}
 
 	if err := auth.bucket.Delete(DocIDForSession(cookie.Value)); err != nil {
-		base.Debugf(base.KeyAuth, "Error while deleting session for cookie %s", base.UD(cookie.Value))
+		base.Debugf(base.KeyAuth, "Error while deleting session for cookie %s, Error: %v", base.UD(cookie.Value), err)
 	}
 
 	newCookie := *cookie

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -60,7 +60,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	bucket := gTestBucket.Bucket
 
 	// Reset bcrypt cost after test
-	defer func() { _ = SetBcryptCost(bcryptDefaultCost) }()
+	defer func() { require.NoError(t, SetBcryptCost(bcryptDefaultCost)) }()
 
 	// Create user
 	auth := NewAuthenticator(bucket, nil)

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -60,7 +60,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	bucket := gTestBucket.Bucket
 
 	// Reset bcrypt cost after test
-	defer SetBcryptCost(bcryptDefaultCost)
+	defer func() { _ = SetBcryptCost(bcryptDefaultCost) }()
 
 	// Create user
 	auth := NewAuthenticator(bucket, nil)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -222,11 +222,7 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (int, error
 		return 0, err
 	}
 
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			Warnf("Error while closing response body from: %s error: %v", UD(uri), err)
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusForbidden {
 		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
@@ -255,11 +251,7 @@ func (bucket *CouchbaseBucketGoCB) GetServerUUID() (uuid string, err error) {
 		return "", err
 	}
 
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			Warnf("Error while closing response body from: /pools error: %v", err)
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -290,11 +282,7 @@ func (bucket *CouchbaseBucketGoCB) GetMaxTTL() (int, error) {
 		return -1, err
 	}
 
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			Warnf("Error while closing response body from: %s error: %v", UD(uri), err)
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -2344,11 +2332,7 @@ func (bucket *CouchbaseBucketGoCB) BucketItemCount() (itemCount int, err error) 
 		return -1, err
 	}
 
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			Warnf("Error while closing response body from: %s error: %v", UD(uri), err)
-		}
-	}()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
 		_, err := ioutil.ReadAll(resp.Body)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1197,7 +1197,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		_ = bucket.Delete(key)
+		require.NoError(t, bucket.Delete(key))
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
@@ -1252,7 +1252,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		_ = bucket.Delete(key)
+		require.NoError(t, bucket.Delete(key))
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1325,7 +1325,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		_ = bucket.DeleteWithXattr(key, xattrName)
+		require.NoError(t, bucket.DeleteWithXattr(key, xattrName))
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
@@ -1651,7 +1651,7 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
 	}
 	// Delete the doc
-	_ = bucket.Delete(key3)
+	require.NoError(t, bucket.Delete(key3))
 
 	// 4. No xattr, no document
 
@@ -1869,7 +1869,8 @@ func TestGetXattr(t *testing.T) {
 
 	//Get Xattr From Tombstoned Doc With Existing Xattr
 	cas, err = bucket.WriteCasWithXattr(key2, SyncXattrName, 0, cas, val2, xattrVal2)
-	_, _ = bucket.Remove(key2, cas)
+	_, err = bucket.Remove(key2, cas)
+	require.NoError(t, err)
 	_, err = testBucket.GetXattr(key2, SyncXattrName, &response)
 	assert.NoError(t, err)
 
@@ -1880,7 +1881,8 @@ func TestGetXattr(t *testing.T) {
 
 	////Get Xattr From Deleted Doc With Deleted Xattr -> SubDocMultiPathFailureDeleted
 	cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)
-	_, _ = bucket.Remove(key3, cas)
+	_, err = bucket.Remove(key3, cas)
+	require.NoError(t, err)
 	_, err = testBucket.GetXattr(key3, xattrName3, &response)
 	assert.Error(t, err)
 	assert.Equal(t, gocbcore.ErrKeyNotFound, err)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -809,7 +809,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 	// Simulate an SDK update
 	updatedVal := make(map[string]interface{})
 	updatedVal["sdk_field"] = "abc"
-	bucket.Set(key, 0, updatedVal)
+	require.NoError(t, bucket.Set(key, 0, updatedVal))
 
 	// Attempt to update with the previous CAS
 	val["sg_field"] = "sg_value_mod"
@@ -1197,7 +1197,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		bucket.Delete(key)
+		_ = bucket.Delete(key)
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
@@ -1252,7 +1252,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		bucket.Delete(key)
+		_ = bucket.Delete(key)
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
@@ -1325,7 +1325,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		bucket.DeleteWithXattr(key, xattrName)
+		_ = bucket.DeleteWithXattr(key, xattrName)
 	}
 
 	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
@@ -1651,7 +1651,7 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
 	}
 	// Delete the doc
-	bucket.Delete(key3)
+	_ = bucket.Delete(key3)
 
 	// 4. No xattr, no document
 
@@ -1869,7 +1869,7 @@ func TestGetXattr(t *testing.T) {
 
 	//Get Xattr From Tombstoned Doc With Existing Xattr
 	cas, err = bucket.WriteCasWithXattr(key2, SyncXattrName, 0, cas, val2, xattrVal2)
-	bucket.Remove(key2, cas)
+	_, _ = bucket.Remove(key2, cas)
 	_, err = testBucket.GetXattr(key2, SyncXattrName, &response)
 	assert.NoError(t, err)
 
@@ -1880,7 +1880,7 @@ func TestGetXattr(t *testing.T) {
 
 	////Get Xattr From Deleted Doc With Deleted Xattr -> SubDocMultiPathFailureDeleted
 	cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)
-	bucket.Remove(key3, cas)
+	_, _ = bucket.Remove(key3, cas)
 	_, err = testBucket.GetXattr(key3, xattrName3, &response)
 	assert.Error(t, err)
 	assert.Equal(t, gocbcore.ErrKeyNotFound, err)

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -357,11 +357,11 @@ func mockCertificatesAndKeys(t *testing.T) {
 func saveAsKeyFile(t *testing.T, filename string, key *ecdsa.PrivateKey) {
 	file, err := os.Create(filename)
 	assert.NoError(t, err)
-	defer func() { _ = file.Close() }()
 	b, err := x509.MarshalECPrivateKey(key)
 	assert.NoError(t, err)
 	err = pem.Encode(file, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
 	assert.NoError(t, err)
+	assert.NoError(t, file.Close())
 }
 
 func saveAsCertFile(t *testing.T, filename string, derBytes []byte) {

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -357,7 +357,7 @@ func mockCertificatesAndKeys(t *testing.T) {
 func saveAsKeyFile(t *testing.T, filename string, key *ecdsa.PrivateKey) {
 	file, err := os.Create(filename)
 	assert.NoError(t, err)
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	b, err := x509.MarshalECPrivateKey(key)
 	assert.NoError(t, err)
 	err = pem.Encode(file, &pem.Block{Type: "EC PRIVATE KEY", Bytes: b})

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -164,7 +164,7 @@ func (c *DCPCommon) rollback(vbucketId uint16, rollbackSeq uint64) error {
 	WarnfCtx(c.loggingCtx, "DCP Rollback request.  Expected RollbackEx call - resetting vbucket %d to 0.", vbucketId)
 	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	c.updateSeq(vbucketId, 0, false)
-	c.setMetaData(vbucketId, nil)
+	_ = c.setMetaData(vbucketId, nil)
 
 	return nil
 }
@@ -174,7 +174,7 @@ func (c *DCPCommon) rollbackEx(vbucketId uint16, vbucketUUID uint64, rollbackSeq
 	WarnfCtx(c.loggingCtx, "DCP RollbackEx request - rolling back DCP feed for: vbucketId: %d, rollbackSeq: %x.", vbucketId, rollbackSeq)
 	c.dbStatsExpvars.Add("dcp_rollback_count", 1)
 	c.updateSeq(vbucketId, rollbackSeq, false)
-	c.setMetaData(vbucketId, rollbackMetaData)
+	_ = c.setMetaData(vbucketId, rollbackMetaData)
 	return nil
 }
 
@@ -436,7 +436,7 @@ func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, cur
 	// Check if it's time to persist and log backfill progress
 	if time.Since(b.lastPersistTime) > kBackfillPersistInterval {
 		b.lastPersistTime = time.Now()
-		b.persistBackfillSequences(bucket, currentSequences)
+		_ = b.persistBackfillSequences(bucket, currentSequences)
 		b.logBackfillProgress()
 	}
 
@@ -444,7 +444,7 @@ func (b *backfillStatus) updateStats(vbno uint16, previousVbSequence uint64, cur
 	if b.receivedSequences >= b.expectedSequences {
 		Infof(KeyDCP, "Backfill complete")
 		b.active = false
-		b.purgeBackfillSequences(bucket)
+		_ = b.purgeBackfillSequences(bucket)
 	}
 }
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -197,7 +197,8 @@ func (d *DCPDest) OpaqueSet(partition string, value []byte) error {
 		d.InitVbMeta(vbNo)
 		d.metaInitComplete[vbNo] = true
 	}
-	return d.setMetaData(vbNo, value)
+	d.setMetaData(vbNo, value)
+	return nil
 }
 
 func (d *DCPDest) Rollback(partition string, rollbackSeq uint64) error {
@@ -347,7 +348,7 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {
-				Debugf(KeyDCP, "Error while closing DCP Feed: %v", err)
+				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(spec.BucketName), feedName, err)
 			}
 		}()
 	}
@@ -491,7 +492,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {
-				Debugf(KeyDCP, "Error while closing DCP Feed: %v", err)
+				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(spec.BucketName), feedName, err)
 			}
 		}()
 	}

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -346,7 +346,9 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 		go func() {
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
-			feed.Close()
+			if err = feed.Close(); err != nil {
+				Debugf(KeyDCP, "Error while closing DCP Feed: %v", err)
+			}
 		}()
 	}
 
@@ -488,7 +490,9 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 		go func() {
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
-			feed.Close()
+			if err = feed.Close(); err != nil {
+				Debugf(KeyDCP, "Error while closing DCP Feed: %v", err)
+			}
 		}()
 	}
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -117,14 +117,12 @@ func (r *DCPReceiver) GetMetaData(vbNo uint16) (
 // RollbackEx should be called by cbdatasource - Rollback required to maintain the interface.  In the event
 // it's called, logs warning and does a hard reset on metadata for the vbucket
 func (r *DCPReceiver) Rollback(vbucketId uint16, rollbackSeq uint64) error {
-	r.rollback(vbucketId, rollbackSeq)
-	return nil
+	return r.rollback(vbucketId, rollbackSeq)
 }
 
 // RollbackEx includes the vbucketUUID needed to reset the metadata correctly
 func (r *DCPReceiver) RollbackEx(vbucketId uint16, vbucketUUID uint64, rollbackSeq uint64) error {
-	r.rollbackEx(vbucketId, vbucketUUID, rollbackSeq, makeVbucketMetadataForSequence(vbucketUUID, rollbackSeq))
-	return nil
+	return r.rollbackEx(vbucketId, vbucketUUID, rollbackSeq, makeVbucketMetadataForSequence(vbucketUUID, rollbackSeq))
 }
 
 // Generate cbdatasource's VBucketMetadata for a vbucket from underlying components
@@ -321,7 +319,9 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		go func() {
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
-			bds.Close()
+			if err = bds.Close(); err != nil {
+				Debugf(KeyDCP, "Error while closing DCP Feed: %v", err)
+			}
 		}()
 	}
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -105,7 +105,8 @@ func (r *DCPReceiver) SnapshotStart(vbNo uint16,
 }
 
 func (r *DCPReceiver) SetMetaData(vbucketId uint16, value []byte) error {
-	return r.setMetaData(vbucketId, value)
+	r.setMetaData(vbucketId, value)
+	return nil
 }
 
 func (r *DCPReceiver) GetMetaData(vbNo uint16) (
@@ -319,8 +320,8 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		go func() {
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
-			if err = bds.Close(); err != nil {
-				Debugf(KeyDCP, "Error while closing DCP Feed: %v", err)
+			if err := bds.Close(); err != nil {
+				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(bucketName), feedID, err)
 			}
 		}()
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -354,7 +354,7 @@ func startHeartbeater(bucket Bucket, cbgtContext *CbgtContext) (Heartbeater, err
 	Debugf(KeyDCP, "Sending CBGT node heartbeats at interval: %vs", intervalSeconds)
 	err = heartbeater.StartSendingHeartbeats(intervalSeconds)
 	if err != nil {
-		Debugf(KeyDCP, "Error start sending heartbeats: %v", err)
+		return nil, err
 	}
 
 	deadNodeHandler := HeartbeatStoppedHandler{

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -352,7 +352,10 @@ func startHeartbeater(bucket Bucket, cbgtContext *CbgtContext) (Heartbeater, err
 	// TODO: Allow customization of heartbeat interval
 	intervalSeconds := 1
 	Debugf(KeyDCP, "Sending CBGT node heartbeats at interval: %vs", intervalSeconds)
-	heartbeater.StartSendingHeartbeats(intervalSeconds)
+	err = heartbeater.StartSendingHeartbeats(intervalSeconds)
+	if err != nil {
+		Debugf(KeyDCP, "Error start sending heartbeats: %v", err)
+	}
 
 	deadNodeHandler := HeartbeatStoppedHandler{
 		Cfg:     cbgtContext.Cfg,

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -553,7 +553,10 @@ func NewCBGTNodeListHandler(cfg cbgt.Cfg) (*cbgtNodeListHandler, error) {
 func (ch *cbgtNodeListHandler) subscribeNodeChanges() error {
 
 	cfgEvents := make(chan cbgt.CfgEvent)
-	ch.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
+	err := ch.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
+	if err != nil {
+		Debugf(KeyDCP, "Error subscribing node changes: %v", err)
+	}
 	go func() {
 		defer FatalPanicHandler()
 		for {

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -556,6 +556,7 @@ func (ch *cbgtNodeListHandler) subscribeNodeChanges() error {
 	err := ch.cfg.Subscribe(cbgt.CfgNodeDefsKey(cbgt.NODE_DEFS_KNOWN), cfgEvents)
 	if err != nil {
 		Debugf(KeyDCP, "Error subscribing node changes: %v", err)
+		return err
 	}
 	go func() {
 		defer FatalPanicHandler()

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -153,7 +153,8 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	nodeDefs.NodeDefs["node1"] = &cbgt.NodeDef{UUID: "node1"}
 	nodeDefs.NodeDefs["node2"] = &cbgt.NodeDef{UUID: "node2"}
 	nodeDefs.NodeDefs["node3"] = &cbgt.NodeDef{UUID: "node3"}
-	_, _ = cbgt.CfgSetNodeDefs(cfgCB, cbgt.NODE_DEFS_KNOWN, nodeDefs, 0)
+	_, err = cbgt.CfgSetNodeDefs(cfgCB, cbgt.NODE_DEFS_KNOWN, nodeDefs, 0)
+	require.NoError(t, err)
 
 	// Create three heartbeaters (representing three nodes)
 	handler1, err := NewCBGTNodeListHandler(cfgCB)

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -153,7 +153,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	nodeDefs.NodeDefs["node1"] = &cbgt.NodeDef{UUID: "node1"}
 	nodeDefs.NodeDefs["node2"] = &cbgt.NodeDef{UUID: "node2"}
 	nodeDefs.NodeDefs["node3"] = &cbgt.NodeDef{UUID: "node3"}
-	cbgt.CfgSetNodeDefs(cfgCB, cbgt.NODE_DEFS_KNOWN, nodeDefs, 0)
+	_, _ = cbgt.CfgSetNodeDefs(cfgCB, cbgt.NODE_DEFS_KNOWN, nodeDefs, 0)
 
 	// Create three heartbeaters (representing three nodes)
 	handler1, err := NewCBGTNodeListHandler(cfgCB)

--- a/base/http_listener.go
+++ b/base/http_listener.go
@@ -35,7 +35,7 @@ func ListenAndServeHTTP(addr string, connLimit int, certFile *string, keyFile *s
 	if config != nil {
 		listener = tls.NewListener(listener, config)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 	server := &http.Server{Addr: addr, Handler: handler}
 	if readTimeout != nil {
 		server.ReadTimeout = time.Duration(*readTimeout) * time.Second

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -134,7 +134,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.Contains(t, fileNames, logFilePrefix+"info-2019-02-02T12-00-00.log.gz")
 	assert.Contains(t, fileNames, logFilePrefix+"info-2019-02-02T12-10-00.log.gz")
 
-	_ = os.RemoveAll(dir)
+	assert.NoError(t, os.RemoveAll(dir))
 
 	//Hit low watermark but not high watermark
 	dir, _ = ioutil.TempDir("", "tempdir2")
@@ -144,7 +144,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
 	assert.Equal(t, 1, len(dirContents))
-	_ = os.RemoveAll(dir)
+	assert.NoError(t, os.RemoveAll(dir))
 
 	//Single file hitting low and high watermark
 	dir, _ = ioutil.TempDir("", "tempdir3")
@@ -154,7 +154,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
 	assert.Empty(t, dirContents)
-	_ = os.RemoveAll(dir)
+	assert.NoError(t, os.RemoveAll(dir))
 
 	//Not hitting low or high therefore no deletion
 	dir, _ = ioutil.TempDir("", "tempdir4")
@@ -164,7 +164,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
 	assert.Equal(t, 1, len(dirContents))
-	_ = os.RemoveAll(dir)
+	assert.NoError(t, os.RemoveAll(dir))
 
 	//Test deletion with files at the end of date boundaries
 	dir, _ = ioutil.TempDir("", "tempdir5")
@@ -190,7 +190,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.Contains(t, fileNames, logFilePrefix+"error-2019-01-01T12-00-00.log.gz")
 	assert.Contains(t, fileNames, logFilePrefix+"error-2019-01-31T23-59-59.log.gz")
 
-	_ = os.RemoveAll(dir)
+	assert.NoError(t, os.RemoveAll(dir))
 
 	//Test deletion with no .gz files to ensure nothing is deleted
 	dir, _ = ioutil.TempDir("", "tempdir6")
@@ -210,7 +210,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.Contains(t, fileNames, logFilePrefix+"error")
 	assert.Contains(t, fileNames, logFilePrefix+"info")
 
-	_ = os.RemoveAll(dir)
+	assert.NoError(t, os.RemoveAll(dir))
 }
 
 func makeTestFile(sizeMB int, name string, dir string) (err error) {
@@ -218,10 +218,10 @@ func makeTestFile(sizeMB int, name string, dir string) (err error) {
 	if err != nil {
 		return err
 	}
-
-	defer func() { _ = f.Close() }()
-
 	if err := f.Truncate(int64(sizeMB * 1024 * 1024)); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 	return nil

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,7 +71,7 @@ func TestFileShouldLog(t *testing.T) {
 
 		t.Run(name, func(ts *testing.T) {
 			got := l.shouldLog(test.logToLevel)
-			goassert.Equals(ts, got, test.expected)
+			assert.Equal(ts, test.expected, got)
 		})
 	}
 }
@@ -135,7 +134,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.Contains(t, fileNames, logFilePrefix+"info-2019-02-02T12-00-00.log.gz")
 	assert.Contains(t, fileNames, logFilePrefix+"info-2019-02-02T12-10-00.log.gz")
 
-	os.RemoveAll(dir)
+	_ = os.RemoveAll(dir)
 
 	//Hit low watermark but not high watermark
 	dir, _ = ioutil.TempDir("", "tempdir2")
@@ -145,7 +144,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
 	assert.Equal(t, 1, len(dirContents))
-	os.RemoveAll(dir)
+	_ = os.RemoveAll(dir)
 
 	//Single file hitting low and high watermark
 	dir, _ = ioutil.TempDir("", "tempdir3")
@@ -155,7 +154,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
 	assert.Empty(t, dirContents)
-	os.RemoveAll(dir)
+	_ = os.RemoveAll(dir)
 
 	//Not hitting low or high therefore no deletion
 	dir, _ = ioutil.TempDir("", "tempdir4")
@@ -165,7 +164,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
 	assert.Equal(t, 1, len(dirContents))
-	os.RemoveAll(dir)
+	_ = os.RemoveAll(dir)
 
 	//Test deletion with files at the end of date boundaries
 	dir, _ = ioutil.TempDir("", "tempdir5")
@@ -191,7 +190,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.Contains(t, fileNames, logFilePrefix+"error-2019-01-01T12-00-00.log.gz")
 	assert.Contains(t, fileNames, logFilePrefix+"error-2019-01-31T23-59-59.log.gz")
 
-	os.RemoveAll(dir)
+	_ = os.RemoveAll(dir)
 
 	//Test deletion with no .gz files to ensure nothing is deleted
 	dir, _ = ioutil.TempDir("", "tempdir6")
@@ -211,7 +210,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.Contains(t, fileNames, logFilePrefix+"error")
 	assert.Contains(t, fileNames, logFilePrefix+"info")
 
-	os.RemoveAll(dir)
+	_ = os.RemoveAll(dir)
 }
 
 func makeTestFile(sizeMB int, name string, dir string) (err error) {
@@ -220,7 +219,7 @@ func makeTestFile(sizeMB int, name string, dir string) (err error) {
 		return err
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if err := f.Truncate(int64(sizeMB * 1024 * 1024)); err != nil {
 		return err

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -129,8 +129,11 @@ func BenchmarkLogRotation(b *testing.B) {
 		b.Run(fmt.Sprintf("rotate:%t-compress:%t-bytes:%v", test.rotate, test.compress, test.numBytes), func(bm *testing.B) {
 			logPath := filepath.Join(os.TempDir(), "benchmark-logrotate")
 			logger := lumberjack.Logger{Filename: filepath.Join(logPath, "output.log"), Compress: test.compress}
-			defer logger.Close()
-			defer os.RemoveAll(logPath)
+
+			defer func() {
+				_ = logger.Close()
+				_ = os.RemoveAll(logPath)
+			}()
 
 			data := make([]byte, test.numBytes)
 			_, err := rand.Read(data)

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -12,6 +12,7 @@ package base
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"math/rand"
 	"os"
@@ -131,8 +132,8 @@ func BenchmarkLogRotation(b *testing.B) {
 			logger := lumberjack.Logger{Filename: filepath.Join(logPath, "output.log"), Compress: test.compress}
 
 			defer func() {
-				_ = logger.Close()
-				_ = os.RemoveAll(logPath)
+				require.NoError(b, logger.Close())
+				require.NoError(b, os.RemoveAll(logPath))
 			}()
 
 			data := make([]byte, test.numBytes)

--- a/base/util.go
+++ b/base/util.go
@@ -961,10 +961,9 @@ func FindPrimaryAddr() (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = conn.Close() }()
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
-	return localAddr.IP, nil
+	return localAddr.IP, conn.Close()
 }
 
 // ReplaceAll returns a string with all of the given chars replaced by new

--- a/base/util.go
+++ b/base/util.go
@@ -961,7 +961,7 @@ func FindPrimaryAddr() (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 	return localAddr.IP, nil

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -25,7 +25,7 @@ func init() {
 
 func parse(jsonStr string) map[string]interface{} {
 	var parsed map[string]interface{}
-	base.JSONUnmarshal([]byte(jsonStr), &parsed)
+	_ = base.JSONUnmarshal([]byte(jsonStr), &parsed)
 	return parsed
 }
 

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -240,7 +240,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 
 	docBody := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}}`
 	var body Body
-	base.JSONUnmarshal([]byte(docBody), &body)
+	require.NoError(t, base.JSONUnmarshal([]byte(docBody), &body))
 	_, _, err = db.Put("doc1", unjson(docBody))
 	log.Printf("Got error on put doc:%v", err)
 	db.Bucket.Dump()

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -885,7 +885,8 @@ func (c *changeCache) WasSkipped(x uint64) bool {
 func (c *changeCache) PushSkipped(sequence uint64) {
 	err := c.skippedSeqs.Push(&SkippedSequence{seq: sequence, timeAdded: time.Now()})
 	if err != nil {
-		base.Debugf(base.KeyCache, "Error pusing skipped sequence: %d, %v", sequence, err)
+		base.Infof(base.KeyCache, "Error pusing skipped sequence: %d, %v", sequence, err)
+		return
 	}
 	c.context.DbStats.statsCacheMap.Set(base.StatKeySkippedSeqLen, base.ExpvarIntVal(c.skippedSeqs.skippedList.Len()))
 }

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -885,7 +885,7 @@ func (c *changeCache) WasSkipped(x uint64) bool {
 func (c *changeCache) PushSkipped(sequence uint64) {
 	err := c.skippedSeqs.Push(&SkippedSequence{seq: sequence, timeAdded: time.Now()})
 	if err != nil {
-		base.Infof(base.KeyCache, "Error pusing skipped sequence: %d, %v", sequence, err)
+		base.Infof(base.KeyCache, "Error pushing skipped sequence: %d, %v", sequence, err)
 		return
 	}
 	c.context.DbStats.statsCacheMap.Set(base.StatKeySkippedSeqLen, base.ExpvarIntVal(c.skippedSeqs.skippedList.Len()))

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -718,7 +718,10 @@ func (c *changeCache) processEntry(change *LogEntry) base.Set {
 		changedChannels = c._addToCache(change)
 		// Add to cache before removing from skipped, to ensure lowSequence doesn't get incremented until results are available
 		// in cache
-		c.RemoveSkipped(sequence)
+		err := c.RemoveSkipped(sequence)
+		if err != nil {
+			base.Debugf(base.KeyCache, "Error removing skipped sequence: #%d from cache: %v", sequence, err)
+		}
 	}
 	return changedChannels
 }
@@ -880,7 +883,10 @@ func (c *changeCache) WasSkipped(x uint64) bool {
 }
 
 func (c *changeCache) PushSkipped(sequence uint64) {
-	c.skippedSeqs.Push(&SkippedSequence{seq: sequence, timeAdded: time.Now()})
+	err := c.skippedSeqs.Push(&SkippedSequence{seq: sequence, timeAdded: time.Now()})
+	if err != nil {
+		base.Debugf(base.KeyCache, "Error pusing skipped sequence: %d, %v", sequence, err)
+	}
 	c.context.DbStats.statsCacheMap.Set(base.StatKeySkippedSeqLen, base.ExpvarIntVal(c.skippedSeqs.skippedList.Len()))
 }
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -439,7 +439,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 	}
 
 	// Wait for everyone to be caught up
-	_ = db.WaitForCaughtUp(caughtUpStart + int64(100))
+	require.NoError(t, db.WaitForCaughtUp(caughtUpStart+int64(100)))
 	log.Printf("Everyone is caught up")
 
 	// Write sequence 1 to all channels, wait for it on feed
@@ -452,7 +452,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 	log.Printf("Everyone's seq 1 arrived")
 
 	// Wait for everyone to be caught up again
-	_ = db.WaitForCaughtUp(caughtUpStart + int64(100))
+	require.NoError(t, db.WaitForCaughtUp(caughtUpStart+int64(100)))
 
 	// Write sequence 3 to all channels, wait for it on feed
 	WriteDirect(db, channelSet, 3)
@@ -465,7 +465,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 	log.Printf("Everyone's seq 2 arrived")
 
 	// Wait for everyone to be caught up again
-	_ = db.WaitForCaughtUp(caughtUpStart + int64(100))
+	require.NoError(t, db.WaitForCaughtUp(caughtUpStart+int64(100)))
 
 	// Close the terminator
 	close(terminator)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1363,7 +1363,8 @@ func TestStopChangeCache(t *testing.T) {
 	WriteDirect(db, []string{"ABC"}, 3)
 
 	// Artificially add 3 skipped, and back date skipped entry by 2 hours to trigger attempted view retrieval during Clean call
-	_ = db.changeCache.skippedSeqs.Push(&SkippedSequence{3, time.Now().Add(time.Duration(time.Hour * -2))})
+	err := db.changeCache.skippedSeqs.Push(&SkippedSequence{3, time.Now().Add(time.Duration(time.Hour * -2))})
+	require.NoError(t, err)
 
 	// tear down the DB.  Should stop the cache before view retrieval of the skipped sequence is attempted.
 	tearDownTestDB(t, db)

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -489,7 +489,7 @@ func WriteDirect(db *Database, channelArray []string, sequence uint64) {
 
 func WriteUserDirect(db *Database, username string, sequence uint64) {
 	docId := base.UserPrefix + username
-	db.Bucket.Add(docId, 0, Body{"sequence": sequence, "name": username})
+	_, _ = db.Bucket.Add(docId, 0, Body{"sequence": sequence, "name": username})
 }
 
 func WriteDirectWithKey(db *Database, key string, channelArray []string, sequence uint64) {
@@ -1363,7 +1363,7 @@ func TestStopChangeCache(t *testing.T) {
 	WriteDirect(db, []string{"ABC"}, 3)
 
 	// Artificially add 3 skipped, and back date skipped entry by 2 hours to trigger attempted view retrieval during Clean call
-	db.changeCache.skippedSeqs.Push(&SkippedSequence{3, time.Now().Add(time.Duration(time.Hour * -2))})
+	_ = db.changeCache.skippedSeqs.Push(&SkippedSequence{3, time.Now().Add(time.Duration(time.Hour * -2))})
 
 	// tear down the DB.  Should stop the cache before view retrieval of the skipped sequence is attempted.
 	tearDownTestDB(t, db)

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -134,7 +134,10 @@ func (listener *changeListener) Stop() {
 	}
 
 	if listener.tapFeed != nil {
-		listener.tapFeed.Close()
+		err := listener.tapFeed.Close()
+		if err != nil {
+			base.Debugf(base.KeyChanges, "Error closing listener tap feed: %v", err)
+		}
 	}
 }
 

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -68,7 +68,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 	require.NotNil(t, authenticator, "db.Authenticator() returned nil")
 	role, err := authenticator.NewRole(roleName, channels.SetOf(t, "ABC"))
 	require.NoError(t, err, "Error creating new role")
-	authenticator.Save(role)
+	require.NoError(t, authenticator.Save(role))
 
 	// Create user
 	username := "bob"

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -40,7 +40,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator()
 	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
-	authenticator.Save(user)
+	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
@@ -139,7 +139,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	// Create a user with access to channel A
 	authenticator := db.Authenticator()
 	user, _ := authenticator.NewUser("alice", "letmein", channels.SetOf(t, "A"))
-	authenticator.Save(user)
+	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
@@ -165,8 +165,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	//Unmarshall into nested maps
 	var x map[string]interface{}
-	base.JSONUnmarshal(rv, &x)
-	goassert.True(t, err == nil)
+	assert.NoError(t, base.JSONUnmarshal(rv, &x))
 
 	sync := x[base.SyncXattrName].(map[string]interface{})
 	sync["sequence"] = 3
@@ -186,7 +185,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	b, err := base.JSONMarshal(x)
 
 	// Update raw document in the bucket
-	db.Bucket.SetRaw("alpha", 0, b)
+	assert.NoError(t, db.Bucket.SetRaw("alpha", 0, b))
 
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 3 and isn't stuck waiting for it.
@@ -225,7 +224,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	// Create a user with access to channel A
 	authenticator := db.Authenticator()
 	user, _ := authenticator.NewUser("alice", "letmein", channels.SetOf(t, "A"))
-	authenticator.Save(user)
+	require.NoError(t, authenticator.Save(user))
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
 
@@ -252,9 +251,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	//Unmarshall into nested maps
 	var x map[string]interface{}
-	base.JSONUnmarshal(rv, &x)
-
-	goassert.True(t, err == nil)
+	assert.NoError(t, base.JSONUnmarshal(rv, &x))
 
 	sync := x[base.SyncXattrName].(map[string]interface{})
 	sync["sequence"] = 3
@@ -270,7 +267,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	b, err := base.JSONMarshal(x)
 
 	// Update raw document in the bucket
-	db.Bucket.SetRaw("alpha", 0, b)
+	require.NoError(t, db.Bucket.SetRaw("alpha", 0, b))
 
 	// Check the _changes feed -- this is to make sure the changeCache properly received
 	// sequence 3 (the modified document) and isn't stuck waiting for it.

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -36,10 +36,10 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	cache := context.changeCache.getChannelCache()
 
 	// Make channels active
-	cache.GetChanges("TestA", ChangesOptions{})
-	cache.GetChanges("TestB", ChangesOptions{})
-	cache.GetChanges("TestC", ChangesOptions{})
-	cache.GetChanges("TestD", ChangesOptions{})
+	_, _ = cache.GetChanges("TestA", ChangesOptions{})
+	_, _ = cache.GetChanges("TestB", ChangesOptions{})
+	_, _ = cache.GetChanges("TestC", ChangesOptions{})
+	_, _ = cache.GetChanges("TestD", ChangesOptions{})
 
 	// Add some entries to caches, leaving some empty caches
 	cache.AddToCache(logEntry(1, "doc1", "1-a", []string{"TestB", "TestC", "TestD"}))

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -36,10 +36,14 @@ func TestChannelCacheMaxSize(t *testing.T) {
 	cache := context.changeCache.getChannelCache()
 
 	// Make channels active
-	_, _ = cache.GetChanges("TestA", ChangesOptions{})
-	_, _ = cache.GetChanges("TestB", ChangesOptions{})
-	_, _ = cache.GetChanges("TestC", ChangesOptions{})
-	_, _ = cache.GetChanges("TestD", ChangesOptions{})
+	_, err := cache.GetChanges("TestA", ChangesOptions{})
+	require.NoError(t, err)
+	_, err = cache.GetChanges("TestB", ChangesOptions{})
+	require.NoError(t, err)
+	_, err = cache.GetChanges("TestC", ChangesOptions{})
+	require.NoError(t, err)
+	_, err = cache.GetChanges("TestD", ChangesOptions{})
+	require.NoError(t, err)
 
 	// Add some entries to caches, leaving some empty caches
 	cache.AddToCache(logEntry(1, "doc1", "1-a", []string{"TestB", "TestC", "TestD"}))

--- a/db/crud.go
+++ b/db/crud.go
@@ -1442,7 +1442,10 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			if err != nil {
 				base.Warnf("Error marshalling doc with id %s and revid %s for webhook post: %v", base.UD(docid), base.UD(newRevID), err)
 			} else {
-				db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels)
+				err = db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels)
+				if err != nil {
+					base.Warnf("Error raising document change event: %v", err)
+				}
 			}
 		}
 	} else {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1444,7 +1444,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			} else {
 				err = db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels)
 				if err != nil {
-					base.Warnf("Error raising document change event: %v", err)
+					base.Debugf(base.KeyCRUD, "Error raising document change event: %v", err)
 				}
 			}
 		}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -844,20 +844,17 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc1", "", false, nil)
-			require.NoError(b, err)
+			_, _ = db.Get1xRevBody("doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc2", "", false, nil)
-			require.NoError(b, err)
+			_, _ = db.Get1xRevBody("doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc3", "", false, nil)
-			require.NoError(b, err)
+			_, _ = db.Get1xRevBody("doc3", "", false, nil)
 		}
 	})
 
@@ -871,20 +868,17 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc1", "1-a", false, nil)
-			require.NoError(b, err)
+			_, _ = db.Get1xRevBody("doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc2", "1-a", false, nil)
-			require.NoError(b, err)
+			_, _ = db.Get1xRevBody("doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.Get1xRevBody("doc3", "1-a", false, nil)
-			require.NoError(b, err)
+			_, _ = db.Get1xRevBody("doc3", "1-a", false, nil)
 		}
 	})
 }
@@ -914,20 +908,17 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc1", "", false, nil)
-			require.NoError(b, err)
+			_, _ = db.GetRev("doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc2", "", false, nil)
-			require.NoError(b, err)
+			_, _ = db.GetRev("doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc3", "", false, nil)
-			require.NoError(b, err)
+			_, _ = db.GetRev("doc3", "", false, nil)
 		}
 	})
 
@@ -941,20 +932,17 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc1", "1-a", false, nil)
-			require.NoError(b, err)
+			_, _ = db.GetRev("doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc2", "1-a", false, nil)
-			require.NoError(b, err)
+			_, _ = db.GetRev("doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := db.GetRev("doc3", "1-a", false, nil)
-			require.NoError(b, err)
+			_, _ = db.GetRev("doc3", "1-a", false, nil)
 		}
 	})
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -878,7 +878,7 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.Get1xRevBody("doc3", "1-a", false, nil)
+			_, _ = db.Get1xRevBody("doc3", "1-a", false, nil)
 		}
 	})
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -844,17 +844,20 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc1", "", false, nil)
+			_, err := db.Get1xRevBody("doc1", "", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc2", "", false, nil)
+			_, err := db.Get1xRevBody("doc2", "", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc3", "", false, nil)
+			_, err := db.Get1xRevBody("doc3", "", false, nil)
+			require.NoError(b, err)
 		}
 	})
 
@@ -868,17 +871,20 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc1", "1-a", false, nil)
+			_, err := db.Get1xRevBody("doc1", "1-a", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc2", "1-a", false, nil)
+			_, err := db.Get1xRevBody("doc2", "1-a", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.Get1xRevBody("doc3", "1-a", false, nil)
+			_, err := db.Get1xRevBody("doc3", "1-a", false, nil)
+			require.NoError(b, err)
 		}
 	})
 }
@@ -908,17 +914,20 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc1", "", false, nil)
+			_, err := db.GetRev("doc1", "", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc2", "", false, nil)
+			_, err := db.GetRev("doc2", "", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc3", "", false, nil)
+			_, err := db.GetRev("doc3", "", false, nil)
+			require.NoError(b, err)
 		}
 	})
 
@@ -932,17 +941,20 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc1", "1-a", false, nil)
+			_, err := db.GetRev("doc1", "1-a", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc2", "1-a", false, nil)
+			_, err := db.GetRev("doc2", "1-a", false, nil)
+			require.NoError(b, err)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, _ = db.GetRev("doc3", "1-a", false, nil)
+			_, err := db.GetRev("doc3", "1-a", false, nil)
+			require.NoError(b, err)
 		}
 	})
 }

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -347,7 +347,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 	var revisionBody Body
 	rawRevision, _, err := db.Bucket.GetRaw(base.SyncPrefix + "rb:4GctXhLVg13d59D0PUTPRD0i58Hbe1d0djgo1qOEpfI=")
 	assert.NoError(t, err, "Couldn't get raw backup revision")
-	base.JSONUnmarshal(rawRevision, &revisionBody)
+	assert.NoError(t, base.JSONUnmarshal(rawRevision, &revisionBody))
 	goassert.Equals(t, revisionBody["version"], rev2a_body["version"])
 	goassert.Equals(t, revisionBody["value"], rev2a_body["value"])
 
@@ -844,17 +844,17 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.Get1xRevBody("doc1", "", false, nil)
+			_, _ = db.Get1xRevBody("doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.Get1xRevBody("doc2", "", false, nil)
+			_, _ = db.Get1xRevBody("doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.Get1xRevBody("doc3", "", false, nil)
+			_, _ = db.Get1xRevBody("doc3", "", false, nil)
 		}
 	})
 
@@ -868,12 +868,12 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.Get1xRevBody("doc1", "1-a", false, nil)
+			_, _ = db.Get1xRevBody("doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.Get1xRevBody("doc2", "1-a", false, nil)
+			_, _ = db.Get1xRevBody("doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
@@ -908,17 +908,17 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.GetRev("doc1", "", false, nil)
+			_, _ = db.GetRev("doc1", "", false, nil)
 		}
 	})
 	b.Run("LongLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.GetRev("doc2", "", false, nil)
+			_, _ = db.GetRev("doc2", "", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.GetRev("doc3", "", false, nil)
+			_, _ = db.GetRev("doc3", "", false, nil)
 		}
 	})
 
@@ -932,17 +932,17 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.GetRev("doc1", "1-a", false, nil)
+			_, _ = db.GetRev("doc1", "1-a", false, nil)
 		}
 	})
 	b.Run("LongOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.GetRev("doc2", "1-a", false, nil)
+			_, _ = db.GetRev("doc2", "1-a", false, nil)
 		}
 	})
 	b.Run("ShortWithAttachmentsOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			db.GetRev("doc3", "1-a", false, nil)
+			_, _ = db.GetRev("doc3", "1-a", false, nil)
 		}
 	})
 }

--- a/db/database.go
+++ b/db/database.go
@@ -553,6 +553,7 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 			err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
 			if err != nil {
 				base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
+				return err
 			}
 		}
 

--- a/db/database.go
+++ b/db/database.go
@@ -269,11 +269,14 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	dbContext.activeChannels = channels.NewActiveChannels(dbStats.StatsCache().Get(base.StatKeyActiveChannels).(*expvar.Int))
 
 	// Initialize the ChangeCache.  Will be locked and unusable until .Start() is called (SG #3558)
-	dbContext.changeCache.Init(
+	err = dbContext.changeCache.Init(
 		dbContext,
 		notifyChange,
 		options.CacheOptions,
 	)
+	if err != nil {
+		base.Debugf(base.KeyDCP, "Error initializing the change cache", err)
+	}
 
 	// Set the DB Context notifyChange callback to call back the changecache DocChanged callback
 	dbContext.SetOnChangeCallback(dbContext.changeCache.DocChanged)
@@ -547,7 +550,10 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 		atomic.StoreUint32(&dc.State, DBOffline)
 
 		if dc.EventMgr.HasHandlerForEvent(DBStateChange) {
-			dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
+			err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
+			if err != nil {
+				base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
+			}
 		}
 
 		return nil

--- a/db/database.go
+++ b/db/database.go
@@ -532,7 +532,7 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
 	dbState := atomic.LoadUint32(&dc.State)
 
-	//If the DB is already trasitioning to: offline or is offline silently return
+	//If the DB is already transitioning to: offline or is offline silently return
 	if dbState == DBOffline || dbState == DBResyncing || dbState == DBStopping {
 		return nil
 	}
@@ -553,7 +553,6 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 			err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
 			if err != nil {
 				base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
-				return err
 			}
 		}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -659,7 +659,8 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Inspect the channel log to confirm that it's only got the last 50 sequences.
 	// There are 101 sequences overall, so the 1st one it has should be #52.
-	_ = db.changeCache.waitForSequence(context.TODO(), 101, base.DefaultWaitForSequence)
+	err = db.changeCache.waitForSequence(context.TODO(), 101, base.DefaultWaitForSequence)
+	require.NoError(t, err)
 	changeLog := db.GetChangeLog("all", 0)
 	assert.Equal(t, 50, len(changeLog))
 	assert.Equal(t, 52, int(changeLog[0].Sequence))
@@ -1446,7 +1447,8 @@ func TestRecentSequenceHistory(t *testing.T) {
 	// Recent sequence pruning only prunes entries older than what's been seen over DCP
 	// (to ensure it's not pruning something that may still be coalesced).  Because of this, test waits
 	// for caching before attempting to trigger pruning.
-	_ = db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence)
+	err = db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence)
+	require.NoError(t, err)
 
 	// Add another sequence to validate pruning when past max (20)
 	revid, doc, err = db.Put("doc1", body)
@@ -1471,7 +1473,8 @@ func TestRecentSequenceHistory(t *testing.T) {
 		seqTracker++
 	}
 
-	_ = db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence) //
+	err = db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence) //
+	require.NoError(t, err)
 	revid, doc, err = db.Put("doc1", body)
 	body[BodyId] = doc.ID
 	body[BodyRev] = revid
@@ -1532,7 +1535,8 @@ func TestConcurrentImport(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
 
 	// Add doc to the underlying bucket:
-	_, _ = db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
+	_, err := db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
+	require.NoError(t, err)
 
 	// Attempt concurrent retrieval of the docs, and validate that they are only imported once (based on revid)
 	var wg sync.WaitGroup

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -659,7 +659,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	// Inspect the channel log to confirm that it's only got the last 50 sequences.
 	// There are 101 sequences overall, so the 1st one it has should be #52.
-	db.changeCache.waitForSequence(context.TODO(), 101, base.DefaultWaitForSequence)
+	_ = db.changeCache.waitForSequence(context.TODO(), 101, base.DefaultWaitForSequence)
 	changeLog := db.GetChangeLog("all", 0)
 	assert.Equal(t, 50, len(changeLog))
 	assert.Equal(t, 52, int(changeLog[0].Sequence))
@@ -716,7 +716,7 @@ func TestUpdatePrincipal(t *testing.T) {
 	// Create a user with access to channel ABC
 	authenticator := db.Authenticator()
 	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "ABC"))
-	authenticator.Save(user)
+	assert.NoError(t, authenticator.Save(user))
 
 	// Validate that a call to UpdatePrincipals with no changes to the user doesn't allocate a sequence
 	userInfo, err := db.GetPrincipal("naomi", true)
@@ -1248,7 +1248,7 @@ func TestAccessFunctionDb(t *testing.T) {
 	// Create the role _after_ creating the documents, to make sure the previously-indexed access
 	// privileges are applied.
 	role, _ := authenticator.NewRole("animefan", nil)
-	authenticator.Save(role)
+	assert.NoError(t, authenticator.Save(role))
 
 	user, err = authenticator.GetUser("naomi")
 	assert.NoError(t, err, "GetUser")
@@ -1446,7 +1446,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 	// Recent sequence pruning only prunes entries older than what's been seen over DCP
 	// (to ensure it's not pruning something that may still be coalesced).  Because of this, test waits
 	// for caching before attempting to trigger pruning.
-	db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence)
+	_ = db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence)
 
 	// Add another sequence to validate pruning when past max (20)
 	revid, doc, err = db.Put("doc1", body)
@@ -1471,7 +1471,7 @@ func TestRecentSequenceHistory(t *testing.T) {
 		seqTracker++
 	}
 
-	db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence) //
+	_ = db.changeCache.waitForSequence(context.TODO(), seqTracker, base.DefaultWaitForSequence) //
 	revid, doc, err = db.Put("doc1", body)
 	body[BodyId] = doc.ID
 	body[BodyRev] = revid
@@ -1532,7 +1532,7 @@ func TestConcurrentImport(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
 
 	// Add doc to the underlying bucket:
-	db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
+	_, _ = db.Bucket.Add("directWrite", 0, Body{"value": "hi"})
 
 	// Attempt concurrent retrieval of the docs, and validate that they are only imported once (based on revid)
 	var wg sync.WaitGroup
@@ -1613,7 +1613,7 @@ func BenchmarkDatabase(b *testing.B) {
 		db, _ := CreateDatabase(context)
 
 		body := Body{"key1": "value1", "key2": 1234}
-		db.Put(fmt.Sprintf("doc%d", i), body)
+		_, _, _ = db.Put(fmt.Sprintf("doc%d", i), body)
 
 		db.Close()
 	}
@@ -1636,7 +1636,7 @@ func BenchmarkPut(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		db.Put(fmt.Sprintf("doc%d", i), body)
+		_, _, _ = db.Put(fmt.Sprintf("doc%d", i), body)
 	}
 
 	db.Close()

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -113,8 +113,14 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		defer func() {
 			// Ensure we're closing the response, so it can be reused
 			if resp != nil && resp.Body != nil {
-				_, _ = io.Copy(ioutil.Discard, resp.Body)
-				_ = resp.Body.Close()
+				_, err := io.Copy(ioutil.Discard, resp.Body)
+				if err != nil {
+					base.Debugf(base.KeyEvents, "Error copying response body: %v", err)
+				}
+				err = resp.Body.Close()
+				if err != nil {
+					base.Debugf(base.KeyEvents, "Error closing response body: %v", err)
+				}
 			}
 		}()
 

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -113,8 +113,8 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		defer func() {
 			// Ensure we're closing the response, so it can be reused
 			if resp != nil && resp.Body != nil {
-				io.Copy(ioutil.Discard, resp.Body)
-				resp.Body.Close()
+				_, _ = io.Copy(ioutil.Discard, resp.Body)
+				_ = resp.Body.Close()
 			}
 		}()
 

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -99,7 +99,8 @@ func TestDocumentChangeEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		assert.NoError(t, err)
 	}
 
 	assertChannelLengthWithTimeout(t, resultChannel, 10, 10*time.Second)
@@ -124,11 +125,13 @@ func TestDBStateChangeEvent(t *testing.T) {
 	em.RegisterEventHandler(testHandler, DBStateChange)
 	//Raise online events
 	for i := 0; i < 10; i++ {
-		_ = em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", "0.0.0.0:0000")
+		err := em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", "0.0.0.0:0000")
+		assert.NoError(t, err)
 	}
 	//Raise offline events
 	for i := 10; i < 20; i++ {
-		_ = em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", "0.0.0.0:0000")
+		err := em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", "0.0.0.0:0000")
+		assert.NoError(t, err)
 	}
 
 	for i := 0; i < 25; i++ {
@@ -177,7 +180,8 @@ func TestSlowExecutionProcessing(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		body, docid, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		assert.NoError(t, err)
 	}
 
 	assertChannelLengthWithTimeout(t, resultChannel, 20, 10*time.Second)
@@ -217,7 +221,8 @@ func TestCustomHandler(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		assert.NoError(t, err)
 	}
 
 	assertChannelLengthWithTimeout(t, resultChannel, 10, 10*time.Second)
@@ -259,7 +264,8 @@ func TestUnhandledEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		assert.NoError(t, err)
 	}
 
 	// Validate that no events were handled
@@ -421,7 +427,8 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 10, wr.GetCount())
@@ -443,7 +450,8 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		assert.NoError(t, err)
 	}
 
 	time.Sleep(50 * time.Millisecond)
@@ -458,7 +466,8 @@ func TestWebhookBasic(t *testing.T) {
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	body, docId, channels := eventForTest(0)
 	bodyBytes, _ := base.JSONMarshalCanonical(body)
-	_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+	err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+	assert.NoError(t, err)
 	time.Sleep(50 * time.Millisecond)
 	receivedPayload := string((wr.GetPayloads())[0])
 	fmt.Println("payload:", receivedPayload)
@@ -476,7 +485,8 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, 100, wr.GetCount())
@@ -513,7 +523,8 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(5 * time.Second)
 	assert.Equal(t, 100, wr.GetCount())
@@ -564,7 +575,8 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		assert.NoError(t, err)
 
 	}
 	time.Sleep(50 * time.Millisecond)
@@ -591,7 +603,8 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 4, wr.GetCount())
@@ -617,7 +630,8 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 4, wr.GetCount())
@@ -640,7 +654,8 @@ func TestWebhookOldDoc(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		assert.NoError(t, err)
 	}
 	for i := 10; i < 20; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -648,7 +663,8 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 10, wr.GetCount())
@@ -697,7 +713,8 @@ func TestWebhookTimeout(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 10, wr.GetCount())
@@ -803,7 +820,8 @@ func TestUnavailableWebhook(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(-i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 0, wr.GetCount())

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -99,7 +99,7 @@ func TestDocumentChangeEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
 	}
 
 	assertChannelLengthWithTimeout(t, resultChannel, 10, 10*time.Second)
@@ -124,11 +124,11 @@ func TestDBStateChangeEvent(t *testing.T) {
 	em.RegisterEventHandler(testHandler, DBStateChange)
 	//Raise online events
 	for i := 0; i < 10; i++ {
-		em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", "0.0.0.0:0000")
+		_ = em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", "0.0.0.0:0000")
 	}
 	//Raise offline events
 	for i := 10; i < 20; i++ {
-		em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", "0.0.0.0:0000")
+		_ = em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", "0.0.0.0:0000")
 	}
 
 	for i := 0; i < 25; i++ {
@@ -177,7 +177,7 @@ func TestSlowExecutionProcessing(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		body, docid, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
 	}
 
 	assertChannelLengthWithTimeout(t, resultChannel, 20, 10*time.Second)
@@ -217,7 +217,7 @@ func TestCustomHandler(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
 	}
 
 	assertChannelLengthWithTimeout(t, resultChannel, 10, 10*time.Second)
@@ -259,7 +259,7 @@ func TestUnhandledEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
 	}
 
 	// Validate that no events were handled
@@ -332,20 +332,20 @@ func GetRouterWithHandler(wr *WebhookRequest) http.Handler {
 	r.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(1 * time.Second)
 		wr.IncrementCount()
-		fmt.Fprintf(w, "OK")
+		_, _ = fmt.Fprintf(w, "OK")
 	})
 	r.HandleFunc("/slow_2s", func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second)
 		wr.IncrementCount()
-		fmt.Fprintf(w, "OK")
+		_, _ = fmt.Fprintf(w, "OK")
 	})
 	r.HandleFunc("/slow_5s", func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Second)
 		wr.IncrementCount()
-		fmt.Fprintf(w, "OK")
+		_, _ = fmt.Fprintf(w, "OK")
 	})
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		r.ParseForm()
+		_ = r.ParseForm()
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("Error trying to read body: %s", err)
@@ -370,7 +370,7 @@ func GetRouterWithHandler(wr *WebhookRequest) http.Handler {
 			}
 		}
 		wr.IncrementCount()
-		fmt.Fprintf(w, "OK")
+		_, _ = fmt.Fprintf(w, "OK")
 	})
 	return r
 }
@@ -421,7 +421,7 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 10, wr.GetCount())
@@ -443,7 +443,7 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	}
 
 	time.Sleep(50 * time.Millisecond)
@@ -458,7 +458,7 @@ func TestWebhookBasic(t *testing.T) {
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	body, docId, channels := eventForTest(0)
 	bodyBytes, _ := base.JSONMarshalCanonical(body)
-	em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+	_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	time.Sleep(50 * time.Millisecond)
 	receivedPayload := string((wr.GetPayloads())[0])
 	fmt.Println("payload:", receivedPayload)
@@ -476,7 +476,7 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	}
 	time.Sleep(500 * time.Millisecond)
 	assert.Equal(t, 100, wr.GetCount())
@@ -513,7 +513,7 @@ func TestWebhookBasic(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	}
 	time.Sleep(5 * time.Second)
 	assert.Equal(t, 100, wr.GetCount())
@@ -564,7 +564,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
 
 	}
 	time.Sleep(50 * time.Millisecond)
@@ -591,7 +591,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 4, wr.GetCount())
@@ -617,7 +617,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 4, wr.GetCount())
@@ -640,7 +640,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	}
 	for i := 10; i < 20; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -648,7 +648,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 10, wr.GetCount())
@@ -697,7 +697,7 @@ func TestWebhookTimeout(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 10, wr.GetCount())
@@ -803,7 +803,7 @@ func TestUnavailableWebhook(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(-i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		_ = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
 	}
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, 0, wr.GetCount())

--- a/db/import.go
+++ b/db/import.go
@@ -221,7 +221,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		newDoc.RevID = newRev
 		err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: parentRev, Deleted: isDelete})
 		if err != nil {
-			base.Infof(base.KeyImport, "Error adding new revision: %s, %v", newRev, err)
+			base.InfofCtx(db.Ctx, base.KeyImport, "Error adding new rev ID for doc %q / %q, Error: %v", base.UD(newDoc.ID), newRev, err)
 		}
 
 		// If the previous revision body is available in the rev cache,
@@ -294,7 +294,7 @@ func (db *Database) migrateMetadata(docid string, body Body, existingDoc *sgbuck
 	// Move any large revision bodies to external storage
 	err = doc.migrateRevisionBodies(db.Bucket)
 	if err != nil {
-		base.Infof(base.KeyMigrate, "Error migrating large revision bodies to external storage: %v", err)
+		base.Infof(base.KeyMigrate, "Error migrating revision bodies to external storage, doc %q, (cas=%d), Error: %v", base.UD(docid), doc.Cas, err)
 	}
 
 	// Persist the document in xattr format

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -154,7 +154,7 @@ func (il *importListener) Stop() {
 			for _, pIndex := range pindexes {
 				err := il.cbgtContext.Manager.ClosePIndex(pIndex)
 				if err != nil {
-					base.Debugf(base.KeyImport, "Error closing primary index: %v", err)
+					base.Debugf(base.KeyImport, "Error closing pindex: %v", err)
 				}
 			}
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -152,7 +152,10 @@ func (il *importListener) Stop() {
 			// Close open PIndexes before stopping the manager.
 			_, pindexes := il.cbgtContext.Manager.CurrentMaps()
 			for _, pIndex := range pindexes {
-				il.cbgtContext.Manager.ClosePIndex(pIndex)
+				err := il.cbgtContext.Manager.ClosePIndex(pIndex)
+				if err != nil {
+					base.Debugf(base.KeyImport, "Error closing primary index: %v", err)
+				}
 			}
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed
 			il.cbgtContext.Manager.Stop()

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
 	"time"
@@ -60,11 +61,12 @@ func TestMigrateMetadata(t *testing.T) {
 		exp := uint32(laterSyncMetaExpiry.Unix())
 		return bodyBytes, &exp, nil
 	}
-	_, _ = testBucket.Bucket.Update(
+	_, err = testBucket.Bucket.Update(
 		key,
 		uint32(laterSyncMetaExpiry.Unix()), // it's a bit confusing why the expiry needs to be passed here AND via the callback fn
 		updateCallbackFn,
 	)
+	require.NoError(t, err)
 
 	// Call migrateMeta with stale args that have old stale expiry
 	_, _, err = db.migrateMetadata(
@@ -156,11 +158,12 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 				exp := uint32(laterSyncMetaExpiry.Unix())
 				return bodyBytes, &exp, nil
 			}
-			_, _ = testBucket.Bucket.Update(
+			_, err = testBucket.Bucket.Update(
 				key,
 				uint32(laterSyncMetaExpiry.Unix()), // it's a bit confusing why the expiry needs to be passed here AND via the callback fn
 				updateCallbackFn,
 			)
+			require.NoError(t, err)
 
 			// Import the doc (will migrate as part of the import since the doc contains sync meta)
 			_, errImportDoc := db.importDoc(key, body, false, existingBucketDoc, ImportOnDemand)

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -60,7 +60,7 @@ func TestMigrateMetadata(t *testing.T) {
 		exp := uint32(laterSyncMetaExpiry.Unix())
 		return bodyBytes, &exp, nil
 	}
-	testBucket.Bucket.Update(
+	_, _ = testBucket.Bucket.Update(
 		key,
 		uint32(laterSyncMetaExpiry.Unix()), // it's a bit confusing why the expiry needs to be passed here AND via the callback fn
 		updateCallbackFn,
@@ -156,7 +156,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 				exp := uint32(laterSyncMetaExpiry.Unix())
 				return bodyBytes, &exp, nil
 			}
-			testBucket.Bucket.Update(
+			_, _ = testBucket.Bucket.Update(
 				key,
 				uint32(laterSyncMetaExpiry.Unix()), // it's a bit confusing why the expiry needs to be passed here AND via the callback fn
 				updateCallbackFn,

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -310,7 +310,7 @@ func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint) err
 
 	// Wait for newly built indexes to be online
 	for _, indexName := range deferredIndexes {
-		gocbBucket.WaitForIndexOnline(indexName)
+		_ = gocbBucket.WaitForIndexOnline(indexName)
 	}
 
 	// Wait for initial readiness queries to complete

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
 
@@ -21,7 +22,8 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	tBucket = testBucket(tester)
 	bucket := tBucket.Bucket
 
-	_ = installViews(bucket)
+	err := installViews(bucket)
+	require.NoError(tester, err)
 
 	// Add harmless docs
 	for i := 0; i < base.DefaultViewQueryPageSize+1; i++ {

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -21,12 +21,12 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	tBucket = testBucket(tester)
 	bucket := tBucket.Bucket
 
-	installViews(bucket)
+	_ = installViews(bucket)
 
 	// Add harmless docs
 	for i := 0; i < base.DefaultViewQueryPageSize+1; i++ {
 		testSyncData := SyncData{}
-		bucket.Add(fmt.Sprintf("foo-%d", i), 0, map[string]interface{}{"foo": "bar", base.SyncPropertyName: testSyncData})
+		_, _ = bucket.Add(fmt.Sprintf("foo-%d", i), 0, map[string]interface{}{"foo": "bar", base.SyncPropertyName: testSyncData})
 		numDocsAdded++
 	}
 
@@ -35,7 +35,7 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	if err != nil {
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
-	bucket.Add(docIdProblematicRevTree, 0, rawDoc)
+	_, _ = bucket.Add(docIdProblematicRevTree, 0, rawDoc)
 	numDocsAdded++
 
 	// Add 2nd doc that should be repaired
@@ -43,7 +43,7 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	if err != nil {
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
-	bucket.Add(docIdProblematicRevTree2, 0, rawDoc)
+	_, _ = bucket.Add(docIdProblematicRevTree2, 0, rawDoc)
 	numDocsAdded++
 
 	return tBucket, numDocsAdded

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -28,7 +28,8 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	// Add harmless docs
 	for i := 0; i < base.DefaultViewQueryPageSize+1; i++ {
 		testSyncData := SyncData{}
-		_, _ = bucket.Add(fmt.Sprintf("foo-%d", i), 0, map[string]interface{}{"foo": "bar", base.SyncPropertyName: testSyncData})
+		_, err = bucket.Add(fmt.Sprintf("foo-%d", i), 0, map[string]interface{}{"foo": "bar", base.SyncPropertyName: testSyncData})
+		require.NoError(tester, err)
 		numDocsAdded++
 	}
 
@@ -37,7 +38,8 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	if err != nil {
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
-	_, _ = bucket.Add(docIdProblematicRevTree, 0, rawDoc)
+	_, err = bucket.Add(docIdProblematicRevTree, 0, rawDoc)
+	require.NoError(tester, err)
 	numDocsAdded++
 
 	// Add 2nd doc that should be repaired
@@ -45,7 +47,8 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 	if err != nil {
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
-	_, _ = bucket.Add(docIdProblematicRevTree2, 0, rawDoc)
+	_, err = bucket.Add(docIdProblematicRevTree2, 0, rawDoc)
+	require.NoError(tester, err)
 	numDocsAdded++
 
 	return tBucket, numDocsAdded

--- a/db/revision.go
+++ b/db/revision.go
@@ -97,7 +97,7 @@ func (body Body) ShallowCopy() Body {
 
 func (body Body) DeepCopy() Body {
 	var copiedBody Body
-	base.DeepCopyInefficient(&copiedBody, body)
+	_ = base.DeepCopyInefficient(&copiedBody, body)
 	return copiedBody
 }
 

--- a/db/revision.go
+++ b/db/revision.go
@@ -97,7 +97,10 @@ func (body Body) ShallowCopy() Body {
 
 func (body Body) DeepCopy() Body {
 	var copiedBody Body
-	_ = base.DeepCopyInefficient(&copiedBody, body)
+	err := base.DeepCopyInefficient(&copiedBody, body)
+	if err != nil {
+		base.Infof(base.KeyCRUD, "Error copying body: %v", err)
+	}
 	return copiedBody
 }
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -183,7 +183,8 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	// Get the raw document directly from the bucket, validate _revisions property isn't found
 	var bucketBody Body
-	_, _ = testBucket.Bucket.Get("doc1", &bucketBody)
+	_, err = testBucket.Bucket.Get("doc1", &bucketBody)
+	require.NoError(t, err)
 	_, ok := bucketBody[BodyRevisions]
 	if ok {
 		t.Error("_revisions property still present in document retrieved directly from bucket.")

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -183,7 +183,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	// Get the raw document directly from the bucket, validate _revisions property isn't found
 	var bucketBody Body
-	testBucket.Bucket.Get("doc1", &bucketBody)
+	_, _ = testBucket.Bucket.Get("doc1", &bucketBody)
 	_, ok := bucketBody[BodyRevisions]
 	if ok {
 		t.Error("_revisions property still present in document retrieved directly from bucket.")

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -157,7 +157,10 @@ func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs 
 					Parent:  parentRevId,
 					Deleted: true,
 				}
-				_ = revTree.addRevision("testdoc", revInfo)
+				err := revTree.addRevision("testdoc", revInfo)
+				if err != nil {
+					panic(fmt.Sprintf("Error: %v", err))
+				}
 
 			}
 

--- a/db/revtree_test.go
+++ b/db/revtree_test.go
@@ -157,7 +157,7 @@ func getMultiBranchTestRevtree1(unconflictedBranchNumRevs, winningBranchNumRevs 
 					Parent:  parentRevId,
 					Deleted: true,
 				}
-				revTree.addRevision("testdoc", revInfo)
+				_ = revTree.addRevision("testdoc", revInfo)
 
 			}
 
@@ -265,7 +265,7 @@ func TestRevTreeAddRevision(t *testing.T) {
 	tempmap := testmap.copy()
 	goassert.DeepEquals(t, tempmap, testmap)
 
-	tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
+	_ = tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
 	goassert.Equals(t, tempmap.getParent("4-four"), "3-three")
 }
 
@@ -315,12 +315,12 @@ func TestRevTreeWinningRev(t *testing.T) {
 	goassert.Equals(t, winner, "3-three")
 	goassert.True(t, branched)
 	goassert.True(t, conflict)
-	tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
+	_ = tempmap.addRevision("testdoc", RevInfo{ID: "4-four", Parent: "3-three"})
 	winner, branched, conflict = tempmap.winningRevision()
 	goassert.Equals(t, winner, "4-four")
 	goassert.True(t, branched)
 	goassert.True(t, conflict)
-	tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four", Deleted: true})
+	_ = tempmap.addRevision("testdoc", RevInfo{ID: "5-five", Parent: "4-four", Deleted: true})
 	winner, branched, conflict = tempmap.winningRevision()
 	goassert.Equals(t, winner, "3-drei")
 	goassert.True(t, branched)
@@ -648,7 +648,7 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	revTree := getMultiBranchTestRevtree1(1, 15, branchSpecs)
 
 	if dumpRevTreeDotFiles {
-		ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_initial.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		_ = ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_initial.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 	}
 
 	maxDepth := uint32(7)
@@ -656,7 +656,7 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	revTree.pruneRevisions(maxDepth, "")
 
 	if dumpRevTreeDotFiles {
-		ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned1.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		_ = ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned1.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 	}
 
 	winningBranchStartRev := fmt.Sprintf("%d-%s", 16, "winning")
@@ -670,13 +670,13 @@ func TestPruneDisconnectedRevTreeWithLongWinningBranch(t *testing.T) {
 	)
 
 	if dumpRevTreeDotFiles {
-		ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_add_winning_revs.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		_ = ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_add_winning_revs.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 	}
 
 	revTree.pruneRevisions(maxDepth, "")
 
 	if dumpRevTreeDotFiles {
-		ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned_final.dot", []byte(revTree.RenderGraphvizDot()), 0666)
+		_ = ioutil.WriteFile("/tmp/TestPruneDisconnectedRevTreeWithLongWinningBranch_pruned_final.dot", []byte(revTree.RenderGraphvizDot()), 0666)
 	}
 
 	// Make sure the winning branch is pruned down to maxDepth, even with the disconnected rev tree
@@ -935,7 +935,7 @@ func TestRevisionPruningLoop(t *testing.T) {
 func addAndGet(revTree RevTree, revID string, parentRevID string, isTombstone bool) error {
 
 	revBody := []byte(`{"foo":"bar"}`)
-	revTree.addRevision("foobar", RevInfo{
+	_ = revTree.addRevision("foobar", RevInfo{
 		ID:      revID,
 		Parent:  parentRevID,
 		Body:    revBody,
@@ -948,7 +948,7 @@ func addAndGet(revTree RevTree, revID string, parentRevID string, isTombstone bo
 }
 
 func addPruneAndGet(revTree RevTree, revID string, parentRevID string, revBody []byte, revsLimit uint32, tombstone bool) (numPruned int, err error) {
-	revTree.addRevision("doc", RevInfo{
+	_ = revTree.addRevision("doc", RevInfo{
 		ID:      revID,
 		Parent:  parentRevID,
 		Body:    revBody,
@@ -1049,7 +1049,7 @@ func addRevs(revTree RevTree, startingParentRevId string, numRevs int, revDigest
 			Deleted:  false,
 			Channels: channels,
 		}
-		revTree.addRevision("testdoc", revInfo)
+		_ = revTree.addRevision("testdoc", revInfo)
 
 		generation += 1
 

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -76,7 +76,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 			// Updating:
 			var generation uint
 			if matchRev != "" {
-				fmt.Sscanf(matchRev, "0-%d", &generation)
+				_, _ = fmt.Sscanf(matchRev, "0-%d", &generation)
 			}
 			revid = fmt.Sprintf("0-%d", generation+1)
 			body[BodyRev] = revid

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -72,10 +72,7 @@ func (h *handler) handleDbOnline() error {
 
 	input.Delay = kDefaultDBOnlineDelay
 
-	err = base.JSONUnmarshal(body, &input)
-	if err != nil {
-		base.Infof(base.KeyCRUD, "Error marshalling JSON body: %v", err)
-	}
+	_ = base.JSONUnmarshal(body, &input)
 
 	base.Infof(base.KeyCRUD, "Taking Database : %v, online in %v seconds", base.MD(h.db.Name), input.Delay)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -101,7 +101,7 @@ func TestUserAPI(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["name"], "snej")
 	goassert.Equals(t, body["email"], "jens@couchbase.com")
 	goassert.DeepEquals(t, body["admin_channels"], []interface{}{"bar", "foo"})
@@ -141,7 +141,7 @@ func TestUserAPI(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_user/snej", "")
 	assertStatus(t, response, 200)
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["name"], "snej")
 
 	// Create a role
@@ -447,7 +447,7 @@ func TestLoggingKeys(t *testing.T) {
 	//Assert default log channels are enabled
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &logKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
 	goassert.DeepEquals(t, logKeys, map[string]interface{}{})
 
 	//Set logKeys, Changes+ should enable Changes (PUT replaces any existing log keys)
@@ -455,7 +455,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var updatedLogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &updatedLogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &updatedLogKeys))
 	goassert.DeepEquals(t, updatedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
 
 	//Disable Changes logKey which should also disable Changes+
@@ -463,7 +463,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var deletedLogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &deletedLogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &deletedLogKeys))
 	goassert.DeepEquals(t, deletedLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Enable Changes++, which should enable Changes (POST append logKeys)
@@ -471,7 +471,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var appendedLogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &appendedLogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &appendedLogKeys))
 	goassert.DeepEquals(t, appendedLogKeys, map[string]interface{}{"Changes": true, "Cache": true, "HTTP": true})
 
 	//Disable Changes++ (POST modifies logKeys)
@@ -479,7 +479,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabledLogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &disabledLogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &disabledLogKeys))
 	goassert.DeepEquals(t, disabledLogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Re-Enable Changes++, which should enable Changes (POST append logKeys)
@@ -490,7 +490,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled2LogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &disabled2LogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &disabled2LogKeys))
 	goassert.DeepEquals(t, disabled2LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Re-Enable Changes++, which should enable Changes (POST append logKeys)
@@ -501,7 +501,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var disabled3LogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &disabled3LogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &disabled3LogKeys))
 	goassert.DeepEquals(t, disabled3LogKeys, map[string]interface{}{"Cache": true, "HTTP": true})
 
 	//Disable all logKeys by using PUT with an empty channel list
@@ -509,7 +509,7 @@ func TestLoggingKeys(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
 	var noLogKeys map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &noLogKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &noLogKeys))
 	goassert.DeepEquals(t, noLogKeys, map[string]interface{}{})
 }
 
@@ -523,7 +523,7 @@ func TestLoggingLevels(t *testing.T) {
 	// Log keys should be blank
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]bool
-	base.JSONUnmarshal(response.Body.Bytes(), &logKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
 	goassert.DeepEquals(t, logKeys, map[string]bool{})
 
 	// Set log level via logLevel query parameter
@@ -557,14 +557,14 @@ func TestLoggingCombined(t *testing.T) {
 	// Log keys should be blank
 	response := rt.SendAdminRequest("GET", "/_logging", "")
 	var logKeys map[string]bool
-	base.JSONUnmarshal(response.Body.Bytes(), &logKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
 	goassert.DeepEquals(t, logKeys, map[string]bool{})
 
 	// Set log keys and log level in a single request
 	assertStatus(t, rt.SendAdminRequest("PUT", "/_logging?logLevel=trace", `{"Changes":true, "Cache":true, "HTTP":true}`), http.StatusOK)
 
 	response = rt.SendAdminRequest("GET", "/_logging", "")
-	base.JSONUnmarshal(response.Body.Bytes(), &logKeys)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &logKeys))
 	goassert.DeepEquals(t, logKeys, map[string]bool{"Changes": true, "Cache": true, "HTTP": true})
 }
 
@@ -684,7 +684,7 @@ func TestRoleAPI(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["name"], "hipster")
 	goassert.DeepEquals(t, body["admin_channels"], []interface{}{"fedoras", "fixies"})
 	goassert.Equals(t, body["password"], nil)
@@ -705,7 +705,7 @@ func TestRoleAPI(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_role/hipster", "")
 	assertStatus(t, response, 200)
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["name"], "hipster")
 	assertStatus(t, rt.SendAdminRequest("DELETE", "/db/_role/hipster", ""), 200)
 }
@@ -721,7 +721,7 @@ func TestGuestUser(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodGet, guestUserEndpoint, "")
 	assertStatus(t, response, http.StatusOK)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["name"], base.GuestUsername)
 	// This ain't no admin-party, this ain't no nightclub, this ain't no fooling around:
 	goassert.DeepEquals(t, body["admin_channels"], nil)
@@ -733,7 +733,7 @@ func TestGuestUser(t *testing.T) {
 	// Get guest user and verify it is now disabled:
 	response = rt.SendAdminRequest(http.MethodGet, guestUserEndpoint, "")
 	assertStatus(t, response, http.StatusOK)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["name"], base.GuestUsername)
 	goassert.DeepEquals(t, body["disabled"], true)
 
@@ -770,7 +770,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	assertStatus(t, response, 401)
 
 	user, err = a.NewUser("pupshaw", "letmein", channels.SetOf(t, "*"))
-	a.Save(user)
+	assert.NoError(t, a.Save(user))
 
 	//create a session with the maximum offset ttl value (30days) 2592000 seconds
 	response = rt.SendAdminRequest("POST", "/db/_session", `{"name":"pupshaw", "ttl":2592000}`)
@@ -779,7 +779,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	layout := "2006-01-02T15:04:05"
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 
 	log.Printf("expires %s", body["expires"].(string))
 	expires, err := time.Parse(layout, body["expires"].(string)[:19])
@@ -790,7 +790,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("expires2 %s", body["expires"].(string))
 	expires2, err := time.Parse(layout, body["expires"].(string)[:19])
 	assert.NoError(t, err)
@@ -965,14 +965,14 @@ func TestDBOfflineSingle(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 }
 
@@ -988,7 +988,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	//Take DB offline concurrently using two goroutines
@@ -1016,7 +1016,7 @@ func TestDBOfflineConcurrent(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 }
@@ -1030,14 +1030,14 @@ func TestStartDBOffline(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, 200)
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 }
 
@@ -1052,7 +1052,7 @@ func TestDBOffline503Response(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1060,7 +1060,7 @@ func TestDBOffline503Response(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	assertStatus(t, rt.SendRequest("GET", "/db/doc1", ""), 503)
@@ -1076,7 +1076,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1084,7 +1084,7 @@ func TestDBOfflinePutDbConfig(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	assertStatus(t, rt.SendRequest("PUT", "/db/_config", ""), 404)
@@ -1109,7 +1109,7 @@ func TestDBGetConfigNames(t *testing.T) {
 
 	response := rt.SendAdminRequest("GET", "/db/_config", "")
 	var body DbConfig
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 
 	goassert.Equals(t, len(body.Users), len(rt.DatabaseConfig.Users))
 
@@ -1133,7 +1133,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1141,7 +1141,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	assertStatus(t, rt.SendAdminRequest("POST", "/db/_resync", ""), 200)
@@ -1165,7 +1165,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1173,7 +1173,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	input := bytes.NewBufferString("")
@@ -1214,7 +1214,7 @@ func TestDBOnlineSingle(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1222,7 +1222,7 @@ func TestDBOnlineSingle(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	rt.SendAdminRequest("POST", "/db/_online", "")
@@ -1232,7 +1232,7 @@ func TestDBOnlineSingle(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 }
 
@@ -1248,7 +1248,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1256,7 +1256,7 @@ func TestDBOnlineConcurrent(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	var wg sync.WaitGroup
@@ -1301,7 +1301,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1309,7 +1309,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	rt.SendAdminRequest("POST", "/db/_online", "{\"delay\":1}")
@@ -1317,7 +1317,7 @@ func TestSingleDBOnlineWithDelay(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
@@ -1346,7 +1346,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 	log.Printf("Taking DB offline")
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1354,7 +1354,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	//Bring DB online with delay of two seconds
@@ -1371,7 +1371,7 @@ func TestDBOnlineWithDelayAndImmediate(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	// Wait until after the 1 second delay, since the online request explicitly asked for a delay
@@ -1399,7 +1399,7 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 
 	response := rt.SendAdminRequest("GET", "/db/", "")
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	rt.SendAdminRequest("POST", "/db/_offline", "")
@@ -1407,7 +1407,7 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	//Bring DB online with delay of one seconds
@@ -1420,21 +1420,21 @@ func TestDBOnlineWithTwoDelays(t *testing.T) {
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Offline")
 
 	time.Sleep(1500 * time.Millisecond)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 
 	time.Sleep(600 * time.Millisecond)
 
 	response = rt.SendAdminRequest("GET", "/db/", "")
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.True(t, body["state"].(string) == "Online")
 }
 
@@ -1444,7 +1444,7 @@ func (rt *RestTester) createSession(t *testing.T, username string) string {
 	assertStatus(t, response, 200)
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	sessionId := body["session_id"].(string)
 
 	return sessionId
@@ -1468,7 +1468,7 @@ func TestPurgeWithNonArrayRevisionList(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
@@ -1481,7 +1481,7 @@ func TestPurgeWithEmptyRevisionList(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
@@ -1494,7 +1494,7 @@ func TestPurgeWithGreaterThanOneRevision(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
@@ -1507,7 +1507,7 @@ func TestPurgeWithNonStarRevision(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{}})
 }
 
@@ -1520,7 +1520,7 @@ func TestPurgeWithStarRevision(t *testing.T) {
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"]}`)
 	assertStatus(t, response, 200)
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	//Create new versions of the doc1 without conflicts
@@ -1538,7 +1538,7 @@ func TestPurgeWithMultipleValidDocs(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}, "doc2": []interface{}{"*"}}})
 
 	//Create new versions of the docs without conflicts
@@ -1564,7 +1564,7 @@ func TestPurgeWithChannelCache(t *testing.T) {
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"]}`)
 	assertStatus(t, resp, http.StatusOK)
 	var body map[string]interface{}
-	base.JSONUnmarshal(resp.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	changes, err = rt.WaitForChanges(1, "/db/_changes?filter=sync_gateway/bychannel&channels=abc,def", "", true)
@@ -1583,7 +1583,7 @@ func TestPurgeWithSomeInvalidDocs(t *testing.T) {
 	response := rt.SendAdminRequest("POST", "/db/_purge", `{"doc1":["*"],"doc2":["1-123"]}`)
 	assertStatus(t, response, 200)
 	var body map[string]interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.DeepEquals(t, body, map[string]interface{}{"purged": map[string]interface{}{"doc1": []interface{}{"*"}}})
 
 	//Create new versions of the doc1 without conflicts

--- a/rest/api.go
+++ b/rest/api.go
@@ -307,7 +307,7 @@ func (h *handler) handleProfiling() error {
 	}
 
 	if fileCloseError := f.Close(); fileCloseError != nil {
-		base.WarnfCtx(h.db.Ctx, "Error closing profile file: %v", err)
+		base.WarnfCtx(h.db.Ctx, "Error closing profile file: %v", fileCloseError)
 	}
 
 	return err

--- a/rest/api.go
+++ b/rest/api.go
@@ -278,16 +278,16 @@ func (h *handler) handleProfiling() error {
 			return err
 		}
 		if profileName != "" {
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 			if profile := pprof.Lookup(profileName); profile != nil {
-				profile.WriteTo(f, 0)
+				_ = profile.WriteTo(f, 0)
 				base.Infof(base.KeyAll, "Wrote %s profile to %s", profileName, base.UD(params.File))
 			} else {
 				return base.HTTPErrorf(http.StatusNotFound, "No such profile %q", profileName)
 			}
 		} else {
 			base.Infof(base.KeyAll, "Starting CPU profile to %s ...", base.UD(params.File))
-			pprof.StartCPUProfile(f)
+			_ = pprof.StartCPUProfile(f)
 		}
 	} else {
 		if profileName != "" {
@@ -318,8 +318,8 @@ func (h *handler) handleHeapProfiling() error {
 	if err != nil {
 		return err
 	}
-	pprof.WriteHeapProfile(f)
-	f.Close()
+	_ = pprof.WriteHeapProfile(f)
+	_ = f.Close()
 	return nil
 }
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -295,13 +295,6 @@ func (h *handler) handleProfiling() error {
 		return err
 	}
 
-	defer func() {
-		fErr := f.Close()
-		if fErr != nil {
-			base.WarnfCtx(h.db.Ctx, "Error closing profile file: %v", err)
-		}
-	}()
-
 	if isCPUProfile {
 		base.Infof(base.KeyAll, "Starting CPU profile to %s ...", base.UD(params.File))
 		err = pprof.StartCPUProfile(f)

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"strings"
 	"testing"
@@ -65,7 +66,7 @@ func BenchmarkReadOps_Get(b *testing.B) {
 	doc1k_putDoc := fmt.Sprintf(doc_1k_format, "")
 	response := rt.SendAdminRequest("PUT", "/db/doc1k", doc1k_putDoc)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(b, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
 	// Create user
@@ -125,7 +126,7 @@ func BenchmarkReadOps_GetRevCacheMisses(b *testing.B) {
 		// revid will be the same for all docs
 		if i == 0 {
 			var body db.Body
-			base.JSONUnmarshal(response.Body.Bytes(), &body)
+			require.NoError(b, base.JSONUnmarshal(response.Body.Bytes(), &body))
 			revid = body["rev"].(string)
 		}
 	}
@@ -193,7 +194,7 @@ func BenchmarkReadOps_Changes(b *testing.B) {
 	}
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(b, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 	_, rev1_digest := db.ParseRevID(revid)
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc1k?rev=%s", revid), doc1k_putDoc)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -56,7 +56,7 @@ func TestRoot(t *testing.T) {
 	response := rt.SendRequest("GET", "/", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["couchdb"], "Welcome")
 
 	response = rt.SendRequest("HEAD", "/", "")
@@ -94,7 +94,7 @@ func (rt *RestTester) createDoc(t *testing.T, docid string) string {
 	response := rt.SendRequest("PUT", "/db/"+docid, `{"prop":true}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revid := body["rev"].(string)
 	if revid == "" {
@@ -122,7 +122,7 @@ func TestDocEtag(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revid := body["rev"].(string)
 	if revid == "" {
@@ -141,7 +141,7 @@ func TestDocEtag(t *testing.T) {
 	//Validate Etag returned when updating doc
 	response = rt.SendRequest("PUT", "/db/doc?rev="+revid, `{"prop":false}`)
 	revid = body["rev"].(string)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revid = body["rev"].(string)
 	if revid == "" {
@@ -161,7 +161,7 @@ func TestDocEtag(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc/attach1?rev="+revid, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -192,7 +192,7 @@ func TestDocAttachment(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc", `{"prop":true}`)
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
 	attachmentBody := "this is the body of attachment"
@@ -238,18 +238,18 @@ func TestDocAttachmentOnRemovedRev(t *testing.T) {
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
-	a.Save(user)
+	assert.NoError(t, a.Save(user))
 
 	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
 	//Put new revision removing document from users channel set
 	response = rt.Send(requestByUser("PUT", "/db/doc?rev="+revid, `{"prop":true}`, "user1"))
 	assertStatus(t, response, 201)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid = body["rev"].(string)
 
 	attachmentBody := "this is the body of attachment"
@@ -276,12 +276,12 @@ func TestDocumentUpdateWithNullBody(t *testing.T) {
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", channels.SetOf(t, "foo"))
-	a.Save(user)
+	assert.NoError(t, a.Save(user))
 	//Create document
 	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user1"))
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revid := body["rev"].(string)
 
 	//Put new revision with null body
@@ -348,7 +348,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 
@@ -380,7 +380,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/AC%2FDC/attachpath%2Fattachment.txt?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment = body["rev"].(string)
 
@@ -412,7 +412,7 @@ func TestFunkyDocAndAttachmentIDs(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/AC%2BDC%2BGC2/attachpath%2Fattachment.txt?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment = body["rev"].(string)
 
@@ -551,7 +551,7 @@ func TestCORSLogoutOriginOnSessionDelete(t *testing.T) {
 	assertStatus(t, response, 404)
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["reason"], "no session")
 }
 
@@ -571,7 +571,7 @@ func TestCORSLogoutOriginOnSessionDeleteNoCORSConfig(t *testing.T) {
 	assertStatus(t, response, 400)
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["reason"], "No CORS")
 }
 
@@ -587,7 +587,7 @@ func TestNoCORSOriginOnSessionDelete(t *testing.T) {
 	assertStatus(t, response, 400)
 
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["reason"], "No CORS")
 }
 
@@ -620,7 +620,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -648,7 +648,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+revIdAfterAttachment, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	body = db.Body{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterUpdateAttachment := body["rev"].(string)
 	if revIdAfterUpdateAttachment == "" {
@@ -662,7 +662,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1", attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	body = db.Body{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterUpdateAttachmentAgain := body["rev"].(string)
 	if revIdAfterUpdateAttachmentAgain == "" {
@@ -684,7 +684,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequest("PUT", "/db/doc1/attach2?rev="+revIdAfterUpdateAttachmentAgain, attachmentBody)
 	assertStatus(t, response, 201)
 	body = db.Body{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterSecondAttachment := body["rev"].(string)
 	if revIdAfterSecondAttachment == "" {
@@ -702,7 +702,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendRequest("GET", "/db/doc1", "")
 	assertStatus(t, response, 200)
 	body = db.Body{}
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	bodyAttachments, ok := body["_attachments"].(map[string]interface{})
 	if !ok {
 		t.Errorf("Attachments must be map")
@@ -740,7 +740,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	response = rt.SendRequestWithHeaders("PUT", "/db/notexistyet/attach1", attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -757,7 +757,7 @@ func TestManualAttachmentNewDoc(t *testing.T) {
 	body = db.Body{}
 	response = rt.SendRequest("GET", "/db/notexistyet", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	// body should only have 3 top-level entries _id, _rev, _attachments
 	goassert.True(t, len(body) == 3)
 }
@@ -815,7 +815,7 @@ func TestBulkDocsIDGeneration(t *testing.T) {
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 	var docs []map[string]string
-	base.JSONUnmarshal(response.Body.Bytes(), &docs)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	log.Printf("response: %s", response.Body.Bytes())
 	assertStatus(t, response, 201)
 	goassert.Equals(t, len(docs), 2)
@@ -1274,7 +1274,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 
 	//Create a test user
 	user, err = a.NewUser("user1", "letmein", nil)
-	a.Save(user)
+	assert.NoError(t, a.Save(user))
 
 	input := `{"docs": [{"_id": "bulk1", "type" : "setaccess", "owner":"user1" , "channel":"chan1"}, {"_id": "bulk2" , "channel":"chan1"}]}`
 
@@ -1282,7 +1282,7 @@ func TestBulkDocsChangeToAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	var docs []interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &docs)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	goassert.Equals(t, len(docs), 2)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-afbcffa8a4641a0f4dd94d3fc9593e74", "id": "bulk1"})
@@ -1335,7 +1335,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	var docs []interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &docs)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	goassert.Equals(t, len(docs), 2)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "1-17424d2a21bf113768dfdbcd344741ac", "id": "bulk1"})
@@ -1356,7 +1356,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
 	response := rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
 	var docs []interface{}
-	base.JSONUnmarshal(response.Body.Bytes(), &docs)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	goassert.Equals(t, len(docs), 2)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "12-abc", "id": "bdne1"})
@@ -1370,7 +1370,7 @@ func TestBulkDocsNoEdits(t *testing.T) {
             ]}`
 	response = rt.SendRequest("POST", "/db/_bulk_docs", input)
 	assertStatus(t, response, 201)
-	base.JSONUnmarshal(response.Body.Bytes(), &docs)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &docs))
 	goassert.Equals(t, len(docs), 1)
 	goassert.DeepEquals(t, docs[0],
 		map[string]interface{}{"rev": "14-jkl", "id": "bdne1"})
@@ -1402,7 +1402,7 @@ func TestRevsDiff(t *testing.T) {
 	response = rt.SendRequest("POST", "/db/_revs_diff", input)
 	assertStatus(t, response, 200)
 	var diffResponse RevsDiffResponse
-	base.JSONUnmarshal(response.Body.Bytes(), &diffResponse)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &diffResponse))
 	sort.Strings(diffResponse["rd1"]["possible_ancestors"])
 	goassert.DeepEquals(t, diffResponse, RevsDiffResponse{
 		"rd1": RevDiffResponse{"missing": []string{"13-def", "12-xyz"},
@@ -1463,17 +1463,17 @@ func TestBulkGetPerDocRevsLimit(t *testing.T) {
 
 		response := rt.SendRequest("PUT", fmt.Sprintf("/db/%v", k), fmt.Sprintf(`{"val":"1-%s"}`, k))
 		assertStatus(t, response, 201)
-		base.JSONUnmarshal(response.Body.Bytes(), &body)
+		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		rev := body["rev"].(string)
 
 		response = rt.SendRequest("PUT", fmt.Sprintf("/db/%v?rev=%s", k, rev), fmt.Sprintf(`{"val":"2-%s"}`, k))
 		assertStatus(t, response, 201)
-		base.JSONUnmarshal(response.Body.Bytes(), &body)
+		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		rev = body["rev"].(string)
 
 		response = rt.SendRequest("PUT", fmt.Sprintf("/db/%v?rev=%s", k, rev), fmt.Sprintf(`{"val":"3-%s"}`, k))
 		assertStatus(t, response, 201)
-		base.JSONUnmarshal(response.Body.Bytes(), &body)
+		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		rev = body["rev"].(string)
 
 		docs[k] = rev
@@ -1662,7 +1662,7 @@ func TestLogin(t *testing.T) {
 	assertStatus(t, response, 401)
 
 	user, err = a.NewUser("pupshaw", "letmein", channels.SetOf(t, "*"))
-	a.Save(user)
+	assert.NoError(t, a.Save(user))
 
 	assertStatus(t, rt.SendRequest("GET", "/db/_session", ""), 200)
 
@@ -2135,7 +2135,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	// Look at alice's _changes feed:
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	assert.Equal(t, 1, len(changes.Results))
 	assert.NoError(t, err)
 	assert.Equal(t, "d1", changes.Results[0].ID)
@@ -2143,7 +2143,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	// The complete _changes feed for zegpold contains docs a1 and g1:
 	changes = changesResults{}
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "g1", changes.Results[0].ID)
@@ -2158,7 +2158,7 @@ func TestChannelAccessChanges(t *testing.T) {
 		"", "zegpold"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	assert.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "a1", changes.Results[0].ID)
 
@@ -2502,14 +2502,14 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_role/role1", "")
 	assertStatus(t, response, 200)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "role1", body["name"])
 
 	//Put document to trigger sync function
 	response = rt.Send(request("PUT", "/db/doc1", `{"user":"user1", "role":"role:role1", "channel":"chan1"}`)) // seq=1
 	assertStatus(t, response, 201)
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 
 	// POST the new user the GET and verify that it shows the assigned role
@@ -2518,7 +2518,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/_user/user1", "")
 	assertStatus(t, response, 200)
 	body = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, "user1", body["name"])
 	goassert.DeepEquals(t, body["roles"], []interface{}{"role1"})
 	goassert.DeepEquals(t, body["all_channels"], []interface{}{"!", "chan1"})
@@ -2568,7 +2568,7 @@ func TestRoleAccessChanges(t *testing.T) {
 		`{"user":"alice","role":["role:hipster","role:bogus"]}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 	fashionRevID := body["rev"].(string)
 
@@ -2616,7 +2616,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	cacheWaiter.Wait()
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("1st _changes looks like: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Equal(t, 3, len(changes.Results))
 	assert.Equal(t, "_user/alice", changes.Results[0].ID)
 	assert.Equal(t, "g1", changes.Results[1].ID)
@@ -2624,7 +2624,7 @@ func TestRoleAccessChanges(t *testing.T) {
 
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("2nd _changes looks like: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Equal(t, 2, len(changes.Results))
 	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
 	assert.Equal(t, "b1", changes.Results[1].ID)
@@ -2661,7 +2661,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	changes.Results = nil
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "zegpold"))
 	log.Printf("3rd _changes looks like: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	log.Printf("changes: %+v", changes.Results)
 	require.Equal(t, len(changes.Results), 3)
 	assert.Equal(t, "_user/zegpold", changes.Results[0].ID)
@@ -2673,7 +2673,7 @@ func TestRoleAccessChanges(t *testing.T) {
 	response = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%v", lastSeqPreGrant), "", "zegpold"))
 	log.Printf("4th _changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
-	base.JSONUnmarshal(response.Body.Bytes(), &changes)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
 	require.Equal(t, 1, len(changes.Results))
 	assert.Equal(t, "g1", changes.Results[0].ID)
 }
@@ -2712,7 +2712,7 @@ func TestAllDocsChannelsAfterChannelMove(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/doc1", `{"foo":"bar", "channels":["ch1"]}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	doc1RevID := body["rev"].(string)
 
@@ -2787,7 +2787,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	response := rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev="+doc1revId, attachmentBody, reqHeaders)
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revIdAfterAttachment := body["rev"].(string)
 	if revIdAfterAttachment == "" {
@@ -2803,7 +2803,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	response = rt.SendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, doc1revId), "", reqHeaders)
 	goassert.Equals(t, response.Code, 200)
 	//validate attachment has data property
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("response body revid1 = %s", body)
 	attachments := body["_attachments"].(map[string]interface{})
 	attach1 := attachments["attach1"].(map[string]interface{})
@@ -2813,7 +2813,7 @@ func TestAttachmentsNoCrossTalk(t *testing.T) {
 	log.Printf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment)
 	response = rt.SendRequestWithHeaders("GET", fmt.Sprintf("/db/doc1?rev=%s&revs=true&attachments=true&atts_since=[\"%s\"]", revIdAfterAttachment, revIdAfterAttachment), "", reqHeaders)
 	goassert.Equals(t, response.Code, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("response body revid1 = %s", body)
 	attachments = body["_attachments"].(map[string]interface{})
 	attach1 = attachments["attach1"].(map[string]interface{})
@@ -2928,7 +2928,7 @@ func TestOldDocHandling(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/testOldDocId", `{"foo":"bar"}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	alphaRevID := body["rev"].(string)
 
@@ -3298,20 +3298,20 @@ func TestBulkGetRevPruning(t *testing.T) {
 	// Do a write
 	response := rt.SendRequest("PUT", "/db/doc1", `{"channels":[]}`)
 	assertStatus(t, response, 201)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId := body["rev"]
 
 	// Update 10 times
 	for i := 0; i < 20; i++ {
 		str := fmt.Sprintf(`{"_rev":%q}`, revId)
 		response = rt.Send(request("PUT", "/db/doc1", str))
-		base.JSONUnmarshal(response.Body.Bytes(), &body)
+		require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 		revId = body["rev"]
 	}
 
 	// Get latest rev id
 	response = rt.SendRequest("GET", "/db/doc1", "")
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId = body[db.BodyRev]
 
 	// Spin up several goroutines to all try to do a _bulk_get on the latest revision.
@@ -3360,7 +3360,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 	resource := fmt.Sprintf("/db/%v", docIdDoc1)
 	response := rt.SendRequest("PUT", resource, `{"prop":true}`)
 	assertStatus(t, response, 201)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revidDoc1 := body["rev"].(string)
 
 	// Add another doc
@@ -3443,7 +3443,7 @@ func TestBulkGetBadAttachmentReproIssue2528(t *testing.T) {
 
 	// Get latest rev id
 	response = rt.SendRequest("GET", resource, "")
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId := body[db.BodyRev]
 
 	// Do a bulk_get to get the doc -- this was causing a panic prior to the fix for #2528
@@ -3550,7 +3550,7 @@ func TestDocExpiry(t *testing.T) {
 	// Validate that exp isn't returned on the standard GET, bulk get
 	response = rt.SendRequest("GET", "/db/expNumericTTL", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok := body["_exp"]
 	goassert.Equals(t, ok, false)
 
@@ -3568,7 +3568,7 @@ func TestDocExpiry(t *testing.T) {
 	body = nil
 	response = rt.SendRequest("GET", "/db/expNumericTTL?show_exp=true", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
 
@@ -3578,7 +3578,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/expNumericUnix?show_exp=true", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	log.Printf("numeric unix response: %s", response.Body.Bytes())
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
@@ -3588,7 +3588,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/expNumericString?show_exp=true", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
 
@@ -3597,7 +3597,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 400)
 	response = rt.SendRequest("GET", "/db/expBadString?show_exp=true", "")
 	assertStatus(t, response, 404)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, false)
 
@@ -3606,7 +3606,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 201)
 	response = rt.SendRequest("GET", "/db/expDateString?show_exp=true", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, true)
 
@@ -3615,7 +3615,7 @@ func TestDocExpiry(t *testing.T) {
 	assertStatus(t, response, 400)
 	response = rt.SendRequest("GET", "/db/expBadDateString?show_exp=true", "")
 	assertStatus(t, response, 404)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	_, ok = body["_exp"]
 	goassert.Equals(t, ok, false)
 
@@ -3633,7 +3633,7 @@ func TestDocSyncFunctionExpiry(t *testing.T) {
 
 	response = rt.SendRequest("GET", "/db/expNumericTTL?show_exp=true", "")
 	assertStatus(t, response, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	value, ok := body["_exp"]
 	goassert.Equals(t, ok, true)
 	log.Printf("value: %v", value)
@@ -3870,13 +3870,13 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc1", `{"channels": ["A"]}`)
 	assert.Equal(t, http.StatusCreated, response.Code)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevID := body["rev"].(string)
 
 	//Delete Doc
 	response = rt.SendRequest("DELETE", "/db/doc1?rev="+docRevID, "")
 	assert.Equal(t, http.StatusOK, response.Code)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevID2 := body["rev"].(string)
 
 	//Update / Revive Doc
@@ -3892,7 +3892,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 
 	var changesResponse = make(map[string]interface{})
-	base.JSONUnmarshal(response.Body.Bytes(), &changesResponse)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changesResponse))
 	assert.NotContains(t, changesResponse["results"].([]interface{})[1], "deleted")
 }
 
@@ -3999,14 +3999,14 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	response := rt.SendRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev2)
 	assertStatus(t, response, http.StatusCreated)
 
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId2 := body["rev"].(string)
 	assert.Equal(t, "2-two", docRevId2)
 
 	reqBodyRev2a := `{"_rev": "2-two", "_revisions": {"ids": ["twoa", "` + docRevDigest + `"], "start": 2}}`
 	response = rt.SendRequest("PUT", "/db/doc1?new_edits=false", reqBodyRev2a)
 	assertStatus(t, response, http.StatusCreated)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId2a := body["rev"].(string)
 	assert.Equal(t, "2-twoa", docRevId2a)
 
@@ -4020,28 +4020,28 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	rev3Attachment := `aGVsbG8gd29ybGQ=` //hello.txt
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1?rev=2-two", rev3Attachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3 := body["rev"].(string)
 
 	//Put attachment on doc1 conflicting rev 2a
 	rev3aAttachment := `Z29vZGJ5ZSBjcnVlbCB3b3JsZA==` //bye.txt
 	response = rt.SendRequestWithHeaders("PUT", "/db/doc1/attach1a?rev=2-twoa", rev3aAttachment, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId3a := body["rev"].(string)
 
 	//Perform small update on doc3
 	rev4Body := `{"_id": "doc1", "_attachments": {"attach1": {"content_type": "content/type", "digest": "sha1-b7fDq/pHG8Nf5F3fe0K2nu0xcw0=", "length": 16, "revpos": 3, "stub":true}}}`
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevId3, rev4Body)
 	assertStatus(t, response, http.StatusCreated)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4 := body["rev"].(string)
 
 	//Perform small update on doc3a
 	rev4aBody := `{"_id": "doc1", "_attachments": {"attach1a": {"content_type": "content/type", "digest": "sha1-rdfKyt3ssqPHnWBUxl/xauXXcUs=", "length": 28, "revpos": 3, "stub": true}}}`
 	response = rt.SendRequest("PUT", "/db/doc1?rev="+docRevId3a, rev4aBody)
 	assertStatus(t, response, http.StatusCreated)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	docRevId4a := body["rev"].(string)
 
 	//Ensure the two attachments are different
@@ -4051,8 +4051,8 @@ func TestConflictingBranchAttachments(t *testing.T) {
 	var body1 db.Body
 	var body2 db.Body
 
-	base.JSONUnmarshal(response1.Body.Bytes(), &body1)
-	base.JSONUnmarshal(response2.Body.Bytes(), &body2)
+	require.NoError(t, base.JSONUnmarshal(response1.Body.Bytes(), &body1))
+	require.NoError(t, base.JSONUnmarshal(response2.Body.Bytes(), &body2))
 
 	assert.NotEqual(t, body1["_attachments"], body2["_attachments"])
 
@@ -4071,7 +4071,7 @@ func TestNumAccessErrors(t *testing.T) {
 	//Create a test user
 	user, err := a.NewUser("user", "letmein", channels.SetOf(t, "A"))
 	assert.NoError(t, err)
-	a.Save(user)
+	assert.NoError(t, a.Save(user))
 
 	response := rt.Send(requestByUser("PUT", "/db/doc", `{"prop":true, "channels":["foo"]}`, "user"))
 	assertStatus(t, response, 403)
@@ -4079,7 +4079,7 @@ func TestNumAccessErrors(t *testing.T) {
 	responseBody := make(map[string]interface{})
 	response = rt.SendAdminRequest("GET", "/_expvar", "")
 
-	base.JSONUnmarshal(response.Body.Bytes(), &responseBody)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody))
 	numAccessErrors := responseBody["syncgateway"].(map[string]interface{})["per_db"].(map[string]interface{})["db"].(map[string]interface{})["security"].(map[string]interface{})["num_access_errors"]
 	assert.Equal(t, float64(1), numAccessErrors)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1309,7 +1309,7 @@ func TestBulkDocsChangeToRoleAccess(t *testing.T) {
 	// Create a role with no channels assigned to it
 	authenticator := rt.ServerContext().Database("db").Authenticator()
 	role, err := authenticator.NewRole("role1", nil)
-	authenticator.Save(role)
+	assert.NoError(t, authenticator.Save(role))
 
 	// Create a user with an explicit role grant for role1
 	user, err := authenticator.NewUser("user1", "letmein", nil)
@@ -1841,7 +1841,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 	// Create a user:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "Cinemax"))
-	a.Save(alice)
+	assert.NoError(t, a.Save(alice))
 
 	// Get a single doc the user has access to:
 	request, _ := http.NewRequest("GET", "/db/doc3", nil)
@@ -2036,9 +2036,9 @@ func TestChannelAccessChanges(t *testing.T) {
 
 	// Create users:
 	alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "zero"))
-	a.Save(alice)
+	assert.NoError(t, a.Save(alice))
 	zegpold, err := a.NewUser("zegpold", "letmein", channels.SetOf(t, "zero"))
-	a.Save(zegpold)
+	assert.NoError(t, a.Save(zegpold))
 
 	// Create some docs that give users access:
 	response := rt.Send(request("PUT", "/db/alpha", `{"owner":"alice"}`))
@@ -2394,10 +2394,9 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	guest, err := a.GetUser("")
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 	guest.SetDisabled(false)
-	err = a.Save(guest)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, a.Save(guest))
 
 	// Create user1
 	response := rt.SendAdminRequest("PUT", "/db/_user/user1", `{"email":"user1@couchbase.com", "password":"letmein", "admin_channels":["alpha"]}`)
@@ -2553,12 +2552,12 @@ func TestRoleAccessChanges(t *testing.T) {
 	assertStatus(t, response, 201)
 	/*
 		alice, err := a.NewUser("alice", "letmein", channels.SetOf(t, "alpha"))
-		a.Save(alice)
+		assert.NoError(t, a.Save(alice))
 		zegpold, err := a.NewUser("zegpold", "letmein", channels.SetOf(t, "beta"))
-		a.Save(zegpold)
+		assert.NoError(t, a.Save(zegpold))
 
 		hipster, err := a.NewRole("hipster", channels.SetOf(t, "gamma"))
-		a.Save(hipster)
+		assert.NoError(t, a.Save(hipster))
 	*/
 
 	// Create some docs in the channels:
@@ -2922,7 +2921,7 @@ func TestOldDocHandling(t *testing.T) {
 
 	// Create user:
 	frank, err := a.NewUser("charles", "1234", nil)
-	a.Save(frank)
+	assert.NoError(t, a.Save(frank))
 
 	// Create a doc:
 	response := rt.Send(request("PUT", "/db/testOldDocId", `{"foo":"bar"}`))
@@ -2988,7 +2987,7 @@ func TestStarAccess(t *testing.T) {
 	// Part 1 - Tests for user with single channel access:
 	//
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "books"))
-	a.Save(bernard)
+	assert.NoError(t, a.Save(bernard))
 
 	// GET /db/docid - basic test for channel user has
 	response := rt.Send(requestByUser("GET", "/db/doc1", "", "bernard"))
@@ -3063,7 +3062,7 @@ func TestStarAccess(t *testing.T) {
 
 	// Create a user:
 	fran, err := a.NewUser("fran", "letmein", channels.SetOf(t, "*"))
-	a.Save(fran)
+	assert.NoError(t, a.Save(fran))
 
 	// GET /db/docid - basic test for doc that has channel
 	response = rt.Send(requestByUser("GET", "/db/doc1", "", "fran"))
@@ -3110,7 +3109,7 @@ func TestStarAccess(t *testing.T) {
 	//
 	// Create a user:
 	manny, err := a.NewUser("manny", "letmein", nil)
-	a.Save(manny)
+	assert.NoError(t, a.Save(manny))
 
 	// GET /db/docid - basic test for doc that has channel
 	response = rt.Send(requestByUser("GET", "/db/doc1", "", "manny"))
@@ -3722,7 +3721,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// Create user:
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	goassert.True(t, err == nil)
-	a.Save(bernard)
+	assert.NoError(t, a.Save(bernard))
 
 	// Issue is only reproducible when the wait counter is zero for all requested channels (including the user channel) - the count=0
 	// triggers early termination of the changes loop.  This can only be reproduced if the feed is restarted after the user is created -
@@ -3864,7 +3863,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 	a := rt.ServerContext().Database("db").Authenticator()
 	jacques, err := a.NewUser("jacques", "letmein", channels.SetOf(t, "A", "B"))
 	assert.NoError(t, err)
-	a.Save(jacques)
+	assert.NoError(t, a.Save(jacques))
 
 	//Create Doc
 	response := rt.SendRequest("PUT", "/db/doc1", `{"channels": ["A"]}`)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2044,7 +2044,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	response := rt.Send(request("PUT", "/db/alpha", `{"owner":"alice"}`))
 	assertStatus(t, response, 201)
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	alphaRevID := body["rev"].(string)
 
@@ -3017,7 +3017,7 @@ func TestStarAccess(t *testing.T) {
 
 	// Ensure docs have been processed before issuing changes requests
 	expectedSeq := uint64(6)
-	rt.WaitForSequence(expectedSeq)
+	_ = rt.WaitForSequence(expectedSeq)
 
 	// GET /db/_changes
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -40,8 +40,8 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 	// Create user:
 	a := it.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
-	goassert.True(t, err == nil)
-	a.Save(bernard)
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
 
 	// Put several documents in channel PBS
 	response := it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -634,16 +634,17 @@ func TestPublicPortAuthentication(t *testing.T) {
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
+	require.NoError(t, err, "Error creating BlipTester")
 	defer btUser1.Close()
 
 	// Send the user1 doc
-	_, _, _, _ = btUser1.SendRev(
+	_, _, _, err = btUser1.SendRev(
 		"foo",
 		"1-abc",
 		[]byte(`{"key": "val", "channels": ["user1"]}`),
 		blip.Properties{},
 	)
+	require.NoError(t, err, "Error sending revision")
 
 	// Create bliptester that is connected as user2, with access to the * channel
 	btUser2, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -653,16 +654,17 @@ func TestPublicPortAuthentication(t *testing.T) {
 		connectingUserChannelGrants: []string{"*"},      // user2 has access to all channels
 		restTester:                  btUser1.restTester, // re-use rest tester, otherwise it will create a new underlying bucket in walrus case
 	})
-	assert.NoError(t, err, "Error creating BlipTester")
+	require.NoError(t, err, "Error creating BlipTester")
 	defer btUser2.Close()
 
 	// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access
-	_, _, _, _ = btUser2.SendRev(
+	_, _, _, err = btUser2.SendRev(
 		"foo2",
 		"1-abcd",
 		[]byte(`{"key": "val", "channels": ["NBC"]}`),
 		blip.Properties{},
 	)
+	require.NoError(t, err, "Error sending revision")
 
 	// Assert that user1 received a single expected change
 	changesChannelUser1 := btUser1.WaitForNumChanges(1)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -638,7 +638,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 	defer btUser1.Close()
 
 	// Send the user1 doc
-	btUser1.SendRev(
+	_, _, _, _ = btUser1.SendRev(
 		"foo",
 		"1-abc",
 		[]byte(`{"key": "val", "channels": ["user1"]}`),
@@ -657,7 +657,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 	defer btUser2.Close()
 
 	// Send the user2 doc, which is in a "random" channel, but it should be accessible due to * channel access
-	btUser2.SendRev(
+	_, _, _, _ = btUser2.SendRev(
 		"foo2",
 		"1-abcd",
 		[]byte(`{"key": "val", "channels": ["NBC"]}`),
@@ -1008,7 +1008,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 	defer bt.Close()
 
 	// Add a doc in the PBS channel
-	bt.SendRev(
+	_, _, _, _ = bt.SendRev(
 		"foo",
 		"1-abc",
 		[]byte(`{"key": "val", "channels": ["PBS"]}`),
@@ -1020,7 +1020,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 	assertStatus(t, response, 201)
 
 	// Add another doc in the PBS channel
-	bt.SendRev(
+	_, _, _, _ = bt.SendRev(
 		"foo2",
 		"1-abc",
 		[]byte(`{"key": "val", "channels": ["PBS"]}`),
@@ -1050,7 +1050,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	defer bt.Close()
 
 	// Add a doc in the PBS channel
-	bt.SendRev(
+	_, _, _, _ = bt.SendRev(
 		"foo",
 		"1-abc",
 		[]byte(`{"key": "val", "channels": ["PBS"]}`),
@@ -1062,7 +1062,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	// Add another doc in the PBS channel
-	bt.SendRev(
+	_, _, _, _ = bt.SendRev(
 		"foo2",
 		"1-abc",
 		[]byte(`{"key": "val", "channels": ["PBS"]}`),
@@ -1112,7 +1112,7 @@ func TestCheckpoint(t *testing.T) {
 	requestSetCheckpoint.SetProfile("setCheckpoint")
 	requestSetCheckpoint.Properties["client"] = client
 	checkpointBody := db.Body{"Key": "Value"}
-	requestSetCheckpoint.SetJSONBody(checkpointBody)
+	assert.NoError(t, requestSetCheckpoint.SetJSONBody(checkpointBody))
 	// requestSetCheckpoint.Properties["rev"] = "rev1"
 	sent = bt.sender.Send(requestSetCheckpoint)
 	if !sent {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -463,7 +463,10 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, params *subChangesParams
 func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]interface{}) error {
 	outrq := blip.NewRequest()
 	outrq.SetProfile("changes")
-	_ = outrq.SetJSONBody(changeArray)
+	err := outrq.SetJSONBody(changeArray)
+	if err != nil {
+		bh.Logf(base.LevelInfo, base.KeyAll, "Error setting changes: %v", err)
+	}
 
 	if len(changeArray) > 0 {
 		sendTime := time.Now()
@@ -629,7 +632,10 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		} else if len(possible) == 0 {
 			output.Write([]byte("[]"))
 		} else {
-			_ = jsonOutput.Encode(possible)
+			err := jsonOutput.Encode(possible)
+			if err != nil {
+				bh.Logf(base.LevelInfo, base.KeyAll, "Error encoding json: %v", err)
+			}
 		}
 		nWritten++
 	}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -463,7 +463,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, params *subChangesParams
 func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]interface{}) error {
 	outrq := blip.NewRequest()
 	outrq.SetProfile("changes")
-	outrq.SetJSONBody(changeArray)
+	_ = outrq.SetJSONBody(changeArray)
 
 	if len(changeArray) > 0 {
 		sendTime := time.Now()
@@ -629,7 +629,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		} else if len(possible) == 0 {
 			output.Write([]byte("[]"))
 		} else {
-			jsonOutput.Encode(possible)
+			_ = jsonOutput.Encode(possible)
 		}
 		nWritten++
 	}

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -395,7 +395,10 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 					} else {
 						_, _ = h.response.Write([]byte(","))
 					}
-					encoder.Encode(entry)
+					err = encoder.Encode(entry)
+					if err != nil {
+						base.Debugf(base.KeyChanges, "Error encoding change feed ebtry: %v", err)
+					}
 					lastSeq = entry.Seq
 				}
 
@@ -451,7 +454,7 @@ func generateBlipSyncChanges(database *db.Database, inChannels base.Set, options
 	// For one-shot changes, invoke the callback w/ nil to trigger the 'caught up' changes message.  (For continuous changes, this
 	// is done by MultiChangesFeed prior to going into Wait mode)
 	if isOneShot {
-		send(nil)
+		_ = send(nil)
 	}
 	return err, forceClose
 }

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -395,10 +395,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 					} else {
 						_, _ = h.response.Write([]byte(","))
 					}
-					err = encoder.Encode(entry)
-					if err != nil {
-						base.Debugf(base.KeyChanges, "Error encoding change feed ebtry: %v", err)
-					}
+					_ = encoder.Encode(entry)
 					lastSeq = entry.Seq
 				}
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -45,7 +45,7 @@ func (h *handler) handleRevsDiff() error {
 		return err
 	}
 
-	h.response.Write([]byte("{"))
+	_, _ = h.response.Write([]byte("{"))
 	first := true
 	for docid, revs := range input {
 		missing, possible := h.db.RevDiff(docid, revs)
@@ -55,14 +55,14 @@ func (h *handler) handleRevsDiff() error {
 				docOutput["possible_ancestors"] = possible
 			}
 			if !first {
-				h.response.Write([]byte(",\n"))
+				_, _ = h.response.Write([]byte(",\n"))
 			}
 			first = false
-			h.response.Write([]byte(fmt.Sprintf("%q:", docid)))
-			h.addJSON(docOutput)
+			_, _ = h.response.Write([]byte(fmt.Sprintf("%q:", docid)))
+			_ = h.addJSON(docOutput)
 		}
 	}
-	h.response.Write([]byte("}"))
+	_, _ = h.response.Write([]byte("}"))
 	return nil
 }
 
@@ -344,7 +344,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 
 	h.setHeader("Content-Type", "application/json")
 	h.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store")
-	h.response.Write([]byte("{\"results\":[\r\n"))
+	_, _ = h.response.Write([]byte("{\"results\":[\r\n"))
 
 	logStatus := h.logStatusWithDuration
 
@@ -393,7 +393,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 					if first {
 						first = false
 					} else {
-						h.response.Write([]byte(","))
+						_, _ = h.response.Write([]byte(","))
 					}
 					encoder.Encode(entry)
 					lastSeq = entry.Seq
@@ -424,7 +424,7 @@ func (h *handler) sendSimpleChanges(channels base.Set, options db.ChangesOptions
 	}
 
 	s := fmt.Sprintf("],\n\"last_seq\":%q}\n", lastSeq.String())
-	h.response.Write([]byte(s))
+	_, _ = h.response.Write([]byte(s))
 	logStatus(http.StatusOK, message)
 	return nil, forceClose
 }
@@ -699,8 +699,8 @@ func (h *handler) sendContinuousChangesByWebSocket(inChannels base.Set, options 
 			}
 			if compress && len(data) > 8 {
 				// Compress JSON, using same GZip context, and send as binary msg:
-				zipWriter.Write(data)
-				zipWriter.Flush()
+				_, _ = zipWriter.Write(data)
+				_ = zipWriter.Flush()
 				data = writer.Bytes()
 				writer.Reset()
 				conn.PayloadType = websocket.BinaryFrame

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -339,7 +339,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 	}()
 
 	// Wait for changes feed to get into wait mode where it is blocked on the longpoll changes feed response
-	_ = it.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
+	require.NoError(t, it.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Put a doc in channel bernard, that also grants bernard access to channel PBS
 	response = it.SendAdminRequest("PUT", "/db/grant1", `{"value":1, "accessUser":"bernard", "accessChannel":"PBS"}`)
@@ -3097,7 +3097,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 		assert.Equal(t, 5, len(changes.Results))
 	}()
 
-	_ = rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Update the user doc to grant access to PBS
 	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"admin_channels":["ABC", "PBS"]}`)
@@ -3283,5 +3283,8 @@ func WriteDirectWithKey(testDb *db.DatabaseContext, key string, channelArray []s
 	syncData.TimeSaved = time.Now()
 	//syncData := fmt.Sprintf(`{"rev":"%s", "sequence":%d, "channels":%s, "TimeSaved":"%s"}`, rev, sequence, chanMap, time.Now())
 
-	_, _ = testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
+	_, err = testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
+	if err != nil {
+		base.Panicf("Error while add ket to bucket: %v", err)
+	}
 }

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -339,7 +339,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 	}()
 
 	// Wait for changes feed to get into wait mode where it is blocked on the longpoll changes feed response
-	it.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
+	_ = it.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
 
 	// Put a doc in channel bernard, that also grants bernard access to channel PBS
 	response = it.SendAdminRequest("PUT", "/db/grant1", `{"value":1, "accessUser":"bernard", "accessChannel":"PBS"}`)
@@ -376,7 +376,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 	response = it.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	it.WaitForPendingChanges()
+	_ = it.WaitForPendingChanges()
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -3097,7 +3097,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 		assert.Equal(t, 5, len(changes.Results))
 	}()
 
-	rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
+	_ = rt.GetDatabase().WaitForCaughtUp(caughtUpCount + 1)
 
 	// Update the user doc to grant access to PBS
 	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"admin_channels":["ABC", "PBS"]}`)
@@ -3283,5 +3283,5 @@ func WriteDirectWithKey(testDb *db.DatabaseContext, key string, channelArray []s
 	syncData.TimeSaved = time.Now()
 	//syncData := fmt.Sprintf(`{"rev":"%s", "sequence":%d, "channels":%s, "TimeSaved":"%s"}`, rev, sequence, chanMap, time.Now())
 
-	testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
+	_, _ = testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -625,7 +625,7 @@ func LoadServerConfig(path string) (config *ServerConfig, err error) {
 		}
 	}
 
-	defer dataReadCloser.Close()
+	defer func() { _ = dataReadCloser.Close() }()
 	return readServerConfig(dataReadCloser)
 }
 
@@ -1033,7 +1033,7 @@ func RunServer(config *ServerConfig) {
 		//runtime.MemProfileRate = 10 * 1024
 		base.Infof(base.KeyAll, "Starting profile server on %s", base.UD(*config.ProfileInterface))
 		go func() {
-			http.ListenAndServe(*config.ProfileInterface, nil)
+			_ = http.ListenAndServe(*config.ProfileInterface, nil)
 		}()
 	}
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -120,7 +120,7 @@ func (h *handler) handleGetDoc() error {
 					if err != nil {
 						revBody = db.Body{"missing": revid} //TODO: More specific error
 					}
-					WriteRevisionAsPart(h.rq.Context(), h.db.DatabaseContext.DbStats.StatsCblReplicationPull(), revBody, err != nil, false, writer)
+					_ = WriteRevisionAsPart(h.rq.Context(), h.db.DatabaseContext.DbStats.StatsCblReplicationPull(), revBody, err != nil, false, writer)
 					h.db.DbStats.StatsDatabase().Add(base.StatKeyNumDocReadsRest, 1)
 				}
 				return nil
@@ -129,7 +129,7 @@ func (h *handler) handleGetDoc() error {
 		} else {
 			base.Debugf(base.KeyHTTP, "Fallback to non-multipart for open_revs")
 			h.setHeader("Content-Type", "application/json")
-			h.response.Write([]byte(`[` + "\n"))
+			_, _ = h.response.Write([]byte(`[` + "\n"))
 			separator := []byte(``)
 			for _, revid := range revids {
 				revBody, err := h.db.Get1xRevBodyWithHistory(docid, revid, revsLimit, revsFrom, attachmentsSince, showExp)
@@ -138,11 +138,11 @@ func (h *handler) handleGetDoc() error {
 				} else {
 					revBody = db.Body{"ok": revBody}
 				}
-				h.response.Write(separator)
+				_, _ = h.response.Write(separator)
 				separator = []byte(",")
-				h.addJSON(revBody)
+				_ = h.addJSON(revBody)
 			}
-			h.response.Write([]byte(`]`))
+			_, _ = h.response.Write([]byte(`]`))
 			h.db.DbStats.StatsDatabase().Add(base.StatKeyNumDocReadsRest, 1)
 		}
 	}
@@ -169,7 +169,7 @@ func (h *handler) handleGetDocReplicator2(docid, revid string) error {
 	}
 
 	h.setHeader("Content-Type", "application/json")
-	h.response.Write(bodyBytes)
+	_, _ = h.response.Write(bodyBytes)
 	h.db.DbStats.StatsDatabase().Add(base.StatKeyNumDocReadsRest, 1)
 
 	return nil
@@ -230,7 +230,7 @@ func (h *handler) handleGetAttachment() error {
 	h.db.DatabaseContext.DbStats.StatsCblReplicationPull().Add(base.StatKeyAttachmentPullCount, 1)
 	h.db.DatabaseContext.DbStats.StatsCblReplicationPull().Add(base.StatKeyAttachmentPullBytes, int64(len(data)))
 	h.response.WriteHeader(status)
-	h.response.Write(data)
+	_, _ = h.response.Write(data)
 	return nil
 
 }

--- a/rest/encoded_response_writer.go
+++ b/rest/encoded_response_writer.go
@@ -95,7 +95,7 @@ func (w *EncodedResponseWriter) sniff(bytes []byte) {
 // Flushes the GZip encoder buffer, and if possible flushes output to the network.
 func (w *EncodedResponseWriter) Flush() {
 	if w.gz != nil {
-		w.gz.Flush()
+		_ = w.gz.Flush()
 	}
 	switch r := w.ResponseWriter.(type) {
 	case http.Flusher:
@@ -136,6 +136,6 @@ func GetGZipWriter(writer io.Writer) *gzip.Writer {
 
 // Closes a gzip writer and returns it to the pool:
 func ReturnGZipWriter(gz *gzip.Writer) {
-	gz.Close()
+	_ = gz.Close()
 	zipperCache.Put(gz)
 }

--- a/rest/facebook.go
+++ b/rest/facebook.go
@@ -61,7 +61,7 @@ func verifyFacebook(fbUrl, accessToken string) (*FacebookResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode >= 300 {
 		return nil, base.HTTPErrorf(http.StatusUnauthorized,

--- a/rest/google.go
+++ b/rest/google.go
@@ -52,7 +52,7 @@ func verifyGoogle(idToken string, allowedAppID []string) (*GoogleResponse, error
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	decoder := base.JSONDecoder(res.Body)
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -483,7 +483,7 @@ func (h *handler) readDocument() (db.Body, error) {
 			reader := multipart.NewReader(bytes.NewReader(raw), attrs["boundary"])
 			body, err := ReadMultipartDocument(reader)
 			if err != nil {
-				ioutil.WriteFile("GatewayPUT.mime", raw, 0600)
+				_ = ioutil.WriteFile("GatewayPUT.mime", raw, 0600)
 				base.Warnf("Error reading MIME data: copied to file GatewayPUT.mime")
 			}
 			return body, err
@@ -583,7 +583,7 @@ func (h *handler) writeRawJSONWithoutClientVerification(status int, b []byte) {
 			h.response.WriteHeader(status)
 			h.setStatus(status, "")
 		}
-		h.response.Write(b)
+		_, _ = h.response.Write(b)
 	} else if status > 0 {
 		h.response.WriteHeader(status)
 		h.setStatus(status, "")
@@ -612,7 +612,7 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 	}
 	if PrettyPrint {
 		var buffer bytes.Buffer
-		json.Indent(&buffer, jsonOut, "", "  ")
+		_ = json.Indent(&buffer, jsonOut, "", "  ")
 		jsonOut = append(buffer.Bytes(), '\n')
 	}
 
@@ -656,7 +656,7 @@ func (h *handler) writeTextStatus(status int, value []byte) {
 		h.response.WriteHeader(status)
 		h.setStatus(status, "")
 	}
-	h.response.Write(value)
+	_, _ = h.response.Write(value)
 }
 
 func (h *handler) addJSON(value interface{}) error {
@@ -695,7 +695,7 @@ func (h *handler) writeMultipart(subtype string, callback func(*multipart.Writer
 		fmt.Sprintf("multipart/%s; boundary=%q", subtype, writer.Boundary()))
 
 	err := callback(writer)
-	writer.Close()
+	_ = writer.Close()
 
 	if err == nil && output == &buffer {
 		// Trim trailing newline; CouchDB is allergic to it:
@@ -754,7 +754,7 @@ func (h *handler) writeStatus(status int, message string) {
 	h.setHeader("Content-Type", "application/json")
 	h.response.WriteHeader(status)
 	h.setStatus(status, message)
-	h.response.Write([]byte(`{"error":"` + errorStr + `","reason":"` + message + `"}`))
+	_, _ = h.response.Write([]byte(`{"error":"` + errorStr + `","reason":"` + message + `"}`))
 }
 
 var kRangeRegex = regexp.MustCompile("^bytes=(\\d+)?-(\\d+)?$")

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -152,7 +152,7 @@ func TestXattrSGTombstone(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -160,7 +160,7 @@ func TestXattrSGTombstone(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
@@ -197,7 +197,7 @@ func TestXattrImportOnCasFailure(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["rev"], "1-111c27be37c17f18ae8fe9faa3bb4e0e")
 	revId := body["rev"].(string)
 
@@ -261,7 +261,7 @@ func TestXattrResurrectViaSG(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -269,14 +269,14 @@ func TestXattrResurrectViaSG(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
 	// 3. Recreate the doc through the SG (with different data)
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", key, revId), `{"channels":"ABC"}`)
 	goassert.Equals(t, response.Code, 201)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	goassert.Equals(t, body["rev"], "3-70c113f08c6622cd87af68f4f60d12e3")
 
@@ -375,7 +375,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -391,7 +391,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 409)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
@@ -424,7 +424,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId := body["rev"].(string)
 
@@ -436,7 +436,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", sdk_key), `{"channels":"ABC"}`)
 	goassert.Equals(t, response.Code, 201)
 	log.Printf("insert response: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 
 	// 2. Delete SDK_delete through the SDK
@@ -453,7 +453,7 @@ func TestViewQueryTombstoneRetrieval(t *testing.T) {
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", key, revId), "")
 	goassert.Equals(t, response.Code, 200)
 	log.Printf("delete response: %s", response.Body.Bytes())
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	goassert.Equals(t, body["ok"], true)
 	revId = body["rev"].(string)
 
@@ -592,7 +592,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -613,7 +613,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	goassert.Equals(t, response.Code, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	goassert.Equals(t, newRevId, revId)
@@ -649,7 +649,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -671,7 +671,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	// rev should have generation 2.
 	putResponse := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s?rev=%s", mobileKey, revId), `{"updated":true}`)
 	goassert.Equals(t, putResponse.Code, 201)
-	base.JSONUnmarshal(putResponse.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(putResponse.Body.Bytes(), &body))
 	log.Printf("Put response details: %s", putResponse.Body.Bytes())
 	newRevId, ok := body["rev"].(string)
 	assert.True(t, ok, "Unable to cast rev to string")
@@ -709,7 +709,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -747,7 +747,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	// Get the doc again, validate rev hasn't changed
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	goassert.Equals(t, response.Code, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	goassert.Equals(t, newRevId, revId)
@@ -867,7 +867,7 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
-	err = base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc)
+	assert.NoError(t, base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc))
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 3)
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 0)
 
@@ -936,7 +936,7 @@ func TestMigrateTombstone(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
-	err = base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc)
+	assert.NoError(t, base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc))
 	goassert.Equals(t, doc.Meta.CurrentRev, "2-6b1e1af9190829c1ceab6f1c8fb9fa3f")
 	goassert.Equals(t, doc.Meta.Sequence, uint64(5))
 
@@ -1007,7 +1007,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key+"?redact=false", "")
 	goassert.Equals(t, rawResponse.Code, 200)
 	var doc treeDoc
-	err = base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc)
+	assert.NoError(t, base.JSONUnmarshal(rawResponse.Body.Bytes(), &doc))
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyKeyMap), 1)
 	goassert.Equals(t, len(doc.Meta.RevTree.BodyMap), 2)
 }
@@ -1151,7 +1151,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	// Create via the SDK with sync metadata intact
 	_, err := bucket.WriteCasWithXattr(key, base.SyncXattrName, 0, 0, []byte(bodyString), []byte(xattrString))
 	assert.NoError(t, err, "Error writing doc w/ xattr")
-	rt.WaitForSequence(5)
+	_ = rt.WaitForSequence(5)
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
 	response := rt.SendAdminRequest("PUT", "/db/"+key+"?rev=2-d", `{"updated":true}`)
@@ -1161,7 +1161,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
 	assert.Equal(t, 200, rawResponse.Code)
 	log.Printf("raw response:%s", rawResponse.Body.Bytes())
-	rt.WaitForSequence(6)
+	_ = rt.WaitForSequence(6)
 
 	// Validate non-xattr document doesn't get upgraded on attempted write
 	nonMobileKey := "TestUpgradeNoXattr"
@@ -1221,7 +1221,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	// Create via the SDK with sync metadata intact
 	_, err := bucket.WriteCasWithXattr(key, base.SyncXattrName, 0, 0, []byte(bodyString), []byte(xattrString))
 	assert.NoError(t, err, "Error writing doc w/ xattr")
-	rt.WaitForSequence(1)
+	_ = rt.WaitForSequence(1)
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
 	response := rt.SendAdminRequest("GET", "/db/_changes", "")
@@ -1858,7 +1858,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	goassert.Equals(t, response.Code, 200)
 	// Extract rev from response for comparison with second GET below
 	var body db.Body
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	revId, ok := body[db.BodyRev].(string)
 	assert.True(t, ok, "No rev included in response")
 
@@ -1883,7 +1883,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	// Attempt to get the document again via Sync Gateway.  Should not trigger import.
 	response = rt.SendAdminRequest("GET", "/db/"+mobileKey, "")
 	goassert.Equals(t, response.Code, 200)
-	base.JSONUnmarshal(response.Body.Bytes(), &body)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	newRevId := body[db.BodyRev].(string)
 	log.Printf("Retrieved via Sync Gateway after non-mobile update, revId:%v", newRevId)
 	goassert.Equals(t, newRevId, revId)

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1151,7 +1151,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	// Create via the SDK with sync metadata intact
 	_, err := bucket.WriteCasWithXattr(key, base.SyncXattrName, 0, 0, []byte(bodyString), []byte(xattrString))
 	assert.NoError(t, err, "Error writing doc w/ xattr")
-	_ = rt.WaitForSequence(5)
+	require.NoError(t, rt.WaitForSequence(5))
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
 	response := rt.SendAdminRequest("PUT", "/db/"+key+"?rev=2-d", `{"updated":true}`)
@@ -1161,7 +1161,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	rawResponse := rt.SendAdminRequest("GET", "/db/_raw/"+key, "")
 	assert.Equal(t, 200, rawResponse.Code)
 	log.Printf("raw response:%s", rawResponse.Body.Bytes())
-	_ = rt.WaitForSequence(6)
+	require.NoError(t, rt.WaitForSequence(6))
 
 	// Validate non-xattr document doesn't get upgraded on attempted write
 	nonMobileKey := "TestUpgradeNoXattr"
@@ -1221,7 +1221,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	// Create via the SDK with sync metadata intact
 	_, err := bucket.WriteCasWithXattr(key, base.SyncXattrName, 0, 0, []byte(bodyString), []byte(xattrString))
 	assert.NoError(t, err, "Error writing doc w/ xattr")
-	_ = rt.WaitForSequence(1)
+	require.NoError(t, rt.WaitForSequence(1))
 
 	// Attempt to update the documents via Sync Gateway.  Should trigger checkForUpgrade handling to detect metadata in xattr, and update normally.
 	response := rt.SendAdminRequest("GET", "/db/_changes", "")

--- a/rest/login_test.go
+++ b/rest/login_test.go
@@ -54,6 +54,8 @@ func TestVerifyHTTPSSupport(t *testing.T) {
 	}
 
 	resp, err := http.Get("https://google.com")
+	defer func() { _ = resp.Body.Close() }()
+
 	if err != nil {
 		// Skip test if dial tcp fails with no such host.
 		// This is to allow tests to be run offline/without third-party dependencies.
@@ -62,5 +64,4 @@ func TestVerifyHTTPSSupport(t *testing.T) {
 		}
 		t.Errorf("Error making HTTPS connection: %v", err)
 	}
-	defer resp.Body.Close()
 }

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -83,7 +83,7 @@ func writeJSONPart(writer *multipart.Writer, contentType string, body db.Body, c
 	if compressed {
 		gz := gzip.NewWriter(part)
 		_, err = gz.Write(bytes)
-		gz.Close()
+		_ = gz.Close()
 	} else {
 		_, err = part.Write(bytes)
 	}
@@ -115,7 +115,7 @@ func WriteMultipartDocument(ctx context.Context, cblReplicationPullStats *expvar
 	}
 
 	// Write the main JSON body:
-	writeJSONPart(writer, "application/json", body, compress)
+	_ = writeJSONPart(writer, "application/json", body, compress)
 
 	// Write the following attachments
 	for _, info := range following {
@@ -129,7 +129,7 @@ func WriteMultipartDocument(ctx context.Context, cblReplicationPullStats *expvar
 			cblReplicationPullStats.Add(base.StatKeyAttachmentPullCount, 1)
 			cblReplicationPullStats.Add(base.StatKeyAttachmentPullBytes, int64(len(info.data)))
 		}
-		part.Write(info.data)
+		_, _ = part.Write(info.data)
 
 	}
 }
@@ -163,7 +163,7 @@ func WriteRevisionAsPart(ctx context.Context, cblReplicationPullStats *expvar.Ma
 			docWriter.Boundary())
 		partHeaders.Set("Content-Type", contentType)
 		WriteMultipartDocument(ctx, cblReplicationPullStats, revBody, docWriter, compressPart)
-		docWriter.Close()
+		_ = docWriter.Close()
 		content := bytes.TrimRight(buffer.Bytes(), "\r\n")
 
 		part, err := writer.CreatePart(partHeaders)
@@ -189,7 +189,7 @@ func ReadMultipartDocument(reader *multipart.Reader) (db.Body, error) {
 	}
 	var body db.Body
 	err = ReadJSONFromMIME(http.Header(mainPart.Header), mainPart, &body)
-	mainPart.Close()
+	_ = mainPart.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func ReadMultipartDocument(reader *multipart.Reader) (db.Body, error) {
 			return nil, err
 		}
 		data, err := ioutil.ReadAll(part)
-		part.Close()
+		_ = part.Close()
 		if err != nil {
 			return nil, err
 		}

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -163,7 +163,10 @@ func (h *handler) handleOidcTestProviderAuthorize() error {
 	if t, err := t.Parse(login_html); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, err.Error())
 	} else {
-		_ = t.Execute(h.response, p)
+		err := t.Execute(h.response, p)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -464,7 +464,7 @@ func writeTokenResponse(h *handler, subject string, issuerUrl string, tokenttl t
 	}
 
 	if bytes, err := base.JSONMarshal(tokenResponse); err == nil {
-		h.response.Write(bytes)
+		_, _ = h.response.Write(bytes)
 	}
 
 	return nil

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -120,7 +120,7 @@ func (h *handler) handleOidcProviderConfiguration() error {
 	}
 
 	if bytes, err := base.JSONMarshal(config); err == nil {
-		h.response.Write(bytes)
+		_, _ = h.response.Write(bytes)
 	}
 
 	return nil
@@ -163,7 +163,7 @@ func (h *handler) handleOidcTestProviderAuthorize() error {
 	if t, err := t.Parse(login_html); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, err.Error())
 	} else {
-		t.Execute(h.response, p)
+		_ = t.Execute(h.response, p)
 	}
 
 	return nil
@@ -239,13 +239,13 @@ func (h *handler) handleOidcTestProviderCerts() error {
 
 	jwk := oidcPrivateKey.JWK()
 
-	h.response.Write([]byte("{\r\n\"keys\":[\r\n"))
+	_, _ = h.response.Write([]byte("{\r\n\"keys\":[\r\n"))
 
 	if bytes, err := jwk.MarshalJSON(); err == nil {
-		h.response.Write(bytes)
+		_, _ = h.response.Write(bytes)
 	}
 
-	h.response.Write([]byte("\r\n]\r\n}"))
+	_, _ = h.response.Write([]byte("\r\n]\r\n}"))
 
 	return nil
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -149,7 +149,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		if sc.config.AdminUI != nil {
 			http.ServeFile(w, r, *sc.config.AdminUI)
 		} else {
-			w.Write(sync_gateway_admin_ui.MustAsset("assets/index.html"))
+			_, _ = w.Write(sync_gateway_admin_ui.MustAsset("assets/index.html"))
 		}
 	})
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -139,7 +139,7 @@ func (sc *ServerContext) Close() {
 	for _, ctx := range sc.databases_ {
 		ctx.Close()
 		if ctx.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
+			_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
 		}
 	}
 
@@ -589,12 +589,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	if config.StartOffline {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
 		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
+			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
 		}
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
 		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
+			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
 		}
 	}
 
@@ -809,7 +809,7 @@ func (sc *ServerContext) getDbConfigFromServer(dbName string) (*DbConfig, error)
 	}
 
 	var config DbConfig
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if err := decodeAndSanitiseConfig(resp.Body, &config); err != nil {
 		return nil, base.HTTPErrorf(http.StatusBadGateway,

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -517,10 +517,13 @@ func (rt *RestTester) WaitForDBOnline() (err error) {
 
 		response := rt.SendAdminRequest("GET", "/db/", "")
 		var body db.Body
-		_ = base.JSONUnmarshal(response.Body.Bytes(), &body)
+		err := base.JSONUnmarshal(response.Body.Bytes(), &body)
+		if err != nil {
+			return err
+		}
 
 		if body["state"].(string) == "Online" {
-			return
+			return nil
 		}
 
 		// Otherwise, sleep and try again

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -295,7 +295,7 @@ func (rt *RestTester) SetAdminParty(partyTime bool) {
 		chans = channels.AtSequence(base.SetOf("*"), 1)
 	}
 	guest.SetExplicitChannels(chans)
-	a.Save(guest)
+	_ = a.Save(guest)
 }
 
 func (rt *RestTester) DisableGuestUser() {
@@ -456,7 +456,7 @@ func (rt *RestTester) WaitForNViewResults(numResultsExpected int, viewUrlPath st
 			return false, fmt.Errorf("Got response code: %d from view call.  Expected 200.", response.Code), sgbucket.ViewResult{}
 		}
 		var result sgbucket.ViewResult
-		base.JSONUnmarshal(response.Body.Bytes(), &result)
+		_ = base.JSONUnmarshal(response.Body.Bytes(), &result)
 
 		if len(result.Rows) >= numResultsExpected {
 			// Got enough results, break out of retry loop
@@ -517,7 +517,7 @@ func (rt *RestTester) WaitForDBOnline() (err error) {
 
 		response := rt.SendAdminRequest("GET", "/db/", "")
 		var body db.Body
-		base.JSONUnmarshal(response.Body.Bytes(), &body)
+		_ = base.JSONUnmarshal(response.Body.Bytes(), &body)
 
 		if body["state"].(string) == "Online" {
 			return
@@ -564,7 +564,7 @@ func (rt *RestTester) GetDocumentSequence(key string) (sequence uint64) {
 	}
 
 	var rawResponse RawResponse
-	base.JSONUnmarshal(response.BodyBytes(), &rawResponse)
+	_ = base.JSONUnmarshal(response.BodyBytes(), &rawResponse)
 	return rawResponse.Sync.Sequence
 }
 

--- a/rest/view_api.go
+++ b/rest/view_api.go
@@ -22,7 +22,7 @@ func (h *handler) handleGetDesignDoc() error {
 		filter := "ok"
 		if h.db.DatabaseContext.ChannelMapper != nil {
 			hash := sha1.New()
-			io.WriteString(hash, h.db.DatabaseContext.ChannelMapper.Function())
+			_, _ = io.WriteString(hash, h.db.DatabaseContext.ChannelMapper.Function())
 			filter = fmt.Sprint(hash.Sum(nil))
 		}
 		result = db.Body{"filters": db.Body{"bychannel": filter}}

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -68,7 +68,7 @@ func TestViewQuery(t *testing.T) {
 	// TODO: update the query to use stale=false and remove the wait
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
 	assert.NoError(t, err, "Got unexpected error")
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 2, len(result.Rows))
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: "ten"}, result.Rows[1])
@@ -176,7 +176,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	a := rt.ServerContext().Database("db").Authenticator()
 	password := "123456"
 	testUser, _ := a.NewUser("testUser", password, channels.SetOf(t, "*"))
-	a.Save(testUser)
+	assert.NoError(t, a.Save(testUser))
 
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
 	assert.NoError(t, err, "Unexpected error in WaitForNUserViewResults")
@@ -212,21 +212,21 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_age", ``)
 	assertStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 2, len(result.Rows))
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)}, result.Rows[1])
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_fname", ``)
 	assertStatus(t, response, http.StatusOK)
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 2, len(result.Rows))
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)}, result.Rows[1])
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_lname", ``)
 	assertStatus(t, response, http.StatusOK)
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 2, len(result.Rows))
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)}, result.Rows[1])
@@ -253,7 +253,7 @@ func TestUserViewQuery(t *testing.T) {
 	// Create a user:
 	password := "123456"
 	quinn, _ := a.NewUser("quinn", password, channels.SetOf(t, "Q", "q"))
-	a.Save(quinn)
+	assert.NoError(t, a.Save(quinn))
 
 	// Have the user query the view:
 	result, err := rt.WaitForNUserViewResults(1, "/db/_design/foo/_view/bar?include_docs=true", quinn, password)
@@ -435,7 +435,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	assertStatus(t, response, http.StatusOK) // Query string was parsed properly
 
 	var result sgbucket.ViewResult
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 1, len(result.Rows))
 
 	// Ensure that query for non-existent keys returns no rows
@@ -443,7 +443,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
 	assertStatus(t, response, http.StatusOK) // Query string was parsed properly
 
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 0, len(result.Rows))
 }
 
@@ -472,7 +472,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
 	assertStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 1, len(result.Rows))
 
 	// Ensure that a query for non-existent key returns no rows
@@ -480,7 +480,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
 	assertStatus(t, response, http.StatusOK)
 
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 0, len(result.Rows))
 }
 
@@ -509,7 +509,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
 	assertStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 1, len(result.Rows))
 
 	// Ensure that a query for non-existent key returns no rows
@@ -518,7 +518,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, viewUrlPath, ``)
 	assertStatus(t, response, http.StatusOK)
 
-	base.JSONUnmarshal(response.Body.Bytes(), &result)
+	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
 	assert.Equal(t, 0, len(result.Rows))
 }
 


### PR DESCRIPTION
Address and handle the cases being caught by errcheck in the Jenkins pipeline from auth package
godeps/src/github.com/couchbase/sync_gateway/auth/auth.go:398:22: auth.bucket.Delete(docIDForUserEmail(user.Email()))
godeps/src/github.com/couchbase/sync_gateway/auth/auth_test.go:488:15: SetBcryptCost(5)
godeps/src/github.com/couchbase/sync_gateway/auth/auth_test.go:505:15: SetBcryptCost(bcryptDefaultCost)
godeps/src/github.com/couchbase/sync_gateway/auth/oidc.go:235:23: defer resp.Body.Close()
godeps/src/github.com/couchbase/sync_gateway/auth/session.go:121:20: auth.bucket.Delete(DocIDForSession(cookie.Value))
godeps/src/github.com/couchbase/sync_gateway/auth/user_test.go:63:21: defer SetBcryptCost(bcryptDefaultCost)