### PR TITLE
CBG-695 - Support external alternate address heuristic

### DIFF
--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -116,7 +116,7 @@ func TestGetExternalAlternateAddress(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			newDest, err := getExternalAlternateAddress(test.altAddrMap, test.dest)
+			newDest, err := getExternalAlternateAddress(nil, test.altAddrMap, test.dest)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedDest, newDest)
 		})

--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -73,3 +73,52 @@ func TestDCPNameLength(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExternalAlternateAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		dest         string
+		altAddrMap   map[string]string
+		expectedDest string
+	}{
+		{
+			name:         "no alts",
+			dest:         "node1.cbs.example.org:1234",
+			expectedDest: "node1.cbs.example.org:1234",
+		},
+		{
+			name: "non-matching alt",
+			dest: "node1.cbs.example.org:1234",
+			altAddrMap: map[string]string{
+				"node9.cbs.example.org": "10.10.10.9:5678",
+			},
+			expectedDest: "node1.cbs.example.org:1234",
+		},
+		{
+			name: "matching alt, alt connect URL",
+			dest: "node1.cbs.example.org:1234",
+			altAddrMap: map[string]string{
+				"node1.cbs.example.org": "10.10.10.1:5678",
+			},
+			expectedDest: "10.10.10.1:5678",
+		},
+		{
+			name: "matching alt multiple",
+			dest: "node2.cbs.example.org:1234",
+			altAddrMap: map[string]string{
+				"node1.cbs.example.org": "10.10.10.1:5678",
+				"node2.cbs.example.org": "10.10.10.2:5678",
+				"node3.cbs.example.org": "10.10.10.3:5678",
+			},
+			expectedDest: "10.10.10.2:5678",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newDest, err := getExternalAlternateAddress(test.altAddrMap, test.dest)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedDest, newDest)
+		})
+	}
+}

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -368,7 +368,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	indexName := feedName
 
 	// cbdatasource expects server URL in http format
-	serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+	serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, nil)
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -15,12 +15,12 @@ import (
 	"errors"
 	"expvar"
 
+	"github.com/couchbase/go-couchbase"
+	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
-
-	"github.com/couchbase/go-couchbase"
-	"github.com/couchbase/go-couchbase/cbdatasource"
+	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 // Memcached binary protocol datatype bit flags (https://github.com/couchbase/memcached/blob/master/docs/BinaryProtocol.md#data-types),
@@ -210,9 +210,14 @@ func (nph NoPasswordAuthHandler) GetCredentials() (username string, password str
 // bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
 func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
 
+	connSpec, err := gocbconnstr.Parse(spec.Server)
+	if err != nil {
+		return err
+	}
+
 	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
 	// reusing the bucket connection we've already established.
-	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, &connSpec)
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}
@@ -292,7 +297,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	}
 
 	// A lookup of host dest to external alternate address hostnames
-	dataSourceOptions.ConnectBucket, dataSourceOptions.Connect, dataSourceOptions.ConnectTLS = alternateAddressShims(spec.IsTLS())
+	dataSourceOptions.ConnectBucket, dataSourceOptions.Connect, dataSourceOptions.ConnectTLS = alternateAddressShims(spec.IsTLS(), connSpec.Addresses)
 
 	DebugfCtx(loggingCtx, KeyDCP, "Connecting to new bucket datasource.  URLs:%s, pool:%s, bucket:%s", MD(urls), MD(poolName), MD(bucketName))
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -297,7 +297,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	}
 
 	// A lookup of host dest to external alternate address hostnames
-	dataSourceOptions.ConnectBucket, dataSourceOptions.Connect, dataSourceOptions.ConnectTLS = alternateAddressShims(spec.IsTLS(), connSpec.Addresses)
+	dataSourceOptions.ConnectBucket, dataSourceOptions.Connect, dataSourceOptions.ConnectTLS = alternateAddressShims(loggingCtx, spec.IsTLS(), connSpec.Addresses)
 
 	DebugfCtx(loggingCtx, KeyDCP, "Connecting to new bucket datasource.  URLs:%s, pool:%s, bucket:%s", MD(urls), MD(poolName), MD(bucketName))
 

--- a/base/util.go
+++ b/base/util.go
@@ -729,10 +729,11 @@ func BoolPtr(b bool) *bool {
 	return &b
 }
 
