### PR TITLE
CBG-730 - Backport CBG-695 to 2.7.1

### DIFF
--- a/base/dcp_common_test.go
+++ b/base/dcp_common_test.go
@@ -1,0 +1,57 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExternalAlternateAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		dest         string
+		altAddrMap   map[string]string
+		expectedDest string
+	}{
+		{
+			name:         "no alts",
+			dest:         "node1.cbs.example.org:1234",
+			expectedDest: "node1.cbs.example.org:1234",
+		},
+		{
+			name: "non-matching alt",
+			dest: "node1.cbs.example.org:1234",
+			altAddrMap: map[string]string{
+				"node9.cbs.example.org": "10.10.10.9:5678",
+			},
+			expectedDest: "node1.cbs.example.org:1234",
+		},
+		{
+			name: "matching alt, alt connect URL",
+			dest: "node1.cbs.example.org:1234",
+			altAddrMap: map[string]string{
+				"node1.cbs.example.org": "10.10.10.1:5678",
+			},
+			expectedDest: "10.10.10.1:5678",
+		},
+		{
+			name: "matching alt multiple",
+			dest: "node2.cbs.example.org:1234",
+			altAddrMap: map[string]string{
+				"node1.cbs.example.org": "10.10.10.1:5678",
+				"node2.cbs.example.org": "10.10.10.2:5678",
+				"node3.cbs.example.org": "10.10.10.3:5678",
+			},
+			expectedDest: "10.10.10.2:5678",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			newDest, err := getExternalAlternateAddress(nil, test.altAddrMap, test.dest)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedDest, newDest)
+		})
+	}
+}

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -365,7 +365,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	indexName := feedName
 
 	// cbdatasource expects server URL in http format
