### PR TITLE
Revert SetUpTestLogging change which fails when tests run in non-verbose mode

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -542,10 +542,6 @@ func NumOpenBuckets(bucketName string) int32 {
 // Shorthand style:
 //     defer SetUpTestLogging(LevelDebug, KeyCache,KeyDCP,KeySync)()
 func SetUpTestLogging(logLevel LogLevel, logKeys ...LogKey) (teardownFn func()) {
-	if !testing.Verbose() {
-		// noop
-		return func() {}
-	}
 	caller := GetCallersName(1, false)
 	Infof(KeyAll, "%s: Setup logging: level: %v - keys: %v", caller, logLevel, logKeys)
 	return setTestLogging(logLevel, caller, logKeys...)


### PR DESCRIPTION
Introduced in #4487 as an optimisation... turned out to break some logging tests when run without `-v`