### PR TITLE
CBG-665 - Add trace file logger

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -126,8 +126,8 @@ func (lfc *FileLoggerConfig) init(level LogLevel, name string, logFilePath strin
 	}
 
 	if lfc.Enabled == nil {
-		// enable for all levels except debug by default
-		lfc.Enabled = BoolPtr(level != LevelDebug)
+		// enable for all levels less verbose than debug by default
+		lfc.Enabled = BoolPtr(level < LevelDebug)
 	}
 
 	if err := lfc.initRotationConfig(name, defaultMaxSize, minAge); err != nil {

--- a/base/logging.go
+++ b/base/logging.go
@@ -322,8 +322,8 @@ func PrependContextID(contextID, format string, params ...interface{}) (newForma
 // *************************************************************************
 
 var (
-	consoleLogger                                                 *ConsoleLogger
-	debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
+	consoleLogger                                                              *ConsoleLogger
+	traceLogger, debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
 
 	// envColorCapable evaluated only once to prevent unnecessary
 	// overhead of checking os.Getenv on each colorEnabled() invocation
@@ -335,6 +335,7 @@ func RotateLogfiles() map[*FileLogger]error {
 	Infof(KeyAll, "Rotating log files...")
 
 	loggers := map[*FileLogger]error{
+		traceLogger: nil,
 		debugLogger: nil,
 		infoLogger:  nil,
 		warnLogger:  nil,
@@ -469,9 +470,10 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 	shouldLogWarn := warnLogger.shouldLog(logLevel)
 	shouldLogInfo := infoLogger.shouldLog(logLevel)
 	shouldLogDebug := debugLogger.shouldLog(logLevel)
+	shouldLogTrace := traceLogger.shouldLog(logLevel)
 
 	// exit early if we aren't going to log anything anywhere.
-	if !(shouldLogConsole || shouldLogError || shouldLogWarn || shouldLogInfo || shouldLogDebug) {
+	if !(shouldLogConsole || shouldLogError || shouldLogWarn || shouldLogInfo || shouldLogDebug || shouldLogTrace) {
 		return
 	}
 
@@ -500,6 +502,9 @@ func logTo(ctx context.Context, logLevel LogLevel, logKey LogKey, format string,
 	}
 	if shouldLogDebug {
 		debugLogger.logf(format, args...)
+	}
+	if shouldLogTrace {
+		traceLogger.logf(format, args...)
 	}
 }
 
@@ -537,6 +542,9 @@ func LogSyncGatewayVersion() {
 	}
 	if debugLogger.shouldLog(LevelNone) {
 		debugLogger.logger.Printf(msg)
+	}
+	if traceLogger.shouldLog(LevelNone) {
+		traceLogger.logger.Printf(msg)
 	}
 }
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -15,6 +15,7 @@ const (
 	infoMinAge  = 3
 	statsMinage = 3
 	debugMinAge = 1
+	traceMinAge = 1
 
 	// defaultConsoleLoggerCollateBufferSize is the number of console logs we'll
 	// buffer and collate, before flushing the buffer to the output.
@@ -39,6 +40,7 @@ type LoggingConfig struct {
 	Warn                 FileLoggerConfig    `json:"warn,omitempty"`            // Warn log file output
 	Info                 FileLoggerConfig    `json:"info,omitempty"`            // Info log file output
 	Debug                FileLoggerConfig    `json:"debug,omitempty"`           // Debug log file output
+	Trace                FileLoggerConfig    `json:"trace,omitempty"`           // Trace log file output
 	Stats                FileLoggerConfig    `json:"stats,omitempty"`           // Stats log file output
 	DeprecatedDefaultLog *LogAppenderConfig  `json:"default,omitempty"`         // Deprecated "default" logging option.
 }
@@ -89,6 +91,11 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (warnings []DeferredLogF
 	}
 
 	debugLogger, err = NewFileLogger(c.Debug, LevelDebug, LevelDebug.String(), c.LogFilePath, debugMinAge)
+	if err != nil {
+		return warnings, err
+	}
+
+	traceLogger, err = NewFileLogger(c.Trace, LevelTrace, LevelTrace.String(), c.LogFilePath, traceMinAge)
 	if err != nil {
 		return warnings, err
 	}


### PR DESCRIPTION
Capture trace-level logs using a file logger, in the same way `sg_debug.log` does (disabled by default).