### PR TITLE
Trace log body and properties of all BLIP messages

### DIFF
--- a/base/logging.go
+++ b/base/logging.go
@@ -635,5 +635,5 @@ func LogDebugEnabled(logKey LogKey) bool {
 // LogTraceEnabled returns true if either the console should log at trace level,
 // or if the traceLogger is enabled.
 func LogTraceEnabled(logKey LogKey) bool {
-	return consoleLogger.shouldLog(LevelTrace, logKey) //|| traceLogger.shouldLog(LevelTrace)
+	return consoleLogger.shouldLog(LevelTrace, logKey) || traceLogger.shouldLog(LevelTrace)
 }

--- a/base/logging.go
+++ b/base/logging.go
@@ -631,3 +631,9 @@ func LogInfoEnabled(logKey LogKey) bool {
 func LogDebugEnabled(logKey LogKey) bool {
 	return consoleLogger.shouldLog(LevelDebug, logKey) || debugLogger.shouldLog(LevelDebug)
 }
+
+// LogTraceEnabled returns true if either the console should log at trace level,
+// or if the traceLogger is enabled.
+func LogTraceEnabled(logKey LogKey) bool {
+	return consoleLogger.shouldLog(LevelTrace, logKey) //|| traceLogger.shouldLog(LevelTrace)
+}

--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -50,6 +50,10 @@ func MD(i interface{}) RedactorFunc {
 			return Metadata(v.String())
 
 		}
+	case []byte:
+		return func() Redactor {
+			return Metadata(string(v))
+		}
 	default:
 		return func() Redactor {
 			typeOf := reflect.ValueOf(i)

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -46,6 +46,10 @@ func SD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return SystemData(v.String())
 		}
+	case []byte:
+		return func() Redactor {
+			return SystemData(string(v))
+		}
 	default:
 		return func() Redactor {
 			valueOf := reflect.ValueOf(i)

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -47,6 +47,10 @@ func UD(i interface{}) RedactorFunc {
 		return func() Redactor {
 			return UserData(v.String())
 		}
+	case []byte:
+		return func() Redactor {
+			return UserData(string(v))
+		}
 	default:
 		return func() Redactor {
 			valueOf := reflect.ValueOf(i)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2384,7 +2384,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 // and checks that full body replication is still supported in CE.
 func TestBlipDeltaSyncPush(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	rt := NewRestTester(t, &rtConfig)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -219,7 +219,7 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 		// Trace log the full message body and properties
 		if base.LogTraceEnabled(base.KeySyncMsg) {
 			rqBody, _ := rq.Body()
-			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "%s: Body: %q Properties: %v", rq, rqBody, rq.Properties)
+			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "Req %s: Body: '%s' Properties: %v", rq, base.UD(rqBody), base.UD(rq.Properties))
 		}
 
 		if err := handlerFn(&handler, rq); err != nil {
@@ -242,7 +242,7 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 				return
 			}
 			respBody, _ := resp.Body()
-			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "%s: Body: %q Properties: %v", resp, respBody, resp.Properties)
+			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "Resp %s: Body: '%s' Properties: %v", resp, base.UD(respBody), base.UD(resp.Properties))
 		}
 	}
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -242,7 +242,7 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 				return
 			}
 			respBody, _ := resp.Body()
-			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "Recv Resp %s: Body: '%s' Properties: %v", resp, base.UD(respBody), base.UD(resp.Properties))
+			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "Recv Rsp %s: Body: '%s' Properties: %v", resp, base.UD(respBody), base.UD(resp.Properties))
 		}
 	}
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -216,6 +216,12 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 			serialNumber:    ctx.incrementSerialNumber(),
 		}
 
