### PR TITLE
Jenkinsfile: Email team when master branch has failing tests or builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -385,5 +385,17 @@ pipeline {
                 sh "go clean -cache"
             }
         }
+        unstable {
+            when { branch 'master' }
+            mail to: 'mobile_dev_sg@couchbase.com',
+                 subject: "Failed tests in master SGW pipeline: ${currentBuild.fullDisplayName}",
+                 body: "At least one test failed: ${env.BUILD_URL}"
+        }
+        failure {
+            when { branch 'master' }
+            mail to: 'mobile_dev_sg@couchbase.com',
+                 subject: "Build failure in master SGW pipeline: ${currentBuild.fullDisplayName}",
+                 body: "Something went wrong building: ${env.BUILD_URL}"
+        }
     }
 }


### PR DESCRIPTION
We can see the PR builds easy enough - but the master builds are kinda hidden away. This should help with the visibility.