### PR TITLE
CBG-820: Add state for OIDC auth code authentication

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -103,18 +103,12 @@ type OIDCProvider struct {
 	DiscoveryURI            string   `json:"discovery_url,omitempty"`          // Non-standard discovery endpoints
 	DisableConfigValidation bool     `json:"disable_cfg_validation,omitempty"` // Bypasses config validation based on the OIDC spec.  Required for some OPs that don't strictly adhere to spec (eg. Yahoo)
 
-	// DisableCallbackState determines whether or not to maintain state between the
-	// Authentication (OAuth 2.0 Authorization) request and the callback. The default
-	// value of DisableCallbackState is false, which means state is maintained between
-	// auth request and the callback. It can be disabled through provider configuration
-	// by setting property "disable_callback_state": false. Disabling callback state is
-	// is vulnerable to Cross-Site Request Forgery (CSRF, XSRF) and NOT recommended.
+	// DisableCallbackState determines whether or not to maintain state between the "/_oidc" and
+	// "/_oidc_callback" endpoints. The default value of DisableCallbackState is false, which means
+	// state is maintained between auth request and the callback. It can be disabled through provider
+	// configuration by setting property "disable_callback_state": true. Disabling callback state is
+	// vulnerable to Cross-Site Request Forgery (CSRF, XSRF) and NOT recommended.
 	DisableCallbackState bool `json:"disable_callback_state,omitempty"`
-
-	// CallbackStateCookieHTTPOnly determines whether or not to make the callback state
-	// cookie inaccessible to JavaScript's Document.cookie API to mitigate cross-site
-	// scripting (XSS) attacks.
-	CallbackStateCookieHTTPOnly bool `json:"callback_state_cookie_http_only"`
 
 	// client represents client configurations to authenticate end-users
 	// with an OpenID Connect provider. It must not be accessed directly,

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -103,6 +103,19 @@ type OIDCProvider struct {
 	DiscoveryURI            string   `json:"discovery_url,omitempty"`          // Non-standard discovery endpoints
 	DisableConfigValidation bool     `json:"disable_cfg_validation,omitempty"` // Bypasses config validation based on the OIDC spec.  Required for some OPs that don't strictly adhere to spec (eg. Yahoo)
 
+	// DisableCallbackState determines whether or not to maintain state between the
+	// Authentication (OAuth 2.0 Authorization) request and the callback. The default
+	// value of DisableCallbackState is false, which means state is maintained between
+	// auth request and the callback. It can be disabled through provider configuration
+	// by setting property "disable_callback_state": false. Disabling callback state is
+	// is vulnerable to Cross-Site Request Forgery (CSRF, XSRF) and NOT recommended.
+	DisableCallbackState bool `json:"disable_callback_state,omitempty"`
+
+	// CallbackStateCookieHTTPOnly determines whether or not to make the callback state
+	// cookie inaccessible to JavaScript's Document.cookie API to mitigate cross-site
+	// scripting (XSS) attacks.
+	CallbackStateCookieHTTPOnly bool `json:"callback_state_cookie_http_only"`
+
 	// client represents client configurations to authenticate end-users
 	// with an OpenID Connect provider. It must not be accessed directly,
 	// use the accessor method GetClient() instead.

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -505,7 +505,7 @@ func mockProviderWithCallbackStateDisabledWithNoRegister(name string) *auth.OIDC
 	}
 }
 
