### PR TITLE
CBG-758: Reliably flush to console on Fatalf

### DIFF
--- a/base/logger.go
+++ b/base/logger.go
@@ -24,6 +24,7 @@ func FlushLogBuffers() {
 
 	for _, logger := range loggers {
 		if logger != nil && cap(logger.collateBuffer) > 1 {
+			logger.collateBufferWg.Wait()
 			flushLogBuffersWaitGroup.Add(1)
 			logger.flushChan <- struct{}{}
 		}
@@ -34,7 +35,7 @@ func FlushLogBuffers() {
 
 // logCollationWorker will take log lines over the given channel, and buffer them until either the buffer is full, or the flushTimeout is exceeded.
 // This is to reduce the number of writes to the log files, in order to batch them up as larger collated chunks, whilst maintaining a low-level of latency with the flush timeout.
-func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
+func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, collageBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
 
 	// The initial duration of the timeout timer doesn't matter,
 	// because we reset it whenever we buffer a log without flushing it.
@@ -45,6 +46,7 @@ func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, logg
 		select {
 		case l := <-collateBuffer:
 			logBuffer = append(logBuffer, l)
+			collageBufferWg.Done()
 			if len(logBuffer) >= maxBufferSize {
 				// Flush if the buffer is full after this log
 				logger.Print(strings.Join(logBuffer, "\n"))

--- a/base/logger.go
+++ b/base/logger.go
@@ -35,7 +35,7 @@ func FlushLogBuffers() {
 
 // logCollationWorker will take log lines over the given channel, and buffer them until either the buffer is full, or the flushTimeout is exceeded.
 // This is to reduce the number of writes to the log files, in order to batch them up as larger collated chunks, whilst maintaining a low-level of latency with the flush timeout.
-func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, collageBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
+func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, collateBufferWg *sync.WaitGroup, logger *log.Logger, maxBufferSize int, collateFlushTimeout time.Duration) {
 
 	// The initial duration of the timeout timer doesn't matter,
 	// because we reset it whenever we buffer a log without flushing it.
@@ -46,7 +46,7 @@ func logCollationWorker(collateBuffer chan string, flushChan chan struct{}, coll
 		select {
 		case l := <-collateBuffer:
 			logBuffer = append(logBuffer, l)
-			collageBufferWg.Done()
+			collateBufferWg.Done()
 			if len(logBuffer) >= maxBufferSize {
 				// Flush if the buffer is full after this log
 				logger.Print(strings.Join(logBuffer, "\n"))

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 
 	"github.com/natefinch/lumberjack"
 )
@@ -59,9 +60,10 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 	if *config.CollationBufferSize > 1 {
 		logger.collateBuffer = make(chan string, *config.CollationBufferSize)
 		logger.flushChan = make(chan struct{}, 1)
+		logger.collateBufferWg = &sync.WaitGroup{}
 
 		// Start up a single worker to consume messages from the buffer
-		go logCollationWorker(logger.collateBuffer, logger.flushChan, &logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
+		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
 	}
 
 	if *config.Enabled {

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -61,7 +61,7 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 		logger.flushChan = make(chan struct{}, 1)
 
 		// Start up a single worker to consume messages from the buffer
-		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
+		go logCollationWorker(logger.collateBuffer, logger.flushChan, &logger.collateBufferWg, logger.logger, *config.CollationBufferSize, consoleLoggerCollateFlushTimeout)
 	}
 
 	if *config.Enabled {
@@ -84,6 +84,7 @@ func NewConsoleLogger(config *ConsoleLoggerConfig) (*ConsoleLogger, []DeferredLo
 
 func (l *ConsoleLogger) logf(format string, args ...interface{}) {
 	if l.collateBuffer != nil {
+		l.collateBufferWg.Add(1)
 		l.collateBuffer <- fmt.Sprintf(format, args...)
 	} else {
 		l.logger.Printf(format, args...)

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/natefinch/lumberjack"
@@ -35,12 +36,13 @@ type FileLogger struct {
 	Enabled bool
 
 	// collateBuffer is used to store log entries to batch up multiple logs.
-	collateBuffer chan string
-	flushChan     chan struct{}
-	level         LogLevel
-	name          string
-	output        io.Writer
-	logger        *log.Logger
+	collateBuffer   chan string
+	collateBufferWg sync.WaitGroup
+	flushChan       chan struct{}
+	level           LogLevel
+	name            string
+	output          io.Writer
+	logger          *log.Logger
 }
 
 type FileLoggerConfig struct {
@@ -80,7 +82,7 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFile
 		logger.flushChan = make(chan struct{}, 1)
 
 		// Start up a single worker to consume messages from the buffer
-		go logCollationWorker(logger.collateBuffer, logger.flushChan, logger.logger, *config.CollationBufferSize, fileLoggerCollateFlushTimeout)
+		go logCollationWorker(logger.collateBuffer, logger.flushChan, &logger.collateBufferWg, logger.logger, *config.CollationBufferSize, fileLoggerCollateFlushTimeout)
 	}
 
 	return logger, nil
@@ -107,6 +109,7 @@ func (l FileLogger) String() string {
 // otherwise will log the message directly.
 func (l *FileLogger) logf(format string, args ...interface{}) {
 	if l.collateBuffer != nil {
+		l.collateBufferWg.Add(1)
 		l.collateBuffer <- fmt.Sprintf(format, args...)
 	} else {
 		l.logger.Printf(format, args...)


### PR DESCRIPTION
Appears that the issue of unreliable flushing to console was due to the fact that when adding a message to the buffer the data may not be sent through the channel before a flush is run. 
Solution is to add a wait group to ensure data sent through the channel is successfully appended before flushing.