### PR TITLE
CBG-653 - Add "norev" handler for detailed logging

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2641,8 +2641,8 @@ func TestBlipNorev(t *testing.T) {
 	norevMsg := NewNoRevMessage()
 	norevMsg.setId("docid")
 	norevMsg.setRev("1-a")
-	norevMsg.setError("norev error")
-	norevMsg.setReason("norev reason")
+	norevMsg.setError("404")
+	norevMsg.setReason("couldn't send xyz")
 
 	// Couchbase Lite always sends noreply=true for norev messages
 	// but set to false so we can block waiting for a reply

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -923,7 +923,7 @@ func (bc *blipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docID
 	if response := outrq.Response(); response != nil {
 		if response.Type() == blip.ErrorType {
 			errorBody, _ := response.Body()
-			bc.Logf(base.LevelWarn, base.KeyAll, "Client returned error in rev response for doc %q / %q: %s", docID, revID, errorBody)
+			bc.Logf(base.LevelWarn, base.KeyAll, "Client returned error in rev response for doc %q / %q: %s", base.UD(docID), revID, errorBody)
 		}
 	}
 
@@ -932,7 +932,7 @@ func (bc *blipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docID
 
 func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 	bh.Logf(base.LevelInfo, base.KeySyncMsg, "%s: norev for doc %q / %q - error: %q - reason: %q",
-		rq.String(), rq.Properties[norevMessageId], rq.Properties[norevMessageRev], rq.Properties[norevMessageError], rq.Properties[norevMessageReason])
+		rq.String(), base.UD(rq.Properties[norevMessageId]), rq.Properties[norevMessageRev], rq.Properties[norevMessageError], rq.Properties[norevMessageReason])
 
 	// Couchbase Lite always sense noreply=true for norev profiles
 	// but for testing purposes, it's useful to know which handler processed the message

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -133,6 +133,7 @@ var kHandlersByProfile = map[string]blipHandlerFunc{
 	messageSubChanges:     userBlipHandler((*blipHandler).handleSubChanges),
 	messageChanges:        userBlipHandler((*blipHandler).handleChanges),
 	messageRev:            userBlipHandler((*blipHandler).handleRev),
+	messageNoRev:          (*blipHandler).handleNoRev,
 	messageGetAttachment:  userBlipHandler((*blipHandler).handleGetAttachment),
 	messageProposeChanges: (*blipHandler).handleProposeChanges,
 }
@@ -924,6 +925,20 @@ func (bc *blipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docID
 			errorBody, _ := response.Body()
 			bc.Logf(base.LevelWarn, base.KeyAll, "Client returned error in rev response for doc %q / %q: %s", docID, revID, errorBody)
 		}
+	}
+
+	return nil
+}
+
+func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
+	bh.Logf(base.LevelInfo, base.KeySyncMsg, "#%d: norev for doc %q / %q - error: %s - reason %s",
+		bh.serialNumber, rq.Properties[norevMessageId], rq.Properties[norevMessageRev], rq.Properties[norevMessageError], rq.Properties[norevMessageReason])
+
+	// Couchbase Lite always sense noreply=true for norev profiles
+	// but for testing purposes, it's useful to know which handler processed the message
+	if !rq.NoReply() && rq.Properties[sgShowHandler] == "true" {
+		response := rq.Response()
+		response.Properties[sgHandler] = "handleNoRev"
 	}
 
 	return nil

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -931,8 +931,8 @@ func (bc *blipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docID
 }
 
 func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
-	bh.Logf(base.LevelInfo, base.KeySyncMsg, "#%d: norev for doc %q / %q - error: %s - reason %s",
-		bh.serialNumber, rq.Properties[norevMessageId], rq.Properties[norevMessageRev], rq.Properties[norevMessageError], rq.Properties[norevMessageReason])
+	bh.Logf(base.LevelInfo, base.KeySyncMsg, "%s: norev for doc %q / %q - error: %q - reason: %q",
+		rq.String(), rq.Properties[norevMessageId], rq.Properties[norevMessageRev], rq.Properties[norevMessageError], rq.Properties[norevMessageReason])
 
 	// Couchbase Lite always sense noreply=true for norev profiles
 	// but for testing purposes, it's useful to know which handler processed the message

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -75,8 +75,8 @@ const (
 	proveAttachmentDigest = "digest"
 
 	// Sync Gateway specific properties (used for testing)
-	sgShowHandler = "sgShowHandler"
-	sgHandler     = "sgHandler"
+	sgShowHandler = "sgShowHandler" // Used to request a response with sgHandler
+	sgHandler     = "sgHandler"     // Used to show which handler processed the message
 )
 
 // Function signature for something that parses a sequence id from a string

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -73,6 +73,10 @@ const (
 
 	// proveAttachment
 	proveAttachmentDigest = "digest"
+
+	// Sync Gateway specific properties (used for testing)
+	sgShowHandler = "sgShowHandler"
+	sgHandler     = "sgHandler"
 )
 
 // Function signature for something that parses a sequence id from a string


### PR DESCRIPTION
## Before
```
2020-01-02T12:07:57.534Z [INF] Sync: c:[487e91a] MSG#1 Type:"norev"
2020-01-02T12:07:57.534Z [INF] Sync: c:[487e91a] MSG#1    --> 404 Unknown profile
```

## After
```
2020-01-02T12:12:20.595Z [INF] SyncMsg: c:[f73be7c] MSG#1: norev for doc "docid" / "1-a" - error: "404" - reason: "couldn't send xyz"
```