### PR TITLE
CBG-731: Channels query performance degradation when using limit and active-only

### DIFF
--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -93,7 +93,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 	for {
 
 		// Query the view or index
-		queryResults, err := dbc.QueryChannels(channelName, startSeq, endSeq, limit)
+		queryResults, err := dbc.QueryChannels(channelName, startSeq, endSeq, limit, activeOnly)
 		if err != nil {
 			return nil, err
 		}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -14,10 +14,9 @@ import (
 )
 
 const (
-	indexNameFormat  = "sg_%s_%s%d"        // Name, xattrs, version.  e.g. "sg_channels_x1"
-	syncToken        = "$sync"             // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
-	indexToken       = "$idx"              // Index token, used to hint which index should be used for the query
-	activeOnlyFilter = "$activeOnlyFilter" // Placeholder to substitute active only filter in channel query
+	indexNameFormat = "sg_%s_%s%d" // Name, xattrs, version.  e.g. "sg_channels_x1"
+	syncToken       = "$sync"      // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
+	indexToken      = "$idx"       // Index token, used to hint which index should be used for the query
 
 	// N1ql-encoded wildcard expression matching the '_sync:' prefix used for all sync gateway's system documents.
 	// Need to escape the underscore in '_sync' to prevent it being treated as a N1QL wildcard
@@ -460,13 +459,12 @@ func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) stri
 	return strings.Replace(statement, indexToken, idx.fullIndexName(useXattrs), -1)
 }
 
