### PR TITLE
CBG-716: Fail on unknown fields on config PUT

### DIFF
--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -874,4 +875,12 @@ func TestParseCommandLineWithIllegalOptionBucket(t *testing.T) {
 	config, err := ParseCommandLine(args, flag.ContinueOnError)
 	assert.Error(t, err, "Parsing commandline arguments without any config file")
 	assert.Empty(t, config, "Couldn't parse commandline arguments")
+}
+
+func TestPutInvalidConfig(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	response := rt.SendAdminRequest("PUT", "/db/_config", `{"db": {"server": "walrus"}}`)
+	assert.Equal(t, http.StatusBadRequest, response.Code)
 }

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -48,6 +48,7 @@ func ReadJSONFromMIME(headers http.Header, input io.ReadCloser, into interface{}
 	}
 
 	decoder := base.JSONDecoder(input)
+	decoder.DisallowUnknownFields()
 	decoder.UseNumber()
 	err := decoder.Decode(into)
 	if err != nil {

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -28,14 +28,14 @@ func TestDesignDocs(t *testing.T) {
 
 	response := rt.SendRequest(http.MethodGet, "/db/_design/foo", "")
 	assertStatus(t, response, http.StatusForbidden)
-	response = rt.SendRequest(http.MethodPut, "/db/_design/foo", `{"prop":true}`)
+	response = rt.SendRequest(http.MethodPut, "/db/_design/foo", `{}`)
 	assertStatus(t, response, http.StatusForbidden)
 	response = rt.SendRequest(http.MethodDelete, "/db/_design/foo", "")
 	assertStatus(t, response, http.StatusForbidden)
 
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo", "")
 	assertStatus(t, response, http.StatusNotFound)
-	response = rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"prop":true}`)
+	response = rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{}`)
 	assertStatus(t, response, http.StatusCreated)
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_design/foo", "")
 


### PR DESCRIPTION
Added disallow unknown fields to JSON decoder used for updating config and other use cases.
This required adapting a couple of tests which were putting fields which don't actually exist on the destination struct.