### PR TITLE
CBG-800: OnDemandImportForWrite migrate handling

### DIFF
--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -105,6 +105,12 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, ca
 	defer b.log(time.Now(), k, xattr, exp, cas)
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
+
+func (b *LoggingBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) {
+	defer b.log(time.Now(), k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
+	return b.bucket.WriteWithXattr(k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
+}
+
 func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	defer b.log(time.Now(), k, xattr, exp)
 	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1420,6 +1420,12 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			if doc, err = unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll); err != nil {
 				return
 			}
+
+			// Check whether Sync Data originated in body
+			if currentXattr == nil && bytes.Contains(currentValue, []byte(base.SyncPropertyName)) {
+				doc.inlineSyncData = true
+			}
+
 			docExists := currentValue != nil
 			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1422,7 +1422,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 
 			// Check whether Sync Data originated in body
-			if currentXattr == nil && bytes.Contains(currentValue, []byte(base.SyncPropertyName)) {
+			if currentXattr == nil && bytes.Contains(currentValue, []byte(`"`+base.SyncPropertyName+`":`)) {
 				doc.inlineSyncData = true
 			}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1422,7 +1422,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 
 			// Check whether Sync Data originated in body
-			if currentXattr == nil && bytes.Contains(currentValue, []byte(`"`+base.SyncPropertyName+`":`)) {
+			if currentXattr == nil && doc.Sequence > 0 {
 				doc.inlineSyncData = true
 			}
 

--- a/db/document.go
+++ b/db/document.go
@@ -335,9 +335,6 @@ func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas
 	if xattrData == nil || len(xattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		doc = NewDocument(docid)
 		err = doc.UnmarshalWithXattr(data, xattrData, unmarshalLevel)

--- a/db/document.go
+++ b/db/document.go
@@ -156,11 +156,11 @@ type Document struct {
 	ID       string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
 	Cas      uint64 // Document cas
 
-	Deleted           bool
-	DocExpiry         uint32
-	RevID             string
-	DocAttachments    AttachmentsMeta
-	migrationRequired bool
+	Deleted        bool
+	DocExpiry      uint32
+	RevID          string
+	DocAttachments AttachmentsMeta
+	inlineSyncData bool
 }
 
 type revOnlySyncData struct {
@@ -335,7 +335,9 @@ func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas
 	if xattrData == nil || len(xattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
-		doc.migrationRequired = true
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		doc = NewDocument(docid)
 		err = doc.UnmarshalWithXattr(data, xattrData, unmarshalLevel)

--- a/db/document.go
+++ b/db/document.go
@@ -156,10 +156,11 @@ type Document struct {
 	ID       string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
 	Cas      uint64 // Document cas
 
-	Deleted        bool
-	DocExpiry      uint32
-	RevID          string
-	DocAttachments AttachmentsMeta
+	Deleted           bool
+	DocExpiry         uint32
+	RevID             string
+	DocAttachments    AttachmentsMeta
+	migrationRequired bool
 }
 
 type revOnlySyncData struct {
@@ -334,6 +335,7 @@ func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas
 	if xattrData == nil || len(xattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
 		doc, err = unmarshalDocument(docid, data)
+		doc.migrationRequired = true
 	} else {
 		doc = NewDocument(docid)
 		err = doc.UnmarshalWithXattr(data, xattrData, unmarshalLevel)

--- a/db/import.go
+++ b/db/import.go
@@ -92,9 +92,10 @@ func (db *Database) ImportDoc(docid string, existingDoc *Document, isDelete bool
 		existingBucketDoc.Xattr = nil
 	} else {
 		existingBucketDoc.Body, existingBucketDoc.Xattr, err = existingDoc.MarshalWithXattr()
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return db.importDoc(docid, existingDoc.Body(), isDelete, existingBucketDoc, mode)

--- a/db/import.go
+++ b/db/import.go
@@ -164,7 +164,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		// If the existing doc is a legacy SG write (_sync in body), check for migrate instead of import.
 		_, ok := body[base.SyncPropertyName]
 		// Also check for sync data in existingDoc body as some routes end with sync data being extracted from body
-		hasSyncInBody := bytes.Contains(existingDoc.Body, []byte(base.SyncPropertyName))
+		hasSyncInBody := bytes.Contains(existingDoc.Body, []byte(`"`+base.SyncPropertyName+`":`))
 		if ok || hasSyncInBody {
 			migratedDoc, requiresImport, migrateErr := db.migrateMetadata(newDoc.ID, body, existingDoc)
 			if migrateErr != nil {

--- a/db/import.go
+++ b/db/import.go
@@ -157,9 +157,13 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 				}
 
 				if doc.inlineSyncData {
-					existingDoc.Body, _ = doc.MarshalBodyAndSync()
+					existingDoc.Body, err = doc.MarshalBodyAndSync()
 				} else {
-					existingDoc.Body, _ = doc.BodyBytes()
+					existingDoc.Body, err = doc.BodyBytes()
+				}
+
+				if err != nil {
+					return nil, nil, nil, err
 				}
 
 				updatedExpiry = &expiry

--- a/db/import.go
+++ b/db/import.go
@@ -169,6 +169,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 		// If the existing doc is a legacy SG write (_sync in body), check for migrate instead of import.
 		_, ok := body[base.SyncPropertyName]
+		fmt.Println("HERE")
 		if ok || doc.inlineSyncData {
 			migratedDoc, requiresImport, migrateErr := db.migrateMetadata(newDoc.ID, body, existingDoc)
 			if migrateErr != nil {

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -120,7 +120,7 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 		{
 			docBody:            rawDocWithSyncMeta(),
 			name:               "rawDocWithSyncMeta",
-			expectedGeneration: 2,
+			expectedGeneration: 1,
 		},
 	}
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a1d64f496b6e469c63d8255a1bee912d3b38306a"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="74d1ca0181faec13d8c00e9cde9ca6252abb31d0"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="a607992c96b97bd6006c418a95b1ee0bd6e3811f"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f498114d1a734c2a12b7a9f6067e578214bf4c1a"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="4fcdd6de819f62027659065cdf48a4a4ce2d19ee"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="a1d64f496b6e469c63d8255a1bee912d3b38306a"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="2eb20fb123c5bda3222aa4c9c26df5f7af4fc8ea"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="a607992c96b97bd6006c418a95b1ee0bd6e3811f"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1194,7 +1194,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1541,6 +1541,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			goassert.True(t, expiry > 0)
 			log.Printf("expiry: %v", expiry)
 			goassert.True(t, expiry == uint32(syncMetaExpiry.Unix()))
+
 		})
 	}
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1194,7 +1194,7 @@ func TestCheckForUpgradeFeed(t *testing.T) {
 	defer rt.Close()
 	bucket := rt.Bucket()
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyCache)()
 
 	// Write doc in SG format (doc + xattr) directly to the bucket
 	key := "TestCheckForUpgrade"

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1501,7 +1501,7 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 		{
 			onDemandCallback:      triggerOnDemandViaWrite,
 			name:                  "triggerOnDemandViaWrite",
-			expectedRevGeneration: 2,
+			expectedRevGeneration: 1,
 		},
 	}
 
@@ -1541,7 +1541,6 @@ func TestOnDemandMigrateWithExpiry(t *testing.T) {
 			goassert.True(t, expiry > 0)
 			log.Printf("expiry: %v", expiry)
 			goassert.True(t, expiry == uint32(syncMetaExpiry.Unix()))
-
 		})
 	}
 


### PR DESCRIPTION
Flow for a PUT requiring import:

![image](https://user-images.githubusercontent.com/3264971/79901498-d2883200-8407-11ea-908b-3773aa81bce2.png)


Doc comes into updateAndReturnDoc and falls into crud.go line 1420:
```
doc, err = unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll)
```
this unmarshals the current bucket document into xattr format (even if currently the sync data is in the body).

We fall through to `OnDemandImportForWrite` with this newly unmarshaled doc.

Fall into `ImportDoc`. Using this doc type to extract data to build sgbucket `BucketDocument`. This sgbucket `BucketDocument` is passed onto `importDoc`.

In `importDoc` through `WriteUpdateWithXattr` callbacks this sgbucket Document eventually ends back as its `currentValue` and `currentXattr` components at crud line 1420 again. In this instance of crud, similar happens. We unmarshal it into a document type. The `importDoc` callback checks if `_sync` data is present in the body, which it isn't so the migration isn't performed.

---

The fix is to ensure that that final `importDoc` steps knows that the sync data was originally in the body and that a migration must be performed.

---

- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/265/
- [X] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/267/
- [x] Merge https://github.com/couchbaselabs/walrus/pull/50
- [x] Merge https://github.com/couchbase/sg-bucket/pull/52
- [x] Update manifest
- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/273/ 