### PR TITLE
Test report XML fix: Prevent 0x0 byte appearing in test output

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1965,7 +1965,7 @@ func TestHandleActiveTasks(t *testing.T) {
 func TestHandleSGCollect(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
-	reqBodyJson := ""
+	reqBodyJson := "invalidjson"
 	resource := "/_sgcollect_info"
 
 	// Check SGCollect status before triggering it; status should be stopped if no process is running.
@@ -1978,7 +1978,7 @@ func TestHandleSGCollect(t *testing.T) {
 	assertStatus(t, resp, http.StatusBadRequest)
 	assert.Contains(t, resp.Body.String(), "Error stopping sgcollect_info: not running")
 
-	// Try to start SGCollect with empty request body; It should throw with unexpected end of JSON input error
+	// Try to start SGCollect with invalid body; It should throw with unexpected end of JSON input error
 	resp = rt.SendAdminRequest(http.MethodPost, resource, reqBodyJson)
 	assertStatus(t, resp, http.StatusBadRequest)
 }


### PR DESCRIPTION
Fixes invalid XML test reports being generated and rejected by Jenkins by changing test data.

<img width="1003" alt="Screenshot 2019-12-10 at 12 55 33" src="https://user-images.githubusercontent.com/1525809/70531247-6db0f700-1b4c-11ea-9323-16c4325131aa.png">

<img width="1078" alt="Screenshot 2019-12-10 at 12 58 22" src="https://user-images.githubusercontent.com/1525809/70531403-c3859f00-1b4c-11ea-81d6-4af24eedfea6.png">
