### PR TITLE
CBG-765 File-based replication config

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -715,7 +715,7 @@ func GetGoCBBucketFromBaseBucket(baseBucket Bucket) (bucket CouchbaseBucketGoCB,
 	}
 }
 
-func StringPointer(value string) *string {
+func StringPtr(value string) *string {
 	return &value
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1805,7 +1805,6 @@ func TestGetOIDCProvider(t *testing.T) {
 	provider, err = context.GetOIDCProvider("Unknown")
 	assert.Nil(t, provider, "Provider doesn't exists in database context")
 	assert.Contains(t, err.Error(), `No provider found for provider name "Unknown"`)
-	testBucket.Close()
 }
 
 // TestSyncFnMutateBody ensures that any mutations made to the body by the sync function aren't persisted

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -44,11 +44,10 @@ func setupTestDB(t testing.TB) (*Database, *base.TestBucket) {
 	return setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 }
 
-func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database, *base.TestBucket) {
+// Sets up test db with the specified database context options.  Note that environment variables can
+// override somedbcOptions properties.
+func setupTestDBWithOptions(t testing.TB, dbcOptions DatabaseContextOptions) (*Database, *base.TestBucket) {
 
-	dbcOptions := DatabaseContextOptions{
-		CacheOptions: &options,
-	}
 	AddOptionsFromEnvironmentVariables(&dbcOptions)
 	tBucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", tBucket.Bucket, false, dbcOptions)
@@ -58,6 +57,14 @@ func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database,
 	return db, tBucket
 }
 
+func setupTestDBWithCacheOptions(t testing.TB, options CacheOptions) (*Database, *base.TestBucket) {
+
+	dbcOptions := DatabaseContextOptions{
+		CacheOptions: &options,
+	}
+	return setupTestDBWithOptions(t, dbcOptions)
+}
+
 // Forces UseViews:true in the database context.  Useful for testing w/ views while running
 // tests against Couchbase Server
 func setupTestDBWithViewsEnabled(t testing.TB) (*Database, *base.TestBucket) {
@@ -65,13 +72,7 @@ func setupTestDBWithViewsEnabled(t testing.TB) (*Database, *base.TestBucket) {
 	dbcOptions := DatabaseContextOptions{
 		UseViews: true,
 	}
-	AddOptionsFromEnvironmentVariables(&dbcOptions)
-	tBucket := base.GetTestBucket(t)
-	context, err := NewDatabaseContext("db", tBucket.Bucket, false, dbcOptions)
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "Couldn't create database 'db'")
-	return db, tBucket
+	return setupTestDBWithOptions(t, dbcOptions)
 }
 
 // Sets up a test bucket with _sync:seq initialized to a high value prior to database creation.  Used to test
@@ -837,12 +838,9 @@ func TestConflictRevLimit(t *testing.T) {
 		AllowConflicts: base.BoolPtr(true),
 	}
 
-	AddOptionsFromEnvironmentVariables(&dbOptions)
-	bucket = base.GetTestBucket(t)
-	context, _ := NewDatabaseContext("db", bucket, false, dbOptions)
-	db, _ = CreateDatabase(context)
+	db, bucket = setupTestDBWithOptions(t, dbOptions)
 	assert.Equal(t, uint32(DefaultRevsLimitConflicts), db.RevsLimit)
-
+	bucket.Close()
 	tearDownTestDB(t, db)
 
 	//Test AllowConflicts false
@@ -850,12 +848,9 @@ func TestConflictRevLimit(t *testing.T) {
 		AllowConflicts: base.BoolPtr(false),
 	}
 
-	AddOptionsFromEnvironmentVariables(&dbOptions)
-	bucket = base.GetTestBucket(t)
-	context, _ = NewDatabaseContext("db", bucket, false, dbOptions)
-	db, _ = CreateDatabase(context)
+	db, bucket = setupTestDBWithOptions(t, dbOptions)
 	assert.Equal(t, uint32(DefaultRevsLimitNoConflicts), db.RevsLimit)
-
+	bucket.Close()
 	tearDownTestDB(t, db)
 
 }
@@ -1789,14 +1784,10 @@ func TestNewDatabaseContextWithOIDCProviderOptions(t *testing.T) {
 }
 
 func TestGetOIDCProvider(t *testing.T) {
-	mockedOIDCOptions := mockOIDCOptions()
-	options := DatabaseContextOptions{OIDCOptions: mockedOIDCOptions}
-	AddOptionsFromEnvironmentVariables(&options)
-	testBucket := base.GetTestBucket(t)
-
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, options)
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
-	assert.NotNil(t, context, "Database context should be created")
+	options := DatabaseContextOptions{OIDCOptions: mockOIDCOptions()}
+	context, testBucket := setupTestDBWithOptions(t, options)
+	defer context.Close()
+	defer testBucket.Close()
 
 	// Lookup default provider by empty name, which exists in database context
 	provider, err := context.GetOIDCProvider("")

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -414,60 +414,61 @@ func TestUpsertReplicationConfig(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate)()
 
 	type rebalanceTest struct {
-		name           string             // Test name
-		existingConfig *ReplicationConfig // Initial replication definition
-		updatedConfig  *ReplicationConfig // Initial replication assignment
-		expectedConfig *ReplicationConfig // Minimum replications per node after rebalance
+		name           string                   // Test name
+		existingConfig *ReplicationConfig       // Initial replication definition
+		updatedConfig  *ReplicationUpsertConfig // Initial replication assignment
+		expectedConfig *ReplicationConfig       // Minimum replications per node after rebalance
 	}
 	testCases := []rebalanceTest{
 		{
 			name: "modify string parameter",
 			existingConfig: &ReplicationConfig{
 				ID:        "foo",
-				Remote:    base.StringPtr("remote"),
-				Direction: base.StringPtr("pull"),
+				Remote:    "remote",
+				Direction: "pull",
 			},
-			updatedConfig: &ReplicationConfig{
+			updatedConfig: &ReplicationUpsertConfig{
 				Direction: base.StringPtr("push"),
 			},
 			expectedConfig: &ReplicationConfig{
 				ID:        "foo",
-				Remote:    base.StringPtr("remote"),
-				Direction: base.StringPtr("push"),
+				Remote:    "remote",
+				Direction: "push",
 			},
 		},
 		{
 			name: "remove string parameter",
 			existingConfig: &ReplicationConfig{
 				ID:                   "foo",
-				Remote:               base.StringPtr("remote"),
-				Direction:            base.StringPtr("pull"),
-				ConflictResolutionFn: base.StringPtr("func(){}"),
+				Remote:               "remote",
+				Direction:            "pull",
+				ConflictResolutionFn: "func(){}",
 			},
-			updatedConfig: &ReplicationConfig{
+			updatedConfig: &ReplicationUpsertConfig{
 				ConflictResolutionFn: base.StringPtr(""),
 			},
 			expectedConfig: &ReplicationConfig{
-				ID:        "foo",
-				Remote:    base.StringPtr("remote"),
-				Direction: base.StringPtr("pull"),
+				ID:                   "foo",
+				Remote:               "remote",
+				Direction:            "pull",
+				ConflictResolutionFn: "",
 			},
 		},
 		{
 			name: "switch QueryParams type",
 			existingConfig: &ReplicationConfig{
 				ID:          "foo",
-				Remote:      base.StringPtr("remote"),
-				Direction:   base.StringPtr("pull"),
+				Remote:      "remote",
+				Direction:   "pull",
 				QueryParams: []string{"ABC"},
 			},
-			updatedConfig: &ReplicationConfig{
+			updatedConfig: &ReplicationUpsertConfig{
 				QueryParams: map[string]interface{}{"ABC": true},
 			},
 			expectedConfig: &ReplicationConfig{
 				ID:          "foo",
-				Remote:      base.StringPtr("remote"),
-				Direction:   base.StringPtr("pull"),
+				Remote:      "remote",
+				Direction:   "pull",
 				QueryParams: map[string]interface{}{"ABC": true},
 			},
 		},
@@ -475,20 +476,20 @@ func TestUpsertReplicationConfig(t *testing.T) {
 			name: "modify all",
 			existingConfig: &ReplicationConfig{
 				ID:                     "foo",
-				Remote:                 base.StringPtr("a"),
-				Direction:              base.StringPtr("a"),
-				ConflictResolutionType: base.StringPtr("a"),
-				ConflictResolutionFn:   base.StringPtr("a"),
-				PurgeOnRemoval:         base.BoolPtr(true),
-				DeltaSyncEnabled:       base.BoolPtr(true),
-				MaxBackoff:             base.IntPtr(5),
-				State:                  base.StringPtr("a"),
-				Continuous:             base.BoolPtr(true),
-				Filter:                 base.StringPtr("a"),
+				Remote:                 "a",
+				Direction:              "a",
+				ConflictResolutionType: "a",
+				ConflictResolutionFn:   "a",
+				PurgeOnRemoval:         true,
+				DeltaSyncEnabled:       true,
+				MaxBackoff:             5,
+				State:                  "a",
+				Continuous:             true,
+				Filter:                 "a",
 				QueryParams:            []interface{}{"ABC"},
-				Cancel:                 base.BoolPtr(true),
+				Cancel:                 true,
 			},
-			updatedConfig: &ReplicationConfig{
+			updatedConfig: &ReplicationUpsertConfig{
 				ID:                     "foo",
 				Remote:                 base.StringPtr("b"),
 				Direction:              base.StringPtr("b"),
@@ -505,18 +506,18 @@ func TestUpsertReplicationConfig(t *testing.T) {
 			},
 			expectedConfig: &ReplicationConfig{
 				ID:                     "foo",
-				Remote:                 base.StringPtr("b"),
-				Direction:              base.StringPtr("b"),
-				ConflictResolutionType: base.StringPtr("b"),
-				ConflictResolutionFn:   base.StringPtr("b"),
-				PurgeOnRemoval:         base.BoolPtr(false),
-				DeltaSyncEnabled:       base.BoolPtr(false),
-				MaxBackoff:             base.IntPtr(10),
-				State:                  base.StringPtr("b"),
-				Continuous:             base.BoolPtr(false),
-				Filter:                 base.StringPtr("b"),
+				Remote:                 "b",
+				Direction:              "b",
+				ConflictResolutionType: "b",
+				ConflictResolutionFn:   "b",
+				PurgeOnRemoval:         false,
+				DeltaSyncEnabled:       false,
+				MaxBackoff:             10,
+				State:                  "b",
+				Continuous:             false,
+				Filter:                 "b",
 				QueryParams:            []interface{}{"DEF"},
-				Cancel:                 base.BoolPtr(false),
+				Cancel:                 false,
 			},
 		},
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -845,7 +845,7 @@ func (h *handler) getReplication() error {
 
 func (h *handler) putReplication() error {
 	body, _ := h.readBody()
-	replicationConfig := &db.ReplicationConfig{}
+	replicationConfig := &db.ReplicationUpsertConfig{}
 	if err := base.JSONUnmarshal(body, replicationConfig); err != nil {
 		return err
 	}
@@ -858,10 +858,6 @@ func (h *handler) putReplication() error {
 		replicationConfig.ID = replicationID
 	}
 
-	validateErr := replicationConfig.ValidateNewReplication(false)
-	if validateErr != nil {
-		return validateErr
-	}
 	created, err := h.db.SGReplicateMgr.UpsertReplication(replicationConfig)
 	if err != nil {
 		return err

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -845,7 +845,7 @@ func (h *handler) getReplication() error {
 
 func (h *handler) putReplication() error {
 	body, _ := h.readBody()
-	replicationConfig := &db.ReplicationCfg{}
+	replicationConfig := &db.ReplicationConfig{}
 	if err := base.JSONUnmarshal(body, replicationConfig); err != nil {
 		return err
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -165,38 +165,39 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                      string                         `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
-	Sync                      *string                        `json:"sync,omitempty"`                         // Sync function defines which users can see which data
-	Users                     map[string]*db.PrincipalConfig `json:"users,omitempty"`                        // Initial user accounts
-	Roles                     map[string]*db.PrincipalConfig `json:"roles,omitempty"`                        // Initial roles
-	RevsLimit                 *uint32                        `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
-	AutoImport                interface{}                    `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
-	ImportPartitions          *uint16                        `json:"import_partitions,omitempty"`            // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
-	ImportFilter              *string                        `json:"import_filter,omitempty"`                // Filter function (import)
-	ImportBackupOldRev        bool                           `json:"import_backup_old_rev"`                  // Whether import should attempt to create a temporary backup of the previous revision body, when available.
-	EventHandlers             interface{}                    `json:"event_handlers,omitempty"`               // Event handlers (webhook)
-	FeedType                  string                         `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword        bool                           `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
-	CacheConfig               *CacheConfig                   `json:"cache,omitempty"`                        // Cache settings
-	DeprecatedRevCacheSize    *uint32                        `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
-	StartOffline              bool                           `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
-	Unsupported               db.UnsupportedOptions          `json:"unsupported,omitempty"`                  // Config for unsupported features
-	Deprecated                DeprecatedOptions              `json:"deprecated,omitempty"`                   // Config for Deprecated features
-	OIDCConfig                *auth.OIDCOptions              `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
-	OldRevExpirySeconds       *uint32                        `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs      *uint32                        `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
-	LocalDocExpirySecs        *uint32                        `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
-	EnableXattrs              *bool                          `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
-	SecureCookieOverride      *bool                          `json:"session_cookie_secure,omitempty"`        // Override cookie secure flag
-	SessionCookieName         string                         `json:"session_cookie_name"`                    // Custom per-database session cookie name
-	SessionCookieHTTPOnly     bool                           `json:"session_cookie_http_only"`               // HTTP only cookies
-	AllowConflicts            *bool                          `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
-	NumIndexReplicas          *uint                          `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
-	UseViews                  bool                           `json:"use_views"`                              // Force use of views instead of GSI
-	SendWWWAuthenticateHeader *bool                          `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
-	BucketOpTimeoutMs         *uint32                        `json:"bucket_op_timeout_ms,omitempty"`         // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	DeltaSync                 *DeltaSyncConfig               `json:"delta_sync,omitempty"`                   // Config for delta sync
-	CompactIntervalDays       *float32                       `json:"compact_interval_days,omitempty"`        //Interval in days between compaction is automatically ran - 0 means don't run
+	Name                      string                           `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
+	Sync                      *string                          `json:"sync,omitempty"`                         // Sync function defines which users can see which data
+	Users                     map[string]*db.PrincipalConfig   `json:"users,omitempty"`                        // Initial user accounts
+	Roles                     map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                        // Initial roles
+	RevsLimit                 *uint32                          `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
+	AutoImport                interface{}                      `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
+	ImportPartitions          *uint16                          `json:"import_partitions,omitempty"`            // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
+	ImportFilter              *string                          `json:"import_filter,omitempty"`                // Filter function (import)
+	ImportBackupOldRev        bool                             `json:"import_backup_old_rev"`                  // Whether import should attempt to create a temporary backup of the previous revision body, when available.
+	EventHandlers             interface{}                      `json:"event_handlers,omitempty"`               // Event handlers (webhook)
+	FeedType                  string                           `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword        bool                             `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
+	CacheConfig               *CacheConfig                     `json:"cache,omitempty"`                        // Cache settings
+	DeprecatedRevCacheSize    *uint32                          `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
+	StartOffline              bool                             `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
+	Unsupported               db.UnsupportedOptions            `json:"unsupported,omitempty"`                  // Config for unsupported features
+	Deprecated                DeprecatedOptions                `json:"deprecated,omitempty"`                   // Config for Deprecated features
+	OIDCConfig                *auth.OIDCOptions                `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds       *uint32                          `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs      *uint32                          `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
+	LocalDocExpirySecs        *uint32                          `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
+	EnableXattrs              *bool                            `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
+	SecureCookieOverride      *bool                            `json:"session_cookie_secure,omitempty"`        // Override cookie secure flag
+	SessionCookieName         string                           `json:"session_cookie_name"`                    // Custom per-database session cookie name
+	SessionCookieHTTPOnly     bool                             `json:"session_cookie_http_only"`               // HTTP only cookies
+	AllowConflicts            *bool                            `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
+	NumIndexReplicas          *uint                            `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
+	UseViews                  bool                             `json:"use_views"`                              // Force use of views instead of GSI
+	SendWWWAuthenticateHeader *bool                            `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	BucketOpTimeoutMs         *uint32                          `json:"bucket_op_timeout_ms,omitempty"`         // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	DeltaSync                 *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                   // Config for delta sync
+	CompactIntervalDays       *float32                         `json:"compact_interval_days,omitempty"`        // Interval between scheduled compaction runs (in days) - 0 means don't run
+	Replications              map[string]*db.ReplicationConfig `json:"replications,omitempty"`                 // sg-replicate replication definitions
 }
 
 type DeltaSyncConfig struct {

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/couchbase/sync_gateway/base"
+
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,8 +21,8 @@ func TestReplicationAPI(t *testing.T) {
 
 	replicationConfig := db.ReplicationConfig{
 		ID:        "replication1",
-		Remote:    "http://remote:4984/db",
-		Direction: "Pull",
+		Remote:    base.StringPtr("http://remote:4984/db"),
+		Direction: base.StringPtr("Pull"),
 	}
 
 	// PUT replication
@@ -34,8 +36,8 @@ func TestReplicationAPI(t *testing.T) {
 	err := json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err)
 	assert.Equal(t, configResponse.ID, "replication1")
-	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
-	assert.Equal(t, configResponse.Direction, "Pull")
+	assert.Equal(t, *configResponse.Remote, "http://remote:4984/db")
+	assert.Equal(t, *configResponse.Direction, "Pull")
 
 	// POST replication
 	replicationConfig.ID = "replication2"
@@ -49,8 +51,10 @@ func TestReplicationAPI(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err)
 	assert.Equal(t, configResponse.ID, "replication2")
-	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
-	assert.Equal(t, configResponse.Direction, "Pull")
+	require.NotNil(t, configResponse.Remote)
+	assert.Equal(t, *configResponse.Remote, "http://remote:4984/db")
+	require.NotNil(t, configResponse.Direction)
+	assert.Equal(t, *configResponse.Direction, "Pull")
 
 	// GET all replications
 	response = rt.SendAdminRequest("GET", "/db/_replication/", "")
@@ -106,13 +110,13 @@ func TestValidateReplicationAPI(t *testing.T) {
 		},
 		{
 			name:                  "Missing Direction",
-			config:                db.ReplicationConfig{ID: "replication1", Remote: "http://remote:4985/db"},
+			config:                db.ReplicationConfig{ID: "replication1", Remote: base.StringPtr("http://remote:4985/db")},
 			expectedResponseCode:  http.StatusBadRequest,
 			expectedErrorContains: "direction must be specified",
 		},
 		{
 			name:                  "Valid Replication",
-			config:                db.ReplicationConfig{ID: "replication1", Remote: "http://remote:4985/db", Direction: "pull"},
+			config:                db.ReplicationConfig{ID: "replication1", Remote: base.StringPtr("http://remote:4985/db"), Direction: base.StringPtr("pull")},
 			expectedResponseCode:  http.StatusCreated,
 			expectedErrorContains: "",
 		},
@@ -167,4 +171,94 @@ func marshalConfig(t *testing.T, config db.ReplicationConfig) string {
 	replicationPayload, err := json.Marshal(config)
 	require.NoError(t, err)
 	return string(replicationPayload)
+}
+
+// Upserts replications via config, validates using _replication response
+func TestReplicationsFromConfig(t *testing.T) {
+
+	replicationConfig1String := `{
+		"replication_id": "replication1",
+		"remote": "http://remote:4985/db",
+		"direction":"pull",
+		"continuous":true,
+		"conflict_resolution_type":"foo",
+		"conflict_resolution_fn":"func()",
+		"purge_on_removal":true,
+		"delta_sync_enabled":true,
+		"max_backoff":100,
+		"state":"stopped",
+		"filter":"sync_gateway/bychannel",
+		"query_params":["ABC"],
+		"cancel":false
+	}`
+	replicationConfig2String := `{
+		"replication_id": "replication2",
+		"remote": "http://remote:4985/db",
+		"direction":"Pull",
+		"continuous":true,
+		"conflict_resolution_type":"foo",
+		"conflict_resolution_fn":"func()",
+		"purge_on_removal":true,
+		"delta_sync_enabled":true,
+		"max_backoff":100,
+		"state":"stopped",
+		"filter":"sync_gateway/bychannel",
+		"query_params":["ABC"],
+		"cancel":false
+	}`
+
+	replicationConfig1 := &db.ReplicationConfig{}
+	err := base.JSONUnmarshal([]byte(replicationConfig1String), replicationConfig1)
+	require.NoError(t, err)
+	replicationConfig2 := &db.ReplicationConfig{}
+	err = base.JSONUnmarshal([]byte(replicationConfig2String), replicationConfig2)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		replicationSet []*db.ReplicationConfig
+		expectedError  error
+	}{
+		{
+			name:           "Single replication",
+			replicationSet: []*db.ReplicationConfig{replicationConfig1},
+		},
+		{
+			name:           "Multiple replications",
+			replicationSet: []*db.ReplicationConfig{replicationConfig1, replicationConfig2},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			dbConfig := &DbConfig{}
+			dbConfig.Replications = make(map[string]*db.ReplicationConfig)
+			for _, rc := range test.replicationSet {
+				dbConfig.Replications[rc.ID] = rc
+			}
+
+			rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: dbConfig})
+			defer rt.Close()
+
+			// Retrieve replications
+			response := rt.SendAdminRequest("GET", "/db/_replication/", "")
+			if test.expectedError != nil {
+				assertStatus(t, response, http.StatusBadRequest)
+				return
+			}
+			assertStatus(t, response, http.StatusOK)
+			var configResponse map[string]*db.ReplicationConfig
+			err := json.Unmarshal(response.BodyBytes(), &configResponse)
+			require.NoError(t, err)
+			assert.Equal(t, len(test.replicationSet), len(configResponse))
+			for _, replication := range test.replicationSet {
+				loadedReplication, ok := configResponse[replication.ID]
+				assert.True(t, ok)
+				equals, equalsErr := loadedReplication.Equals(replication)
+				assert.True(t, equals)
+				assert.NoError(t, equalsErr)
+			}
+		})
+	}
+
 }

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
-
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,9 +50,7 @@ func TestReplicationAPI(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err)
 	assert.Equal(t, configResponse.ID, "replication2")
-	require.NotNil(t, configResponse.Remote)
 	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
-	require.NotNil(t, configResponse.Direction)
 	assert.Equal(t, configResponse.Direction, "Pull")
 
 	// GET all replications
@@ -217,7 +214,6 @@ func TestReplicationsFromConfig(t *testing.T) {
 	testCases := []struct {
 		name           string
 		replicationSet []*db.ReplicationConfig
-		expectedError  error
 	}{
 		{
 			name:           "Single replication",
@@ -242,10 +238,6 @@ func TestReplicationsFromConfig(t *testing.T) {
 
 			// Retrieve replications
 			response := rt.SendAdminRequest("GET", "/db/_replication/", "")
-			if test.expectedError != nil {
-				assertStatus(t, response, http.StatusBadRequest)
-				return
-			}
 			assertStatus(t, response, http.StatusOK)
 			var configResponse map[string]*db.ReplicationConfig
 			err := json.Unmarshal(response.BodyBytes(), &configResponse)

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -21,8 +21,8 @@ func TestReplicationAPI(t *testing.T) {
 
 	replicationConfig := db.ReplicationConfig{
 		ID:        "replication1",
-		Remote:    base.StringPtr("http://remote:4984/db"),
-		Direction: base.StringPtr("Pull"),
+		Remote:    "http://remote:4984/db",
+		Direction: "Pull",
 	}
 
 	// PUT replication
@@ -36,8 +36,8 @@ func TestReplicationAPI(t *testing.T) {
 	err := json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err)
 	assert.Equal(t, configResponse.ID, "replication1")
-	assert.Equal(t, *configResponse.Remote, "http://remote:4984/db")
-	assert.Equal(t, *configResponse.Direction, "Pull")
+	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
+	assert.Equal(t, configResponse.Direction, "Pull")
 
 	// POST replication
 	replicationConfig.ID = "replication2"
@@ -52,9 +52,9 @@ func TestReplicationAPI(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, configResponse.ID, "replication2")
 	require.NotNil(t, configResponse.Remote)
-	assert.Equal(t, *configResponse.Remote, "http://remote:4984/db")
+	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
 	require.NotNil(t, configResponse.Direction)
-	assert.Equal(t, *configResponse.Direction, "Pull")
+	assert.Equal(t, configResponse.Direction, "Pull")
 
 	// GET all replications
 	response = rt.SendAdminRequest("GET", "/db/_replication/", "")
@@ -110,13 +110,13 @@ func TestValidateReplicationAPI(t *testing.T) {
 		},
 		{
 			name:                  "Missing Direction",
-			config:                db.ReplicationConfig{ID: "replication1", Remote: base.StringPtr("http://remote:4985/db")},
+			config:                db.ReplicationConfig{ID: "replication1", Remote: "http://remote:4985/db"},
 			expectedResponseCode:  http.StatusBadRequest,
 			expectedErrorContains: "direction must be specified",
 		},
 		{
 			name:                  "Valid Replication",
-			config:                db.ReplicationConfig{ID: "replication1", Remote: base.StringPtr("http://remote:4985/db"), Direction: base.StringPtr("pull")},
+			config:                db.ReplicationConfig{ID: "replication1", Remote: "http://remote:4985/db", Direction: "pull"},
 			expectedResponseCode:  http.StatusCreated,
 			expectedErrorContains: "",
 		},

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -604,17 +604,15 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			return nil, fmt.Errorf("replication_id %q does not match replications key %q in replication config", replicationConfig.ID, replicationID)
 		}
 		replicationConfig.ID = replicationID
-		if validateErr := replicationConfig.ValidateNewReplication(true); validateErr != nil {
+		if validateErr := replicationConfig.ValidateReplication(true); validateErr != nil {
 			return nil, validateErr
 		}
 	}
 
-	// Validation was successful, can upsert replications
-	for _, replicationConfig := range config.Replications {
-		_, replicationErr := dbcontext.SGReplicateMgr.UpsertReplication(replicationConfig)
-		if replicationErr != nil {
-			return nil, replicationErr
-		}
+	// Validation was successful, can update replications
+	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
+	if replicationErr != nil {
+		return nil, replicationErr
 	}
 
 	dbcontext.ExitChanges = make(chan struct{})

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -596,9 +596,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, err
 	}
 
-	// Upsert config-based replications
-
-	// Validate all replications before upserting any
+	// Validate all replications before updating any
 	for replicationID, replicationConfig := range config.Replications {
 		if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
 			return nil, fmt.Errorf("replication_id %q does not match replications key %q in replication config", replicationConfig.ID, replicationID)


### PR DESCRIPTION
Adds file-based replication config to database config.  Modify config to use primarily pointers as part of support for upsert of existing replications.

Adds upsert operation, which treats nil values as unchanged, and empty values as removals.

Includes some standardization of TestDB setup which ultimately wasn’t needed for this PR, but is still useful.