### PR TITLE
CBG-688: Change gocbcore to latest revision which returns error originated from a x509

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -38,7 +38,7 @@
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
   <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="9903e427e0c7cc786dd4fe8efad15db3a338bd06" />
 
-  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="45bfb9040dc54c0344f8182b5ae527cc88db2dac"/>
+  <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="6d89e4508941884e4d27e2ead8e074ef9885e9f8"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1916,9 +1916,8 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 // - Reply to all changes saying all docs are wanted
 // - Wait to receive rev messages for all 5 docs
 //   - Expected: receive all 5 docs (4 revs and 1 norev)
-//   - Actual: only recieve 4 docs (4 revs)
+//   - Actual: only receive 4 docs (4 revs)
 func TestMissingNoRev(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, nil)
 	btSpec := BlipTesterSpec{
 		restTester: rt,
@@ -1943,7 +1942,7 @@ func TestMissingNoRev(t *testing.T) {
 	targetDb, err := db.GetDatabase(targetDbContext, nil)
 	assert.NoError(t, err, "failed")
 
-	// Make sure all 5 docs can be pulled
+	// Pull docs, expect to pull 5 docs since none of them has purged yet.
 	docs := bt.WaitForNumDocsViaChanges(5)
 	goassert.True(t, len(docs) == 5)
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1943,6 +1943,10 @@ func TestMissingNoRev(t *testing.T) {
 	targetDb, err := db.GetDatabase(targetDbContext, nil)
 	assert.NoError(t, err, "failed")
 
+	// Make sure all 5 docs can be pulled
+	docs := bt.WaitForNumDocsViaChanges(5)
+	goassert.True(t, len(docs) == 5)
+
 	// Purge one doc
 	doc0Id := fmt.Sprintf("doc-%d", 0)
 	err = targetDb.Purge(doc0Id)
@@ -1952,9 +1956,8 @@ func TestMissingNoRev(t *testing.T) {
 	targetDb.FlushRevisionCacheForTest()
 
 	// Pull docs, expect to pull 4 since one was purged.  (also expect to NOT get stuck)
-	docs := bt.WaitForNumDocsViaChanges(4)
+	docs = bt.WaitForNumDocsViaChanges(4)
 	goassert.True(t, len(docs) == 4)
-
 }
 
 // TestBlipDeltaSyncPull tests that a simple pull replication uses deltas in EE,

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1918,7 +1918,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 //   - Expected: receive all 5 docs (4 revs and 1 norev)
 //   - Actual: only recieve 4 docs (4 revs)
 func TestMissingNoRev(t *testing.T) {
-
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, nil)
 	btSpec := BlipTesterSpec{
 		restTester: rt,


### PR DESCRIPTION


https://github.com/couchbase/gocbcore/commit/6d89e4508941884e4d27e2ead8e074ef9885e9f8