-// Replace $activeOnlyFilter placeholder with activeOnlyFilterFilterExpression if activeOnly is true and the limit
-// is grater than zero. If activeOnly is false or limit is not grater than 0, the $activeOnlyFilter placeholder will
-// be replaced with an empty string in the channel query statement.
-func replaceActiveOnlyFilter(statement string, limit int, activeOnly bool) string {
-	activeOnlyFilterFilterExpression := "($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false) AND"
-	if limit > 0 && activeOnly {
-		return strings.Replace(statement, activeOnlyFilter, activeOnlyFilterFilterExpression, -1)
+// Replace $$activeOnlyFilter placeholder with activeOnlyFilterExpression if activeOnly is true
+// and an empty string otherwise in the channel query statement.
+func replaceActiveOnlyFilter(statement string, activeOnly bool) string {
+	activeOnlyFilterExpression := "AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)"
+	if activeOnly {
+		return strings.Replace(statement, activeOnlyFilter, activeOnlyFilterExpression, -1)
 	} else {
 		return strings.Replace(statement, activeOnlyFilter, "", -1)
 	}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -14,10 +14,9 @@ import (
 )
 
 const (
-	indexNameFormat  = "sg_%s_%s%d"        // Name, xattrs, version.  e.g. "sg_channels_x1"
-	syncToken        = "$sync"             // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
-	indexToken       = "$idx"              // Index token, used to hint which index should be used for the query
-	activeOnlyFilter = "$activeOnlyFilter" // Placeholder to substitute active only filter in channel query
+	indexNameFormat = "sg_%s_%s%d" // Name, xattrs, version.  e.g. "sg_channels_x1"
+	syncToken       = "$sync"      // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
+	indexToken      = "$idx"       // Index token, used to hint which index should be used for the query
 
 	// N1ql-encoded wildcard expression matching the '_sync:' prefix used for all sync gateway's system documents.
 	// Need to escape the underscore in '_sync' to prevent it being treated as a N1QL wildcard
@@ -458,13 +457,4 @@ func replaceSyncTokensQuery(statement string, useXattrs bool) string {
 // Replace index tokens ($idx) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
 func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) string {
 	return strings.Replace(statement, indexToken, idx.fullIndexName(useXattrs), -1)
-}
-
-// Replace $activeOnlyFilter placeholder in the channel query statement.
-func replaceActiveOnlyFilter(statement string, limit int, activeOnly bool) string {
-	if limit > 0 && activeOnly {
-		return strings.Replace(statement, activeOnlyFilter, "BITTEST($sync.flags, 1) AND", -1)
-	} else {
-		return strings.Replace(statement, activeOnlyFilter, "", -1)
-	}
 }

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -462,8 +462,10 @@ func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) stri
 
 // Replace $activeOnlyFilter placeholder in the channel query statement.
 func replaceActiveOnlyFilter(statement string, limit int, activeOnly bool) string {
+	activeOnlyFilterFilterExpression := "(($sync.flags IS NOT MISSING AND BITTEST($sync.flags, " +
+		"1) = false) OR $sync.flags IS MISSING) AND"
 	if limit > 0 && activeOnly {
-		return strings.Replace(statement, activeOnlyFilter, "BITTEST($sync.flags, 1) AND", -1)
+		return strings.Replace(statement, activeOnlyFilter, activeOnlyFilterFilterExpression, -1)
 	} else {
 		return strings.Replace(statement, activeOnlyFilter, "", -1)
 	}

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	indexNameFormat = "sg_%s_%s%d" // Name, xattrs, version.  e.g. "sg_channels_x1"
-	syncToken       = "$sync"      // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
-	indexToken      = "$idx"       // Index token, used to hint which index should be used for the query
+	indexNameFormat  = "sg_%s_%s%d"        // Name, xattrs, version.  e.g. "sg_channels_x1"
+	syncToken        = "$sync"             // Sync token, used to swap between xattr/non-xattr handling in n1ql statements
+	indexToken       = "$idx"              // Index token, used to hint which index should be used for the query
+	activeOnlyFilter = "$activeOnlyFilter" // Placeholder to substitute active only filter in channel query
 
 	// N1ql-encoded wildcard expression matching the '_sync:' prefix used for all sync gateway's system documents.
 	// Need to escape the underscore in '_sync' to prevent it being treated as a N1QL wildcard
@@ -457,4 +458,13 @@ func replaceSyncTokensQuery(statement string, useXattrs bool) string {
 // Replace index tokens ($idx) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
 func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) string {
 	return strings.Replace(statement, indexToken, idx.fullIndexName(useXattrs), -1)
+}
+
+// Replace $activeOnlyFilter placeholder in the channel query statement.
+func replaceActiveOnlyFilter(statement string, limit int, activeOnly bool) string {
+	if limit > 0 && activeOnly {
+		return strings.Replace(statement, activeOnlyFilter, "BITTEST($sync.flags, 1) AND", -1)
+	} else {
+		return strings.Replace(statement, activeOnlyFilter, "", -1)
+	}
 }

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -460,10 +460,11 @@ func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) stri
 	return strings.Replace(statement, indexToken, idx.fullIndexName(useXattrs), -1)
 }
 
-// Replace $activeOnlyFilter placeholder in the channel query statement.
+// Replace $activeOnlyFilter placeholder with activeOnlyFilterFilterExpression if activeOnly is true and the limit
+// is grater than zero. If activeOnly is false or limit is not grater than 0, the $activeOnlyFilter placeholder will
+// be replaced with an empty string in the channel query statement.
 func replaceActiveOnlyFilter(statement string, limit int, activeOnly bool) string {
-	activeOnlyFilterFilterExpression := "(($sync.flags IS NOT MISSING AND BITTEST($sync.flags, " +
-		"1) = false) OR $sync.flags IS MISSING) AND"
+	activeOnlyFilterFilterExpression := "($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false) AND"
 	if limit > 0 && activeOnly {
 		return strings.Replace(statement, activeOnlyFilter, activeOnlyFilterFilterExpression, -1)
 	} else {

--- a/db/query.go
+++ b/db/query.go
@@ -76,8 +76,7 @@ var QueryChannels = SGQuery{
 			"FROM `%s` "+
 			"USE INDEX ($idx) "+
 			"UNNEST OBJECT_PAIRS($sync.channels) AS op "+
-			"WHERE [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),"+
-			"IFMISSING(op.val.del,null)]  BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq] "+
+			"WHERE [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)]  BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq] "+
 			"ORDER BY seq",
 		base.BucketQueryToken, base.BucketQueryToken),
 	adhoc: false,

--- a/db/query.go
+++ b/db/query.go
@@ -64,8 +64,13 @@ type QueryAccessRow struct {
 	Value channels.TimedSet
 }
 
-// Placeholder to substitute active only filter in channel query.
-const activeOnlyFilter = "$$activeOnlyFilter"
+const (
+	// Placeholder to substitute active only filter in channel query.
+	activeOnlyFilter = "$$activeOnlyFilter"
+
+	// Filter expression to be used in channel query to select only active documents.
+	activeOnlyFilterExpression = "AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)"
+)
 
 var QueryChannels = SGQuery{
 	name: QueryTypeChannels,
@@ -580,7 +585,6 @@ func (e *EmptyResultIterator) Close() error {
 // Replace $$activeOnlyFilter placeholder with activeOnlyFilterExpression if activeOnly is true
 // and an empty string otherwise in the channel query statement.
 func replaceActiveOnlyFilter(statement string, activeOnly bool) string {
-	activeOnlyFilterExpression := "AND ($sync.flags IS MISSING OR BITTEST($sync.flags,1) = false)"
 	if activeOnly {
 		return strings.Replace(statement, activeOnlyFilter, activeOnlyFilterExpression, -1)
 	} else {

--- a/db/query.go
+++ b/db/query.go
@@ -81,8 +81,8 @@ var QueryChannels = SGQuery{
 			"UNNEST OBJECT_PAIRS($sync.channels) AS op "+
 			"WHERE ([op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),"+
 			"IFMISSING(op.val.del,null)]  BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq]) "+
-			"$$activeOnlyFilter ORDER BY seq",
-		base.BucketQueryToken, base.BucketQueryToken),
+			"%s ORDER BY seq",
+		base.BucketQueryToken, base.BucketQueryToken, activeOnlyFilter),
 	adhoc: false,
 }
 

--- a/db/query.go
+++ b/db/query.go
@@ -76,10 +76,44 @@ var QueryChannels = SGQuery{
 			"FROM `%s` "+
 			"USE INDEX ($idx) "+
 			"UNNEST OBJECT_PAIRS($sync.channels) AS op "+
-			"WHERE $activeOnlyFilter [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),"+
+			"WHERE [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),"+
 			"IFMISSING(op.val.del,null)]  BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq] "+
 			"ORDER BY seq",
 		base.BucketQueryToken, base.BucketQueryToken),
+	adhoc: false,
+}
+
+var QueryChannelsActiveOnly = SGQuery{
+	name: QueryTypeChannels,
+	statement: fmt.Sprintf(
+		"SELECT [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)][1] AS seq, "+
+			"[op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)][2] AS rRev, "+
+			"[op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)][3] AS rDel, "+
+			"$sync.rev AS rev, "+
+			"$sync.flags AS flags, "+
+			"META(`%s`).id AS id "+
+			"FROM `%s` "+
+			"USE INDEX ($idx) "+
+			"UNNEST OBJECT_PAIRS($sync.channels) AS op "+
+			"WHERE $sync.flags IS NOT MISSING AND BITTEST($sync.flags, 1) = false "+
+			"AND [op.name, LEAST($sync.sequence, op.val.seq),"+
+			"IFMISSING(op.val.rev,null),"+
+			"IFMISSING(op.val.del,null)]  BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq] "+
+			"UNION SELECT [op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),"+
+			"IFMISSING(op.val.del,null)][1] AS seq, "+
+			"[op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)][2] AS rRev, "+
+			"[op.name, LEAST($sync.sequence, op.val.seq),IFMISSING(op.val.rev,null),IFMISSING(op.val.del,null)][3] AS rDel, "+
+			"$sync.rev AS rev, "+
+			"$sync.flags AS flags, "+
+			"META(`%s`).id AS id "+
+			"FROM `%s` "+
+			"USE INDEX ($idx) "+
+			"UNNEST OBJECT_PAIRS($sync.channels) AS op "+
+			"WHERE $sync.flags IS MISSING AND [op.name, LEAST($sync.sequence, op.val.seq),"+
+			"IFMISSING(op.val.rev,null),"+
+			"IFMISSING(op.val.del,null)]  BETWEEN  [$channelName, $startSeq] AND [$channelName, $endSeq] "+
+			"ORDER BY seq",
+		base.BucketQueryToken, base.BucketQueryToken, base.BucketQueryToken, base.BucketQueryToken),
 	adhoc: false,
 }
 
@@ -365,14 +399,16 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	activeOnly bool) (statement string, params map[string]interface{}) {
 
 	channelQuery := QueryChannels
+	if activeOnly {
+		channelQuery = QueryChannelsActiveOnly
+	}
 	index := sgIndexes[IndexChannels]
 	if channelName == "*" {
 		channelQuery = QueryStarChannel
 		index = sgIndexes[IndexAllDocs]
 	}
 
-	channelQueryStatement := replaceActiveOnlyFilter(channelQuery.statement, limit, activeOnly)
-	channelQueryStatement = replaceSyncTokensQuery(channelQueryStatement, context.UseXattrs())
+	channelQueryStatement := replaceSyncTokensQuery(channelQuery.statement, context.UseXattrs())
 	channelQueryStatement = replaceIndexTokensQuery(channelQueryStatement, index, context.UseXattrs())
 	if limit > 0 {
 		channelQueryStatement = fmt.Sprintf("%s LIMIT %d", channelQueryStatement, limit)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -614,7 +614,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	require.NoError(t, err, "Couldn't create revision 1-a of doc3")
 	endSeq := doc.Sequence
 
-	// Issue channel query with limit and activeOnly true
+	// Get changes in ABC channel with limit and activeOnly true
 	entries, err := db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 2, true)
 	assert.Len(t, entries, 2)
 	assert.Equal(t, "doc2", entries[0].DocID)
@@ -624,7 +624,17 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	assert.Equal(t, uint8(0x14), entries[0].Flags)
 	assert.Equal(t, uint8(0x0), entries[1].Flags)
 
-	// Issue channel query with no limit and activeOnly true
+	// Get changes in star channel with limit and activeOnly true
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 2, true)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "doc2", entries[0].DocID)
+	assert.Equal(t, "2-b", entries[0].RevID)
+	assert.Equal(t, "doc3", entries[1].DocID)
+	assert.Equal(t, "1-a", entries[1].RevID)
+	assert.Equal(t, uint8(0x14), entries[0].Flags)
+	assert.Equal(t, uint8(0x0), entries[1].Flags)
+
+	// Get changes in ABC channel with no limit and activeOnly true
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, true)
 	assert.Len(t, entries, 2)
 	assert.Equal(t, "doc2", entries[0].DocID)
@@ -634,7 +644,17 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	assert.Equal(t, "1-a", entries[1].RevID)
 	assert.Equal(t, uint8(0x0), entries[1].Flags)
 
-	// Issue channel query with limit and activeOnly false
+	// Get changes in star channel with no limit and activeOnly true
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 0, true)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "doc2", entries[0].DocID)
+	assert.Equal(t, "2-b", entries[0].RevID)
+	assert.Equal(t, uint8(0x14), entries[0].Flags)
+	assert.Equal(t, "doc3", entries[1].DocID)
+	assert.Equal(t, "1-a", entries[1].RevID)
+	assert.Equal(t, uint8(0x0), entries[1].Flags)
+
+	// Get changes in ABC channel with limit and activeOnly false
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 2, false)
 	assert.Len(t, entries, 2)
 	assert.Equal(t, "doc1", entries[0].DocID)
