### PR TITLE
CBG-661 - Fully escape string for JSON in writeStatus error handling

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -134,6 +134,12 @@ func ConvertJSONString(s string) string {
 	}
 }
 
+// ConvertToJSONString takes a string, and returns a JSON string, with any illegal characters escaped.
+func ConvertToJSONString(s string) string {
+	b, _ := JSONMarshal(s)
+	return string(b)
+}
+
 // Concatenates and merges multiple string arrays into one, discarding all duplicates (including
 // duplicates within a single array.) Ordering is preserved.
 func MergeStringArrays(arrays ...[]string) (merged []string) {

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -41,8 +41,54 @@ func TestFixJSONNumbers(t *testing.T) {
 }
 
 func TestConvertJSONString(t *testing.T) {
-	goassert.Equals(t, ConvertJSONString(`"blah"`), "blah")
-	goassert.Equals(t, ConvertJSONString("blah"), "blah")
+	assert.Equal(t, "blah", ConvertJSONString(`"blah"`))
+	assert.Equal(t, "blah", ConvertJSONString("blah"))
+}
+
+func TestJSONStringUtils(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{`test`, `"test"`},
+		{`"test"`, `"\"test\""`},
+		{"\x00", `"\u0000"`},
+	}
+
+	for _, test := range tests {
+		t.Run("ConvertToJSONString "+test.input, func(t *testing.T) {
+			out := ConvertToJSONString(test.input)
+			assert.Equal(t, test.output, out)
+		})
+		t.Run("ConvertJSONString "+test.input, func(t *testing.T) {
+			out := ConvertJSONString(test.output)
+			assert.Equal(t, test.input, out)
+		})
+	}
+}
+
+func BenchmarkJSONStringUtils(b *testing.B) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{`test`, `"test"`},
+		{`"test"`, `"\"test\""`},
+		{"\x00", `"\u0000"`},
+	}
+
+	for _, test := range tests {
+		b.Run("ConvertToJSONString "+test.input, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ConvertToJSONString(test.input)
+			}
+		})
+		b.Run("ConvertJSONString "+test.input, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = ConvertJSONString(test.output)
+			}
+		})
+	}
 }
 
 func TestConvertBackQuotedStrings(t *testing.T) {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -755,7 +755,7 @@ func (h *handler) writeStatus(status int, message string) {
 	h.response.WriteHeader(status)
 	h.setStatus(status, message)
 
-	_, _ = h.response.Write([]byte(`{"error":"` + errorStr + `","reason":` + strconv.Quote(message) + `}`))
+	_, _ = h.response.Write([]byte(`{"error":"` + errorStr + `","reason":` + base.ConvertToJSONString(message) + `}`))
 }
 
 var kRangeRegex = regexp.MustCompile("^bytes=(\\d+)?-(\\d+)?$")


### PR DESCRIPTION
Original PR for CBG-661 (#4437) covered only double quotes.
This uses the `json.Marshal` of a string (which is cheap enough, about the same as `strconv.Quote` was) to fully escape it.

https://www.ietf.org/rfc/rfc4627.txt
> 2.5.  Strings
> ... All Unicode characters may be placed within the
>     quotation marks except for the characters that must be escaped:
>     quotation mark, reverse solidus, and the control characters (U+0000
>     through U+001F).

Benchmark:

```
BenchmarkJSONStringUtils/ConvertToJSONString_test-12             7265204               163 ns/op              24 B/op        2 allocs/op
BenchmarkJSONStringUtils/ConvertJSONString_test-12               6503089               182 ns/op              32 B/op        3 allocs/op
BenchmarkJSONStringUtils/ConvertToJSONString_"test"-12           6854858               174 ns/op              32 B/op        2 allocs/op
BenchmarkJSONStringUtils/ConvertJSONString_"test"-12             5121307               234 ns/op              48 B/op        4 allocs/op
BenchmarkJSONStringUtils/ConvertToJSONString_\x00-12             7233552               169 ns/op              24 B/op        2 allocs/op
BenchmarkJSONStringUtils/ConvertJSONString_\x00-12               5590149               214 ns/op              32 B/op        3 allocs/op
```