### PR TITLE
Change the logCollationWorker timeout to prevent idle spinning 

### DIFF
--- a/base/logger.go
+++ b/base/logger.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"log"
+	"math"
 	"strings"
 	"time"
 )
@@ -11,26 +12,31 @@ func FlushLogBuffers() {
 	time.Sleep(loggerCollateFlushDelay)
 }
 
+// logCollationWorker will take log lines over the given channel, and buffer them until either the buffer is full, or the flushTimeout is exceeded.
+// This is to reduce the number of writes to the log files, in order to batch them up as larger collated chunks, whilst maintaining a low-level of latency with the flush timeout.
 func logCollationWorker(collateBuffer chan string, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
-	// This is the temporary buffer we'll store logs in.
+
+	// The initial duration of the timeout timer doesn't matter,
+	// because we start it whenever we buffer a log without flushing it.
+	t := time.NewTimer(math.MaxInt64)
 	logBuffer := make([]string, 0, maxBufferSize)
+
 	for {
 		select {
-		// Add log to buffer and flush to output if it's full.
 		case l := <-collateBuffer:
 			logBuffer = append(logBuffer, l)
 			if len(logBuffer) >= maxBufferSize {
+				// flush if the buffer is full after this log
 				logger.Print(strings.Join(logBuffer, "\n"))
-				// Empty buffer
 				logBuffer = logBuffer[:0]
+			} else {
+				// Start the timeout timer going to flush this partial buffer
+				t.Reset(collateFlushTimeout)
 			}
-		// Flush the buffer to the output after this time, even if we don't fill it.
-		case <-time.After(collateFlushTimeout):
-			if len(logBuffer) > 0 {
-				logger.Print(strings.Join(logBuffer, "\n"))
-				// Empty buffer
-				logBuffer = logBuffer[:0]
-			}
+		case <-t.C:
+			// We've timed out waiting for more logs to be put into the buffer, so flush it now.
+			logger.Print(strings.Join(logBuffer, "\n"))
+			logBuffer = logBuffer[:0]
 		}
 	}
 }

--- a/base/logger.go
+++ b/base/logger.go
@@ -31,12 +31,14 @@ func logCollationWorker(collateBuffer chan string, logger *log.Logger, maxBuffer
 				logBuffer = logBuffer[:0]
 			} else {
 				// Start the timeout timer going to flush this partial buffer
-				t.Reset(collateFlushTimeout)
+				_ = t.Reset(collateFlushTimeout)
 			}
 		case <-t.C:
-			// We've timed out waiting for more logs to be put into the buffer, so flush it now.
-			logger.Print(strings.Join(logBuffer, "\n"))
-			logBuffer = logBuffer[:0]
+			if len(logBuffer) > 0 {
+				// We've timed out waiting for more logs to be put into the buffer, so flush it now.
+				logger.Print(strings.Join(logBuffer, "\n"))
+				logBuffer = logBuffer[:0]
+			}
 		}
 	}
 }


### PR DESCRIPTION
This loop is pretty tight, so instanciating a `time.After` on each iteration is
very costly for GC. It also loops when idle.

<table>
<tr>
<th>alloc_objects</th>
<th>alloc_space</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1525809/73658040-6c530500-468b-11ea-8ca7-b901dde46a74.png" width="100%" /></td>
<td><img src="https://user-images.githubusercontent.com/1525809/73658111-a6240b80-468b-11ea-8b6d-a8769473fe78.png" width="100%" /></td>
</tr>
</table>

By switching to use a single `time.Timer` which is restarted whenever we recieve a non-flushing log message, we can drastically improve the GC load, and also prevent idle spinning in this select loop.

<table>
<tr>
<th>Before (time.After)</th>
<th>After (time.Timer with Reset)</th>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/1525809/73843055-c253b400-4815-11ea-90af-0c529c94fb07.png" width="100%" /></td>
<td><img src="https://user-images.githubusercontent.com/1525809/73843058-c384e100-4815-11ea-994c-aeae8761507f.png" width="100%" /></td>
</tr>
</table>