-// Checks End to end OpenID Connect Authorization Code flow.
+// E2E test that checks OpenID Connect Authorization Code Flow.
 func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 	type test struct {
 		name                string

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"regexp"
@@ -74,6 +75,10 @@ const (
 	// notConfiguredProviderErr forces SG to return an authentication error when the
 	// user initiate an auth request with a provider which is not configured.
 	notConfiguredProviderErr
+
+	// invalidStateErr forces the /auth API to return an invalid state token in the
+	// callback URL.
+	invalidStateErr
 )
 
 // grantType refers to the way a relying party gets an access token.
@@ -222,6 +227,9 @@ func renderJSON(w http.ResponseWriter, r *http.Request, statusCode int, data int
 func (s *mockAuthServer) authHandler(w http.ResponseWriter, r *http.Request) {
 	var redirectionURL string
 	state := r.URL.Query().Get(requestParamState)
+	if s.options.forceError.errorType == invalidStateErr {
+		state = "aW52YWxpZCBzdGF0ZQo=" // Invalid state to simulate CSRF
+	}
 	redirect := r.URL.Query().Get(requestParamRedirectURI)
 	if redirect == "" {
 		base.Errorf("No redirect URL found in auth request")
@@ -436,7 +444,7 @@ func mockProviderWithRegisterWithAccessToken(name string) *auth.OIDCProvider {
 	}
 }
 
-// Returns a new OIDCProvider with IncludeAccessToken flags enabled.
+// Returns a new OIDCProvider with IncludeAccessToken flag enabled.
 func mockProviderWithAccessToken(name string) *auth.OIDCProvider {
 	return &auth.OIDCProvider{
 		Name:               name,
@@ -447,7 +455,57 @@ func mockProviderWithAccessToken(name string) *auth.OIDCProvider {
 	}
 }
 
-// E2E test that checks OpenID Connect Authorization Code Flow.
+// Returns a new OIDCProvider with CallbackStateCookieHTTPOnly flag enabled.
+func mockProviderWithCallbackStateCookieHTTPOnly(name string) *auth.OIDCProvider {
+	return &auth.OIDCProvider{
+		Name:                        name,
+		ClientID:                    "baz",
+		UserPrefix:                  name,
+		ValidationKey:               base.StringPtr("qux"),
+		Register:                    true,
+		IncludeAccessToken:          true,
+		CallbackStateCookieHTTPOnly: true,
+	}
+}
+
+// Returns a new OIDCProvider with CallbackStateCookieHTTPOnly flag enabled and Register flag disabled.
+func mockProviderWithCallbackStateCookieHTTPOnlyWithNoRegister(name string) *auth.OIDCProvider {
+	return &auth.OIDCProvider{
+		Name:                        name,
+		ClientID:                    "baz",
+		UserPrefix:                  name,
+		ValidationKey:               base.StringPtr("qux"),
+		IncludeAccessToken:          true,
+		CallbackStateCookieHTTPOnly: true,
+	}
+}
+
+// Returns a new OIDCProvider with callback state disabled
+func mockProviderWithCallbackStateDisabled(name string) *auth.OIDCProvider {
+	return &auth.OIDCProvider{
+		Name:                 name,
+		ClientID:             "baz",
+		UserPrefix:           name,
+		ValidationKey:        base.StringPtr("qux"),
+		Register:             true,
+		IncludeAccessToken:   true,
+		DisableCallbackState: true,
+	}
+}
+
+// Returns a new OIDCProvider with callback state disabled with no Register flag.
+func mockProviderWithCallbackStateDisabledWithNoRegister(name string) *auth.OIDCProvider {
+	return &auth.OIDCProvider{
+		Name:                 name,
+		ClientID:             "baz",
+		UserPrefix:           name,
+		ValidationKey:        base.StringPtr("qux"),
+		IncludeAccessToken:   true,
+		DisableCallbackState: true,
+	}
+}
+
+// Checks End to end OpenID Connect Authorization Code flow.
 func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 	type test struct {
 		name                string
@@ -696,6 +754,61 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			defaultProvider:     "foo",
 			authURL:             "/db/_oidc?provider=foo&offline=true",
 			requireExistingUser: true,
+		}, {
+			name: "successful new user authentication with HttpOnly cookie enabled",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithCallbackStateCookieHTTPOnly("foo"),
+			},
+			defaultProvider: "foo",
+			authURL:         "/db/_oidc?provider=foo&offline=true",
+		}, {
+			name: "successful new user authentication with callback state disabled",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithCallbackStateDisabled("foo"),
+			},
+			defaultProvider: "foo",
+			authURL:         "/db/_oidc?provider=foo&offline=true",
+		}, {
+			name: "unsuccessful new user authentication against csrf attack",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithRegisterWithAccessToken("foo"),
+			},
+			defaultProvider: "foo",
+			authURL:         "/db/_oidc?provider=foo&offline=true",
+			forceAuthError: forceError{
+				errorType:            invalidStateErr,
+				expectedErrorCode:    http.StatusBadRequest,
+				expectedErrorMessage: "State mismatch",
+			},
+		}, {
+			name: "successful registered user authentication with HttpOnly cookie enabled",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithCallbackStateCookieHTTPOnlyWithNoRegister("foo"),
+			},
+			defaultProvider:     "foo",
+			authURL:             "/db/_oidc?provider=foo&offline=true",
+			requireExistingUser: true,
+		}, {
+			name: "successful registered user authentication with callback state disabled",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithCallbackStateDisabledWithNoRegister("foo"),
+			},
+			defaultProvider:     "foo",
+			authURL:             "/db/_oidc?provider=foo&offline=true",
+			requireExistingUser: true,
+		}, {
+			name: "unsuccessful registered user authentication against csrf attack",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithAccessToken("foo"),
+			},
+			defaultProvider: "foo",
+			authURL:         "/db/_oidc?provider=foo&offline=true",
+			forceAuthError: forceError{
+				errorType:            invalidStateErr,
+				expectedErrorCode:    http.StatusBadRequest,
+				expectedErrorMessage: "State mismatch",
+			},
+			requireExistingUser: true,
 		},
 	}
 
