### PR TITLE
Rename CreateUUID to GenerateRandomID to avoid confusion

### DIFF
--- a/base/replicator.go
+++ b/base/replicator.go
@@ -91,7 +91,7 @@ func (r *Replicator) StopReplications() error {
 func (r *Replicator) startReplication(parameters sgreplicate.ReplicationParameters) (*Task, error) {
 	// Generate ID if blank for the new replication
 	if parameters.ReplicationId == "" {
-		parameters.ReplicationId = CreateRandomHex()
+		parameters.ReplicationId = GenerateRandomID()
 	}
 
 	parameters.LogFn = sgreplicateLogFn

--- a/base/replicator.go
+++ b/base/replicator.go
@@ -91,7 +91,7 @@ func (r *Replicator) StopReplications() error {
 func (r *Replicator) startReplication(parameters sgreplicate.ReplicationParameters) (*Task, error) {
 	// Generate ID if blank for the new replication
 	if parameters.ReplicationId == "" {
-		parameters.ReplicationId = CreateUUID()
+		parameters.ReplicationId = CreateRandomHex()
 	}
 
 	parameters.LogFn = sgreplicateLogFn

--- a/base/util.go
+++ b/base/util.go
@@ -74,12 +74,17 @@ func GenerateRandomID() string {
 
 // randCryptoHex returns a cryptographically-secure random number of length sizeBits encoded as a hex string.
 func randCryptoHex(sizeBits int) (string, error) {
-	sizeBytes := sizeBits / 8
-	b := make([]byte, sizeBytes)
-	n, err := rand.Read(b)
-	if n < sizeBytes || err != nil {
+	if sizeBits%8 != 0 {
+		return "", fmt.Errorf("randCryptoHex sizeBits must be a multiple of 8: %d", sizeBits)
+	}
+
+	b := make([]byte, sizeBits/8)
+
+	_, err := rand.Read(b)
+	if err != nil {
 		return "", err
 	}
+
 	return fmt.Sprintf("%x", b), nil
 }
 

--- a/base/util.go
+++ b/base/util.go
@@ -54,23 +54,33 @@ func RedactBasicAuthURL(url string) string {
 	return basicAuthURLRegexp.ReplaceAllLiteralString(url, "://****:****@")
 }
 
+// GenerateRandomSecret returns a cryptographically-secure 160-bit random number encoded as a hex string.
 func GenerateRandomSecret() string {
-	randomBytes := make([]byte, 20)
-	n, err := io.ReadFull(rand.Reader, randomBytes)
-	if n < len(randomBytes) || err != nil {
+	val, err := randCryptoHex(160)
+	if err != nil {
 		panic("RNG failed, can't create password")
 	}
-	return fmt.Sprintf("%x", randomBytes)
+	return val
 }
 
-// CreateRandomHex returns a cryptographically-random 160-bit number encoded as a hex string.
-func CreateRandomHex() string {
-	b := make([]byte, 16)
-	n, err := rand.Read(b)
-	if n < 16 {
+// GenerateRandomID returns a cryptographically-secure 128-bit random number encoded as a hex string.
+func GenerateRandomID() string {
+	val, err := randCryptoHex(128)
+	if err != nil {
 		Panicf("Failed to generate random ID: %s", err)
 	}
-	return fmt.Sprintf("%x", b)
+	return val
+}
+
+// randCryptoHex returns a cryptographically-secure random number of length sizeBits encoded as a hex string.
+func randCryptoHex(sizeBits int) (string, error) {
+	sizeBytes := sizeBits / 8
+	b := make([]byte, sizeBytes)
+	n, err := rand.Read(b)
+	if n < sizeBytes || err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", b), nil
 }
 
 // This is a workaround for an incompatibility between Go's JSON marshaler and CouchDB.

--- a/base/util.go
+++ b/base/util.go
@@ -63,14 +63,14 @@ func GenerateRandomSecret() string {
 	return fmt.Sprintf("%x", randomBytes)
 }
 
-// Returns a cryptographically-random 160-bit number encoded as a hex string.
-func CreateUUID() string {
-	bytes := make([]byte, 16)
-	n, err := rand.Read(bytes)
+// CreateRandomHex returns a cryptographically-random 160-bit number encoded as a hex string.
+func CreateRandomHex() string {
+	b := make([]byte, 16)
+	n, err := rand.Read(b)
 	if n < 16 {
 		Panicf("Failed to generate random ID: %s", err)
 	}
-	return fmt.Sprintf("%x", bytes)
+	return fmt.Sprintf("%x", b)
 }
 
 // This is a workaround for an incompatibility between Go's JSON marshaler and CouchDB.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -83,7 +83,7 @@ func GetTestBucketSpec(bucketType CouchbaseBucketType) BucketSpec {
 
 	if spec.IsWalrusBucket() {
 		// Use a unique bucket name to reduce the chance of interference between temporary test walrus buckets
-		spec.BucketName = fmt.Sprintf("%s-%s", spec.BucketName, CreateUUID())
+		spec.BucketName = fmt.Sprintf("%s-%s", spec.BucketName, CreateRandomHex())
 	}
 
 	return spec

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -83,7 +83,7 @@ func GetTestBucketSpec(bucketType CouchbaseBucketType) BucketSpec {
 
 	if spec.IsWalrusBucket() {
 		// Use a unique bucket name to reduce the chance of interference between temporary test walrus buckets
-		spec.BucketName = fmt.Sprintf("%s-%s", spec.BucketName, CreateRandomHex())
+		spec.BucketName = fmt.Sprintf("%s-%s", spec.BucketName, GenerateRandomID())
 	}
 
 	return spec

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -318,7 +318,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 	for docNum := 0; docNum < numDocs; docNum++ {
 
 		// Create the parent rev
-		docid := base.CreateRandomHex()
+		docid := base.GenerateRandomID()
 		docBody := createDoc(numKeys, valSizeBytes)
 		revId, _, err := db.Put(docid, docBody)
 		if err != nil {

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -318,7 +318,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 	for docNum := 0; docNum < numDocs; docNum++ {
 
 		// Create the parent rev
-		docid := base.CreateUUID()
+		docid := base.CreateRandomHex()
 		docBody := createDoc(numKeys, valSizeBytes)
 		revId, _, err := db.Put(docid, docBody)
 		if err != nil {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1561,7 +1561,7 @@ func (db *Database) Post(body Body) (string, string, *Document, error) {
 	// If there's an incoming _id property, use that as the doc ID.
 	docid, idFound := body[BodyId].(string)
 	if !idFound {
-		docid = base.CreateUUID()
+		docid = base.CreateRandomHex()
 	}
 
 	rev, doc, err := db.Put(docid, body)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1561,7 +1561,7 @@ func (db *Database) Post(body Body) (string, string, *Document, error) {
 	// If there's an incoming _id property, use that as the doc ID.
 	docid, idFound := body[BodyId].(string)
 	if !idFound {
-		docid = base.CreateRandomHex()
+		docid = base.GenerateRandomID()
 	}
 
 	rev, doc, err := db.Put(docid, body)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1568,7 +1568,7 @@ func TestViewCustom(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	// add some docs
-	docId := base.CreateUUID()
+	docId := base.CreateRandomHex()
 	_, _, err := db.Put(docId, Body{"val": "one"})
 	if err != nil {
 		log.Printf("error putting doc: %v", err)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1568,7 +1568,7 @@ func TestViewCustom(t *testing.T) {
 	defer tearDownTestDB(t, db)
 
 	// add some docs
-	docId := base.CreateRandomHex()
+	docId := base.GenerateRandomID()
 	_, _, err := db.Put(docId, Body{"val": "one"})
 	if err != nil {
 		log.Printf("error putting doc: %v", err)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4461,7 +4461,7 @@ func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		//PUT a new document until test run has completed
 		for pb.Next() {
-			prt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.CreateUUID()), threekdoc)
+			prt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.CreateRandomHex()), threekdoc)
 		}
 	})
 }
@@ -4479,7 +4479,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		//PUT a new document until test run has completed
 		for pb.Next() {
-			qrt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.CreateUUID()), threekdoc)
+			qrt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.CreateRandomHex()), threekdoc)
 		}
 	})
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4461,7 +4461,7 @@ func Benchmark_RestApiPutDocPerformanceDefaultSyncFunc(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		//PUT a new document until test run has completed
 		for pb.Next() {
-			prt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.CreateRandomHex()), threekdoc)
+			prt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.GenerateRandomID()), threekdoc)
 		}
 	})
 }
@@ -4479,7 +4479,7 @@ func Benchmark_RestApiPutDocPerformanceExplicitSyncFunc(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		//PUT a new document until test run has completed
 		for pb.Next() {
-			qrt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.CreateRandomHex()), threekdoc)
+			qrt.SendRequest("PUT", fmt.Sprintf("/db/doc-%v", base.GenerateRandomID()), threekdoc)
 		}
 	})
 }


### PR DESCRIPTION
- Rename `CreateUUID` to `GenerateRandomID`
- Pull common crypto rand code out into funcion that takes bit size as input