### PR TITLE
CBG-815: Avoid mutating sgIndexes in tests

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -84,9 +84,9 @@ func TestsShouldDropIndexes() bool {
 // TestsDisableGSI returns true if tests should be forced to avoid any GSI-specific code.
 func TestsDisableGSI() bool {
 	// FIXME: CBG-813 - Re-enable GSI in integration tests after CB 6.5.1 Beta
-	// if true {
-	// 	return true
-	// }
+	if true {
+		return true
+	}
 	// Disable GSI when running with Walrus
 	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
 		return true

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -83,10 +83,6 @@ func TestsShouldDropIndexes() bool {
 
 // TestsDisableGSI returns true if tests should be forced to avoid any GSI-specific code.
 func TestsDisableGSI() bool {
-	// FIXME: CBG-813 - Re-enable GSI in integration tests after CB 6.5.1 Beta
-	if true {
-		return true
-	}
 
 	// Disable GSI when running with Walrus
 	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -83,7 +83,10 @@ func TestsShouldDropIndexes() bool {
 
 // TestsDisableGSI returns true if tests should be forced to avoid any GSI-specific code.
 func TestsDisableGSI() bool {
-
+	// FIXME: CBG-813 - Re-enable GSI in integration tests after CB 6.5.1 Beta
+	// if true {
+	// 	return true
+	// }
 	// Disable GSI when running with Walrus
 	if !TestUseCouchbaseServer() && UnitTestUrlIsWalrus() {
 		return true

--- a/db/database.go
+++ b/db/database.go
@@ -522,7 +522,7 @@ func (context *DatabaseContext) RemoveObsoleteIndexes(previewOnly bool) (removed
 		return make([]string, 0), nil
 	}
 
-	return removeObsoleteIndexes(gocbBucket, previewOnly, context.UseXattrs(), context.UseViews())
+	return removeObsoleteIndexes(gocbBucket, previewOnly, context.UseXattrs(), context.UseViews(), sgIndexes)
 }
 
 // Trigger terminate check handling for connected continuous replications.

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -385,7 +385,7 @@ func isIndexerError(err error) bool {
 // Iterates over the index set, removing obsolete indexes:
 //  - indexes based on the inverse value of xattrs being used by the database
 //  - indexes associated with previous versions of the index, for either xattrs=true or xattrs=false
-func removeObsoleteIndexes(bucket base.N1QLBucket, previewOnly bool, useXattrs bool, useViews bool) (removedIndexes []string, err error) {
+func removeObsoleteIndexes(bucket base.N1QLBucket, previewOnly bool, useXattrs bool, useViews bool, indexMap map[SGIndexType]SGIndex) (removedIndexes []string, err error) {
 	removedIndexes = make([]string, 0)
 
 	if !bucket.IsSupported(sgbucket.BucketFeatureN1ql) {
@@ -394,7 +394,7 @@ func removeObsoleteIndexes(bucket base.N1QLBucket, previewOnly bool, useXattrs b
 
 	// Build set of candidates for cleanup
 	removalCandidates := make([]string, 0)
-	for _, sgIndex := range sgIndexes {
+	for _, sgIndex := range indexMap {
 		// Current version, opposite xattr setting
 		removalCandidates = append(removalCandidates, sgIndex.fullIndexName(!useXattrs))
 		// If using views we can remove current version for xattr setting too
@@ -469,4 +469,14 @@ func replaceSyncTokensQuery(statement string, useXattrs bool) string {
 // Replace index tokens ($idx) in the provided createIndex statement with the appropriate token, depending on whether xattrs should be used.
 func replaceIndexTokensQuery(statement string, idx SGIndex, useXattrs bool) string {
 	return strings.Replace(statement, indexToken, idx.fullIndexName(useXattrs), -1)
+}
+
+func copySGIndexes(inputMap map[SGIndexType]SGIndex) map[SGIndexType]SGIndex {
+	outputMap := make(map[SGIndexType]SGIndex, len(inputMap))
+
+	for idx, value := range inputMap {
+		outputMap[idx] = value
+	}
+
+	return outputMap
 }

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -158,6 +158,14 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 1)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
+
+	// Restore indexes after test
+	err := InitializeIndexes(testBucket, db.UseXattrs(), 0)
+	assert.NoError(t, err)
+
+	validateErr := validateAllIndexesOnline(testBucket)
+	assert.NoError(t, validateErr, "Error validating indexes online")
+
 }
 
 func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
@@ -207,6 +215,13 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	// Restore ddocs after test
 	err = InitializeViews(gocbBucket)
 	assert.NoError(t, err)
+
+	// Restore indexes after test
+	err = InitializeIndexes(testBucket, db.UseXattrs(), 0)
+	assert.NoError(t, err)
+
+	validateErr := validateAllIndexesOnline(testBucket)
+	assert.NoError(t, validateErr, "Error validating indexes online")
 }
 
 func TestRemoveObsoleteIndexOnFail(t *testing.T) {

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -94,7 +94,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 	// We don't know the current state of the bucket (may already have xattrs enabled), so run
 	// an initial cleanup to remove existing obsolete indexes
-	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), db.UseViews())
+	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), db.UseViews(), sgIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
@@ -102,17 +102,17 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, true, !db.UseXattrs(), db.UseViews())
+	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
 
 	// Running again w/ preview=false to perform cleanup
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, !db.UseXattrs(), db.UseViews())
+	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
 
 	// One more time to make sure they are actually gone
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, !db.UseXattrs(), db.UseViews())
+	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	goassert.Equals(t, len(removedIndexes), 0)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
@@ -122,10 +122,6 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 }
 
 func TestPostUpgradeIndexesVersionChange(t *testing.T) {
-
-	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
-	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
-	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
@@ -138,35 +134,33 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	gocbBucket, ok := base.AsGoCBBucket(testBucket.Bucket)
 	assert.True(t, ok)
 
+	copiedIndexes := copySGIndexes(sgIndexes)
+
 	// Validate that removeObsoleteIndexes is a no-op for the default case
-	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, true, db.UseXattrs(), db.UseViews())
+	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 0)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
 
 	// Hack sgIndexes to simulate new version of indexes
-	accessIndex := sgIndexes[IndexAccess]
-	restoreIndex := sgIndexes[IndexAccess]
+	accessIndex := copiedIndexes[IndexAccess]
+	restoreIndex := copiedIndexes[IndexAccess]
 	defer func() {
-		sgIndexes[IndexAccess] = restoreIndex
+		copiedIndexes[IndexAccess] = restoreIndex
 	}()
 
 	accessIndex.version = 2
 	accessIndex.previousVersions = []int{1}
-	sgIndexes[IndexAccess] = accessIndex
+	copiedIndexes[IndexAccess] = accessIndex
 
 	// Validate that removeObsoleteIndexes now triggers removal of one index
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, true, db.UseXattrs(), db.UseViews())
+	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 1)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 }
 
 func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
-
-	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
-	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
-	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
 
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
@@ -175,6 +169,8 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	db, testBucket := setupTestDB(t)
 	defer testBucket.Close()
 	defer db.Close()
+
+	copiedIndexes := copySGIndexes(sgIndexes)
 
 	gocbBucket, ok := base.AsGoCBBucket(testBucket.Bucket)
 	assert.True(t, ok)
@@ -190,11 +186,11 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		expectedIndexes--
 	}
 