@@ -644,8 +664,31 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	assert.Equal(t, uint8(0x1), entries[0].Flags)
 	assert.Equal(t, uint8(0x14), entries[1].Flags)
 
-	// Issue channel query with no limit and activeOnly false
+	// Get changes in star channel with limit and activeOnly false
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 2, false)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "doc1", entries[0].DocID)
+	assert.Equal(t, "2-a", entries[0].RevID)
+	assert.Equal(t, "doc2", entries[1].DocID)
+	assert.Equal(t, "2-b", entries[1].RevID)
+	assert.Equal(t, uint8(0x1), entries[0].Flags)
+	assert.Equal(t, uint8(0x14), entries[1].Flags)
+
+	// Get changes in ABC channel with no limit and activeOnly false
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, false)
+	assert.Len(t, entries, 3)
+	assert.Equal(t, "doc1", entries[0].DocID)
+	assert.Equal(t, "2-a", entries[0].RevID)
+	assert.Equal(t, "doc2", entries[1].DocID)
+	assert.Equal(t, "2-b", entries[1].RevID)
+	assert.Equal(t, "doc3", entries[2].DocID)
+	assert.Equal(t, "1-a", entries[2].RevID)
+	assert.Equal(t, uint8(0x1), entries[0].Flags)
+	assert.Equal(t, uint8(0x14), entries[1].Flags)
+	assert.Equal(t, uint8(0x0), entries[2].Flags)
+
+	// Get changes in star channel with no limit and activeOnly false
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 0, false)
 	assert.Len(t, entries, 3)
 	assert.Equal(t, "doc1", entries[0].DocID)
 	assert.Equal(t, "2-a", entries[0].RevID)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -579,118 +579,175 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	var sequence = 1
