### PR TITLE
CBG-701: Added context and changed logging

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -564,7 +564,7 @@ func (h *handler) handleSGCollect() error {
 
 	zipFilename := sgcollectFilename()
 
-	if err := sgcollectInstance.Start(zipFilename, params); err != nil {
+	if err := sgcollectInstance.Start(h.serialNumber, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3283,7 +3283,7 @@ func WriteDirectWithKey(testDb *db.DatabaseContext, key string, channelArray []s
 	syncData.TimeSaved = time.Now()
 	//syncData := fmt.Sprintf(`{"rev":"%s", "sequence":%d, "channels":%s, "TimeSaved":"%s"}`, rev, sequence, chanMap, time.Now())
 
-	_, err = testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
+	_, err := testDb.Bucket.Add(key, 0, db.Body{base.SyncPropertyName: syncData, "key": key})
 	if err != nil {
 		base.Panicf("Error while add ket to bucket: %v", err)
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -1143,7 +1143,8 @@ func ServerMain() {
 
 	var unknownFieldsErr error
 
-	config, err := ParseCommandLine(os.Args, flag.ExitOnError)
+	var err error
+	config, err = ParseCommandLine(os.Args, flag.ExitOnError)
 	if errors.Cause(err) == ErrUnknownField {
 		unknownFieldsErr = err
 	} else if err != nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1143,7 +1143,7 @@ func ServerMain() {
 
 	var unknownFieldsErr error
 
-	config, err = ParseCommandLine(os.Args, flag.ExitOnError)
+	config, err := ParseCommandLine(os.Args, flag.ExitOnError)
 	if errors.Cause(err) == ErrUnknownField {
 		unknownFieldsErr = err
 	} else if err != nil {

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -28,12 +28,12 @@ var (
 
 	validateTicketPattern = regexp.MustCompile(`\d{1,7}`)
 
-	sgPath, sgCollectPath, err = sgCollectPaths()
-	sgcollectInstance          = sgCollect{
+	sgPath, sgCollectPath, sgCollectPathErr = sgCollectPaths()
+	sgcollectInstance                       = sgCollect{
 		status:        base.Uint32Ptr(sgStopped),
 		sgPath:        sgPath,
 		sgCollectPath: sgCollectPath,
-		pathError:     err,
+		pathError:     sgCollectPathErr,
 	}
 )
 

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -84,11 +86,9 @@ func (sg *sgCollect) Start(zipFilename string, params sgCollectOptions) error {
 	args = append(args, "--sync-gateway-executable", sgPath)
 	args = append(args, zipPath)
 
-	sg.context = context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: base.NewTaskID("Something", "Something")})
+	sg.context = context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: fmt.Sprintf("SGCollect-%s", strconv.Itoa(rand.Intn(65536)))})
 
-	var cancelFunc context.CancelFunc
-	sg.context, cancelFunc = context.WithCancel(sg.context)
-	sg.cancel = cancelFunc
+	sg.context, sg.cancel = context.WithCancel(sg.context)
 	cmd := exec.CommandContext(sg.context, sgCollectPath, args...)
 
 	// Send command stderr/stdout to pipes


### PR DESCRIPTION
- Add HTTP context ID to sgcollect logging
- Fixed erroneous error return in sgcollect.go.
- Renamed global `err` global error introduced in sgcollect.go. 