### PR TITLE
CBG-617 - Flip activeOnly to false once caught up on initial replication

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -680,6 +680,12 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
 			output <- nil
 
+			// If this is an initial replication (from zero) with the activeOnly set, flip it now the client has caught up.
+			if !options.Since.IsNonZero() && options.ActiveOnly {
+				base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed initial replication caught up - setting activeOnly to false... %s", base.UD(to))
+				options.ActiveOnly = false
+			}
+
 		waitForChanges:
 			for {
 				// If we're in a deferred Backfill, the user may not get notification when the cache catches up to the backfill (e.g. when the granting doc isn't

--- a/db/changes.go
+++ b/db/changes.go
@@ -25,17 +25,18 @@ import (
 
 // Options for changes-feeds
 type ChangesOptions struct {
-	Since       SequenceID      // sequence # to start _after_
-	Limit       int             // Max number of changes to return, if nonzero
-	Conflicts   bool            // Show all conflicting revision IDs, not just winning one?
-	IncludeDocs bool            // Include doc body of each change?
-	Wait        bool            // Wait for results, instead of immediately returning empty result?
-	Continuous  bool            // Run continuously until terminated?
-	Terminator  chan bool       // Caller can close this channel to terminate the feed
-	HeartbeatMs uint64          // How often to send a heartbeat to the client
-	TimeoutMs   uint64          // After this amount of time, close the longpoll connection
-	ActiveOnly  bool            // If true, only return information on non-deleted, non-removed revisions
-	Ctx         context.Context // Used for adding context to logs
+	Since        SequenceID      // sequence # to start _after_
+	Limit        int             // Max number of changes to return, if nonzero
+	Conflicts    bool            // Show all conflicting revision IDs, not just winning one?
+	IncludeDocs  bool            // Include doc body of each change?
+	Wait         bool            // Wait for results, instead of immediately returning empty result?
+	Continuous   bool            // Run continuously until terminated?
+	Terminator   chan bool       // Caller can close this channel to terminate the feed
+	HeartbeatMs  uint64          // How often to send a heartbeat to the client
+	TimeoutMs    uint64          // After this amount of time, close the longpoll connection
+	ActiveOnly   bool            // If true, only return information on non-deleted, non-removed revisions
+	ClientIsCBL2 bool            // If the replication is being started from a CBL 2.x client
+	Ctx          context.Context // Used for adding context to logs
 }
 
 // A changes entry; Database.GetChanges returns an array of these.
@@ -382,8 +383,6 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 		var userChanged bool                // Whether the user document has changed in a given iteration loop
 		var deferredBackfill bool           // Whether there's a backfill identified in the user doc that's deferred while the SG cache catches up
 
-		var fromZero = !options.Since.IsNonZero() // If this replication has started from seq zero
-
 		// Retrieve the current max cached sequence - ensures there isn't a race between the subsequent channel cache queries
 		currentCachedSequence = db.changeCache.getChannelCache().GetHighCacheSequence()
 		if options.Wait {
@@ -682,8 +681,8 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
 			output <- nil
 
-			// If this is an initial replication (active only and from zero), flip activeOnly now the client has caught up.
-			if fromZero && options.ActiveOnly {
+			// If this is an initial replication using CBL 2.x (active only), flip activeOnly now the client has caught up.
+			if options.ClientIsCBL2 && options.ActiveOnly {
 				base.DebugfCtx(db.Ctx, base.KeyChanges, "%v MultiChangesFeed initial replication caught up - setting ActiveOnly to false... %s", options.Since, base.UD(to))
 				options.ActiveOnly = false
 			}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2309,3 +2309,37 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 
 	//assert.Equal(t, `{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":2,"stub":true}},"_id":"doc1","_rev":"2-10000d5ec533b29b117e60274b1e3653","greetings":[{"hello":"world!"},{"hi":"alice"}]}`, resp.Body.String())
 }
+
+// Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
+func TestActiveOnlyContinuous(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClient(t, rt)
+	require.NoError(t, err)
+	defer btc.Close()
+
+	require.NoError(t, btc.StartPullSince("true", "0", "true"))
+
+	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"test":true}`)
+	assertStatus(t, resp, http.StatusCreated)
+	var docResp struct {
+		Rev string `json:"rev"`
+	}
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &docResp))
+
+	rev, found := btc.WaitForRev("doc1", docResp.Rev)
+	assert.True(t, found)
+	assert.Equal(t, `{"test":true}`, string(rev))
+
+	resp = rt.SendAdminRequest(http.MethodDelete, "/db/doc1?rev="+docResp.Rev, ``)
+	assertStatus(t, resp, http.StatusOK)
+	require.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &docResp))
+
+	rev, found = btc.WaitForRev("doc1", docResp.Rev)
+	assert.True(t, found)
+	assert.Equal(t, `{}`, string(rev))
+}

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -416,15 +416,15 @@ func NewBlipTesterClient(tb testing.TB, rt *RestTester) (client *BlipTesterClien
 
 // StartPull will begin a continuous pull replication since 0 between the client and server
 func (btc *BlipTesterClient) StartPull() (err error) {
-	return btc.StartPullSince("true", "0")
+	return btc.StartPullSince("true", "0", "false")
 }
 
 func (btc *BlipTesterClient) StartOneshotPull() (err error) {
-	return btc.StartPullSince("false", "0")
+	return btc.StartPullSince("false", "0", "false")
 }
 
 // StartPullSince will begin a pull replication between the client and server with the given params.
-func (btc *BlipTesterClient) StartPullSince(continuous, since string) (err error) {
+func (btc *BlipTesterClient) StartPullSince(continuous, since, activeOnly string) (err error) {
 	getCheckpointRequest := blip.NewRequest()
 	getCheckpointRequest.SetProfile(messageGetCheckpoint)
 	getCheckpointRequest.Properties[blipClient] = btc.pullReplication.id
@@ -436,6 +436,7 @@ func (btc *BlipTesterClient) StartPullSince(continuous, since string) (err error
 	subChangesRequest.SetProfile(messageSubChanges)
 	subChangesRequest.Properties[subChangesContinuous] = continuous
 	subChangesRequest.Properties[subChangesSince] = since
+	subChangesRequest.Properties[subChangesActiveOnly] = activeOnly
 	subChangesRequest.SetNoReply(true)
 	if err := btc.pullReplication.sendMsg(subChangesRequest); err != nil {
 		return err

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -391,12 +391,13 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, params *subChangesParams
 	bh.Logf(base.LevelInfo, base.KeySync, "Sending changes since %v", params.since())
 
 	options := db.ChangesOptions{
-		Since:      params.since(),
-		Conflicts:  false, // CBL 2.0/BLIP don't support branched rev trees (LiteCore #437)
-		Continuous: bh.continuous,
-		ActiveOnly: bh.activeOnly,
-		Terminator: bh.blipSyncContext.terminator,
-		Ctx:        bh.db.Ctx,
+		Since:        params.since(),
+		Conflicts:    false, // CBL 2.0/BLIP don't support branched rev trees (LiteCore #437)
+		Continuous:   bh.continuous,
+		ActiveOnly:   bh.activeOnly,
+		Terminator:   bh.blipSyncContext.terminator,
+		Ctx:          bh.db.Ctx,
+		ClientIsCBL2: true,
 	}
 
 	channelSet := bh.channels


### PR DESCRIPTION
Prevents clients who start a continuous replication using the activeOnly flag from never getting tombstones by flipping the activeOnly flag back to false after the client has caught up on their initial replication.