-	seqLogEntries := make(map[int]LogEntry)
+	docIdFlagMap := make(map[string]uint8)
+	var startSeq, endSeq uint64
 	body := Body{"channels": []string{"ABC"}}
 
-	createDocs := func(name string, revs int) (startSeq, endSeq uint64) {
-		for i := 1; i <= revs; i++ {
-			body["version"] = "1-a"
-			id := name + strconv.Itoa(i)
-			doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
-			require.NoError(t, err, "Couldn't create document")
-			require.Equal(t, "1-a", revId)
-			seqLogEntries[sequence] = LogEntry{DocID: doc.ID, RevID: revId}
-			sequence++
-			if i == 1 {
-				startSeq = doc.Sequence
-			}
-			endSeq = doc.Sequence
-		}
-		delete(body, "version")
-		return startSeq, endSeq
-	}
-
-	deleteDocs := func(name string, revs int) (startSeq, endSeq uint64) {
-		for i := 1; i <= revs; i++ {
-			id := name + strconv.Itoa(i)
-			body[BodyDeleted] = true
-			doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
-			require.NoError(t, err, "Couldn't create document")
-			require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
-			seqLogEntries[sequence] = LogEntry{DocID: doc.ID, RevID: revId, Flags: uint8(0x1)}
-			sequence++
-			if i == 1 {
-				startSeq = doc.Sequence
-			}
-			endSeq = doc.Sequence
-		}
-		return startSeq, endSeq
-	}
-
-	checkDocs := func(entries LogEntries, sequence int) {
+	checkFlags := func(entries LogEntries) {
 		for _, entry := range entries {
-			assert.Equal(t, seqLogEntries[sequence].DocID, entry.DocID)
-			assert.Equal(t, seqLogEntries[sequence].RevID, entry.RevID)
-			assert.Equal(t, seqLogEntries[sequence].Flags, entry.Flags)
-			sequence++
+			assert.Equal(t, docIdFlagMap[entry.DocID], entry.Flags, "Flags mismatch for doc %v", entry.DocID)
 		}
 	}
 
-	// Create 10 active documents and 2 inactive documents.
-	startSeq, endSeq := createDocs("alice", 10)
-	_, endSeq = deleteDocs("alice", 2)
+	// Create 10 added documents
+	for i := 1; i <= 10; i++ {
+		id := "created" + strconv.Itoa(i)
+		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		require.NoError(t, err, "Couldn't create document")
+		require.Equal(t, "1-a", revId)
+		docIdFlagMap[doc.ID] = uint8(0x0)
+		if i == 1 {
+			startSeq = doc.Sequence
+		}
+		endSeq = doc.Sequence
+	}
+
+	// Create 10 deleted documents
+	for i := 1; i <= 10; i++ {
+		id := "deleted" + strconv.Itoa(i)
+		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		require.NoError(t, err, "Couldn't create document")
+		require.Equal(t, "1-a", revId)
+
+		body[BodyDeleted] = true
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create document")
+		require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
+
+		docIdFlagMap[doc.ID] = uint8(0x1) // 1 = Deleted(1)
+		endSeq = doc.Sequence
+	}
+
+	// Create 10 branched documents (two branches, one branch is tombstoned)
+	for i := 1; i <= 10; i++ {
+		body["sound"] = "meow"
+		id := "branched" + strconv.Itoa(i)
+		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		require.NoError(t, err, "Couldn't create document revision 1-a")
+		require.Equal(t, "1-a", revId)
+
+		body["sound"] = "bark"
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-b", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create revision 2-b")
+		require.Equal(t, "2-b", revId)
+
+		body["sound"] = "bleat"
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create revision 2-a")
+		require.Equal(t, "2-a", revId)
+
+		body[BodyDeleted] = true
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"3-a", "2-a"}, false)
+		require.NoError(t, err, "Couldn't create document")
+		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
+
+		docIdFlagMap[doc.ID] = uint8(0x14) // 20 = Branched (16) + Hidden(4)
+		endSeq = doc.Sequence
+	}
+
+	// Create 10 branched|deleted documents (two branches, both branches tombstoned)
+	for i := 1; i <= 10; i++ {
+		body["sound"] = "meow"
+		id := "branched|deleted" + strconv.Itoa(i)
+		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		require.NoError(t, err, "Couldn't create document revision 1-a")
+		require.Equal(t, "1-a", revId)
+
+		body["sound"] = "bark"
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-b", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create revision 2-b")
+		require.Equal(t, "2-b", revId)
+
+		body["sound"] = "bleat"
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create revision 2-a")
+		require.Equal(t, "2-a", revId)
+
+		body[BodyDeleted] = true
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"3-a", "2-a"}, false)
+		require.NoError(t, err, "Couldn't create document")
+		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
+
+		body[BodyDeleted] = true
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"3-b", "2-b"}, false)
+		require.NoError(t, err, "Couldn't create document")
+		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
+
+		docIdFlagMap[doc.ID] = uint8(0x11) // 17 = Branched (16) + Deleted(1)
+		endSeq = doc.Sequence
+	}
+
+	// Create 10 branched|conflict (two branched, neither branch tombstoned) documents
+	for i := 1; i <= 10; i++ {
+		body["sound"] = "meow"
+		id := "branched|conflict" + strconv.Itoa(i)
+		doc, revId, err := db.PutExistingRevWithBody(id, body, []string{"1-a"}, false)
+		require.NoError(t, err, "Couldn't create document revision 1-a")
+		require.Equal(t, "1-a", revId)
+
+		body["sound"] = "bark"
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-b", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create revision 2-b")
+		require.Equal(t, "2-b", revId)
+
+		body["sound"] = "bleat"
+		doc, revId, err = db.PutExistingRevWithBody(id, body, []string{"2-a", "1-a"}, false)
+		require.NoError(t, err, "Couldn't create revision 2-a")
+		require.Equal(t, "2-a", revId)
+
+		docIdFlagMap[doc.ID] = uint8(0x1c) // 28 = Branched(16) + Conflict(8) + Hidden(4)
+		endSeq = doc.Sequence
+	}
+
+	// At this point the bucket has 50 documents
+	// 30 active documents (10 created + 10 branched + 10 branched|conflict)
+	// 20 Deleted documents (10 deleted + 10 branched|deleted)
 
 	// Get changes from channel "ABC" with limit and activeOnly true
