### PR TITLE
CBG-644: Remove command-line bucket option from Sync Gateway

### DIFF
--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -362,10 +362,10 @@ func mockCertificatesAndKeys(t *testing.T) (certPath, clientCertPath, clientKeyP
 	require.NoError(t, err, "Client certificate should be generated")
 	saveAsCertFile(t, clientCertPath, certBytes)
 
-	require.True(t, fileExists(rootKeyPath), "File %v should exists", rootKeyPath)
-	require.True(t, fileExists(rootCertPath), "File %v should exists", rootCertPath)
-	require.True(t, fileExists(clientKeyPath), "File %v should exists", clientKeyPath)
-	require.True(t, fileExists(clientCertPath), "File %v should exists", clientCertPath)
+	require.True(t, FileExists(rootKeyPath), "File %v should exists", rootKeyPath)
+	require.True(t, FileExists(rootCertPath), "File %v should exists", rootCertPath)
+	require.True(t, FileExists(clientKeyPath), "File %v should exists", clientKeyPath)
+	require.True(t, FileExists(clientCertPath), "File %v should exists", clientCertPath)
 
 	return certPath, clientCertPath, clientKeyPath, rootCertPath, rootKeyPath
 }
@@ -389,22 +389,6 @@ func saveAsCertFile(t *testing.T, filename string, derBytes []byte) {
 	require.NoError(t, err, "No error while closing cert.pem")
 }
 
-func fileExists(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
-}
-
-func dirExists(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return info.IsDir()
-}
-
 func TestTLSConfig(t *testing.T) {
 	// Mock fake root CA and client certificates for verification
 	certPath, clientCertPath, clientKeyPath, rootCertPath, rootKeyPath := mockCertificatesAndKeys(t)
@@ -412,7 +396,7 @@ func TestTLSConfig(t *testing.T) {
 	// Remove the keys and certificates after verification
 	defer func() {
 		assert.NoError(t, os.RemoveAll(certPath))
-		assert.False(t, dirExists(certPath), "Directory: %v shouldn't exists", certPath)
+		assert.False(t, DirExists(certPath), "Directory: %v shouldn't exists", certPath)
 	}()
 
 	// Simulate error creating tlsConfig for DCP processing

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -636,3 +636,19 @@ func testRetryUntilTrueCustom(t *testing.T, retryFunc RetryUntilTrueFunc, waitTi
 	}
 	assert.Fail(t, fmt.Sprintf("Retry until function didn't succeed within timeout (%d ms)", timeoutMs))
 }
+
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func DirExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return info.IsDir()
+}

--- a/rest/config.go
+++ b/rest/config.go
@@ -816,7 +816,6 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 	deploymentID := flagSet.String("deploymentID", "", "Customer/project identifier for stats reporting")
 	couchbaseURL := flagSet.String("url", DefaultServer, "Address of Couchbase server")
 	poolName := flagSet.String("pool", DefaultPool, "Name of pool")
-	bucketName := flagSet.String("bucket", "sync_gateway", "Name of bucket")
 	dbName := flagSet.String("dbname", "", "Name of Couchbase Server database (defaults to name of bucket)")
 	pretty := flagSet.Bool("pretty", false, "Pretty-print JSON responses")
 	verbose := flagSet.Bool("verbose", false, "Log more info about requests")
@@ -901,8 +900,9 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 
 	} else {
 		// If no config file is given, create a default config, filled in from command line flags:
+		var defaultBucketName = "sync_gateway"
 		if *dbName == "" {
-			*dbName = *bucketName
+			*dbName = defaultBucketName
 		}
 
 		// At this point the addr is either:
@@ -933,7 +933,7 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 					Name: *dbName,
 					BucketConfig: BucketConfig{
 						Server:     couchbaseURL,
-						Bucket:     bucketName,
+						Bucket:     &defaultBucketName,
 						Pool:       poolName,
 						CertPath:   *certpath,
 						CACertPath: *cacertpath,

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -864,39 +864,11 @@ func TestValidateServerContext(t *testing.T) {
 	assert.Subset(t, []string{"db1", "db2"}, SharedBucketError.GetSharedBucket().dbNames)
 }
 
-func TestParseCommandLineWihIllegalOptionBucket(t *testing.T) {
-	var (
-		adminInterface     = "127.0.0.1:4985"
-		bucket             = "sync_gateway"
-		cacertpath         = "/etc/ssl/certs/ca.cert"
-		certpath           = "/etc/ssl/certs/client.pem"
-		configServer       = "http://127.0.0.1:4981/conf"
-		dbname             = "beer_sample"
-		defaultLogFilePath = "/var/log/sync_gateway"
-		deploymentID       = "DEPID100"
-		interfaceAddress   = "4984"
-		keypath            = "/etc/ssl/certs/key.pem"
-		logKeys            = "Admin,Access,Auth,Bucket"
-		logFilePath        = "/var/log/sync_gateway"
-		pool               = "liverpool"
-	)
+func TestParseCommandLineWithIllegalOptionBucket(t *testing.T) {
 	args := []string{
 		"sync_gateway",
-		"--adminInterface", adminInterface,
-		"--bucket", bucket, // Bucket option has been removed
-		"--cacertpath", cacertpath,
-		"--certpath", certpath,
-		"--configServer", configServer,
-		"--dbname", dbname,
-		"--defaultLogFilePath", defaultLogFilePath,
-		"--deploymentID", deploymentID,
-		"--interface", interfaceAddress,
-		"--keypath", keypath,
-		"--log", logKeys,
-		"--logFilePath", logFilePath,
-		"--pool", pool,
-		"--pretty"}
-
+		"--bucket", "sync_gateway", // Bucket option has been removed
+	}
 	config, err := ParseCommandLine(args, flag.ContinueOnError)
 	assert.Error(t, err, "Parsing commandline arguments without any config file")
 	assert.Empty(t, config, "Couldn't parse commandline arguments")


### PR DESCRIPTION
The real intention of this PR is to make the changes for removing command line `bucket` option. But while working on adding unit test, I’ve noticed the use of `os.TempDir()` in `TestParseCommandLineWithConfigContent` and  in `TestParseCommandLineWithBadConfigContent`. So replaced `os.TempDir()` with `ioutil.TempFile()` in both the tests. Also moved and exported both FileExists and DirExists functions to util_testing.go for reusability.