### PR TITLE
CBG-495: Created incoming document custom struct

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -204,11 +204,7 @@ type AttachmentCallback func(name string, digest string, knownData []byte, meta 
 // its data. The callback is told whether the attachment body is known to the database, according
 // to its digest. If the attachment isn't known, the callback can return data for it, which will
 // be added to the metadata as a "data" property.
-func (db *Database) ForEachStubAttachment(body Body, minRevpos int, callback AttachmentCallback) error {
-	atts := GetBodyAttachments(body)
-	if atts == nil && body[BodyAttachments] != nil {
-		return base.HTTPErrorf(400, "Invalid _attachments")
-	}
+func (db *Database) ForEachStubAttachment(atts AttachmentsMeta, minRevpos int, callback AttachmentCallback) error {
 	for name, value := range atts {
 		meta, ok := value.(map[string]interface{})
 		if !ok {

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -454,14 +454,16 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 	// Call ForEachStubAttachment with invalid attachment; simulates the error scenario.
 	doc := `{"_attachments": "No Attachment"}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = db.ForEachStubAttachment(body, 0x1, callback)
+	_, err = body.ToIncomingDoc(nil)
 	assert.Error(t, err, "It should throw 400 Invalid _attachments")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
 
 	// Call ForEachStubAttachment with invalid attachment; simulates the error scenario.
 	doc = `{"_attachments": {"image1.jpeg": "", "image2.jpeg": ""}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = db.ForEachStubAttachment(body, 0x1, callback)
+	newDoc, err := body.ToIncomingDoc(nil)
+	assert.NoError(t, err)
+	err = db.ForEachStubAttachment(newDoc.DocAttachment, 0x1, callback)
 	assert.Error(t, err, "It should throw 400 Invalid _attachments")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
 
@@ -469,20 +471,26 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 	// Check whether the attachment iteration is getting skipped if revpos < minRevpos
 	doc = `{"_attachments": {"image.jpg": {"stub":true, "revpos":1}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = db.ForEachStubAttachment(body, 0x2, callback)
+	newDoc, err = body.ToIncomingDoc(nil)
+	assert.NoError(t, err)
+	err = db.ForEachStubAttachment(newDoc.DocAttachment, 0x2, callback)
 	assert.NoError(t, err, "It should not throw any error")
 
 	// Call ForEachStubAttachment with no data in attachment and revpos; simulates the error scenario.
 	// Check whether the attachment iteration is getting skipped if there is no revpos.
 	doc = `{"_attachments": {"image.jpg": {"stub":true}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = db.ForEachStubAttachment(body, 0x2, callback)
+	newDoc, err = body.ToIncomingDoc(nil)
+	assert.NoError(t, err)
+	err = db.ForEachStubAttachment(newDoc.DocAttachment, 0x2, callback)
 	assert.NoError(t, err, "It should not throw any error")
 
 	// Should throw invalid attachment error is the digest is not valid string or empty.
 	doc = `{"_attachments": {"image.jpg": {"stub":true, "revpos":1, "digest":true}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = db.ForEachStubAttachment(body, 0x1, callback)
+	newDoc, err = body.ToIncomingDoc(nil)
+	assert.NoError(t, err)
+	err = db.ForEachStubAttachment(newDoc.DocAttachment, 0x1, callback)
 	assert.Error(t, err, "It should throw 400 Invalid attachments")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
 
@@ -490,7 +498,9 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 	// document error and invoke the callback function.
 	doc = `{"_attachments": {"image.jpg": {"stub":true, "revpos":1, "digest":"9304cdd066efa64f78387e9cc9240a70527271bc"}}}`
 	assert.NoError(t, base.JSONUnmarshal([]byte(doc), &body))
-	err = db.ForEachStubAttachment(body, 0x1, callback)
+	newDoc, err = body.ToIncomingDoc(nil)
+	assert.NoError(t, err)
+	err = db.ForEachStubAttachment(newDoc.DocAttachment, 0x1, callback)
 	assert.NoError(t, err, "It should not throw any error")
 
 	// Simulate an error from the callback function; it should return the same error from ForEachStubAttachment.
@@ -499,7 +509,9 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 	callback = func(name string, digest string, knownData []byte, meta map[string]interface{}) ([]byte, error) {
 		return nil, errors.New("Can't work with this digest value!")
 	}
-	err = db.ForEachStubAttachment(body, 0x1, callback)
+	newDoc, err = body.ToIncomingDoc(nil)
+	assert.NoError(t, err)
+	err = db.ForEachStubAttachment(newDoc.DocAttachment, 0x1, callback)
 	assert.Error(t, err, "It should throw the actual error")
 	assert.Contains(t, err.Error(), "Can't work with this digest value!")
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -954,7 +954,7 @@ func createChangesEntry(docid string, db *Database, options ChangesOptions) *Cha
 	changes := make([]ChangeRev, 1)
 	changes[0] = ChangeRev{"rev": populatedDoc.CurrentRev}
 	row.Changes = changes
-	row.Deleted = populatedDoc.Deleted
+	row.Deleted = populatedDoc.IsDeleted()
 	row.Seq = SequenceID{Seq: populatedDoc.Sequence}
 	row.SetBranched((populatedDoc.Flags & channels.Branched) != 0)
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -634,7 +634,7 @@ func (db *Database) getAvailableRevAttachments(doc *Document, revid string) (anc
 
 // Moves a revision's ancestor's body out of the document object and into a separate db doc.
 func (db *Database) backupAncestorRevs(doc *Document, newDoc *IncomingDocument) {
-	newBodyBytes, err := newDoc.BodyBytes()
+	newBodyBytes, err := newDoc.GetBodyBytes()
 	if err != nil {
 		base.Warnf("Error getting body bytes when backing up ancestor revs")
 		return
@@ -1381,7 +1381,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 		}
 
 		// Lazily marshal bytes for storage in revcache
-		storedDocBytes, err := storedDoc.BodyBytes()
+		storedDocBytes, err := storedDoc.GetBodyBytes()
 		if err != nil {
 			return nil, "", err
 		}
@@ -1396,7 +1396,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			Attachments:      doc.Attachments,
 			Expiry:           doc.Expiry,
 			Deleted:          doc.History[newRevID].Deleted,
-			_shallowCopyBody: storedDoc.Body(),
+			_shallowCopyBody: storedDoc.GetBody(),
 		}
 		db.revisionCache.Put(documentRevision)
 		if db.EventMgr.HasHandlerForEvent(DocumentChange) {

--- a/db/crud.go
+++ b/db/crud.go
@@ -787,9 +787,9 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		newDoc.UpdateBody(body)
 
 		// If no special properties were stripped and document wasn't deleted, the canonical bytes represent the current
-		// body.  In this scenario, store canonical bytes as newDoc._rawBody
+		// body.  In this scenario, store canonical bytes as newDoc.RawBody
 		if !wasStripped && !isDeleted {
-			newDoc._rawBody = canonicalBytesForRevID
+			newDoc.RawBody = canonicalBytesForRevID
 		}
 
 		if err := doc.History.addRevision(newDoc.ID, RevInfo{ID: newRev, Parent: matchRev, Deleted: deleted}); err != nil {
@@ -892,7 +892,7 @@ func (db *Database) PutExistingRev(newDoc *IncomingDocument, docHistory []string
 
 func (db *Database) PutExistingRevWithBody(docid string, body Body, docHistory []string, noConflicts bool) (doc *Document, newRev string, err error) {
 	body[BodyId] = docid
-	newDoc, err := body.ToIncomingDoc()
+	newDoc, err := body.ToIncomingDoc(nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -943,7 +943,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	body := Body{"foo": "bar"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
 
-	getDelta := func(newDoc *Document) {
+	getDelta := func(newDoc *IncomingDocument) {
 		deltaSrcRev, _ := db.GetRev("doc1", "1-a", false, nil)
 
 		deltaSrcBody, _ := deltaSrcRev.DeepMutableBody()
@@ -958,7 +958,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	}
 
 	b.Run("SmallDiff", func(b *testing.B) {
-		newDoc := &Document{
+		newDoc := &IncomingDocument{
 			ID:    "doc1",
 			RevID: "1a",
 		}
@@ -969,7 +969,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	})
 
 	b.Run("Huge Diff", func(b *testing.B) {
-		newDoc := &Document{
+		newDoc := &IncomingDocument{
 			ID:    "doc1",
 			RevID: "1a",
 		}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -954,7 +954,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 		}
 
 		deltaSrcMap := map[string]interface{}(deltaSrcBody)
-		_ = base.Patch(&deltaSrcMap, newDoc.Body())
+		_ = base.Patch(&deltaSrcMap, newDoc.GetBody())
 	}
 
 	b.Run("SmallDiff", func(b *testing.B) {
@@ -963,7 +963,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 				ID:    "doc1",
 				RevID: "1a",
 			},
-			RawBody: []byte(`{"foo": "bart"}`),
+			BodyBytes: []byte(`{"foo": "bart"}`),
 		}
 		for n := 0; n < b.N; n++ {
 			getDelta(newDoc)
@@ -979,7 +979,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 				ID:    "doc1",
 				RevID: "1a",
 			},
-			RawBody: bodyBytes,
+			BodyBytes: bodyBytes,
 		}
 		for n := 0; n < b.N; n++ {
 			getDelta(newDoc)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -963,24 +963,24 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 				ID:    "doc1",
 				RevID: "1a",
 			},
+			RawBody: []byte(`{"foo": "bart"}`),
 		}
-		newDoc.UpdateBodyBytes([]byte(`{"foo": "bart"}`))
 		for n := 0; n < b.N; n++ {
 			getDelta(newDoc)
 		}
 	})
 
 	b.Run("Huge Diff", func(b *testing.B) {
+		largeDoc := make([]byte, 1000000)
+		longBody := Body{"val": string(largeDoc)}
+		bodyBytes, _ := base.JSONMarshal(longBody)
 		newDoc := &IncomingDocument{
 			SpecialProperties: SpecialProperties{
 				ID:    "doc1",
 				RevID: "1a",
 			},
+			RawBody: bodyBytes,
 		}
-		largeDoc := make([]byte, 1000000)
-		longBody := Body{"val": string(largeDoc)}
-		bodyBytes, _ := base.JSONMarshal(longBody)
-		newDoc.UpdateBodyBytes(bodyBytes)
 		for n := 0; n < b.N; n++ {
 			getDelta(newDoc)
 		}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -959,8 +959,10 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 
 	b.Run("SmallDiff", func(b *testing.B) {
 		newDoc := &IncomingDocument{
-			ID:    "doc1",
-			RevID: "1a",
+			SpecialProperties: SpecialProperties{
+				ID:    "doc1",
+				RevID: "1a",
+			},
 		}
 		newDoc.UpdateBodyBytes([]byte(`{"foo": "bart"}`))
 		for n := 0; n < b.N; n++ {
@@ -970,8 +972,10 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 
 	b.Run("Huge Diff", func(b *testing.B) {
 		newDoc := &IncomingDocument{
-			ID:    "doc1",
-			RevID: "1a",
+			SpecialProperties: SpecialProperties{
+				ID:    "doc1",
+				RevID: "1a",
+			},
 		}
 		largeDoc := make([]byte, 1000000)
 		longBody := Body{"val": string(largeDoc)}

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1924,7 +1924,6 @@ func TestConcurrentPushSameNewRevision(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCRUD)()
 	var db *Database
 	var enableCallback bool
-	var revId string
 
 	writeUpdateCallback := func(key string) {
 		if enableCallback {
@@ -1950,7 +1949,7 @@ func TestConcurrentPushSameNewRevision(t *testing.T) {
 	assert.Equal(t, "409 Document exists", err.Error())
 
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
-	assert.Equal(t, revId, doc.RevID)
+	assert.Equal(t, "1-9d374b41c24611a6d1cc3a1cea6ce202", doc.CurrentRev)
 	assert.NoError(t, err, "Couldn't retrieve document")
 	assert.Equal(t, "Bob", doc.Body()["name"])
 	assert.Equal(t, json.Number("52"), doc.Body()["age"])

--- a/db/document.go
+++ b/db/document.go
@@ -159,8 +159,8 @@ type Document struct {
 }
 
 type IncomingDocument struct {
-	UnmarshalledBody Body
-	RawBody          []byte
+	UnmarshalledBody Body   // Stored unmarshaled body without special properties
+	RawBody          []byte // Stored marshaled body without special properties
 
 	SpecialProperties
 }
@@ -258,12 +258,6 @@ func stampSyncFnSpecialProperties(docBody map[string]interface{}, properties Spe
 	if properties.Deleted {
 		docBody[BodyDeleted] = properties.Deleted
 	}
-}
-
-// TODO: Mostly unused, can be removed once work is complete
-func (doc *IncomingDocument) UpdateBody(body Body) {
-	doc.UnmarshalledBody = body
-	doc.RawBody = nil
 }
 
 func (doc *IncomingDocument) Body() Body {

--- a/db/document.go
+++ b/db/document.go
@@ -246,11 +246,7 @@ func (b Body) ExtractSpecialProperties(specialProperties *SpecialProperties) err
 	return nil
 }
 
-func (doc *IncomingDocument) UpdateBodyBytes(bodyBytes []byte) {
-	doc.RawBody = bodyBytes
-	doc.UnmarshalledBody = nil
-}
-
+// TODO: Mostly unused, can be removed once work is complete
 func (doc *IncomingDocument) UpdateBody(body Body) {
 	doc.UnmarshalledBody = body
 	doc.RawBody = nil

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -238,7 +238,7 @@ func BenchmarkMarshalStack(b *testing.B) {
 	b.Run("Copy", func(bm *testing.B) {
 		for i := 0; i < bm.N; i++ {
 			newDoc, _ := body.ToIncomingDoc(nil)
-			copiedBody := newDoc.UnmarshalledBody.DeepCopy()
+			copiedBody := newDoc.Body.DeepCopy()
 			stampSyncFnSpecialProperties(copiedBody, newDoc.SpecialProperties)
 		}
 	})

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -222,3 +222,25 @@ func TestParseDocumentCas(t *testing.T) {
 
 	goassert.Equals(t, casInt, uint64(1492749160563736576))
 }
+
+func BenchmarkMarshalStack(b *testing.B) {
+	body := Body{
+		"val": "foo",
+	}
+
+	b.Run("MarshalStack", func(bm *testing.B) {
+		for i := 0; i < bm.N; i++ {
+			newDoc, _ := body.ToIncomingDoc(nil)
+			_, _ = newDoc.GetSyncFnBody()
+		}
+	})
+
+	b.Run("Copy", func(bm *testing.B) {
+		for i := 0; i < bm.N; i++ {
+			newDoc, _ := body.ToIncomingDoc(nil)
+			copiedBody := newDoc.UnmarshalledBody.DeepCopy()
+			stampSyncFnSpecialProperties(copiedBody, newDoc.SpecialProperties)
+		}
+	})
+
+}

--- a/db/import.go
+++ b/db/import.go
@@ -113,14 +113,14 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		body = Body{}
 	}
 
-	newDoc := &Document{
+	newDoc := &IncomingDocument{
 		ID:      docid,
 		Deleted: isDelete,
 	}
 
 	var newRev string
 	var alreadyImportedDoc *Document
-	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *IncomingDocument, resultAttachmentData AttachmentData, updatedExpiry *uint32, resultErr error) {
 
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.

--- a/db/import.go
+++ b/db/import.go
@@ -114,8 +114,10 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 	}
 
 	newDoc := &IncomingDocument{
-		ID:      docid,
-		Deleted: isDelete,
+		SpecialProperties: SpecialProperties{
+			ID:      docid,
+			Deleted: isDelete,
+		},
 	}
 
 	var newRev string

--- a/db/import.go
+++ b/db/import.go
@@ -259,7 +259,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 		newDoc.UpdateBody(body)
 		if !wasStripped && !isDelete {
-			newDoc._rawBody = rawBodyForRevID
+			newDoc.RawBody = rawBodyForRevID
 		}
 
 		// Note - no attachments processing is done during ImportDoc.  We don't (currently) support writing attachments through anything but SG.

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -1098,7 +1098,10 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 		}
 	} else {
 		if newBody != nil {
-			newDoc.UpdateBody(newBody)
+			newDoc, err = newBody.ToIncomingDoc(&newDoc.SpecialProperties)
+			if err != nil {
+				return base.HTTPErrorf(http.StatusInternalServerError, "Failed to build IncomingDoc from body: %v", err)
+			}
 		}
 	}
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -991,8 +991,10 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	}
 
 	newDoc := &db.IncomingDocument{
-		ID:    docID,
-		RevID: revID,
+		SpecialProperties: db.SpecialProperties{
+			ID:    docID,
+			RevID: revID,
+		},
 	}
 	newDoc.UpdateBodyBytes(bodyBytes)
 

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -998,7 +998,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 			RevID:   revID,
 			Deleted: revMessage.deleted(),
 		},
-		RawBody: bodyBytes,
+		BodyBytes: bodyBytes,
 	}
 
 	var newBody db.Body
@@ -1085,7 +1085,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 
 	if hasAttachments || hasExpiry {
 		if newBody == nil {
-			newBody = newDoc.Body()
+			newBody = newDoc.GetBody()
 		}
 		newDoc, err = newBody.ToIncomingDoc(&newDoc.SpecialProperties)
 		if err != nil {

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -990,7 +990,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Missing docID or revID")
 	}
 
-	newDoc := &db.Document{
+	newDoc := &db.IncomingDocument{
 		ID:    docID,
 		RevID: revID,
 	}
@@ -1092,7 +1092,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 			return err
 		}
 
-		newDoc.DocAttachments = db.GetBodyAttachments(body)
+		newDoc.DocAttachment = db.GetBodyAttachments(body)
 		delete(body, db.BodyAttachments)
 		newDoc.UpdateBody(body)
 	}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -368,7 +368,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		return base.ErrEmptyDocument
 	}
 
-	newDoc := &db.Document{
+	newDoc := &db.IncomingDocument{
 		ID: docid,
 	}
 	newDoc.UpdateBodyBytes(bodyBytes)
@@ -408,7 +408,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	if bytes.Contains(bodyBytes, []byte(db.BodyAttachments)) {
 		body := newDoc.Body()
 
-		newDoc.DocAttachments = db.GetBodyAttachments(body)
+		newDoc.DocAttachment = db.GetBodyAttachments(body)
 		delete(body, db.BodyAttachments)
 		newDoc.UpdateBody(body)
 	}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -369,7 +369,9 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 	}
 
 	newDoc := &db.IncomingDocument{
-		ID: docid,
+		SpecialProperties: db.SpecialProperties{
+			ID: docid,
+		},
 	}
 	newDoc.UpdateBodyBytes(bodyBytes)
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -372,7 +372,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		SpecialProperties: db.SpecialProperties{
 			ID: docid,
 		},
-		RawBody: bodyBytes,
+		BodyBytes: bodyBytes,
 	}
 
 	var parentRev string
@@ -397,7 +397,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 
 	// Handle and pull out expiry
 	if bytes.Contains(bodyBytes, []byte(db.BodyExpiry)) || bytes.Contains(bodyBytes, []byte(db.BodyAttachments)) {
-		body := newDoc.Body()
+		body := newDoc.GetBody()
 		newDoc, err = body.ToIncomingDoc(&newDoc.SpecialProperties)
 		if err != nil {
 			return err

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -98,6 +98,7 @@ func TestDocumentNumbers(t *testing.T) {
 			//Create document
 			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", test.name), test.body)
 			assertStatus(ts, response, 201)
+			base.Infof(base.KeyAll, "Initial Response %s", response.BodyBytes())
 
 			// Get document, validate number value
 			getResponse := rt.SendAdminRequest("GET", fmt.Sprintf("/db/%s", test.name), "")
@@ -106,6 +107,9 @@ func TestDocumentNumbers(t *testing.T) {
 			// Check the raw bytes, because unmarshalling the response would be another opportunity for the number to get modified
 			responseString := string(getResponse.Body.Bytes())
 			if !strings.Contains(responseString, test.expectedString) {
+				base.Infof(base.KeyAll, "Expected result: %s", test.expectedString)
+				base.Infof(base.KeyAll, "Actual result: %s", responseString)
+
 				ts.Errorf("Response does not contain the expected number format (%s).  Response: %s", test.name, responseString)
 			}
 


### PR DESCRIPTION
# Overview

Use case of new IncomingDoc struct and corresponding methods is to pass around BodyBytes and Body, which Document is currently being used for. The use case, however, has been extended to "standardise" incoming documents in order to keep the process as uniform as possible.

IncomingDoc should always include bodyBytes:
- When we have a unmarshaled Body we use the ToIncomingDoc function which also marshals the data.
- In the event we don't have a Body we can build the struct manually, this should only be done when there is no Body, and therefore will have BodyBytes.
We should also always have specialProperties for the document which, if we provide a body, are extracted.

The SyncFnBody is another of the 'main' functions. Unfortunately we cannot use our already unmarshaled Body for the SyncFn as this can alter the body and we don't want our IncomingDoc altered. This means we need to ensure that the SyncFnBody returned is mutable. This is done by unmarshaling the BodyBytes we have which is cheaper than doing a copy.

- [ ] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-ben/118/
- [ ] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration-ben/119/