### PR TITLE
CBG-661 - Fix error strings containing double quotes producing invalid JSON

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1897,7 +1897,9 @@ func TestHandleDeleteDB(t *testing.T) {
 	// Try to delete the database which doesn't exists
 	resp := rt.SendAdminRequest(http.MethodDelete, "/albums/", "{}")
 	assertStatus(t, resp, http.StatusNotFound)
-	assert.Contains(t, resp.Body.String(), "no such database")
+	assert.Contains(t, string(resp.BodyBytes()), "no such database")
+	var v map[string]interface{}
+	assert.NoError(t, json.Unmarshal(resp.BodyBytes(), &v), "couldn't unmarshal %s", string(resp.BodyBytes()))
 
 	// Create the database
 	resp = rt.SendAdminRequest(http.MethodPut, "/albums/", "{}")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4560,7 +4560,7 @@ func TestHandleProfiling(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodPost, "/_profile/unknown", reqBodyText)
 	log.Printf("string(response.BodyBytes()): %v", string(response.BodyBytes()))
 	assertStatus(t, response, http.StatusNotFound)
-	assert.Contains(t, string(response.BodyBytes()), `{"error":"not_found","reason":"No such profile "unknown""}`)
+	assert.Contains(t, string(response.BodyBytes()), `No such profile \"unknown\"`)
 
 	// Send profile request with filename and empty profile name; it should end up creating cpu profile
 	filePath = filepath.Join(dirPath, "cpu.pprof")

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -754,7 +754,8 @@ func (h *handler) writeStatus(status int, message string) {
 	h.setHeader("Content-Type", "application/json")
 	h.response.WriteHeader(status)
 	h.setStatus(status, message)
-	_, _ = h.response.Write([]byte(`{"error":"` + errorStr + `","reason":"` + message + `"}`))
+
+	_, _ = h.response.Write([]byte(`{"error":"` + errorStr + `","reason":` + strconv.Quote(message) + `}`))
 }
 
 var kRangeRegex = regexp.MustCompile("^bytes=(\\d+)?-(\\d+)?$")


### PR DESCRIPTION
Error strings that contained double quotes, mostly via `%q` (like `no such database "db"`) were producing invalid JSON by not escaping these double quotes first.

## Before
```json
{"error":"not_found","reason":"no such database "db""}
```

## After
```json
{"error":"not_found","reason":"no such database \"db\""}
```