-	// 8 documents in channel "ABC" are active and 2 documents are inactive at this point.
-	// Retrieved active documents from channel "ABC" must be equal to limit.
-	limit := 4         // Set limit to retrieve only 4 documents
-	activeOnly := true // Set activeOnly to retrieve only active documents.
-	entries, err := db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, limit, activeOnly)
+	entries, err := db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 25, true)
 	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
-	require.Len(t, entries, limit)
-	checkDocs(entries, 3)
+	require.Len(t, entries, 25)
+	checkFlags(entries)
 
 	// Get changes from channel "*" with limit and activeOnly true
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, limit, activeOnly)
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 25, true)
 	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
-	require.Len(t, entries, limit)
-	checkDocs(entries, 3)
+	require.Len(t, entries, 25)
+	checkFlags(entries)
 
-	// Get changes from channel "ABC" without limit and activeOnly true.
-	// 8 documents in channel "ABC" are active and 2 documents are inactive at this point.
-	// All the active documents (8) should be retrieved from channel "ABC" when limit is 0.
-	limit = 0 // Set limit to retrieve all documents
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, limit, activeOnly)
-	require.NoError(t, err, "Couldn't query active docs from channel ABC without limit")
-	require.Len(t, entries, 8) // 8 active documents
-	checkDocs(entries, 3)
+	// Get changes from channel "ABC" without limit and activeOnly true
+	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, true)
+	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
+	require.Len(t, entries, 30)
+	checkFlags(entries)
 
