### PR TITLE
CBG-631: Fix sgw-unix-build failure due to TestHandleProfiling test failure.

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -283,7 +283,7 @@ func (h *handler) handleProfiling() error {
 	// Handle no file
 	if params.File == "" {
 		if isCPUProfile {
-			base.InfofCtx(h.db.Ctx, base.KeyAll, "... ending CPU profile")
+			base.Infof(base.KeyAll, "... ending CPU profile")
 			pprof.StopCPUProfile()
 			return nil
 		}

--- a/rest/api.go
+++ b/rest/api.go
@@ -307,7 +307,7 @@ func (h *handler) handleProfiling() error {
 	}
 
 	if fileCloseError := f.Close(); fileCloseError != nil {
-		base.WarnfCtx(h.db.Ctx, "Error closing profile file: %v", fileCloseError)
+		base.Warnf("Error closing profile file: %v", fileCloseError)
 	}
 
 	return err
@@ -334,7 +334,7 @@ func (h *handler) handleHeapProfiling() error {
 	err = pprof.WriteHeapProfile(f)
 
 	if fileCloseError := f.Close(); fileCloseError != nil {
-		base.WarnfCtx(h.db.Ctx, "Error closing profile file: %v", fileCloseError)
+		base.Warnf("Error closing profile file: %v", fileCloseError)
 	}
 
 	return err


### PR DESCRIPTION
Use Infof instead of InfofCtx while ending CPU profiling