### PR TITLE
Prevent entire test suite from exiting when bucket fails to initialize

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -129,14 +129,14 @@ func testBucketInit(tester testing.TB, useGSI bool) base.TestBucket {
 		testBucket := base.GetTestBucket(tester)
 		err := installViews(testBucket.Bucket)
 		if err != nil {
-			log.Fatalf("Couldn't connect to bucket: %v", err)
+			tester.Fatalf("Couldn't connect to bucket: %v", err)
 			// ^^ effectively panics
 		}
 
 		if useGSI {
 			err = InitializeIndexes(testBucket.Bucket, base.TestUseXattrs(), 0)
 			if err != nil {
-				log.Fatalf("Unable to initialize GSI indexes for test: %v", err)
+				tester.Fatalf("Unable to initialize GSI indexes for test: %v", err)
 				// ^^ effectively panics
 			}
 
@@ -147,7 +147,7 @@ func testBucketInit(tester testing.TB, useGSI bool) base.TestBucket {
 				if waitForIndexRollbackErr != nil {
 					base.Infof(base.KeyAll, "Error WaitForIndexEmpty: %v.  Drop indexes and retry", waitForIndexRollbackErr)
 					if err := base.DropAllBucketIndexes(gocbBucket); err != nil {
-						log.Fatalf("Unable to drop GSI indexes for test: %v", err)
+						tester.Fatalf("Unable to drop GSI indexes for test: %v", err)
 						// ^^ effectively panics
 					}
 					testBucket.Close() // Close the bucket, it will get re-opened on next loop iteration


### PR DESCRIPTION
Prevent entire test suite from exiting when bucket fails to initialize. Fail only the single test responsible.

These are what were causing the test suite to fail, but with no test-specific failure reported. Example:

```
2020-01-10T00:56:38.100Z [WRN] RetryLoop for Wait for index to be empty giving up after 31 attempts -- base.RetryLoop() at util.go:397
2020-01-10T00:56:38.100Z [INF] Error WaitForIndexEmpty: RetryLoop for Wait for index to be empty giving up after 31 attempts.  Drop indexes and retry
2020-01-10 00:56:38.197704 I | Dropping index sg_allDocs_1...
2020-01-10 00:56:38.197802 I | Dropping index sg_syncDocs_1...
2020-01-10 00:56:38.197868 I | Dropping index sg_channels_1...
2020-01-10 00:56:38.197949 I | Dropping index sg_channels_1...
2020-01-10 00:56:38.198038 I | Dropping index sg_syncDocs_1...
2020-01-10 00:56:38.198098 I | Dropping index sg_syncDocs_1...
2020-01-10 00:56:38.198161 I | Dropping index sg_access_1...
2020-01-10 00:56:38.198275 I | Dropping index sg_roleAccess_x1...
2020-01-10 00:56:38.198347 I | ...successfully dropped index sg_syncDocs_1
2020-01-10 00:56:38.198358 I | Dropping index sg_roleAccess_1...
2020-01-10 00:56:38.198391 I | ...successfully dropped index sg_allDocs_1
2020-01-10 00:56:38.198402 I | ...successfully dropped index sg_channels_1
2020-01-10 00:56:38.198438 I | Dropping index sg_syncDocs_1...
2020-01-10 00:56:38.198528 I | Dropping index sg_syncDocs_x1...
2020-01-10 00:56:38.198623 I | Dropping index sg_allDocs_1...
2020-01-10 00:56:38.198750 I | Dropping index sg_access_x1...
2020-01-10 00:56:38.198881 I | ...successfully dropped index sg_syncDocs_1
2020-01-10 00:56:38.198891 I | Dropping index sg_tombstones_x1...
2020-01-10 00:56:38.199015 I | Dropping index sg_allDocs_1...
2020-01-10 00:56:38.199096 I | Dropping index sg_access_1...
2020-01-10 00:56:38.199190 I | Dropping index sg_access_1...
2020-01-10 00:56:38.199245 I | Dropping index sg_roleAccess_1...
2020-01-10 00:56:38.199293 I | Dropping index sg_syncDocs_1...
2020-01-10 00:56:38.199341 I | Dropping index sg_allDocs_1...
2020-01-10 00:56:38.199394 I | Dropping index sg_roleAccess_1...
2020-01-10 00:56:38.199438 I | Dropping index sg_channels_1...
2020-01-10 00:56:38.199479 I | Dropping index sg_access_1...
2020-01-10 00:56:38.199525 I | Dropping index sg_channels_1...
2020-01-10 00:56:38.199572 I | Dropping index sg_roleAccess_1...
2020-01-10 00:56:38.199615 I | Dropping index sg_access_1...
2020-01-10 00:56:38.199655 I | Dropping index sg_roleAccess_1...
2020-01-10 00:56:38.199694 I | Dropping index sg_allDocs_x1...
2020-01-10 00:56:38.199736 I | Dropping index sg_allDocs_1...
2020-01-10 00:56:38.199776 I | Dropping index sg_channels_x1...
2020-01-10 00:56:38.199818 I | Dropping index sg_channels_1...
2020-01-10 00:56:38.199857 I | ...successfully dropped index sg_access_1
2020-01-10 00:56:38.199864 I | ...successfully dropped index sg_channels_1
2020-01-10 00:56:38.199869 I | ...successfully dropped index sg_roleAccess_1
2020-01-10 00:56:38.199874 I | ...successfully dropped index sg_syncDocs_1
2020-01-10 00:56:38.199879 I | ...successfully dropped index sg_syncDocs_1
2020-01-10 00:56:38.200004 I | ...successfully dropped index sg_allDocs_1
2020-01-10 00:56:38.200208 I | ...successfully dropped index sg_allDocs_1
2020-01-10 00:56:38.200675 I | ...successfully dropped index sg_access_1
2020-01-10 00:56:38.200733 I | ...successfully dropped index sg_roleAccess_1
2020-01-10 00:56:38.200795 I | ...successfully dropped index sg_access_1
2020-01-10 00:56:38.200946 I | ...successfully dropped index sg_allDocs_1
2020-01-10 00:56:38.200985 I | ...successfully dropped index sg_roleAccess_1
2020-01-10 00:56:38.200994 I | ...successfully dropped index sg_syncDocs_1
2020-01-10 00:56:38.201507 I | ...successfully dropped index sg_access_1
2020-01-10 00:56:38.201560 I | ...successfully dropped index sg_access_1
2020-01-10 00:56:38.201573 I | ...successfully dropped index sg_channels_1
2020-01-10 00:56:38.201588 I | ...successfully dropped index sg_allDocs_1
2020-01-10 00:56:38.201603 I | ...successfully dropped index sg_channels_1
2020-01-10 00:56:38.201668 I | ...successfully dropped index sg_roleAccess_1
2020-01-10 00:56:38.201680 I | ...successfully dropped index sg_roleAccess_1
2020-01-10 00:56:38.201795 I | ...successfully dropped index sg_channels_1
2020-01-10 00:56:38.416097 I | ...successfully dropped index sg_roleAccess_x1
2020-01-10 00:56:38.632050 I | ...successfully dropped index sg_syncDocs_x1
2020-01-10 00:56:38.861287 I | ...successfully dropped index sg_access_x1
2020-01-10 00:56:39.088860 I | ...successfully dropped index sg_tombstones_x1
2020-01-10 00:56:39.328156 I | ...successfully dropped index sg_channels_x1
2020-01-10 00:56:39.543241 I | ...successfully dropped index sg_allDocs_x1
2020-01-10 00:56:39.543275 I | Unable to drop GSI indexes for test: [5000] GSI index sg_syncDocs_1 not found.
FAIL	github.com/couchbase/sync_gateway/db	646.037s
```