### PR TITLE
CBG-633 Clarify usage of context vs handler db instance

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -54,7 +54,7 @@ var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 // This connection remains open until the client closes it, and can receive any number of requests.
 type blipSyncContext struct {
 	blipContext         *blip.Context
-	db                  *db.Database
+	blipContextDb       *db.Database // 'master' database instance for the replication, used as source when creating handler-specific databases
 	dbUserLock          sync.RWMutex // Must be held when refreshing the db user
 	batchSize           int
 	gotSubChanges       bool
@@ -76,8 +76,8 @@ type blipSyncContext struct {
 
 type blipHandler struct {
 	*blipSyncContext
-	db           *db.Database
-	serialNumber uint64 // This blip handler's serial number to differentiate logs w/ other handlers
+	db           *db.Database // Handler-specific copy of the blipSyncContext's blipContextDb
+	serialNumber uint64       // This blip handler's serial number to differentiate logs w/ other handlers
 }
 
 type blipHandlerFunc func(*blipHandler, *blip.Message) error
@@ -110,18 +110,17 @@ func (bh *blipHandler) refreshUser() error {
 		// If changed, refresh the user and db while holding the lock
 		if userChanged {
 			// Refresh the blipSyncContext database
-			newUser, err := bc.db.Authenticator().GetUser(bc.userName)
+			newUser, err := bc.blipContextDb.Authenticator().GetUser(bc.userName)
 			if err != nil {
 				bc.dbUserLock.Unlock()
 				return err
 			}
 			bc.userChangeWaiter.RefreshUserKeys(newUser)
-			bc.db.SetUser(newUser)
+			bc.blipContextDb.SetUser(newUser)
 
 			// refresh the handler's database with the new blipSyncContext database
 			bh.db = bh._copyContextDatabase()
 		}
-
 		bc.dbUserLock.Unlock()
 	}
 	return nil
@@ -163,7 +162,7 @@ func (h *handler) handleBLIPSync() error {
 	// Create a BLIP-sync context and register handlers:
 	ctx := blipSyncContext{
 		blipContext:      blipContext,
-		db:               h.db,
+		blipContextDb:    h.db,
 		terminator:       make(chan bool),
 		userChangeWaiter: h.db.NewUserWaiter(),
 		dbStats:          h.db.DatabaseContext.DbStats,
@@ -175,7 +174,7 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	// determine if SG has delta sync enabled for the given database
-	ctx.sgCanUseDeltas = ctx.db.DeltaSyncEnabled()
+	ctx.sgCanUseDeltas = h.db.DeltaSyncEnabled()
 
 	blipContext.DefaultHandler = ctx.notFound
 	for profile, handlerFn := range kHandlersByProfile {
@@ -259,15 +258,15 @@ func (ctx *blipSyncContext) notFound(rq *blip.Message) {
 func (ctx *blipSyncContext) Logf(logLevel base.LogLevel, logKey base.LogKey, format string, args ...interface{}) {
 	switch logLevel {
 	case base.LevelError:
-		base.ErrorfCtx(ctx.db.Ctx, format, args...)
+		base.ErrorfCtx(ctx.blipContextDb.Ctx, format, args...)
 	case base.LevelWarn:
-		base.WarnfCtx(ctx.db.Ctx, format, args...)
+		base.WarnfCtx(ctx.blipContextDb.Ctx, format, args...)
 	case base.LevelInfo:
-		base.InfofCtx(ctx.db.Ctx, logKey, format, args...)
+		base.InfofCtx(ctx.blipContextDb.Ctx, logKey, format, args...)
 	case base.LevelDebug:
-		base.DebugfCtx(ctx.db.Ctx, logKey, format, args...)
+		base.DebugfCtx(ctx.blipContextDb.Ctx, logKey, format, args...)
 	case base.LevelTrace:
-		base.TracefCtx(ctx.db.Ctx, logKey, format, args...)
+		base.TracefCtx(ctx.blipContextDb.Ctx, logKey, format, args...)
 	}
 }
 
@@ -487,8 +486,8 @@ func (bc *blipSyncContext) copyContextDatabase() *db.Database {
 }
 
 func (bc *blipSyncContext) _copyContextDatabase() *db.Database {
-	databaseCopy, _ := db.GetDatabase(bc.db.DatabaseContext, bc.db.User())
-	databaseCopy.Ctx = bc.db.Ctx
+	databaseCopy, _ := db.GetDatabase(bc.blipContextDb.DatabaseContext, bc.blipContextDb.User())
+	databaseCopy.Ctx = bc.blipContextDb.Ctx
 	return databaseCopy
 }
 


### PR DESCRIPTION
Renamed context db for clarity - the bulk of this work was already done as part of CBG-628.