### PR TITLE
CBG-814 Do not prepend filtered query results to channel cache

### DIFF
--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -312,7 +312,8 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 		require.NoError(t, err, "Couldn't delete document")
 	}
 
-	db.WaitForPendingChanges(context.Background())
+	waitErr := db.WaitForPendingChanges(context.Background())
+	assert.NoError(t, waitErr)
 
 	changesOptions := ChangesOptions{
 		Since:      SequenceID{Seq: 0},

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -284,6 +285,57 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 		Changes: []ChangeRev{{"rev": "3-e99405a23fa102238fa8c3fd499b15bc"}}})
 
 	printChanges(changes)
+}
+
+func TestActiveOnlyCacheUpdate(t *testing.T) {
+
+	db, testBucket := setupTestDB(t)
+	defer testBucket.Close()
+	defer tearDownTestDB(t, db)
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
+	log.Printf("Starting actual test code")
+	// Create 10 documents
+	revId := ""
+	var err error
+	for i := 1; i <= 10; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		body := Body{"foo": "bar"}
+		revId, _, err = db.Put(key, body)
+		require.NoError(t, err, "Couldn't create document")
+	}
+
+	// Tombstone 5 documents
+	for i := 2; i <= 6; i++ {
+		key := fmt.Sprintf("%s_%d", t.Name(), i)
+		_, err = db.DeleteDoc(key, revId)
+		require.NoError(t, err, "Couldn't delete document")
+	}
+
+	db.WaitForPendingChanges(context.Background())
+
+	changesOptions := ChangesOptions{
+		Since:      SequenceID{Seq: 0},
+		ActiveOnly: true,
+	}
+
+	initQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+
+	// Get changes with active_only=true
+	activeChanges, err := db.GetChanges(base.SetOf("*"), changesOptions)
+	require.NoError(t, err, "Error getting changes with active_only true")
+	require.Equal(t, 5, len(activeChanges))
+
+	// Ensure the test is triggering a query, and not serving from DCP-generated cache
+	postChangesQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	assert.Equal(t, postChangesQueryCount, initQueryCount+1)
+
+	// Get changes with active_only=false
+	changesOptions.ActiveOnly = false
+	allChanges, err := db.GetChanges(base.SetOf("*"), changesOptions)
+	require.NoError(t, err, "Error getting changes with active_only true")
+	require.Equal(t, 10, len(allChanges))
+
 }
 
 // Benchmark to validate fix for https://github.com/couchbase/sync_gateway/issues/2428

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -412,13 +412,16 @@ func (c *singleChannelCacheImpl) GetChanges(options ChangesOptions) ([]*LogEntry
 
 	// Cache some of the query results, if there's room in the cache.  If query hit the limit,
 	// the query results are only valid for the range of sequences in the result set.
-	resultValidTo := endSeq
-	numResults := len(resultFromQuery)
-	if options.Limit != 0 && numResults >= options.Limit {
-		resultValidTo = resultFromQuery[numResults-1].Sequence
-	}
-	if len(resultFromCache) < c.options.ChannelCacheMaxLength {
-		c.prependChanges(resultFromQuery, startSeq, resultValidTo)
+	// Don't cache when active_only=true since query results aren't complete.
+	if options.ActiveOnly != true {
+		resultValidTo := endSeq
+		numResults := len(resultFromQuery)
+		if options.Limit != 0 && numResults >= options.Limit {
+			resultValidTo = resultFromQuery[numResults-1].Sequence
+		}
+		if len(resultFromCache) < c.options.ChannelCacheMaxLength {
+			c.prependChanges(resultFromQuery, startSeq, resultValidTo)
+		}
 	}
 
 	result := resultFromQuery


### PR DESCRIPTION
The change to include the active-only criteria in the N1QL query, instead of post-cache retrieval filtering, resulted in invalid cache contents.  Active-only query results should not be cached.

- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/210/