@@ -729,7 +842,10 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			requestURL := mockSyncGatewayURL + tc.authURL
 			request, err := http.NewRequest(http.MethodGet, requestURL, nil)
 			require.NoError(t, err, "Error creating new request")
-			response, err := http.DefaultClient.Do(request)
+			jar, err := cookiejar.New(nil)
+			require.NoError(t, err, "Error creating new cookie jar")
+			client := &http.Client{Jar: jar}
+			response, err := client.Do(request)
 			require.NoError(t, err, "Error sending request")
 			if (forceError{}) != tc.forceAuthError {
 				assertHttpResponse(t, response, tc.forceAuthError)
@@ -758,7 +874,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			request, err = http.NewRequest(http.MethodGet, dbEndpoint, nil)
 			require.NoError(t, err, "Error creating new request")
 			request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
-			response, err = http.DefaultClient.Do(request)
+			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
@@ -771,7 +887,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			requestURL = mockSyncGatewayURL + "/db/_oidc_refresh?refresh_token=" + authResponseActual.RefreshToken
 			request, err = http.NewRequest(http.MethodGet, requestURL, nil)
 			require.NoError(t, err, "Error creating new request")
-			response, err = http.DefaultClient.Do(request)
+			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request")
 			if (forceError{}) != tc.forceRefreshError {
 				assertHttpResponse(t, response, tc.forceRefreshError)
@@ -796,7 +912,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			request, err = http.NewRequest(http.MethodGet, dbEndpoint, nil)
 			require.NoError(t, err, "Error creating new request")
 			request.Header.Add("Authorization", BearerToken+" "+refreshResponseActual.IDToken)
-			response, err = http.DefaultClient.Do(request)
+			response, err = client.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
 			require.Equal(t, http.StatusOK, response.StatusCode)
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -455,31 +455,6 @@ func mockProviderWithAccessToken(name string) *auth.OIDCProvider {
 	}
 }
 
-// Returns a new OIDCProvider with CallbackStateCookieHTTPOnly flag enabled.
-func mockProviderWithCallbackStateCookieHTTPOnly(name string) *auth.OIDCProvider {
-	return &auth.OIDCProvider{
-		Name:                        name,
-		ClientID:                    "baz",
-		UserPrefix:                  name,
-		ValidationKey:               base.StringPtr("qux"),
-		Register:                    true,
-		IncludeAccessToken:          true,
-		CallbackStateCookieHTTPOnly: true,
-	}
-}
-
-// Returns a new OIDCProvider with CallbackStateCookieHTTPOnly flag enabled and Register flag disabled.
-func mockProviderWithCallbackStateCookieHTTPOnlyWithNoRegister(name string) *auth.OIDCProvider {
-	return &auth.OIDCProvider{
-		Name:                        name,
-		ClientID:                    "baz",
-		UserPrefix:                  name,
-		ValidationKey:               base.StringPtr("qux"),
-		IncludeAccessToken:          true,
-		CallbackStateCookieHTTPOnly: true,
-	}
-}
-
 // Returns a new OIDCProvider with callback state disabled
 func mockProviderWithCallbackStateDisabled(name string) *auth.OIDCProvider {
 	return &auth.OIDCProvider{
@@ -755,13 +730,6 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			authURL:             "/db/_oidc?provider=foo&offline=true",
 			requireExistingUser: true,
 		}, {
-			name: "successful new user authentication with HttpOnly cookie enabled",
-			providers: auth.OIDCProviderMap{
-				"foo": mockProviderWithCallbackStateCookieHTTPOnly("foo"),
-			},
-			defaultProvider: "foo",
-			authURL:         "/db/_oidc?provider=foo&offline=true",
-		}, {
 			name: "successful new user authentication with callback state disabled",
 			providers: auth.OIDCProviderMap{
 				"foo": mockProviderWithCallbackStateDisabled("foo"),
@@ -780,14 +748,6 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 				expectedErrorCode:    http.StatusBadRequest,
 				expectedErrorMessage: "State mismatch",
 			},
-		}, {
-			name: "successful registered user authentication with HttpOnly cookie enabled",
-			providers: auth.OIDCProviderMap{
-				"foo": mockProviderWithCallbackStateCookieHTTPOnlyWithNoRegister("foo"),
-			},
-			defaultProvider:     "foo",
-			authURL:             "/db/_oidc?provider=foo&offline=true",
-			requireExistingUser: true,
 		}, {
 			name: "successful registered user authentication with callback state disabled",
 			providers: auth.OIDCProviderMap{


### PR DESCRIPTION
- Add disable_callback_state option to determines whether or not to maintain state between the Authentication (OAuth 2.0 Authorization) request and the callback.
- Add callback_state_cookie_http_only to determine whether or not to make the callback state  cookie inaccessible to JavaScript's Document.cookie API to mitigate cross-site scripting (XSS) attacks.
- Add 'sg-oidc-state' cookie to maintain the state token with a duration of 5 minutes.
- Introduce ErrNoStateCookie, ErrStateMismatch, ErrReadStateCookie errors for callback state error handling.
- Set state parameter to prevent cross-site request forgery (CSRF) when DisableCallbackState is not enabled.
- Validate state parameter to prevent cross-site request forgery (CSRF) when callback state is enabled.
- Delete the state cookie on successful state validation.
- Add an error type invalidStateErr to force the /auth API to return an invalid state token in the callback URL for unit testing.
- Add cookieJar to HttpClient instance to insert relevant cookies into every outbound Request and update it with the cookie values of every inbound Response.
- Add coverage for the following scenarios:
  - Successful new user authentication with HttpOnly cookie enabled.
  - Successful new user authentication with HttpOnly cookie enabled.
  - Successful new user authentication with callback state disabled.
  - Unsuccessful new user authentication against csrf attack.
  - Successful registered user authentication with HttpOnly cookie enabled.
  - Successful registered user authentication with callback state disabled.
  - Unsuccessful registered user authentication against csrf attack.