-	// Get changes from channel "*" without limit and activeOnly true.
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, limit, activeOnly)
-	require.NoError(t, err, "Couldn't query active docs from channel * without limit")
-	require.Len(t, entries, 8) // 8 active documents
-	checkDocs(entries, 3)
+	// Get changes from channel "*" without limit and activeOnly true
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 0, true)
+	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
+	require.Len(t, entries, 30)
+	checkFlags(entries)
 
 	// Get changes from channel "ABC" with limit and activeOnly false
-	// 8 documents in channel "ABC" are active and 2 documents are inactive at this point.
-	// Retrieved active/inactive documents from channel "ABC" must be equal to limit.
-	limit = 6          // Set limit to retrieve only 6 documents
-	activeOnly = false // Set activeOnly to false to retrieve both active and inactive documents.
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 6, activeOnly)
-	require.NoError(t, err, "Couldn't query both active and inactive docs from channel ABC with limit")
-	require.Len(t, entries, limit) // 6 active/inactive documents
-	checkDocs(entries, 3)
+	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 45, false)
+	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
+	require.Len(t, entries, 45)
+	checkFlags(entries)
 
 	// Get changes from channel "*" with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 6, activeOnly)
-	require.NoError(t, err, "Couldn't query both active and inactive docs from channel * with limit")
-	require.Len(t, entries, limit) // 6 active/inactive documents
-	checkDocs(entries, 3)
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 45, false)
+	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
+	require.Len(t, entries, 45)
+	checkFlags(entries)
 
-	// Get changes from channel "ABC" with limit and activeOnly false
-	// 8 documents in channel "ABC" are active and 2 documents are inactive at this point.
-	// Retrieved active/inactive documents from channel "ABC" must be equal to limit.
-	limit = 0          // Set limit to retrieve all documents
-	activeOnly = false // Set activeOnly to false to retrieve both active and inactive documents.
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, limit, activeOnly)
-	require.NoError(t, err, "Couldn't query both active and inactive docs from channel ABC without limit")
-	require.Len(t, entries, 10) // 8 active + 2 inactive docs
-	checkDocs(entries, 3)
+	// Get changes from channel "ABC" without limit and activeOnly false
+	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, false)
+	require.NoError(t, err, "Couldn't query active docs from channel ABC with limit")
+	require.Len(t, entries, 50)
+	checkFlags(entries)
 
-	// Get changes from channel "*" with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, limit, activeOnly)
-	require.NoError(t, err, "Couldn't query both active and inactive docs from channel * without limit")
-	require.Len(t, entries, 10) // 8 active + 2 inactive docs
-	checkDocs(entries, 3)
+	// Get changes from channel "*" without limit and activeOnly true
+	entries, err = db.getChangesInChannelFromQuery("*", startSeq, endSeq, 0, false)
+	require.NoError(t, err, "Couldn't query active docs from channel * with limit")
+	require.Len(t, entries, 50)
+	checkFlags(entries)
 }

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -641,7 +641,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
-		docIdFlagMap[doc.ID] = channels.Branched + channels.Hidden // 20 = Branched (16) + Hidden(4)
+		docIdFlagMap[doc.ID] = channels.Branched | channels.Hidden // 20 = Branched (16) + Hidden(4)
 		endSeq = doc.Sequence
 	}
 
@@ -673,7 +673,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
 
-		docIdFlagMap[doc.ID] = channels.Branched + channels.Deleted // 17 = Branched (16) + Deleted(1)
+		docIdFlagMap[doc.ID] = channels.Branched | channels.Deleted // 17 = Branched (16) + Deleted(1)
 		endSeq = doc.Sequence
 	}
 
@@ -696,7 +696,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.Equal(t, "2-a", revId)
 
 		// 28 = Branched(16) + Conflict(8) + Hidden(4)
-		docIdFlagMap[doc.ID] = channels.Branched + channels.Conflict + channels.Hidden
+		docIdFlagMap[doc.ID] = channels.Branched | channels.Conflict | channels.Hidden
 		endSeq = doc.Sequence
 	}
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -611,7 +611,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	// Create doc3
 	body["name"] = "Emily"
 	doc, _, err = db.PutExistingRevWithBody("doc3", body, []string{"1-a"}, false)
-	require.NoError(t, err, "Couldn't create revision 2-a of doc3")
+	require.NoError(t, err, "Couldn't create revision 1-a of doc3")
 	endSeq := doc.Sequence
 
 	// Issue channel query with limit and activeOnly true