-	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), true)
+	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), true, copiedIndexes)
 	assert.Equal(t, expectedIndexes, len(removedIndexes))
 	assert.NoError(t, removeErr)
 
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), false)
+	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), false, copiedIndexes)
 	require.Len(t, removedIndexes, 0)
 	assert.NoError(t, removeErr)
 
@@ -215,10 +211,6 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
 func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 
-	// FIXME: CBG-815 - Overwriting sgIndexes global map is disrupting the async bucket pooling workers
-	// Is there a way of refactoring removeObsoleteIndexes to pass in the index map instead?
-	t.Skipf("FIXME: can't touch sgIndexes map - bucket pooling relies on it")
-
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}
@@ -228,33 +220,25 @@ func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 	defer db.Close()
 
 	leakyBucket := base.NewLeakyBucket(testBucket.Bucket, base.LeakyBucketConfig{DropIndexErrorNames: []string{"sg_access_1", "sg_access_x1"}})
-
-	//Copy references to existing indexes to variable for future use
-	oldIndexes := sgIndexes
-
-	//Remove all index references used in testing and restore the earlier indexes
-	defer func() {
-		sgIndexes = map[SGIndexType]SGIndex{}
-		sgIndexes = oldIndexes
-	}()
+	copiedIndexes := copySGIndexes(sgIndexes)
 
 	//Use existing versions of IndexAccess and IndexChannels and create an old version that will be removed by obsolete
 	//indexes. Resulting from the removal candidates for removeObsoleteIndexes will be:
 	// All previous versions and opposite of current xattr setting eg. for this test ran with non-xattrs:
 	// [sg_channels_x2 sg_channels_x1 sg_channels_1 sg_access_x2 sg_access_x1 sg_access_1]
-	sgIndexes = map[SGIndexType]SGIndex{}
+	testIndexes := map[SGIndexType]SGIndex{}
 
-	accessIndex := oldIndexes[IndexAccess]
+	accessIndex := copiedIndexes[IndexAccess]
 	accessIndex.version = 2
 	accessIndex.previousVersions = []int{1}
-	sgIndexes[IndexAccess] = accessIndex
+	testIndexes[IndexAccess] = accessIndex
 
-	channelIndex := oldIndexes[IndexChannels]
+	channelIndex := copiedIndexes[IndexChannels]
 	channelIndex.version = 2
 	channelIndex.previousVersions = []int{1}
-	sgIndexes[IndexChannels] = channelIndex
+	testIndexes[IndexChannels] = channelIndex
 
-	removedIndex, removeErr := removeObsoleteIndexes(leakyBucket, false, db.UseXattrs(), db.UseViews())
+	removedIndex, removeErr := removeObsoleteIndexes(leakyBucket, false, db.UseXattrs(), db.UseViews(), testIndexes)
 	assert.NoError(t, removeErr)
 
 	if base.TestUseXattrs() {
@@ -266,6 +250,9 @@ func TestRemoveObsoleteIndexOnFail(t *testing.T) {
 	// Restore indexes after test
 	err := InitializeIndexes(testBucket, db.UseXattrs(), 0)
 	assert.NoError(t, err)
+
+	validateErr := validateAllIndexesOnline(testBucket)
+	assert.NoError(t, validateErr, "Error validating indexes online")
 
 }
 


### PR DESCRIPTION
Avoid modifying `sgIndexes` in tests.
If we want to run removeObsoleteIndexes with some modified indexes instead of modifying `sgIndexes` directly we copy `sgIndexes` into a new map and then pass that to removeObsoleteIndexes. 
Added a function to copy `sgIndexes` into a new map and switched `removeObsoleteIndexes` to take a map of indexes and loop over that rather than looping over `sgIndexes` which it used to do.

Also added `InitializeIndexes` in a few places where indexes would be removed but not re-created. 

This runs fine locally against CB.