### PR TITLE
CBG-621: Disable TestHandleProfiling and TestHandleHeapProfiling temporarily

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4470,6 +4470,7 @@ func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
 }
 
 func TestHandleProfiling(t *testing.T) {
+	t.Skip("skipping test for a limited period of time")
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -4544,6 +4545,7 @@ func TestHandleProfiling(t *testing.T) {
 }
 
 func TestHandleHeapProfiling(t *testing.T) {
+	t.Skip("skipping test for a limited period of time")
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4470,7 +4470,7 @@ func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
 }
 
 func TestHandleProfiling(t *testing.T) {
-	t.Skip("skipping test for a limited period of time")
+	t.Skip("test fails on windows due to file path handling")
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -4545,7 +4545,7 @@ func TestHandleProfiling(t *testing.T) {
 }
 
 func TestHandleHeapProfiling(t *testing.T) {
-	t.Skip("skipping test for a limited period of time")
+	t.Skip("test fails on windows due to file path handling")
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 


### PR DESCRIPTION
Disable TestHandleProfiling and TestHandleHeapProfiling temporarily