### PR TITLE
Prefix external logger warn/errors with log keys

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -34,9 +34,9 @@ var _ gocb.Logger = GoCBLogger{}
 func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
-		Errorf(format, v...)
+		Errorf(KeyGoCB.String()+": "+format, v...)
 	case gocb.LogWarn:
-		Warnf(format, v...)
+		Warnf(KeyGoCB.String()+": "+format, v...)
 	case gocb.LogInfo:
 		Debugf(KeyGoCB, format, v...)
 	case gocb.LogDebug, gocb.LogTrace:
@@ -63,9 +63,9 @@ var _ gocbcore.Logger = GoCBCoreLogger{}
 func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:
-		Errorf(format, v...)
+		Errorf(KeyGoCB.String()+": "+format, v...)
 	case gocbcore.LogWarn:
-		Warnf(format, v...)
+		Warnf(KeyGoCB.String()+": "+format, v...)
 	case gocbcore.LogInfo:
 		Debugf(KeyGoCB, format, v...)
 	case gocbcore.LogDebug, gocbcore.LogTrace:
@@ -91,11 +91,11 @@ func sgreplicateLogFn(level clog.LogLevel, format string, args ...interface{}) {
 	case clog.LevelNormal:
 		Infof(KeyReplicate, format, args...)
 	case clog.LevelWarning:
-		Warnf(format, args...)
+		Warnf(KeyReplicate.String()+": "+format, args...)
 	case clog.LevelError:
-		Errorf(format, args...)
+		Errorf(KeyReplicate.String()+": "+format, args...)
 	case clog.LevelPanic:
-		Errorf(format, args...)
+		Errorf(KeyReplicate.String()+": "+format, args...)
 	}
 }
 
@@ -108,7 +108,7 @@ func sgreplicateLogFn(level clog.LogLevel, format string, args ...interface{}) {
 func ClogCallback(level, format string, v ...interface{}) string {
 	switch level {
 	case "ERRO", "FATA", "CRIT":
-		Errorf(format, v...)
+		Errorf(KeyDCP.String()+": "+format, v...)
 	case "WARN":
 		// TODO: cbgt currently logs a lot of what we'd consider info as WARN,
 		//    (i.e. diagnostic information that's not actionable by users), so

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -119,7 +119,7 @@ func NewSyncRunner(funcSource string) (*SyncRunner, error) {
 	funcSource = wrappedFuncSource(funcSource)
 	runner := &SyncRunner{}
 	err := runner.InitWithLogging(funcSource,
-		func(s string) { base.Errorf("Sync %s", base.UD(s)) },
+		func(s string) { base.Errorf(base.KeyJavascript.String()+": Sync %s", base.UD(s)) },
 		func(s string) { base.Infof(base.KeyJavascript, "Sync %s", base.UD(s)) })
 	if err != nil {
 		return nil, err

--- a/db/event.go
+++ b/db/event.go
@@ -90,7 +90,7 @@ type jsEventTask struct {
 func newJsEventTask(funcSource string) (sgbucket.JSServerTask, error) {
 	eventTask := &jsEventTask{}
 	err := eventTask.InitWithLogging(funcSource,
-		func(s string) { base.Errorf("Webhook %s", base.UD(s)) },
+		func(s string) { base.Errorf(base.KeyJavascript.String()+": Webhook %s", base.UD(s)) },
 		func(s string) { base.Infof(base.KeyJavascript, "Webhook %s", base.UD(s)) })
 	if err != nil {
 		return nil, err

--- a/db/import.go
+++ b/db/import.go
@@ -403,7 +403,7 @@ type jsImportFilterRunner struct {
 func newImportFilterRunner(funcSource string) (sgbucket.JSServerTask, error) {
 	importFilterRunner := &jsEventTask{}
 	err := importFilterRunner.InitWithLogging(funcSource,
-		func(s string) { base.Errorf("Import %s", base.UD(s)) },
+		func(s string) { base.Errorf(base.KeyJavascript.String()+": Import %s", base.UD(s)) },
 		func(s string) { base.Infof(base.KeyJavascript, "Import %s", base.UD(s)) })
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Logs for warnings and errors have no log keys (since #4311), but they were providing some additional context for the external loggers, so restored that behaviour manually for `gocb`, `cbdatasource`, `sg-replicate`, and `JSRunner`.

## E.g Before/After;
```
2019-12-11T21:33:04.073-08:00 [ERR] Reschedule failed, failing request (request was already queued somewhere else) -- base.GoCBCoreLogger.Log() at logger_external.go:66
2019-12-11T21:33:04.073-08:00 [ERR] gocb: Reschedule failed, failing request (request was already queued somewhere else) -- base.GoCBCoreLogger.Log() at logger_external.go:66
```