### PR TITLE
CBG-437 - Return error when delta is pushed on top of a tombstone

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2448,6 +2448,26 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"hello": "world!"}, greetings[0])
 	assert.Equal(t, map[string]interface{}{"hi": "alice"}, greetings[1])
 	assert.Equal(t, map[string]interface{}{"howdy": "bob"}, greetings[2])
+
+	// tombstone doc1 (gets rev 3-f3be6c85e0362153005dae6f08fc68bb)
+	resp = rt.SendAdminRequest(http.MethodDelete, "/db/doc1?rev="+newRev, "")
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	data, ok = client.WaitForRev("doc1", "3-f3be6c85e0362153005dae6f08fc68bb")
+	assert.True(t, ok)
+	assert.Equal(t, `{}`, string(data))
+
+	if base.IsEnterpriseEdition() {
+		// Now make the client push up a delta that has the parent of the tombstone. This is not a valid scenario, and is actively prevented on the CBL side.
+		deltaPushDocCountStart := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltaPushDocCount))
+		revID, err := client.PushRev("doc1", "3-f3be6c85e0362153005dae6f08fc68bb", []byte(`{"undelete":true}`))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Found tombstone for deltaSrc")
+		assert.Equal(t, "", revID)
+
+		deltaPushDocCountEnd := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDeltaSync().Get(base.StatKeyDeltaPushDocCount))
+		assert.Equal(t, deltaPushDocCountStart, deltaPushDocCountEnd)
+	}
 }
 
 // TestBlipNonDeltaSyncPush tests that a client that doesn't support deltas can push to a SG that supports deltas (either CE or EE)

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -1012,9 +1012,14 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 			return base.HTTPErrorf(http.StatusNotFound, "Can't fetch doc for deltaSrc=%s %v", deltaSrcRevID, err)
 		}
 
+		// Receiving a delta to be applied on top of a tombstone is not valid.
+		if deltaSrcRev.Deleted {
+			return base.HTTPErrorf(http.StatusNotFound, "Can't use delta. Found tombstone for deltaSrc=%s", deltaSrcRevID)
+		}
+
 		deltaSrcBody, err := deltaSrcRev.DeepMutableBody()
 		if err != nil {
-			return base.HTTPErrorf(http.StatusInternalServerError, "Unable to marshal mutable body for deltaSrc=%s %v", deltaSrcRevID, err)
+			return base.HTTPErrorf(http.StatusInternalServerError, "Unable to unmarshal mutable body for deltaSrc=%s %v", deltaSrcRevID, err)
 		}
 
 		// Stamp attachments so we can patch them

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -1,0 +1,48 @@
+package rest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBlipSyncContextSetUseDeltas verifies all permutations of setUseDeltas()
+func TestBlipSyncContextSetUseDeltas(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeySync)()
+
+	tests := []struct {
+		startingCtxDeltas,
+		sgCanUseDeltas,
+		clientCanUseDeltas,
+		expectedCtxDeltas bool
+	}{
+		// deltas starting enabled
+		{true, true, true, true},    // both sides on
+		{true, false, false, false}, // both sides off
+		{true, false, true, false},  // server off
+		{true, true, false, false},  // client off
+
+		// deltas starting disabled
+		{false, true, true, true},    // both sides on
+		{false, false, false, false}, // both sides off
+		{false, false, true, false},  // server off
+		{false, true, false, false},  // client off
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			ctx := &blipSyncContext{
+				dbStats:        db.NewDatabaseStats(),
+				blipContextDb:  &db.Database{Ctx: context.TODO()},
+				useDeltas:      tt.startingCtxDeltas,
+				sgCanUseDeltas: tt.sgCanUseDeltas,
+			}
+
+			ctx.setUseDeltas(tt.clientCanUseDeltas)
+			assert.Equal(t, tt.expectedCtxDeltas, ctx.useDeltas)
+		})
+	}
+}

--- a/rest/blip_sync_test.go
+++ b/rest/blip_sync_test.go
@@ -14,26 +14,29 @@ func TestBlipSyncContextSetUseDeltas(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeySync)()
 
 	tests := []struct {
+		name string
 		startingCtxDeltas,
 		sgCanUseDeltas,
 		clientCanUseDeltas,
 		expectedCtxDeltas bool
 	}{
-		// deltas starting enabled
-		{true, true, true, true},    // both sides on
-		{true, false, false, false}, // both sides off
-		{true, false, true, false},  // server off
-		{true, true, false, false},  // client off
+		// fast-path (no change to current state)
+		{"start off, both sides off", false, false, false, false},
+		{"start off, server off", false, false, true, false},
+		{"start off, client off", false, true, false, false},
+		{"start on, both sides on", true, true, true, true},
 
-		// deltas starting disabled
-		{false, true, true, true},    // both sides on
-		{false, false, false, false}, // both sides off
-		{false, false, true, false},  // server off
-		{false, true, false, false},  // client off
+		// turn on
+		{"start off, both sides on", false, true, true, true},
+
+		// Scenarios that aren't currently possible (starting on, and then turning off)
+		{"both sides off", true, false, false, false},
+		{"server off", true, false, true, false},
+		{"client off", true, true, false, false},
 	}
 
 	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			ctx := &blipSyncContext{
 				dbStats:        db.NewDatabaseStats(),
 				blipContextDb:  &db.Database{Ctx: context.TODO()},
@@ -43,6 +46,48 @@ func TestBlipSyncContextSetUseDeltas(t *testing.T) {
 
 			ctx.setUseDeltas(tt.clientCanUseDeltas)
 			assert.Equal(t, tt.expectedCtxDeltas, ctx.useDeltas)
+		})
+	}
+}
+
+// BenchmarkBlipSyncContextSetUseDeltas verifies all permutations of setUseDeltas()
+func BenchmarkBlipSyncContextSetUseDeltas(b *testing.B) {
+	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
+
+	tests := []struct {
+		name string
+		startingCtxDeltas,
+		sgCanUseDeltas,
+		clientCanUseDeltas,
+		expectedCtxDeltas bool
+	}{
+		// fast-path (no change to current state)
+		{"start off, both sides off", false, false, false, false},
+		{"start off, server off", false, false, true, false},
+		{"start off, client off", false, true, false, false},
+		{"start on, both sides on", true, true, true, true},
+
+		// turn on
+		{"start off, both sides on", false, true, true, true},
+
+		// Scenarios that aren't currently possible (starting on, and then turning off)
+		{"start on, both sides off", true, false, false, false},
+		{"start on, server off", true, false, true, false},
+		{"start on, client off", true, true, false, false},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			ctx := &blipSyncContext{
+				dbStats:       db.NewDatabaseStats(),
+				blipContextDb: &db.Database{Ctx: context.TODO()},
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx.useDeltas = tt.startingCtxDeltas
+				ctx.sgCanUseDeltas = tt.sgCanUseDeltas
+				ctx.setUseDeltas(tt.clientCanUseDeltas)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Returns a `404` when `deltaSrc` is a tombstone.
  - Expected behaviour for clients is to fall back to full body replication, in the same way they can send a delta for a `deltaSrc` we don't have any more.
- Fixed BLIP test client to specify parent revision in history when sending rev (prevents branched revtrees from `client.PushRev`)
- Fixed data race in `setUseDeltas` when the client requests a delta, and SG is running in CE mode (or has deltas disabled)
  - Added unit test for all combinations