### PR TITLE
Jenkinsfile: Fix incorrect when condition for post-failure email

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -386,16 +386,22 @@ pipeline {
             }
         }
         unstable {
-            when { branch 'master' }
-            mail to: 'mobile_dev_sg@couchbase.com',
-                 subject: "Failed tests in master SGW pipeline: ${currentBuild.fullDisplayName}",
-                 body: "At least one test failed: ${env.BUILD_URL}"
+            script {
+                if (${env.BRANCH_NAME} == 'master') {
+                    mail to: 'mobile_dev_sg@couchbase.com',
+                        subject: "Failed tests in master SGW pipeline: ${currentBuild.fullDisplayName}",
+                        body: "At least one test failed: ${env.BUILD_URL}"
+                }
+            }
         }
         failure {
-            when { branch 'master' }
-            mail to: 'mobile_dev_sg@couchbase.com',
-                 subject: "Build failure in master SGW pipeline: ${currentBuild.fullDisplayName}",
-                 body: "Something went wrong building: ${env.BUILD_URL}"
+            script {
+                if (${env.BRANCH_NAME} == 'master') {
+                    mail to: 'mobile_dev_sg@couchbase.com',
+                        subject: "Build failure in master SGW pipeline: ${currentBuild.fullDisplayName}",
+                        body: "Something went wrong building: ${env.BUILD_URL}"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The `when` condition can't be used inside a `post` action, only in a `stage`.

```
java.lang.NoSuchMethodError: No such DSL method 'when' found among steps [ ... ]
```
http://uberjenkins.sc.couchbase.com:8080/job/_sync-gateway_github_pipeline/job/sync_gateway/job/master/501/console

Need to drop down to a Groovy script instead to only send mail on master failures.