### PR TITLE
CBG-625 - Integration Test Bucket Pooling

### DIFF
--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -23,7 +23,7 @@ func mockClaims() *jose.Claims {
 		"name":  "John Wick",
 		"aud":   audience,
 		"iat":   1516239022,
-		"exp":   1586239022,
+		"exp":   3000000000, // 2065-01-24
 		"email": "johnwick@couchbase.com"}
 	return claims
 }
@@ -165,7 +165,7 @@ func TestGetJWTExpiry(t *testing.T) {
 		{
 			name:        "Test GetJWTExpiry with a good JWT token",
 			input:       mockToken(t),
-			expiresAt:   "2020-04-07 05:57:02 +0000 UTC",
+			expiresAt:   "2065-01-24 05:20:00 +0000 UTC",
 			expectedErr: "",
 		},
 		{

--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"os"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+func TestMain(m *testing.M) {
+	base.TestBucketPool = base.NewTestBucketPool(base.BucketEmptierFunc, base.PrimaryIndexInitFunc)
+
+	status := m.Run()
+
+	base.TestBucketPool.Close()
+
+	os.Exit(status)
+}

--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	base.TestBucketPool = base.NewTestBucketPool(base.BucketEmptierFunc, base.PrimaryIndexInitFunc)
+	base.TestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
 
 	status := m.Run()
 

--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	base.TestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
+	base.GTestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
 
 	status := m.Run()
 
-	base.TestBucketPool.Close()
+	base.GTestBucketPool.Close()
 
 	os.Exit(status)
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2710,7 +2710,7 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 		underlyingBucket = typedBucket.GetUnderlyingBucket()
 	case *LeakyBucket:
 		underlyingBucket = typedBucket.GetUnderlyingBucket()
-	case TestBucket:
+	case *TestBucket:
 		underlyingBucket = typedBucket.Bucket
 	default:
 		// bail out for unrecognised/unsupported buckets

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -62,7 +62,7 @@ func TestSetGetRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -91,7 +91,7 @@ func TestAddRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -146,7 +146,7 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			key := fmt.Sprintf("%s_%d", getTestKeyNamespace(), i)
+			key := fmt.Sprintf("%s_%d", getTestKeyNamespace(t), i)
 			added, err := bucket.AddRaw(key, 0, largeDoc)
 			if err != nil {
 				if pkgerrors.Cause(err) != gocb.ErrTimeout {
@@ -183,7 +183,7 @@ func TestBulkGetRaw(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		iStr := strconv.Itoa(i)
-		key := getTestKeyNamespace() + iStr
+		key := getTestKeyNamespace(t) + iStr
 		val := []byte("bar" + iStr)
 		keySet[i] = key
 		valueSet[key] = val
@@ -234,7 +234,7 @@ func TestWriteCasBasic(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	val := []byte("bar2")
 
 	_, _, err := bucket.GetRaw(key)
@@ -276,7 +276,7 @@ func TestWriteCasAdvanced(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
@@ -320,9 +320,9 @@ func TestSetBulk(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key1 := getTestKeyNamespace() + "1"
-	key2 := getTestKeyNamespace() + "2"
-	key3 := getTestKeyNamespace() + "3"
+	key1 := getTestKeyNamespace(t) + "1"
+	key2 := getTestKeyNamespace(t) + "2"
+	key3 := getTestKeyNamespace(t) + "3"
 	var returnVal interface{}
 
 	// Cleanup
@@ -422,7 +422,7 @@ func TestUpdate(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	valInitial := []byte("initial")
 	valUpdated := []byte("updated")
 
@@ -478,7 +478,7 @@ func TestIncrCounter(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 
 	defer func() {
 		err := bucket.Delete(key)
@@ -517,7 +517,7 @@ func TestGetAndTouchRaw(t *testing.T) {
 	// There's no easy way to validate the expiry time of a doc (that I know of)
 	// so this is just a smoke test
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	val := []byte("bar")
 
 	testBucket := GetTestBucket(t)
@@ -631,7 +631,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -699,7 +699,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -765,7 +765,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["sg_field"] = "sg_value"
@@ -839,7 +839,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -892,7 +892,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -976,7 +976,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -1061,7 +1061,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["counter"] = float64(1)
@@ -1185,7 +1185,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1240,7 +1240,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	xattrVal["seq"] = 1
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1313,7 +1313,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1361,10 +1361,10 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace() + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace() + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace() + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace() + "NoDocNoXattr"
+	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1461,10 +1461,10 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace() + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace() + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace() + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace() + "NoDocNoXattr"
+	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1545,7 +1545,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 		return
 	}
 
-	key := getTestKeyNamespace() + "1"
+	key := getTestKeyNamespace(t) + "1"
 	xattrName := SyncXattrName
 	createTombstonedDoc(bucket, key, xattrName)
 
@@ -1594,10 +1594,10 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace() + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace() + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace() + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace() + "NoDocNoXattr"
+	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1686,10 +1686,10 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace() + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace() + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace() + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace() + "NoDocNoXattr"
+	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1800,7 +1800,7 @@ func TestGetXattr(t *testing.T) {
 	}
 
 	//Doc 1
-	key1 := getTestKeyNamespace() + "DocExistsXattrExists"
+	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
 	val1 := make(map[string]interface{})
 	val1["type"] = key1
 	xattrName1 := "sync"
@@ -1809,7 +1809,7 @@ func TestGetXattr(t *testing.T) {
 	xattrVal1["rev"] = "1-foo"
 
 	//Doc 2 - Tombstone
-	key2 := getTestKeyNamespace() + "TombstonedDocXattrExists"
+	key2 := getTestKeyNamespace(t) + "TombstonedDocXattrExists"
 	val2 := make(map[string]interface{})
 	val2["type"] = key2
 	xattrVal2 := make(map[string]interface{})
@@ -1817,7 +1817,7 @@ func TestGetXattr(t *testing.T) {
 	xattrVal2["rev"] = "1-foo"
 
 	//Doc 3 - To Delete
-	key3 := getTestKeyNamespace() + "DeletedDocXattrExists"
+	key3 := getTestKeyNamespace(t) + "DeletedDocXattrExists"
 	val3 := make(map[string]interface{})
 	val3["type"] = key3
 	xattrName3 := "sync"

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -127,6 +127,7 @@ func TestAddRaw(t *testing.T) {
 // TestAddRawTimeout attempts to fill up the gocbpipeline by writing large documents concurrently with a small timeout,
 // to verify that timeout errors are returned, and the operation isn't retried (which would return a cas error).
 //   (see CBG-463)
+// TODO: Lower limits if possible? Seems to be exceeding the pooled 200MB bucket limit occasionally.
 func TestAddRawTimeoutRetry(t *testing.T) {
 
 	testBucket := GetTestBucket(t)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -62,7 +62,7 @@ func TestSetGetRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -91,7 +91,7 @@ func TestAddRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -234,7 +234,7 @@ func TestWriteCasBasic(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	val := []byte("bar2")
 
 	_, _, err := bucket.GetRaw(key)
@@ -276,7 +276,7 @@ func TestWriteCasAdvanced(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
@@ -422,7 +422,7 @@ func TestUpdate(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	valInitial := []byte("initial")
 	valUpdated := []byte("updated")
 
@@ -478,7 +478,7 @@ func TestIncrCounter(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 
 	defer func() {
 		err := bucket.Delete(key)
@@ -517,7 +517,7 @@ func TestGetAndTouchRaw(t *testing.T) {
 	// There's no easy way to validate the expiry time of a doc (that I know of)
 	// so this is just a smoke test
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	val := []byte("bar")
 
 	testBucket := GetTestBucket(t)
@@ -631,7 +631,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -699,7 +699,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -765,7 +765,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["sg_field"] = "sg_value"
@@ -839,7 +839,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -892,7 +892,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -976,7 +976,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -1061,7 +1061,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["counter"] = float64(1)
@@ -1185,7 +1185,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1240,7 +1240,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	xattrVal["seq"] = 1
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1313,7 +1313,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1545,7 +1545,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 		return
 	}
 
-	key := getTestKeyNamespace(t) + "1"
+	key := getTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	createTombstonedDoc(bucket, key, xattrName)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -127,7 +127,6 @@ func TestAddRaw(t *testing.T) {
 // TestAddRawTimeout attempts to fill up the gocbpipeline by writing large documents concurrently with a small timeout,
 // to verify that timeout errors are returned, and the operation isn't retried (which would return a cas error).
 //   (see CBG-463)
-// TODO: Lower limits if possible? Seems to be exceeding the pooled 200MB bucket limit occasionally.
 func TestAddRawTimeoutRetry(t *testing.T) {
 
 	testBucket := GetTestBucket(t)
@@ -164,8 +163,6 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 }
 
 func TestBulkGetRaw(t *testing.T) {
-
-	defer SetUpTestLogging(LevelTrace, KeyHTTP, KeyBucket, KeyCRUD, KeyCache)()
 
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
@@ -627,8 +624,6 @@ func SkipXattrTestsIfNotEnabled(t *testing.T) {
 
 // TestXattrWriteCasSimple.  Validates basic write of document with xattr, and retrieval of the same doc w/ xattr.
 func TestXattrWriteCasSimple(t *testing.T) {
-
-	defer SetUpTestLogging(LevelInfo, KeyAll)()
 
 	SkipXattrTestsIfNotEnabled(t)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -135,14 +135,14 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 
 	gocbBucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
 	if ok {
-		gocbBucket.Bucket.SetOperationTimeout(100 * time.Millisecond)
+		gocbBucket.Bucket.SetOperationTimeout(250 * time.Millisecond)
 	}
 
 	largeDoc := make([]byte, 1000000)
 	rand.Read(largeDoc)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -14,6 +14,7 @@ const MaxQueryRetries = 30            // Maximum query retries on indexer error
 const IndexStateOnline = "online"     // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created and built.
 const IndexStateDeferred = "deferred" // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created but not built.
 const IndexStatePending = "pending"   // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created, build is in progress
+const PrimaryIndexName = "#primary"
 
 var SlowQueryWarningThreshold time.Duration
 

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -20,7 +20,7 @@ func TestN1qlQuery(t *testing.T) {
 	// Disabled due to CBG-755:
 	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -128,7 +128,7 @@ func TestN1qlFilterExpression(t *testing.T) {
 	// Disabled due to CBG-755:
 	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -205,7 +205,7 @@ func TestIndexMeta(t *testing.T) {
 	// Disabled due to CBG-755:
 	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -248,7 +248,7 @@ func TestIndexMeta(t *testing.T) {
 
 // Ensure that n1ql query errors are handled and returned (and don't result in panic etc)
 func TestMalformedN1qlQuery(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -315,7 +315,7 @@ func TestMalformedN1qlQuery(t *testing.T) {
 }
 
 func TestCreateAndDropIndex(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -343,7 +343,7 @@ func TestCreateAndDropIndex(t *testing.T) {
 }
 
 func TestCreateDuplicateIndex(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -375,7 +375,7 @@ func TestCreateDuplicateIndex(t *testing.T) {
 }
 
 func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -403,7 +403,7 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 }
 
 func TestDeferredCreateIndex(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -446,7 +446,7 @@ func TestDeferredCreateIndex(t *testing.T) {
 }
 
 func TestBuildDeferredIndexes(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -512,7 +512,7 @@ func TestBuildDeferredIndexes(t *testing.T) {
 }
 
 func TestCreateAndDropIndexErrors(t *testing.T) {
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -591,7 +591,7 @@ func tearDownTestIndex(bucket *CouchbaseBucketGoCB, indexName string) (err error
 
 func TestWaitForBucketExistence(t *testing.T) {
 
-	if TestsUseViews() {
+	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -20,8 +20,8 @@ func TestN1qlQuery(t *testing.T) {
 	// Disabled due to CBG-755:
 	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
 	testBucket := GetTestBucket(t)
@@ -128,8 +128,8 @@ func TestN1qlFilterExpression(t *testing.T) {
 	// Disabled due to CBG-755:
 	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
 	testBucket := GetTestBucket(t)
@@ -205,8 +205,8 @@ func TestIndexMeta(t *testing.T) {
 	// Disabled due to CBG-755:
 	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
 
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
 	testBucket := GetTestBucket(t)
@@ -248,9 +248,10 @@ func TestIndexMeta(t *testing.T) {
 
 // Ensure that n1ql query errors are handled and returned (and don't result in panic etc)
 func TestMalformedN1qlQuery(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
@@ -314,9 +315,10 @@ func TestMalformedN1qlQuery(t *testing.T) {
 }
 
 func TestCreateAndDropIndex(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
@@ -341,9 +343,10 @@ func TestCreateAndDropIndex(t *testing.T) {
 }
 
 func TestCreateDuplicateIndex(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
@@ -372,9 +375,10 @@ func TestCreateDuplicateIndex(t *testing.T) {
 }
 
 func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
@@ -399,9 +403,10 @@ func TestCreateAndDropIndexSpecialCharacters(t *testing.T) {
 }
 
 func TestDeferredCreateIndex(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -441,9 +446,10 @@ func TestDeferredCreateIndex(t *testing.T) {
 }
 
 func TestBuildDeferredIndexes(t *testing.T) {
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 
@@ -506,10 +512,10 @@ func TestBuildDeferredIndexes(t *testing.T) {
 }
 
 func TestCreateAndDropIndexErrors(t *testing.T) {
-
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
@@ -585,11 +591,11 @@ func tearDownTestIndex(bucket *CouchbaseBucketGoCB, indexName string) (err error
 
 func TestWaitForBucketExistence(t *testing.T) {
 
-	defer SetUpTestLogging(LevelDebug, KeyAll)()
-
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
+	if TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
+
+	defer SetUpTestLogging(LevelDebug, KeyAll)()
 
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -584,6 +584,9 @@ func tearDownTestIndex(bucket *CouchbaseBucketGoCB, indexName string) (err error
 }
 
 func TestWaitForBucketExistence(t *testing.T) {
+
+	defer SetUpTestLogging(LevelDebug, KeyAll)()
+
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -595,8 +595,6 @@ func TestWaitForBucketExistence(t *testing.T) {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
-	defer SetUpTestLogging(LevelDebug, KeyAll)()
-
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 	bucket, ok := AsGoCBBucket(testBucket)

--- a/base/constants.go
+++ b/base/constants.go
@@ -47,8 +47,8 @@ const (
 	// Should the tests drop the GSI indexes?
 	TestEnvSyncGatewayDropIndexes = "SG_TEST_DROP_INDEXES"
 
-	// Should the tests force the use of views?
-	TestEnvSyncGatewayUseViews = "SG_TEST_USE_VIEWS"
+	// Should the tests disable the use of any GSI-related code?
+	TestEnvSyncGatewayDisableGSI = "SG_TEST_DISABLE_GSI"
 
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"

--- a/base/constants.go
+++ b/base/constants.go
@@ -47,6 +47,9 @@ const (
 	// Should the tests drop the GSI indexes?
 	TestEnvSyncGatewayDropIndexes = "SG_TEST_DROP_INDEXES"
 
+	// Should the tests force the use of views?
+	TestEnvSyncGatewayUseViews = "SG_TEST_USE_VIEWS"
+
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"
 
@@ -140,6 +143,7 @@ var (
 	DefaultWarnThresholdGrantsPerDoc   = uint32(50)
 )
 
+// UnitTestUrl returns the configured test URL.
 func UnitTestUrl() string {
 	if TestUseCouchbaseServer() {
 		testCouchbaseServerUrl := os.Getenv(TestEnvCouchbaseServerUrl)
@@ -154,6 +158,7 @@ func UnitTestUrl() string {
 	}
 }
 
+// UnitTestUrlIsWalrus returns true if we're running with a Walrus test URL.
 func UnitTestUrlIsWalrus() bool {
 	unitTestUrl := UnitTestUrl()
 	return strings.Contains(unitTestUrl, kTestWalrusURL)

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -55,7 +55,7 @@ type LeakyBucketConfig struct {
 	IncrCallback func()
 }
 
-func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) Bucket {
+func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) *LeakyBucket {
 	return &LeakyBucket{
 		bucket: bucket,
 		config: config,
@@ -154,6 +154,9 @@ func (b *LeakyBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error
 	return val, err
 }
 
+func (b *LeakyBucket) GetDDocs(value interface{}) error {
+	return b.bucket.GetDDocs(value)
+}
 func (b *LeakyBucket) GetDDoc(docname string, value interface{}) error {
 	if b.config.DDocGetErrorCount > 0 {
 		b.config.DDocGetErrorCount--

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -41,6 +41,7 @@ const (
 	KeySyncMsg
 	KeyWebSocket
 	KeyWebSocketFrame
+	KeySGTest
 
 	LogKeyCount // Count for logKeyNames init
 )
@@ -70,6 +71,7 @@ var (
 		KeySyncMsg:        "SyncMsg",
 		KeyWebSocket:      "WS",
 		KeyWebSocketFrame: "WSFrame",
+		KeySGTest:         "~~~~~ TEST",
 	}
 	logKeyNamesInverse = inverselogKeyNames(logKeyNames)
 )

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -71,7 +71,7 @@ var (
 		KeySyncMsg:        "SyncMsg",
 		KeyWebSocket:      "WS",
 		KeyWebSocketFrame: "WSFrame",
-		KeySGTest:         "~~~~~ TEST",
+		KeySGTest:         "TEST",
 	}
 	logKeyNamesInverse = inverselogKeyNames(logKeyNames)
 )

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -133,6 +133,11 @@ func (b *LoggingBucket) GetXattr(k string, xattr string, xv interface{}) (cas ui
 	defer func() { Tracef(KeyBucket, "GetXattr(%q, ...) [%v]", UD(k), time.Since(start)) }()
 	return b.bucket.GetXattr(k, xattr, xv)
 }
+func (b *LoggingBucket) GetDDocs(value interface{}) error {
+	start := time.Now()
+	defer func() { Tracef(KeyBucket, "GetDDoc(...) [%v]", time.Since(start)) }()
+	return b.bucket.GetDDocs(value)
+}
 func (b *LoggingBucket) GetDDoc(docname string, value interface{}) error {
 	start := time.Now()
 	defer func() { Tracef(KeyBucket, "GetDDoc(%q, ...) [%v]", UD(docname), time.Since(start)) }()

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -1,7 +1,9 @@
 package base
 
 import (
+	"context"
 	"expvar"
+	"sync"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -9,227 +11,207 @@ import (
 
 // A wrapper around a Bucket that transparently adds logging of all the API calls.
 type LoggingBucket struct {
-	bucket Bucket
+	bucket     Bucket
+	logCtx     context.Context
+	logCtxOnce sync.Once
+}
+
+func (b *LoggingBucket) ctx() context.Context {
+	b.logCtxOnce.Do(func() {
+		b.logCtx = bucketCtx(context.Background(), b)
+	})
+	return b.logCtx
+}
+
+func (b *LoggingBucket) log(start time.Time, args ...interface{}) {
+	caller := GetCallersName(1, false)
+	TracefCtx(b.ctx(), KeyBucket, "%s(%v) [%v]", caller, UD(args), time.Since(start))
 }
 
 func (b *LoggingBucket) GetName() string {
-	//Tracef(KeyBucket, "GetName()")
+	// b.log() depends on this, so don't log here otherwise we'd stack overflow
 	return b.bucket.GetName()
 }
 func (b *LoggingBucket) Get(k string, rv interface{}) (uint64, error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Get(%q) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k)
 	return b.bucket.Get(k, rv)
 }
 func (b *LoggingBucket) GetRaw(k string) (v []byte, cas uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetRaw(%q) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k)
 	return b.bucket.GetRaw(k)
 }
 func (b *LoggingBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetAndTouchRaw(%q) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.GetAndTouchRaw(k, exp)
 }
 func (b *LoggingBucket) Touch(k string, exp uint32) (cas uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Touch(%q) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.Touch(k, exp)
 }
 func (b *LoggingBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetBulkRaw(%q) [%v]", UD(keys), time.Since(start)) }()
+	defer b.log(time.Now(), keys)
 	return b.bucket.GetBulkRaw(keys)
 }
 func (b *LoggingBucket) Add(k string, exp uint32, v interface{}) (added bool, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Add(%q, %d, ...) [%v]", UD(k), exp, time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.Add(k, exp, v)
 }
 func (b *LoggingBucket) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "AddRaw(%q, %d, ...) [%v]", UD(k), exp, time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.AddRaw(k, exp, v)
 }
 func (b *LoggingBucket) Append(k string, data []byte) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Append(%q, ...) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k)
 	return b.bucket.Append(k, data)
 }
 func (b *LoggingBucket) Set(k string, exp uint32, v interface{}) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Set(%q, %d, ...) [%v]", UD(k), exp, time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.Set(k, exp, v)
 }
 func (b *LoggingBucket) SetRaw(k string, exp uint32, v []byte) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "SetRaw(%q, %d, ...) [%v]", UD(k), exp, time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.SetRaw(k, exp, v)
 }
 func (b *LoggingBucket) Delete(k string) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Delete(%q) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k)
 	return b.bucket.Delete(k)
 }
 func (b *LoggingBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Remove(%q) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, cas)
 	return b.bucket.Remove(k, cas)
 }
 func (b *LoggingBucket) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
-	start := time.Now()
-	defer func() {
-		Tracef(KeyBucket, "Write(%q, 0x%x, %d, ..., 0x%x) [%v]", UD(k), flags, exp, opt, time.Since(start))
-	}()
+	defer b.log(time.Now(), k, flags, exp, opt)
 	return b.bucket.Write(k, flags, exp, v, opt)
 }
 func (b *LoggingBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
-	start := time.Now()
-	defer func() {
-		Tracef(KeyBucket, "WriteCas(%q, 0x%x, %d, %d, ..., 0x%x) [%v]", UD(k), flags, exp, cas, opt, time.Since(start))
-	}()
+	defer b.log(time.Now(), k, flags, exp, cas, opt)
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
 func (b *LoggingBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc) (casOut uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Update(%q, %d, ...) --> %v [%v]", UD(k), exp, err, time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.Update(k, exp, callback)
 }
 func (b *LoggingBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "WriteUpdate(%q, %d, ...) --> %v [%v]", UD(k), exp, err, time.Since(start)) }()
+	defer b.log(time.Now(), k, exp)
 	return b.bucket.WriteUpdate(k, exp, callback)
 }
 
 func (b *LoggingBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Incr(%q, %d, %d, %d) [%v]", UD(k), amt, def, exp, time.Since(start)) }()
+	defer b.log(time.Now(), k, amt, def, exp)
 	return b.bucket.Incr(k, amt, def, exp)
 }
 func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "WriteCasWithXattr(%q, ...) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, xattr, exp, cas)
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
-	start := time.Now()
-	defer func() {
-		Tracef(KeyBucket, "WriteUpdateWithXattr(%q, %d, ...) --> %v [%v]", UD(k), exp, err, time.Since(start))
-	}()
+	defer b.log(time.Now(), k, xattr, exp)
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
 }
 func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetWithXattr(%q, ...) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, xattr)
 	return b.bucket.GetWithXattr(k, xattr, rv, xv)
 }
 func (b *LoggingBucket) DeleteWithXattr(k string, xattr string) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "DeleteWithXattr(%q, ...) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, xattr)
 	return b.bucket.DeleteWithXattr(k, xattr)
 }
 func (b *LoggingBucket) GetXattr(k string, xattr string, xv interface{}) (cas uint64, err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetXattr(%q, ...) [%v]", UD(k), time.Since(start)) }()
+	defer b.log(time.Now(), k, xattr)
 	return b.bucket.GetXattr(k, xattr, xv)
 }
 func (b *LoggingBucket) GetDDocs(value interface{}) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetDDoc(...) [%v]", time.Since(start)) }()
+	defer b.log(time.Now())
 	return b.bucket.GetDDocs(value)
 }
 func (b *LoggingBucket) GetDDoc(docname string, value interface{}) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "GetDDoc(%q, ...) [%v]", UD(docname), time.Since(start)) }()
+	defer b.log(time.Now(), docname)
 	return b.bucket.GetDDoc(docname, value)
 }
 func (b *LoggingBucket) PutDDoc(docname string, value interface{}) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "PutDDoc(%q, ...) [%v]", UD(docname), time.Since(start)) }()
+	defer b.log(time.Now(), docname)
 	return b.bucket.PutDDoc(docname, value)
 }
 func (b *LoggingBucket) DeleteDDoc(docname string) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "DeleteDDoc(%q, ...) [%v]", UD(docname), time.Since(start)) }()
+	defer b.log(time.Now(), docname)
 	return b.bucket.DeleteDDoc(docname)
 }
 func (b *LoggingBucket) View(ddoc, name string, params map[string]interface{}) (sgbucket.ViewResult, error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "View(%q, %q, ...) [%v]", MD(ddoc), UD(name), time.Since(start)) }()
+	defer b.log(time.Now(), ddoc, name)
 	return b.bucket.View(ddoc, name, params)
 }
 
 func (b *LoggingBucket) ViewCustom(ddoc, name string, params map[string]interface{}, vres interface{}) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "ViewCustom(%q, %q, ...) [%v]", MD(ddoc), UD(name), time.Since(start)) }()
+	defer b.log(time.Now(), ddoc, name)
 	return b.bucket.ViewCustom(ddoc, name, params, vres)
 }
 
 func (b *LoggingBucket) ViewQuery(ddoc, name string, params map[string]interface{}) (sgbucket.QueryResultIterator, error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "ViewQuery(%q, %q, ...) [%v]", MD(ddoc), UD(name), time.Since(start)) }()
+	defer b.log(time.Now(), ddoc, name)
 	return b.bucket.ViewQuery(ddoc, name, params)
 }
 
 func (b *LoggingBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "SetBulk(%q, ...) --> %v [%v]", UD(entries), err, time.Since(start)) }()
+	defer b.log(time.Now(), entries)
 	return b.bucket.SetBulk(entries)
 }
 
 func (b *LoggingBucket) Refresh() error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Refresh() [%v]", time.Since(start)) }()
+	defer b.log(time.Now())
 	return b.bucket.Refresh()
 }
 
 func (b *LoggingBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "StartTapFeed(...) [%v]", time.Since(start)) }()
+	defer b.log(time.Now())
 	return b.bucket.StartTapFeed(args, dbStats)
 }
 
 func (b *LoggingBucket) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "StartDcpFeed(...) [%v]", time.Since(start)) }()
+	defer b.log(time.Now())
 	return b.bucket.StartDCPFeed(args, callback, dbStats)
 }
 
 func (b *LoggingBucket) Close() {
-	start := time.Now()
-	defer func() { Tracef(KeyBucket, "Close() [%v]", time.Since(start)) }()
+	defer b.log(time.Now())
 	b.bucket.Close()
 }
 func (b *LoggingBucket) Dump() {
-	Tracef(KeyBucket, "Dump()")
+	defer b.log(time.Now())
 	b.bucket.Dump()
 }
 func (b *LoggingBucket) VBHash(docID string) uint32 {
-	Tracef(KeyBucket, "VBHash()")
+	defer b.log(time.Now())
 	return b.bucket.VBHash(docID)
 }
 
 func (b *LoggingBucket) GetMaxVbno() (uint16, error) {
+	defer b.log(time.Now())
 	return b.bucket.GetMaxVbno()
 }
 
 func (b *LoggingBucket) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
+	defer b.log(time.Now())
 	return b.bucket.CouchbaseServerVersion()
 }
 
 func (b *LoggingBucket) UUID() (string, error) {
+	defer b.log(time.Now())
 	return b.bucket.UUID()
 }
 
 func (b *LoggingBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
+	defer b.log(time.Now())
 	return b.bucket.GetStatsVbSeqno(maxVbno, useAbsHighSeqNo)
 }
 
 // GetUnderlyingBucket returns the underlying bucket for the LoggingBucket.
 func (b *LoggingBucket) GetUnderlyingBucket() Bucket {
+	defer b.log(time.Now())
 	return b.bucket
 }
 
 func (b *LoggingBucket) IsSupported(feature sgbucket.BucketFeature) bool {
+	defer b.log(time.Now())
 	return b.bucket.IsSupported(feature)
 }

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -13,6 +13,12 @@ type LogContext struct {
 	// CorrelationID is a pre-formatted identifier used to correlate logs.
 	// E.g: Either blip context ID or HTTP Serial number.
 	CorrelationID string
+
+	// TestName can be a unit test name (from t.Name())
+	TestName string
+
+	// TestBucketName is the name of a bucket used during a test
+	TestBucketName string
 }
 
 // addContext returns a string format with additional log context if present.
@@ -23,6 +29,14 @@ func (lc *LogContext) addContext(format string) string {
 
 	if lc.CorrelationID != "" {
 		format = "c:" + lc.CorrelationID + " " + format
+	}
+
+	if lc.TestBucketName != "" {
+		format = "b:" + lc.TestBucketName + " " + format
+	}
+
+	if lc.TestName != "" {
+		format = "t:" + lc.TestName + " " + format
 	}
 
 	return format

--- a/base/logging_context.go
+++ b/base/logging_context.go
@@ -1,8 +1,10 @@
 package base
 
 import (
+	"context"
 	"math/rand"
 	"strconv"
+	"testing"
 )
 
 // LogContextKey is used to key a LogContext value
@@ -48,4 +50,24 @@ func FormatBlipContextID(contextID string) string {
 
 func NewTaskID(contextID string, taskName string) string {
 	return contextID + "-" + taskName + "-" + strconv.Itoa(rand.Intn(65536))
+}
+
+// testCtx creates a log context for the given test.
+func testCtx(t testing.TB) context.Context {
+	return context.WithValue(context.Background(), LogContextKey{}, LogContext{TestName: t.Name()})
+}
+
+// bucketCtx extends the parent context with a bucket name.
+func bucketCtx(parent context.Context, b Bucket) context.Context {
+	return bucketNameCtx(parent, b.GetName())
+}
+
+// bucketNameCtx extends the parent context with a bucket name.
+func bucketNameCtx(parent context.Context, bucketName string) context.Context {
+	parentLogCtx, _ := parent.Value(LogContextKey{}).(LogContext)
+	newCtx := LogContext{
+		TestName:       parentLogCtx.TestName,
+		TestBucketName: bucketName,
+	}
+	return context.WithValue(parent, LogContextKey{}, newCtx)
 }

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -338,3 +338,60 @@ func CaptureConsolefLogOutput(f func()) string {
 	consoleFOutput = os.Stderr
 	return buf.String()
 }
+
+func BenchmarkGetCallersName(b *testing.B) {
+	tests := []struct {
+		depth       int
+		includeLine bool
+	}{
+		{
+			depth:       1,
+			includeLine: false,
+		},
+		{
+			depth:       2,
+			includeLine: false,
+		},
+		{
+			depth:       3,
+			includeLine: false,
+		},
+		{
+			// depth of 4 exceeds the call stack size for this benchnark
+			// this should actually exit-early and be faster than the above
+			depth:       4,
+			includeLine: false,
+		},
+		{
+			depth:       100,
+			includeLine: false,
+		},
+		{
+			depth:       1,
+			includeLine: true,
+		},
+		{
+			depth:       2,
+			includeLine: true,
+		},
+		{
+			depth:       3,
+			includeLine: true,
+		},
+		{
+			depth:       4,
+			includeLine: true,
+		},
+		{
+			depth:       100,
+			includeLine: true,
+		},
+	}
+	for _, tt := range tests {
+		b.Run(fmt.Sprintf("%v-%v", tt.depth, tt.includeLine), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				GetCallersName(tt.depth, tt.includeLine)
+			}
+		})
+	}
+}

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -1,0 +1,16 @@
+package base
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	TestBucketPool = NewTestBucketPool(BucketEmptierFunc, PrimaryIndexInitFunc)
+
+	status := m.Run()
+
+	TestBucketPool.Close()
+
+	os.Exit(status)
+}

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	TestBucketPool = NewTestBucketPool(BucketEmptierFunc, PrimaryIndexInitFunc)
+	TestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
 
 	status := m.Run()
 

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	TestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
+	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
 
 	status := m.Run()
 
-	TestBucketPool.Close()
+	GTestBucketPool.Close()
 
 	os.Exit(status)
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -1,0 +1,621 @@
+package base
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/couchbase/gocb"
+	"github.com/couchbaselabs/walrus"
+	"github.com/pkg/errors"
+)
+
+const (
+	testBucketQuotaMB    = 100
+	testBucketNamePrefix = "sg_int_"
+	testClusterUsername  = "Administrator"
+	testClusterPassword  = "password"
+
+	// Creates this many buckets in the backing store to be pooled for testing.
+	defaultBucketPoolSize = 10
+	testEnvPoolSize       = "SG_TEST_BUCKET_POOL_SIZE"
+
+	// Prevents reuse and cleanup of buckets used in failed tests for later inspection.
+	// When all pooled buckets are in a preserved state, any remaining tests are skipped.
+	testEnvPreserve = "SG_TEST_BUCKET_POOL_PRESERVE"
+
+	// When set to true, first, all existing test buckets are removed, before creating new ones.
+	testEnvRecreate = "SG_TEST_BACKING_STORE_RECREATE"
+
+	// Prints detailed logs from the test pooling framework.
+	testEnvVerbose = "SG_TEST_BUCKET_POOL_DEBUG"
+)
+
+type bucketName string
+
+type bucketPoolStats struct {
+	TotalBucketInitDurationNano    int64
+	TotalBucketInitCount           int32
+	TotalBucketReadierDurationNano int64
+	TotalBucketReadierCount        int32
+	NumBucketsOpened               int32
+	NumBucketsClosed               int32
+	TotalWaitingForReadyBucketNano int64
+	TotalInuseBucketNano           int64
+}
+
+type GocbTestBucketPool struct {
+	integrationMode        bool
+	readyBucketPool        chan *CouchbaseBucketGoCB
+	bucketReadierQueue     chan bucketName
+	bucketReadierWaitGroup *sync.WaitGroup
+	cluster                *gocb.Cluster
+	clusterMgr             *gocb.ClusterManager
+	ctxCancelFunc          context.CancelFunc
+	defaultBucketSpec      BucketSpec
+
+	BucketInitFunc BucketInitFunc
+
+	stats bucketPoolStats
+
+	useGSI bool
+
+	// preserveBuckets can be set to true to prevent removal of a bucket used in a failing test.
+	preserveBuckets bool
+	// keep track of number of preserved buckets to prevent bucket exhaustion deadlock
+	preservedBucketCount uint32
+
+	// Enables test pool logging
+	verbose AtomicBool
+}
+
+// numBuckets returns the configured number of buckets to use in the pool.
+func numBuckets() int {
+	numBuckets := defaultBucketPoolSize
+	if envPoolSize := os.Getenv(testEnvPoolSize); envPoolSize != "" {
+		var err error
+		numBuckets, err = strconv.Atoi(envPoolSize)
+		if err != nil {
+			log.Fatalf("Couldn't parse %s: %v", testEnvPoolSize, err)
+		}
+	}
+	return numBuckets
+}
+
+func testCluster(server string) *gocb.Cluster {
+	spec := BucketSpec{
+		Server: server,
+	}
+
+	connStr, err := spec.GetGoCBConnString()
+	if err != nil {
+		log.Fatalf("error getting connection string: %v", err)
+	}
+
+	cluster, err := gocb.Connect(connStr)
+	if err != nil {
+		log.Fatalf("Couldn't connect to %q: %v", server, err)
+	}
+
+	err = cluster.Authenticate(gocb.PasswordAuthenticator{
+		Username: testClusterUsername,
+		Password: testClusterPassword,
+	})
+	if err != nil {
+		log.Fatalf("Couldn't authenticate with %q: %v", server, err)
+	}
+
+	return cluster
+}
+
+type BucketInitFunc func(ctx context.Context, b Bucket, tbp *GocbTestBucketPool) error
+
+type GocbBucketReadierFunc func(ctx context.Context, b *CouchbaseBucketGoCB, tbp *GocbTestBucketPool) error
+
+// BucketEmptierFunc ensures the bucket is empty.
+var BucketEmptierFunc GocbBucketReadierFunc = func(ctx context.Context, b *CouchbaseBucketGoCB, tbp *GocbTestBucketPool) error {
+	if hasPrimary, _, err := b.getIndexMetaWithoutRetry(PrimaryIndexName); err != nil {
+		return err
+	} else if !hasPrimary {
+		return fmt.Errorf("bucket does not have primary index, so can't empty bucket using N1QL")
+	}
+
+	if itemCount, err := b.QueryBucketItemCount(); err != nil {
+		return err
+	} else if itemCount == 0 {
+		tbp.Logf(ctx, "Bucket already empty - skipping")
+	} else {
+		tbp.Logf(ctx, "Bucket not empty (%d items), emptying bucket via N1QL", itemCount)
+		// Use N1QL to empty bucket, with the hope that the query service is happier to deal with this than a bucket flush/rollback.
+		// Requires a primary index on the bucket.
+		res, err := b.Query(`DELETE FROM $_bucket`, nil, gocb.RequestPlus, false)
+		if err != nil {
+			return err
+		}
+		_ = res.Close()
+	}
+
+	return nil
+}
+
+// PrimaryIndexInitFunc creates a primary index on the given bucket, if the bucket is a gocbbucket.
+var PrimaryIndexInitFunc BucketInitFunc = func(ctx context.Context, b Bucket, tbp *GocbTestBucketPool) error {
+	gocbBucket, ok := AsGoCBBucket(b)
+	if !ok {
+		tbp.Logf(ctx, "skipping primary index creation for non-gocb bucket")
+		return nil
+	}
+
+	if hasPrimary, _, err := gocbBucket.getIndexMetaWithoutRetry(PrimaryIndexName); err != nil {
+		return err
+	} else if !hasPrimary {
+		err := gocbBucket.CreatePrimaryIndex(PrimaryIndexName, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var defaultBucketSpec = BucketSpec{
+	Server:          UnitTestUrl(),
+	CouchbaseDriver: GoCBCustomSGTranscoder,
+	Auth: TestAuthenticator{
+		Username: testClusterUsername,
+		Password: testClusterPassword,
+	},
+	UseXattrs: TestUseXattrs(),
+}
+
+func tbpEnvVerbose() bool {
+	verbose, _ := strconv.ParseBool(os.Getenv(testEnvVerbose))
+	return verbose
+}
+
+// NewTestBucketPool initializes a new GocbTestBucketPool. To be called from TestMain for packages requiring test buckets.
+// Set useGSI to false to skip index creation for packages that don't require GSI, to speed up bucket readiness.
+func NewTestBucketPool(bucketReadierFunc GocbBucketReadierFunc, bucketInitFunc BucketInitFunc) *GocbTestBucketPool {
+	// We can safely skip setup when we want Walrus buckets to be used. They'll be created on-demand via GetTestBucketAndSpec.
+	if !TestUseCouchbaseServer() {
+		tbp := GocbTestBucketPool{
+			BucketInitFunc: bucketInitFunc,
+		}
+		tbp.verbose.Set(tbpEnvVerbose())
+		return &tbp
+	}
+
+	_, err := SetMaxFileDescriptors(5000)
+	if err != nil {
+		panic(err)
+	}
+
+	numBuckets := numBuckets()
+	// TODO: What about pooling servers too??
+	// That way, we can have unlimited buckets available in a single test pool... True horizontal scalability in tests!
+	cluster := testCluster(UnitTestUrl())
+
+	// Used to manage cancellation of worker goroutines
+	ctx, ctxCancelFunc := context.WithCancel(context.Background())
+
+	preserveBuckets, _ := strconv.ParseBool(os.Getenv(testEnvPreserve))
+
+	tbp := GocbTestBucketPool{
+		integrationMode:    true,
+		readyBucketPool:    make(chan *CouchbaseBucketGoCB, numBuckets),
+		bucketReadierQueue: make(chan bucketName, numBuckets),
+		cluster:            cluster,
+		clusterMgr:         cluster.Manager(testClusterUsername, testClusterPassword),
+		ctxCancelFunc:      ctxCancelFunc,
+		defaultBucketSpec:  defaultBucketSpec,
+		preserveBuckets:    preserveBuckets,
+		BucketInitFunc:     bucketInitFunc,
+	}
+	tbp.verbose.Set(tbpEnvVerbose())
+
+	// Start up an async readier worker to process dirty buckets
+	go tbp.bucketReadierWorker(ctx, bucketReadierFunc)
+
+	// Remove old test buckets (if desired)
+	removeOldBuckets, _ := strconv.ParseBool(os.Getenv(testEnvRecreate))
+	if removeOldBuckets {
+		err := tbp.removeOldTestBuckets()
+		if err != nil {
+			log.Fatalf("Couldn't remove old test buckets: %v", err)
+		}
+	}
+
+	// Make sure the test buckets are created and put into the readier worker queue
+	start := time.Now()
+	if err := tbp.createTestBuckets(numBuckets, bucketInitFunc); err != nil {
+		log.Fatalf("Couldn't create test buckets: %v", err)
+	}
+	atomic.AddInt32(&tbp.stats.TotalBucketInitCount, int32(numBuckets))
+	atomic.AddInt64(&tbp.stats.TotalBucketInitDurationNano, time.Since(start).Nanoseconds())
+
+	return &tbp
+}
+
+func (tbp *GocbTestBucketPool) Logf(ctx context.Context, format string, args ...interface{}) {
+	if tbp != nil && !tbp.verbose.IsTrue() {
+		return
+	}
+
+	format = addPrefixes(format, ctx, LevelNone, KeySGTest)
+	if colorEnabled() {
+		// Green
+		format = "\033[0;32m" + format + "\033[0m"
+	}
+
+	_, _ = fmt.Fprintf(consoleFOutput, format+"\n", args...)
+}
+
+// GetTestBucket returns a bucket to be used during a test.
+// The returned teardownFn must be called once the test is done,
+// which closes the bucket, readies it for a new test, and releases back into the pool.
+func (tbp *GocbTestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s BucketSpec, teardownFn func()) {
+
+	ctx := testCtx(t)
+
+	// Return a new Walrus bucket when tbp has not been initialized
+	if !tbp.integrationMode {
+		if !UnitTestUrlIsWalrus() {
+			tbp.Logf(ctx, "nil TestBucketPool, but not using a Walrus test URL")
+			os.Exit(1)
+		}
+
+		walrusBucket := walrus.NewBucket(testBucketNamePrefix + GenerateRandomID())
+		ctx := bucketCtx(ctx, walrusBucket)
+		tbp.Logf(ctx, "Creating new walrus test bucket")
+
+		initFuncStart := time.Now()
+		err := tbp.BucketInitFunc(ctx, walrusBucket, tbp)
+		if err != nil {
+			panic(err)
+		}
+		atomic.AddInt32(&tbp.stats.TotalBucketInitCount, 1)
+		atomic.AddInt64(&tbp.stats.TotalBucketInitDurationNano, time.Since(initFuncStart).Nanoseconds())
+
+		atomic.AddInt32(&tbp.stats.NumBucketsOpened, 1)
+		openedStart := time.Now()
+		return walrusBucket, getBucketSpec(bucketName(walrusBucket.GetName())), func() {
+			atomic.AddInt32(&tbp.stats.NumBucketsClosed, 1)
+			atomic.AddInt64(&tbp.stats.TotalInuseBucketNano, time.Since(openedStart).Nanoseconds())
+			tbp.Logf(ctx, "Teardown called - Closing walrus test bucket")
+			walrusBucket.Close()
+		}
+	}
+
+	if atomic.LoadUint32(&tbp.preservedBucketCount) >= uint32(cap(tbp.readyBucketPool)) {
+		tbp.Logf(ctx,
+			"No more buckets available for testing. All pooled buckets have been preserved by failing tests.")
+		t.Skipf("No more buckets available for testing. All pooled buckets have been preserved for failing tests.")
+	}
+
+	tbp.Logf(ctx, "Attempting to get test bucket from pool")
+	waitingBucketStart := time.Now()
+	gocbBucket := <-tbp.readyBucketPool
+	atomic.AddInt64(&tbp.stats.TotalWaitingForReadyBucketNano, time.Since(waitingBucketStart).Nanoseconds())
+	ctx = bucketCtx(ctx, gocbBucket)
+	tbp.Logf(ctx, "Got test bucket from pool")
+
+	atomic.AddInt32(&tbp.stats.NumBucketsOpened, 1)
+	bucketOpenStart := time.Now()
+	return gocbBucket, getBucketSpec(bucketName(gocbBucket.GetName())), func() {
+		atomic.AddInt32(&tbp.stats.NumBucketsClosed, 1)
+		atomic.AddInt64(&tbp.stats.TotalInuseBucketNano, time.Since(bucketOpenStart).Nanoseconds())
+		tbp.Logf(ctx, "Teardown called - closing bucket")
+		gocbBucket.Close()
+
+		if tbp.preserveBuckets && t.Failed() {
+			tbp.Logf(ctx, "Test using bucket failed. Preserving bucket for later inspection")
+			atomic.AddUint32(&tbp.preservedBucketCount, 1)
+			return
+		}
+
+		tbp.Logf(ctx, "Teardown called - Pushing into bucketReadier queue")
+		tbp.bucketReadierQueue <- bucketName(gocbBucket.GetName())
+	}
+}
+
+// bucketCtx extends the parent context with a bucket name.
+func bucketCtx(parent context.Context, b Bucket) context.Context {
+	return bucketNameCtx(parent, b.GetName())
+}
+
+// bucketNameCtx extends the parent context with a bucket name.
+func bucketNameCtx(parent context.Context, bucketName string) context.Context {
+	parentLogCtx, _ := parent.Value(LogContextKey{}).(LogContext)
+	newCtx := LogContext{
+		TestName:       parentLogCtx.TestName,
+		TestBucketName: bucketName,
+	}
+	return context.WithValue(parent, LogContextKey{}, newCtx)
+}
+
+// testCtx creates a log context for the given test.
+func testCtx(t testing.TB) context.Context {
+	return context.WithValue(context.Background(), LogContextKey{}, LogContext{TestName: t.Name()})
+}
+
+// Close cleans up any buckets, and closes the pool.
+func (tbp *GocbTestBucketPool) Close() {
+	if tbp == nil {
+		// noop
+		return
+	}
+
+	// Cancel async workers
+	if tbp.ctxCancelFunc != nil {
+		tbp.bucketReadierWaitGroup.Wait()
+		tbp.ctxCancelFunc()
+	}
+
+	if tbp.cluster != nil {
+		if err := tbp.cluster.Close(); err != nil {
+			tbp.Logf(context.Background(), "Couldn't close cluster connection: %v", err)
+		}
+	}
+
+	tbp.printStats()
+}
+
+func (tbp *GocbTestBucketPool) printStats() {
+	origVerbose := tbp.verbose.IsTrue()
+	tbp.verbose.Set(true)
+
+	ctx := context.Background()
+
+	totalBucketInitTime := time.Duration(atomic.LoadInt64(&tbp.stats.TotalBucketInitDurationNano))
+	totalBucketInitCount := time.Duration(atomic.LoadInt32(&tbp.stats.TotalBucketInitCount))
+
+	totalBucketReadierTime := time.Duration(atomic.LoadInt64(&tbp.stats.TotalBucketReadierDurationNano))
+	totalBucketReadierCount := time.Duration(atomic.LoadInt32(&tbp.stats.TotalBucketReadierCount))
+
+	totalBucketWaitTime := time.Duration(atomic.LoadInt64(&tbp.stats.TotalWaitingForReadyBucketNano))
+	numBucketsOpened := time.Duration(atomic.LoadInt32(&tbp.stats.NumBucketsOpened))
+
+	totalBucketUseTime := time.Duration(atomic.LoadInt64(&tbp.stats.TotalInuseBucketNano))
+
+	tbp.Logf(ctx, "==========================")
+	tbp.Logf(ctx, "= Test Bucket Pool Stats =")
+	tbp.Logf(ctx, "==========================")
+	if totalBucketInitCount > 0 {
+		tbp.Logf(ctx, "Total bucket init time: %s for %d buckets (avg: %s)", totalBucketInitTime, totalBucketInitCount, totalBucketInitTime/totalBucketInitCount)
+	} else {
+		tbp.Logf(ctx, "Total bucket init time: %s for %d buckets", totalBucketInitTime, totalBucketInitCount)
+	}
+	if totalBucketReadierCount > 0 {
+		tbp.Logf(ctx, "Total bucket readier time: %s for %d buckets (avg: %s)", totalBucketReadierTime, totalBucketReadierCount, totalBucketReadierTime/totalBucketReadierCount)
+	} else {
+		tbp.Logf(ctx, "Total bucket readier time: %s for %d buckets", totalBucketReadierTime, totalBucketReadierCount)
+	}
+	tbp.Logf(ctx, "Total buckets opened/closed: %d/%d", numBucketsOpened, atomic.LoadInt32(&tbp.stats.NumBucketsClosed))
+	if numBucketsOpened > 0 {
+		tbp.Logf(ctx, "Total time waiting for ready bucket: %s over %d buckets (avg: %s)", totalBucketWaitTime, numBucketsOpened, totalBucketWaitTime/numBucketsOpened)
+		tbp.Logf(ctx, "Total time tests using buckets: %s (avg: %s)", totalBucketUseTime, totalBucketUseTime/numBucketsOpened)
+	} else {
+		tbp.Logf(ctx, "Total time waiting for ready bucket: %s over %d buckets", totalBucketWaitTime, numBucketsOpened)
+		tbp.Logf(ctx, "Total time tests using buckets: %s", totalBucketUseTime)
+	}
+	tbp.Logf(ctx, "==========================")
+
+	tbp.verbose.Set(origVerbose)
+}
+
+// removes any integration test buckets
+func (tbp *GocbTestBucketPool) removeOldTestBuckets() error {
+	buckets, err := tbp.clusterMgr.GetBuckets()
+	if err != nil {
+		return errors.Wrap(err, "couldn't retrieve buckets from cluster manager")
+	}
+
+	wg := sync.WaitGroup{}
+
+	for _, b := range buckets {
+		if strings.HasPrefix(b.Name, testBucketNamePrefix) {
+			ctx := bucketNameCtx(context.Background(), b.Name)
+			tbp.Logf(ctx, "Removing old test bucket")
+			wg.Add(1)
+
+			// Run the RemoveBucket requests concurrently, as it takes a while per bucket.
+			go func(b *gocb.BucketSettings) {
+				err := tbp.clusterMgr.RemoveBucket(b.Name)
+				if err != nil {
+					tbp.Logf(ctx, "Error removing old test bucket: %v", err)
+				} else {
+					tbp.Logf(ctx, "Removed old test bucket")
+				}
+
+				wg.Done()
+			}(b)
+		}
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+// creates a new set of integration test buckets and pushes them into the readier queue.
+func (tbp *GocbTestBucketPool) createTestBuckets(numBuckets int, bucketInitFunc BucketInitFunc) error {
+
+	wg := sync.WaitGroup{}
+
+	existingBuckets, err := tbp.clusterMgr.GetBuckets()
+	if err != nil {
+		return err
+	}
+
+	openBuckets := make([]*CouchbaseBucketGoCB, numBuckets)
+
+	// create required buckets
+	for i := 0; i < numBuckets; i++ {
+		testBucketName := testBucketNamePrefix + strconv.Itoa(i)
+		ctx := bucketNameCtx(context.Background(), testBucketName)
+
+		var bucketExists bool
+		for _, b := range existingBuckets {
+			if testBucketName == b.Name {
+				tbp.Logf(ctx, "Skipping InsertBucket... Bucket already exists")
+				bucketExists = true
+			}
+		}
+
+		wg.Add(1)
+
+		// Bucket creation takes a few seconds for each bucket,
+		// so create and wait for readiness concurrently.
+		go func(i int, bucketExists bool) {
+			if !bucketExists {
+				tbp.Logf(ctx, "Creating new test bucket")
+				err := tbp.clusterMgr.InsertBucket(&gocb.BucketSettings{
+					Name:          testBucketName,
+					Quota:         testBucketQuotaMB,
+					Type:          gocb.Couchbase,
+					FlushEnabled:  true,
+					IndexReplicas: false,
+					Replicas:      0,
+				})
+				if err != nil {
+					tbp.Logf(ctx, "Couldn't create test bucket: %v", err)
+					os.Exit(1)
+				}
+			}
+
+			b, err := tbp.openTestBucket(bucketName(testBucketName), CreateSleeperFunc(5*numBuckets, 1000))
+			if err != nil {
+				tbp.Logf(ctx, "Timed out trying to open new bucket: %v", err)
+				os.Exit(1)
+			}
+			openBuckets[i] = b
+
+			wg.Done()
+		}(i, bucketExists)
+	}
+
+	wg.Wait()
+
+	// All the buckets are ready, so now we can perform some synchronous setup (e.g. Creating GSI indexes)
+	for i := 0; i < numBuckets; i++ {
+		testBucketName := testBucketNamePrefix + strconv.Itoa(i)
+		ctx := bucketNameCtx(context.Background(), testBucketName)
+
+		tbp.Logf(ctx, "running bucketInitFunc")
+		b := openBuckets[i]
+
+		if err, _ := RetryLoop(b.GetName()+"bucketInitRetry", func() (bool, error, interface{}) {
+			tbp.Logf(ctx, "Running bucket through init function")
+			err = bucketInitFunc(ctx, b, tbp)
+			if err != nil {
+				tbp.Logf(ctx, "Couldn't init bucket, got error: %v - Retrying", err)
+				return true, err, nil
+			}
+			return false, nil, nil
+		}, CreateSleeperFunc(5, 1000)); err != nil {
+			tbp.Logf(ctx, "Couldn't init bucket, got error: %v - Aborting", err)
+			os.Exit(1)
+		}
+
+		b.Close()
+
+		tbp.Logf(ctx, "Putting gocbBucket onto bucketReadierQueue")
+		tbp.bucketReadierQueue <- bucketName(testBucketName)
+	}
+
+	return nil
+}
+
+// bucketReadierWorker reads a channel of "dirty" buckets (bucketReadierQueue), does something to get them ready, and then puts them back into the pool.
+// The mechanism for getting the bucket ready can vary by package being tested (for instance, a package not requiring views or GSI can use the BucketEmptierFunc function)
+// A package requiring views or GSI, will need to pass in the db.ViewsAndGSIBucketReadier function.
+func (tbp *GocbTestBucketPool) bucketReadierWorker(ctx context.Context, bucketReadierFunc GocbBucketReadierFunc) {
+	tbp.Logf(context.Background(), "Starting bucketReadier")
+
+	tbp.bucketReadierWaitGroup = &sync.WaitGroup{}
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			tbp.Logf(context.Background(), "bucketReadier got ctx cancelled")
+			break loop
+
+		case testBucketName := <-tbp.bucketReadierQueue:
+			tbp.bucketReadierWaitGroup.Add(1)
+			atomic.AddInt32(&tbp.stats.TotalBucketReadierCount, 1)
+			ctx := bucketNameCtx(ctx, string(testBucketName))
+			tbp.Logf(ctx, "bucketReadier got bucket")
+
+			go func(testBucketName bucketName) {
+				start := time.Now()
+				b, err := tbp.openTestBucket(testBucketName, CreateSleeperFunc(5, 1000))
+				if err != nil {
+					tbp.Logf(ctx, "Couldn't open bucket to get ready, got error: %v", err)
+					return
+				}
+
+				err, _ = RetryLoop(b.GetName()+"bucketReadierRetry", func() (bool, error, interface{}) {
+					tbp.Logf(ctx, "Running bucket through readier function")
+					err = bucketReadierFunc(ctx, b, tbp)
+					if err != nil {
+						tbp.Logf(ctx, "Couldn't ready bucket, got error: %v - Retrying", err)
+						return true, err, nil
+					}
+					return false, nil, nil
+				}, CreateSleeperFunc(5, 1000))
+				if err != nil {
+					tbp.Logf(ctx, "Couldn't ready bucket, got error: %v - Aborting readier for bucket", err)
+					return
+				}
+
+				tbp.Logf(ctx, "Bucket ready, putting back into ready pool")
+				tbp.readyBucketPool <- b
+				atomic.AddInt64(&tbp.stats.TotalBucketReadierDurationNano, time.Since(start).Nanoseconds())
+
+				tbp.bucketReadierWaitGroup.Done()
+			}(testBucketName)
+		}
+	}
+
+	tbp.Logf(context.Background(), "Stopped bucketReadier")
+}
+
+func (tbp *GocbTestBucketPool) openTestBucket(testBucketName bucketName, sleeper RetrySleeper) (*CouchbaseBucketGoCB, error) {
+
+	ctx := bucketNameCtx(context.Background(), string(testBucketName))
+
+	bucketSpec := tbp.defaultBucketSpec
+	bucketSpec.BucketName = string(testBucketName)
+
+	waitForNewBucketWorker := func() (shouldRetry bool, err error, value interface{}) {
+		gocbBucket, err := GetCouchbaseBucketGoCBFromCluster(tbp.cluster, bucketSpec)
+		if err != nil {
+			tbp.Logf(ctx, "Retrying OpenBucket")
+			return true, err, nil
+		}
+		return false, nil, gocbBucket
+	}
+
+	tbp.Logf(ctx, "Opening bucket")
+	err, val := RetryLoop("waitForNewBucket", waitForNewBucketWorker,
+		// The more buckets we're creating simultaneously on the cluster,
+		// the longer this seems to take, so scale the wait time.
+		sleeper)
+
+	gocbBucket := val.(*CouchbaseBucketGoCB)
+
+	return gocbBucket, err
+}
+
+func getBucketSpec(testBucketName bucketName) BucketSpec {
+	bucketSpec := defaultBucketSpec
+	bucketSpec.BucketName = string(testBucketName)
+	return bucketSpec
+}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	testBucketQuotaMB    = 100
+	testBucketQuotaMB    = 150
 	testBucketNamePrefix = "sg_int_"
 	testClusterUsername  = "Administrator"
 	testClusterPassword  = "password"

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -604,7 +604,7 @@ func (tbp *GocbTestBucketPool) openTestBucket(testBucketName bucketName, sleeper
 	bucketSpec.BucketName = string(testBucketName)
 
 	waitForNewBucketWorker := func() (shouldRetry bool, err error, value interface{}) {
-		gocbBucket, err := GetCouchbaseBucketGoCBFromCluster(tbp.cluster, bucketSpec)
+		gocbBucket, err := GetCouchbaseBucketGoCBFromAuthenticatedCluster(tbp.cluster, bucketSpec, "")
 		if err != nil {
 			tbp.Logf(ctx, "Retrying OpenBucket")
 			return true, err, nil

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -109,7 +109,7 @@ func NewTestBucketPool(bucketReadierFunc TBPBucketReadierFunc, bucketInitFunc TB
 		ctxCancelFunc:          ctxCancelFunc,
 		defaultBucketSpec:      tbpDefaultBucketSpec,
 		preserveBuckets:        preserveBuckets,
-		BucketInitFunc:         bucketInitFunc,
+		bucketInitFunc:         bucketInitFunc,
 	}
 
 	tbp.verbose.Set(tbpVerbose())
@@ -175,7 +175,7 @@ func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s Bucke
 		tbp.Logf(ctx, "Creating new walrus test bucket")
 
 		initFuncStart := time.Now()
-		err := tbp.BucketInitFunc(ctx, b, tbp)
+		err := tbp.bucketInitFunc(ctx, b, tbp)
 		if err != nil {
 			panic(err)
 		}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -29,8 +29,8 @@ const (
 	tbpBucketNamePrefix = "sg_int_"
 
 	// Creates this many buckets in the backing store to be pooled for testing.
-	defaultBucketPoolSize = 10
-	tbpEnvPoolSize        = "SG_TEST_BUCKET_POOL_SIZE"
+	tbpDefaultBucketPoolSize = 3
+	tbpEnvPoolSize           = "SG_TEST_BUCKET_POOL_SIZE"
 
 	defaultBucketQuotaMB = 150
 	tbpEnvBucketQuotaMB  = "SG_TEST_BUCKET_QUOTA_MB"
@@ -642,7 +642,7 @@ func getBucketSpec(testBucketName tbpBucketName) BucketSpec {
 
 // tbpNumBuckets returns the configured number of buckets to use in the pool.
 func tbpNumBuckets() int {
-	numBuckets := defaultBucketPoolSize
+	numBuckets := tbpDefaultBucketPoolSize
 	if envPoolSize := os.Getenv(tbpEnvPoolSize); envPoolSize != "" {
 		var err error
 		numBuckets, err = strconv.Atoi(envPoolSize)

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -526,6 +526,7 @@ var NoopInitFunc TBPBucketInitFunc = func(ctx context.Context, b Bucket, tbp *Go
 }
 
 // PrimaryIndexInitFunc creates a primary index on the given bucket. This can then be used with N1QLBucketEmptierFunc, for improved compatibility with GSI.
+// Will be used when GSI is re-enabled (CBG-813)
 var PrimaryIndexInitFunc TBPBucketInitFunc = func(ctx context.Context, b Bucket, tbp *GocbTestBucketPool) error {
 	gocbBucket, ok := AsGoCBBucket(b)
 	if !ok {
@@ -553,6 +554,7 @@ var FlushBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b *C
 }
 
 // N1QLBucketEmptierFunc ensures the bucket is empty by using N1QL deletes. This is the preferred approach when using GSI.
+// Will be used when GSI is re-enabled (CBG-813)
 var N1QLBucketEmptierFunc TBPBucketReadierFunc = func(ctx context.Context, b *CouchbaseBucketGoCB, tbp *GocbTestBucketPool) error {
 	if hasPrimary, _, err := b.getIndexMetaWithoutRetry(PrimaryIndexName); err != nil {
 		return err

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -12,12 +12,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocb"
 	"github.com/stretchr/testify/assert"
 )
 
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
 // util_test.go, which is only accessible from the base package.
+
+// TestBucketPool is used to manage a pool of buckets for testing.
+// This is safe to leave as nil to use Walrus test buckets.
+var TestBucketPool *GocbTestBucketPool
 
 var TestExternalRevStorage = false
 var numOpenBucketsByName map[string]int32
@@ -35,21 +38,20 @@ func init() {
 type TestBucket struct {
 	Bucket
 	BucketSpec BucketSpec
+	closeFn    func()
 }
 
 func (tb TestBucket) Close() {
-
-	tb.Bucket.Close()
-
-	DecrNumOpenBuckets(tb.Bucket.GetName())
+	tb.closeFn()
 }
 
-func GetTestBucket(tester testing.TB) TestBucket {
-	return GetBucketCommon(DataBucket, tester)
-}
-
-func GetTestIndexBucket(tester testing.TB) TestBucket {
-	return GetBucketCommon(IndexBucket, tester)
+func GetTestBucket(t testing.TB) TestBucket {
+	bucket, spec, closeFn := TestBucketPool.GetTestBucketAndSpec(t)
+	return TestBucket{
+		Bucket:     bucket,
+		BucketSpec: spec,
+		closeFn:    closeFn,
+	}
 }
 
 func GetTestBucketSpec(bucketType CouchbaseBucketType) BucketSpec {
@@ -87,80 +89,6 @@ func GetTestBucketSpec(bucketType CouchbaseBucketType) BucketSpec {
 	}
 
 	return spec
-
-}
-
-func GetBucketCommon(bucketType CouchbaseBucketType, tester testing.TB) TestBucket {
-
-	spec := GetTestBucketSpec(bucketType)
-
-	if !spec.IsWalrusBucket() {
-
-		// If this is not testing against a walrus bucket, then it's testing against a Coucbhase Server bucket,
-		// and therefore needs to create the bucket if it doesn't already exist, or flush it if it does.
-
-		tbm := NewTestBucketManager(spec)
-		bucketExists, err := tbm.OpenTestBucket()
-		if err != nil {
-			tester.Fatalf("Error checking if bucket exists.  Spec: %+v err: %v", spec, err)
-		}
-		switch bucketExists {
-		case true:
-			// Empty it
-			if err := tbm.RecreateOrEmptyBucket(); err != nil {
-				tester.Fatalf("Error trying to empty bucket.  Spec: %+v.  err: %v", spec, err)
-
-			}
-		case false:
-			// Create a brand new bucket
-			// TODO: in this case, we should still wait until it's empty, just in case there was somehow residue
-			// TODO: in between deleting and recreating it, if it happened in rapid succession
-			if err := tbm.CreateTestBucket(); err != nil {
-				tester.Fatalf("Could not create bucket.  Spec: %+v Err: %v", spec, err)
-			}
-		}
-
-		// Close the bucket and any other temporary resources associated with the TestBucketManager
-		tbm.Close()
-
-	}
-
-	// Now open the bucket _again_ to ensure it's open with the correct driver
-	bucket, err := GetBucket(spec)
-	if err != nil {
-		tester.Fatalf("Could not open bucket: %v", err)
-	}
-
-	return TestBucket{
-		Bucket:     bucket,
-		BucketSpec: spec,
-	}
-
-}
-
-func GetBucketWithInvalidUsernamePassword(bucketType CouchbaseBucketType) (TestBucket, error) {
-
-	spec := GetTestBucketSpec(bucketType)
-
-	// Override spec's auth with invalid creds
-	spec.Auth = TestAuthenticator{
-		Username:   "invalid_username",
-		Password:   "invalid_password",
-		BucketName: spec.BucketName,
-	}
-
-	// Attempt to open a test bucket with invalid creds. We should expect an error.
-	bucket, err := GetBucket(spec)
-	return TestBucket{Bucket: bucket}, err
-
-}
-
-// Convenience function that will cause a bucket to be created if it doesn't already exist.
-func InitializeBucket(bucketType CouchbaseBucketType, tester testing.TB) {
-
-	// Create
-	tempBucket := GetBucketCommon(bucketType, tester)
-	tempBucket.Close()
 
 }
 
@@ -208,62 +136,6 @@ type TestAuthenticator struct {
 
 func (t TestAuthenticator) GetCredentials() (username, password, bucketname string) {
 	return t.Username, t.Password, t.BucketName
-}
-
-type TestBucketManager struct {
-	AdministratorUsername string
-	AdministratorPassword string
-	BucketSpec            BucketSpec
-	Bucket                *CouchbaseBucketGoCB
-	AuthHandler           AuthHandler
-	Cluster               *gocb.Cluster
-	ClusterManager        *gocb.ClusterManager
-}
-
-func NewTestBucketManager(spec BucketSpec) *TestBucketManager {
-
-	tbm := TestBucketManager{
-		AdministratorUsername: DefaultCouchbaseAdministrator,
-		AdministratorPassword: DefaultCouchbasePassword,
-		AuthHandler:           spec.Auth,
-		BucketSpec:            spec,
-	}
-
-	return &tbm
-
-}
-
-func (tbm *TestBucketManager) OpenTestBucket() (bucketExists bool, err error) {
-
-	if NumOpenBuckets(tbm.BucketSpec.BucketName) > 0 {
-		return false, fmt.Errorf("There are already %d open buckets with name: %s.  The tests expect all buckets to be closed.", NumOpenBuckets(tbm.BucketSpec.BucketName), tbm.BucketSpec.BucketName)
-	}
-
-	IncrNumOpenBuckets(tbm.BucketSpec.BucketName)
-
-	tbm.Bucket, err = GetCouchbaseBucketGoCB(tbm.BucketSpec)
-	if err != nil {
-		return false, err
-	}
-
-	return true, nil
-
-}
-
-func (tbm *TestBucketManager) Close() {
-	tbm.Bucket.Close()
-}
-
-// GOCB doesn't currently offer a way to do this, and so this is a workaround to go directly
-// to Couchbase Server REST API.
-// See https://forums.couchbase.com/t/is-there-a-way-to-get-the-number-of-items-in-a-bucket/12816/4
-// for GOCB discussion.
-func (tbm *TestBucketManager) BucketItemCount() (itemCount int, err error) {
-	return tbm.Bucket.BucketItemCount()
-}
-
-func (tbm *TestBucketManager) DropIndexes() error {
-	return DropAllBucketIndexes(tbm.Bucket)
 }
 
 // Reset bucket state
@@ -334,153 +206,6 @@ func getIndexes(gocbBucket *CouchbaseBucketGoCB) (indexes []string, err error) {
 	}
 
 	return indexes, nil
-
-}
-
-func (tbm *TestBucketManager) FlushBucket() error {
-
-	// Try to Flush the bucket in a retry loop
-	// Ignore sporadic errors like:
-	// Error trying to empty bucket. err: {"_":"Flush failed with unexpected error. Check server logs for details."}
-
-	Infof(KeyAll, "Flushing bucket %s", tbm.Bucket.Name())
-
-	workerFlush := func() (shouldRetry bool, err error, value interface{}) {
-		err = tbm.Bucket.Flush()
-		if err != nil {
-			Warnf("Error flushing bucket: %v  Will retry.", err)
-		}
-		shouldRetry = (err != nil) // retry (until max attempts) if there was an error
-		return shouldRetry, err, nil
-	}
-
-	err, _ := RetryLoop("EmptyTestBucket", workerFlush, CreateDoublingSleeperFunc(12, 10))
-	if err != nil {
-		return err
-	}
-
-	maxTries := 20
-	numTries := 0
-	for {
-
-		itemCount, err := tbm.BucketItemCount()
-		if err != nil {
-			return err
-		}
-
-		if itemCount == 0 {
-			// Bucket flushed, we're done
-			break
-		}
-
-		if numTries > maxTries {
-			return fmt.Errorf("Timed out waiting for bucket to be empty after flush.  ItemCount: %v", itemCount)
-		}
-
-		// Still items left, wait a little bit and try again
-		Warnf("TestBucketManager.EmptyBucket(): still %d items in bucket after flush, waiting for no items.  Will retry.", itemCount)
-		time.Sleep(time.Millisecond * 500)
-
-		numTries += 1
-
-	}
-
-	return nil
-
-}
-
-func (tbm *TestBucketManager) RecreateOrEmptyBucket() error {
-
-	if TestsShouldDropIndexes() {
-		if err := tbm.DropIndexes(); err != nil {
-			return err
-		}
-	}
-
-	if err := tbm.FlushBucket(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (tbm *TestBucketManager) DeleteTestBucket() error {
-
-	err := tbm.ClusterManager.RemoveBucket(tbm.BucketSpec.BucketName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (tbm *TestBucketManager) CreateTestBucket() error {
-
-	username, password, _ := tbm.BucketSpec.Auth.GetCredentials()
-
-	log.Printf("Create bucket with username: %v password: %v", username, password)
-
-	ramQuotaMB := 100
-
-	bucketSettings := gocb.BucketSettings{
-		Name:          tbm.BucketSpec.BucketName,
-		Type:          gocb.Couchbase,
-		Password:      password,
-		Quota:         ramQuotaMB,
-		Replicas:      0,
-		IndexReplicas: false,
-		FlushEnabled:  true,
-	}
-
-	err := tbm.ClusterManager.InsertBucket(&bucketSettings)
-	if err != nil {
-		return err
-	}
-
-	// Add an RBAC user
-	// TODO: This isn't working, filed a question here: https://forums.couchbase.com/t/creating-rbac-user-via-go-sdk-against-couchbase-server-5-0-0-build-2958/12983
-	// TODO: This is only needed if server is 5.0 or later, but not sure how to check couchbase server version
-	//roles := []gocb.UserRole{
-	//	gocb.UserRole{
-	//		Role:       "bucket_admin",
-	//		// BucketName: tbm.BucketSpec.BucketName,
-	//		BucketName: "test_data_bucket",
-	//	},
-	//}
-	//userSettings := &gocb.UserSettings{
-	//	// Name:     username,
-	//	// Password: password,
-	//	Name: "test_data_bucket",
-	//	Password: "password",
-	//	Roles:    roles,
-	//}
-	//err = tbm.ClusterManager.UpsertUser(username, userSettings)
-	//if err != nil {
-	//	log.Printf("Error UpsertUser: %v", err)
-	//	return err
-	//}
-
-	numTries := 0
-	maxTries := 20
-	for {
-
-		bucket, errOpen := GetBucket(tbm.BucketSpec)
-
-		if errOpen == nil {
-			// We were able to open the bucket, so it worked and we're done
-			bucket.Close()
-			return nil
-		}
-
-		if numTries >= maxTries {
-			return fmt.Errorf("Created bucket, but unable to connect to it after several attempts.  Spec: %+v", tbm.BucketSpec)
-		}
-
-		// Maybe it's not ready yet, wait a little bit and retry
-		numTries += 1
-		time.Sleep(time.Millisecond * 500)
-
-	}
 }
 
 // Generates a string of size int
@@ -492,39 +217,6 @@ func CreateProperty(size int) (result string) {
 		resultBytes[i] = alphaNumeric[i%len(alphaNumeric)]
 	}
 	return string(resultBytes)
-}
-
-func IncrNumOpenBuckets(bucketName string) {
-	MutateNumOpenBuckets(bucketName, 1)
-
-}
-
-func DecrNumOpenBuckets(bucketName string) {
-	MutateNumOpenBuckets(bucketName, -1)
-}
-
-func MutateNumOpenBuckets(bucketName string, delta int32) {
-	mutexNumOpenBucketsByName.Lock()
-	defer mutexNumOpenBucketsByName.Unlock()
-
-	numOpen, ok := numOpenBucketsByName[bucketName]
-	if !ok {
-		numOpen = 0
-		numOpenBucketsByName[bucketName] = numOpen
-	}
-
-	numOpen += delta
-	numOpenBucketsByName[bucketName] = numOpen
-}
-
-func NumOpenBuckets(bucketName string) int32 {
-	mutexNumOpenBucketsByName.Lock()
-	defer mutexNumOpenBucketsByName.Unlock()
-	numOpen, ok := numOpenBucketsByName[bucketName]
-	if !ok {
-		return 0
-	}
-	return numOpen
 }
 
 // SetUpTestLogging will set the given log level and log keys,

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -45,9 +45,9 @@ func (tb TestBucket) Close() {
 	tb.closeFn()
 }
 
-func GetTestBucket(t testing.TB) TestBucket {
+func GetTestBucket(t testing.TB) *TestBucket {
 	bucket, spec, closeFn := TestBucketPool.GetTestBucketAndSpec(t)
-	return TestBucket{
+	return &TestBucket{
 		Bucket:     bucket,
 		BucketSpec: spec,
 		closeFn:    closeFn,

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -127,7 +127,9 @@ func TestsShouldDropIndexes() bool {
 // This is always true for Walrus buckets, and defaults to false for Couchbase buckets.
 func TestsUseViews() bool {
 	// TODO: Undo force UseViews=true after 6.5.1 GSI fixes.
-	return true
+	if true {
+		return true
+	}
 
 	// Force views when running with Walrus anyway.
 	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -120,6 +121,20 @@ func TestsShouldDropIndexes() bool {
 	// Otherwise fallback to hardcoded default
 	return DefaultDropIndexes
 
+}
+
+// TestsUseViews returns true if tests should be forced to use views.
+// This is always true for Walrus buckets, and defaults to false for Couchbase buckets.
+func TestsUseViews() bool {
+	// TODO: Undo force UseViews=true after 6.5.1 GSI fixes.
+	return true
+
+	// Force views when running with Walrus anyway.
+	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
+		return true
+	}
+	useViews, _ := strconv.ParseBool(os.Getenv(TestEnvSyncGatewayUseViews))
+	return useViews
 }
 
 // Check the whether tests are being run with SG_TEST_BACKING_STORE=Couchbase

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -346,3 +346,8 @@ func DirExists(filename string) bool {
 	}
 	return info.IsDir()
 }
+
+// getTestKeyNamespace returns a unique doc key namespace that can be prepended in tests.
+func getTestKeyNamespace() string {
+	return GetCallersName(1, false)
+}

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -123,20 +123,19 @@ func TestsShouldDropIndexes() bool {
 
 }
 
-// TestsUseViews returns true if tests should be forced to use views.
-// This is always true for Walrus buckets, and defaults to false for Couchbase buckets.
-func TestsUseViews() bool {
-	// TODO: Undo force UseViews=true after 6.5.1 GSI fixes.
+// TestsDisableGSI returns true if tests should be forced to avoid any GSI-specific code.
+func TestsDisableGSI() bool {
+	// TODO: Undo force TestsDisableGSI=true override after 6.5.1
 	if true {
 		return true
 	}
 
-	// Force views when running with Walrus anyway.
+	// Disable GSI when running with Walrus
 	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
 		return true
 	}
-	useViews, _ := strconv.ParseBool(os.Getenv(TestEnvSyncGatewayUseViews))
-	return useViews
+	disableGSI, _ := strconv.ParseBool(os.Getenv(TestEnvSyncGatewayDisableGSI))
+	return disableGSI
 }
 
 // Check the whether tests are being run with SG_TEST_BACKING_STORE=Couchbase

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -51,44 +51,6 @@ func GetTestBucket(t testing.TB) *TestBucket {
 	}
 }
 
-func GetTestBucketSpec(bucketType CouchbaseBucketType) BucketSpec {
-
-	bucketName := DefaultTestBucketname
-	username := DefaultTestUsername
-	password := DefaultTestPassword
-
-	// Use a different bucket name for index buckets to avoid interference
-	switch bucketType {
-	case IndexBucket:
-		bucketName = DefaultTestIndexBucketname
-		username = DefaultTestIndexUsername
-		password = DefaultTestIndexPassword
-	}
-
-	testAuth := TestAuthenticator{
-		Username:   username,
-		Password:   password,
-		BucketName: bucketName,
-	}
-
-	spec := BucketSpec{
-		Server:     UnitTestUrl(),
-		BucketName: bucketName,
-
-		CouchbaseDriver: ChooseCouchbaseDriver(bucketType),
-		Auth:            testAuth,
-		UseXattrs:       TestUseXattrs(),
-	}
-
-	if spec.IsWalrusBucket() {
-		// Use a unique bucket name to reduce the chance of interference between temporary test walrus buckets
-		spec.BucketName = fmt.Sprintf("%s-%s", spec.BucketName, GenerateRandomID())
-	}
-
-	return spec
-
-}
-
 // Should Sync Gateway use XATTRS functionality when running unit tests?
 func TestUseXattrs() bool {
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -43,7 +43,7 @@ func (tb TestBucket) Close() {
 }
 
 func GetTestBucket(t testing.TB) *TestBucket {
-	bucket, spec, closeFn := TestBucketPool.GetTestBucketAndSpec(t)
+	bucket, spec, closeFn := GTestBucketPool.GetTestBucketAndSpec(t)
 	return &TestBucket{
 		Bucket:     bucket,
 		BucketSpec: spec,

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -121,7 +121,7 @@ func TestsShouldDropIndexes() bool {
 
 // TestsDisableGSI returns true if tests should be forced to avoid any GSI-specific code.
 func TestsDisableGSI() bool {
-	// TODO: Undo force TestsDisableGSI=true override after 6.5.1
+	// FIXME: CBG-813 - Re-enable GSI in integration tests after CB 6.5.1 Beta
 	if true {
 		return true
 	}
@@ -130,6 +130,7 @@ func TestsDisableGSI() bool {
 	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
 		return true
 	}
+
 	disableGSI, _ := strconv.ParseBool(os.Getenv(TestEnvSyncGatewayDisableGSI))
 	return disableGSI
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -323,6 +323,6 @@ func DirExists(filename string) bool {
 }
 
 // getTestKeyNamespace returns a unique doc key namespace that can be prepended in tests.
-func getTestKeyNamespace() string {
-	return GetCallersName(1, false)
+func getTestKeyNamespace(t *testing.T) string {
+	return t.Name()
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -19,10 +19,6 @@ import (
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
 // util_test.go, which is only accessible from the base package.
 
-// TestBucketPool is used to manage a pool of buckets for testing.
-// This is safe to leave as nil to use Walrus test buckets.
-var TestBucketPool *GocbTestBucketPool
-
 var TestExternalRevStorage = false
 var numOpenBucketsByName map[string]int32
 var mutexNumOpenBucketsByName sync.Mutex

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -341,7 +341,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket base.TestBucket
+	var testBucket *base.TestBucket
 	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer testBucket.Close()
 	defer db.Close()
@@ -402,7 +402,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket base.TestBucket
+	var testBucket *base.TestBucket
 	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer testBucket.Close()
 	defer db.Close()

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -226,7 +226,7 @@ func TestAttachments(t *testing.T) {
 
 func TestAttachmentForRejectedDocument(t *testing.T) {
 
-	testBucket := testBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
@@ -341,8 +341,10 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer tearDownTestDB(t, db)
+	var testBucket base.TestBucket
+	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
+	defer testBucket.Close()
+	defer db.Close()
 
 	// Test creating & updating a document:
 
@@ -400,8 +402,10 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer tearDownTestDB(t, db)
+	var testBucket base.TestBucket
+	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
+	defer testBucket.Close()
+	defer db.Close()
 
 	// Test creating & updating a document:
 

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -16,7 +16,7 @@ func TestUserWaiter(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// Create user
 	username := "bob"
@@ -60,7 +60,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// Create role
 	roleName := "good_egg"

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -31,7 +31,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
@@ -132,7 +132,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -217,7 +217,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -292,7 +292,7 @@ func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()
-	defer tearDownTestDB(b, db)
+	defer db.Close()
 
 	fieldVal := func(valSizeBytes int) string {
 		buffer := bytes.Buffer{}

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -18,9 +18,11 @@ func TestDuplicateDocID(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
 
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
 
@@ -65,10 +67,11 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
 
 	// Add some entries to cache
@@ -98,10 +101,11 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
 
 	// Add some entries to cache
@@ -131,10 +135,11 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
 
 	// Add some entries to cache
@@ -205,10 +210,11 @@ func TestPrependChanges(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	// 1. Test prepend to empty cache
 	cache := newSingleChannelCache(context, "PrependEmptyCache", 0, &expvar.Map{})
 	changesToPrepend := LogEntries{
@@ -389,10 +395,11 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
 
 	// Add some entries to cache
@@ -429,10 +436,11 @@ func TestChannelCacheStats(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	testStats := &expvar.Map{}
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 
@@ -500,10 +508,11 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	testStats := &expvar.Map{}
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
@@ -531,10 +540,11 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	b := base.GetTestBucket(t)
+	defer b.Close()
+	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	testStats := &expvar.Map{}
 	cache := newSingleChannelCache(context, "Test1", 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
@@ -610,20 +620,21 @@ func TestBypassSingleChannelCache(t *testing.T) {
 
 	entries, err := bypassCache.GetChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
 	assert.NoError(t, err)
-	assert.Equal(t, 10, len(entries))
+	require.Len(t, entries, 10)
 
 	validFrom, cachedEntries := bypassCache.GetCachedChanges(ChangesOptions{Since: SequenceID{Seq: 0}})
 	assert.Equal(t, uint64(math.MaxUint64), validFrom)
-	assert.Equal(t, 0, len(cachedEntries))
+	require.Len(t, cachedEntries, 0)
 }
 
 func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate doc IDs
 	docIDs := make([]string, b.N)
@@ -639,10 +650,11 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate doc IDs
 
@@ -656,10 +668,11 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate doc IDs
 
@@ -673,10 +686,11 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate doc IDs
 
@@ -690,10 +704,11 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate doc IDs
 
@@ -708,10 +723,11 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
 
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate doc IDs
 
@@ -725,10 +741,11 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	context := testBucketContext(b)
+	testBucket := base.GetTestBucket(b)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(b, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
 	// generate docs
 	docs := make([]*LogEntry, b.N)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -29,14 +29,15 @@ func TestChannelCacheMaxSize(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	context := testBucketContext(t)
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	require.NoError(t, err)
 	defer context.Close()
-	defer base.DecrNumOpenBuckets(context.Bucket.GetName())
-
 	cache := context.changeCache.getChannelCache()
 
 	// Make channels active
-	_, err := cache.GetChanges("TestA", ChangesOptions{})
+	_, err = cache.GetChanges("TestA", ChangesOptions{})
 	require.NoError(t, err)
 	_, err = cache.GetChanges("TestB", ChangesOptions{})
 	require.NoError(t, err)

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -56,7 +56,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 
 	db, testBucket := setupTestDBWithViewsEnabled(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	base.TestExternalRevStorage = true
 
@@ -100,7 +100,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	base.TestExternalRevStorage = true
 
@@ -284,7 +284,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	base.TestExternalRevStorage = true
 
@@ -442,7 +442,7 @@ func TestOldRevisionStorage(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	prop_1000_bytes := base.CreateProperty(1000)
 
@@ -602,8 +602,9 @@ func TestOldRevisionStorageError(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		ForceErrorSetRawKeys: []string{forceErrorKey},
 	}
-	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	defer tearDownTestDB(t, db)
+	db, testBucket := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
+	defer testBucket.Close()
+	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`)
 
@@ -731,7 +732,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 func TestLargeSequence(t *testing.T) {
 
 	db, testBucket := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -772,7 +773,7 @@ const rawDocMalformedRevisionStorage = `
 func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`)
 
@@ -823,7 +824,7 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()
-	defer tearDownTestDB(b, db)
+	defer db.Close()
 
 	body := Body{"foo": "bar", "rev": "1-a"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
@@ -880,7 +881,7 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()
-	defer tearDownTestDB(b, db)
+	defer db.Close()
 
 	body := Body{"foo": "bar", "rev": "1-a"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
@@ -938,7 +939,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 
 	db, testBucket := setupTestDB(b)
 	defer testBucket.Close()
-	defer tearDownTestDB(b, db)
+	defer db.Close()
 
 	body := Body{"foo": "bar"}
 	_, _, _ = db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)

--- a/db/database.go
+++ b/db/database.go
@@ -513,7 +513,7 @@ func (context *DatabaseContext) RemoveObsoleteDesignDocs(previewOnly bool) (remo
 	return removeObsoleteDesignDocs(context.Bucket, previewOnly, context.UseViews())
 }
 
-// Removes previous versions of Sync Gateway's design docs found on the server
+// Removes previous versions of Sync Gateway's indexes found on the server
 func (context *DatabaseContext) RemoveObsoleteIndexes(previewOnly bool) (removedIndexes []string, err error) {
 
 	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -110,13 +110,11 @@ func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyO
 // If certain environemnt variables are set, for example to turn on XATTR support, then update
 // the DatabaseContextOptions accordingly
 func AddOptionsFromEnvironmentVariables(dbcOptions *DatabaseContextOptions) {
-
 	if base.TestUseXattrs() {
 		dbcOptions.EnableXattr = true
 	}
 
-	// Force views if not testing against Couchbase Server
-	if !base.TestUseCouchbaseServer() {
+	if base.TestsUseViews() {
 		dbcOptions.UseViews = true
 	}
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -114,7 +114,7 @@ func AddOptionsFromEnvironmentVariables(dbcOptions *DatabaseContextOptions) {
 		dbcOptions.EnableXattr = true
 	}
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		dbcOptions.UseViews = true
 	}
 }

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -40,11 +40,11 @@ func init() {
 // Its important to call tearDownTestDB() on the database and .Close() on the TestBucket that is returned by this helper.
 // For example, if .Close() is not called on the TestBucket before the test is finished, it will be detected and
 // the next test will fail.
-func setupTestDB(t testing.TB) (*Database, base.TestBucket) {
+func setupTestDB(t testing.TB) (*Database, *base.TestBucket) {
 	return setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 }
 
-func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database, base.TestBucket) {
+func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database, *base.TestBucket) {
 
 	dbcOptions := DatabaseContextOptions{
 		CacheOptions: &options,
@@ -60,7 +60,7 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database,
 
 // Forces UseViews:true in the database context.  Useful for testing w/ views while running
 // tests against Couchbase Server
-func setupTestDBWithViewsEnabled(t testing.TB) (*Database, base.TestBucket) {
+func setupTestDBWithViewsEnabled(t testing.TB) (*Database, *base.TestBucket) {
 
 	dbcOptions := DatabaseContextOptions{
 		UseViews: true,
@@ -76,7 +76,7 @@ func setupTestDBWithViewsEnabled(t testing.TB) (*Database, base.TestBucket) {
 
 // Sets up a test bucket with _sync:seq initialized to a high value prior to database creation.  Used to test
 // issues with custom _sync:seq values without triggering skipped sequences between 0 and customSeq
-func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, base.TestBucket) {
+func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, *base.TestBucket) {
 
 	dbcOptions := DatabaseContextOptions{}
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
@@ -93,7 +93,7 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) (*Database, ba
 	return db, tBucket
 }
 
-func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyOptions base.LeakyBucketConfig) (*Database, base.TestBucket) {
+func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyOptions base.LeakyBucketConfig) (*Database, *base.TestBucket) {
 	dbcOptions := DatabaseContextOptions{
 		CacheOptions: &options,
 	}
@@ -1869,7 +1869,7 @@ func TestConcurrentPushSameNewRevision(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket base.TestBucket
+	var testBucket *base.TestBucket
 	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
@@ -1907,7 +1907,7 @@ func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket base.TestBucket
+	var testBucket *base.TestBucket
 	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
@@ -1964,7 +1964,7 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket base.TestBucket
+	var testBucket *base.TestBucket
 	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
@@ -2021,7 +2021,7 @@ func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket base.TestBucket
+	var testBucket *base.TestBucket
 	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)

--- a/db/design_doc_test.go
+++ b/db/design_doc_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRemoveObsoleteDesignDocs(t *testing.T) {
 
-	testBucket := testBucket(t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 	mapFunction := `function (doc, meta) { emit(); }`
@@ -75,7 +75,7 @@ func TestRemoveDesignDocsUseViewsTrueAndFalse(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	mapFunction := `function (doc, meta){ emit(); }`
 
@@ -130,10 +130,10 @@ func TestRemoveObsoleteDesignDocsErrors(t *testing.T) {
 		DDocGetErrorCount:    1,
 		DDocDeleteErrorCount: 1,
 	}
-	testBucket := testLeakyBucket(leakyBucketConfig, t)
+	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
+	bucket := base.NewLeakyBucket(testBucket.Bucket, leakyBucketConfig)
 
-	bucket := testBucket
 	mapFunction := `function (doc, meta){ emit(); }`
 
 	err := bucket.PutDDoc(DesignDocSyncGatewayPrefix+"_test", sgbucket.DesignDoc{

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -33,7 +33,7 @@ func TestMigrateMetadata(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	key := "TestMigrateMetadata"
 	bodyBytes := rawDocWithSyncMeta()
@@ -104,7 +104,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	type testcase struct {
 		docBody            []byte
@@ -229,7 +229,7 @@ func TestImportNullDoc(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	key := "TestImportNullDoc"
 	var body Body
@@ -247,7 +247,7 @@ func TestImportNullDocRaw(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// Feed import of null doc
 	exp := uint32(0)
@@ -271,7 +271,7 @@ func TestEvaluateFunction(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyImport)()
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// Simulate unexpected error invoking import filter for document
 	body := Body{"key": "value", "version": "1a"}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -375,7 +375,6 @@ func waitForIndex(bucket *base.CouchbaseBucketGoCB, indexName string, queryState
 		r, err := bucket.Query(queryStatement, nil, gocb.RequestPlus, true)
 		// Retry on timeout error, otherwise return
 		if err == nil {
-			_ = r.Close()
 			return nil
 		}
 		if err == base.ErrViewTimeoutError {

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -270,7 +270,7 @@ func (i *SGIndex) createIfNeeded(bucket *base.CouchbaseBucketGoCB, useXattrs boo
 }
 
 // Initializes Sync Gateway indexes for bucket.  Creates required indexes if not found, then waits for index readiness.
-func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint, createPrimary bool) error {
+func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint) error {
 
 	gocbBucket, ok := base.AsGoCBBucket(bucket)
 	if !ok {
@@ -298,18 +298,6 @@ func InitializeIndexes(bucket base.Bucket, useXattrs bool, numReplicas uint, cre
 			deferredIndexes = append(deferredIndexes, fullIndexName)
 		}
 		allSGIndexes = append(allSGIndexes, fullIndexName)
-	}
-
-	if createPrimary {
-		err := gocbBucket.CreatePrimaryIndex(base.PrimaryIndexName, &base.N1qlIndexOptions{
-			NumReplica: 0,
-			DeferBuild: true,
-		})
-		if err == nil {
-			deferredIndexes = append(deferredIndexes, base.PrimaryIndexName)
-		} else if err != base.ErrIndexAlreadyExists {
-			return err
-		}
 	}
 
 	// Issue BUILD INDEX for any deferred indexes.
@@ -372,7 +360,7 @@ func waitForIndexes(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 func waitForIndex(bucket *base.CouchbaseBucketGoCB, indexName string, queryStatement string) error {
 
 	for {
-		r, err := bucket.Query(queryStatement, nil, gocb.RequestPlus, true)
+		_, err := bucket.Query(queryStatement, nil, gocb.RequestPlus, true)
 		// Retry on timeout error, otherwise return
 		if err == nil {
 			return nil

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -23,7 +23,7 @@ func TestInitializeIndexes(t *testing.T) {
 	defer db.Close()
 
 	goCbBucket, isGoCBBucket := base.AsGoCBBucket(testBucket)
-	goassert.True(t, isGoCBBucket)
+	require.True(t, isGoCBBucket)
 
 	dropErr := base.DropAllBucketIndexes(goCbBucket)
 	assert.NoError(t, dropErr, "Error dropping all indexes")

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestInitializeIndexes(t *testing.T) {
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -74,7 +74,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -126,7 +126,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -167,7 +167,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
@@ -218,7 +218,7 @@ func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestInitializeIndexes(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Index tests require Couchbase Bucket")
+	if base.TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -74,8 +74,8 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Index tests require Couchbase Bucket")
+	if base.TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -122,13 +122,13 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Index tests require Couchbase Bucket")
-	}
-
 	// FIXME: Overwriting sgIndexes global map is disrupting the async bucket pooling workers
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
+
+	if base.TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
+	}
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
@@ -167,8 +167,8 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Index tests require Couchbase Bucket")
+	if base.TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -218,13 +218,9 @@ func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("Index tests require Couchbase Bucket")
+	if base.TestsUseViews() {
+		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
-
-	// FIXME: Overwriting sgIndexes global map is disrupting the async bucket pooling workers
-	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
-	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -102,7 +102,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
-	err := InitializeIndexes(testBucket, db.UseXattrs(), 0, false)
+	err := InitializeIndexes(testBucket, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
@@ -121,7 +121,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 	// Restore indexes after test
-	err = InitializeIndexes(testBucket, db.UseXattrs(), 0, false)
+	err = InitializeIndexes(testBucket, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 }
 
@@ -268,7 +268,7 @@ func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 	}
 
 	// Restore indexes after test
-	err := InitializeIndexes(testBucket, db.UseXattrs(), 0, false)
+	err := InitializeIndexes(testBucket, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 
 }

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -28,8 +28,13 @@ func TestInitializeIndexes(t *testing.T) {
 	dropErr := base.DropAllBucketIndexes(goCbBucket)
 	assert.NoError(t, dropErr, "Error dropping all indexes")
 
-	initErr := InitializeIndexes(testBucket, db.UseXattrs(), 0, true)
+	initErr := InitializeIndexes(testBucket, db.UseXattrs(), 0)
 	assert.NoError(t, initErr, "Error initializing all indexes")
+
+	if !base.TestsDisableGSI() {
+		err := goCbBucket.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+		assert.NoError(t, err)
+	}
 
 	validateErr := validateAllIndexesOnline(testBucket)
 	assert.NoError(t, validateErr, "Error validating indexes online")

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -70,7 +70,7 @@ func validateAllIndexesOnline(bucket base.Bucket) error {
 
 func TestPostUpgradeIndexesSimple(t *testing.T) {
 
-	// FIXME: Overwriting sgIndexes global map is disrupting the async bucket pooling workers
+	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
@@ -122,7 +122,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 
-	// FIXME: Overwriting sgIndexes global map is disrupting the async bucket pooling workers
+	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
@@ -163,7 +163,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 
 func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
-	// FIXME: Overwriting sgIndexes global map is disrupting the async bucket pooling workers
+	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
@@ -214,7 +214,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
 func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 
-	// FIXME: Overwriting sgIndexes global map is disrupting the async bucket pooling workers
+	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
 	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
 	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -75,10 +75,6 @@ func validateAllIndexesOnline(bucket base.Bucket) error {
 
 func TestPostUpgradeIndexesSimple(t *testing.T) {
 
-	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
-	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
-	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
-
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	"os"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+func TestMain(m *testing.M) {
+	base.TestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
+
+	status := m.Run()
+
+	base.TestBucketPool.Close()
+
+	os.Exit(status)
+}

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	base.TestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
+	base.GTestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
 
 	status := m.Run()
 
-	base.TestBucketPool.Close()
+	base.GTestBucketPool.Close()
 
 	os.Exit(status)
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -16,8 +16,8 @@ import (
 // Validate stats for view query
 func TestQueryChannelsStatsView(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is walrus-only (requires views)")
+	if !base.UnitTestUrlIsWalrus() || !base.TestsUseViews() {
+		t.Skip("This test is Walrus and UseViews=true only")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -68,7 +68,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 // Validate stats for n1ql query
 func TestQueryChannelsStatsN1ql(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() {
+	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
 		t.Skip("This test is Couchbase Server only")
 	}
 
@@ -213,8 +213,8 @@ func TestQuerySequencesStatsView(t *testing.T) {
 // Validate query and stats for sequence view query
 func TestQuerySequencesStatsN1ql(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is Couchbase Server only")
+	if !base.UnitTestUrlIsWalrus() || !base.TestsUseViews() {
+		t.Skip("This test is Walrus and UseViews=true only")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -310,8 +310,8 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 // Validate that channels queries (channels, starChannel) are covering
 func TestCoveringQueries(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is Couchbase Server only")
+	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -365,8 +365,8 @@ func TestCoveringQueries(t *testing.T) {
 
 func TestAllDocsQuery(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is Couchbase Server only")
+	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -428,8 +428,8 @@ func TestAllDocsQuery(t *testing.T) {
 }
 
 func TestAccessQuery(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test is Couchbase Server only")
+	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
 	db, testBucket := setupTestDB(t)
@@ -571,8 +571,8 @@ func countQueryResults(results sgbucket.QueryResultIterator) int {
 }
 
 func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() {
-		t.Skip("This test require Couchbase Server")
+	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
 	db, testBucket := setupTestDB(t)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -213,8 +213,8 @@ func TestQuerySequencesStatsView(t *testing.T) {
 // Validate query and stats for sequence view query
 func TestQuerySequencesStatsN1ql(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() || !base.TestsUseViews() {
-		t.Skip("This test is Walrus and UseViews=true only")
+	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
 	db, testBucket := setupTestDB(t)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -16,7 +16,7 @@ import (
 // Validate stats for view query
 func TestQueryChannelsStatsView(t *testing.T) {
 
-	if !base.UnitTestUrlIsWalrus() || !base.TestsUseViews() {
+	if !base.UnitTestUrlIsWalrus() || !base.TestsDisableGSI() {
 		t.Skip("This test is Walrus and UseViews=true only")
 	}
 
@@ -68,7 +68,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 // Validate stats for n1ql query
 func TestQueryChannelsStatsN1ql(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server only")
 	}
 
@@ -213,7 +213,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 // Validate query and stats for sequence view query
 func TestQuerySequencesStatsN1ql(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
@@ -310,7 +310,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 // Validate that channels queries (channels, starChannel) are covering
 func TestCoveringQueries(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
@@ -365,7 +365,7 @@ func TestCoveringQueries(t *testing.T) {
 
 func TestAllDocsQuery(t *testing.T) {
 
-	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
@@ -428,7 +428,7 @@ func TestAllDocsQuery(t *testing.T) {
 }
 
 func TestAccessQuery(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
@@ -571,7 +571,7 @@ func countQueryResults(results sgbucket.QueryResultIterator) int {
 }
 
 func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
-	if base.UnitTestUrlIsWalrus() || base.TestsUseViews() {
+	if base.UnitTestUrlIsWalrus() || base.TestsDisableGSI() {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -22,7 +22,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -74,7 +74,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 3)
@@ -122,7 +122,7 @@ func TestQuerySequencesStatsView(t *testing.T) {
 
 	db, testBucket := setupTestDBWithViewsEnabled(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 20)
@@ -219,7 +219,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// docID -> Sequence
 	docSeqMap := make(map[string]uint64, 20)
@@ -316,7 +316,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	gocbBucket, ok := base.AsGoCBBucket(testBucket)
 	if !ok {
@@ -371,7 +371,7 @@ func TestAllDocsQuery(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// Add docs with channel assignment
 	for i := 1; i <= 10; i++ {
@@ -434,7 +434,7 @@ func TestAccessQuery(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 	access(doc.accessUser, doc.accessChannel)
@@ -485,7 +485,7 @@ func TestRoleAccessQuery(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
 	role(doc.accessUser, "role:" + doc.accessChannel)

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -16,7 +16,7 @@ const (
 	docIdProblematicRevTree2 = "docIdProblematicRevTree2"
 )
 
-func testBucketWithViewsAndBrokenDoc(t testing.TB) (tBucket base.TestBucket, numDocs int) {
+func testBucketWithViewsAndBrokenDoc(t testing.TB) (tBucket *base.TestBucket, numDocs int) {
 
 	numDocsAdded := 0
 	tBucket = base.GetTestBucket(t)

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -169,7 +169,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	// Invalid _revisions property will be stripped.  Should also not be present in the rev cache.
 	rev1body := Body{
@@ -218,7 +218,7 @@ func TestBypassRevisionCache(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	docBody := Body{
 		"value": 1234,
@@ -280,7 +280,7 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	rev1body := Body{
 		"value":         1234,
@@ -322,7 +322,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	defer db.Close()
 
 	docKey := "doc1"
 	rev1body := Body{

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -42,7 +42,7 @@ func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.GocbTestBuc
 // ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
 var ViewsAndGSIBucketReadier base.GocbBucketReadierFunc = func(ctx context.Context, b *base.CouchbaseBucketGoCB, tbp *base.GocbTestBucketPool) error {
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		tbp.Logf(ctx, "flushing bucket and readying views only")
 		if err := base.FlushBucketEmptierFunc(ctx, b, tbp); err != nil {
 			return err
@@ -84,7 +84,7 @@ var ViewsAndGSIBucketInit base.BucketInitFunc = func(ctx context.Context, b base
 	}
 
 	// Exit early if we're not using GSI.
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		return nil
 	}
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"expvar"
 	"fmt"
@@ -13,56 +14,137 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Removes any existing views and installs a new set into the given bucket.
+func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.GocbTestBucketPool) error {
+	var ddocs map[string]interface{}
+	err := b.GetDDocs(&ddocs)
+	if err != nil {
+		return err
+	}
+
+	for ddocName, _ := range ddocs {
+		tbp.Logf(ctx, "removing existing view: %s", ddocName)
+		if err := b.DeleteDDoc(ddocName); err != nil {
+			return err
+		}
+	}
+
+	tbp.Logf(ctx, "initializing bucket views")
+	err = InitializeViews(b)
+	if err != nil {
+		return err
+	}
+
+	tbp.Logf(ctx, "bucket views initialized")
+	return nil
+}
+
+// ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
+var ViewsAndGSIBucketReadier base.GocbBucketReadierFunc = func(ctx context.Context, b *base.CouchbaseBucketGoCB, tbp *base.GocbTestBucketPool) error {
+
+	err := base.BucketEmptierFunc(ctx, b, tbp)
+	if err != nil {
+		return err
+	}
+
+	err = viewBucketReadier(ctx, b, tbp)
+	if err != nil {
+		return err
+	}
+
+	tbp.Logf(ctx, "waiting for empty bucket indexes")
+	// we can't init indexes concurrently, so we'll just wait for them to be empty after emptying instead of recreating.
+	err = WaitForIndexEmpty(b, base.TestUseXattrs())
+	if err != nil {
+		tbp.Logf(ctx, "WaitForIndexEmpty returned an error: %v", err)
+		return err
+	}
+	tbp.Logf(ctx, "bucket indexes empty")
+
+	return nil
+}
+
+// ViewsAndGSIBucketInit is run synchronously only once per-bucket to do any initial setup. For non-integration Walrus buckets, this is run for each new Walrus bucket.
+var ViewsAndGSIBucketInit base.BucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.GocbTestBucketPool) error {
+	gocbBucket, ok := base.AsGoCBBucket(b)
+	if !ok {
+		// Check we're not running with an invalid combination of backing store and xattrs.
+		if base.TestUseXattrs() {
+			return fmt.Errorf("xattrs not supported when using Walrus buckets")
+		}
+
+		tbp.Logf(ctx, "bucket not a gocb bucket... skipping GSI setup")
+		return viewBucketReadier(ctx, b, tbp)
+	}
+
+	if empty, err := isIndexEmpty(gocbBucket, base.TestUseXattrs()); empty && err == nil {
+		tbp.Logf(ctx, "indexes already created, and already empty - skipping")
+		return nil
+	} else {
+		tbp.Logf(ctx, "indexes not empty (or doesn't exist) - %v %v", empty, err)
+	}
+
+	tbp.Logf(ctx, "dropping existing bucket indexes")
+	if err := base.DropAllBucketIndexes(gocbBucket); err != nil {
+		tbp.Logf(ctx, "Failed to drop bucket indexes: %v", err)
+		return err
+	}
+
+	tbp.Logf(ctx, "creating SG bucket indexes")
+	if err := InitializeIndexes(gocbBucket, base.TestUseXattrs(), 0, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) (bool, error) {
+	// Create the star channel query
+	statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement) // append LIMIT 1 since we only care if there are any results or not
+	starChannelQueryStatement := replaceActiveOnlyFilter(statement, false)
+	starChannelQueryStatement = replaceSyncTokensQuery(starChannelQueryStatement, useXattrs)
+	starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
+	params := map[string]interface{}{}
+	params[QueryParamStartSeq] = 0
+	params[QueryParamEndSeq] = math.MaxInt64
+
+	// Execute the query
+	results, err := bucket.Query(starChannelQueryStatement, params, gocb.RequestPlus, true)
+
+	// If there was an error, then retry.  Assume it's an "index rollback" error which happens as
+	// the index processes the bucket flush operation
+	if err != nil {
+		return false, err
+	}
+
+	// If it's empty, we're done
+	var queryRow AllDocsIndexQueryRow
+	found := results.Next(&queryRow)
+	resultsCloseErr := results.Close()
+	if resultsCloseErr != nil {
+		return false, err
+	}
+
+	return !found, nil
+}
+
 // Workaround SG #3570 by doing a polling loop until the star channel query returns 0 results.
 // Uses the star channel index as a proxy to indicate that _all_ indexes are empty (which might not be true)
 func WaitForIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 
 	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
-
-		var results gocb.QueryResults
-
-		// Create the star channel query
-		statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement) // append LIMIT 1 since we only care if there are any results or not
-		starChannelQueryStatement := replaceActiveOnlyFilter(statement, false)
-		starChannelQueryStatement = replaceSyncTokensQuery(starChannelQueryStatement, useXattrs)
-		starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
-		params := map[string]interface{}{}
-		params[QueryParamStartSeq] = 0
-		params[QueryParamEndSeq] = math.MaxInt64
-
-		// Execute the query
-		results, err = bucket.Query(starChannelQueryStatement, params, gocb.RequestPlus, true)
-
-		// If there was an error, then retry.  Assume it's an "index rollback" error which happens as
-		// the index processes the bucket flush operation
+		empty, err := isIndexEmpty(bucket, useXattrs)
 		if err != nil {
-			base.Infof(base.KeyAll, "Error querying star channel: %v.  Assuming it's a temp error, will retry", err)
 			return true, err, nil
 		}
-
-		// If it's empty, we're done
-		var queryRow AllDocsIndexQueryRow
-		found := results.Next(&queryRow)
-		resultsCloseErr := results.Close()
-		if resultsCloseErr != nil {
-			return false, resultsCloseErr, nil
-		}
-		if !found {
-			base.Infof(base.KeyAll, "WaitForIndexEmpty found 0 results.  GSI index appears to be empty.")
-			return false, nil, nil
-		}
-
-		// Otherwise, retry
-		base.Infof(base.KeyAll, "WaitForIndexEmpty found non-zero results.  Retrying until the GSI index is empty.")
-		return true, nil, nil
-
+		return !empty, nil, empty
 	}
 
 	// Kick off the retry loop
 	err, _ := base.RetryLoop(
 		"Wait for index to be empty",
 		retryWorker,
-		base.CreateMaxDoublingSleeperFunc(30, 100, 2000),
+		base.CreateMaxDoublingSleeperFunc(60, 500, 5000),
 	)
 	return err
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -247,7 +247,12 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 	}
 
 	tbp.Logf(ctx, "creating SG bucket indexes")
-	if err := InitializeIndexes(gocbBucket, base.TestUseXattrs(), 0, true); err != nil {
+	if err := InitializeIndexes(gocbBucket, base.TestUseXattrs(), 0); err != nil {
+		return err
+	}
+
+	err := gocbBucket.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	if err != nil {
 		return err
 	}
 

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -185,7 +185,7 @@ func WaitForUserWaiterChange(userWaiter *ChangeWaiter) bool {
 }
 
 // ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
-var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b *base.CouchbaseBucketGoCB, tbp *base.GocbTestBucketPool) error {
+var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b *base.CouchbaseBucketGoCB, tbp *base.TestBucketPool) error {
 
 	if base.TestsDisableGSI() {
 		tbp.Logf(ctx, "flushing bucket and readying views only")
@@ -216,7 +216,7 @@ var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Contex
 }
 
 // ViewsAndGSIBucketInit is run synchronously only once per-bucket to do any initial setup. For non-integration Walrus buckets, this is run for each new Walrus bucket.
-var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.GocbTestBucketPool) error {
+var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
 	gocbBucket, ok := base.AsGoCBBucket(b)
 	if !ok {
 		// Check we're not running with an invalid combination of backing store and xattrs.
@@ -255,7 +255,7 @@ var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b b
 }
 
 // viewBucketReadier removes any existing views and installs a new set into the given bucket.
-func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.GocbTestBucketPool) error {
+func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.TestBucketPool) error {
 	var ddocs map[string]interface{}
 	err := b.GetDDocs(&ddocs)
 	if err != nil {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -40,7 +40,7 @@ func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.GocbTestBuc
 }
 
 // ViewsAndGSIBucketReadier empties the bucket, initializes Views, and waits until GSI indexes are empty. It is run asynchronously as soon as a test is finished with a bucket.
-var ViewsAndGSIBucketReadier base.GocbBucketReadierFunc = func(ctx context.Context, b *base.CouchbaseBucketGoCB, tbp *base.GocbTestBucketPool) error {
+var ViewsAndGSIBucketReadier base.TBPBucketReadierFunc = func(ctx context.Context, b *base.CouchbaseBucketGoCB, tbp *base.GocbTestBucketPool) error {
 
 	if base.TestsDisableGSI() {
 		tbp.Logf(ctx, "flushing bucket and readying views only")
@@ -71,7 +71,7 @@ var ViewsAndGSIBucketReadier base.GocbBucketReadierFunc = func(ctx context.Conte
 }
 
 // ViewsAndGSIBucketInit is run synchronously only once per-bucket to do any initial setup. For non-integration Walrus buckets, this is run for each new Walrus bucket.
-var ViewsAndGSIBucketInit base.BucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.GocbTestBucketPool) error {
+var ViewsAndGSIBucketInit base.TBPBucketInitFunc = func(ctx context.Context, b base.Bucket, tbp *base.GocbTestBucketPool) error {
 	gocbBucket, ok := base.AsGoCBBucket(b)
 	if !ok {
 		// Check we're not running with an invalid combination of backing store and xattrs.

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -35,10 +35,10 @@
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="6d89e4508941884e4d27e2ead8e074ef9885e9f8"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="f1b8a89d740738af8cc69efa090b99d34579cd31"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2d5aa1946c83327377ade1eadabf915a96711023"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="de3a040899d6acf57077599b2ea15b3677f56864"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="06b1872917f154d2ace0b26a11313b4d29852317"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2d5aa1946c83327377ade1eadabf915a96711023"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4fcdd6de819f62027659065cdf48a4a4ce2d19ee"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="06b1872917f154d2ace0b26a11313b4d29852317"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="b7fe191c4a6b7f2e72dca62c718656f38235483d"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1644,7 +1644,7 @@ func TestResponseEncoding(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeyCRUD, base.KeyCache, base.KeyBucket)()
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1644,6 +1644,8 @@ func TestResponseEncoding(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1644,8 +1644,6 @@ func TestResponseEncoding(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeyCRUD, base.KeyCache, base.KeyBucket)()
-
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1499,10 +1499,11 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 	goassert.True(t, sent)
 
 	// Get all docs and attachment via subChanges request
-	allDocs := bt.WaitForNumDocsViaChanges(1)
+	allDocs, ok := bt.WaitForNumDocsViaChanges(1)
+	require.True(t, ok)
 
 	// make assertions on allDocs -- make sure attachment is present w/ expected body
-	goassert.Equals(t, len(allDocs), 1)
+	require.Len(t, allDocs, 1)
 	retrievedDoc := allDocs[input.docId]
 
 	// doc assertions
@@ -1924,8 +1925,10 @@ func TestMissingNoRev(t *testing.T) {
 	}
 	defer rt.Close()
 	bt, err := NewBlipTesterFromSpec(t, btSpec)
-	assert.NoError(t, err, "Unexpected error creating BlipTester")
+	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
+
+	require.NoError(t, rt.WaitForDBOnline())
 
 	// Create 5 docs
 	for i := 0; i < 5; i++ {
@@ -1943,8 +1946,8 @@ func TestMissingNoRev(t *testing.T) {
 	assert.NoError(t, err, "failed")
 
 	// Pull docs, expect to pull 5 docs since none of them has purged yet.
-	docs := bt.WaitForNumDocsViaChanges(5)
-	goassert.True(t, len(docs) == 5)
+	docs, ok := bt.WaitForNumDocsViaChanges(5)
+	assert.Len(t, docs, 5)
 
 	// Purge one doc
 	doc0Id := fmt.Sprintf("doc-%d", 0)
@@ -1955,8 +1958,10 @@ func TestMissingNoRev(t *testing.T) {
 	targetDb.FlushRevisionCacheForTest()
 
 	// Pull docs, expect to pull 4 since one was purged.  (also expect to NOT get stuck)
-	docs = bt.WaitForNumDocsViaChanges(4)
-	goassert.True(t, len(docs) == 4)
+	docs, ok = bt.WaitForNumDocsViaChanges(4)
+	assert.True(t, ok)
+	assert.Len(t, docs, 4)
+
 }
 
 // TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3127,6 +3127,7 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 	longpollWg.Wait()
 }
 
+// TODO: RETEST
 func TestTombstoneCompaction(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -30,66 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type indexTester struct {
-	RestTester
-	_indexBucket base.Bucket
-}
-
-func initRestTester(syncFn string, testing testing.TB) *indexTester {
-	return initIndexTester(syncFn, testing)
-}
-
-func initIndexTester(syncFn string, tb testing.TB) *indexTester {
-
-	it := &indexTester{RestTester: *NewRestTester(tb, nil)}
-	it.SyncFn = syncFn
-
-	it.RestTesterServerContext = NewServerContext(&ServerConfig{
-		Facebook: &FacebookConfig{},
-	})
-
-	var syncFnPtr *string
-	if len(it.SyncFn) > 0 {
-		syncFnPtr = &it.SyncFn
-	}
-
-	// TODO: this should be able to use either a Walrus or a Couchbase bucket.
-	//       When supported, set dbConfig.UseViews conditionally
-
-	serverName := "walrus:"
-	//serverName := "http://localhost:8091"
-	bucketName := "sg_bucket"
-
-	feedType := "tap"
-
-	dbConfig := &DbConfig{
-		BucketConfig: BucketConfig{
-			Server: &serverName,
-			Bucket: &bucketName},
-		Name:     "db",
-		Sync:     syncFnPtr,
-		FeedType: feedType,
-		UseViews: true, // walrus only supports views
-	}
-
-	_, err := it.RestTesterServerContext.AddDatabaseFromConfig(dbConfig)
-	if err != nil {
-		panic(fmt.Sprintf("Error from AddDatabaseFromConfig: %v", err))
-	}
-
-	it.RestTesterBucket = it.RestTesterServerContext.Database("db").Bucket
-
-	return it
-}
-
-func (it *indexTester) Close() {
-	it.RestTesterServerContext.Close()
-}
-
-func (it *indexTester) ServerContext() *ServerContext {
-	return it.RestTesterServerContext
-}
-
 // Reproduces issue #2383 by forcing a partial error from the view on the first changes request.
 func TestReproduce2383(t *testing.T) {
 
@@ -99,8 +39,12 @@ func TestReproduce2383(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
+	testBucket := base.GetTestBucket(t)
+	leakyBucket := base.NewLeakyBucket(testBucket.Bucket, base.LeakyBucketConfig{})
+	testBucket.Bucket = leakyBucket
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
+	rt.WithTestBucket(&testBucket)
 
 	a := rt.ServerContext().Database("db").Authenticator()
 	user, err := a.NewUser("ben", "letmein", channels.SetOf(t, "PBS"))
@@ -127,8 +71,6 @@ func TestReproduce2383(t *testing.T) {
 		Last_Seq interface{}
 	}
 
-	leakyBucket, ok := rt.Bucket().(*base.LeakyBucket)
-	assert.True(t, ok, "Bucket was not of type LeakyBucket")
 	// Force a partial error for the first ViewCustom call we make to initialize an invalid cache.
 	leakyBucket.SetFirstTimeViewCustomPartialError(true)
 
@@ -249,28 +191,28 @@ func TestPostChangesInteger(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
 
-	postChanges(t, it)
+	postChanges(t, rt)
 }
 
-func postChanges(t *testing.T, it *indexTester) {
+func postChanges(t *testing.T, rt *RestTester) {
 
 	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
 	// Put several documents
-	response := it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/abc1", `{"value":1, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/abc1", `{"value":1, "channel":["ABC"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	var changes struct {
@@ -278,7 +220,7 @@ func postChanges(t *testing.T, it *indexTester) {
 		Last_Seq db.SequenceID
 	}
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -295,11 +237,11 @@ func TestPostChangesUserTiming(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel); access(doc.accessUser, doc.accessChannel)}`})
+	defer rt.Close()
 
 	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "bernard"))
 	assert.True(t, err == nil)
 	assert.NoError(t, a.Save(bernard))
@@ -307,14 +249,14 @@ func TestPostChangesUserTiming(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Put several documents to channel PBS
-	response := it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	caughtUpCount := base.ExpvarVar2Int(it.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsCaughtUp))
+	caughtUpCount := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsCaughtUp))
 
 	wg.Add(1)
 	go func() {
@@ -324,7 +266,7 @@ func TestPostChangesUserTiming(t *testing.T) {
 			Last_Seq string
 		}
 		changesJSON := `{"style":"all_docs", "timeout":6000, "feed":"longpoll", "limit":50, "since":"0"}`
-		changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+		changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 		// Validate that the user receives backfill plus the new doc
 		err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 		assert.NoError(t, err, "Error unmarshalling changes response")
@@ -339,10 +281,10 @@ func TestPostChangesUserTiming(t *testing.T) {
 	}()
 
 	// Wait for changes feed to get into wait mode where it is blocked on the longpoll changes feed response
-	require.NoError(t, it.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
+	require.NoError(t, rt.GetDatabase().WaitForCaughtUp(caughtUpCount+1))
 
 	// Put a doc in channel bernard, that also grants bernard access to channel PBS
-	response = it.SendAdminRequest("PUT", "/db/grant1", `{"value":1, "accessUser":"bernard", "accessChannel":"PBS"}`)
+	response = rt.SendAdminRequest("PUT", "/db/grant1", `{"value":1, "accessUser":"bernard", "accessChannel":"PBS"}`)
 	assertStatus(t, response, 201)
 	wg.Wait()
 
@@ -356,27 +298,27 @@ func TestPostChangesSinceInteger(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
 
-	postChangesSince(t, it)
+	postChangesSince(t, rt)
 }
 
 func TestPostChangesWithQueryString(t *testing.T) {
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
 
 	// Put several documents
-	response := it.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/pbs1", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/abc1", `{"value":1, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/abc1", `{"value":1, "channel":["ABC"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs3", `{"value":3, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	_ = it.WaitForPendingChanges()
+	_ = rt.WaitForPendingChanges()
 
 	var changes struct {
 		Results  []db.ChangeEntry
@@ -385,7 +327,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 
 	// Test basic properties
 	changesJSON := `{"heartbeat":50, "feed":"normal", "limit":1, "since":"3"}`
-	changesResponse := it.SendAdminRequest("POST", "/db/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
+	changesResponse := rt.SendAdminRequest("POST", "/db/_changes?feed=longpoll&limit=10&since=0&heartbeat=50000", changesJSON)
 
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -397,7 +339,7 @@ func TestPostChangesWithQueryString(t *testing.T) {
 		Last_Seq db.SequenceID
 	}
 	changesJSON = `{"feed":"longpoll"}`
-	changesResponse = it.SendAdminRequest("POST", "/db/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
+	changesResponse = rt.SendAdminRequest("POST", "/db/_changes?feed=longpoll&filter=sync_gateway/bychannel&channels=ABC", changesJSON)
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &filteredChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -405,24 +347,24 @@ func TestPostChangesWithQueryString(t *testing.T) {
 }
 
 // Basic _changes test with since value
-func postChangesSince(t *testing.T, it *indexTester) {
+func postChangesSince(t *testing.T, rt *RestTester) {
 
 	// Create user
-	response := it.SendAdminRequest("PUT", "/db/_user/bernard", `{"email":"bernard@bb.com", "password":"letmein", "admin_channels":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"email":"bernard@bb.com", "password":"letmein", "admin_channels":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	cacheWaiter := it.GetDatabase().NewDCPCachingCountWaiter(t)
+	cacheWaiter := rt.GetDatabase().NewDCPCachingCountWaiter(t)
 
 	// Put several documents
-	response = it.SendAdminRequest("PUT", "/db/pbs1-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs1-0000609", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000609", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000609", `{"channel":["ABC"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000799", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000799", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2-0000609", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs3-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs3-0000609", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
@@ -431,7 +373,7 @@ func postChangesSince(t *testing.T, it *indexTester) {
 		Last_Seq interface{}
 	}
 	changesJSON := `{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"0"}`
-	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
 	err := base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
@@ -439,18 +381,18 @@ func postChangesSince(t *testing.T, it *indexTester) {
 	require.Len(t, changes.Results, 5)
 
 	// Put several more documents, some to the same vbuckets
-	response = it.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/abc1-0000609", `{"value":1, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/abc1-0000609", `{"value":1, "channel":["ABC"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2-0000799", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2-0000799", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs4", `{"value":4, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs4", `{"value":4, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	cacheWaiter.AddAndWait(4)
 
 	changesJSON = fmt.Sprintf(`{"style":"all_docs", "heartbeat":300000, "feed":"longpoll", "limit":50, "since":"%s"}`, changes.Last_Seq)
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	log.Printf("Changes:%s", changesResponse.Body.Bytes())
 	assert.NoError(t, err, "Error unmarshalling changes response")
@@ -462,32 +404,32 @@ func TestPostChangesChannelFilterInteger(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
 
-	postChangesChannelFilter(t, it)
+	postChangesChannelFilter(t, rt)
 }
 
 // Test _changes with channel filter
-func postChangesChannelFilter(t *testing.T, it *indexTester) {
+func postChangesChannelFilter(t *testing.T, rt *RestTester) {
 
 	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	cacheWaiter := it.GetDatabase().NewDCPCachingCountWaiter(t)
+	cacheWaiter := rt.GetDatabase().NewDCPCachingCountWaiter(t)
 	// Put several documents
-	response := it.SendAdminRequest("PUT", "/db/pbs1-0000609", `{"channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/pbs1-0000609", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000609", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000609", `{"channel":["ABC"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000799", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/samevbdiffchannel-0000799", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2-0000609", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs3-0000609", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs3-0000609", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
@@ -497,23 +439,23 @@ func postChangesChannelFilter(t *testing.T, it *indexTester) {
 	}
 
 	changesJSON := `{"filter":"sync_gateway/bychannel", "channels":"PBS"}`
-	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 4)
 
 	// Put several more documents, some to the same vbuckets
-	response = it.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs1-0000799", `{"value":1, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/abc1-0000609", `{"value":1, "channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/abc1-0000609", `{"value":1, "channel":["ABC"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs2-0000799", `{"value":2, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs2-0000799", `{"value":2, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs4", `{"value":4, "channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs4", `{"value":4, "channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 	cacheWaiter.AddAndWait(4)
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	for _, result := range changes.Results {
@@ -531,32 +473,32 @@ func TestPostChangesAdminChannelGrantInteger(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
-	postChangesAdminChannelGrant(t, it)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
+	postChangesAdminChannelGrant(t, rt)
 }
 
 // _changes with admin-based channel grant
-func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
+func postChangesAdminChannelGrant(t *testing.T, rt *RestTester) {
 
 	// Create user with access to channel ABC:
-	a := it.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	cacheWaiter := it.GetDatabase().NewDCPCachingCountWaiter(t)
+	cacheWaiter := rt.GetDatabase().NewDCPCachingCountWaiter(t)
 
 	// Put several documents in channel ABC and PBS
-	response := it.SendAdminRequest("PUT", "/db/pbs-1", `{"channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/pbs-1", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs-2", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs-2", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs-3", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs-3", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/pbs-4", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs-4", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/abc-1", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/abc-1", `{"channel":["ABC"]}`)
 	assertStatus(t, response, 201)
 	cacheWaiter.AddAndWait(5)
 
@@ -566,7 +508,7 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	}
 
 	// Issue simple changes request
-	changesResponse := it.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
+	changesResponse := rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	assertStatus(t, changesResponse, 200)
 
 	log.Printf("Response:%+v", changesResponse.Body)
@@ -575,13 +517,13 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	require.Len(t, changes.Results, 1)
 
 	// Update the user doc to grant access to PBS
-	response = it.SendAdminRequest("PUT", "/db/_user/bernard", `{"admin_channels":["ABC", "PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/_user/bernard", `{"admin_channels":["ABC", "PBS"]}`)
 	assertStatus(t, response, 200)
 
 	time.Sleep(500 * time.Millisecond)
 
 	// Issue a new changes request with since=last_seq ensure that user receives all records for channel PBS
-	changesResponse = it.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq),
+	changesResponse = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq),
 		"", "bernard"))
 	assertStatus(t, changesResponse, 200)
 
@@ -594,15 +536,15 @@ func postChangesAdminChannelGrant(t *testing.T, it *indexTester) {
 	require.Len(t, changes.Results, 5) // 4 PBS docs, plus the updated user doc
 
 	// Write a few more docs
-	response = it.SendAdminRequest("PUT", "/db/pbs-5", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/pbs-5", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/abc-2", `{"channel":["ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/abc-2", `{"channel":["ABC"]}`)
 	assertStatus(t, response, 201)
 
 	cacheWaiter.AddAndWait(2)
 
 	// Issue another changes request - ensure we don't backfill again
-	changesResponse = it.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq),
+	changesResponse = rt.Send(requestByUser("GET", fmt.Sprintf("/db/_changes?since=%s", changes.Last_Seq),
 		"", "bernard"))
 	assertStatus(t, changesResponse, 200)
 	log.Printf("Response:%+v", changesResponse.Body)
@@ -1269,9 +1211,9 @@ func _testConcurrentNewEditsFalseDelete(t *testing.T) {
 func TestChangesActiveOnlyInteger(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyHTTP)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
-	changesActiveOnly(t, it)
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
+	changesActiveOnly(t, rt)
 }
 
 func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
@@ -1691,42 +1633,42 @@ func TestChangesIncludeDocs(t *testing.T) {
 }
 
 // Test _changes with channel filter
-func changesActiveOnly(t *testing.T, it *indexTester) {
+func changesActiveOnly(t *testing.T, rt *RestTester) {
 
 	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
 	// Put several documents
 	var body db.Body
-	response := it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
-	response = it.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	// Create a conflict, then tombstone it
-	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
+	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
+	response = rt.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
 	assertStatus(t, response, 200)
 
 	// Create a conflict, and don't tombstone it
-	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
+	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
 	assertStatus(t, response, 201)
 
 	var changes struct {
@@ -1736,28 +1678,28 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 
 	// Pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
-	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
 
 	// Delete
-	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
+	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
 	assertStatus(t, response, 200)
 
 	// Removed
-	response = it.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
+	response = rt.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
 	assertStatus(t, response, 201)
 
 	// Partially removed
-	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
+	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
 	assertStatus(t, response, 201)
 
 	time.Sleep(100 * time.Millisecond)
 
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
@@ -1771,7 +1713,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	// Active only, POST
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 3)
@@ -1784,7 +1726,7 @@ func changesActiveOnly(t *testing.T, it *indexTester) {
 	}
 	// Active only, GET
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
+	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 3)
@@ -2295,8 +2237,12 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	testBucket := base.GetTestBucket(t)
+	leakyBucket := base.NewLeakyBucket(testBucket.Bucket, base.LeakyBucketConfig{})
+	testBucket.Bucket = leakyBucket
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
+	rt.testBucket = &testBucket
 
 	// Create user:
 	a := rt.ServerContext().Database("db").Authenticator()
@@ -2332,8 +2278,6 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 
 	// Set up PostQueryCallback on bucket - will be invoked when changes triggers the cache backfill view query
 
-	leakyBucket, ok := rt.Bucket().(*base.LeakyBucket)
-	assert.True(t, ok, "Bucket was not of type LeakyBucket")
 	postQueryCallback := func(ddoc, viewName string, params map[string]interface{}) {
 		log.Printf("Got callback for %s, %s, %v", ddoc, viewName, params)
 		// Check which channel the callback was invoked for
@@ -2400,10 +2344,10 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
 
-	testDb := it.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database("db")
 
 	// Create user:
 	a := testDb.Authenticator()
@@ -2415,33 +2359,33 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Put several documents
 	var body db.Body
-	response := it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
-	response = it.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	// Create a conflict, then tombstone it
-	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
+	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
+	response = rt.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
 	assertStatus(t, response, 200)
 
 	// Create a conflict, and don't tombstone it
-	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
+	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
 	assertStatus(t, response, 201)
 
 	var changes struct {
@@ -2452,40 +2396,40 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 
 	// Pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
-	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
 
 	// Delete
-	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
+	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
 	assertStatus(t, response, 200)
 
 	// Removed
-	response = it.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
+	response = rt.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
 	assertStatus(t, response, 201)
 
 	// Partially removed
-	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
+	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
 	assertStatus(t, response, 201)
 
 	//Create additional active docs
-	response = it.SendAdminRequest("PUT", "/db/activeDoc1", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc1", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc2", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc2", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc3", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc3", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc4", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc4", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	cacheWaiter.AddAndWait(8)
 
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 10)
@@ -2499,7 +2443,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Active only NO Limit, POST
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 8)
@@ -2514,7 +2458,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Active only with Limit, POST
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
@@ -2527,7 +2471,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	}
 	// Active only with Limit, GET
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
+	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
@@ -2541,7 +2485,7 @@ func TestChangesActiveOnlyWithLimit(t *testing.T) {
 	// Active only with Limit set higher than number of revisions, POST
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 8)
@@ -2561,45 +2505,45 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
 
-	it := initIndexTester(`function(doc) {channel(doc.channel);}`, t)
-	defer it.Close()
+	rt := NewRestTester(t, &RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel);}`})
+	defer rt.Close()
 
 	// Create user:
-	a := it.ServerContext().Database("db").Authenticator()
+	a := rt.ServerContext().Database("db").Authenticator()
 	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "PBS", "ABC"))
 	assert.NoError(t, err)
 	assert.NoError(t, a.Save(bernard))
 
-	cacheWaiter := it.ServerContext().Database("db").NewDCPCachingCountWaiter(t)
+	cacheWaiter := rt.ServerContext().Database("db").NewDCPCachingCountWaiter(t)
 	// Put several documents
 	var body db.Body
-	response := it.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
+	response := rt.SendAdminRequest("PUT", "/db/deletedDoc", `{"channel":["PBS"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	deletedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/removedDoc", `{"channel":["PBS"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	removedRev := body["rev"].(string)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc0", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
-	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", `{"channel":["PBS","ABC"]}`)
 	assert.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	partialRemovalRev := body["rev"].(string)
 	assertStatus(t, response, 201)
 
-	response = it.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/conflictedDoc", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	// Create a conflict, then tombstone it
-	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
+	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictTombstone"}], "new_edits":false}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
+	response = rt.SendAdminRequest("DELETE", "/db/conflictedDoc?rev=1-conflictTombstone", "")
 	assertStatus(t, response, 200)
 
 	// Create a conflict, and don't tombstone it
-	response = it.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
+	response = rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"docs":[{"_id":"conflictedDoc","channel":["PBS"], "_rev":"1-conflictActive"}], "new_edits":false}`)
 	assertStatus(t, response, 201)
 
 	var changes struct {
@@ -2611,40 +2555,40 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 
 	// Get pre-delete changes
 	changesJSON := `{"style":"all_docs"}`
-	changesResponse := it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
 
 	// Delete
-	response = it.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
+	response = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/deletedDoc?rev=%s", deletedRev), "")
 	assertStatus(t, response, 200)
 
 	// Removed
-	response = it.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
+	response = rt.SendAdminRequest("PUT", "/db/removedDoc", fmt.Sprintf(`{"_rev":%q, "channel":["HBO"]}`, removedRev))
 	assertStatus(t, response, 201)
 
 	// Partially removed
-	response = it.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
+	response = rt.SendAdminRequest("PUT", "/db/partialRemovalDoc", fmt.Sprintf(`{"_rev":%q, "channel":["PBS"]}`, partialRemovalRev))
 	assertStatus(t, response, 201)
 
 	//Create additional active docs
-	response = it.SendAdminRequest("PUT", "/db/activeDoc1", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc1", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc2", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc2", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc3", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc3", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc4", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc4", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
-	response = it.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
+	response = rt.SendAdminRequest("PUT", "/db/activeDoc5", `{"channel":["PBS"]}`)
 	assertStatus(t, response, 201)
 
 	cacheWaiter.AddAndWait(8)
 
 	// Normal changes
 	changesJSON = `{"style":"all_docs"}`
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 10)
@@ -2656,12 +2600,12 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	}
 
 	// Active only NO Limit, POST
-	testDb := it.ServerContext().Database("db")
+	testDb := rt.ServerContext().Database("db")
 	assert.NoError(t, testDb.FlushChannelCache())
 
 	changesJSON = `{"style":"all_docs", "active_only":true}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 8)
@@ -2677,7 +2621,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	assert.NoError(t, testDb.FlushChannelCache())
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":5}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
@@ -2692,7 +2636,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// Active only with Limit, GET
 	assert.NoError(t, testDb.FlushChannelCache())
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
+	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true&limit=5", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 5)
@@ -2707,7 +2651,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	assert.NoError(t, testDb.FlushChannelCache())
 	changesJSON = `{"style":"all_docs", "active_only":true, "limit":15}`
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, changes.Results, 8)
@@ -2722,10 +2666,10 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 	// No limit active only, GET, followed by normal (https://github.com/couchbase/sync_gateway/issues/2955)
 	assert.NoError(t, testDb.FlushChannelCache())
 	changes.Results = nil
-	changesResponse = it.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
+	changesResponse = rt.Send(requestByUser("GET", "/db/_changes?style=all_docs&active_only=true", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
-	assert.Equal(t, 8, len(changes.Results))
+	require.Len(t, changes.Results, 8)
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 		if entry.ID == "conflictedDoc" {
@@ -2737,7 +2681,7 @@ func TestChangesActiveOnlyWithLimitAndViewBackfill(t *testing.T) {
 		Results  []db.ChangeEntry
 		Last_Seq interface{}
 	}
-	changesResponse = it.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
+	changesResponse = rt.Send(requestByUser("GET", "/db/_changes", "", "bernard"))
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &updatedChanges)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Len(t, updatedChanges.Results, 10)

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3127,7 +3127,6 @@ func TestCacheCompactDuringChangesWait(t *testing.T) {
 	longpollWg.Wait()
 }
 
-// TODO: RETEST
 func TestTombstoneCompaction(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -828,6 +828,7 @@ func TestValidateServerContext(t *testing.T) {
 					Username: tb1User,
 					Password: tb1Password,
 				},
+				UseViews:         base.TestsUseViews(),
 				NumIndexReplicas: base.UintPtr(0),
 			},
 			"db2": {
@@ -837,6 +838,7 @@ func TestValidateServerContext(t *testing.T) {
 					Username: tb1User,
 					Password: tb1Password,
 				},
+				UseViews:         base.TestsUseViews(),
 				NumIndexReplicas: base.UintPtr(0),
 			},
 			"db3": {
@@ -846,6 +848,7 @@ func TestValidateServerContext(t *testing.T) {
 					Username: tb2User,
 					Password: tb2Password,
 				},
+				UseViews:         base.TestsUseViews(),
 				NumIndexReplicas: base.UintPtr(0),
 			},
 		},

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -811,40 +811,40 @@ func TestValidateServerContext(t *testing.T) {
 		t.Skip("Skipping this test; requires Couchbase Bucket")
 	}
 
-	var (
-		couchbaseURL    = base.UnitTestUrl()
-		testDataBucket  = base.DefaultTestBucketname
-		testIndexBucket = base.DefaultTestIndexBucketname
-		username        = base.DefaultCouchbaseAdministrator
-		password        = base.DefaultCouchbasePassword
-	)
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+	tb2 := base.GetTestBucket(t)
+	defer tb2.Close()
+
+	tb1User, tb1Password, _ := tb1.BucketSpec.Auth.GetCredentials()
+	tb2User, tb2Password, _ := tb2.BucketSpec.Auth.GetCredentials()
 
 	config = &ServerConfig{
 		Databases: map[string]*DbConfig{
 			"db1": {
 				BucketConfig: BucketConfig{
-					Server:   &couchbaseURL,
-					Bucket:   &testDataBucket,
-					Username: username,
-					Password: password,
+					Server:   &tb1.BucketSpec.Server,
+					Bucket:   &tb1.BucketSpec.BucketName,
+					Username: tb1User,
+					Password: tb1Password,
 				},
 				NumIndexReplicas: base.UintPtr(0),
 			},
 			"db2": {
 				BucketConfig: BucketConfig{
-					Server:   &couchbaseURL,
-					Bucket:   &testDataBucket,
-					Username: username,
-					Password: password,
+					Server:   &tb1.BucketSpec.Server,
+					Bucket:   &tb1.BucketSpec.BucketName,
+					Username: tb1User,
+					Password: tb1Password,
 				},
 				NumIndexReplicas: base.UintPtr(0),
 			},
 			"db3": {
 				BucketConfig: BucketConfig{
-					Server:   &couchbaseURL,
-					Bucket:   &testIndexBucket,
-					Username: username,
-					Password: password,
+					Server:   &tb2.BucketSpec.Server,
+					Bucket:   &tb2.BucketSpec.BucketName,
+					Username: tb2User,
+					Password: tb2Password,
 				},
 				NumIndexReplicas: base.UintPtr(0),
 			},
@@ -863,7 +863,7 @@ func TestValidateServerContext(t *testing.T) {
 	sharedBucketErrors := validateServerContext(sc)
 	SharedBucketError, ok := sharedBucketErrors[0].(*SharedBucketError)
 	require.True(t, ok)
-	assert.Equal(t, testDataBucket, SharedBucketError.GetSharedBucket().bucketName)
+	assert.Equal(t, tb1.BucketSpec.BucketName, SharedBucketError.GetSharedBucket().bucketName)
 	assert.Subset(t, []string{"db1", "db2"}, SharedBucketError.GetSharedBucket().dbNames)
 }
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -828,7 +828,7 @@ func TestValidateServerContext(t *testing.T) {
 					Username: tb1User,
 					Password: tb1Password,
 				},
-				UseViews:         base.TestsUseViews(),
+				UseViews:         base.TestsDisableGSI(),
 				NumIndexReplicas: base.UintPtr(0),
 			},
 			"db2": {
@@ -838,7 +838,7 @@ func TestValidateServerContext(t *testing.T) {
 					Username: tb1User,
 					Password: tb1Password,
 				},
-				UseViews:         base.TestsUseViews(),
+				UseViews:         base.TestsDisableGSI(),
 				NumIndexReplicas: base.UintPtr(0),
 			},
 			"db3": {
@@ -848,7 +848,7 @@ func TestValidateServerContext(t *testing.T) {
 					Username: tb2User,
 					Password: tb2Password,
 				},
-				UseViews:         base.TestsUseViews(),
+				UseViews:         base.TestsDisableGSI(),
 				NumIndexReplicas: base.UintPtr(0),
 			},
 		},

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -1,0 +1,19 @@
+package rest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+)
+
+func TestMain(m *testing.M) {
+	base.TestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
+
+	status := m.Run()
+
+	base.TestBucketPool.Close()
+
+	os.Exit(status)
+}

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	base.TestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
+	base.GTestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
 
 	status := m.Run()
 
-	base.TestBucketPool.Close()
+	base.GTestBucketPool.Close()
 
 	os.Exit(status)
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -432,7 +432,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			numReplicas = *config.NumIndexReplicas
 		}
 
-		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
+		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas, false)
 		if indexErr != nil {
 			return nil, indexErr
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -230,7 +230,10 @@ func (sc *ServerContext) PostUpgrade(preview bool) (postUpgradeResults PostUpgra
 		removedDDocs, _ := database.RemoveObsoleteDesignDocs(preview)
 
 		// Index cleanup
-		removedIndexes, _ := database.RemoveObsoleteIndexes(preview)
+		var removedIndexes []string
+		if !base.TestsDisableGSI() {
+			removedIndexes, _ = database.RemoveObsoleteIndexes(preview)
+		}
 
 		postUpgradeResults[name] = PostUpgradeDatabaseResult{
 			RemovedDDocs:   removedDDocs,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -435,7 +435,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			numReplicas = *config.NumIndexReplicas
 		}
 
-		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas, false)
+		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
 		if indexErr != nil {
 			return nil, indexErr
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -115,7 +115,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		rt.DatabaseConfig = &DbConfig{}
 	}
 
-	if base.TestsUseViews() {
+	if base.TestsDisableGSI() {
 		rt.DatabaseConfig.UseViews = true
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -115,8 +115,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		rt.DatabaseConfig = &DbConfig{}
 	}
 
-	// Force views if running against walrus
-	if !base.TestUseCouchbaseServer() {
+	if base.TestsUseViews() {
 		rt.DatabaseConfig.UseViews = true
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -1076,9 +1076,10 @@ func (bt *BlipTester) GetChanges() (changes [][]interface{}) {
 
 }
 
-func (bt *BlipTester) WaitForNumDocsViaChanges(numDocsExpected int) (docs map[string]RestDocument) {
+func (bt *BlipTester) WaitForNumDocsViaChanges(numDocsExpected int) (docs map[string]RestDocument, ok bool) {
 
 	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
+		fmt.Println("BT WaitForNumDocsViaChanges retry")
 		allDocs := bt.PullDocs()
 		if len(allDocs) >= numDocsExpected {
 			return false, nil, allDocs
@@ -1092,11 +1093,11 @@ func (bt *BlipTester) WaitForNumDocsViaChanges(numDocsExpected int) (docs map[st
 	_, allDocs := base.RetryLoop(
 		"WaitForNumDocsViaChanges",
 		retryWorker,
-		base.CreateDoublingSleeperFunc(10, 10),
+		base.CreateDoublingSleeperFunc(20, 10),
 	)
 
-	return allDocs.(map[string]RestDocument)
-
+	docs, ok = allDocs.(map[string]RestDocument)
+	return docs, ok
 }
 
 // Get all documents and their attachments via the following steps:

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -554,6 +554,8 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 }
 
 func TestPostInstallCleanup(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -554,8 +554,6 @@ func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
 }
 
 func TestPostInstallCleanup(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
-
 	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()


### PR DESCRIPTION
This speeds up full integration test runs significantly, by moving the
bucket setup/teardown into an async worker which gets buckets ready in
the background while tests are running using a different bucket.

## Usage:

```
export SG_TEST_BACKING_STORE=Couchbase
export SG_TEST_COUCHBASE_SERVER_URL=couchbase://localhost
go test -v -p=1 -count=1 ./...
```

### Configuration
#### Existing
- `SG_TEST_BACKING_STORE` (default `Walrus`)
	- Can be set to `Couchbase` to enable integration tests
- `SG_TEST_COUCHBASE_SERVER_URL` (default `http://localhost:8091`)
	- The connection string to connect with Couchbase Server

#### New
- `SG_TEST_USERNAME` (default `"Administrator"`)
	- The username to use when connecting to the test server
- `SG_TEST_PASSWORD` (default `"password"`)
	- The password to use when connecting to the test server
- `SG_TEST_BUCKET_POOL_SIZE` (default `3`)
    - Specify how many buckets to create and use.
- `SG_TEST_BUCKET_QUOTA_MB` (default `150`)
    - Specify how many MB each bucket's RAM quota should be
- `SG_TEST_BACKING_STORE_RECREATE` (default `false`)
    - Drops any existing test buckets, and creates new ones
    before continuing to add them to the pool. If this is
    not set, previous buckets are just readied as normal.
- `SG_TEST_BUCKET_POOL_PRESERVE` (default `false`)
	- In the event of a failing test, the bucket used is not emptied
	and put back into the pool. This may result in exhaustion of
	buckets if more tests fail than the pool size.
- `SG_TEST_BUCKET_POOL_DEBUG` (default `false`)
    - If "true", verbose bucket pool logging is turned on,
    to see what is happening to each bucket whilst running.
- `SG_TEST_DISABLE_GSI`
	- Always set to true until CBG-818

## Depends on:
- [x] https://github.com/couchbaselabs/walrus/pull/49
- [x] https://github.com/couchbase/sg-bucket/pull/50

## Integration Tests (da4bcbd)
- [x] xattr=true http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-ben/162/
- [x] xattr=false http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-ben/161/

repeat runs:
- [x] xattr=true http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-ben/163/
- [x] xattr=false http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration-ben/164/

## After PR comments addressed (37dc74f)
- [x] xattr=true http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration/197/
- [x] xattr=false http://uberjenkins.sc.couchbase.com/job/sync-gateway-integration/198/

## Non-test changes of note:
- https://github.com/couchbase/sync_gateway/pull/4493/commits/da4bcbd723e4ccefd4facc979bd8895d6ff8f97d - Adds retry loop for UpsertDesignDocuments requests to handle sporadic Erlang 500 errors.