### PR TITLE
Fixes TestValidateServerContext when run against single node Couchbase Server cluster

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -711,6 +711,10 @@ func Uint32Ptr(u uint32) *uint32 {
 	return &u
 }
 
+func UintPtr(u uint) *uint {
+	return &u
+}
+
 func IntPtr(i int) *int {
 	return &i
 }


### PR DESCRIPTION
`TestValidateServerContext` doesn't work when the user doesn't have permission to `/var/log/sync_gateway`, or when the Couchbase Server cluster is only a single node (because of the default `NumIndexReplicas=1`)

- Set NumIndexReplicas to zero for testing against single-node Couchbase Servers
- Removed unnecessary logging config/setup
- Removed unnecessary users from server config

```
=== RUN   TestValidateServerContext
--- FAIL: TestValidateServerContext (0.00s)
    require.go:794: 
        	Error Trace:	config_test.go:874
        	Error:      	Received unexpected error:
        	            	mkdir /var/log/sync_gateway: permission denied
        	            	invalid log file path
        	            	github.com/couchbase/sync_gateway/base.validateLogFilePath
        	            		/home/jenkins/jenkins/workspace/sync-gateway-integration-ben/godeps/src/github.com/couchbase/sync_gateway/base/logging_config.go:124
        	            	github.com/couchbase/sync_gateway/base.(*LoggingConfig).Init
        	            		/home/jenkins/jenkins/workspace/sync-gateway-integration-ben/godeps/src/github.com/couchbase/sync_gateway/base/logging_config.go:69
        	            	github.com/couchbase/sync_gateway/rest.(*ServerConfig).SetupAndValidateLogging
        	            		/home/jenkins/jenkins/workspace/sync-gateway-integration-ben/godeps/src/github.com/couchbase/sync_gateway/rest/config.go:696
        	            	github.com/couchbase/sync_gateway/rest.TestValidateServerContext
        	            		/home/jenkins/jenkins/workspace/sync-gateway-integration-ben/godeps/src/github.com/couchbase/sync_gateway/rest/config_test.go:873
        	            	testing.tRunner
        	            		/home/jenkins/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go_1.13.4_SGW_2.7_/src/testing/testing.go:909
        	            	runtime.goexit
        	            		/home/jenkins/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go_1.13.4_SGW_2.7_/src/runtime/asm_amd64.s:1357
        	Test:       	TestValidateServerContext
        	Messages:   	Error whilst setting up logging
```

```
--- FAIL: TestValidateServerContext (0.28s)
    require.go:794: 
        	Error Trace:	config_test.go:884
        	Error:      	Received unexpected error:
        	            	Unable to install index allDocs: Error installing Couchbase index: sg_allDocs_1: Unable to create indexes with the specified number of replicas (1).  Increase the number of index nodes, or modify 'num_index_replicas' in your Sync Gateway database config.
        	Test:       	TestValidateServerContext
        	Messages:   	Couldn't add database from config
```