### PR TITLE
CBG-623 Avoid duplicate marshalling during write/import during rev id generation

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -39,6 +39,10 @@ type DocAttachment struct {
 // inline bodies, copies the bodies into the Couchbase db, and replaces the bodies with the 'digest' attributes which
 // are the keys to retrieving them.
 func (db *Database) storeAttachments(doc *Document, newAttachmentsMeta AttachmentsMeta, generation int, parentRev string, docHistory []string) (AttachmentData, error) {
+	if len(newAttachmentsMeta) == 0 {
+		return nil, nil
+	}
+
 	var parentAttachments map[string]interface{}
 	newAttachmentData := make(AttachmentData, 0)
 	atts := newAttachmentsMeta

--- a/db/document.go
+++ b/db/document.go
@@ -237,7 +237,7 @@ func (doc *Document) Body() Body {
 	}
 
 	if doc._rawBody == nil {
-		base.Warnf("Empty doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
+		base.Warnf("Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil
 	}
 
@@ -298,7 +298,7 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 	}
 
 	if doc._body == nil {
-		base.Warnf("Empty doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
+		base.Warnf("Null doc body/rawBody %s/%s from %s", base.UD(doc.ID), base.UD(doc.RevID), caller)
 		return nil, nil
 	}
 

--- a/db/import.go
+++ b/db/import.go
@@ -92,6 +92,12 @@ func (db *Database) ImportDoc(docid string, existingDoc *Document, isDelete bool
 	return db.importDoc(docid, existingDoc.Body(), isDelete, existingBucketDoc, mode)
 }
 
+// Import document
+//   docid  - document key
+//   body - marshalled body of document to be imported
+//   isDelete - whether the document to be imported is a delete
+//   existingDoc - bytes/cas/expiry of the  document to be imported (including xattr when available)
+//   mode - ImportMode - ImportFromFeed or ImportOnDemand
 func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDoc *sgbucket.BucketDocument, mode ImportMode) (docOut *Document, err error) {
 
 	base.Debugf(base.KeyImport, "Attempting to import doc %q...", base.UD(docid))

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -236,12 +236,6 @@ func TestImportNullDoc(t *testing.T) {
 	importedDoc, err := db.importDoc(key+"1", body, false, existingDoc, ImportOnDemand)
 	goassert.Equals(t, err, base.ErrEmptyDocument)
 	assert.True(t, importedDoc == nil, "Expected no imported doc")
-
-	// Do a valid on-demand import from a null document
-	body = Body{"new": true}
-	importedDoc, err = db.importDoc(key+"2", body, false, existingDoc, ImportOnDemand)
-	assert.NoError(t, err)
-	assert.False(t, importedDoc == nil, "Expected imported doc")
 }
 
 func TestImportNullDocRaw(t *testing.T) {

--- a/db/revision.go
+++ b/db/revision.go
@@ -332,7 +332,8 @@ func (body Body) FixJSONNumbers() {
 
 func createRevID(generation int, parentRevID string, body Body) (string, error) {
 	// This should produce the same results as TouchDB.
-	encoding, err := base.JSONMarshalCanonical(stripSpecialProperties(body))
+	strippedBody, _ := stripSpecialProperties(body)
+	encoding, err := base.JSONMarshalCanonical(strippedBody)
 	if err != nil {
 		return "", err
 	}
@@ -406,17 +407,17 @@ func compareRevIDs(id1, id2 string) int {
 }
 
 // stripSpecialProperties returns a copy of the given body with all underscore-prefixed keys removed, except _attachments and _deleted.
-func stripSpecialProperties(b Body) Body {
+func stripSpecialProperties(b Body) (Body, bool) {
 	return stripSpecialPropertiesExcept(b, BodyAttachments, BodyDeleted)
 }
 
 // stripAllSpecialProperties returns a copy of the given body with all underscore-prefixed keys removed.
-func stripAllSpecialProperties(b Body) Body {
+func stripAllSpecialProperties(b Body) (Body, bool) {
 	return stripSpecialPropertiesExcept(b)
 }
 
 // stripSpecialPropertiesExcept returns a copy of the given body with all underscore-prefixed keys removed, except those given.
-func stripSpecialPropertiesExcept(b Body, exceptions ...string) Body {
+func stripSpecialPropertiesExcept(b Body, exceptions ...string) (sb Body, foundSpecialProps bool) {
 	// Assume no properties removed for the initial capacity to reduce allocs on large docs.
 	stripped := make(Body, len(b))
 	for k, v := range b {
@@ -424,9 +425,16 @@ func stripSpecialPropertiesExcept(b Body, exceptions ...string) Body {
 			base.StringSliceContains(exceptions, k) {
 			// property is allowed
 			stripped[k] = v
+		} else {
+			foundSpecialProps = true
 		}
 	}
-	return stripped
+	if foundSpecialProps {
+		return stripped, true
+	} else {
+		// Return original body if nothing was removed
+		return b, false
+	}
 }
 
 // containsUserSpecialProperties returns true if the given body contains a non-SG special property (underscore prefixed)

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -93,7 +93,7 @@ func (db *Database) putSpecial(doctype string, docid string, matchRev string, bo
 
 func (db *Database) PutSpecial(doctype string, docid string, body Body) (string, error) {
 	matchRev, _ := body[BodyRev].(string)
-	body = stripAllSpecialProperties(body)
+	body, _ = stripAllSpecialProperties(body)
 	return db.putSpecial(doctype, docid, matchRev, body)
 }
 


### PR DESCRIPTION
Leverage existing body for rev id generation (import) and retain marshalled body for subsequent write when appropriate.

http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/61/
http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/62/

http://perf.jenkins.couchbase.com/job/hebe_sg_multiimport/30/ 
 - throughput 21595 (vs. 18224 for 2.7.0-159, although there have been other performance enhancements on the branch since then)