### PR TITLE
CBG-752: SGCollect avoid unnecessary unzip

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -327,8 +327,10 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
                 # As long as a task that monitors this log file path has not already been added, add a new task
                 if log_file_item_path not in sg_log_file_paths:
+                    print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
+                    # If we're redacting a gzipped log file, we'll need to extract, redact and recompress it.
+                    # If we're not redacting, we can skip extraction entirely, and use the existing .gz log file.
                     if should_redact:
-                        print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
                         task = add_gzip_file_task(sourcefile_path=log_file_item_path, salt=salt)
                         sg_tasks.append(task)
                     else:

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -206,7 +206,7 @@ def extract_element_from_logging_config(element, config):
             return
 
 
-def make_collect_logs_tasks(zip_dir, sg_url, salt):
+def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
 
     sg_log_files = {
         "sg_error.log": "sg_error.log",
@@ -327,9 +327,13 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
                 # As long as a task that monitors this log file path has not already been added, add a new task
                 if log_file_item_path not in sg_log_file_paths:
-                    print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
-                    task = add_gzip_file_task(sourcefile_path=log_file_item_path, salt=salt)
-                    sg_tasks.append(task)
+                    if should_redact:
+                        print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
+                        task = add_gzip_file_task(sourcefile_path=log_file_item_path, salt=salt)
+                        sg_tasks.append(task)
+                    else:
+                        task = add_file_task(sourcefile_path=log_file_item_path)
+                        sg_tasks.append(task)
 
                 # Track which log file paths have been added so far
                 sg_log_file_paths[log_file_item_path] = log_file_item_path
@@ -481,7 +485,7 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
         sg_binary_path = sync_gateway_executable_path
 
     # Collect logs
-    collect_logs_tasks = make_collect_logs_tasks(zip_dir, sg_url, salt)
+    collect_logs_tasks = make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact)
 
     py_expvar_task = make_download_expvars_task(sg_url)
 


### PR DESCRIPTION
When running sgcollect we open each rotated log file, redact and zip it again. When we don't redact this is wasted work and used a little more ram to store the extracted file.
This avoids opening the file when unnecessary 