### PR TITLE
2.7.0 RC2 - Pre-allocate length of log collation string slice (#4374)

### DIFF
--- a/base/logger.go
+++ b/base/logger.go
@@ -11,15 +11,15 @@ func FlushLogBuffers() {
 	time.Sleep(loggerCollateFlushDelay)
 }
 
-func logCollationWorker(collateBuffer chan string, logger *log.Logger, bufferSize int) {
+func logCollationWorker(collateBuffer chan string, logger *log.Logger, maxBufferSize int) {
 	// This is the temporary buffer we'll store logs in.
-	logBuffer := []string{}
+	logBuffer := make([]string, 0, maxBufferSize)
 	for {
 		select {
 		// Add log to buffer and flush to output if it's full.
 		case l := <-collateBuffer:
 			logBuffer = append(logBuffer, l)
-			if len(logBuffer) >= bufferSize {
+			if len(logBuffer) >= maxBufferSize {
 				logger.Print(strings.Join(logBuffer, "\n"))
 				// Empty buffer
 				logBuffer = logBuffer[:0]


### PR DESCRIPTION
Merging into 2.7.0-rc2 branch
Cherry-Pick: Pre-allocate length of log collation string slice (#4374)