### PR TITLE
Fix test-util DropAllBucketIndexes to only remove indexes on the bucket

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -326,7 +326,9 @@ func getIndexes(gocbBucket *CouchbaseBucketGoCB) (indexes []string, err error) {
 	}
 
 	for _, indexInfo := range indexInfo {
-		indexes = append(indexes, indexInfo.Name)
+		if indexInfo.Keyspace == gocbBucket.GetName() {
+			indexes = append(indexes, indexInfo.Name)
+		}
 	}
 
 	return indexes, nil


### PR DESCRIPTION
`getIndexes` is used to fetch all indexes belonging to the given bucket, but it's actually returning all indexes in the cluster, so `DropAllBucketIndexes` actually removes all indexes from the cluster.