### PR TITLE
CBG-754: Disable builds of old releases

### DIFF
--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -64,6 +64,7 @@
             "start_build": 1
         },
         "manifest/2.0.0.xml": {
+            "do-build": false,
             "release": "2.0.0.0",
             "release_name": "Couchbase Sync Gateway 2.0.0.0",
             "production": true,
@@ -72,6 +73,7 @@
             "start_build": 838
         },
         "manifest/2.1.0.xml": {
+            "do-build": false,
             "release": "2.1.0",
             "release_name": "Couchbase Sync Gateway 2.1.0",
             "production": true,
@@ -80,6 +82,7 @@
             "start_build": 107
         },
         "manifest/2.1.1.xml": {
+            "do-build": false,
             "release": "2.1.1",
             "release_name": "Couchbase Sync Gateway 2.1.1",
             "production": true,
@@ -88,6 +91,7 @@
             "start_build": 1
         },
         "manifest/2.1/2.1.2.xml": {
+            "do-build": false,
             "release": "2.1.2",
             "release_name": "Couchbase Sync Gateway 2.1.2",
             "production": true,
@@ -96,6 +100,7 @@
             "start_build": 1
         },
         "manifest/2.1/2.1.3.xml": {
+            "do-build": false,
             "release": "2.1.3",
             "release_name": "Couchbase Sync Gateway 2.1.3",
             "production": true,
@@ -104,6 +109,7 @@
             "start_build": 1
         },
         "manifest/2.1/2.1.2.1.xml": {
+            "do-build": false,
             "release": "2.1.2.1",
             "release_name": "Couchbase Sync Gateway 2.1.2.1",
             "production": true,
@@ -112,6 +118,7 @@
             "start_build": 1
         },
         "manifest/2.1.xml": {
+            "do-build": false,
             "release": "2.1.3.1",
             "release_name": "Couchbase Sync Gateway 2.1.3.1",
             "production": true,
@@ -120,6 +127,7 @@
             "start_build": 1
         },
         "manifest/2.5.xml": {
+            "do-build": false,
             "release": "2.5.1.1",
             "release_name": "Couchbase Sync Gateway 2.5.1.1",
             "production": true,
@@ -128,6 +136,7 @@
             "start_build": 1
         },
         "manifest/2.5/2.5.0.xml": {
+            "do-build": false,
             "release": "2.5.0",
             "release_name": "Couchbase Sync Gateway 2.5.0",
             "production": true,
@@ -136,6 +145,7 @@
             "start_build": 270
         },
         "manifest/2.5/2.5.1.xml": {
+            "do-build": false,
             "release": "2.5.1",
             "release_name": "Couchbase Sync Gateway 2.5.1",
             "production": true,
@@ -144,6 +154,7 @@
             "start_build": 13
         },
         "manifest/2.6.xml": {
+            "do-build": false,
             "release": "2.6.1.1",
             "release_name": "Couchbase Sync Gateway 2.6.1.1",
             "production": true,
@@ -152,6 +163,7 @@
             "start_build": 1
         },
         "manifest/2.6/2.6.1.xml": {
+            "do-build": false,
             "release": "2.6.1",
             "release_name": "Couchbase Sync Gateway 2.6.1",
             "production": true,
@@ -160,6 +172,7 @@
             "start_build": 28
         },
         "manifest/2.6/2.6.0.xml": {
+            "do-build": false,
             "release": "2.6.0",
             "release_name": "Couchbase Sync Gateway 2.6.0",
             "production": true,
@@ -168,6 +181,7 @@
             "start_build": 138
         },
         "manifest/2.7.xml": {
+            "do-build": false,
             "release": "2.7.2",
             "release_name": "Couchbase Sync Gateway 2.7.2",
             "production": true,
@@ -176,6 +190,7 @@
             "start_build": 1
         },
         "manifest/2.7/2.7.1.xml": {
+            "do-build": false,
             "release": "2.7.1",
             "release_name": "Couchbase Sync Gateway 2.7.1",
             "production": true,
@@ -184,6 +199,7 @@
             "start_build": 14
         },
         "manifest/2.7/2.7.0.xml": {
+            "do-build": false,
             "release": "2.7.0",
             "release_name": "Couchbase Sync Gateway 2.7.0",
             "production": true,


### PR DESCRIPTION
Disabled builds of old releases. On advice from the build team we can disable builds for a release which has been cut when we don't expect it to be updated in the future. 