@@ -626,29 +626,23 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 
 	// Issue channel query with no limit and activeOnly true
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, true)
-	assert.Len(t, entries, 3)
-	assert.Equal(t, "doc1", entries[0].DocID)
-	assert.Equal(t, "2-a", entries[0].RevID)
-	assert.Equal(t, "doc2", entries[1].DocID)
-	assert.Equal(t, "2-b", entries[1].RevID)
-	assert.Equal(t, "doc3", entries[2].DocID)
-	assert.Equal(t, "1-a", entries[2].RevID)
-	assert.Equal(t, uint8(0x1), entries[0].Flags)
-	assert.Equal(t, uint8(0x14), entries[1].Flags)
-	assert.Equal(t, uint8(0x0), entries[2].Flags)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "doc2", entries[0].DocID)
+	assert.Equal(t, "2-b", entries[0].RevID)
+	assert.Equal(t, uint8(0x14), entries[0].Flags)
+	assert.Equal(t, "doc3", entries[1].DocID)
+	assert.Equal(t, "1-a", entries[1].RevID)
+	assert.Equal(t, uint8(0x0), entries[1].Flags)
 
 	// Issue channel query with limit and activeOnly false
-	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 3, false)
-	assert.Len(t, entries, 3)
+	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 2, false)
+	assert.Len(t, entries, 2)
 	assert.Equal(t, "doc1", entries[0].DocID)
 	assert.Equal(t, "2-a", entries[0].RevID)
 	assert.Equal(t, "doc2", entries[1].DocID)
 	assert.Equal(t, "2-b", entries[1].RevID)
-	assert.Equal(t, "doc3", entries[2].DocID)
-	assert.Equal(t, "1-a", entries[2].RevID)
 	assert.Equal(t, uint8(0x1), entries[0].Flags)
 	assert.Equal(t, uint8(0x14), entries[1].Flags)
-	assert.Equal(t, uint8(0x0), entries[2].Flags)
 
 	// Issue channel query with no limit and activeOnly false
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, false)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -579,25 +579,34 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 	defer testBucket.Close()
 	defer tearDownTestDB(t, db)
 
-	// Create doc1  and mark it as tombstone
+	// Create doc1, revision 1-a
 	body := Body{"channels": []string{"ABC"}, "name": "Alice"}
 	doc, _, err := db.PutExistingRevWithBody("doc1", body, []string{"1-a"}, false)
 	require.NoError(t, err, "Couldn't create document")
 	startSeq := doc.Sequence
+
+	// Tombstone doc1, revision 2-a
 	body[BodyDeleted] = true
 	doc, _, err = db.PutExistingRevWithBody("doc1", body, []string{"2-a", "1-a"}, false)
 	require.NoError(t, err, "Couldn't create document")
 
-	// Create doc2 with two conflicting changes:
+	// Create doc2 and two conflicting changes:
 	body["name"] = "Bob"
 	_, _, err = db.PutExistingRevWithBody("doc2", body, []string{"1-a"}, false)
 	require.NoError(t, err, "Couldn't create document")
+
 	body["name"] = "Owen"
 	_, _, err = db.PutExistingRevWithBody("doc2", body, []string{"2-b", "1-a"}, false)
 	require.NoError(t, err, "Couldn't create revision 2-b of doc2")
+
 	body["name"] = "Chloe"
 	_, _, err = db.PutExistingRevWithBody("doc2", body, []string{"2-a", "1-a"}, false)
 	require.NoError(t, err, "Couldn't create revision 2-a of doc2")
+
+	// Tombstone the non-winning branch of a conflicted document
+	body[BodyDeleted] = true
+	_, _, err = db.PutExistingRevWithBody("doc2", body, []string{"3-a", "2-a"}, false)
+	assert.NoError(t, err, "Add 3-a (tombstone)")
 
 	// Create doc3
 	body["name"] = "Emily"
@@ -607,11 +616,11 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 
 	// Issue channel query with limit and activeOnly true
 	entries, err := db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 2, true)
-	assert.Len(t, entries, 2)
+	assert.Len(t, entries, 1)
 
 	// Issue channel query with no limit and activeOnly true
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, true)
-	assert.Len(t, entries, 2)
+	assert.Len(t, entries, 3)
 
 	// Issue channel query with limit and activeOnly false
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 3, false)

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -614,7 +614,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "2-a", revId, "Couldn't create tombstone revision")
 
-		docIdFlagMap[doc.ID] = uint8(0x1) // 1 = Deleted(1)
+		docIdFlagMap[doc.ID] = channels.Deleted // 1 = Deleted(1)
 		endSeq = doc.Sequence
 	}
 
@@ -641,7 +641,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-a", revId, "Couldn't create tombstone revision")
 
-		docIdFlagMap[doc.ID] = uint8(0x14) // 20 = Branched (16) + Hidden(4)
+		docIdFlagMap[doc.ID] = channels.Branched + channels.Hidden // 20 = Branched (16) + Hidden(4)
 		endSeq = doc.Sequence
 	}
 
