### PR TITLE
CBG-852 Stub out new sg-replicate API

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -98,6 +98,7 @@ type DatabaseContext struct {
 	terminator         chan bool                // Signal termination of background goroutines
 	activeChannels     *channels.ActiveChannels // Tracks active replications by channel
 	CfgSG              *base.CfgSG              // Sync Gateway cluster shared config
+	SGReplicateMgr     *sgReplicateManager      // Manages interactions with sg-replicate replications
 }
 
 type DatabaseContextOptions struct {
@@ -286,8 +287,15 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	// Initialize the tap Listener for notify handling
 	dbContext.mutationListener.Init(bucket.GetName())
 
-	// Initialize sg cluster config if needed
-	err = dbContext.InitCfgSG()
+	// Initialize sg cluster config.  Required even if import and sgreplicate are disabled
+	// on this node, to support replication REST API calls
+	dbContext.CfgSG, err = base.NewCfgSG(dbContext.Bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize sg-replicate manager
+	dbContext.SGReplicateMgr, err = NewSGReplicateManager(dbContext.CfgSG, dbName)
 	if err != nil {
 		return nil, err
 	}
@@ -414,26 +422,16 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	return dbContext, nil
 }
 
+// InitCfgSG initializes Sync Gateway cluster config.  Used to manage shared import and sg-replicate config
+// between Sync Gateway nodes.  Required even if import is disabled and sgreplicate_enabled=false
+// to support REST API _replication/_replicationStatus requests.
 func (context *DatabaseContext) InitCfgSG() (err error) {
 
-	requiresCfg := false
-
-	// Import requires cfg
-	if context.UseXattrs() && context.autoImport {
-		requiresCfg = true
+	context.CfgSG, err = base.NewCfgSG(context.Bucket)
+	if err != nil {
+		base.Warnf("Error initializing cfg for cluster HA: %v", err)
+		return err
 	}
-
-	// sg-replicate requires cfg
-	// TODO: check for replication definitions
-
-	if requiresCfg {
-		context.CfgSG, err = base.NewCfgSG(context.Bucket)
-		if err != nil {
-			base.Warnf("Error initializing cfg for cluster HA: %v", err)
-			return err
-		}
-	}
-
 	return nil
 
 }

--- a/db/database.go
+++ b/db/database.go
@@ -422,20 +422,6 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	return dbContext, nil
 }
 
-// InitCfgSG initializes Sync Gateway cluster config.  Used to manage shared import and sg-replicate config
-// between Sync Gateway nodes.  Required even if import is disabled and sgreplicate_enabled=false
-// to support REST API _replication/_replicationStatus requests.
-func (context *DatabaseContext) InitCfgSG() (err error) {
-
-	context.CfgSG, err = base.NewCfgSG(context.Bucket)
-	if err != nil {
-		base.Warnf("Error initializing cfg for cluster HA: %v", err)
-		return err
-	}
-	return nil
-
-}
-
 func (context *DatabaseContext) GetOIDCProvider(providerName string) (*auth.OIDCProvider, error) {
 
 	// If providerName isn't specified, check whether there's a default provider

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -25,7 +25,7 @@ func TestReplicateManagerReplications(t *testing.T) {
 	require.NoError(t, err)
 
 	replication1_id := "replication1"
-	err = manager.AddReplication(&ReplicationCfg{ID: replication1_id})
+	err = manager.AddReplication(testReplicationCfg(replication1_id, ""))
 
 	r, err := manager.GetReplication(replication1_id)
 	require.NoError(t, err)
@@ -36,12 +36,12 @@ func TestReplicateManagerReplications(t *testing.T) {
 	require.Error(t, err, base.ErrNotFound)
 
 	// Attempt to add existing replication
-	err = manager.AddReplication(&ReplicationCfg{ID: replication1_id})
+	err = manager.AddReplication(testReplicationCfg(replication1_id, ""))
 	require.Error(t, err, base.ErrAlreadyExists)
 
 	// Add a second replication
 	replication2_id := "replication2"
-	err = manager.AddReplication(&ReplicationCfg{ID: replication2_id})
+	err = manager.AddReplication(testReplicationCfg(replication2_id, ""))
 	require.NoError(t, err)
 
 	r, err = manager.GetReplication(replication1_id)
@@ -190,7 +190,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 		replicationWg.Add(1)
 		go func(i int) {
 			defer replicationWg.Done()
-			err := manager.AddReplication(&ReplicationCfg{ID: fmt.Sprintf("r_%d", i)})
+			err := manager.AddReplication(testReplicationCfg(fmt.Sprintf("r_%d", i), ""))
 			assert.NoError(t, err)
 		}(i)
 	}
@@ -215,6 +215,13 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	require.Equal(t, 0, len(replications))
 }
 
+func testReplicationCfg(id, assignedNode string) *ReplicationCfg {
+	return &ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{ID: id},
+		AssignedNode:      assignedNode,
+	}
+}
+
 func TestRebalanceReplications(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate)()
@@ -236,9 +243,9 @@ func TestRebalanceReplications(t *testing.T) {
 				"n3": {Host: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n1"},
-				"r2": {ID: "r2", AssignedNode: "n1"},
-				"r3": {ID: "r3", AssignedNode: "n1"},
+				"r1": testReplicationCfg("r1", "n1"),
+				"r2": testReplicationCfg("r2", "n1"),
+				"r3": testReplicationCfg("r3", "n1"),
 			},
 			expectedMinPerNode:    1,
 			expectedMaxPerNode:    1,
@@ -252,9 +259,9 @@ func TestRebalanceReplications(t *testing.T) {
 				"n3": {Host: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: ""},
-				"r2": {ID: "r2", AssignedNode: ""},
-				"r3": {ID: "r3", AssignedNode: ""},
+				"r1": testReplicationCfg("r1", ""),
+				"r2": testReplicationCfg("r2", ""),
+				"r3": testReplicationCfg("r3", ""),
 			},
 			expectedMinPerNode:    1,
 			expectedMaxPerNode:    1,
@@ -267,10 +274,10 @@ func TestRebalanceReplications(t *testing.T) {
 				"n2": {Host: "n2"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n1"},
-				"r2": {ID: "r2", AssignedNode: "n2"},
-				"r3": {ID: "r3", AssignedNode: "n3"},
-				"r4": {ID: "r4", AssignedNode: "n4"},
+				"r1": testReplicationCfg("r1", "n1"),
+				"r2": testReplicationCfg("r2", "n2"),
+				"r3": testReplicationCfg("r3", "n3"),
+				"r4": testReplicationCfg("r4", "n4"),
 			},
 			expectedMinPerNode:    2,
 			expectedMaxPerNode:    2,
@@ -280,9 +287,9 @@ func TestRebalanceReplications(t *testing.T) {
 			name:  "no nodes",
 			nodes: map[string]*SGNode{},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n1"},
-				"r2": {ID: "r2", AssignedNode: "n1"},
-				"r3": {ID: "r3", AssignedNode: "n2"},
+				"r1": testReplicationCfg("r1", "n1"),
+				"r2": testReplicationCfg("r2", "n1"),
+				"r3": testReplicationCfg("r3", "n2"),
 			},
 			expectedMinPerNode:    0,
 			expectedMaxPerNode:    0,
@@ -294,9 +301,9 @@ func TestRebalanceReplications(t *testing.T) {
 				"n1": {Host: "n1"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n1"},
-				"r2": {ID: "r2", AssignedNode: "n2"},
-				"r3": {ID: "r3", AssignedNode: ""},
+				"r1": testReplicationCfg("r1", "n1"),
+				"r2": testReplicationCfg("r2", "n2"),
+				"r3": testReplicationCfg("r3", ""),
 			},
 			expectedMinPerNode:    3,
 			expectedMaxPerNode:    3,
@@ -309,9 +316,9 @@ func TestRebalanceReplications(t *testing.T) {
 				"n2": {Host: "n2"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n1"},
-				"r2": {ID: "r2", AssignedNode: "n1"},
-				"r3": {ID: "r3", AssignedNode: "n1"},
+				"r1": testReplicationCfg("r1", "n1"),
+				"r2": testReplicationCfg("r2", "n1"),
+				"r3": testReplicationCfg("r3", "n1"),
 			},
 			expectedMinPerNode:    1,
 			expectedMaxPerNode:    2,
@@ -325,12 +332,12 @@ func TestRebalanceReplications(t *testing.T) {
 				"n3": {Host: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n1"},
-				"r2": {ID: "r2", AssignedNode: "n1"},
-				"r3": {ID: "r3", AssignedNode: "n1"},
-				"r4": {ID: "r4", AssignedNode: "n1"},
-				"r5": {ID: "r5", AssignedNode: "n1"},
-				"r6": {ID: "r6", AssignedNode: "n1"},
+				"r1": testReplicationCfg("r1", "n1"),
+				"r2": testReplicationCfg("r2", "n1"),
+				"r3": testReplicationCfg("r3", "n1"),
+				"r4": testReplicationCfg("r4", "n1"),
+				"r5": testReplicationCfg("r5", "n1"),
+				"r6": testReplicationCfg("r6", "n1"),
 			},
 			expectedMinPerNode:    2,
 			expectedMaxPerNode:    2,
@@ -344,12 +351,12 @@ func TestRebalanceReplications(t *testing.T) {
 				"n3": {Host: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: ""},
-				"r2": {ID: "r2", AssignedNode: ""},
-				"r3": {ID: "r3", AssignedNode: ""},
-				"r4": {ID: "r4", AssignedNode: ""},
-				"r5": {ID: "r5", AssignedNode: "n1"},
-				"r6": {ID: "r6", AssignedNode: "n2"},
+				"r1": testReplicationCfg("r1", ""),
+				"r2": testReplicationCfg("r2", ""),
+				"r3": testReplicationCfg("r3", ""),
+				"r4": testReplicationCfg("r4", ""),
+				"r5": testReplicationCfg("r5", "n1"),
+				"r6": testReplicationCfg("r6", "n1"),
 			},
 			expectedMinPerNode:    2,
 			expectedMaxPerNode:    2,
@@ -362,10 +369,10 @@ func TestRebalanceReplications(t *testing.T) {
 				"n2": {Host: "n2"},
 			},
 			replications: map[string]*ReplicationCfg{
-				"r1": {ID: "r1", AssignedNode: "n3"},
-				"r2": {ID: "r2", AssignedNode: "n3"},
-				"r3": {ID: "r3", AssignedNode: "n3"},
-				"r4": {ID: "r4", AssignedNode: "n3"},
+				"r1": testReplicationCfg("r1", "n3"),
+				"r2": testReplicationCfg("r2", "n3"),
+				"r3": testReplicationCfg("r3", "n3"),
+				"r4": testReplicationCfg("r4", "n3"),
 			},
 			expectedMinPerNode:    2,
 			expectedMaxPerNode:    2,

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -147,7 +147,7 @@ func (h *handler) handleReplicate() error {
 		return err
 	}
 
-	params, cancel, _, err := h.readReplicationParametersFromJSON(body)
+	params, cancel, _, err := h.readReplicateV1ParametersFromJSON(body)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (h *handler) handleReplicate() error {
 
 }
 
-type ReplicationConfig struct {
+type ReplicateV1Config struct {
 	Source           string      `json:"source"`
 	Target           string      `json:"target"`
 	Continuous       bool        `json:"continuous"`
@@ -217,17 +217,17 @@ type ReplicationConfig struct {
 	ReplicationId    string      `json:"replication_id"`
 }
 
-func (h *handler) readReplicationParametersFromJSON(jsonData []byte) (params sgreplicate.ReplicationParameters, cancel bool, localdb bool, err error) {
+func (h *handler) readReplicateV1ParametersFromJSON(jsonData []byte) (params sgreplicate.ReplicationParameters, cancel bool, localdb bool, err error) {
 
-	var in ReplicationConfig
+	var in ReplicateV1Config
 	if err = base.JSONUnmarshal(jsonData, &in); err != nil {
 		return params, false, localdb, err
 	}
 
-	return validateReplicationParameters(in, false, *h.server.config.AdminInterface)
+	return validateReplicateV1Parameters(in, false, *h.server.config.AdminInterface)
 }
 
-func validateReplicationParameters(requestParams ReplicationConfig, paramsFromConfig bool, adminInterface string) (params sgreplicate.ReplicationParameters, cancel bool, localdb bool, err error) {
+func validateReplicateV1Parameters(requestParams ReplicateV1Config, paramsFromConfig bool, adminInterface string) (params sgreplicate.ReplicationParameters, cancel bool, localdb bool, err error) {
 	if requestParams.CreateTarget {
 		err = base.HTTPErrorf(http.StatusBadRequest, "/_replicate create_target option is not currently supported.")
 		return
@@ -818,3 +818,92 @@ func (h *handler) handlePurge() error {
 
 	return nil
 }
+
+// sg-replicate endpoints
+func (h *handler) getReplications() error {
+	replications, err := h.db.SGReplicateMgr.GetReplications()
+	if err != nil {
+		return err
+	}
+	bytes, err := base.JSONMarshal(replications)
+	h.writeRawJSON(bytes)
+	return err
+}
+
+func (h *handler) getReplication() error {
+	replicationID := mux.Vars(h.rq)["replicationID"]
+	replication, err := h.db.SGReplicateMgr.GetReplication(replicationID)
+	if replication == nil {
+		if err == nil {
+			return kNotFoundError
+		}
+		return err
+	}
+
+	bytes, err := base.JSONMarshal(replication)
+	h.writeRawJSON(bytes)
+	return err
+}
+
+func (h *handler) putReplication() error {
+	replicationID := mux.Vars(h.rq)["replicationID"]
+	return h.upsertReplication(replicationID)
+}
+
+func (h *handler) upsertReplication(replicationID string) error {
+	body, _ := h.readBody()
+	replicationConfig := &db.ReplicationCfg{}
+	if err := base.JSONUnmarshal(body, replicationConfig); err != nil {
+		return err
+	}
+
+	if h.rq.Method == "PUT" {
+		if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
+			return base.HTTPErrorf(http.StatusBadRequest, "Replication ID in body %q does not match request URI", replicationConfig.ID)
+		}
+		replicationConfig.ID = replicationID
+	}
+
+	validateErr := replicationConfig.ValidateNewReplication(false)
+	if validateErr != nil {
+		return validateErr
+	}
+	created, err := h.db.SGReplicateMgr.UpsertReplication(replicationConfig)
+	if err != nil {
+		return err
+	}
+	if created {
+		h.writeStatus(http.StatusCreated, "Created")
+	}
+
+	return nil
+}
+
+func (h *handler) deleteReplication() error {
+	replicationID := mux.Vars(h.rq)["replicationID"]
+	return h.db.SGReplicateMgr.DeleteReplication(replicationID)
+}
+
+func (h *handler) getReplicationsStatus() error {
+	h.writeJSON(h.db.SGReplicateMgr.GetReplicationStatusAll())
+	return nil
+}
+
+func (h *handler) getReplicationStatus() error {
+	replicationID := mux.Vars(h.rq)["replicationID"]
+	h.writeJSON(h.db.SGReplicateMgr.GetReplicationStatus(replicationID))
+	return nil
+}
+
+func (h *handler) putReplicationStatus() error {
+	replicationID := mux.Vars(h.rq)["replicationID"]
+
+	action := h.getQuery("action")
+	if action == "" {
+		return base.HTTPErrorf(http.StatusBadRequest, "Query parameter 'action' must be specified")
+	}
+
+	return h.db.SGReplicateMgr.PutReplicationStatus(replicationID, action)
+}
+
+// Delete tests need to cover 'not found'

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -825,9 +825,8 @@ func (h *handler) getReplications() error {
 	if err != nil {
 		return err
 	}
-	bytes, err := base.JSONMarshal(replications)
-	h.writeRawJSON(bytes)
-	return err
+	h.writeJSON(replications)
+	return nil
 }
 
 func (h *handler) getReplication() error {
@@ -840,17 +839,11 @@ func (h *handler) getReplication() error {
 		return err
 	}
 
-	bytes, err := base.JSONMarshal(replication)
-	h.writeRawJSON(bytes)
-	return err
+	h.writeJSON(replication)
+	return nil
 }
 
 func (h *handler) putReplication() error {
-	replicationID := mux.Vars(h.rq)["replicationID"]
-	return h.upsertReplication(replicationID)
-}
-
-func (h *handler) upsertReplication(replicationID string) error {
 	body, _ := h.readBody()
 	replicationConfig := &db.ReplicationCfg{}
 	if err := base.JSONUnmarshal(body, replicationConfig); err != nil {
@@ -858,6 +851,7 @@ func (h *handler) upsertReplication(replicationID string) error {
 	}
 
 	if h.rq.Method == "PUT" {
+		replicationID := mux.Vars(h.rq)["replicationID"]
 		if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
 			return base.HTTPErrorf(http.StatusBadRequest, "Replication ID in body %q does not match request URI", replicationConfig.ID)
 		}
@@ -905,5 +899,3 @@ func (h *handler) putReplicationStatus() error {
 
 	return h.db.SGReplicateMgr.PutReplicationStatus(replicationID, action)
 }
-
-// Delete tests need to cover 'not found'

--- a/rest/config.go
+++ b/rest/config.go
@@ -92,7 +92,7 @@ type ServerConfig struct {
 	MaxFileDescriptors         *uint64                  `json:",omitempty"`                       // Max # of open file descriptors (RLIMIT_NOFILE)
 	CompressResponses          *bool                    `json:",omitempty"`                       // If false, disables compression of HTTP responses
 	Databases                  DbConfigMap              `json:",omitempty"`                       // Pre-configured databases, mapped by name
-	Replications               []*ReplicationConfig     `json:",omitempty"`                       // sg-replicate replication definitions
+	Replications               []*ReplicateV1Config     `json:",omitempty"`                       // sg-replicate replication definitions
 	MaxHeartbeat               uint64                   `json:",omitempty"`                       // Max heartbeat value for _changes request (seconds)
 	ClusterConfig              *ClusterConfig           `json:"cluster_config,omitempty"`         // Bucket and other config related to CBGT
 	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`            // Config for unsupported features
@@ -209,7 +209,7 @@ type DeprecatedOptions struct {
 
 type DbConfigMap map[string]*DbConfig
 
-type ReplConfigMap map[string]*ReplicationConfig
+type ReplConfigMap map[string]*ReplicateV1Config
 
 type FacebookConfig struct {
 	Register bool // If true, server will register new user accounts

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1,0 +1,157 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicationAPI(t *testing.T) {
+
+	var rt = NewRestTester(t, nil)
+	defer rt.Close()
+
+	replicationConfig := db.ReplicationConfig{
+		ID:        "replication1",
+		Remote:    "http://remote:4984/db",
+		Direction: "Pull",
+	}
+
+	// PUT replication
+	response := rt.SendAdminRequest("PUT", "/db/_replication/replication1", marshalConfig(t, replicationConfig))
+	assertStatus(t, response, http.StatusCreated)
+
+	// GET replication for PUT
+	response = rt.SendAdminRequest("GET", "/db/_replication/replication1", "")
+	assertStatus(t, response, http.StatusOK)
+	var configResponse db.ReplicationConfig
+	err := json.Unmarshal(response.BodyBytes(), &configResponse)
+	require.NoError(t, err)
+	assert.Equal(t, configResponse.ID, "replication1")
+	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
+	assert.Equal(t, configResponse.Direction, "Pull")
+
+	// POST replication
+	replicationConfig.ID = "replication2"
+	response = rt.SendAdminRequest("POST", "/db/_replication/", marshalConfig(t, replicationConfig))
+	assertStatus(t, response, http.StatusCreated)
+
+	// GET replication for POST
+	response = rt.SendAdminRequest("GET", "/db/_replication/replication2", "")
+	assertStatus(t, response, http.StatusOK)
+	configResponse = db.ReplicationConfig{}
+	err = json.Unmarshal(response.BodyBytes(), &configResponse)
+	require.NoError(t, err)
+	assert.Equal(t, configResponse.ID, "replication2")
+	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
+	assert.Equal(t, configResponse.Direction, "Pull")
+
+	// GET all replications
+	response = rt.SendAdminRequest("GET", "/db/_replication/", "")
+	assertStatus(t, response, http.StatusOK)
+	var replicationsResponse map[string]db.ReplicationConfig
+	log.Printf("response: %s", response.BodyBytes())
+	err = json.Unmarshal(response.BodyBytes(), &replicationsResponse)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(replicationsResponse))
+	_, ok := replicationsResponse["replication1"]
+	assert.True(t, ok)
+	_, ok = replicationsResponse["replication2"]
+	assert.True(t, ok)
+}
+
+func TestValidateReplicationAPI(t *testing.T) {
+
+	var rt = NewRestTester(t, nil)
+	defer rt.Close()
+
+	replicationID := "replication1"
+
+	tests := []struct {
+		name                  string
+		config                db.ReplicationConfig
+		expectedResponseCode  int
+		expectedErrorContains string
+	}{
+		{
+			name:                  "ID Mismatch",
+			config:                db.ReplicationConfig{ID: "replication2"},
+			expectedResponseCode:  http.StatusBadRequest,
+			expectedErrorContains: "does not match request URI",
+		},
+		{
+			name:                  "Missing Remote",
+			config:                db.ReplicationConfig{ID: "replication1"},
+			expectedResponseCode:  http.StatusBadRequest,
+			expectedErrorContains: "remote must be specified",
+		},
+		{
+			name:                  "Missing Direction",
+			config:                db.ReplicationConfig{ID: "replication1", Remote: "http://remote:4985/db"},
+			expectedResponseCode:  http.StatusBadRequest,
+			expectedErrorContains: "direction must be specified",
+		},
+		{
+			name:                  "Valid Replication",
+			config:                db.ReplicationConfig{ID: "replication1", Remote: "http://remote:4985/db", Direction: "pull"},
+			expectedResponseCode:  http.StatusCreated,
+			expectedErrorContains: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/_replication/%s", replicationID), marshalConfig(t, test.config))
+			assertStatus(t, response, test.expectedResponseCode)
+			if test.expectedErrorContains != "" {
+				assert.Contains(t, string(response.Body.Bytes()), test.expectedErrorContains)
+			}
+		})
+	}
+
+}
+
+// TODO: Pending CBG-768, test should be updated to validate response data
+func TestReplicationStatusAPI(t *testing.T) {
+
+	var rt = NewRestTester(t, nil)
+	defer rt.Close()
+
+	// GET replication status for replication ID
+	response := rt.SendAdminRequest("GET", "/db/_replicationStatus/replication1", "")
+	assertStatus(t, response, http.StatusOK)
+	var statusResponse db.ReplicationStatus
+	err := json.Unmarshal(response.BodyBytes(), &statusResponse)
+	require.NoError(t, err)
+	assert.Equal(t, statusResponse.ID, "replication1")
+
+	// GET replication status for all replications
+	response = rt.SendAdminRequest("GET", "/db/_replicationStatus/", "")
+	assertStatus(t, response, http.StatusOK)
+	var allStatusResponse []*db.ReplicationStatus
+	err = json.Unmarshal(response.BodyBytes(), &allStatusResponse)
+	require.NoError(t, err)
+	assert.Equal(t, allStatusResponse[0].ID, "sampleReplication1")
+	assert.Equal(t, allStatusResponse[1].ID, "sampleReplication2")
+
+	// PUT replication status, no action
+	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1", "")
+	assertStatus(t, response, http.StatusBadRequest)
+
+	// PUT replication status with action
+	response = rt.SendAdminRequest("PUT", "/db/_replicationStatus/replication1?action=start", "")
+	assertStatus(t, response, http.StatusOK)
+
+}
+
+func marshalConfig(t *testing.T, config db.ReplicationConfig) string {
+	replicationPayload, err := json.Marshal(config)
+	require.NoError(t, err)
+	return string(replicationPayload)
+}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -64,6 +64,19 @@ func TestReplicationAPI(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = replicationsResponse["replication2"]
 	assert.True(t, ok)
+
+	// DELETE replication
+	response = rt.SendAdminRequest("DELETE", "/db/_replication/replication1", "")
+	assertStatus(t, response, http.StatusOK)
+
+	// Verify delete was successful
+	response = rt.SendAdminRequest("GET", "/db/_replication/replication1", "")
+	assertStatus(t, response, http.StatusNotFound)
+
+	// DELETE non-existent replication
+	response = rt.SendAdminRequest("DELETE", "/db/_replication/replication3", "")
+	assertStatus(t, response, http.StatusNotFound)
+
 }
 
 func TestValidateReplicationAPI(t *testing.T) {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -195,6 +195,24 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_role/{name}",
 		makeHandler(sc, adminPrivs, (*handler).deleteRole)).Methods("DELETE")
 
+	dbr.Handle("/_replication/",
+		makeHandler(sc, adminPrivs, (*handler).getReplications)).Methods("GET", "HEAD")
+	dbr.Handle("/_replication/",
+		makeHandler(sc, adminPrivs, (*handler).putReplication)).Methods("POST")
+	dbr.Handle("/_replication/{replicationID}",
+		makeHandler(sc, adminPrivs, (*handler).getReplication)).Methods("GET", "HEAD")
+	dbr.Handle("/_replication/{replicationID}",
+		makeHandler(sc, adminPrivs, (*handler).putReplication)).Methods("PUT")
+	dbr.Handle("/_replication/{replicationID}",
+		makeHandler(sc, adminPrivs, (*handler).deleteReplication)).Methods("DELETE")
+
+	dbr.Handle("/_replicationStatus/",
+		makeHandler(sc, adminPrivs, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
+	dbr.Handle("/_replicationStatus/{replicationID}",
+		makeHandler(sc, adminPrivs, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
+	dbr.Handle("/_replicationStatus/{replicationID}",
+		makeHandler(sc, adminPrivs, (*handler).putReplicationStatus)).Methods("PUT")
+
 	r.Handle("/_logging",
 		makeHandler(sc, adminPrivs, (*handler).handleGetLogging)).Methods("GET")
 	r.Handle("/_logging",
@@ -215,6 +233,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
 		makeOfflineHandler(sc, adminPrivs, (*handler).handleActiveTasks)).Methods("GET")
+
 	r.Handle("/_status",
 		makeHandler(sc, adminPrivs, (*handler).handleGetStatus)).Methods("GET")
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -110,7 +110,7 @@ func (sc *ServerContext) startReplicators() {
 
 	for _, replicationConfig := range sc.config.Replications {
 
-		params, _, _, err := validateReplicationParameters(*replicationConfig, true, *sc.config.AdminInterface)
+		params, _, _, err := validateReplicateV1Parameters(*replicationConfig, true, *sc.config.AdminInterface)
 		if err != nil {
 			base.Errorf("Error validating replication parameters: %v", err)
 			continue


### PR DESCRIPTION
Adds _replication and _replicationStatus endpoints.  Replication endpoints are wired up to cfg, replication status just returns a (formatted) static response.  Minimal request validation included, remainder is being left for CBG-766 and CBG-768.