### PR TITLE
2.7.0 RC2 - CBG-479 Upgrade to Go 1.13.4 (#4379)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'sync-gateway-pipeline-builder' }
 
     environment {
-        GO_VERSION = 'go1.12.10'
+        GO_VERSION = 'go1.13.4'
         GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/godeps"

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.12.10",
+            "go_version": "1.13.4",
             "start_build": 1
         },
         "manifest/1.4.0.xml": {


### PR DESCRIPTION
Merging into 2.7.0-rc2 branch
Cherry-Pick: Upgrade to Go 1.13.4 (#4379)