### PR TITLE
Enable trace pprof endpoint

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -11,7 +11,6 @@ package rest
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	httpprof "net/http/pprof"
 	"os"
@@ -354,8 +353,7 @@ func (h *handler) handlePprofGoroutine() error {
 
 // Go execution tracer
 func (h *handler) handlePprofTrace() error {
-	log.Panicf("Disabled until we require Go1.5 as minimal version to build with")
-	// httpprof.Trace(h.response, h.rq)
+	httpprof.Trace(h.response, h.rq)
 	return nil
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4609,14 +4609,6 @@ func TestHandleHeapProfiling(t *testing.T) {
 	assert.Contains(t, string(response.BodyBytes()), "Internal error: open")
 }
 
-func TestHandlePprofTrace(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-	// Get and Post requests for pprof trace
-	assert.Panics(t, func() { rt.SendAdminRequest(http.MethodGet, "/_debug/pprof/trace", "") })
-	assert.Panics(t, func() { rt.SendAdminRequest(http.MethodPost, "/_debug/pprof/trace", "") })
-}
-
 func TestHandlePprofsCmdlineAndSymbol(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
@@ -4659,22 +4651,32 @@ func TestHandlePprofs(t *testing.T) {
 	}{
 		{
 			inputProfile:  "heap",
-			inputResource: "/_debug/pprof/heap?seconds=1"},
+			inputResource: "/_debug/pprof/heap?seconds=1",
+		},
 		{
 			inputProfile:  "profile",
-			inputResource: "/_debug/pprof/profile?seconds=1"},
+			inputResource: "/_debug/pprof/profile?seconds=1",
+		},
 		{
 			inputProfile:  "block",
-			inputResource: "/_debug/pprof/block?seconds=1"},
+			inputResource: "/_debug/pprof/block?seconds=1",
+		},
 		{
 			inputProfile:  "threadcreate",
-			inputResource: "/_debug/pprof/threadcreate"},
+			inputResource: "/_debug/pprof/threadcreate",
+		},
 		{
 			inputProfile:  "mutex",
-			inputResource: "/_debug/pprof/mutex?seconds=1"},
+			inputResource: "/_debug/pprof/mutex?seconds=1",
+		},
 		{
 			inputProfile:  "goroutine",
-			inputResource: "/_debug/pprof/goroutine?debug=0&gc=1"},
+			inputResource: "/_debug/pprof/goroutine?debug=0&gc=1",
+		},
+		{
+			inputProfile:  "trace",
+			inputResource: "/_debug/pprof/trace?seconds=1",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Enables the trace pprof endpoint `/_debug/pprof/trace`

![Screenshot 2020-01-14 at 18 50 45](https://user-images.githubusercontent.com/1525809/72372767-dfa5ce80-36fe-11ea-9f6c-1a71d41bed2a.png)