### PR TITLE
Test assertion fixes moved from CBG-625

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -579,13 +579,11 @@ func TestConcurrentUserWrites(t *testing.T) {
 
 	// Get the user, validate channels and email
 	user, getErr = auth.GetUser(username)
-	if getErr != nil {
-		t.Errorf("Error retrieving user: %v", getErr)
-	}
+	require.NoError(t, getErr)
 
 	assert.Equal(t, email, user.Email())
-	assert.Equal(t, 3, len(user.Channels()))
-	assert.Equal(t, 2, len(user.RoleNames()))
+	require.Len(t, user.Channels(), 3)
+	require.Len(t, user.RoleNames(), 2)
 
 	// Check the password hash bcrypt cost
 	userImpl := user.(*userImpl)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -92,7 +92,7 @@ func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err e
 			return nil, pkgerrors.WithStack(certAuthErr)
 		}
 	} else if spec.Auth != nil {
-		Infof(KeyAuth, "Attempting credential authentication %s", connString)
+		Infof(KeyAuth, "Attempting credential authentication against bucket %s on server %s", MD(spec.BucketName), MD(spec.Server))
 		user, pass, _ := spec.Auth.GetCredentials()
 		authErr := cluster.Authenticate(gocb.PasswordAuthenticator{
 			Username: user,
@@ -147,10 +147,12 @@ func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err e
 	user, pass, _ := spec.Auth.GetCredentials()
 	nodesMetadata, err := cluster.Manager(user, pass).Internal().GetNodesMetadata()
 	if err != nil {
+		_ = goCBBucket.Close()
 		return nil, err
 	}
 
 	if len(nodesMetadata) == 0 {
+		_ = goCBBucket.Close()
 		return nil, errors.New("Unable to get server cluster compatibility")
 	}
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -86,13 +86,14 @@ func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err e
 	password := ""
 	// Check for client cert (x.509) authentication
 	if spec.Certpath != "" {
+		Infof(KeyAuth, "Attempting cert authentication against bucket %s on %s", MD(spec.BucketName), MD(connString))
 		certAuthErr := cluster.Authenticate(gocb.CertAuthenticator{})
 		if certAuthErr != nil {
 			Infof(KeyAuth, "Error Attempting certificate authentication %s", certAuthErr)
 			return nil, pkgerrors.WithStack(certAuthErr)
 		}
 	} else if spec.Auth != nil {
-		Infof(KeyAuth, "Attempting credential authentication against bucket %s on server %s", MD(spec.BucketName), MD(spec.Server))
+		Infof(KeyAuth, "Attempting credential authentication against bucket %s on %s", MD(spec.BucketName), MD(connString))
 		user, pass, _ := spec.Auth.GetCredentials()
 		authErr := cluster.Authenticate(gocb.PasswordAuthenticator{
 			Username: user,

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"testing"
 
 	"github.com/couchbase/gocb"
@@ -42,10 +41,8 @@ func TestN1qlQuery(t *testing.T) {
 
 	indexExpression := "val"
 	err := bucket.CreateIndex("testIndex_value", indexExpression, "", testN1qlOptions)
-	if err != nil {
-		if !strings.Contains(err.Error(), "index testIndex_value already exists") {
-			t.Errorf("Error creating index: %s", err)
-		}
+	if err != nil && err != ErrIndexAlreadyExists {
+		t.Errorf("Error creating index: %s", err)
 	}
 
 	// Wait for index readiness

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -414,7 +414,7 @@ func TestTLSConfig(t *testing.T) {
 	conf = spec.TLSConfig()
 	assert.NotEmpty(t, conf)
 	assert.NotNil(t, conf.RootCAs)
-	assert.Equal(t, 1, len(conf.Certificates))
+	require.Len(t, conf.Certificates, 1)
 	assert.False(t, conf.InsecureSkipVerify)
 
 	// Check TLSConfig with no CA certificate; InsecureSkipVerify should be true
@@ -422,7 +422,7 @@ func TestTLSConfig(t *testing.T) {
 	conf = spec.TLSConfig()
 	assert.NotEmpty(t, conf)
 	assert.True(t, conf.InsecureSkipVerify)
-	assert.Equal(t, 1, len(conf.Certificates))
+	require.Len(t, conf.Certificates, 1)
 	assert.Nil(t, conf.RootCAs)
 
 	// Check TLSConfig by providing invalid root CA certificate; provide root certificate key path

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -57,23 +57,23 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 		},
 	}
 	for _, h := range heartbeaters {
-		t.Run(h.name, func(tt *testing.T) {
+		t.Run(h.name, func(t *testing.T) {
 			testBucket := GetTestBucket(t)
 			defer testBucket.Close()
 
 			// Create three heartbeaters (representing three nodes)
 			handler1 := h.nodeSetHandlerConstructor(testBucket)
-			assert.NotNil(tt, handler1)
+			assert.NotNil(t, handler1)
 			node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", handler1)
-			assert.NoError(tt, err)
+			assert.NoError(t, err)
 			handler2 := h.nodeSetHandlerConstructor(testBucket)
-			assert.NotNil(tt, handler2)
+			assert.NotNil(t, handler2)
 			node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", handler2)
-			assert.NoError(tt, err)
+			assert.NoError(t, err)
 			handler3 := h.nodeSetHandlerConstructor(testBucket)
-			assert.NotNil(tt, handler3)
+			assert.NotNil(t, handler3)
 			node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", handler3)
-			assert.NoError(tt, err)
+			assert.NoError(t, err)
 
 			assert.NoError(t, node1.StartSendingHeartbeats(1))
 			assert.NoError(t, node2.StartSendingHeartbeats(1))
@@ -114,7 +114,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 			// Validate current node list
 			activeNodes, err := handler2.GetNodes()
 			require.NoError(t, err, "Error getting node list")
-			assert.Equal(t, 2, len(activeNodes))
+			require.Len(t, activeNodes, 2)
 			assert.NotContains(t, activeNodes, "node1")
 			assert.Contains(t, activeNodes, "node2")
 			assert.Contains(t, activeNodes, "node3")
@@ -209,7 +209,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	// Validate current node list
 	activeNodes, err := handler2.GetNodes()
 	require.NoError(t, err, "Error getting node list")
-	assert.Equal(t, 2, len(activeNodes))
+	require.Len(t, activeNodes, 2)
 	assert.NotContains(t, activeNodes, "node1")
 	assert.Contains(t, activeNodes, "node2")
 	assert.Contains(t, activeNodes, "node3")

--- a/base/logger_file_test.go
+++ b/base/logger_file_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fileShouldLogTests = []struct {
@@ -122,7 +123,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	err = runLogDeletion(dir, "info", 5, 7)
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
-	assert.Equal(t, 3, len(dirContents))
+	require.Len(t, dirContents, 3)
 
 	var fileNames = []string{}
 
@@ -143,7 +144,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	err = runLogDeletion(dir, "error", 2, 4)
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
-	assert.Equal(t, 1, len(dirContents))
+	require.Len(t, dirContents, 1)
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Single file hitting low and high watermark
@@ -163,7 +164,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	err = runLogDeletion(dir, "error", 2, 4)
 	assert.NoError(t, err)
 	dirContents, err = ioutil.ReadDir(dir)
-	assert.Equal(t, 1, len(dirContents))
+	require.Len(t, dirContents, 1)
 	assert.NoError(t, os.RemoveAll(dir))
 
 	//Test deletion with files at the end of date boundaries
@@ -180,7 +181,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 
 	dirContents, err = ioutil.ReadDir(dir)
-	assert.Equal(t, 2, len(dirContents))
+	require.Len(t, dirContents, 2)
 
 	fileNames = []string{}
 	for fileIndex := range dirContents {
@@ -200,7 +201,7 @@ func TestRotatedLogDeletion(t *testing.T) {
 	assert.NoError(t, err)
 
 	dirContents, err = ioutil.ReadDir(dir)
-	assert.Equal(t, 2, len(dirContents))
+	require.Len(t, dirContents, 2)
 
 	fileNames = []string{}
 	for fileIndex := range dirContents {

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -234,8 +234,10 @@ func TestLoggingLevel(t *testing.T) {
 }
 
 func TestLogColor(t *testing.T) {
-	consoleLogger.ColorEnabled = true
+	origColor := consoleLogger.ColorEnabled
+	defer func() { consoleLogger.ColorEnabled = origColor }()
 
+	consoleLogger.ColorEnabled = true
 	if colorEnabled() {
 		assert.Equal(t, "\x1b[0;36mFormat\x1b[0m", color("Format", LevelDebug))
 		assert.Equal(t, "\x1b[1;34mFormat\x1b[0m", color("Format", LevelInfo))

--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbaselabs/sg-replicate"
+	sgreplicate "github.com/couchbaselabs/sg-replicate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReplicator(t *testing.T) {
 	r := NewReplicator()
-	assert.Equal(t, 0, len(r.ActiveTasks()))
+	require.Len(t, r.ActiveTasks(), 0)
 
 	params := sgreplicate.ReplicationParameters{
 		SourceDb:  "db1",

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -794,7 +794,7 @@ func TestLowSequenceHandling(t *testing.T) {
 
 	changes, err := verifySequencesInFeed(feed, []uint64{1, 2, 5, 6})
 	goassert.True(t, err == nil)
-	goassert.Equals(t, len(changes), 4)
+	require.Len(t, changes, 4)
 	goassert.DeepEquals(t, changes[0], &ChangeEntry{
 		Seq:     SequenceID{Seq: 1, TriggeredBy: 0, LowSeq: 2},
 		ID:      "doc-1",
@@ -1770,7 +1770,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 			body := Body{"serialnumber": int64(i), "channels": channels}
 			docID := fmt.Sprintf("loadCache-%d", i)
 			_, _, err := db.Put(docID, body)
-			assert.NoError(t, err, "Couldn't create document")
+			require.NoError(t, err, "Couldn't create document")
 			if i < inProgressCount {
 				writesInProgress.Done()
 			}
@@ -1780,7 +1780,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	// Wait for writes to be in progress, then getChanges for channel zero
 	writesInProgress.Wait()
 	changes, err := db.GetChanges(channels.SetOf(t, "zero"), ChangesOptions{})
-	assert.NoError(t, err, "Couldn't GetChanges")
+	require.NoError(t, err, "Couldn't GetChanges")
 	firstChangesCount := len(changes)
 	var lastSeq SequenceID
 	if firstChangesCount > 0 {
@@ -1791,7 +1791,7 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	cacheWaiter.Wait()
 
 	changes, err = db.GetChanges(channels.SetOf(t, "zero"), ChangesOptions{Since: lastSeq})
-	assert.NoError(t, err, "Couldn't GetChanges")
+	require.NoError(t, err, "Couldn't GetChanges")
 	secondChangesCount := len(changes)
 	assert.Equal(t, docCount, firstChangesCount+secondChangesCount)
 
@@ -2096,8 +2096,8 @@ func TestMakeFeedBytes(t *testing.T) {
 
 	body, xattr, err := parseXattrStreamData(base.SyncXattrName, rawBytes)
 	assert.NoError(t, err)
-	assert.Equal(t, 11, len(body))
-	assert.Equal(t, 13, len(xattr))
+	require.Len(t, body, 11)
+	require.Len(t, xattr, 13)
 
 }
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -61,7 +61,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 	changes, err := db.GetChanges(base.SetOf("*"), getZeroSequence())
 	assert.NoError(t, err, "Couldn't GetChanges")
 	printChanges(changes)
-	assert.Equal(t, 3, len(changes))
+	require.Len(t, changes, 3)
 
 	// doc1, from ABC
 	assert.Equal(t, "doc1", changes[0].ID)
@@ -90,7 +90,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	assert.NoError(t, err, "Couldn't GetChanges (2nd)")
 
-	assert.Equal(t, 1, len(changes))
+	require.Len(t, changes, 1)
 	assert.Equal(t, "doc2", changes[0].ID)
 	assert.Equal(t, []ChangeRev{{"rev": revid}}, changes[0].Changes)
 

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDuplicateDocID(t *testing.T) {
@@ -29,7 +30,7 @@ func TestDuplicateDocID(t *testing.T) {
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
 	assert.True(t, err == nil)
@@ -37,7 +38,7 @@ func TestDuplicateDocID(t *testing.T) {
 	// Add a new revision matching mid-list
 	cache.addToCache(testLogEntry(4, "doc3", "3-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 4}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc5", "doc3"}))
 	assert.True(t, err == nil)
@@ -45,7 +46,7 @@ func TestDuplicateDocID(t *testing.T) {
 	// Add a new revision matching first
 	cache.addToCache(testLogEntry(5, "doc1", "1-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
 	assert.True(t, err == nil)
@@ -53,7 +54,7 @@ func TestDuplicateDocID(t *testing.T) {
 	// Add a new revision matching last
 	cache.addToCache(testLogEntry(6, "doc1", "1-c"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 4, 6}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc5", "doc3", "doc1"}))
 	assert.True(t, err == nil)
@@ -76,7 +77,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(5, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 3, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
 	assert.True(t, err == nil)
@@ -85,7 +86,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(2, "doc2", "2-a"))
 	cache.addToCache(testLogEntry(2, "doc2", "2-a"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3, 5}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc5"}))
@@ -109,7 +110,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache.addToCache(testLogEntry(15, "doc3", "3-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{5, 10, 15}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3"}))
 	assert.True(t, err == nil)
@@ -118,7 +119,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(3, "doc0", "0-a"))
 	cache.addToCache(testLogEntry(3, "doc0", "0-a"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{3, 5, 10, 15}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc0", "doc1", "doc2", "doc3"}))
@@ -143,7 +144,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.addToCache(testLogEntry(40, "doc4", "4-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	assert.True(t, verifyChannelSequences(entries, []uint64{10, 20, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc2", "doc3", "doc4"}))
 	assert.True(t, err == nil)
@@ -152,7 +153,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(25, "doc1", "1-c"))
 	cache.addToCache(testLogEntry(25, "doc1", "1-c"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
@@ -162,7 +163,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(15, "doc1", "1-b"))
 	cache.addToCache(testLogEntry(15, "doc1", "1-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 25, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
@@ -172,7 +173,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(27, "doc1", "1-d"))
 	cache.addToCache(testLogEntry(27, "doc1", "1-d"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 40}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
@@ -182,7 +183,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(41, "doc4", "4-b"))
 	cache.addToCache(testLogEntry(41, "doc4", "4-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{20, 27, 30, 41}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc2", "doc1", "doc3", "doc4"}))
@@ -192,7 +193,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	cache.AddLateSequence(testLogEntry(45, "doc2", "2-b"))
 	cache.addToCache(testLogEntry(45, "doc2", "2-b"), false)
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 4, len(entries))
+	require.Len(t, entries, 4)
 	writeEntries(entries)
 	assert.True(t, verifyChannelSequences(entries, []uint64{27, 30, 41, 45}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc4", "doc2"}))
@@ -222,7 +223,7 @@ func TestPrependChanges(t *testing.T) {
 	// Validate cache
 	validFrom, cachedChanges := cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(5), validFrom)
-	assert.Equal(t, 3, len(cachedChanges))
+	require.Len(t, cachedChanges, 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
 	cache = newSingleChannelCache(context, "PrependPopulatedCache", 0, &expvar.Map{})
@@ -244,7 +245,7 @@ func TestPrependChanges(t *testing.T) {
 	// Validate cache
 	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(5), validFrom)
-	assert.Equal(t, 4, len(cachedChanges))
+	require.Len(t, cachedChanges, 4)
 	if len(cachedChanges) == 4 {
 		assert.Equal(t, "doc3", cachedChanges[0].DocID)
 		assert.Equal(t, "2-a", cachedChanges[0].RevID)
@@ -260,7 +261,7 @@ func TestPrependChanges(t *testing.T) {
 	cache.addToCache(testLogEntry(24, "doc3", "3-a"), false)
 	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(5), validFrom)
-	assert.Equal(t, 4, len(cachedChanges))
+	require.Len(t, cachedChanges, 4)
 	if len(cachedChanges) == 4 {
 		assert.Equal(t, "doc5", cachedChanges[0].DocID)
 		assert.Equal(t, "2-a", cachedChanges[0].RevID)
@@ -276,7 +277,7 @@ func TestPrependChanges(t *testing.T) {
 	cache.prependChanges(LogEntries{}, 5, 14)
 	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(5), validFrom)
-	assert.Equal(t, 4, len(cachedChanges))
+	require.Len(t, cachedChanges, 4)
 
 	// 3. Test prepend that exceeds cache capacity
 	cache = newSingleChannelCache(context, "PrependToFillCache", 0, &expvar.Map{})
@@ -301,7 +302,7 @@ func TestPrependChanges(t *testing.T) {
 	// Validate cache
 	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(10), validFrom)
-	assert.Equal(t, 5, len(cachedChanges))
+	require.Len(t, cachedChanges, 5)
 	if len(cachedChanges) == 5 {
 		assert.Equal(t, "doc6", cachedChanges[0].DocID)
 		assert.Equal(t, "2-a", cachedChanges[0].RevID)
@@ -333,7 +334,7 @@ func TestPrependChanges(t *testing.T) {
 	assert.Equal(t, 0, numPrepended)
 	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(5), validFrom)
-	assert.Equal(t, 4, len(cachedChanges))
+	require.Len(t, cachedChanges, 4)
 	if len(cachedChanges) == 5 {
 		assert.Equal(t, "doc1", cachedChanges[0].DocID)
 		assert.Equal(t, "2-a", cachedChanges[0].RevID)
@@ -369,7 +370,7 @@ func TestPrependChanges(t *testing.T) {
 	// Validate cache
 	validFrom, cachedChanges = cache.GetCachedChanges(ChangesOptions{})
 	assert.Equal(t, uint64(13), validFrom)
-	assert.Equal(t, 5, len(cachedChanges))
+	require.Len(t, cachedChanges, 5)
 	if len(cachedChanges) == 5 {
 		assert.Equal(t, "doc1", cachedChanges[0].DocID)
 		assert.Equal(t, "2-a", cachedChanges[0].RevID)
@@ -400,7 +401,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	cache.addToCache(testLogEntry(3, "doc5", "5-a"), false)
 
 	entries, err := cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 3, len(entries))
+	require.Len(t, entries, 3)
 	assert.True(t, verifyChannelSequences(entries, []uint64{1, 2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc1", "doc3", "doc5"}))
 	assert.True(t, err == nil)
@@ -408,7 +409,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// Now remove doc1
 	cache.Remove([]string{"doc1"}, time.Now())
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 2, len(entries))
+	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
 	assert.True(t, err == nil)
@@ -418,7 +419,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	// [DBG] Cache+: Skipping removal of doc "doc5" from cache "Test1" - received after purge
 	cache.Remove([]string{"doc5"}, time.Now().Add(-time.Second*5))
 	entries, err = cache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
-	assert.Equal(t, 2, len(entries))
+	require.Len(t, entries, 2)
 	assert.True(t, verifyChannelSequences(entries, []uint64{2, 3}))
 	assert.True(t, verifyChannelDocIDs(entries, []string{"doc3", "doc5"}))
 	assert.True(t, err == nil)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -638,7 +638,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	alldocs, err := allDocIDs(db)
 	assert.NoError(t, err, "AllDocIDs failed")
-	assert.Equal(t, 100, len(alldocs))
+	require.Len(t, alldocs, 100)
 	for i, entry := range alldocs {
 		assert.True(t, entry.Equal(ids[i]))
 	}
@@ -649,7 +649,7 @@ func TestAllDocsOnly(t *testing.T) {
 
 	alldocs, err = allDocIDs(db)
 	assert.NoError(t, err, "AllDocIDs failed")
-	assert.Equal(t, 99, len(alldocs))
+	require.Len(t, alldocs, 99)
 	for i, entry := range alldocs {
 		j := i
 		if i >= 23 {
@@ -663,7 +663,7 @@ func TestAllDocsOnly(t *testing.T) {
 	err = db.changeCache.waitForSequence(context.TODO(), 101, base.DefaultWaitForSequence)
 	require.NoError(t, err)
 	changeLog := db.GetChangeLog("all", 0)
-	assert.Equal(t, 50, len(changeLog))
+	require.Len(t, changeLog, 50)
 	assert.Equal(t, "alldoc-51", changeLog[0].DocID)
 
 	// Now check the changes feed:
@@ -672,7 +672,7 @@ func TestAllDocsOnly(t *testing.T) {
 	defer close(options.Terminator)
 	changes, err := db.GetChanges(channels.SetOf(t, "all"), options)
 	assert.NoError(t, err, "Couldn't GetChanges")
-	assert.Equal(t, 100, len(changes))
+	require.Len(t, changes, 100)
 
 	for i, change := range changes {
 		docIndex := i

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitializeIndexes(t *testing.T) {
@@ -176,7 +177,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, removeErr)
 
 	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), false)
-	assert.Equal(t, 0, len(removedIndexes))
+	require.Len(t, removedIndexes, 0)
 	assert.NoError(t, removeErr)
 
 	// Cleanup design docs created during test

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -327,14 +327,18 @@ func TestCoveringQueries(t *testing.T) {
 	plan, explainErr := gocbBucket.ExplainQuery(channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := isCovered(plan)
-	assert.True(t, covered, "Channel query isn't covered by index")
+	planJSON, err := base.JSONMarshal(plan)
+	assert.NoError(t, err)
+	assert.True(t, covered, "Channel query isn't covered by index: %s", planJSON)
 
 	// star channel
 	channelStarStatement, params := db.buildChannelsQuery("*", 0, 10, 100)
 	plan, explainErr = gocbBucket.ExplainQuery(channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = isCovered(plan)
-	assert.True(t, covered, "Star channel query isn't covered by index")
+	planJSON, err = base.JSONMarshal(plan)
+	assert.NoError(t, err)
+	assert.True(t, covered, "Star channel query isn't covered by index: %s", planJSON)
 
 	// Access and roleAccess currently aren't covering, because of the need to target the user property by name
 	// in the SELECT.
@@ -343,14 +347,18 @@ func TestCoveringQueries(t *testing.T) {
 	plan, explainErr = gocbBucket.ExplainQuery(accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = isCovered(plan)
-	//assert.True(t, covered, "Access query isn't covered by index")
+	planJSON, err = base.JSONMarshal(plan)
+	assert.NoError(t, err)
+	//assert.True(t, covered, "Access query isn't covered by index: %s", planJSON)
 
 	// roleAccess
 	roleAccessStatement := db.buildRoleAccessQuery("user1")
 	plan, explainErr = gocbBucket.ExplainQuery(roleAccessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for roleAccess query")
 	covered = isCovered(plan)
-	//assert.True(t, !covered, "RoleAccess query isn't covered by index")
+	planJSON, err = base.JSONMarshal(plan)
+	assert.NoError(t, err)
+	//assert.True(t, !covered, "RoleAccess query isn't covered by index: %s", planJSON)
 
 }
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -5,11 +5,10 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -2,9 +2,10 @@ package db
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
@@ -16,20 +17,20 @@ const (
 	docIdProblematicRevTree2 = "docIdProblematicRevTree2"
 )
 
-func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket, numDocs int) {
+func testBucketWithViewsAndBrokenDoc(t testing.TB) (tBucket base.TestBucket, numDocs int) {
 
 	numDocsAdded := 0
-	tBucket = testBucket(tester)
+	tBucket = base.GetTestBucket(t)
 	bucket := tBucket.Bucket
 
 	err := installViews(bucket)
-	require.NoError(tester, err)
+	require.NoError(t, err)
 
 	// Add harmless docs
 	for i := 0; i < base.DefaultViewQueryPageSize+1; i++ {
 		testSyncData := SyncData{}
 		_, err = bucket.Add(fmt.Sprintf("foo-%d", i), 0, map[string]interface{}{"foo": "bar", base.SyncPropertyName: testSyncData})
-		require.NoError(tester, err)
+		require.NoError(t, err)
 		numDocsAdded++
 	}
 
@@ -39,7 +40,7 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
 	_, err = bucket.Add(docIdProblematicRevTree, 0, rawDoc)
-	require.NoError(tester, err)
+	require.NoError(t, err)
 	numDocsAdded++
 
 	// Add 2nd doc that should be repaired
@@ -48,7 +49,7 @@ func testBucketWithViewsAndBrokenDoc(tester testing.TB) (tBucket base.TestBucket
 		panic(fmt.Sprintf("Error unmarshalling doc: %v", err))
 	}
 	_, err = bucket.Add(docIdProblematicRevTree2, 0, rawDoc)
-	require.NoError(tester, err)
+	require.NoError(t, err)
 	numDocsAdded++
 
 	return tBucket, numDocsAdded

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -138,7 +138,7 @@ func TestReproduce2383(t *testing.T) {
 	assert.NoError(t, err, "Error unmarshalling changes response")
 
 	// In the first changes request since cache flush, we're forcing a nil cache with no error. Thereforce we'd expect to see zero results.
-	assert.Equal(t, 0, len(changes.Results))
+	require.Len(t, changes.Results, 0)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -150,7 +150,7 @@ func TestReproduce2383(t *testing.T) {
 
 	// Now we should expect 3 results, as the invalid cache was not persisted.
 	// The second call to ViewCustom will succeed and properly create the channel cache.
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -167,7 +167,7 @@ func TestReproduce2383(t *testing.T) {
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -200,7 +200,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "alice"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
 
@@ -217,7 +217,7 @@ func TestDocDeletionFromChannel(t *testing.T) {
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	changes.Results = nil
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 
 	assert.Equal(t, "alpha", changes.Results[0].ID)
 	assert.Equal(t, true, changes.Results[0].Deleted)
@@ -282,7 +282,7 @@ func postChanges(t *testing.T, it *indexTester) {
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 
 }
 
@@ -335,7 +335,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 			log.Printf("changesResponse status code: %v.  Headers: %+v", changesResponse.Code, changesResponse.Header())
 			log.Printf("changesResponse raw body: %s", changesResponse.Body.String())
 		}
-		assert.Equal(t, 3, len(changes.Results))
+		require.Len(t, changes.Results, 3)
 	}()
 
 	// Wait for changes feed to get into wait mode where it is blocked on the longpoll changes feed response
@@ -389,7 +389,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 
 	// Test channel filter
 	var filteredChanges struct {
@@ -401,7 +401,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &filteredChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 1, len(filteredChanges.Results))
+	require.Len(t, filteredChanges.Results, 1)
 }
 
 // Basic _changes test with since value
@@ -436,7 +436,7 @@ func postChangesSince(t *testing.T, it *indexTester) {
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 
 	// Put several more documents, some to the same vbuckets
 	response = it.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
@@ -454,7 +454,7 @@ func postChangesSince(t *testing.T, it *indexTester) {
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 
 }
 
@@ -501,7 +501,7 @@ func postChangesChannelFilter(t *testing.T, it *indexTester) {
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 
 	// Put several more documents, some to the same vbuckets
 	response = it.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
@@ -519,7 +519,7 @@ func postChangesChannelFilter(t *testing.T, it *indexTester) {
 	for _, result := range changes.Results {
 		log.Printf("changes result:%+v", result)
 	}
-	assert.Equal(t, 7, len(changes.Results))
+	require.Len(t, changes.Results, 7)
 
 }
 
@@ -572,7 +572,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	log.Printf("Response:%+v", changesResponse.Body)
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 
 	// Update the user doc to grant access to PBS
 	response = it.SendAdminRequest("PUT", "/db/_user/bernard", `{"admin_channels":["ABC", "PBS"]}`)
@@ -591,7 +591,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
-	assert.Equal(t, 5, len(changes.Results)) // 4 PBS docs, plus the updated user doc
+	require.Len(t, changes.Results, 5) // 4 PBS docs, plus the updated user doc
 
 	// Write a few more docs
 	response = it.SendAdminRequest("PUT", "/db/pbs-5", `{"channel":["PBS"]}`)
@@ -611,7 +611,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
-	assert.Equal(t, 2, len(changes.Results)) // 2 docs
+	require.Len(t, changes.Results, 2) // 2 docs
 
 }
 
@@ -677,7 +677,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 0, len(changes.Results))
+	require.Len(t, changes.Results, 0)
 
 	// Send a missing doc - low sequence should move to 3
 	WriteDirect(testDb, []string{"PBS"}, 3)
@@ -691,7 +691,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 
 	// Send a later doc - low sequence still 3, high sequence goes to 7
 	WriteDirect(testDb, []string{"PBS"}, 7)
@@ -703,7 +703,7 @@ func TestChangesLoopingWhenLowSequence(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 
 }
 
@@ -758,7 +758,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 5, len(changes.Results)) // Includes user doc
+	require.Len(t, changes.Results, 5) // Includes user doc
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
 	assert.Equal(t, "5", changes.Last_Seq)
@@ -776,7 +776,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
 	// Write a few more docs
@@ -790,7 +790,7 @@ func TestChangesLoopingWhenLowSequenceOneShotUser(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
@@ -888,7 +888,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	response := rt.SendAdminRequest("GET", "/db/_changes", "")
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
 	assert.Equal(t, "5", changes.Last_Seq)
@@ -906,7 +906,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
 	// Write a few more docs
@@ -920,7 +920,7 @@ func TestChangesLoopingWhenLowSequenceOneShotAdmin(t *testing.T) {
 	response = rt.SendAdminRequest("POST", "/db/_changes", changesJSON)
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
 	// Write another doc, then the skipped doc - both should be sent, last_seq should move to 13
@@ -1023,7 +1023,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	response = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	log.Printf("_changes 1 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 5, len(changes.Results)) // Includes user doc
+	require.Len(t, changes.Results, 5) // Includes user doc
 	since := changes.Results[0].Seq
 	assert.Equal(t, uint64(1), since.Seq)
 	assert.Equal(t, "5", changes.Last_Seq)
@@ -1041,7 +1041,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 2 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "5::10", changes.Last_Seq)
 
 	// Write a few more docs
@@ -1055,7 +1055,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 	response = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	log.Printf("_changes 3 looks like: %s", response.Body.Bytes())
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	assert.Equal(t, "5::12", changes.Last_Seq)
 
 	caughtUpCount := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsCaughtUp))
@@ -1070,7 +1070,7 @@ func TestChangesLoopingWhenLowSequenceLongpollUser(t *testing.T) {
 		log.Printf("longpoll changes looks like: %s", longPollResponse.Body.Bytes())
 		assert.NoError(t, base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes))
 		// Expect to get 6 through 12
-		assert.Equal(t, 7, len(changes.Results))
+		require.Len(t, changes.Results, 7)
 		assert.Equal(t, "12", changes.Last_Seq)
 	}()
 
@@ -1328,7 +1328,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	assert.Equal(t, "doc4", changes.Results[1].ID)
 
 	//User has access to different single channel
@@ -1338,7 +1338,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	assert.Equal(t, "docD", changes.Results[2].ID)
 
 	//User has access to multiple channels
@@ -1348,7 +1348,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "docD", changes.Results[3].ID)
 
 	//User has no channel access
@@ -1358,7 +1358,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 0, len(changes.Results))
+	require.Len(t, changes.Results, 0)
 
 	//User has "*" channel access
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1", "docA"]}`
@@ -1367,7 +1367,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 
 	//User has "*" channel access, override POST with GET params
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1", "docA"]}`
@@ -1376,7 +1376,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 
 	//User has "*" channel access, use GET
 	request, _ = http.NewRequest("GET", `/db/_changes?filter=_doc_ids&doc_ids=["docC","doc1","docD"]`, nil)
@@ -1384,7 +1384,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 
 	//User has "*" channel access, use GET with doc_ids plain comma separated list
 	request, _ = http.NewRequest("GET", `/db/_changes?filter=_doc_ids&doc_ids=docC,doc1,doc2,docD`, nil)
@@ -1392,14 +1392,14 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 
 	//Admin User
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "docA"]}`
 	response = rt.SendAdminRequest("POST", "/db/_changes", body)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 
 	//Use since value to restrict results
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "since":6}`
@@ -1408,7 +1408,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	assert.Equal(t, "docD", changes.Results[2].ID)
 
 	//Use since value and limit value to restrict results
@@ -1418,7 +1418,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc4", changes.Results[0].ID)
 
 	//test parameter include_docs=true
@@ -1428,7 +1428,7 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "docD", changes.Results[3].ID)
 	var docBody db.Body
 	assert.NoError(t, base.JSONUnmarshal(changes.Results[3].Doc, &docBody))
@@ -1444,9 +1444,9 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &changes))
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 	assert.Equal(t, "docC", changes.Results[3].ID)
-	assert.Equal(t, 2, len(changes.Results[3].Changes))
+	require.Len(t, changes.Results[3].Changes, 2)
 }
 
 func updateTestDoc(rt *RestTester, docid string, revid string, body string) (newRevId string, err error) {
@@ -1739,7 +1739,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 
 	// Delete
 	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
@@ -1760,11 +1760,11 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 3, len(entry.Changes))
+			require.Len(t, entry.Changes, 3)
 		}
 	}
 
@@ -1774,12 +1774,12 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 	// Active only, GET
@@ -1787,11 +1787,11 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 }
@@ -1846,7 +1846,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -1859,7 +1859,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -1917,7 +1917,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -1930,7 +1930,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -1944,7 +1944,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -1958,7 +1958,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2014,7 +2014,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2028,7 +2028,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2041,7 +2041,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2113,7 +2113,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 6, len(changes.Results))
+	require.Len(t, changes.Results, 6)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2127,7 +2127,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 6, len(changes.Results))
+	require.Len(t, changes.Results, 6)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2187,7 +2187,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2199,7 +2199,7 @@ func TestChangesViewBackfill(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2259,7 +2259,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for index, entry := range changes.Results {
 		// Expects docs in sequence order from 1-5
 		assert.Equal(t, uint64(index+1), entry.Seq.Seq)
@@ -2273,7 +2273,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for index, entry := range changes.Results {
 		// Expects docs in sequence order from 1-5
 		assert.Equal(t, uint64(index+1), entry.Seq.Seq)
@@ -2371,7 +2371,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2385,7 +2385,7 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 2, len(changes.Results))
+	require.Len(t, changes.Results, 2)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
@@ -2455,7 +2455,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 
 	// Delete
 	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
@@ -2488,11 +2488,11 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 3, len(entry.Changes))
+			require.Len(t, entry.Changes, 3)
 		}
 	}
 
@@ -2502,12 +2502,12 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2517,12 +2517,12 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 	// Active only with Limit, GET
@@ -2530,11 +2530,11 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2544,12 +2544,12 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 }
@@ -2614,7 +2614,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 
 	// Delete
 	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
@@ -2647,11 +2647,11 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 3, len(entry.Changes))
+			require.Len(t, entry.Changes, 3)
 		}
 	}
 
@@ -2664,12 +2664,12 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2680,12 +2680,12 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2695,11 +2695,11 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2710,12 +2710,12 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2729,7 +2729,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2740,7 +2740,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	changesResponse = it.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &updatedChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(updatedChanges.Results))
+	require.Len(t, updatedChanges.Results, 10)
 
 }
 
@@ -2812,7 +2812,7 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 
 	// Delete
 	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
@@ -2845,11 +2845,11 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 10, len(changes.Results))
+	require.Len(t, changes.Results, 10)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 3, len(entry.Changes))
+			require.Len(t, entry.Changes, 3)
 		}
 	}
 
@@ -2859,12 +2859,12 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2874,12 +2874,12 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 	// Active only with Limit, GET
@@ -2887,11 +2887,11 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 5, len(changes.Results))
+	require.Len(t, changes.Results, 5)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 
@@ -2901,12 +2901,12 @@ func TestChangesActiveOnlyWithLimitLowRevCache(t *testing.T) {
 	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		// validate conflicted handling
 		if entry.ID == "conflictedDoc" {
-			assert.Equal(t, 2, len(entry.Changes))
+			require.Len(t, entry.Changes, 2)
 		}
 	}
 }
@@ -2944,8 +2944,8 @@ func TestChangesIncludeConflicts(t *testing.T) {
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("changes response: %s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 1, len(changes.Results))
-	assert.Equal(t, 2, len(changes.Results[0].Changes))
+	require.Len(t, changes.Results, 1)
+	require.Len(t, changes.Results[0].Changes, 2)
 
 }
 
@@ -2983,7 +2983,7 @@ func TestChangesLargeSequences(t *testing.T) {
 	changesResponse := rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775800", "")
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 1, len(changes.Results))
+	require.Len(t, changes.Results, 1)
 	assert.Equal(t, uint64(9223372036854775808), changes.Results[0].Seq.Seq)
 	assert.Equal(t, "9223372036854775808", changes.Last_Seq)
 
@@ -2991,13 +2991,13 @@ func TestChangesLargeSequences(t *testing.T) {
 	changesResponse = rt.SendAdminRequest("GET", "/db/_changes?since=9223372036854775808", "")
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 0, len(changes.Results))
+	require.Len(t, changes.Results, 0)
 
 	// Validate incoming since value isn't being truncated
 	changesResponse = rt.SendAdminRequest("POST", "/db/_changes", `{"since":9223372036854775808}`)
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 0, len(changes.Results))
+	require.Len(t, changes.Results, 0)
 
 }
 
@@ -3040,7 +3040,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	log.Printf("admin response: %s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	// Expect three docs, no user docs
-	assert.Equal(t, 3, len(changes.Results))
+	require.Len(t, changes.Results, 3)
 
 	// Get as user
 	changes.Results = nil
@@ -3049,7 +3049,7 @@ func TestIncludeDocsWithPrincipals(t *testing.T) {
 	log.Printf("userChangesResponse: %s", userChangesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	// Expect three docs and the authenticated user's user doc
-	assert.Equal(t, 4, len(changes.Results))
+	require.Len(t, changes.Results, 4)
 
 }
 
@@ -3094,7 +3094,7 @@ func TestChangesAdminChannelGrantLongpollNotify(t *testing.T) {
 		log.Printf("longpoll changes response looks like: %s", longPollResponse.Body.Bytes())
 		assert.NoError(t, base.JSONUnmarshal(longPollResponse.Body.Bytes(), &changes))
 		// Expect to get 4 docs plus user doc
-		assert.Equal(t, 5, len(changes.Results))
+		require.Len(t, changes.Results, 5)
 	}()
 
 	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
@@ -3147,7 +3147,7 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 			changesResponse := rt.SendAdminRequest("GET", changesURL, "")
 			assert.NoError(t, base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes))
 			// Expect to get 1 doc
-			assert.Equal(t, 1, len(changes.Results))
+			require.Len(t, changes.Results, 1)
 		}(i)
 	}
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -320,7 +320,7 @@ func TestDeprecatedCacheConfig(t *testing.T) {
 	warnings := dbConfig.deprecatedConfigCacheFallback()
 
 	// Check we have 8 warnings as this is the number of deprecated values we are testing
-	assert.Equal(t, 8, len(warnings))
+	require.Len(t, warnings, 8)
 
 	// Check that the deprecated values have correctly been propagated upto the new config values
 	assert.Equal(t, *dbConfig.CacheConfig.RevCacheConfig.Size, uint32(10))
@@ -350,7 +350,7 @@ func TestDeprecatedCacheConfig(t *testing.T) {
 	warnings = dbConfig.deprecatedConfigCacheFallback()
 
 	// Check we have 2 warnings as this is the number of deprecated values we are testing
-	assert.Equal(t, 2, len(warnings))
+	require.Len(t, warnings, 2)
 
 	// Check that the deprecated value has been ignored as the new value is the priority
 	assert.Equal(t, *dbConfig.CacheConfig.RevCacheConfig.Size, uint32(20))

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1837,7 +1837,6 @@ func TestDcpBackfill(t *testing.T) {
 		DatabaseConfig: &DbConfig{
 			AutoImport: true,
 		},
-		NoFlush: true,
 	}
 	newRt := NewRestTester(t, &newRtConfig)
 	defer newRt.Close()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -32,7 +32,6 @@ func TestConfigServer(t *testing.T) {
 		}`))
 
 	rt := NewRestTester(t, nil)
-	rt.NoFlush = true
 	defer rt.Close()
 
 	sc := rt.ServerContext()
@@ -84,7 +83,6 @@ func TestConfigServerWithSyncFunction(t *testing.T) {
 	mockClient.RespondToGET(fakeConfigURL+"/db2", MakeResponse(200, nil, responseBody))
 
 	rt := NewRestTester(t, nil)
-	rt.NoFlush = true
 	defer rt.Close()
 
 	sc := rt.ServerContext()

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -69,23 +69,23 @@ func TestViewQuery(t *testing.T) {
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
 	assert.NoError(t, err, "Got unexpected error")
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: "ten"}, result.Rows[1])
 
 	result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?limit=1")
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"}, result.Rows[0])
 
 	result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?endkey=9")
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: "seven"}, result.Rows[0])
 
 	if base.UnitTestUrlIsWalrus() {
 		// include_docs=true only works with walrus as documented here:
 		// https://forums.couchbase.com/t/do-the-viewquery-options-omit-include-docs-on-purpose/12399
 		result, err = rt.WaitForNAdminViewResults(1, "/db/_design/foo/_view/bar?include_docs=true&endkey=9")
-		assert.Equal(t, 1, len(result.Rows))
+		require.Len(t, result.Rows, 1)
 		assert.Equal(t, map[string]interface{}{"key": 7.0, "value": "seven"}, *result.Rows[0].Doc)
 	}
 
@@ -106,17 +106,17 @@ func TestViewQueryMultipleViews(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_age")
 	assert.NoError(t, err, "Unexpected error")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)}, result.Rows[1])
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_fname")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)}, result.Rows[1])
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/by_lname")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)}, result.Rows[1])
 }
@@ -134,13 +134,13 @@ func TestViewQueryWithParams(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&endkey="test2"&endkey_docid=doc2&end_key_doc_id=doc2&startkey="test1"&startkey_docid=doc1`)
 	assert.NoError(t, err, "Unexpected error")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc1", Key: "test1", Value: interface{}(nil)})
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc2", Key: "test2", Value: interface{}(nil)})
 
 	result, err = rt.WaitForNAdminViewResults(2, `/db/_design/foodoc/_view/foobarview?conflicts=true&descending=false&conflicts=true&descending=false&keys=["test1", "test2"]`)
 	assert.NoError(t, err, "Unexpected error")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc1", Key: "test1", Value: interface{}(nil)})
 	assert.Contains(t, result.Rows, &sgbucket.ViewRow{ID: "doc2", Key: "test2", Value: interface{}(nil)})
 }
@@ -161,14 +161,14 @@ func TestViewQueryUserAccess(t *testing.T) {
 
 	result, err := rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
 	assert.NoError(t, err, "Unexpected error in WaitForNAdminViewResults")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"}, result.Rows[1])
 
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar?stale=false")
 	assert.NoError(t, err, "Unexpected error in WaitForNAdminViewResults")
 
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"}, result.Rows[1])
 
@@ -181,7 +181,7 @@ func TestViewQueryUserAccess(t *testing.T) {
 	result, err = rt.WaitForNUserViewResults(2, "/db/_design/foo/_view/bar?stale=false", testUser, password)
 	assert.NoError(t, err, "Unexpected error in WaitForNUserViewResults")
 
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "state1", Value: "doc1"}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "state2", Value: "doc2"}, result.Rows[1])
 
@@ -213,21 +213,21 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: 7.0, Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: 10.0, Value: interface{}(nil)}, result.Rows[1])
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_fname", ``)
 	assertStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Alice", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Bob", Value: interface{}(nil)}, result.Rows[1])
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo/_view/by_lname", ``)
 	assertStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc2", Key: "Seven", Value: interface{}(nil)}, result.Rows[0])
 	assert.Equal(t, &sgbucket.ViewRow{ID: "doc1", Key: "Ten", Value: interface{}(nil)}, result.Rows[1])
 }
@@ -258,7 +258,7 @@ func TestUserViewQuery(t *testing.T) {
 	// Have the user query the view:
 	result, err := rt.WaitForNUserViewResults(1, "/db/_design/foo/_view/bar?include_docs=true", quinn, password)
 	assert.NoError(t, err, "Unexpected error")
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	assert.Equal(t, 1, result.TotalRows)
 	row := result.Rows[0]
 	assert.Equal(t, float64(7), row.Key)
@@ -273,7 +273,7 @@ func TestUserViewQuery(t *testing.T) {
 	// Admin should see both rows:
 	result, err = rt.WaitForNAdminViewResults(2, "/db/_design/foo/_view/bar")
 	assert.NoError(t, err, "Unexpected error")
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	row = result.Rows[0]
 	assert.Equal(t, float64(7), row.Key)
 	assert.Equal(t, "seven", row.Value)
@@ -327,7 +327,7 @@ func TestAdminReduceViewQuery(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	row := result.Rows[0]
 	value := row.Value.(float64)
 	assert.True(t, value == 10)
@@ -372,7 +372,7 @@ func TestAdminReduceSumQuery(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 1 row with the reduce result
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 	row := result.Rows[0]
 	value := row.Value.(float64)
 	assert.Equal(t, 108.0, value)
@@ -403,7 +403,7 @@ func TestAdminGroupReduceSumQuery(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 2 row with the reduce result
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	row := result.Rows[1]
 	value := row.Value.(float64)
 	assert.Equal(t, 99.0, value)
@@ -436,7 +436,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 
 	// Ensure that query for non-existent keys returns no rows
 	viewUrlPath = "/db/_design/foo/_view/bar?keys=%5B%22channel_b%22%5D&stale=false"
@@ -444,7 +444,7 @@ func TestViewQueryWithKeys(t *testing.T) {
 	assertStatus(t, response, http.StatusOK) // Query string was parsed properly
 
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 0, len(result.Rows))
+	require.Len(t, result.Rows, 0)
 }
 
 func TestViewQueryWithCompositeKeys(t *testing.T) {
@@ -473,7 +473,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 
 	// Ensure that a query for non-existent key returns no rows
 	viewUrlPath = "/db/_design/foo/_view/composite_key_test?keys=%5B%5B%22channel_b%22%2C%2055%5D%5D&stale=false"
@@ -481,7 +481,7 @@ func TestViewQueryWithCompositeKeys(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 0, len(result.Rows))
+	require.Len(t, result.Rows, 0)
 }
 
 func TestViewQueryWithIntKeys(t *testing.T) {
@@ -510,7 +510,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	var result sgbucket.ViewResult
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 1, len(result.Rows))
+	require.Len(t, result.Rows, 1)
 
 	// Ensure that a query for non-existent key returns no rows
 	//   keys:[65,75]
@@ -519,7 +519,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &result))
-	assert.Equal(t, 0, len(result.Rows))
+	require.Len(t, result.Rows, 0)
 }
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
@@ -547,7 +547,7 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error")
 
 	// we should get 2 row with the reduce result
-	assert.Equal(t, 2, len(result.Rows))
+	require.Len(t, result.Rows, 2)
 	row := result.Rows[1]
 	value := row.Value.(float64)
 	assert.Equal(t, 99.0, value)
@@ -585,7 +585,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.True(t, postUpgradeResponse.Preview)
-	assert.Equal(t, 2, len(postUpgradeResponse.Result["db"].RemovedDDocs))
+	require.Lenf(t, postUpgradeResponse.Result["db"].RemovedDDocs, 2, "Response: %#v", postUpgradeResponse)
 
 	// Run post-upgrade in non-preview mode
 	postUpgradeResponse = PostUpgradeResponse{}
@@ -593,7 +593,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.False(t, postUpgradeResponse.Preview)
-	assert.Equal(t, 2, len(postUpgradeResponse.Result["db"].RemovedDDocs))
+	require.Len(t, postUpgradeResponse.Result["db"].RemovedDDocs, 2)
 
 	// Run post-upgrade in preview mode again, expect no results for database
 	postUpgradeResponse = PostUpgradeResponse{}
@@ -601,7 +601,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.True(t, postUpgradeResponse.Preview)
-	assert.Equal(t, 0, len(postUpgradeResponse.Result["db"].RemovedDDocs))
+	require.Len(t, postUpgradeResponse.Result["db"].RemovedDDocs, 0)
 
 	// Run post-upgrade in non-preview mode again, expect no results for database
 	postUpgradeResponse = PostUpgradeResponse{}
@@ -609,7 +609,7 @@ func TestPostInstallCleanup(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &postUpgradeResponse), "Error unmarshalling post_upgrade response")
 	assert.False(t, postUpgradeResponse.Preview)
-	assert.Equal(t, 0, len(postUpgradeResponse.Result["db"].RemovedDDocs))
+	require.Len(t, postUpgradeResponse.Result["db"].RemovedDDocs, 0)
 }
 
 func TestViewQueryWrappers(t *testing.T) {


### PR DESCRIPTION
Trying to reduce the amount of changes in the bucket pooling branch ahead of PR.

- mostly preventing panics under failure scenarios (e.g. length checks of slices to stop out of range panics)
