### PR TITLE
CBG-652 - Show correct line number/callers for external warn/error loggers

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -37,10 +37,8 @@ var _ gocb.Logger = GoCBLogger{}
 func (GoCBLogger) Log(level gocb.LogLevel, _ int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
-		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 		logTo(context.TODO(), LevelError, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocb.LogWarn:
-		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 		logTo(context.TODO(), LevelWarn, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocb.LogInfo:
 		logTo(context.TODO(), LevelDebug, KeyGoCB, format, v...)
@@ -68,10 +66,8 @@ var _ gocbcore.Logger = GoCBCoreLogger{}
 func (GoCBCoreLogger) Log(level gocbcore.LogLevel, _ int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:
-		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 		logTo(context.TODO(), LevelError, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocbcore.LogWarn:
-		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 		logTo(context.TODO(), LevelWarn, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocbcore.LogInfo:
 		logTo(context.TODO(), LevelDebug, KeyGoCB, format, v...)
@@ -94,10 +90,8 @@ func (GoCBCoreLogger) Log(level gocbcore.LogLevel, _ int, format string, v ...in
 func sgreplicateLogFn(level clog.LogLevel, format string, args ...interface{}) {
 	switch level {
 	case clog.LevelError, clog.LevelPanic:
-		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 		logTo(context.TODO(), LevelError, KeyAll, KeyReplicate.String()+": "+format, args...)
 	case clog.LevelWarning:
-		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 		logTo(context.TODO(), LevelWarn, KeyAll, KeyReplicate.String()+": "+format, args...)
 	case clog.LevelNormal:
 		logTo(context.TODO(), LevelInfo, KeyReplicate, format, args...)
@@ -115,7 +109,6 @@ func sgreplicateLogFn(level clog.LogLevel, format string, args ...interface{}) {
 func ClogCallback(level, format string, v ...interface{}) string {
 	switch level {
 	case "ERRO", "FATA", "CRIT":
-		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 		logTo(context.TODO(), LevelError, KeyAll, KeyDCP.String()+": "+format, v...)
 	case "WARN":
 		// TODO: cbgt currently logs a lot of what we'd consider info as WARN,
@@ -154,24 +147,20 @@ func (CBGoUtilsLogger) Level() logging.Level {
 }
 
 func (CBGoUtilsLogger) Fatalf(fmt string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 	FlushLogBuffers()
 	os.Exit(1)
 }
 
 func (CBGoUtilsLogger) Severef(fmt string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Errorf(fmt string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Warnf(fmt string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 	logTo(context.TODO(), LevelWarn, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -1,6 +1,9 @@
 package base
 
 import (
+	"context"
+	"os"
+
 	"github.com/couchbase/clog"
 	"github.com/couchbase/gocb"
 	"github.com/couchbase/goutils/logging"
@@ -31,16 +34,18 @@ var _ gocb.Logger = GoCBLogger{}
 //   Debug  -> SG Trace
 //   Trace  -> SG Trace
 //   Others -> no-op
-func (GoCBLogger) Log(level gocb.LogLevel, offset int, format string, v ...interface{}) error {
+func (GoCBLogger) Log(level gocb.LogLevel, _ int, format string, v ...interface{}) error {
 	switch level {
 	case gocb.LogError:
-		Errorf(KeyGoCB.String()+": "+format, v...)
+		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+		logTo(context.TODO(), LevelError, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocb.LogWarn:
-		Warnf(KeyGoCB.String()+": "+format, v...)
+		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
+		logTo(context.TODO(), LevelWarn, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocb.LogInfo:
-		Debugf(KeyGoCB, format, v...)
+		logTo(context.TODO(), LevelDebug, KeyGoCB, format, v...)
 	case gocb.LogDebug, gocb.LogTrace:
-		Tracef(KeyGoCB, format, v...)
+		logTo(context.TODO(), LevelTrace, KeyGoCB, format, v...)
 	}
 	return nil
 }
@@ -60,16 +65,18 @@ var _ gocbcore.Logger = GoCBCoreLogger{}
 //   Debug  -> SG Trace
 //   Trace  -> SG Trace
 //   Others -> no-op
-func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v ...interface{}) error {
+func (GoCBCoreLogger) Log(level gocbcore.LogLevel, _ int, format string, v ...interface{}) error {
 	switch level {
 	case gocbcore.LogError:
-		Errorf(KeyGoCB.String()+": "+format, v...)
+		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+		logTo(context.TODO(), LevelError, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocbcore.LogWarn:
-		Warnf(KeyGoCB.String()+": "+format, v...)
+		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
+		logTo(context.TODO(), LevelWarn, KeyAll, KeyGoCB.String()+": "+format, v...)
 	case gocbcore.LogInfo:
-		Debugf(KeyGoCB, format, v...)
+		logTo(context.TODO(), LevelDebug, KeyGoCB, format, v...)
 	case gocbcore.LogDebug, gocbcore.LogTrace:
-		Tracef(KeyGoCB, format, v...)
+		logTo(context.TODO(), LevelTrace, KeyGoCB, format, v...)
 	}
 	return nil
 }
@@ -86,16 +93,16 @@ func (GoCBCoreLogger) Log(level gocbcore.LogLevel, offset int, format string, v 
 
 func sgreplicateLogFn(level clog.LogLevel, format string, args ...interface{}) {
 	switch level {
-	case clog.LevelDebug:
-		Debugf(KeyReplicate, format, args...)
-	case clog.LevelNormal:
-		Infof(KeyReplicate, format, args...)
+	case clog.LevelError, clog.LevelPanic:
+		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+		logTo(context.TODO(), LevelError, KeyAll, KeyReplicate.String()+": "+format, args...)
 	case clog.LevelWarning:
-		Warnf(KeyReplicate.String()+": "+format, args...)
-	case clog.LevelError:
-		Errorf(KeyReplicate.String()+": "+format, args...)
-	case clog.LevelPanic:
-		Errorf(KeyReplicate.String()+": "+format, args...)
+		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
+		logTo(context.TODO(), LevelWarn, KeyAll, KeyReplicate.String()+": "+format, args...)
+	case clog.LevelNormal:
+		logTo(context.TODO(), LevelInfo, KeyReplicate, format, args...)
+	case clog.LevelDebug:
+		logTo(context.TODO(), LevelDebug, KeyReplicate, format, args...)
 	}
 }
 
@@ -108,21 +115,22 @@ func sgreplicateLogFn(level clog.LogLevel, format string, args ...interface{}) {
 func ClogCallback(level, format string, v ...interface{}) string {
 	switch level {
 	case "ERRO", "FATA", "CRIT":
-		Errorf(KeyDCP.String()+": "+format, v...)
+		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+		logTo(context.TODO(), LevelError, KeyAll, KeyDCP.String()+": "+format, v...)
 	case "WARN":
 		// TODO: cbgt currently logs a lot of what we'd consider info as WARN,
 		//    (i.e. diagnostic information that's not actionable by users), so
 		//    routing to Info pending potential enhancements on cbgt side.
-		Infof(KeyDCP, format, v...)
+		logTo(context.TODO(), LevelInfo, KeyDCP, format, v...)
 	case "INFO":
 		// TODO: cbgt currently logs a lot of what we'd consider debug as INFO,
 		//    (i.e. diagnostic information that's not actionable by users), so
 		//    routing to Info pending potential enhancements on cbgt side.
-		Infof(KeyDCP, format, v...)
+		logTo(context.TODO(), LevelInfo, KeyDCP, format, v...)
 	case "DEBU":
-		Debugf(KeyDCP, format, v...)
+		logTo(context.TODO(), LevelDebug, KeyDCP, format, v...)
 	case "TRAC":
-		Tracef(KeyDCP, format, v...)
+		logTo(context.TODO(), LevelTrace, KeyDCP, format, v...)
 	}
 	return ""
 }
@@ -146,39 +154,45 @@ func (CBGoUtilsLogger) Level() logging.Level {
 }
 
 func (CBGoUtilsLogger) Fatalf(fmt string, args ...interface{}) {
-	Fatalf("CBGoUtilsLogger: "+fmt, args...)
+	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+	FlushLogBuffers()
+	os.Exit(1)
 }
 
 func (CBGoUtilsLogger) Severef(fmt string, args ...interface{}) {
-	Errorf("CBGoUtilsLogger: "+fmt, args...)
+	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Errorf(fmt string, args ...interface{}) {
-	Errorf("CBGoUtilsLogger: "+fmt, args...)
+	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+	logTo(context.TODO(), LevelError, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Warnf(fmt string, args ...interface{}) {
-	Warnf("CBGoUtilsLogger: "+fmt, args...)
+	StatsResourceUtilization().Add(StatKeyWarnCount, 1)
+	logTo(context.TODO(), LevelWarn, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Infof(fmt string, args ...interface{}) {
-	Infof(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+	logTo(context.TODO(), LevelInfo, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Requestf(rlevel logging.Level, fmt string, args ...interface{}) {
-	Tracef(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+	logTo(context.TODO(), LevelTrace, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Tracef(fmt string, args ...interface{}) {
-	Tracef(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+	logTo(context.TODO(), LevelTrace, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Debugf(fmt string, args ...interface{}) {
-	Debugf(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+	logTo(context.TODO(), LevelDebug, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 func (CBGoUtilsLogger) Logf(level logging.Level, fmt string, args ...interface{}) {
-	Infof(KeyAll, "CBGoUtilsLogger: "+fmt, args...)
+	logTo(context.TODO(), LevelInfo, KeyAll, "CBGoUtilsLogger: "+fmt, args...)
 }
 
 // go-couchbase/gomemcached don't use Pair/Map logs, so these are all stubs

--- a/base/logging.go
+++ b/base/logging.go
@@ -264,11 +264,6 @@ func GetCallersName(depth int, includeLine bool) string {
 	return fmt.Sprintf("%s() at %s:%d", fnname, lastComponent(file), line)
 }
 
-// Partial interface for the SGLogger
-type SGLogger interface {
-	Logf(logLevel LogLevel, logKey LogKey, format string, args ...interface{})
-}
-
 func lastComponent(path string) string {
 	if index := strings.LastIndex(path, "/"); index >= 0 {
 		path = path[index+1:]

--- a/base/logging.go
+++ b/base/logging.go
@@ -360,7 +360,6 @@ func init() {
 
 // PanicfCtx logs the given formatted string and args to the error log level and given log key and then panics.
 func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(ctx, LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	panic(fmt.Sprintf(format, args...))
@@ -368,7 +367,6 @@ func PanicfCtx(ctx context.Context, format string, args ...interface{}) {
 
 // FatalfCtx logs the given formatted string and args to the error log level and given log key and then exits.
 func FatalfCtx(ctx context.Context, format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(ctx, LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	os.Exit(1)
@@ -376,13 +374,11 @@ func FatalfCtx(ctx context.Context, format string, args ...interface{}) {
 
 // ErrorfCtx logs the given formatted string and args to the error log level and given log key.
 func ErrorfCtx(ctx context.Context, format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(ctx, LevelError, KeyAll, format, args...)
 }
 
 // WarnfCtx logs the given formatted string and args to the warn log level and given log key.
 func WarnfCtx(ctx context.Context, format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 	logTo(ctx, LevelWarn, KeyAll, format, args...)
 }
 
@@ -403,7 +399,6 @@ func TracefCtx(ctx context.Context, logKey LogKey, format string, args ...interf
 
 // Panicf logs the given formatted string and args to the error log level and given log key and then panics.
 func Panicf(format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	panic(fmt.Sprintf(format, args...))
@@ -411,7 +406,6 @@ func Panicf(format string, args ...interface{}) {
 
 // Fatalf logs the given formatted string and args to the error log level and given log key and then exits.
 func Fatalf(format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
 	FlushLogBuffers()
 	os.Exit(1)
@@ -419,13 +413,11 @@ func Fatalf(format string, args ...interface{}) {
 
 // Errorf logs the given formatted string and args to the error log level and given log key.
 func Errorf(format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyErrorCount, 1)
 	logTo(context.TODO(), LevelError, KeyAll, format, args...)
 }
 
 // Warnf logs the given formatted string and args to the warn log level and given log key.
 func Warnf(format string, args ...interface{}) {
-	StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 	logTo(context.TODO(), LevelWarn, KeyAll, format, args...)
 }
 
@@ -458,6 +450,12 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 	// Defensive bounds-check for log level. All callers of this function should be within this range.
 	if logLevel < LevelNone || logLevel >= levelCount {
 		return
+	}
+
+	if logLevel == LevelError {
+		StatsResourceUtilization().Add(StatKeyErrorCount, 1)
+	} else if logLevel == LevelWarn {
+		StatsResourceUtilization().Add(StatKeyWarnCount, 1)
 	}
 
 	shouldLogConsole := consoleLogger.shouldLog(logLevel, logKey)

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -94,7 +95,7 @@ type subChangesBody struct {
 }
 
 // Create a new subChanges helper
-func newSubChangesParams(rq *blip.Message, logger base.SGLogger, zeroSeq db.SequenceID, sequenceIDParser SequenceIDParser) (*subChangesParams, error) {
+func newSubChangesParams(logCtx context.Context, rq *blip.Message, zeroSeq db.SequenceID, sequenceIDParser SequenceIDParser) (*subChangesParams, error) {
 
 	params := &subChangesParams{
 		rq: rq,
@@ -105,7 +106,7 @@ func newSubChangesParams(rq *blip.Message, logger base.SGLogger, zeroSeq db.Sequ
 	if sinceStr, found := rq.Properties[subChangesSince]; found {
 		var err error
 		if sinceSequenceId, err = sequenceIDParser(base.ConvertJSONString(sinceStr)); err != nil {
-			logger.Logf(base.LevelInfo, base.KeySync, "%s: Invalid sequence ID in 'since': %s", rq, sinceStr)
+			base.InfofCtx(logCtx, base.KeySync, "%s: Invalid sequence ID in 'since': %s", rq, sinceStr)
 			return params, err
 		}
 	}
@@ -114,7 +115,7 @@ func newSubChangesParams(rq *blip.Message, logger base.SGLogger, zeroSeq db.Sequ
 	// rq.BodyReader() returns an EOF for a non-existent body, so using rq.Body() here
 	docIDs, err := readDocIDsFromRequest(rq)
 	if err != nil {
-		logger.Logf(base.LevelInfo, base.KeySync, "%s: Error reading doc IDs on subChanges request: %s", rq, err)
+		base.InfofCtx(logCtx, base.KeySync, "%s: Error reading doc IDs on subChanges request: %s", rq, err)
 		return params, err
 	}
 	params._docIDs = docIDs

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"testing"
 
 	"github.com/couchbase/go-blip"
@@ -72,12 +73,7 @@ func TestSubChangesSince(t *testing.T) {
 
 	zeroSinceVal := db.SequenceID{}
 
-	subChangesParams, err := newSubChangesParams(
-		rq,
-		TestLogger{},
-		zeroSinceVal,
-		testDb.ParseSequenceID,
-	)
+	subChangesParams, err := newSubChangesParams(context.TODO(), rq, zeroSinceVal, testDb.ParseSequenceID)
 	goassert.True(t, err == nil)
 
 	seqId := subChangesParams.since()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1520,15 +1520,3 @@ func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	}
 
 }
-
-type TestLogger struct {
-	T *testing.T
-}
-
-func (l TestLogger) Logf(logLevel base.LogLevel, logKey base.LogKey, format string, args ...interface{}) {
-	l.T.Logf(
-		logLevel.String()+" "+
-			logKey.String()+": "+
-			format, args...,
-	)
-}


### PR DESCRIPTION
- Remove BLIP-specific logger and use existing context-aware logging functions.
- Call `logTo` (and associated stats) directly from external logger wrappers to avoid the caller being reported as `Warnf`, `Errorf` instead of the actual caller.