### PR TITLE
Fix test for 6.5.0 cluster - Set adhoc=true flag for EXPLAIN queries

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -91,8 +91,7 @@ func (bucket *CouchbaseBucketGoCB) Query(statement string, params interface{}, c
 
 func (bucket *CouchbaseBucketGoCB) ExplainQuery(statement string, params interface{}) (plan map[string]interface{}, err error) {
 	explainStatement := fmt.Sprintf("EXPLAIN %s", statement)
-
-	explainResults, explainErr := bucket.Query(explainStatement, params, gocb.RequestPlus, false)
+	explainResults, explainErr := bucket.Query(explainStatement, params, gocb.RequestPlus, true)
 
 	if explainErr != nil {
 		return nil, explainErr


### PR DESCRIPTION
Fixes a currently test-only issue, where `TestCoveringQueries` was failing when run against a 6.5.0 cluster.

In 6.0.3 preparing a statement for an EXPLAIN query seemed to be OK,
but in 6.5.0 this returns a syntax error.

```json
{
  "code": 3000,
  "msg": "syntax error - at EXPLAIN",
  "query": "PREPARE EXPLAIN SELECT `test_data_bucket`._sync.access.`user1` as `value` FROM `test_data_bucket` WHERE any op in object_pairs(`test_data_bucket`._sync.access) satisfies op.name = $userName end;"
}
```