-	serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+	serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, nil)
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -8,6 +8,7 @@ import (
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/pkg/errors"
+	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
 const CBGTIndexTypeSyncGatewayImport = "syncGateway-import-"
@@ -76,7 +77,7 @@ func cbgtFeedParams(spec BucketSpec) (string, error) {
 // TODO: If the index definition already exists in the cfg, it appears like this step can be bypassed,
 //       as we don't currently have a scenario where we want to update an existing index def.  Needs
 //       additional testing to validate.
-func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec BucketSpec, numPartitions uint16) error {
+func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSpec, numPartitions uint16) error {
 
 	// sourceType is based on cbgt.source_gocouchbase non-public constant.
 	// TODO: Request that cbgt make this and source_gocb public.
@@ -115,8 +116,8 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 	// TODO: If this isn't well-formed JSON, cbgt emits errors when opening locally persisted pindex files.  Review
 	//       how this can be optimized if we're not actually using it in the indexImpl
 	indexParams := `{"name": "` + dbName + `"}`
-
 	indexName := dbName + "_import"
+	InfofCtx(c.Cfg.loggingCtx, KeyDCP, "Creating cbgt index %q for db %q", indexName, MD(dbName))
 
 	// Required for initial pools request, before BucketDataSourceOptions kick in
 	if spec.Certpath != "" {
@@ -126,20 +127,25 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 		couchbase.SetSkipVerify(false)
 	}
 
+	connSpec, err := gocbconnstr.Parse(spec.Server)
+	if err != nil {
+		return err
+	}
+
 	// Register bucketDataSource callback for new index if we need to configure TLS
-	cbgt.RegisterBucketDataSourceOptionsCallback(indexName, manager.UUID(), func(options *cbdatasource.BucketDataSourceOptions) *cbdatasource.BucketDataSourceOptions {
+	cbgt.RegisterBucketDataSourceOptionsCallback(indexName, c.Manager.UUID(), func(options *cbdatasource.BucketDataSourceOptions) *cbdatasource.BucketDataSourceOptions {
 		if spec.IsTLS() {
 			options.TLSConfig = func() *tls.Config {
 				return spec.TLSConfig()
 			}
 		}
-		options.ConnectBucket, options.Connect, options.ConnectTLS = alternateAddressShims(spec.IsTLS())
+		options.ConnectBucket, options.Connect, options.ConnectTLS = alternateAddressShims(c.Cfg.loggingCtx, spec.IsTLS(), connSpec.Addresses)
 		return options
 	})
 
-	_, previousIndexUUID, err := getCBGTIndexUUID(manager, indexName)
+	_, previousIndexUUID, err := getCBGTIndexUUID(c.Manager, indexName)
 	indexType := CBGTIndexTypeSyncGatewayImport + dbName
-	err = manager.CreateIndex(
+	err = c.Manager.CreateIndex(
 		sourceType,        // sourceType
 		bucket.GetName(),  // sourceName
 		bucketUUID,        // sourceUUID
@@ -150,9 +156,9 @@ func createCBGTIndex(manager *cbgt.Manager, dbName string, bucket Bucket, spec B
 		planParams,        // planParams
 		previousIndexUUID, // prevIndexUUID
 	)
-	manager.Kick("NewIndexesCreated")
+	c.Manager.Kick("NewIndexesCreated")
 
-	Infof(KeyDCP, "Initialized sharded DCP feed %s with %d partitions.", indexName, numPartitions)
+	InfofCtx(c.Cfg.loggingCtx, KeyDCP, "Initialized sharded DCP feed %s with %d partitions.", indexName, numPartitions)
 	return err
 
 }
@@ -233,7 +239,7 @@ func initCBGTManager(dbName string, bucket Bucket, spec BucketSpec) (*CbgtContex
 	var serverURL string
 	if feedType == cbgtFeedType_cbdatasource {
 		// cbdatasource expects server URL in http format
-		serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+		serverURLs, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, nil)
 		if errConvertServerSpec != nil {
 			return nil, errConvertServerSpec
 		}
@@ -293,7 +299,7 @@ func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec
 	}
 
 	// Add the index definition for this feed to the cbgt cfg, in case it's not already present.
-	err = createCBGTIndex(c.Manager, dbName, bucket, spec, numPartitions)
+	err = createCBGTIndex(c, dbName, bucket, spec, numPartitions)
 	if err != nil {
 		Errorf("cbgt index creation failed: %v", err)
 		return err
@@ -309,7 +315,7 @@ func initCfgCB(bucket Bucket, spec BucketSpec) (*cbgt.CfgCB, error) {
 	options := map[string]interface{}{
 		"keyPrefix": SyncPrefix,
 	}
-	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server)
+	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, nil)
 	if errConvertServerSpec != nil {
 		return nil, errConvertServerSpec
 	}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -220,15 +220,15 @@ func TestCouchbaseURIToHttpURL(t *testing.T) {
 	}
 
 	for _, inputAndExpected := range inputsAndExpected {
-		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input)
+		actual, err := CouchbaseURIToHttpURL(nil, inputAndExpected.input, nil)
 		assert.NoError(t, err, "Unexpected error")
 		goassert.DeepEquals(t, actual, inputAndExpected.expected)
 	}
 
 	// With a nil (or walrus bucket) and a couchbase or couchbases url, expect errors
-	_, err := CouchbaseURIToHttpURL(nil, "couchbases://host1:18191,host2:18191")
+	_, err := CouchbaseURIToHttpURL(nil, "couchbases://host1:18191,host2:18191", nil)
 	goassert.True(t, err != nil)
-	_, err = CouchbaseURIToHttpURL(nil, "couchbase://host1")
+	_, err = CouchbaseURIToHttpURL(nil, "couchbase://host1", nil)
 	goassert.True(t, err != nil)
 
 }


### PR DESCRIPTION
Conflicts resolved:

```diff
diff --cc base/dcp_sharded.go
index a409d879,aa406813..00000000
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@@ -115,8 -122,8 +116,13 @@@ func createCBGTIndex(c *CbgtContext, db
        // TODO: If this isn't well-formed JSON, cbgt emits errors when opening locally persisted pindex files.  Review
        //       how this can be optimized if we're not actually using it in the indexImpl
        indexParams := `{"name": "` + dbName + `"}`
++<<<<<<< HEAD
 +
 +      indexName := dbName + "_import"
++=======
+       indexName := GenerateIndexName(dbName)
+       InfofCtx(c.Cfg.loggingCtx, KeyDCP, "Creating cbgt index %q for db %q", indexName, MD(dbName))
++>>>>>>> 3206f685... CBG-695 - Support external alternate address heuristic (#4506)
  
        // Required for initial pools request, before BucketDataSourceOptions kick in
        if spec.Certpath != "" {
* Unmerged path base/dcp_common_test.go
```

---

CBG-695 - Support external alternate address heuristic (#4506)

* CBG-695 - Support external alternate address heuristic

* Pass down Cbgt logging context into alt address shims

* Always use nodes listed in nodeServices for alternate address mapping

* Improve logging

* Invert logic - default to external host (if present) - and use internal when any given connStr host matches a default/internal network hostname.