### PR TITLE
Switch test GetBucketCommon panic to t.Fatalf

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -108,7 +108,7 @@ func GetBucketCommon(bucketType CouchbaseBucketType, tester testing.TB) TestBuck
 		case true:
 			// Empty it
 			if err := tbm.RecreateOrEmptyBucket(); err != nil {
-				panic(fmt.Sprintf("Error trying to empty bucket.  Spec: %+v.  err: %v", spec, err))
+				tester.Fatalf("Error trying to empty bucket.  Spec: %+v.  err: %v", spec, err)
 
 			}
 		case false:


### PR DESCRIPTION
```
--- FAIL: TestDocLifecycle (62.88s)
panic: Error trying to empty bucket.  Spec: {Server:http://integration-cbs-55.sc.couchbase.com:8091 PoolName: BucketName:test_data_bucket FeedType: Auth:{Username:test_data_bucket Password:password BucketName:test_data_bucket} CouchbaseDriver:GoCBCustomSGTranscoder Certpath: Keypath: CACertPath: KvTLSPort:0 MaxNumRetries:0 InitialRetrySleepTimeMS:0 UseXattrs:true ViewQueryTimeoutSecs:<nil> BucketOpTimeout:<nil> KvPoolSize:0}.  err: Timed out waiting for bucket to be empty after flush.  ItemCount: 7 [recovered]
	panic: Error trying to empty bucket.  Spec: {Server:http://integration-cbs-55.sc.couchbase.com:8091 PoolName: BucketName:test_data_bucket FeedType: Auth:{Username:test_data_bucket Password:password BucketName:test_data_bucket} CouchbaseDriver:GoCBCustomSGTranscoder Certpath: Keypath: CACertPath: KvTLSPort:0 MaxNumRetries:0 InitialRetrySleepTimeMS:0 UseXattrs:true ViewQueryTimeoutSecs:<nil> BucketOpTimeout:<nil> KvPoolSize:0}.  err: Timed out waiting for bucket to be empty after flush.  ItemCount: 7

goroutine 20226 [running]:
testing.tRunner.func1(0xc026d3ac00)
	/root/.gvm/gos/go1.13.4/src/testing/testing.go:874 +0x69f
panic(0x13934c0, 0xc0132b3e60)
	/root/.gvm/gos/go1.13.4/src/runtime/panic.go:679 +0x1b2
github.com/couchbase/sync_gateway/base.GetBucketCommon(0x0, 0x17e20e0, 0xc026d3ac00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/util_testing.go:111 +0x943
github.com/couchbase/sync_gateway/base.GetTestBucket(0x17e20e0, 0xc026d3ac00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/base/util_testing.go:48 +0xa1
github.com/couchbase/sync_gateway/rest.(*RestTester).Bucket(0xc02778d7a0, 0x1, 0xc000000067)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:95 +0x18f5
github.com/couchbase/sync_gateway/rest.(*RestTester).ServerContext(0xc02778d7a0, 0xc000000001)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:233 +0x51
github.com/couchbase/sync_gateway/rest.(*RestTester).TestPublicHandler.func1()
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:355 +0x68
sync.(*Once).doSlow(0xc02778d800, 0xc0004d5cc0)
	/root/.gvm/gos/go1.13.4/src/sync/once.go:66 +0x101
sync.(*Once).Do(0xc02778d800, 0xc0004d5cc0)
	/root/.gvm/gos/go1.13.4/src/sync/once.go:57 +0x69
github.com/couchbase/sync_gateway/rest.(*RestTester).TestPublicHandler(0xc02778d7a0, 0x28, 0x404)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:354 +0x7e
github.com/couchbase/sync_gateway/rest.(*RestTester).Send(0xc02778d7a0, 0xc026d3ad00, 0xc01f2329c8)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:337 +0x20d
github.com/couchbase/sync_gateway/rest.(*RestTester).SendRequest(0xc02778d7a0, 0x152c3f7, 0x3, 0xc01f2329c8, 0x7, 0x1536c88, 0xd, 0x1f5ad60)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:315 +0xa2
github.com/couchbase/sync_gateway/rest.(*RestTester).createDoc(0xc02778d7a0, 0xc026d3ac00, 0x152c523, 0x3, 0x2e, 0x349)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/api_test.go:96 +0xcb
github.com/couchbase/sync_gateway/rest.TestDocLifecycle(0xc026d3ac00)
	/var/jenkins/workspace/sync-gateway-integration/godeps/src/github.com/couchbase/sync_gateway/rest/api_test.go:112 +0xd5
testing.tRunner(0xc026d3ac00, 0x1593588)
	/root/.gvm/gos/go1.13.4/src/testing/testing.go:909 +0x19a
created by testing.(*T).Run
	/root/.gvm/gos/go1.13.4/src/testing/testing.go:960 +0x652
FAIL	github.com/couchbase/sync_gateway/rest	2065.248s
FAIL
```