### PR TITLE
CBD-3147: disable or reduce frequency of older releases for scan-manifest to function

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -10,6 +10,7 @@
             "start_build": 1
         },
         "manifest/1.4.0.xml": {
+            "do-build": false,
             "release": "1.4.0.2",
             "release_name": "Couchbase Sync Gateway 1.4.0.2",
             "production": true,
@@ -18,6 +19,7 @@
             "start_build": 1
         },
         "manifest/1.4.1.xml": {
+            "do-build": false,
             "release": "1.4.1.3",
             "release_name": "Couchbase Sync Gateway 1.4.1.3",
             "production": true,
@@ -26,6 +28,7 @@
             "start_build": 1
         },
         "manifest/1.3.1.xml": {
+            "do-build": false,
             "release": "1.3.1.5",
             "release_name": "Couchbase Sync Gateway 1.3.1.5",
             "production": true,
@@ -34,6 +37,7 @@
             "start_build": 1
         },
         "manifest/1.5.0.xml": {
+            "do-build": false,
             "release": "1.5.0.0",
             "release_name": "Couchbase Sync Gateway 1.5.0.0",
             "production": true,
@@ -42,6 +46,7 @@
             "start_build": 587
         },
         "manifest/1.5.1.xml": {
+            "do-build": false,
             "release": "1.5.1.0",
             "release_name": "Couchbase Sync Gateway 1.5.1.0",
             "production": true,
@@ -50,6 +55,7 @@
             "start_build": 1
         },
         "manifest/1.5.2.xml": {
+            "do-build": false,
             "release": "1.5.2",
             "release_name": "Couchbase Sync Gateway 1.5.2",
             "production": true,
@@ -61,7 +67,7 @@
             "release": "2.0.0.0",
             "release_name": "Couchbase Sync Gateway 2.0.0.0",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 838
         },
@@ -69,7 +75,7 @@
             "release": "2.1.0",
             "release_name": "Couchbase Sync Gateway 2.1.0",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 107
         },
@@ -77,7 +83,7 @@
             "release": "2.1.1",
             "release_name": "Couchbase Sync Gateway 2.1.1",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 1
         },
@@ -85,7 +91,7 @@
             "release": "2.1.2",
             "release_name": "Couchbase Sync Gateway 2.1.2",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 1
         },
@@ -93,7 +99,7 @@
             "release": "2.1.3",
             "release_name": "Couchbase Sync Gateway 2.1.3",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 1
         },
@@ -101,7 +107,7 @@
             "release": "2.1.2.1",
             "release_name": "Couchbase Sync Gateway 2.1.2.1",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 1
         },
@@ -109,7 +115,7 @@
             "release": "2.1.3.1",
             "release_name": "Couchbase Sync Gateway 2.1.3.1",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.8.5",
             "start_build": 1
         },
@@ -117,7 +123,7 @@
             "release": "2.5.1.1",
             "release_name": "Couchbase Sync Gateway 2.5.1.1",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.11.5",
             "start_build": 1
         },
@@ -125,7 +131,7 @@
             "release": "2.5.0",
             "release_name": "Couchbase Sync Gateway 2.5.0",
             "production": true,
-            "interval": 120,
+            "interval": 1440,
             "go_version": "1.11.5",
             "start_build": 270
         },
@@ -133,7 +139,7 @@
             "release": "2.5.1",
             "release_name": "Couchbase Sync Gateway 2.5.1",
             "production": true,
-            "interval": "120",
+            "interval": 1440,
             "go_version": "1.11.5",
             "start_build": 13
         },


### PR DESCRIPTION
CBD-3147: disable or reduce frequency of older releases so that scan-manifest can trigger newer product builds properly

-Ming Ho