### PR TITLE
CBG-823: JSON error improvements

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"time"
@@ -141,6 +142,9 @@ var (
 	DefaultWarnThresholdXattrSize      = 0.9 * float64(couchbaseMaxSystemXattrSize)
 	DefaultWarnThresholdChannelsPerDoc = uint32(50)
 	DefaultWarnThresholdGrantsPerDoc   = uint32(50)
+
+	// ErrUnknownField is marked as the cause of the error when trying to decode JSON with unknown fields
+	ErrUnknownField = errors.New("unrecognized config value")
 )
 
 // UnitTestUrl returns the configured test URL.

--- a/base/constants.go
+++ b/base/constants.go
@@ -143,8 +143,8 @@ var (
 	DefaultWarnThresholdChannelsPerDoc = uint32(50)
 	DefaultWarnThresholdGrantsPerDoc   = uint32(50)
 
-	// ErrUnknownField is marked as the cause of the error when trying to decode JSON with unknown fields
-	ErrUnknownField = errors.New("unrecognized config value")
+	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
+	ErrUnknownField = errors.New("unrecognized JSON field")
 )
 
 // UnitTestUrl returns the configured test URL.

--- a/base/util.go
+++ b/base/util.go
@@ -1259,11 +1259,9 @@ func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, kvPairs []KVPairBytes)
 	return newJSON
 }
 
-func UnknownFieldErrCheck(err error) error {
+// WrapJSONUnknownFieldErr wraps JSON unknown field errors with ErrUnknownField for later checking via errors.Cause
+func WrapJSONUnknownFieldErr(err error) error {
 	if err != nil && strings.Contains(err.Error(), "unknown field") {
-		// Special handling for unknown field errors
-		// json.Decode continues to decode the full data into the struct
-		// so it's safe to use even after this error
 		return pkgerrors.WithMessage(ErrUnknownField, err.Error())
 	}
 	return err

--- a/base/util.go
+++ b/base/util.go
@@ -1259,6 +1259,16 @@ func injectJSONPropertyFromBytes(b []byte, bIsEmpty bool, kvPairs []KVPairBytes)
 	return newJSON
 }
 
+func UnknownFieldErrCheck(err error) error {
+	if err != nil && strings.Contains(err.Error(), "unknown field") {
+		// Special handling for unknown field errors
+		// json.Decode continues to decode the full data into the struct
+		// so it's safe to use even after this error
+		return pkgerrors.WithMessage(ErrUnknownField, err.Error())
+	}
+	return err
+}
+
 // UseStdlibJSON if true, uses the stdlib JSON package.
 // This variable is not thread-safe, and should be set only once on startup.
 var UseStdlibJSON bool

--- a/rest/config.go
+++ b/rest/config.go
@@ -44,9 +44,6 @@ var (
 
 	// The value of defaultLogFilePath is populated by --defaultLogFilePath in ParseCommandLine()
 	defaultLogFilePath string
-
-	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
-	ErrUnknownField = errors.New("unrecognized JSON field")
 )
 
 var config *ServerConfig

--- a/rest/config.go
+++ b/rest/config.go
@@ -44,6 +44,9 @@ var (
 
 	// The value of defaultLogFilePath is populated by --defaultLogFilePath in ParseCommandLine()
 	defaultLogFilePath string
+
+	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
+	ErrUnknownField = errors.New("unrecognized JSON field")
 )
 
 var config *ServerConfig
@@ -639,7 +642,7 @@ func decodeAndSanitiseConfig(r io.Reader, config interface{}) (err error) {
 	d := base.JSONDecoder(bytes.NewBuffer(b))
 	d.DisallowUnknownFields()
 	err = d.Decode(config)
-	return base.UnknownFieldErrCheck(err)
+	return base.WrapJSONUnknownFieldErr(err)
 }
 
 func (config *ServerConfig) setupAndValidateDatabases() []error {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -41,7 +41,7 @@ func TestReadServerConfig(t *testing.T) {
 		{
 			name:        "unknown field",
 			config:      `{"invalid": true}`,
-			errStdlib:   `json: unknown field "invalid": unrecognized config value`,
+			errStdlib:   `json: unknown field "invalid": unrecognized JSON field`,
 			errJSONIter: `found unknown field: invalid`,
 		},
 		{

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -53,7 +53,7 @@ func ReadJSONFromMIME(headers http.Header, input io.ReadCloser, into interface{}
 	decoder.UseNumber()
 	err := decoder.Decode(into)
 	if err != nil {
-		err = base.UnknownFieldErrCheck(err)
+		err = base.WrapJSONUnknownFieldErr(err)
 		base.Warnf("Couldn't parse JSON in HTTP request: %v", err)
 		if errors.Cause(err) == base.ErrUnknownField {
 			err = base.HTTPErrorf(http.StatusBadRequest, "JSON Unknown Field: %s", err.Error())

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/pkg/errors"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -52,8 +53,13 @@ func ReadJSONFromMIME(headers http.Header, input io.ReadCloser, into interface{}
 	decoder.UseNumber()
 	err := decoder.Decode(into)
 	if err != nil {
+		err = base.UnknownFieldErrCheck(err)
 		base.Warnf("Couldn't parse JSON in HTTP request: %v", err)
-		err = base.HTTPErrorf(http.StatusBadRequest, "Bad JSON")
+		if errors.Cause(err) == base.ErrUnknownField {
+			err = base.HTTPErrorf(http.StatusBadRequest, "JSON Unknown Field: %s", err.Error())
+		} else {
+			err = base.HTTPErrorf(http.StatusBadRequest, "Bad JSON: %s", err.Error())
+		}
 	}
 
 	_ = input.Close()


### PR DESCRIPTION
Return Bad JSON error with specific error:
```
curl -X POST http://localhost:4984/test/_session -H 'Content-Type: application/json' -d 'invalidjson'
{"error":"Bad Request","reason":"Bad JSON: invalid character 'i' looking for beginning of value"}
```


If error is unknown field return "JSON Unknown Field" with unknown field error appended:
```
curl -X POST http://localhost:4984/test/_session -H 'Content-Type: application/json' -d '{"uknown":true}'
{"error":"Bad Request","reason":"JSON Unknown Field: json: unknown field \"uknown\": unrecognized config value"}
```