@@ -673,7 +673,7 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.NoError(t, err, "Couldn't create document")
 		require.Equal(t, "3-b", revId, "Couldn't create tombstone revision")
 
-		docIdFlagMap[doc.ID] = uint8(0x11) // 17 = Branched (16) + Deleted(1)
+		docIdFlagMap[doc.ID] = channels.Branched + channels.Deleted // 17 = Branched (16) + Deleted(1)
 		endSeq = doc.Sequence
 	}
 
@@ -695,7 +695,8 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		require.NoError(t, err, "Couldn't create revision 2-a")
 		require.Equal(t, "2-a", revId)
 
-		docIdFlagMap[doc.ID] = uint8(0x1c) // 28 = Branched(16) + Conflict(8) + Hidden(4)
+		// 28 = Branched(16) + Conflict(8) + Hidden(4)
+		docIdFlagMap[doc.ID] = channels.Branched + channels.Conflict + channels.Hidden
 		endSeq = doc.Sequence
 	}
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -616,17 +616,50 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 
 	// Issue channel query with limit and activeOnly true
 	entries, err := db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 2, true)
-	assert.Len(t, entries, 1)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "doc2", entries[0].DocID)
+	assert.Equal(t, "2-b", entries[0].RevID)
+	assert.Equal(t, "doc3", entries[1].DocID)
+	assert.Equal(t, "1-a", entries[1].RevID)
+	assert.Equal(t, uint8(0x14), entries[0].Flags)
+	assert.Equal(t, uint8(0x0), entries[1].Flags)
 
 	// Issue channel query with no limit and activeOnly true
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, true)
 	assert.Len(t, entries, 3)
+	assert.Equal(t, "doc1", entries[0].DocID)
+	assert.Equal(t, "2-a", entries[0].RevID)
+	assert.Equal(t, "doc2", entries[1].DocID)
+	assert.Equal(t, "2-b", entries[1].RevID)
+	assert.Equal(t, "doc3", entries[2].DocID)
+	assert.Equal(t, "1-a", entries[2].RevID)
+	assert.Equal(t, uint8(0x1), entries[0].Flags)
+	assert.Equal(t, uint8(0x14), entries[1].Flags)
+	assert.Equal(t, uint8(0x0), entries[2].Flags)
 
 	// Issue channel query with limit and activeOnly false
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 3, false)
 	assert.Len(t, entries, 3)
+	assert.Equal(t, "doc1", entries[0].DocID)
+	assert.Equal(t, "2-a", entries[0].RevID)
+	assert.Equal(t, "doc2", entries[1].DocID)
+	assert.Equal(t, "2-b", entries[1].RevID)
+	assert.Equal(t, "doc3", entries[2].DocID)
+	assert.Equal(t, "1-a", entries[2].RevID)
+	assert.Equal(t, uint8(0x1), entries[0].Flags)
+	assert.Equal(t, uint8(0x14), entries[1].Flags)
+	assert.Equal(t, uint8(0x0), entries[2].Flags)
 
 	// Issue channel query with no limit and activeOnly false
 	entries, err = db.getChangesInChannelFromQuery("ABC", startSeq, endSeq, 0, false)
 	assert.Len(t, entries, 3)
+	assert.Equal(t, "doc1", entries[0].DocID)
+	assert.Equal(t, "2-a", entries[0].RevID)
+	assert.Equal(t, "doc2", entries[1].DocID)
+	assert.Equal(t, "2-b", entries[1].RevID)
+	assert.Equal(t, "doc3", entries[2].DocID)
+	assert.Equal(t, "1-a", entries[2].RevID)
+	assert.Equal(t, uint8(0x1), entries[0].Flags)
+	assert.Equal(t, uint8(0x14), entries[1].Flags)
+	assert.Equal(t, uint8(0x0), entries[2].Flags)
 }

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -23,7 +23,8 @@ func WaitForIndexEmpty(bucket *base.CouchbaseBucketGoCB, useXattrs bool) error {
 
 		// Create the star channel query
 		statement := fmt.Sprintf("%s LIMIT 1", QueryStarChannel.statement) // append LIMIT 1 since we only care if there are any results or not
-		starChannelQueryStatement := replaceSyncTokensQuery(statement, useXattrs)
+		starChannelQueryStatement := replaceActiveOnlyFilter(statement, false)
+		starChannelQueryStatement = replaceSyncTokensQuery(starChannelQueryStatement, useXattrs)
 		starChannelQueryStatement = replaceIndexTokensQuery(starChannelQueryStatement, sgIndexes[IndexAllDocs], useXattrs)
 		params := map[string]interface{}{}
 		params[QueryParamStartSeq] = 0


### PR DESCRIPTION
Added an additional channel query definition for changes feed request with active-only and limit options. This statement only selects the active entries and can be used in buildChannelsQuery while building the statement based on the value of activeOnly parameter.