### PR TITLE
Benchmark Improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,7 +362,7 @@ pipeline {
             steps{
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]){
                     warnError(message: "one or more benchmarks failed") {
-                        sh "go test -timeout=20m -count=1 -run=- -bench=. -benchmem -v ${SGW_REPO}/... | tee benchmark.out"
+                        sh "go test -timeout=20m -count=1 -run=- -bench=. -benchmem -benchtime 0.5s -v ${SGW_REPO}/... | tee benchmark.out"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,7 +362,7 @@ pipeline {
             steps{
                 withEnv(["PATH+=${GO}:${GOPATH}/bin"]){
                     warnError(message: "one or more benchmarks failed") {
-                        sh "go test -timeout=20m -count=1 -run=- -bench=. -benchmem -benchtime 0.5s -v ${SGW_REPO}/... | tee benchmark.out"
+                        sh "go test -timeout=20m -count=1 -run=- -bench=. -benchmem -benchtime 0.1s -v ${SGW_REPO}/... | tee benchmark.out"
                     }
                 }
             }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1963,8 +1963,6 @@ func (f *testProcessEntryFeed) Next() *LogEntry {
 //   - non-unique doc ids?
 
 func BenchmarkProcessEntry(b *testing.B) {
-	b.Skip("Long Running Benchmark")
-
 	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache|base.KeyChanges)()
 	processEntryBenchmarks := []struct {
 		name           string
@@ -2190,8 +2188,6 @@ func (f *testDocChangedFeed) Next() sgbucket.FeedEvent {
 //   - non-unique doc ids?
 
 func BenchmarkDocChanged(b *testing.B) {
-	b.Skip("Long Running Benchmark")
-
 	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache|base.KeyChanges)()
 	processEntryBenchmarks := []struct {
 		name           string

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1963,6 +1963,7 @@ func (f *testProcessEntryFeed) Next() *LogEntry {
 //   - non-unique doc ids?
 
 func BenchmarkProcessEntry(b *testing.B) {
+	b.Skip("Long Running Benchmark")
 
 	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache|base.KeyChanges)()
 	processEntryBenchmarks := []struct {
@@ -2189,6 +2190,7 @@ func (f *testDocChangedFeed) Next() sgbucket.FeedEvent {
 //   - non-unique doc ids?
 
 func BenchmarkDocChanged(b *testing.B) {
+	b.Skip("Long Running Benchmark")
 
 	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache|base.KeyChanges)()
 	processEntryBenchmarks := []struct {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -288,6 +288,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 // Benchmark to validate fix for https://github.com/couchbase/sync_gateway/issues/2428
 func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
+	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()
 
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type treeDoc struct {
@@ -827,20 +826,16 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	defer tearDownTestDB(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, err = db.PutExistingRevWithBody("doc2", longBody, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc2", longBody, []string{"1-a"}, false)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
-	err = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	require.NoError(b, err)
-	_, _, err = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
+	_, _, _ = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -859,12 +854,9 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, err = db.PutExistingRevWithBody("doc1", updateBody, []string{"2-a", "1-a"}, false)
-	assert.NoError(b, err)
-	_, _, err = db.PutExistingRevWithBody("doc2", updateBody, []string{"2-a", "1-a"}, false)
-	assert.NoError(b, err)
-	_, _, err = db.PutExistingRevWithBody("doc3", updateBody, []string{"2-a", "1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc1", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody("doc2", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody("doc3", updateBody, []string{"2-a", "1-a"}, false)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -891,20 +883,16 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	defer tearDownTestDB(b, db)
 
 	body := Body{"foo": "bar", "rev": "1-a"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
 
 	largeDoc := make([]byte, 1000000)
 	longBody := Body{"val": string(largeDoc), "rev": "1-a"}
-	_, _, err = db.PutExistingRevWithBody("doc2", longBody, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc2", longBody, []string{"1-a"}, false)
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
-	err = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
-	require.NoError(b, err)
-	_, _, err = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
+	_, _, _ = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
 
 	b.Run("ShortLatest", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -923,12 +911,9 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 	})
 
 	updateBody := Body{"rev": "2-a"}
-	_, _, err = db.PutExistingRevWithBody("doc1", updateBody, []string{"2-a", "1-a"}, false)
-	assert.NoError(b, err)
-	_, _, err = db.PutExistingRevWithBody("doc2", updateBody, []string{"2-a", "1-a"}, false)
-	assert.NoError(b, err)
-	_, _, err = db.PutExistingRevWithBody("doc3", updateBody, []string{"2-a", "1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc1", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody("doc2", updateBody, []string{"2-a", "1-a"}, false)
+	_, _, _ = db.PutExistingRevWithBody("doc3", updateBody, []string{"2-a", "1-a"}, false)
 
 	b.Run("ShortOld", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
@@ -956,15 +941,12 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	defer tearDownTestDB(b, db)
 
 	body := Body{"foo": "bar"}
-	_, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
-	assert.NoError(b, err)
+	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
 
 	getDelta := func(newDoc *Document) {
-		deltaSrcRev, err := db.GetRev("doc1", "1-a", false, nil)
-		assert.NoError(b, err)
+		deltaSrcRev, _ := db.GetRev("doc1", "1-a", false, nil)
 
-		deltaSrcBody, err := deltaSrcRev.DeepMutableBody()
-		assert.NoError(b, err)
+		deltaSrcBody, _ := deltaSrcRev.DeepMutableBody()
 
 		// Stamp attachments so we can patch them
 		if len(deltaSrcRev.Attachments) > 0 {
@@ -972,7 +954,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 		}
 
 		deltaSrcMap := map[string]interface{}(deltaSrcBody)
-		err = base.Patch(&deltaSrcMap, newDoc.Body())
+		_ = base.Patch(&deltaSrcMap, newDoc.Body())
 	}
 
 	b.Run("SmallDiff", func(b *testing.B) {
@@ -993,8 +975,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 		}
 		largeDoc := make([]byte, 1000000)
 		longBody := Body{"val": string(largeDoc)}
-		bodyBytes, err := base.JSONMarshal(longBody)
-		assert.NoError(b, err)
+		bodyBytes, _ := base.JSONMarshal(longBody)
 		newDoc.UpdateBodyBytes(bodyBytes)
 		for n := 0; n < b.N; n++ {
 			getDelta(newDoc)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -834,7 +834,7 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	var shortWithAttachmentsDataBody Body
 	shortWithAttachmentsData := `{"test": true, "_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="}}, "rev":"1-a"}`
-	base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
+	_ = base.JSONUnmarshal([]byte(shortWithAttachmentsData), &shortWithAttachmentsDataBody)
 	_, _, _ = db.PutExistingRevWithBody("doc3", shortWithAttachmentsDataBody, []string{"1-a"}, false)
 
 	b.Run("ShortLatest", func(b *testing.B) {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1626,15 +1626,12 @@ func BenchmarkDatabase(b *testing.B) {
 func BenchmarkPut(b *testing.B) {
 	defer base.DisableTestLogging()()
 
-	bucket, err := ConnectToBucket(base.BucketSpec{
+	bucket, _ := ConnectToBucket(base.BucketSpec{
 		Server:          base.UnitTestUrl(),
 		CouchbaseDriver: base.ChooseCouchbaseDriver(base.DataBucket),
 		BucketName:      "Bucket"})
-	assert.NoError(b, err)
-	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
-	assert.NoError(b, err)
-	db, err := CreateDatabase(context)
-	assert.NoError(b, err)
+	context, _ := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
+	db, _ := CreateDatabase(context)
 
 	body := Body{"key1": "value1", "key2": 1234}
 	b.ResetTimer()

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -431,6 +431,7 @@ func TestConcurrentLoad(t *testing.T) {
 }
 
 func BenchmarkRevisionCacheRead(b *testing.B) {
+	defer base.SetUpBenchmarkLogging(base.LevelDebug, base.KeyAll)()
 
 	cacheHitCounter, cacheMissCounter, getDocumentCounter, getRevisionCounter := expvar.Int{}, expvar.Int{}, expvar.Int{}, expvar.Int{}
 	cache := NewLRURevisionCache(5000, &testBackingStore{nil, &getDocumentCounter, &getRevisionCounter}, &cacheHitCounter, &cacheMissCounter)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -438,8 +438,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 
 	// trigger load into cache
 	for i := 0; i < 5000; i++ {
-		_, err := cache.Get(fmt.Sprintf("doc%d", i), "1-abc", RevCacheOmitBody, RevCacheOmitDelta)
-		assert.NoError(b, err, "Error initializing cache for BenchmarkRevisionCacheRead")
+		_, _ = cache.Get(fmt.Sprintf("doc%d", i), "1-abc", RevCacheOmitBody, RevCacheOmitDelta)
 	}
 
 	b.ResetTimer()
@@ -447,10 +446,7 @@ func BenchmarkRevisionCacheRead(b *testing.B) {
 		//GET the document until test run has completed
 		for pb.Next() {
 			docId := fmt.Sprintf("doc%d", rand.Intn(5000))
-			docrev, err := cache.Get(docId, "1-abc", RevCacheOmitBody, RevCacheOmitDelta)
-			if err != nil {
-				assert.Fail(b, "Unexpected error for docrev:%+v", docrev)
-			}
+			_, _ = cache.Get(docId, "1-abc", RevCacheOmitBody, RevCacheOmitDelta)
 		}
 	})
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4451,8 +4451,7 @@ func Benchmark_RestApiGetDocPerformance(b *testing.B) {
 var threekdoc = `{"cols":["Name","Address","Location","phone"],"data":[["MelyssaF.Stokes","Ap#166-9804ProinSt.","52.01352,-9.4151","(306)773-3853"],["RuthT.Richards","Ap#180-8417TemporRoad","8.07909,-118.55952","(662)733-8043"],["CedricN.Witt","Ap#575-4625NuncSt.","74.419,153.71285","(850)995-0417"],["ElianaF.Ashley","Ap#169-2030Nibh.St.","87.98632,97.47442","(903)272-5949"],["ChesterJ.Holland","2905ProinSt.","-43.14706,-64.25893","(911)435-9200"],["AleaT.Bishop","Ap#493-4894ConvallisRd.","42.54157,64.98534","(479)848-2988"],["HerrodT.Barron","Ap#822-1444EtAvenue","9.50706,-111.54064","(390)300-8534"],["YoshiP.Sanchez","Ap#796-4679Arcu.Avenue","-16.49557,-137.69","(913)606-8930"],["GrahamO.Velazquez","415EratRd.","-5.30634,171.81751","(691)700-3072"],["BryarF.Sargent","Ap#180-6507Lacus.St.","17.64959,-19.93008","(516)890-6469"],["XerxesM.Gaines","370-1967NislStreet","-39.28978,-23.74924","(461)907-9563"],["KayI.Jones","565-351ElitAve","25.58317,17.43545","(145)441-5007"],["ImaZ.Curry","Ap#143-8377MagnaAve","-86.72025,-161.94081","(484)924-8145"],["GiselleW.Macdonald","962AdipiscingRoad","-21.55826,-121.06657","(137)255-2241"],["TarikJ.Kane","P.O.Box447,5949PhasellusSt.","57.28914,-125.89595","(356)758-8271"],["ChristopherJ.Travis","5246InRd.","-69.12682,31.20181","(298)963-1855"],["QuinnT.Pace","P.O.Box935,212Laoreet,St.","-62.00241,1.31111","(157)419-0182"],["BrentK.Guy","156-417LoremSt.","26.67571,-29.35786","(125)687-6610"],["JocelynN.Cash","Ap#502-9209VehiculaSt.","-26.05925,160.61357","(782)351-4211"],["DaphneS.King","571-1485FringillaRoad","-76.33262,-142.5655","(356)476-4508"],["MicahJ.Eaton","3468ProinRd.","61.30187,-128.8584","(942)467-7558"],["ChaneyM.Gay","444-1647Pede.Rd.","84.32739,-43.59781","(386)231-0872"],["LacotaM.Guerra","9863NuncRoad","21.81253,-54.90423","(694)443-8520"],["KimberleyY.Jensen","6403PurusSt.","67.5704,65.90554","(181)309-7780"],["JenaY.Brennan","Ap#533-7088MalesuadaStreet","78.58624,-172.89351","(886)688-0617"],["CarterK.Dotson","Ap#828-1931IpsumAve","59.54845,53.30366","(203)546-8704"],["EllaU.Buckner","Ap#141-1401CrasSt.","78.34425,-172.24474","(214)243-6054"],["HamiltonE.Estrada","8676Iaculis,St.","11.67468,-130.12233","(913)624-2612"],["IanT.Saunders","P.O.Box519,3762DictumRd.","-10.97019,73.47059","(536)391-7018"],["CairoK.Craft","6619Sem.St.","9.28931,-5.69682","(476)804-7898"],["JohnB.Norman","Ap#865-7121CubiliaAve","50.96552,-126.5271","(309)323-6975"],["SawyerD.Hale","Ap#512-820EratRd.","-65.1931,166.14822","(180)527-8987"],["CiaranQ.Cole","P.O.Box262,9220SedAvenue","69.753,121.39921","(272)654-8755"],["BrandenJ.Thompson","Ap#846-5470MetusAv.","44.61386,-44.18375","(388)776-0689"]]}`
 
 func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
-
-	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyAll)()
+	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
 
 	prt := NewRestTester(b, nil)
 	defer prt.Close()
@@ -4486,7 +4485,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 }
 
 func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelDebug, base.KeyHTTP)()
+	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()
 	//Create test documents
 	rt := NewRestTester(b, nil)
 	defer rt.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4486,8 +4486,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 }
 
 func Benchmark_RestApiGetDocPerformanceFullRevCache(b *testing.B) {
-
-	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyAll)()
+	defer base.SetUpBenchmarkLogging(base.LevelDebug, base.KeyHTTP)()
 	//Create test documents
 	rt := NewRestTester(b, nil)
 	defer rt.Close()


### PR DESCRIPTION
- Remove some more logging so that the Benchmark runs are completely clean and there is no other logging within the Benchmark output.
- Shorten runs

Local runs seem to have shaved the run time down to sub 2 minutes from 8 minutes