### PR TITLE
CBG-743 - Fix _deleted=false property appearing in sync function doc body

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1226,7 +1226,9 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 
 	syncFnBody[BodyId] = doc.ID
 	syncFnBody[BodyRev] = newRevID
-	syncFnBody[BodyDeleted] = newDoc.Deleted
+	if newDoc.Deleted {
+		syncFnBody[BodyDeleted] = true
+	}
 
 	syncExpiry, oldBodyJSON, channelSet, access, roles, err := db.runSyncFn(doc, syncFnBody, newRevID)
 	if err != nil {


### PR DESCRIPTION
- Reworked `TestSyncFnBodyProperties` to exactly match ALL properties in the doc, not just the ones we expect.
- Fixed `_deleted=false` appearing in sync function doc bodies.