### PR TITLE
Replace GetTestKeyNamespace with t.Name

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -62,7 +62,7 @@ func TestSetGetRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -91,7 +91,7 @@ func TestAddRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -146,7 +146,7 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			key := fmt.Sprintf("%s_%d", getTestKeyNamespace(t), i)
+			key := fmt.Sprintf("%s_%d", GetTestKeyNamespace(t), i)
 			added, err := bucket.AddRaw(key, 0, largeDoc)
 			if err != nil {
 				if pkgerrors.Cause(err) != gocb.ErrTimeout {
@@ -183,7 +183,7 @@ func TestBulkGetRaw(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		iStr := strconv.Itoa(i)
-		key := getTestKeyNamespace(t) + iStr
+		key := GetTestKeyNamespace(t) + iStr
 		val := []byte("bar" + iStr)
 		keySet[i] = key
 		valueSet[key] = val
@@ -234,7 +234,7 @@ func TestWriteCasBasic(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	val := []byte("bar2")
 
 	_, _, err := bucket.GetRaw(key)
@@ -276,7 +276,7 @@ func TestWriteCasAdvanced(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
@@ -320,9 +320,9 @@ func TestSetBulk(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key1 := getTestKeyNamespace(t) + "1"
-	key2 := getTestKeyNamespace(t) + "2"
-	key3 := getTestKeyNamespace(t) + "3"
+	key1 := GetTestKeyNamespace(t) + "1"
+	key2 := GetTestKeyNamespace(t) + "2"
+	key3 := GetTestKeyNamespace(t) + "3"
 	var returnVal interface{}
 
 	// Cleanup
@@ -422,7 +422,7 @@ func TestUpdate(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	valInitial := []byte("initial")
 	valUpdated := []byte("updated")
 
@@ -478,7 +478,7 @@ func TestIncrCounter(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 
 	defer func() {
 		err := bucket.Delete(key)
@@ -517,7 +517,7 @@ func TestGetAndTouchRaw(t *testing.T) {
 	// There's no easy way to validate the expiry time of a doc (that I know of)
 	// so this is just a smoke test
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	val := []byte("bar")
 
 	testBucket := GetTestBucket(t)
@@ -631,7 +631,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -699,7 +699,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -765,7 +765,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["sg_field"] = "sg_value"
@@ -839,7 +839,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -892,7 +892,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -976,7 +976,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -1061,7 +1061,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["counter"] = float64(1)
@@ -1185,7 +1185,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1240,7 +1240,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	xattrVal["seq"] = 1
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1313,7 +1313,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1361,10 +1361,10 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1461,10 +1461,10 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1545,7 +1545,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 		return
 	}
 
-	key := getTestKeyNamespace(t)
+	key := GetTestKeyNamespace(t)
 	xattrName := SyncXattrName
 	createTombstonedDoc(bucket, key, xattrName)
 
@@ -1594,10 +1594,10 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1686,10 +1686,10 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := getTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := getTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := getTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
+	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
+	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
+	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1800,7 +1800,7 @@ func TestGetXattr(t *testing.T) {
 	}
 
 	//Doc 1
-	key1 := getTestKeyNamespace(t) + "DocExistsXattrExists"
+	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
 	val1 := make(map[string]interface{})
 	val1["type"] = key1
 	xattrName1 := "sync"
@@ -1809,7 +1809,7 @@ func TestGetXattr(t *testing.T) {
 	xattrVal1["rev"] = "1-foo"
 
 	//Doc 2 - Tombstone
-	key2 := getTestKeyNamespace(t) + "TombstonedDocXattrExists"
+	key2 := GetTestKeyNamespace(t) + "TombstonedDocXattrExists"
 	val2 := make(map[string]interface{})
 	val2["type"] = key2
 	xattrVal2 := make(map[string]interface{})
@@ -1817,7 +1817,7 @@ func TestGetXattr(t *testing.T) {
 	xattrVal2["rev"] = "1-foo"
 
 	//Doc 3 - To Delete
-	key3 := getTestKeyNamespace(t) + "DeletedDocXattrExists"
+	key3 := GetTestKeyNamespace(t) + "DeletedDocXattrExists"
 	val3 := make(map[string]interface{})
 	val3["type"] = key3
 	xattrName3 := "sync"

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -62,7 +62,7 @@ func TestSetGetRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -91,7 +91,7 @@ func TestAddRaw(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	val := []byte("bar")
 
 	_, _, err := bucket.GetRaw(key)
@@ -146,7 +146,7 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			key := fmt.Sprintf("%s_%d", GetTestKeyNamespace(t), i)
+			key := fmt.Sprintf("%s_%d", t.Name(), i)
 			added, err := bucket.AddRaw(key, 0, largeDoc)
 			if err != nil {
 				if pkgerrors.Cause(err) != gocb.ErrTimeout {
@@ -183,7 +183,7 @@ func TestBulkGetRaw(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		iStr := strconv.Itoa(i)
-		key := GetTestKeyNamespace(t) + iStr
+		key := t.Name() + iStr
 		val := []byte("bar" + iStr)
 		keySet[i] = key
 		valueSet[key] = val
@@ -234,7 +234,7 @@ func TestWriteCasBasic(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	val := []byte("bar2")
 
 	_, _, err := bucket.GetRaw(key)
@@ -276,7 +276,7 @@ func TestWriteCasAdvanced(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
@@ -320,9 +320,9 @@ func TestSetBulk(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key1 := GetTestKeyNamespace(t) + "1"
-	key2 := GetTestKeyNamespace(t) + "2"
-	key3 := GetTestKeyNamespace(t) + "3"
+	key1 := t.Name() + "1"
+	key2 := t.Name() + "2"
+	key3 := t.Name() + "3"
 	var returnVal interface{}
 
 	// Cleanup
@@ -422,7 +422,7 @@ func TestUpdate(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	valInitial := []byte("initial")
 	valUpdated := []byte("updated")
 
@@ -478,7 +478,7 @@ func TestIncrCounter(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 
 	defer func() {
 		err := bucket.Delete(key)
@@ -517,7 +517,7 @@ func TestGetAndTouchRaw(t *testing.T) {
 	// There's no easy way to validate the expiry time of a doc (that I know of)
 	// so this is just a smoke test
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	val := []byte("bar")
 
 	testBucket := GetTestBucket(t)
@@ -631,7 +631,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -699,7 +699,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -765,7 +765,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 	defer testBucket.Close()
 	bucket := testBucket.Bucket
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["sg_field"] = "sg_value"
@@ -839,7 +839,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -892,7 +892,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -976,7 +976,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["body_field"] = "1234"
@@ -1061,7 +1061,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	}
 	bucket.SetTranscoder(SGTranscoder{})
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	val := make(map[string]interface{})
 	val["counter"] = float64(1)
@@ -1185,7 +1185,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1240,7 +1240,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	xattrVal["seq"] = 1
 	xattrVal["rev"] = "1-1234"
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1313,7 +1313,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	_, _, err := bucket.GetRaw(key)
 	if err == nil {
 		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
@@ -1361,10 +1361,10 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 		return
 	}
 
-	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := t.Name() + "DocExistsXattrExists"
+	key2 := t.Name() + "DocExistsNoXattr"
+	key3 := t.Name() + "XattrExistsNoDoc"
+	key4 := t.Name() + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1461,10 +1461,10 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := t.Name() + "DocExistsXattrExists"
+	key2 := t.Name() + "DocExistsNoXattr"
+	key3 := t.Name() + "XattrExistsNoDoc"
+	key4 := t.Name() + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1545,7 +1545,7 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 		return
 	}
 
-	key := GetTestKeyNamespace(t)
+	key := t.Name()
 	xattrName := SyncXattrName
 	createTombstonedDoc(bucket, key, xattrName)
 
@@ -1594,10 +1594,10 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := t.Name() + "DocExistsXattrExists"
+	key2 := t.Name() + "DocExistsNoXattr"
+	key3 := t.Name() + "XattrExistsNoDoc"
+	key4 := t.Name() + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1686,10 +1686,10 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 		return
 	}
 
-	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
-	key2 := GetTestKeyNamespace(t) + "DocExistsNoXattr"
-	key3 := GetTestKeyNamespace(t) + "XattrExistsNoDoc"
-	key4 := GetTestKeyNamespace(t) + "NoDocNoXattr"
+	key1 := t.Name() + "DocExistsXattrExists"
+	key2 := t.Name() + "DocExistsNoXattr"
+	key3 := t.Name() + "XattrExistsNoDoc"
+	key4 := t.Name() + "NoDocNoXattr"
 
 	// 1. Create document with XATTR
 	val := make(map[string]interface{})
@@ -1800,7 +1800,7 @@ func TestGetXattr(t *testing.T) {
 	}
 
 	//Doc 1
-	key1 := GetTestKeyNamespace(t) + "DocExistsXattrExists"
+	key1 := t.Name() + "DocExistsXattrExists"
 	val1 := make(map[string]interface{})
 	val1["type"] = key1
 	xattrName1 := "sync"
@@ -1809,7 +1809,7 @@ func TestGetXattr(t *testing.T) {
 	xattrVal1["rev"] = "1-foo"
 
 	//Doc 2 - Tombstone
-	key2 := GetTestKeyNamespace(t) + "TombstonedDocXattrExists"
+	key2 := t.Name() + "TombstonedDocXattrExists"
 	val2 := make(map[string]interface{})
 	val2["type"] = key2
 	xattrVal2 := make(map[string]interface{})
@@ -1817,7 +1817,7 @@ func TestGetXattr(t *testing.T) {
 	xattrVal2["rev"] = "1-foo"
 
 	//Doc 3 - To Delete
-	key3 := GetTestKeyNamespace(t) + "DeletedDocXattrExists"
+	key3 := t.Name() + "DeletedDocXattrExists"
 	val3 := make(map[string]interface{})
 	val3["type"] = key3
 	xattrName3 := "sync"

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -321,7 +321,7 @@ func DirExists(filename string) bool {
 	return info.IsDir()
 }
 
-// getTestKeyNamespace returns a unique doc key namespace that can be prepended in tests.
-func getTestKeyNamespace(t *testing.T) string {
+// GetTestKeyNamespace returns a unique doc key namespace that can be prepended in tests.
+func GetTestKeyNamespace(t *testing.T) string {
 	return t.Name()
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -320,8 +320,3 @@ func DirExists(filename string) bool {
 	}
 	return info.IsDir()
 }
-
-// GetTestKeyNamespace returns a unique doc key namespace that can be prepended in tests.
-func GetTestKeyNamespace(t *testing.T) string {
-	return t.Name()
-}


### PR DESCRIPTION
I want to use `GetTestKeyNamespace()` from the db package, so opening standalone PR for this.