### PR TITLE
CBG-821 Query limit for channel queries

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -41,6 +41,7 @@ var (
 	ErrNotFound              = &sgError{"Not Found"}
 	ErrUpdateCancel          = &sgError{"Cancel update"}
 	ErrImportCancelledPurged = &sgError{"Import Cancelled Due to Purge"}
+	ErrChannelFeed           = &sgError{"Error while building channel feed"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.

--- a/base/util.go
+++ b/base/util.go
@@ -1295,3 +1295,10 @@ func FatalPanicHandler() {
 		Fatalf("Unexpected panic: %v - stopping process\n%v", r, string(debug.Stack()))
 	}
 }
+
+func MinInt(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -139,6 +139,7 @@ func DefaultCacheOptions() CacheOptions {
 			MaxNumChannels:              DefaultChannelCacheMaxNumber,
 			CompactHighWatermarkPercent: DefaultCompactHighWatermarkPercent,
 			CompactLowWatermarkPercent:  DefaultCompactLowWatermarkPercent,
+			ChannelQueryLimit:           DefaultChannelQueryLimit,
 		},
 	}
 }

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -22,6 +22,7 @@ var (
 	DefaultChannelCacheMaxNumber       = 50000            // Default of 50k channel caches
 	DefaultCompactHighWatermarkPercent = 80               // Default compaction high watermark (percent of MaxNumber)
 	DefaultCompactLowWatermarkPercent  = 60               // Default compaction low watermark (percent of MaxNumber)
+	DefaultChannelQueryLimit           = 5000             // Default channel query limit
 )
 
 type ChannelCache interface {

--- a/db/channel_cache_single.go
+++ b/db/channel_cache_single.go
@@ -158,6 +158,7 @@ type ChannelCacheOptions struct {
 	MaxNumChannels              int           // Maximum number of per-channel caches which will exist at any one point
 	CompactHighWatermarkPercent int           // Compact HWM (as percent of MaxNumChannels)
 	CompactLowWatermarkPercent  int           // Compact LWM (as percent of MaxNumChannels)
+	ChannelQueryLimit           int           // Query limit
 }
 
 func (c *singleChannelCacheImpl) ChannelName() string {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -283,3 +283,14 @@ func viewBucketReadier(ctx context.Context, b base.Bucket, tbp *base.TestBucketP
 	tbp.Logf(ctx, "bucket views initialized")
 	return nil
 }
+
+func (db *DatabaseContext) GetChannelQueryCount() int64 {
+
+	queryCountExpvar := fmt.Sprintf(base.StatKeyN1qlQueryCountExpvarFormat, QueryTypeChannels)
+	if db.UseViews() {
+		queryCountExpvar = fmt.Sprintf(base.StatKeyViewQueryCountExpvarFormat, DesignDocSyncGateway(), ViewChannels)
+	}
+
+	return base.ExpvarVar2Int(db.DbStats.StatsGsiViews().Get(queryCountExpvar))
+
+}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="b7fe191c4a6b7f2e72dca62c718656f38235483d"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e6271c4f9759e8739a514e62f7925c8075a462b6"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e6271c4f9759e8739a514e62f7925c8075a462b6"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="2eb20fb123c5bda3222aa4c9c26df5f7af4fc8ea"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -2225,6 +2225,293 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 
 }
 
+// Tests query backfill with limit
+func TestChangesQueryBackfillWithLimit(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+
+	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	testDb := rt.GetDatabase()
+
+	changesLimitTests := []struct {
+		name                string // test name
+		queryLimit          int    // CacheOptions.ChannelQueryLimit
+		requestLimit        int    // _changes request limit
+		totalDocuments      int    // Total document in the user's channel (documents also created in non-user channel)
+		expectedQueryCount  int64  // Expected number of channel queries performed for channel
+		expectedResultCount int    // Expected number of documents returned by _changes
+	}{
+		{ // queryLimit < requestLimit < totalDocuments
+			name:                "case1",
+			queryLimit:          5,
+			requestLimit:        15,
+			totalDocuments:      20,
+			expectedQueryCount:  3,
+			expectedResultCount: 15,
+		},
+		{ // queryLimit <  totalDocuments < requestLimit
+			name:                "case2",
+			queryLimit:          5,
+			requestLimit:        25,
+			totalDocuments:      20,
+			expectedQueryCount:  5,
+			expectedResultCount: 20,
+		},
+		{ // requestLimit < queryLimit < totalDocuments
+			name:                "case3",
+			queryLimit:          10,
+			requestLimit:        5,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 5,
+		},
+		{ // requestLimit < totalDocuments < queryLimit
+			name:                "case4",
+			queryLimit:          25,
+			requestLimit:        15,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 15,
+		},
+		{ // totalDocuments < queryLimit < requestLimit
+			name:                "case5",
+			queryLimit:          25,
+			requestLimit:        30,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 20,
+		},
+		{ // totalDocuments < requestLimit < queryLimit
+			name:                "case6",
+			queryLimit:          30,
+			requestLimit:        25,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 20,
+		},
+		{ // totalDocuments = requestLimit < queryLimit
+			name:                "case7",
+			queryLimit:          30,
+			requestLimit:        20,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 20,
+		},
+		{ // totalDocuments = queryLimit < requestLimit
+			name:                "case8",
+			queryLimit:          20,
+			requestLimit:        30,
+			totalDocuments:      20,
+			expectedQueryCount:  2,
+			expectedResultCount: 20,
+		},
+		{ // queryLimit < totalDocuments = requestLimit
+			name:                "case9",
+			queryLimit:          20,
+			requestLimit:        30,
+			totalDocuments:      30,
+			expectedQueryCount:  2,
+			expectedResultCount: 30,
+		},
+		{ // requestLimit < totalDocuments = queryLimit
+			name:                "case10",
+			queryLimit:          30,
+			requestLimit:        30,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 20,
+		},
+		{ // queryLimit = requestLimit < totalDocuments
+			name:                "case11",
+			queryLimit:          20,
+			requestLimit:        20,
+			totalDocuments:      30,
+			expectedQueryCount:  1,
+			expectedResultCount: 20,
+		},
+		{ // totalDocuments < requestLimit = queryLimit
+			name:                "case12",
+			queryLimit:          30,
+			requestLimit:        30,
+			totalDocuments:      20,
+			expectedQueryCount:  1,
+			expectedResultCount: 20,
+		},
+	}
+
+	for _, test := range changesLimitTests {
+
+		t.Run(test.name, func(t *testing.T) {
+			testDb.Options.CacheOptions.ChannelQueryLimit = test.queryLimit
+
+			// Create user
+			username := "user_" + test.name
+			a := testDb.Authenticator()
+			testUser, err := a.NewUser(username, "letmein", channels.SetOf(t, test.name))
+			assert.NoError(t, err)
+			assert.NoError(t, a.Save(testUser))
+
+			// Put documents
+			cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
+			for i := 1; i <= test.totalDocuments; i++ {
+				response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s_%d", test.name, i), fmt.Sprintf(`{"channels":["%s"]}`, test.name))
+				assertStatus(t, response, 201)
+				// write a document not in the channel, to ensure high sequence as query end value doesn't bypass query edge cases
+				response = rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s_%d_other", test.name, i), `{"channels":["other"]}`)
+				assertStatus(t, response, 201)
+			}
+			cacheWaiter.AddAndWait(test.totalDocuments * 2)
+
+			// Flush the channel cache
+			assert.NoError(t, testDb.FlushChannelCache())
+			startQueryCount := testDb.GetChannelQueryCount()
+
+			// Issue a since=0 changes request.
+			var changes struct {
+				Results  []db.ChangeEntry
+				Last_Seq interface{}
+			}
+			changesJSON := fmt.Sprintf(`{"since":0, "limit":%d}`, test.requestLimit)
+			changes.Results = nil
+			changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, username))
+			err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+			assert.NoError(t, err, "Error unmarshalling changes response")
+			require.Equal(t, test.expectedResultCount, len(changes.Results))
+
+			// Validate expected number of queries
+			finalQueryCount := testDb.GetChannelQueryCount()
+			// We expect one query for the public channel, so need to subtract one for the expected count for the channel
+			assert.Equal(t, test.expectedQueryCount, finalQueryCount-startQueryCount-1)
+		})
+	}
+
+}
+
+// Tests query backfill with limit
+func TestMultichannelChangesQueryBackfillWithLimit(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+
+	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	testDb := rt.GetDatabase()
+
+	testDb.Options.CacheOptions.ChannelQueryLimit = 5
+
+	// Create user with access to three channels
+	username := "user_" + t.Name()
+	a := testDb.Authenticator()
+	testUser, err := a.NewUser(username, "letmein", channels.SetOf(t, "ch1", "ch2", "ch3"))
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(testUser))
+
+	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
+
+	// Put documents with varying channel values:
+	//    Sequences      Channels
+	//    ---------      --------
+	//     1-10			ch1
+	//     11-20		ch1, ch3
+	//     21-30		ch1
+	//     31-40		ch2
+	//     41-50		ch1, ch2, ch3
+	channelSets := []string{`"ch1"`, `"ch1", "ch3"`, `"ch1"`, `"ch2"`, `"ch1", "ch2", "ch3"`}
+
+	for i := 0; i < 50; i++ {
+		channelSet := channelSets[i/10]
+		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s_%d", t.Name(), i), fmt.Sprintf(`{"channels":[%s]}`, channelSet))
+		assertStatus(t, response, 201)
+	}
+	cacheWaiter.AddAndWait(50)
+
+	// Flush the channel cache
+	assert.NoError(t, testDb.FlushChannelCache())
+
+	// 1. Issue a since=0 changes request, validate results
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+	changesJSON := fmt.Sprintf(`{"since":0}`)
+	changes.Results = nil
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, username))
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Equal(t, 50, len(changes.Results))
+
+	// Verify results ordering
+	for i := 0; i < 50; i++ {
+		assert.Equal(t, fmt.Sprintf("%s_%d", t.Name(), i), changes.Results[i].ID)
+	}
+
+	// 2. Same again, but with limit on the changes request
+	assert.NoError(t, testDb.FlushChannelCache())
+	changes.Results = nil
+	changesJSON = fmt.Sprintf(`{"since":0, "limit":25}`)
+	changes.Results = nil
+	changesResponse = rt.Send(requestByUser("POST", "/db/_changes", changesJSON, username))
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Equal(t, 25, len(changes.Results))
+
+	// Verify results ordering
+	for i := 0; i < 25; i++ {
+		assert.Equal(t, fmt.Sprintf("%s_%d", t.Name(), i), changes.Results[i].ID)
+	}
+
+}
+
+// Tests star channel query backfill with limit
+func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyChanges, base.KeyCache)()
+
+	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
+	queryLimit := 5
+	rtConfig.DatabaseConfig = &DbConfig{CacheConfig: &CacheConfig{ChannelCacheConfig: &ChannelCacheConfig{QueryLimit: &queryLimit}}}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	// Create user:
+	a := rt.ServerContext().Database("db").Authenticator()
+	bernard, err := a.NewUser("bernard", "letmein", channels.SetOf(t, "*"))
+	assert.NoError(t, err)
+	assert.NoError(t, a.Save(bernard))
+
+	testDb := rt.ServerContext().Database("db")
+	cacheWaiter := testDb.NewDCPCachingCountWaiter(t)
+
+	// Put 10 documents
+	for i := 1; i <= 10; i++ {
+		key := fmt.Sprintf("%s%d", t.Name(), i)
+		response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", key), `{"starChannel":"istrue"}`)
+		assertStatus(t, response, 201)
+	}
+
+	cacheWaiter.AddAndWait(10)
+
+	// Flush the channel cache
+	assert.NoError(t, testDb.FlushChannelCache())
+	startQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+
+	// Issue a since=0 changes request.  Validate that there's a view-based backfill
+	var changes struct {
+		Results  []db.ChangeEntry
+		Last_Seq interface{}
+	}
+	changesJSON := `{"since":0, "limit":7}`
+	changes.Results = nil
+	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
+	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
+	assert.NoError(t, err, "Error unmarshalling changes response")
+	require.Equal(t, len(changes.Results), 7)
+	finalQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	assert.Equal(t, 2, finalQueryCount-startQueryCount)
+}
+
 // Tests view backfill with slow query, checks duplicate handling for cache entries if a document is updated after query runs, but before document is
 // prepended to the cache.  Reproduces #3475
 func TestChangesViewBackfillSlowQuery(t *testing.T) {
@@ -2259,10 +2546,8 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 
 	cacheWaiter.Wait()
 
-	log.Printf("about to flush")
 	// Flush the channel cache
 	assert.NoError(t, testDb.FlushChannelCache())
-	log.Printf("flush done")
 
 	// Write another doc, to initialize the cache (and guarantee overlap)
 	response = rt.SendAdminRequest("PUT", "/db/doc2", `{"channels":["PBS"]}`)

--- a/rest/config.go
+++ b/rest/config.go
@@ -279,6 +279,7 @@ type ChannelCacheConfig struct {
 	MaxLength            *int    `json:"max_length,omitempty"`                 // Maximum number of entries maintained in cache per channel
 	MinLength            *int    `json:"min_length,omitempty"`                 // Minimum number of entries maintained in cache per channel
 	ExpirySeconds        *int    `json:"expiry_seconds,omitempty"`             // Time (seconds) to keep entries in cache beyond the minimum retained
+	QueryLimit           *int    `json:"query_limit,omitempty"`                // Limit used for channel queries, if not specified by client
 }
 
 type UnsupportedServerConfig struct {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -906,6 +907,8 @@ func TestConfigToDatabaseOptions(t *testing.T) {
 			"username": "` + bucketUser + `",
 			"password": "` + bucketPassword + `",
 			"bucket": "` + spec.BucketName + `",
+			"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
+			"num_index_replicas": 0,
 			"cache":{
 				"channel_cache":{
 					  "query_limit": 200

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"net/http"
@@ -886,4 +887,42 @@ func TestPutInvalidConfig(t *testing.T) {
 
 	response := rt.SendAdminRequest("PUT", "/db/_config", `{"db": {"server": "walrus"}}`)
 	assert.Equal(t, http.StatusBadRequest, response.Code)
+}
+
+// Validate basic mapping from config to database options
+func TestConfigToDatabaseOptions(t *testing.T) {
+
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+
+	bucketUser, bucketPassword, _ := bucket.BucketSpec.Auth.GetCredentials()
+	spec := bucket.BucketSpec
+
+	jsonConfig := []byte(`
+{
+	"databases": {
+		"db": {
+			"server": "` + spec.Server + `",
+			"username": "` + bucketUser + `",
+			"password": "` + bucketPassword + `",
+			"bucket": "` + spec.BucketName + `",
+			"cache":{
+				"channel_cache":{
+					  "query_limit": 200
+				}
+			}
+		}
+	}
+}
+`)
+	var config ServerConfig
+	unmarshalErr := json.Unmarshal(jsonConfig, &config)
+	require.NoError(t, unmarshalErr)
+
+	sc := NewServerContext(&config)
+	database, addDatabaseError := sc.AddDatabaseFromConfig(config.Databases["db"])
+	require.NoError(t, addDatabaseError)
+
+	assert.Equal(t, *config.Databases["db"].CacheConfig.ChannelCacheConfig.QueryLimit, database.Options.CacheOptions.ChannelQueryLimit)
+
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -397,6 +397,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			if config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent != nil && *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent > 0 {
 				cacheOptions.CompactLowWatermarkPercent = *config.CacheConfig.ChannelCacheConfig.HighWatermarkPercent
 			}
+			if config.CacheConfig.ChannelCacheConfig.QueryLimit != nil && *config.CacheConfig.ChannelCacheConfig.QueryLimit > 0 {
+				cacheOptions.ChannelQueryLimit = *config.CacheConfig.ChannelCacheConfig.QueryLimit
+			}
 		}
 
 		if config.CacheConfig.RevCacheConfig != nil {


### PR DESCRIPTION
Adds query pagination for channel queries triggered by changes processing.  Default query limit for pagination is 5000, and can be modified with a new ‘query_limit’ config property in channel cache config.

Pagination is done while building the per-channel feed (go-channel). This avoids storing the entire cross-query resultset in memory, allows streaming of results as soon as the first query completes, and optimizes interaction with any changes request limit.  This has implications for cache warming - only the last (query_limit) entries will be prepended to the cache per changes request.

Query errors midway through pagination are communicated to the feed worker via an error changeEntry, which terminates the changes processing. This required an additional error check when working the per-channel feeds, as we didn’t previously raise an error mid-feed, as queries were executed prior to feed setup.

Depends on https://github.com/couchbase/sg-bucket/pull/51. 
- [x] Update manifest once sg-bucket PR is merged