### PR TITLE
CBG-825: Allow session create with invalid session

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -79,10 +79,9 @@ type handler struct {
 type handlerPrivs int
 
 const (
-	regularPrivs              = iota // Handler requires valid authentication
-	publicPrivs                      // Handler ensures valid auth if present, but doesn't require it
-	adminPrivs                       // Handler ignores auth, always runs with root/admin privs
-	ignoreInvalidSessionPrivs        // Handler will continue as guest if session auth fails
+	regularPrivs = iota // Handler requires valid authentication
+	publicPrivs         // Handler Handler checks auth and falls back to guest if invalid or missing
+	adminPrivs          // Handler ignores auth, always runs with root/admin privs
 )
 
 type handlerMethod func(*handler) error
@@ -354,7 +353,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 
 	// Check cookie
 	h.user, err = context.Authenticator().AuthenticateCookie(h.rq, h.response)
-	if err != nil && h.privs != ignoreInvalidSessionPrivs {
+	if err != nil && h.privs != publicPrivs {
 		return err
 	} else if h.user != nil {
 		return nil

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -79,8 +79,8 @@ type handler struct {
 type handlerPrivs int
 
 const (
-	regularPrivs              = iota // Handler requires authentication
-	publicPrivs                      // Handler checks auth but doesn't require it
+	regularPrivs              = iota // Handler requires valid authentication
+	publicPrivs                      // Handler ensures valid auth if present, but doesn't require it
 	adminPrivs                       // Handler ignores auth, always runs with root/admin privs
 	ignoreInvalidSessionPrivs        // Handler will continue as guest if session auth fails
 )

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -79,9 +79,10 @@ type handler struct {
 type handlerPrivs int
 
 const (
-	regularPrivs = iota // Handler requires authentication
-	publicPrivs         // Handler checks auth but doesn't require it
-	adminPrivs          // Handler ignores auth, always runs with root/admin privs
+	regularPrivs              = iota // Handler requires authentication
+	publicPrivs                      // Handler checks auth but doesn't require it
+	adminPrivs                       // Handler ignores auth, always runs with root/admin privs
+	ignoreInvalidSessionPrivs        // Handler will continue as guest if session auth fails
 )
 
 type handlerMethod func(*handler) error
@@ -353,7 +354,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 
 	// Check cookie
 	h.user, err = context.Authenticator().AuthenticateCookie(h.rq, h.response)
-	if err != nil {
+	if err != nil && h.privs != ignoreInvalidSessionPrivs {
 		return err
 	} else if h.user != nil {
 		return nil

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -117,7 +117,7 @@ func createHandler(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mux.Rou
 func CreatePublicHandler(sc *ServerContext) http.Handler {
 	r, dbr := createHandler(sc, regularPrivs)
 
-	dbr.Handle("/_session", makeHandler(sc, publicPrivs,
+	dbr.Handle("/_session", makeHandler(sc, ignoreInvalidSessionPrivs,
 		(*handler).handleSessionPOST)).Methods("POST")
 	dbr.Handle("/_session", makeHandler(sc, regularPrivs,
 		(*handler).handleSessionDELETE)).Methods("DELETE")

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -117,7 +117,7 @@ func createHandler(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mux.Rou
 func CreatePublicHandler(sc *ServerContext) http.Handler {
 	r, dbr := createHandler(sc, regularPrivs)
 
-	dbr.Handle("/_session", makeHandler(sc, ignoreInvalidSessionPrivs,
+	dbr.Handle("/_session", makeHandler(sc, publicPrivs,
 		(*handler).handleSessionPOST)).Methods("POST")
 	dbr.Handle("/_session", makeHandler(sc, regularPrivs,
 		(*handler).handleSessionDELETE)).Methods("DELETE")


### PR DESCRIPTION
Currently a request to create a session will fail if an invalid session cookie is provided. This is the case even if valid user credentials are sent in the request body.

In order to stop this I've added a new 'priv' which specifies that when a session auth fails we can continue to authenticate as a guest.