### PR TITLE
CBG-658 Refactor LogKey to do string lookup via slice

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -6,16 +6,19 @@ import (
 	"sync/atomic"
 )
 
-// LogKey is a bitfield of log keys.
-type LogKey uint64
+// LogKeyMask is a bitfield of log keys.
+type LogKeyMask uint64
+
+// LogKeyMask is slice index for log keys.  Entries in LogKeySet are stored at 2^LogKeyMask
+type LogKey uint8
 
 // Values for log keys.
 const (
 	// KeyNone is shorthand for no log keys.
-	KeyNone LogKey = 0
+	KeyNone LogKey = iota
 
 	// KeyAll is a wildcard for all log keys.
-	KeyAll LogKey = 1 << iota
+	KeyAll
 
 	KeyAdmin
 	KeyAccess
@@ -38,69 +41,84 @@ const (
 	KeySyncMsg
 	KeyWebSocket
 	KeyWebSocketFrame
+
+	LogKeyCount // Count for logKeyNames init
 )
 
-var (
-	logKeyNames = map[LogKey]string{
-		KeyNone:           "",
-		KeyAll:            "*",
-		KeyAdmin:          "Admin",
-		KeyAccess:         "Access",
-		KeyAuth:           "Auth",
-		KeyBucket:         "Bucket",
-		KeyCache:          "Cache",
-		KeyChanges:        "Changes",
-		KeyCRUD:           "CRUD",
-		KeyDCP:            "DCP",
-		KeyEvents:         "Events",
-		KeyGoCB:           "gocb",
-		KeyHTTP:           "HTTP",
-		KeyHTTPResp:       "HTTP+", // Infof printed as HTTP+
-		KeyImport:         "Import",
-		KeyJavascript:     "Javascript",
-		KeyMigrate:        "Migrate",
-		KeyQuery:          "Query",
-		KeyReplicate:      "Replicate",
-		KeySync:           "Sync",
-		KeySyncMsg:        "SyncMsg",
-		KeyWebSocket:      "WS",
-		KeyWebSocketFrame: "WSFrame",
-	}
+var logKeyNames []string
+var logKeyNamesInverse map[string]LogKey
 
-	// Inverse of the map above. Optimisation for string -> LogKey lookups in ToLogKey
+func init() {
+	logKeyNames = make([]string, LogKeyCount)
+	logKeyNames[KeyNone] = ""
+	logKeyNames[KeyAll] = "*"
+
+	logKeyNames[KeyAdmin] = "Admin"
+	logKeyNames[KeyAccess] = "Access"
+	logKeyNames[KeyAuth] = "Auth"
+	logKeyNames[KeyBucket] = "Bucket"
+	logKeyNames[KeyCache] = "Cache"
+	logKeyNames[KeyChanges] = "Changes"
+	logKeyNames[KeyCRUD] = "CRUD"
+	logKeyNames[KeyDCP] = "DCP"
+	logKeyNames[KeyEvents] = "Events"
+	logKeyNames[KeyGoCB] = "gocb"
+	logKeyNames[KeyHTTP] = "HTTP"
+	logKeyNames[KeyHTTPResp] = "HTTP+" // Infof printed as HTTP+
+	logKeyNames[KeyImport] = "Import"
+	logKeyNames[KeyJavascript] = "Javascript"
+	logKeyNames[KeyMigrate] = "Migrate"
+	logKeyNames[KeyQuery] = "Query"
+	logKeyNames[KeyReplicate] = "Replicate"
+	logKeyNames[KeySync] = "Sync"
+	logKeyNames[KeySyncMsg] = "SyncMsg"
+	logKeyNames[KeyWebSocket] = "WS"
+	logKeyNames[KeyWebSocketFrame] = "WSFrame"
+
+	// Inverse of the map above. Optimisation for string -> LogKeyMask lookups in ToLogKey
 	logKeyNamesInverse = inverselogKeyNames(logKeyNames)
-)
+
+}
+
+// KeyMaskValue converts a log key index to the bitfield position.
+// e.g. 0->0, 1->1, 2->2, 3->4, 4->8, 5->16...
+func (i LogKey) KeyMaskValue() uint64 {
+	if i == 0 {
+		return 0
+	}
+	return 1 << (i - 1)
+}
 
 // Enable will enable the given logKey in keyMask.
-func (keyMask *LogKey) Enable(logKey LogKey) {
+func (keyMask *LogKeyMask) Enable(logKey LogKey) {
 	val := atomic.LoadUint64((*uint64)(keyMask))
-	atomic.StoreUint64((*uint64)(keyMask), val|uint64(logKey))
+	atomic.StoreUint64((*uint64)(keyMask), val|logKey.KeyMaskValue())
 }
 
 // Disable will disable the given logKey in keyMask.
-func (keyMask *LogKey) Disable(logKey LogKey) {
+func (keyMask *LogKeyMask) Disable(logKey LogKey) {
 	val := atomic.LoadUint64((*uint64)(keyMask))
-	atomic.StoreUint64((*uint64)(keyMask), val & ^uint64(logKey))
+	atomic.StoreUint64((*uint64)(keyMask), val & ^logKey.KeyMaskValue())
 }
 
 // Set will override the keyMask with the given logKey.
-func (keyMask *LogKey) Set(logKey LogKey) {
-	atomic.StoreUint64((*uint64)(keyMask), uint64(logKey))
+func (keyMask *LogKeyMask) Set(logKey LogKey) {
+	atomic.StoreUint64((*uint64)(keyMask), logKey.KeyMaskValue())
 }
 
 // Enabled returns true if the given logKey is enabled in keyMask.
 // Always returns true if KeyAll is enabled in keyMask.
-func (keyMask *LogKey) Enabled(logKey LogKey) bool {
+func (keyMask *LogKeyMask) Enabled(logKey LogKey) bool {
 	return keyMask.enabled(logKey, true)
 }
 
 // Enabled returns true if the given logKey is enabled in keyMask.
-func (keyMask *LogKey) EnabledExcludingWildcard(logKey LogKey) bool {
+func (keyMask *LogKeyMask) EnabledExcludingWildcard(logKey LogKey) bool {
 	return keyMask.enabled(logKey, false)
 }
 
 // enabled returns true if the given logKey is enabled in keyMask, with an optional wildcard check.
-func (keyMask *LogKey) enabled(logKey LogKey, checkWildcards bool) bool {
+func (keyMask *LogKeyMask) enabled(logKey LogKey, checkWildcards bool) bool {
 	if keyMask == nil {
 		return false
 	}
@@ -108,25 +126,21 @@ func (keyMask *LogKey) enabled(logKey LogKey, checkWildcards bool) bool {
 	flag := atomic.LoadUint64((*uint64)(keyMask))
 
 	// If KeyAll is set, return true for everything.
-	if checkWildcards && flag&uint64(KeyAll) != 0 {
+	if checkWildcards && flag&KeyAll.KeyMaskValue() != 0 {
 		return true
 	}
 
-	return flag&uint64(logKey) != 0
+	return flag&logKey.KeyMaskValue() != 0
 }
 
-// String returns the string representation of one or more log keys.
-func (logKey LogKey) String() string {
-	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
-	if str, ok := logKeyNames[logKey]; ok {
-		return str
-	}
+// String returns the string representation of one or more log keys in a LogKeyMask
+func (logKeyMask LogKeyMask) String() string {
 
 	// Try to pretty-print a set of log keys.
 	names := []string{}
-	for k, v := range logKeyNames {
-		if logKey&k != 0 {
-			names = append(names, v)
+	for keyIndex, keyName := range logKeyNames {
+		if logKeyMask.Enabled(LogKey(keyIndex)) {
+			names = append(names, keyName)
 		}
 	}
 	if len(names) > 0 {
@@ -134,27 +148,37 @@ func (logKey LogKey) String() string {
 	}
 
 	// Fall back to a binary representation.
-	return fmt.Sprintf("LogKey(%b)", logKey)
+	return fmt.Sprintf("LogKeyMask(%b)", logKeyMask)
+}
+
+// String returns the string representation of one log key.
+func (logKey LogKey) String() string {
+	// No lock required to read concurrently, as long as nobody writes to logKeyNames.
+	if int(logKey) < len(logKeyNames) {
+		return logKeyNames[logKey]
+	}
+
+	// Fall back to a binary representation.
+	return fmt.Sprintf("LogKeyMask(%b)", logKey)
 }
 
 // EnabledLogKeys returns a slice of enabled log key names.
-func (keyMask *LogKey) EnabledLogKeys() []string {
+func (keyMask *LogKeyMask) EnabledLogKeys() []string {
 	if keyMask == nil {
 		return []string{}
 	}
 	var logKeys = make([]string, 0, len(logKeyNames))
 	for i := 0; i < len(logKeyNames); i++ {
-		logKey := LogKey(1) << uint64(i)
-		if keyMask.enabled(logKey, false) {
-			logKeys = append(logKeys, logKey.String())
+		if keyMask.enabled(LogKey(i), false) {
+			logKeys = append(logKeys, logKeyNames[i])
 		}
 	}
 	return logKeys
 }
 
-// ToLogKey takes a slice of case-sensitive log key names and will return a LogKey bitfield
+// ToLogKey takes a slice of case-sensitive log key names and will return a LogKeyMask bitfield
 // and a slice of deferred log functions for any warnings that may occurr.
-func ToLogKey(keysStr []string) (logKeys LogKey, warnings []DeferredLogFn) {
+func ToLogKey(keysStr []string) (logKeys LogKeyMask, warnings []DeferredLogFn) {
 
 	for _, key := range keysStr {
 		// Take a copy of key, so we can use it in a closure outside the scope
@@ -162,8 +186,10 @@ func ToLogKey(keysStr []string) (logKeys LogKey, warnings []DeferredLogFn) {
 		originalKey := key
 
 		// Some old log keys (like HTTP+), we want to handle slightly (map to a different key)
-		if newLogKey, ok := convertSpecialLogKey(key); ok {
-			logKeys.Enable(*newLogKey)
+		if newLogKeys, ok := convertSpecialLogKey(key); ok {
+			for _, newLogKey := range newLogKeys {
+				logKeys.Enable(newLogKey)
+			}
 			continue
 		}
 
@@ -190,28 +216,32 @@ func ToLogKey(keysStr []string) (logKeys LogKey, warnings []DeferredLogFn) {
 	return logKeys, warnings
 }
 
-func inverselogKeyNames(in map[LogKey]string) map[string]LogKey {
+func inverselogKeyNames(in []string) map[string]LogKey {
 	var out = make(map[string]LogKey, len(in))
-	for k, v := range in {
-		out[v] = k
+	for i, v := range in {
+		out[v] = LogKey(i)
 	}
 	return out
 }
 
-// convertSpecialLogKey handles the conversion of some legacy log keys we want to map to a different value.
-func convertSpecialLogKey(oldLogKey string) (*LogKey, bool) {
-	var logKey *LogKey
+// convertSpecialLogKey handles the conversion of some legacy log keys we want to map to one or more different value.
+func convertSpecialLogKey(oldLogKey string) ([]LogKey, bool) {
 
+	var logKeys []LogKey
 	switch oldLogKey {
 	case "HTTP+":
 		// HTTP+ Should enable both KeyHTTP and KeyHTTPResp
-		logKey = logKeyPtr(KeyHTTP | KeyHTTPResp)
+		logKeys = []LogKey{KeyHTTP, KeyHTTPResp}
 	}
 
-	return logKey, logKey != nil
+	return logKeys, logKeys != nil
 }
 
-// logKeyPtr is a convenience function that returns a pointer to the given logKey
-func logKeyPtr(logKey LogKey) *LogKey {
-	return &logKey
+// logKeyPtr is a convenience function that returns a LogKeyMask for the given logKeys
+func logKeyMask(logKeys ...LogKey) *LogKeyMask {
+	var mask LogKeyMask
+	for _, logKey := range logKeys {
+		mask.Enable(logKey)
+	}
+	return &mask
 }

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -16,7 +16,7 @@ type ConsoleLogger struct {
 	FileLogger
 
 	LogLevel     *LogLevel
-	LogKey       *LogKey
+	LogKeyMask   *LogKeyMask
 	ColorEnabled bool
 
 	// isStderr is true when the console logger is configured with no FileOutput
@@ -46,7 +46,7 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 
 	logger := &ConsoleLogger{
 		LogLevel:     config.LogLevel,
-		LogKey:       &logKey,
+		LogKeyMask:   &logKey,
 		ColorEnabled: *config.ColorEnabled && isStderr,
 		FileLogger: FileLogger{
 			Enabled: *config.Enabled,
@@ -101,12 +101,12 @@ func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
 	}
 
 	// Log key All should always log at this point, unless KeyNone is set
-	if logKey == KeyAll && !l.LogKey.Enabled(KeyNone) {
+	if logKey == KeyAll && !l.LogKeyMask.Enabled(KeyNone) {
 		return true
 	}
 
 	// Finally, check the specific log key is enabled
-	return l.LogKey.Enabled(logKey)
+	return l.LogKeyMask.Enabled(logKey)
 }
 
 // init validates and sets any defaults for the given ConsoleLoggerConfig

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -137,7 +137,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: false},
 				LogLevel:   logLevelPtr(LevelNone),
-				LogKey:     logKeyPtr(KeyHTTP),
+				LogKeyMask: logKeyMask(KeyHTTP),
 				isStderr:   false,
 			},
 		},
@@ -147,7 +147,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: true},
 				LogLevel:   logLevelPtr(LevelInfo),
-				LogKey:     logKeyPtr(KeyHTTP | KeyCRUD),
+				LogKeyMask: logKeyMask(KeyHTTP, KeyCRUD),
 				isStderr:   true,
 			},
 		},
@@ -157,7 +157,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: true},
 				LogLevel:   logLevelPtr(LevelWarn),
-				LogKey:     logKeyPtr(KeyHTTP),
+				LogKeyMask: logKeyMask(KeyHTTP),
 				isStderr:   true,
 			},
 		},
@@ -167,7 +167,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 			expected: ConsoleLogger{
 				FileLogger: FileLogger{Enabled: true},
 				LogLevel:   logLevelPtr(LevelWarn),
-				LogKey:     logKeyPtr(KeyHTTP | KeyCRUD),
+				LogKeyMask: logKeyMask(KeyHTTP, KeyCRUD),
 				isStderr:   true,
 			},
 		},
@@ -179,7 +179,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)
-			assert.Equal(tt, *test.expected.LogKey, *logger.LogKey)
+			assert.Equal(tt, *test.expected.LogKeyMask, *logger.LogKeyMask)
 			assert.Equal(tt, test.expected.isStderr, logger.isStderr)
 		})
 	}

--- a/base/logging.go
+++ b/base/logging.go
@@ -229,7 +229,7 @@ func GetLogKeys() map[string]bool {
 // UpdateLogKeys updates the console's log keys from a map
 func UpdateLogKeys(keys map[string]bool, replace bool) {
 	if replace {
-		ConsoleLogKey().Set(KeyNone)
+		ConsoleLogKey().Set(logKeyMask(KeyNone))
 	}
 
 	for k, v := range keys {

--- a/base/logging.go
+++ b/base/logging.go
@@ -542,7 +542,7 @@ func LogSyncGatewayVersion() {
 }
 
 // addPrefixes will modify the format string to add timestamps, log level, and other common prefixes.
-// E.g: 2006-01-02T15:04:05.000Z07:00 [LVL] LogKey: format_str
+// E.g: 2006-01-02T15:04:05.000Z07:00 [LVL] LogKeyMask: format_str
 func addPrefixes(format string, ctx context.Context, logLevel LogLevel, logKey LogKey) string {
 	timestampPrefix := time.Now().Format(ISO8601Format) + " "
 
@@ -609,8 +609,8 @@ func ConsoleLogLevel() *LogLevel {
 }
 
 // ConsoleLogKey returns the console log key.
-func ConsoleLogKey() *LogKey {
-	return consoleLogger.LogKey
+func ConsoleLogKey() *LogKeyMask {
+	return consoleLogger.LogKeyMask
 }
 
 // LogInfoEnabled returns true if either the console should log at info level,

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -56,7 +56,7 @@ func TestRedactedLogFuncs(t *testing.T) {
 
 func Benchmark_LoggingPerformance(b *testing.B) {
 
-	defer SetUpBenchmarkLogging(LevelInfo, KeyHTTP|KeyCRUD)()
+	defer SetUpBenchmarkLogging(LevelInfo, KeyHTTP, KeyCRUD)()
 
 	b.ResetTimer()
 

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -570,31 +570,31 @@ func TestRedactBasicAuthURL(t *testing.T) {
 func TestSetUpTestLogging(t *testing.T) {
 	// Check default state of logging is as expected.
 	require.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	require.Equal(t, KeyHTTP, *consoleLogger.LogKey)
+	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
-	teardownFn := SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
+	teardownFn := SetUpTestLogging(LevelDebug, KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
-	assert.Equal(t, KeyDCP|KeySync, *consoleLogger.LogKey)
+	assert.Equal(t, *logKeyMask(KeyDCP, KeySync), *consoleLogger.LogKeyMask)
 
 	teardownFn()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	assert.Equal(t, KeyHTTP, *consoleLogger.LogKey)
+	assert.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
 	teardownFn = DisableTestLogging()
 	assert.Equal(t, LevelNone, *consoleLogger.LogLevel)
-	assert.Equal(t, KeyNone, *consoleLogger.LogKey)
+	assert.Equal(t, *logKeyMask(KeyNone), *consoleLogger.LogKeyMask)
 
 	teardownFn()
 	assert.Equal(t, LevelInfo, *consoleLogger.LogLevel)
-	assert.Equal(t, KeyHTTP, *consoleLogger.LogKey)
+	assert.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)
 
-	SetUpTestLogging(LevelDebug, KeyDCP|KeySync)
+	SetUpTestLogging(LevelDebug, KeyDCP, KeySync)
 	assert.Equal(t, LevelDebug, *consoleLogger.LogLevel)
-	assert.Equal(t, KeyDCP|KeySync, *consoleLogger.LogKey)
+	assert.Equal(t, *logKeyMask(KeyDCP, KeySync), *consoleLogger.LogKeyMask)
 
 	// Now we should panic because we forgot to call teardown!
 	assert.Panics(t, func() {
-		SetUpTestLogging(LevelError, KeyAuth|KeyCRUD)
+		SetUpTestLogging(LevelError, KeyAuth, KeyCRUD)
 	}, "Expected panic from multiple SetUpTestLogging calls")
 	teardownFn()
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -579,7 +579,7 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 	}
 
 	consoleLogger.LogLevel.Set(logLevel)
-	consoleLogger.LogKeyMask = logKeyMask(logKeys...)
+	consoleLogger.LogKeyMask.Set(logKeyMask(logKeys...))
 
 	return func() {
 		// Return logging to a default state

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -584,7 +584,7 @@ func setTestLogging(logLevel LogLevel, caller string, logKeys ...LogKey) (teardo
 	return func() {
 		// Return logging to a default state
 		consoleLogger.LogLevel.Set(initialLogLevel)
-		consoleLogger.LogKeyMask = initialLogKey
+		consoleLogger.LogKeyMask.Set(initialLogKey)
 		if caller != "" {
 			Infof(KeyAll, "%v: Reset logging", caller)
 		}

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -250,7 +250,7 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -370,7 +370,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
 	cacheOptions := shortWaitCache()
 	cacheOptions.ChannelCacheOptions.MaxNumChannels = 100
@@ -551,7 +551,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyDCP)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyDCP)()
 
 	db, testBucket := setupTestDB(t)
 	defer tearDownTestDB(t, db)
@@ -590,7 +590,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -656,7 +656,7 @@ func TestContinuousChangesBackfill(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyChanges|base.KeyDCP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -757,7 +757,7 @@ func TestLowSequenceHandling(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyQuery)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -823,7 +823,7 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyQuery)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -881,7 +881,7 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges|base.KeyQuery)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyQuery)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -1082,7 +1082,7 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyCache)()
 
 	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer tearDownTestDB(t, db)
@@ -1339,7 +1339,7 @@ func TestStopChangeCache(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges|base.KeyDCP)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyDCP)()
 
 	if base.TestUseXattrs() {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
@@ -1602,7 +1602,7 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	}
 
 	// Enable relevant logging
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyChanges)()
 
 	// Create a test db that uses channel cache
 	channelOptions := ChannelCacheOptions{
@@ -1804,7 +1804,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 func TestNotifyForInactiveChannel(t *testing.T) {
 
 	// Enable relevant logging
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyDCP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyDCP)()
 
 	db, testBucket := setupTestDB(t)
 	defer tearDownTestDB(t, db)
@@ -1871,7 +1871,7 @@ func TestChangeCache_InsertPendingEntries(t *testing.T) {
 		t.Skip("This test does not work with XATTRs due to calling WriteDirect().  Skipping.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.CachePendingSeqMaxWait = 100 * time.Millisecond
@@ -1963,7 +1963,7 @@ func (f *testProcessEntryFeed) Next() *LogEntry {
 //   - non-unique doc ids?
 
 func BenchmarkProcessEntry(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache, base.KeyChanges)()
 	processEntryBenchmarks := []struct {
 		name           string
 		feed           *testProcessEntryFeed
@@ -2188,7 +2188,7 @@ func (f *testDocChangedFeed) Next() sgbucket.FeedEvent {
 //   - non-unique doc ids?
 
 func BenchmarkDocChanged(b *testing.B) {
-	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpBenchmarkLogging(base.LevelError, base.KeyCache, base.KeyChanges)()
 	processEntryBenchmarks := []struct {
 		name           string
 		feed           *testDocChangedFeed

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUserWaiter(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
@@ -56,7 +56,7 @@ func TestUserWaiter(t *testing.T) {
 
 func TestUserWaiterForRoleChange(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -33,7 +33,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -706,7 +706,7 @@ func TestAllDocsOnly(t *testing.T) {
 // Unit test for bug #673
 func TestUpdatePrincipal(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -2,10 +2,11 @@ package db
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
@@ -28,7 +29,7 @@ func TestMigrateMetadata(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate|base.KeyImport)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate, base.KeyImport)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
@@ -99,7 +100,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate|base.KeyImport)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyMigrate, base.KeyImport)()
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -592,7 +592,7 @@ func TestGetStatus(t *testing.T) {
 // Test user delete while that user has an active changes feed (see issue 809)
 func TestUserDeleteDuringChangesWithAccess(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyCache|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache, base.KeyHTTP)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); if(doc.type == "setaccess") { access(doc.owner, doc.channel);}}`}
 	rt := NewRestTester(t, &rtConfig)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2024,7 +2024,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 
 func TestChannelAccessChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {access(doc.owner, doc._id);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2203,7 +2203,7 @@ func TestChannelAccessChanges(t *testing.T) {
 
 func TestAccessOnTombstone(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc,oldDoc) {
 			 if (doc.owner) {
@@ -2389,7 +2389,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache|base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyAccess, base.KeyCRUD, base.KeyChanges)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channels)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2485,7 +2485,7 @@ func TestUserJoiningPopulatedChannel(t *testing.T) {
 
 func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2531,7 +2531,7 @@ func TestRoleAssignmentBeforeUserExists(t *testing.T) {
 
 func TestRoleAccessChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess|base.KeyCRUD|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAccess, base.KeyCRUD, base.KeyChanges)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {role(doc.user, doc.role);channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -3709,7 +3709,7 @@ func TestLongpollWithWildcard(t *testing.T) {
 	// TODO: Test disabled because it fails with -race
 	t.Skip("WARNING: TEST DISABLED")
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -3900,7 +3900,7 @@ func TestDocIDFilterResurrection(t *testing.T) {
 
 func TestSyncFunctionErrorLogging(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyJavascript)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyJavascript)()
 
 	rtConfig := RestTesterConfig{SyncFn: `
 		function(doc) {

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -32,7 +32,7 @@ func TestChangesAccessNotifyInteger(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel);}`, t)
 	defer it.Close()
@@ -87,7 +87,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -35,7 +35,7 @@ import (
 // Replication Spec: https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#proposechanges
 func TestBlipPushRevisionInspectChanges(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -150,7 +150,7 @@ func TestBlipPushRevisionInspectChanges(t *testing.T) {
 // Wait until we get the expected updates
 func TestContinuousChangesSubscription(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -266,7 +266,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -422,7 +422,7 @@ func TestBlipOneShotChangesSubscription(t *testing.T) {
 // Test subChanges w/ docID filter
 func TestBlipSubChangesDocIDFilter(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -590,7 +590,7 @@ func TestBlipSubChangesDocIDFilter(t *testing.T) {
 // 4. Make sure that the server responds to accept the changes (empty array)
 func TestProposedChangesNoConflictsMode(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
@@ -629,7 +629,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 // Connect to public port with authentication
 func TestPublicPortAuthentication(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
 	btUser1, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -689,7 +689,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 // Connect to public port with authentication, and validate user update during a replication
 func TestPublicPortAuthenticationUserUpdate(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
@@ -756,7 +756,7 @@ function(doc, oldDoc) {
 // Write a doc that grants access to itself for the active replication's user
 func TestContinuousChangesDynamicGrant(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
 function(doc, oldDoc) {
@@ -886,7 +886,7 @@ function(doc, oldDoc) {
 
 func TestConcurrentRefreshUser(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg, base.KeyChanges, base.KeyCache)()
 	// Initialize restTester here, so that we can use custom sync function, and later modify user
 	syncFunction := `
 function(doc, oldDoc) {
@@ -1029,7 +1029,7 @@ function(doc, oldDoc) {
 //   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetRev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Setup
 	rtConfig := RestTesterConfig{
@@ -1081,7 +1081,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 //   Validate deleted handling (includes check for https://github.com/couchbase/sync_gateway/issues/3341)
 func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Setup
 	rtConfig := RestTesterConfig{
@@ -1142,7 +1142,7 @@ func TestMultiChannelContinousChangesSubscription(t *testing.T) {
 // Test setting and getting checkpoints
 func TestBlipSetCheckpoint(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Setup
 	rtConfig := RestTesterConfig{
@@ -1197,7 +1197,7 @@ func TestNoConflictsModeReplication(t *testing.T) {
 // Reproduces https://github.com/couchbase/sync_gateway/issues/2717
 func TestReloadUser(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	syncFn := `
 		function(doc) {
@@ -1268,7 +1268,7 @@ func TestReloadUser(t *testing.T) {
 // it shows up in the user's changes feed
 func TestAccessGrantViaSyncFunction(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Setup
 	rtConfig := RestTesterConfig{
@@ -1316,7 +1316,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 // it shows up in the user's changes feed
 func TestAccessGrantViaAdminApi(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1355,7 +1355,7 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 
 func TestCheckpoint(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1425,7 +1425,7 @@ func TestCheckpoint(t *testing.T) {
 // - Get attachment via REST and verifies it returns the correct content
 func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1471,7 +1471,7 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
 func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1555,7 +1555,7 @@ func TestPutInvalidAttachment(t *testing.T) {
 		},
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1600,7 +1600,7 @@ func TestPutInvalidAttachment(t *testing.T) {
 // returns an error code
 func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	syncFn := `
 		function(doc) {
@@ -1651,7 +1651,7 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 
 func TestPutInvalidRevMalformedBody(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1690,7 +1690,7 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 
 func TestPutRevNoConflictsMode(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1718,7 +1718,7 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 
 func TestPutRevConflictsMode(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
@@ -1759,7 +1759,7 @@ func TestPutRevConflictsMode(t *testing.T) {
 //
 func TestGetRemovedDoc(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	// Setup
 	rtConfig := RestTesterConfig{
@@ -1849,7 +1849,7 @@ func TestGetRemovedDoc(t *testing.T) {
 // - Open a one-off subChanges request, assert no error
 func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
 	bt, err := NewBlipTester(t)
 	assert.NoError(t, err, "Error creating BlipTester")
@@ -2155,7 +2155,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 // └──────────────┘           └───────────┘          └───────────┘
 func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP|base.KeyCache|base.KeySync|base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{noAdminParty: true, DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -247,7 +247,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 
 func TestPostChangesInteger(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()
@@ -293,7 +293,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`, t)
 	defer it.Close()
@@ -460,7 +460,7 @@ func postChangesSince(t *testing.T, it *indexTester) {
 
 func TestPostChangesChannelFilterInteger(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()
@@ -529,7 +529,7 @@ func TestPostChangesAdminChannelGrantInteger(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()
@@ -1090,7 +1090,7 @@ func TestUnusedSequences(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD, base.KeyHTTP)()
 
 	// Only do 10 iterations if running against walrus.  If against a live couchbase server,
 	// just do single iteration.  (Takes approx 30s)
@@ -1267,7 +1267,7 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 }
 
 func TestChangesActiveOnlyInteger(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()
@@ -1799,7 +1799,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 // Tests view backfills into empty cache and validates that results are prepended to cache
 func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -1871,7 +1871,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 // Validate that non-contiguous query results (due to limit) are not prepended to the cache
 func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -1970,7 +1970,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 // Tests multiple view backfills and validates that results are prepended to cache
 func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2054,7 +2054,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 // Tests multiple view backfills and validates that results are prepended to cache
 func TestChangesViewBackfillNoOverlap(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2140,7 +2140,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 // Tests view backfill and validates that results are prepended to cache
 func TestChangesViewBackfill(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2211,7 +2211,7 @@ func TestChangesViewBackfill(t *testing.T) {
 // Tests view backfill and validates that results are prepended to cache
 func TestChangesViewBackfillStarChannel(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2292,7 +2292,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 		t.Skip("Skip test with LeakyBucket dependency test when running in integration")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	rt := NewRestTester(t, &rtConfig)
@@ -2398,7 +2398,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 
 func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()
@@ -2559,7 +2559,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 // additional to general view handling.
 func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
 	defer it.Close()
@@ -2746,7 +2746,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP|base.KeyChanges|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	cacheSize := 2
 	shortWaitConfig := &DbConfig{
@@ -2914,7 +2914,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 // Test _changes returning conflicts
 func TestChangesIncludeConflicts(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache|base.KeyChanges|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyCRUD)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc,oldDoc) {
 			 channel(doc.channel)
@@ -3056,7 +3056,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 // Validate that an admin channel grant wakes up a waiting changes request
 func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges|base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -65,7 +65,7 @@ func TestXattrImportOldDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Test oldDoc behaviour during SDK insert
 	key := "TestImportDelete"
@@ -140,7 +140,7 @@ func TestXattrSGTombstone(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create doc through SG
 	key := "TestXattrSGTombstone"
@@ -249,7 +249,7 @@ func TestXattrResurrectViaSG(t *testing.T) {
 
 	rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create and import doc
 	key := "TestResurrectViaSG"
@@ -363,7 +363,7 @@ func TestXattrDoubleDelete(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create and import doc
 	key := "TestDoubleDelete"
@@ -487,7 +487,7 @@ func TestXattrImportFilterOptIn(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create two docs via the SDK, one matching filter
 	mobileKey := "TestImportFilterValid"
@@ -578,7 +578,7 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportMultiActorUpdate"
@@ -635,7 +635,7 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportMultiActorUpdate"
@@ -695,7 +695,7 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// Create doc via the SDK
 	mobileKey := "TestImportMultiActorFeed"
@@ -770,7 +770,7 @@ func TestXattrImportLargeNumbers(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestImportLargeNumbers"
@@ -819,7 +819,7 @@ func TestMigrateLargeInlineRevisions(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateLargeInlineRevisions"
@@ -888,7 +888,7 @@ func TestMigrateTombstone(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateTombstone"
@@ -957,7 +957,7 @@ func TestMigrateWithExternalRevisions(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestMigrateWithExternalRevisions"
@@ -1033,7 +1033,7 @@ func TestCheckForUpgradeOnRead(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1112,7 +1112,7 @@ func TestCheckForUpgradeOnWrite(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1194,7 +1194,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"
@@ -1254,7 +1254,7 @@ func TestXattrFeedBasedImportPreservesExpiry(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create docs via the SDK with expiry set
 	mobileKey := "TestXattrImportPreservesExpiry"
@@ -1312,7 +1312,7 @@ func TestFeedBasedMigrateWithExpiry(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// Write doc in SG format directly to the bucket
 	key := "TestFeedBasedMigrateWithExpiry"
@@ -1362,7 +1362,7 @@ func TestOnDemandWriteImportReplacingNullDoc(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	key := "TestXattrOnDemandImportNullBody"
 
@@ -1434,7 +1434,7 @@ func TestXattrOnDemandImportPreservesExpiry(t *testing.T) {
 			defer rt.Close()
 			bucket := rt.Bucket()
 
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 			key := fmt.Sprintf("TestXattrOnDemandImportPreservesExpiry-%d", i)
 
@@ -1520,7 +1520,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			defer rt.Close()
 			bucket := rt.Bucket()
 
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+			defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 			// Create via the SDK with sync metadata intact
 			expirySeconds := time.Second * 30
@@ -1567,7 +1567,7 @@ func TestXattrSGWriteOfNonImportedDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create doc via SG
 	sgWriteKey := "TestImportFilterSGWrite"
@@ -1615,7 +1615,7 @@ func TestImportBinaryDoc(t *testing.T) {
 
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD|base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
 
 	// 1. Write a binary doc through the SDK
 	rawBytes := []byte("some bytes")
@@ -1881,7 +1881,7 @@ func TestUnexpectedBodyOnTombstone(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport|base.KeyCRUD)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD)()
 
 	// 1. Create doc via the SDK
 	mobileKey := "TestTombstoneUpdate"


### PR DESCRIPTION
LogKey is now the index position in a simple slice of names.

Retains LogKeyMask bitfield for enabled/disabled handling, to avoid rewrite of locking.  Does index-to-bitfield position conversion in enabled/disabled calls.