### PR TITLE
CBG-626 - Add test to verify DCP feed names do not exceed 200 chars

### DIFF
--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -54,7 +54,7 @@ func TestDCPNameLength(t *testing.T) {
 
 	for _, dbName := range dbNames {
 		t.Run("cbgt-index-"+dbName, func(t *testing.T) {
-			indexName := dbName // GenerateIndexName(dbName)
+			indexName := GenerateIndexName(dbName)
 
 			// Verify we pass CBGT's index name validation
 			matched, err := regexp.Match(cbgt.INDEX_NAME_REGEXP, []byte(indexName))

--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -1,0 +1,43 @@
+package base
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/couchbase/cbgt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateDcpStreamName(t *testing.T) {
+	const maxDCPNameLength = 200
+
+	feedIDs := []string{
+		DCPCachingFeedID,
+		DCPImportFeedID,
+	}
+
+	for _, feedID := range feedIDs {
+		t.Run(feedID, func(t *testing.T) {
+			dcpStreamName, err := GenerateDcpStreamName(feedID)
+			require.NoError(t, err)
+			t.Logf("generated name of length %d: %s", len(dcpStreamName), dcpStreamName)
+
+			assert.Truef(t, len(dcpStreamName) <= maxDCPNameLength,
+				"len(dcpStreamName)=%d is exceeds max allowed %d chars: %s",
+				len(dcpStreamName), maxDCPNameLength, dcpStreamName)
+		})
+		t.Run("cbgt"+feedID, func(t *testing.T) {
+			dcpStreamName, err := GenerateDcpStreamName(feedID)
+			require.NoError(t, err)
+
+			cbgtDCPName := fmt.Sprintf("%s%s-%x", cbgt.DCPFeedPrefix, dcpStreamName, rand.Int31())
+			t.Logf("generated name of length %d: %s", len(cbgtDCPName), cbgtDCPName)
+
+			assert.Truef(t, len(cbgtDCPName) <= maxDCPNameLength,
+				"len(cbgtDCPName)=%d is exceeds max allowed %d chars: %s",
+				len(cbgtDCPName), maxDCPNameLength, cbgtDCPName)
+		})
+	}
+}

--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -3,6 +3,7 @@ package base
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 
 	"github.com/couchbase/cbgt"
@@ -10,7 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateDcpStreamName(t *testing.T) {
+func TestDCPNameLength(t *testing.T) {
+	// https://issues.couchbase.com/browse/MB-34280
 	const maxDCPNameLength = 200
 
 	feedIDs := []string{
@@ -28,16 +30,46 @@ func TestGenerateDcpStreamName(t *testing.T) {
 				"len(dcpStreamName)=%d is exceeds max allowed %d chars: %s",
 				len(dcpStreamName), maxDCPNameLength, dcpStreamName)
 		})
+
 		t.Run("cbgt"+feedID, func(t *testing.T) {
 			dcpStreamName, err := GenerateDcpStreamName(feedID)
 			require.NoError(t, err)
 
+			// Format string copied from cbgt's 'NewDCPFeed'
 			cbgtDCPName := fmt.Sprintf("%s%s-%x", cbgt.DCPFeedPrefix, dcpStreamName, rand.Int31())
 			t.Logf("generated name of length %d: %s", len(cbgtDCPName), cbgtDCPName)
 
 			assert.Truef(t, len(cbgtDCPName) <= maxDCPNameLength,
 				"len(cbgtDCPName)=%d is exceeds max allowed %d chars: %s",
 				len(cbgtDCPName), maxDCPNameLength, cbgtDCPName)
+		})
+	}
+
+	dbNames := []string{
+		"db1",
+		"db1$a", // dollars aren't allowed in cbgt index names, but are valid in SG/CouchDB database names
+		"123",   // indexes and db names can't start with a digit
+		"db1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	for _, dbName := range dbNames {
+		t.Run("cbgt-index-"+dbName, func(t *testing.T) {
+			indexName := dbName // GenerateIndexName(dbName)
+
+			// Verify we pass CBGT's index name validation
+			matched, err := regexp.Match(cbgt.INDEX_NAME_REGEXP, []byte(indexName))
+			require.NoError(t, err)
+			assert.True(t, matched, "index name is not a valid cbgt index name")
+
+			// The format of a cbgt index name is of the following format:
+			// sg:db0xbdcaa3f7_index_167dfc5a122bde31_f47365c5-2e5220ce
+			// where 'sg:db0x..._index' are SG's generated name, and the rest is from CBGT.
+			cbgtIndexDCPName := fmt.Sprintf("%s_167dfc5a122bde31_f47365c5-2e5220ce", indexName)
+			t.Logf("generated name of length %d: %s", len(cbgtIndexDCPName), cbgtIndexDCPName)
+
+			assert.Truef(t, len(cbgtIndexDCPName) <= maxDCPNameLength,
+				"len(cbgtIndexDCPName)=%d is exceeds max allowed %d chars: %s",
+				len(cbgtIndexDCPName), maxDCPNameLength, cbgtIndexDCPName)
 		})
 	}
 }

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -122,6 +122,7 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 	//       how this can be optimized if we're not actually using it in the indexImpl
 	indexParams := `{"name": "` + dbName + `"}`
 	indexName := GenerateIndexName(dbName)
+	Infof(KeyDCP, "Creating cbgt index %q for db %q", indexName, MD(dbName))
 
 	// Required for initial pools request, before BucketDataSourceOptions kick in
 	if spec.Certpath != "" {

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -69,6 +69,12 @@ func cbgtFeedParams(spec BucketSpec) (string, error) {
 	return string(paramBytes), nil
 }
 
+// Given a dbName, generate a unique and length-constrained index name for CBGT to use as part of their DCP name.
+func GenerateIndexName(dbName string) string {
+	// Index names *must* start with a letter, so we'll prepend 'db' before the per-database checksum (which starts with '0x')
+	return "db" + Crc32cHashString([]byte(dbName)) + "_index"
+}
+
 // Creates a CBGT index definition for the specified bucket.  This adds the index definition
 // to the manager's cbgt cfg.  Nodes that have registered for this indexType with the manager via
 // RegisterPIndexImplType (see importListener.RegisterImportPindexImpl)
@@ -115,8 +121,7 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 	// TODO: If this isn't well-formed JSON, cbgt emits errors when opening locally persisted pindex files.  Review
 	//       how this can be optimized if we're not actually using it in the indexImpl
 	indexParams := `{"name": "` + dbName + `"}`
-
-	indexName := dbName + "_import"
+	indexName := GenerateIndexName(dbName)
 
 	// Required for initial pools request, before BucketDataSourceOptions kick in
 	if spec.Certpath != "" {


### PR DESCRIPTION
Seems we're well off the limit, even with cbgt names prepended to our feed IDs.

```
=== RUN   TestGenerateDcpStreamName/SG
    --- PASS: TestGenerateDcpStreamName/SG (0.00s)
        dcp_common_test.go:25: generated name of length 65: SG-v-2.8-commit-1e72cde-uuid-6606e6e4-3957-11ea-9835-acde48001122
=== RUN   TestGenerateDcpStreamName/cbgtSG
    --- PASS: TestGenerateDcpStreamName/cbgtSG (0.00s)
        dcp_common_test.go:36: generated name of length 76: sg:SG-v-2.8-commit-1e72cde-uuid-6606f1b6-3957-11ea-9835-acde48001122-a310e77
=== RUN   TestGenerateDcpStreamName/SGI
    --- PASS: TestGenerateDcpStreamName/SGI (0.00s)
        dcp_common_test.go:25: generated name of length 66: SGI-v-2.8-commit-1e72cde-uuid-6606f3fa-3957-11ea-9835-acde48001122
=== RUN   TestGenerateDcpStreamName/cbgtSGI
    --- PASS: TestGenerateDcpStreamName/cbgtSGI (0.00s)
        dcp_common_test.go:36: generated name of length 78: sg:SGI-v-2.8-commit-1e72cde-uuid-6606f5d0-3957-11ea-9835-acde48001122-7e80ffa9
```