### PR TITLE
CBG-618 - Gather more information for jenkins-only flaky test

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2155,7 +2155,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 // └──────────────┘           └───────────┘          └───────────┘
 func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP|base.KeyCache|base.KeySync|base.KeySyncMsg)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{noAdminParty: true, DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2213,10 +2213,11 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 	msg, ok := client1.pullReplication.WaitForMessage(5)
 	assert.True(t, ok)
+	assert.Equal(t, msg.Profile(), messageRev, "unexpected profile for message 5 in %v", client1.pullReplication.GetMessages())
 	msgBody, err := msg.Body()
 	assert.NoError(t, err)
-	assert.Equal(t, `{}`, string(msgBody))
-	assert.Equal(t, "1", msg.Properties[revMessageDeleted])
+	assert.Equal(t, `{}`, string(msgBody), "unexpected body for message 5 in %v", client1.pullReplication.GetMessages())
+	assert.Equal(t, "1", msg.Properties[revMessageDeleted], "unexpected deleted property for message 5 in %v", client1.pullReplication.GetMessages())
 
 	// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
 	err = client2.StartOneshotPull()
@@ -2228,10 +2229,11 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 	msg, ok = client2.pullReplication.WaitForMessage(6)
 	assert.True(t, ok)
+	assert.Equal(t, msg.Profile(), messageRev, "unexpected profile for message 6 in %v", client2.pullReplication.GetMessages())
 	msgBody, err = msg.Body()
 	assert.NoError(t, err)
-	assert.Equal(t, `{}`, string(msgBody))
-	assert.Equal(t, "1", msg.Properties[revMessageDeleted])
+	assert.Equal(t, `{}`, string(msgBody), "unexpected body for message 6 in %v", client2.pullReplication.GetMessages())
+	assert.Equal(t, "1", msg.Properties[revMessageDeleted], "unexpected deleted property for message 6 in %v", client2.pullReplication.GetMessages())
 
 	deltaCacheHitsEnd := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltaCacheHits))
 	deltaCacheMissesEnd := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltaCacheMisses))

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2172,7 +2172,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer client1.Close()
 
 	client2, err := NewBlipTesterClientOpts(t, rt, &BlipTesterClientOpts{
@@ -2180,11 +2180,11 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		Channels:     []string{"*"},
 		ClientDeltas: true,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer client2.Close()
 
 	err = client1.StartPull()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// create doc1 rev 1-e89945d756a1d444fa212bffbbb31941
 	resp := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"channels": ["public"], "greetings": [{"hello": "world!"}]}`)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -48,6 +48,7 @@ type BlipTesterReplicator struct {
 }
 
 func (btr *BlipTesterReplicator) Close() {
+	btr.bt.Close()
 	btr.messagesLock.Lock()
 	btr.messages = make(map[blip.MessageNumber]*blip.Message, 0)
 	btr.messagesLock.Unlock()

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -649,6 +649,19 @@ func (btr *BlipTesterReplicator) GetMessage(serialNumber blip.MessageNumber) (ms
 	return nil, false
 }
 
+// GetMessages returns a copy of all messages stored in the Client keyed by serial number
+func (btr *BlipTesterReplicator) GetMessages() map[blip.MessageNumber]blip.Message {
+	btr.messagesLock.RLock()
+	defer btr.messagesLock.RUnlock()
+
+	messages := make(map[blip.MessageNumber]blip.Message, len(btr.messages))
+	for k, v := range btr.messages {
+		messages[k] = *v
+	}
+
+	return messages
+}
+
 // WaitForMessage blocks until the given message serial number has been stored by the replicator, and returns the message when found.
 func (btr *BlipTesterReplicator) WaitForMessage(serialNumber blip.MessageNumber) (msg *blip.Message, found bool) {
 	ticker := time.NewTicker(50 * time.Millisecond)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -718,6 +718,7 @@ type BlipTester struct {
 
 // Close the bliptester
 func (bt BlipTester) Close() {
+	bt.sender.Close()
 	bt.restTester.Close()
 }
 


### PR DESCRIPTION
Doesn't fix underlying issue reported in CBG-618, but logs more information that would help proper diagnosis.

## Test fixes
- Close `BlipTester` from `BlipTesterReplicator.Close()`, and close `BlipTester.sender` on `BlipTester.Close()`
	- Prevents idle open websockets even after test has finished
- Require no error on `TestBlipDeltaSyncPullTombstonedStarChan` setup to prevent test panics under setup failure

## More assertions and more debug logging
- Increase log verbosity for flaky test
- Additional assert on message profile 
- Print list of blip messages on assertion failure for diagnosis