### PR TITLE
CBG-738: Support use of cacert without certpath/keypath for DCP bootstrap

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -443,14 +443,16 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 
 	// If using client certificate for authentication, configure go-couchbase for cbdatasource's initial
 	// connection to retrieve cluster configuration.
-	if spec.Certpath != "" {
+	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
+		// TODO: x.509 not supported for cbgt with cbdatasource until cbAuth supports
+		// a way to use NoPasswordAuthHandler, and custom options.Connect
+		// auth = NoPasswordAuthHandler{handler: spec.Auth}
+	}
+	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
-		// TODO: x.509 not supported for cbgt with cbdatasource until cbAuth supports
-		//    a way to use NoPasswordAuthHandler, and custom options.Connect
-		//auth = NoPasswordAuthHandler{handler: spec.Auth}
 	}
 
 	// If using TLS, pass a custom connect method to support using TLS for cbdatasource's memcached connections

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -282,12 +282,14 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 
 	// If using client certificate for authentication, configure go-couchbase for cbdatasource's initial
 	// connection to retrieve cluster configuration.
-	if spec.Certpath != "" {
+	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
+		auth = NoPasswordAuthHandler{handler: spec.Auth}
+	}
+	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
-		auth = NoPasswordAuthHandler{handler: spec.Auth}
 	}
 
 	if spec.IsTLS() {

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -126,9 +126,11 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 	InfofCtx(c.Cfg.loggingCtx, KeyDCP, "Creating cbgt index %q for db %q", indexName, MD(dbName))
 
 	// Required for initial pools request, before BucketDataSourceOptions kick in
-	if spec.Certpath != "" {
+	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
+	}
+	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
 	}


### PR DESCRIPTION
During DCP setup, SG/cbdatasource makes an initial bucket connection, then opens the DCP streams. The initial bucket connection only specifies the cacert if an x.509 cert is also specified (certpath/keypath). If a certpath isn't specified, the cacert isn't provided, and InsecureSkipVerify is set to true. However, the subsequent 'open stream' requests use the cacert and set InsecureSkipVerify=false, even if certpath/keypath isn't specified. The initial bootstrap should be fixed to use the same approach and change needs to be applied at the below three places:

1. While creating CBGT index definitions for the specified buckets
**createCBGTIndex**: https://github.com/couchbase/sync_gateway/blob/master/base/dcp_sharded.go#L129

2. While starting the DCP feed
**StartDCPFeed**: https://github.com/couchbase/sync_gateway/blob/master/base/dcp_receiver.go#L285
**StartCbgtCbdatasourceFeed**: https://github.com/couchbase/sync_gateway/blob/master/base/dcp_dest.go#L446