-// Convert a Couchbase URI (eg, couchbase://host1,host2) to a list of HTTP URLs with ports (eg, ["http://host1:8091", "http://host2:8091"])
+// Convert a Bucket, or a Couchbase URI (eg, couchbase://host1,host2) to a list of HTTP URLs with ports (eg, ["http://host1:8091", "http://host2:8091"])
+// connSpec can be optionally passed in if available, to prevent unnecessary double-parsing of connstr
 // Primary use case is for backwards compatibility with go-couchbase, cbdatasource, and CBGT. Supports secure URI's as well (couchbases://).
 // Related CBGT ticket: https://issues.couchbase.com/browse/MB-25522
-func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string) (httpUrls []string, err error) {
+func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string, connSpec *gocbconnstr.ConnSpec) (httpUrls []string, err error) {
 
 	// If we're using a gocb bucket, use the bucket to retrieve the mgmt endpoints.  Note that incoming bucket may be CouchbaseBucketGoCB or *CouchbaseBucketGoCB.
 	switch typedBucket := bucket.(type) {
@@ -753,11 +754,20 @@ func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string) (httpUrls []strin
 		return []string{singleHttpUrl}, nil
 	}
 
-	// Unable to do simple URL parse, try to parse into components w/ gocbconnstr
-	connSpec, errParse := gocbconnstr.Parse(couchbaseUri)
-	if errParse != nil {
-		return httpUrls, pkgerrors.WithStack(RedactErrorf("Error parsing gocb connection string: %v.  Error: %v", MD(couchbaseUri), errParse))
+	// Parse the given URI if we've not already got a connSpec
+	if connSpec == nil {
+		// Unable to do simple URL parse, try to parse into components w/ gocbconnstr
+		newConnSpec, errParse := gocbconnstr.Parse(couchbaseUri)
+		if errParse != nil {
+			return httpUrls, pkgerrors.WithStack(RedactErrorf("Error parsing gocb connection string: %v.  Error: %v", MD(couchbaseUri), errParse))
+		}
+		connSpec = &newConnSpec
 	}
+
+	return connSpecToHTTPURLs(*connSpec)
+}
+
+func connSpecToHTTPURLs(connSpec gocbconnstr.ConnSpec) (httpUrls []string, err error) {
 
 	for _, address := range connSpec.Addresses {
 
@@ -770,7 +780,7 @@ func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string) (httpUrls []strin
 		case "couchbase":
 			fallthrough
 		case "couchbases":
-			return nil, RedactErrorf("couchbase:// and couchbases:// URI schemes can only be used with GoCB buckets.  Bucket: %+v", MD(bucket))
+			return nil, RedactErrorf("couchbase:// and couchbases:// URI schemes can only be used with GoCB buckets.")
 		case "https":
 			translatedScheme = "https"
 		}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -266,15 +266,15 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 	}
 
 	for _, inputAndExpected := range inputsAndExpected {
-		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input)
+		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input, nil)
 		assert.NoError(t, err, "Unexpected error")
 		goassert.DeepEquals(t, actual, inputAndExpected.expected)
 	}
 
 	// With a nil (or walrus bucket) and a couchbase or couchbases url, expect errors
-	_, err := CouchbaseURIToHttpURL(nil, "couchbases://host1:18191,host2:18191")
+	_, err := CouchbaseURIToHttpURL(nil, "couchbases://host1:18191,host2:18191", nil)
 	goassert.True(t, err != nil)
-	_, err = CouchbaseURIToHttpURL(nil, "couchbase://host1")
+	_, err = CouchbaseURIToHttpURL(nil, "couchbase://host1", nil)
 	goassert.True(t, err != nil)
 
 }


### PR DESCRIPTION
- Use `/pools/default/nodeServices` instead of `/pools/default` for fetching external alternate address/port information.
- Promoted a couple of key log lines around alternate addresses to info/debug from trace level.
- Included log context.
- Apply external alternate address heuristic based on which URLs were used in the initial server connstr.
  - If any of the URLs in the connstr match any default/internal host, don't do any alternate address mapping.
  - Otherwise, if an external address is present, use that. CBS guarantees the server always has a list of exposed ports.