### PR TITLE
Faster colorEnabled() evaluation by reading env capability on startup

### DIFF
--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/couchbase/goutils/logging"
@@ -251,6 +252,42 @@ func TestLogColor(t *testing.T) {
 	assert.Equal(t, "Format", color("Format", LevelError))
 	assert.Equal(t, "Format", color("Format", LevelTrace))
 	assert.Equal(t, "Format", color("Format", LevelNone))
+}
+
+func BenchmarkLogColorEnabled(b *testing.B) {
+	if runtime.GOOS == "windows" {
+		b.Skipf("color not supported in Windows")
+	}
+
+	b.Run("enabled", func(b *testing.B) {
+		consoleLogger.ColorEnabled = true
+		require.NoError(b, os.Setenv("TERM", "xterm-256color"))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = colorEnabled()
+		}
+	})
+
+	b.Run("disabled console color", func(b *testing.B) {
+		consoleLogger.ColorEnabled = false
+		require.NoError(b, os.Setenv("TERM", "xterm-256color"))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = colorEnabled()
+		}
+	})
+
+	b.Run("disabled term color", func(b *testing.B) {
+		consoleLogger.ColorEnabled = true
+		require.NoError(b, os.Setenv("TERM", "dumb"))
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = colorEnabled()
+		}
+	})
 }
 
 func TestMarshalTextError(t *testing.T) {


### PR DESCRIPTION
This speeds up logging when when color is enabled.

`colorEnabled()` is called every time we log, to determine whether to apply ANSI escape sequences to color log output.

Checking `consoleLogger.ColorEnabled` is fast enough as an exit early, but we were also checking whether the environment is capable of color on each invocation. Now we only do that once, at startup, and use that cached result.

```
14:03 $ benchstat before.out after.out
name                                       old time/op    new time/op    delta
LogColorEnabled/enabled-12                   95.0ns ± 0%     0.6ns ± 0%  -99.39%  (p=0.000 n=5+4)
LogColorEnabled/disabled_console_color-12    0.58ns ± 0%    0.58ns ± 0%     ~     (all equal)
LogColorEnabled/disabled_term_color-12       96.0ns ± 0%     0.6ns ± 0%  -99.40%  (p=0.008 n=5+5)

name                                       old alloc/op   new alloc/op   delta
LogColorEnabled/enabled-12                    0.00B          0.00B          ~     (all equal)
LogColorEnabled/disabled_console_color-12     0.00B          0.00B          ~     (all equal)
LogColorEnabled/disabled_term_color-12        0.00B          0.00B          ~     (all equal)

name                                       old allocs/op  new allocs/op  delta
LogColorEnabled/enabled-12                     0.00           0.00          ~     (all equal)
LogColorEnabled/disabled_console_color-12      0.00           0.00          ~     (all equal)
LogColorEnabled/disabled_term_color-12         0.00           0.00          ~     (all equal)
```