### PR TITLE
CBG-771 Refactor CfgSG for reuse by sg-replicate

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -403,8 +403,8 @@ func IsCasMismatch(err error) bool {
 func GetFeedType(bucket Bucket) (feedType string) {
 	switch typedBucket := bucket.(type) {
 	case *CouchbaseBucketGoCB:
-		if typedBucket.spec.FeedType != "" {
-			return strings.ToLower(typedBucket.spec.FeedType)
+		if typedBucket.Spec.FeedType != "" {
+			return strings.ToLower(typedBucket.Spec.FeedType)
 		} else {
 			return DcpFeedType
 		}

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -73,14 +73,6 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 
 	casOut, err := c.bucket.WriteCas(bucketKey, 0, 0, cas, val, 0)
 
-	/*
-		if cas == 0 {
-			casOut, err = c.bucket.Insert(bucketKey, val, 0)
-		} else {
-			casOut, err = c.bucket.Replace(bucketKey, val, gocb.Cas(cas), 0)
-		}
-	*/
-
 	if err == gocb.ErrKeyExists {
 		InfofCtx(c.loggingCtx, KeyDCP, "cfg_sg: Set, ErrKeyExists key: %s, cas: %d", cfgKey, cas)
 		return 0, &cbgt.CfgCASError{}

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -8,25 +8,27 @@ import (
 	"github.com/couchbase/gocb"
 )
 
-// CfgSG is an implementation of Cfg that uses Sync Gateway's existing
-// bucket connection, and existing caching feed to get change notifications.
+// CfgSG is used to manage shared information between Sync Gateway nodes.
+// It implements cbgt.Cfg for use with cbgt, but can be used for to manage
+// any shared data.  It uses Sync Gateway's existing
+// bucket as a keystore, and existing caching feed for change notifications.
 //
 type CfgSG struct {
-	bucket        *gocb.Bucket
+	bucket        Bucket
 	loggingCtx    context.Context
 	subscriptions map[string][]chan<- cbgt.CfgEvent // Keyed by key
 	lock          sync.Mutex                        // mutex for subscriptions
 }
 
-// NewCfgCB returns a Cfg implementation that reads/writes its entries
+// NewCfgSG returns a Cfg implementation that reads/writes its entries
 // from/to a couchbase bucket, using DCP streams to subscribe to
 // changes.
 //
 // urlStr: single URL or multiple URLs delimited by ';'
 // bucket: couchbase bucket name
-func NewCfgSG(bucket *gocb.Bucket) (*CfgSG, error) {
+func NewCfgSG(bucket Bucket) (*CfgSG, error) {
 
-	cfgContextID := MD(bucket.Name()).Redact() + "-" + DCPImportFeedID
+	cfgContextID := MD(bucket.GetName()).Redact() + "-cfgSG"
 	loggingCtx := context.WithValue(context.Background(), LogContextKey{},
 		LogContext{CorrelationID: cfgContextID},
 	)
@@ -50,7 +52,7 @@ func (c *CfgSG) Get(cfgKey string, cas uint64) (
 	bucketKey := sgCfgBucketKey(cfgKey)
 	var value []byte
 	casOut, err := c.bucket.Get(bucketKey, &value)
-	if err != nil && err != gocb.ErrKeyNotFound {
+	if err != nil && !IsKeyNotFoundError(c.bucket, err) {
 		InfofCtx(c.loggingCtx, KeyDCP, "cfg_sg: Get, key: %s, cas: %d, err: %v", cfgKey, cas, err)
 		return nil, 0, err
 	}
@@ -66,14 +68,18 @@ func (c *CfgSG) Get(cfgKey string, cas uint64) (
 func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 
 	InfofCtx(c.loggingCtx, KeyDCP, "cfg_sg: Set, key: %s, cas: %d", cfgKey, cas)
-	var casOut gocb.Cas
 	var err error
 	bucketKey := sgCfgBucketKey(cfgKey)
-	if cas == 0 {
-		casOut, err = c.bucket.Insert(bucketKey, val, 0)
-	} else {
-		casOut, err = c.bucket.Replace(bucketKey, val, gocb.Cas(cas), 0)
-	}
+
+	casOut, err := c.bucket.WriteCas(bucketKey, 0, 0, cas, val, 0)
+
+	/*
+		if cas == 0 {
+			casOut, err = c.bucket.Insert(bucketKey, val, 0)
+		} else {
+			casOut, err = c.bucket.Replace(bucketKey, val, gocb.Cas(cas), 0)
+		}
+	*/
 
 	if err == gocb.ErrKeyExists {
 		InfofCtx(c.loggingCtx, KeyDCP, "cfg_sg: Set, ErrKeyExists key: %s, cas: %d", cfgKey, cas)
@@ -83,20 +89,20 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 		return 0, err
 	}
 
-	c.FireEvent(cfgKey, uint64(casOut), nil)
-	return uint64(casOut), nil
+	c.FireEvent(cfgKey, casOut, nil)
+	return casOut, nil
 }
 
 func (c *CfgSG) Del(cfgKey string, cas uint64) error {
 
 	InfofCtx(c.loggingCtx, KeyDCP, "cfg_sg: Del, key: %s, cas: %d", cfgKey, cas)
 	bucketKey := sgCfgBucketKey(cfgKey)
-	casOut, err := c.bucket.Remove(bucketKey, gocb.Cas(cas))
-	if err != nil && err != gocb.ErrKeyNotFound {
+	casOut, err := c.bucket.Remove(bucketKey, cas)
+	if err != nil && !IsKeyNotFoundError(c.bucket, err) {
 		return err
 	}
 
-	c.FireEvent(cfgKey, uint64(casOut), nil)
+	c.FireEvent(cfgKey, casOut, nil)
 	return err
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -97,6 +97,7 @@ type DatabaseContext struct {
 	CompactState       uint32                   // Status of database compaction
 	terminator         chan bool                // Signal termination of background goroutines
 	activeChannels     *channels.ActiveChannels // Tracks active replications by channel
+	CfgSG              *base.CfgSG              // Sync Gateway cluster shared config
 }
 
 type DatabaseContextOptions struct {
@@ -285,6 +286,9 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	// Initialize the tap Listener for notify handling
 	dbContext.mutationListener.Init(bucket.GetName())
 
+	// Initialize sg cluster config if needed
+	dbContext.InitCfgSG()
+
 	// If this is an xattr import node, start import feed
 	if dbContext.UseXattrs() && dbContext.autoImport {
 		dbContext.ImportListener = NewImportListener()
@@ -405,6 +409,30 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	return dbContext, nil
+}
+
+func (context *DatabaseContext) InitCfgSG() (err error) {
+
+	requiresCfg := false
+
+	// Import requires cfg
+	if context.UseXattrs() && context.autoImport {
+		requiresCfg = true
+	}
+
+	// sg-replicate requires cfg
+	// TODO: check for replication definitions
+
+	if requiresCfg {
+		context.CfgSG, err = base.NewCfgSG(context.Bucket)
+		if err != nil {
+			base.Warnf("Error initializing cfg for cluster HA: %v", err)
+			return err
+		}
+	}
+
+	return nil
+
 }
 
 func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDCProvider, error) {

--- a/db/database.go
+++ b/db/database.go
@@ -287,7 +287,10 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	dbContext.mutationListener.Init(bucket.GetName())
 
 	// Initialize sg cluster config if needed
-	dbContext.InitCfgSG()
+	err = dbContext.InitCfgSG()
+	if err != nil {
+		return nil, err
+	}
 
 	// If this is an xattr import node, start import feed
 	if dbContext.UseXattrs() && dbContext.autoImport {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -60,7 +60,7 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *DatabaseS
 		// Non-gocb bucket or CE, start a non-sharded feed
 		return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap)
 	} else {
-		il.cbgtContext, err = gocbBucket.StartShardedDCPFeed(dbContext.Name, il.database.Options.ImportOptions.ImportPartitions)
+		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, gocbBucket, dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
 		return err
 	}
 


### PR DESCRIPTION
Prerequisite to CBG-771 work.

Move CfgSG to database context to support use by both import and sg-replicate2.

Use distinct logging contexts for cbgt and cfgSG.

Switch CfgSG to use Bucket (instead of gocbBucket) for testing flexibility.

Make CouchbaseBucketGoCB.Spec public to avoid nested StartShardedDCPFeed calls.