### PR TITLE
Default kv_pool_size to 2

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -99,7 +99,7 @@ type BucketSpec struct {
 	UseXattrs                              bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs                   *uint32        // the view query timeout in seconds (default: 75 seconds)
 	BucketOpTimeout                        *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	KvPoolSize                             int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnStringmk,......
+	KvPoolSize                             int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }
 
 // Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -159,11 +159,17 @@ func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err e
 
 	// Define channels to limit the number of concurrent single and bulk operations,
 	// to avoid gocb queue overflow issues
+
+	numPools := 1
+	if spec.KvPoolSize > 0 {
+		numPools = spec.KvPoolSize
+	}
+
 	bucket = &CouchbaseBucketGoCB{
 		goCBBucket,
 		spec,
-		make(chan struct{}, MaxConcurrentSingleOps*nodeCount),
-		make(chan struct{}, MaxConcurrentBulkOps*nodeCount),
+		make(chan struct{}, MaxConcurrentSingleOps*nodeCount*numPools),
+		make(chan struct{}, MaxConcurrentBulkOps*nodeCount*numPools),
 		make(chan struct{}, MaxConcurrentViewOps*nodeCount),
 		clusterCompat,
 	}

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -29,20 +29,26 @@ func TestBucketSpec(t *testing.T) {
 
 	connStr, err := bucketSpec.GetGoCBConnString()
 	assert.NoError(t, err, "Error creating connection string for bucket spec")
-	assert.Equal(t, "http://localhost:8091?cacertpath=.%2FmyCACertPath&certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath&n1ql_timeout=30000&operation_tracing=false", connStr)
+	assert.Equal(t, "http://localhost:8091?cacertpath=.%2FmyCACertPath&certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath&kv_pool_size="+DefaultGocbKvPoolSize+"&n1ql_timeout=30000&operation_tracing=false", connStr)
 
 	// CACertPath not required
 	bucketSpec.CACertPath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
 	assert.NoError(t, err, "Error creating connection string for bucket spec")
-	assert.Equal(t, "http://localhost:8091?certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath&n1ql_timeout=30000&operation_tracing=false", connStr)
+	assert.Equal(t, "http://localhost:8091?certpath=%2FmyCertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&keypath=%2Fmy%2Fkey%2Fpath&kv_pool_size="+DefaultGocbKvPoolSize+"&n1ql_timeout=30000&operation_tracing=false", connStr)
 
 	// Certpath and keypath must both be defined - if either are missing, they shouldn't be included in connection string
 	bucketSpec.CACertPath = "./myCACertPath"
 	bucketSpec.Certpath = ""
 	connStr, err = bucketSpec.GetGoCBConnString()
 	assert.NoError(t, err, "Error creating connection string for bucket spec")
-	assert.Equal(t, "http://localhost:8091?cacertpath=.%2FmyCACertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&n1ql_timeout=30000&operation_tracing=false", connStr)
+	assert.Equal(t, "http://localhost:8091?cacertpath=.%2FmyCACertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&kv_pool_size="+DefaultGocbKvPoolSize+"&n1ql_timeout=30000&operation_tracing=false", connStr)
+
+	// Specify kv_pool_size in server
+	bucketSpec.Server = "http://localhost:8091?kv_pool_size=2"
+	connStr, err = bucketSpec.GetGoCBConnString()
+	assert.NoError(t, err, "Error creating connection string for bucket spec")
+	assert.Equal(t, "http://localhost:8091?cacertpath=.%2FmyCACertPath&http_idle_conn_timeout=90000&http_max_idle_conns=64000&http_max_idle_conns_per_host=256&kv_pool_size=2&n1ql_timeout=30000&operation_tracing=false", connStr)
 
 	// Standard no-cert
 	bucketSpec.CACertPath = ""

--- a/base/constants.go
+++ b/base/constants.go
@@ -80,6 +80,9 @@ const (
 	// Keep idle connections around for a maximimum of 90 seconds.  This is the same value used by the Go DefaultTransport.
 	DefaultHttpIdleConnTimeoutMilliseconds = "90000"
 
+	// Number of kv connections (pipelines) per Couchbase Server node
+	DefaultGocbKvPoolSize = "4"
+
 	// The limit in Couchbase Server for total system xattr size
 	couchbaseMaxSystemXattrSize = 1 * 1024 * 1024 // 1MB
 

--- a/base/constants.go
+++ b/base/constants.go
@@ -81,7 +81,7 @@ const (
 	DefaultHttpIdleConnTimeoutMilliseconds = "90000"
 
 	// Number of kv connections (pipelines) per Couchbase Server node
-	DefaultGocbKvPoolSize = "4"
+	DefaultGocbKvPoolSize = "2"
 
 	// The limit in Couchbase Server for total system xattr size
 	couchbaseMaxSystemXattrSize = 1 * 1024 * 1024 // 1MB


### PR DESCRIPTION
If kv_pool_size is set via 'server' in config, it will override the default setting.

kv_pool_size is also used as a multiplier for concurrent kv bucket ops throttling in bucket_gocb.