+		// Trace log the full message body and properties
+		if base.LogTraceEnabled(base.KeySyncMsg) {
+			rqBody, _ := rq.Body()
+			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "%s: Body: %q Properties: %v", rq, rqBody, rq.Properties)
+		}
+
 		if err := handlerFn(&handler, rq); err != nil {
 			status, msg := base.ErrorAsHTTPStatus(err)
 			if response := rq.Response(); response != nil {
@@ -223,11 +229,20 @@ func (ctx *blipSyncContext) register(profile string, handlerFn func(*blipHandler
 			}
 			ctx.Logf(base.LevelInfo, base.KeySyncMsg, "#%d: Type:%s   --> %d %s Time:%v", handler.serialNumber, profile, status, msg, time.Since(startTime))
 		} else {
-
 			// Log the fact that the handler has finished, except for the "subChanges" special case which does it's own termination related logging
 			if profile != "subChanges" {
 				ctx.Logf(base.LevelDebug, base.KeySyncMsg, "#%d: Type:%s   --> OK Time:%v", handler.serialNumber, profile, time.Since(startTime))
 			}
+		}
+
+		// Trace log the full response body and properties
+		if base.LogTraceEnabled(base.KeySyncMsg) {
+			resp := rq.Response()
+			if resp == nil {
+				return
+			}
+			respBody, _ := resp.Body()
+			ctx.Logf(base.LevelTrace, base.KeySyncMsg, "%s: Body: %q Properties: %v", resp, respBody, resp.Properties)
 		}
 	}
 


### PR DESCRIPTION
- Log body and properties of all _incoming_ BLIP messages (and their responses if sent) at trace level
- Log body and properties of all _outgoing_ BLIP messages (but not their responses ... Don't want to block any code)
- Make MD/UD/SD helpers support `[]byte("str")` without type conversion beforehand

Example:

```
2020-01-08T18:29:47.671Z [TRC] SyncMsg+: c:[65801165] Recv Req MSG#1: Body: '' Properties: map[Profile:getCheckpoint client:pull9f8d7bf0-1e50-4846-8df8-727a5648cf37]
2020-01-08T18:29:47.670Z [TRC] SyncMsg+: c:[65801165] Recv Req MSG#2: Body: '' Properties: map[Profile:subChanges activeOnly:false continuous:true since:0]
2020-01-08T18:29:47.671Z [TRC] SyncMsg+: c:[65801165] Recv Rsp ERR#1: Body: 'missing' Properties: map[Error-Code:404 Error-Domain:HTTP]
2020-01-08T18:29:47.671Z [TRC] SyncMsg+: c:[65801165] Send Req MSG#0~: Body: 'null' Properties: map[Content-Type:application/json Profile:changes]
2020-01-08T18:29:47.776Z [TRC] SyncMsg+: c:[65801165] Send Req MSG#0~: Body: '[[1,"doc1","1-0335a345b6ffed05707ccc4cbc1b67f4"]]' Properties: map[Content-Type:application/json Profile:changes]
2020-01-08T18:29:47.777Z [TRC] SyncMsg+: c:[65801165] Send Req MSG#0~: Body: '{"greetings":[{"hello":"world!"},{"hi":"alice"}]}' Properties: map[Content-Type:application/json Profile:rev id:doc1 rev:1-0335a345b6ffed05707ccc4cbc1b67f4 sequence:1]
2020-01-08T18:29:47.824Z [TRC] SyncMsg+: c:[4a354b9c] Recv Req MSG#1: Body: '[["doc1","2-abcxyz","1-0335a345b6ffed05707ccc4cbc1b67f4"]]' Properties: map[Profile:proposeChanges]
2020-01-08T18:29:47.824Z [TRC] SyncMsg+: c:[4a354b9c] Recv Rsp RPY#1~: Body: '[]' Properties: map[deltas:true]
2020-01-08T18:29:47.825Z [TRC] SyncMsg+: c:[4a354b9c] Recv Req MSG#2: Body: '{"greetings":{"2-":[{"howdy":"bob"}]}}' Properties: map[Profile:rev deltaSrc:1-0335a345b6ffed05707ccc4cbc1b67f4 id:doc1 rev:2-abcxyz]
2020-01-08T18:29:47.825Z [TRC] SyncMsg+: c:[65801165] Send Req MSG#0~: Body: '[[2,"doc1","2-abcxyz"]]' Properties: map[Content-Type:application/json Profile:changes]
```