### PR TITLE
Fix leaked goroutines in TestLogKeyConcurrency

### DIFF
--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -154,7 +154,7 @@ func TestLogKeyConcurrency(t *testing.T) {
 	}()
 
 	time.Sleep(time.Millisecond * 100)
-	stop <- struct{}{}
+	close(stop)
 }
 
 func BenchmarkLogKeyEnabled(b *testing.B) {


### PR DESCRIPTION
The channel was only stopping one goroutine instead of all 3 by sending instead of closing.