### PR TITLE
Fix incorrect cbbuild revision for 2.7.2 and 2.7.1

### DIFF
--- a/manifest/2.7.xml
+++ b/manifest/2.7.xml
@@ -13,7 +13,7 @@
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
-    <project name="build" path="cbbuild" remote="couchbase" revision="a08bf70a05fc5b94e62c6aa2d349d3f1e261f1cc">
+    <project name="build" path="cbbuild" remote="couchbase" revision="6b173f045016bf510d6d2076c97fb54d7df01a69">
         <annotation name="VERSION" value="2.7.2"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>

--- a/manifest/2.7/2.7.1.xml
+++ b/manifest/2.7/2.7.1.xml
@@ -13,7 +13,7 @@
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
-    <project name="build" path="cbbuild" remote="couchbase" revision="a08bf70a05fc5b94e62c6aa2d349d3f1e261f1cc">
+    <project name="build" path="cbbuild" remote="couchbase" revision="6b173f045016bf510d6d2076c97fb54d7df01a69">
         <annotation name="VERSION" value="2.7.1"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
The old revision was somehow a Sync Gateway commit hash.
This is the intended build revision from 2.7.1-5