### PR TITLE
CBG-673 - Add USE INDEX hint to queries

### DIFF
--- a/db/indexes.go
+++ b/db/indexes.go
@@ -16,6 +16,7 @@ import (
 const (
 	indexNameFormat = "sg_%s_%s%d" // Name, xattrs, version.  e.g. "sg_channels_x1"
 	syncToken       = "$sync"      // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
+	indexToken      = "$idx"       // Index token, used to hint which index should be used for the query
 
 	// N1ql-encoded wildcard expression matching the '_sync:' prefix used for all sync gateway's system documents.
 	// Need to escape the underscore in '_sync' to prevent it being treated as a N1QL wildcard
@@ -451,4 +452,9 @@ func replaceSyncTokensQuery(statement string, useXattrs bool) string {
 	} else {
 		return strings.Replace(statement, syncToken, syncNoXattr, -1)
 	}
+}
+
+// Replace index tokens ($idx) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
+func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) string {
+	return strings.Replace(statement, indexToken, idx.fullIndexName(useXattrs), -1)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -24,6 +24,7 @@ func WaitForIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 		// Create the star channel query
 		statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement) // append LIMIT 1 since we only care if there are any results or not
 		starChannelQueryStatement := replaceSyncTokensQuery(statement, useXattrs)
+		starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexChannels], useXattrs)
 		params := map[string]interface{}{}
 		params[QueryParamStartSeq] = 0
 		params[QueryParamEndSeq] = math.MaxInt64

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -24,7 +24,7 @@ func WaitForIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 		// Create the star channel query
 		statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement) // append LIMIT 1 since we only care if there are any results or not
 		starChannelQueryStatement := replaceSyncTokensQuery(statement, useXattrs)
-		starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexChannels], useXattrs)
+		starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
 		params := map[string]interface{}{}
 		params[QueryParamStartSeq] = 0
 		params[QueryParamEndSeq] = math.MaxInt64


### PR DESCRIPTION
Adds index hints to force queries to use the applicable index.

## Integration tests:
- [x] xattrs=true - http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration-ben/92/
- [x] xattrs=false - http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration-ben/94/

| Query            | Index Hint      |
| ---------------- | --------------- |
| QueryAccess      | IndexAccess     |
| QueryRoleAccess  | IndexRoleAccess |
| QueryChannels    | IndexChannels   |
| QueryStarChannel | IndexAllDocs    |
| QuerySequences   | IndexAllDocs    |
| QueryPrincipals  | IndexSyncDocs   |
| QuerySessions    | IndexSyncDocs   |
| QueryTombstones  | IndexTombstones |
| QueryResync      | IndexAllDocs    |
| QueryAllDocs     | IndexAllDocs    |