### PR TITLE
CBG-755 - Disable tests that were creating indexes e.g: 'testIndex_value'

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -17,6 +17,9 @@ var testN1qlOptions = &N1qlIndexOptions{
 
 func TestN1qlQuery(t *testing.T) {
 
+	// Disabled due to CBG-755:
+	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
+
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
@@ -122,6 +125,9 @@ func TestN1qlQuery(t *testing.T) {
 
 func TestN1qlFilterExpression(t *testing.T) {
 
+	// Disabled due to CBG-755:
+	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
+
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
@@ -195,6 +201,10 @@ func TestN1qlFilterExpression(t *testing.T) {
 
 // Test index state retrieval
 func TestIndexMeta(t *testing.T) {
+
+	// Disabled due to CBG-755:
+	t.Skip("WARNING: TEST DISABLED - the testIndex_value creation is causing issues with CB 6.5.0")
+
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}


### PR DESCRIPTION
https://issues.couchbase.com/browse/MB-37622 

Skipping tests that create indexes. It seems to be causing problems when buckets are being flushed in CBS 6.5.0

- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/176/