### PR TITLE
Logging test fixes

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -499,7 +499,7 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 	}
 }
 
-var consoleOutput io.Writer = os.Stderr
+var consoleFOutput io.Writer = os.Stderr
 
 // Consolef logs the given formatted string and args to the given log level and log key,
 // as well as making sure the message is *always* logged to stdout.
@@ -509,7 +509,7 @@ func Consolef(logLevel LogLevel, logKey LogKey, format string, args ...interface
 	// If the above logTo didn't already log to stderr, do it directly here
 	if !consoleLogger.isStderr || !consoleLogger.shouldLog(logLevel, logKey) {
 		format = addPrefixes(format, context.Background(), logLevel, logKey)
-		_, _ = fmt.Fprintf(consoleOutput, format+"\n", args...)
+		_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
 	}
 }
 

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -273,14 +273,14 @@ func TestLogSyncGatewayVersion(t *testing.T) {
 	for i := LevelNone; i < levelCount; i++ {
 		t.Run(i.String(), func(t *testing.T) {
 			consoleLogger.LogLevel.Set(i)
-			out := CaptureOutput(LogSyncGatewayVersion)
+			out := CaptureConsolefLogOutput(LogSyncGatewayVersion)
 			assert.Contains(t, out, LongVersionString)
 		})
 	}
 	consoleLogger.LogLevel.Set(LevelInfo)
 }
 
-func CaptureOutput(f func()) string {
+func CaptureConsolefLogOutput(f func()) string {
 	buf := bytes.Buffer{}
 	consoleOutput = &buf
 	f()

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -30,7 +30,7 @@ func assertLogContains(t *testing.T, s string, f func()) {
 	// temporarily override logger output for the given function call
 	consoleLogger.logger.SetOutput(&b)
 	f()
-	consoleLogger.logger.SetOutput(consoleOutput)
+	consoleLogger.logger.SetOutput(os.Stderr)
 
 	assert.Contains(t, b.String(), s)
 }
@@ -282,8 +282,8 @@ func TestLogSyncGatewayVersion(t *testing.T) {
 
 func CaptureConsolefLogOutput(f func()) string {
 	buf := bytes.Buffer{}
-	consoleOutput = &buf
+	consoleFOutput = &buf
 	f()
-	consoleOutput = os.Stderr
+	consoleFOutput = os.Stderr
 	return buf.String()
 }

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -25,15 +25,13 @@ import (
 
 // asserts that the logs produced by function f contain string s.
 func assertLogContains(t *testing.T, s string, f func()) {
-	originalLogger := consoleLogger
 	b := bytes.Buffer{}
 
-	// temporarily override logger for the function call
-	level := LevelDebug
-	consoleLogger = &ConsoleLogger{LogLevel: &level, FileLogger: FileLogger{Enabled: true, logger: log.New(&b, "", 0)}}
-	defer func() { consoleLogger = originalLogger }()
-
+	// temporarily override logger output for the given function call
+	consoleLogger.logger.SetOutput(&b)
 	f()
+	consoleLogger.logger.SetOutput(consoleOutput)
+
 	assert.Contains(t, b.String(), s)
 }
 

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -523,34 +523,34 @@ func TestRedactBasicAuthURL(t *testing.T) {
 
 func TestSetUpTestLogging(t *testing.T) {
 	// Check default state of logging is as expected.
-	goassert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
-	goassert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+	require.Equal(t, LevelInfo, *consoleLogger.LogLevel)
+	require.Equal(t, KeyHTTP, *consoleLogger.LogKey)
 
 	teardownFn := SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
-	goassert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
-	goassert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
+	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
+	assert.Equal(t, KeyDCP|KeySync, *consoleLogger.LogKey)
 
 	teardownFn()
-	goassert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
-	goassert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
+	assert.Equal(t, KeyHTTP, *consoleLogger.LogKey)
 
 	teardownFn = DisableTestLogging()
-	goassert.Equals(t, *consoleLogger.LogLevel, LevelNone)
-	goassert.Equals(t, *consoleLogger.LogKey, KeyNone)
+	assert.Equal(t, LevelNone, *consoleLogger.LogLevel)
+	assert.Equal(t, KeyNone, *consoleLogger.LogKey)
 
 	teardownFn()
-	goassert.Equals(t, *consoleLogger.LogLevel, LevelInfo)
-	goassert.Equals(t, *consoleLogger.LogKey, KeyHTTP)
+	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
+	assert.Equal(t, KeyHTTP, *consoleLogger.LogKey)
 
 	SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
-	goassert.Equals(t, *consoleLogger.LogLevel, LevelDebug)
-	goassert.Equals(t, *consoleLogger.LogKey, KeyDCP|KeySync)
+	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
+	assert.Equal(t, KeyDCP|KeySync, *consoleLogger.LogKey)
 
 	// Now we should panic because we forgot to call teardown!
-	defer func() {
-		assert.True(t, recover() != nil, "Expected panic from multiple SetUpTestLogging calls")
-	}()
-	SetUpTestLogging(LevelError, KeyAuth|KeyCRUD)
+	assert.Panics(t, func() {
+		SetUpTestLogging(LevelError, KeyAuth|KeyCRUD)
+	}, "Expected panic from multiple SetUpTestLogging calls")
+	teardownFn()
 }
 
 func TestEncodeDecodeCompatVersion(t *testing.T) {


### PR DESCRIPTION
- Changed `TestSetUpTestLogging` so that it can work when -test.count > 1 (by running the teardown once done)
- Prevent data race in `TestRedactedLogFuncs` by changing `assertLogContains` to switch only the consoleLogger output, instead of the entire global `consoleLogger`
- Renamed `Consolef` specific variables to better indicate usage