### PR TITLE
CBG-779: Add ActiveReplicator APIs and implement blipsync

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -320,3 +320,16 @@ func DirExists(filename string) bool {
 	}
 	return info.IsDir()
 }
+
+// WaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.
+func WaitForStat(getStatFunc func() int64, expected int64) (int64, bool) {
+	workerFunc := func() (shouldRetry bool, err error, val interface{}) {
+		val = getStatFunc()
+		return val != expected, nil, val
+	}
+	// wait for up to 20 seconds for the stat to meet the expected value
+	err, val := RetryLoop("waitForStat retry loop", workerFunc, CreateSleeperFunc(200, 100))
+	valInt64, ok := val.(int64)
+
+	return valInt64, err == nil && ok
+}

--- a/replicator/active_replicator.go
+++ b/replicator/active_replicator.go
@@ -13,9 +13,7 @@ import (
 
 // ActiveReplicator is a common interface used for the Bidirectional, Push, and Pull active replicators.
 type ActiveReplicator interface {
-	// Connect initiates a connection to the target, but does not send any replication instructions.
-	Connect() error
-	// Start will trigger the replicator to start its replication for the connection.
+	// Start will trigger the replicator to connect to the target, and start replication.
 	Start() error
 	// Close stops and closes any ongoing replications and connections.
 	Close() error
@@ -42,22 +40,6 @@ func NewBidirectionalActiveReplicator(ctx context.Context, config *ActiveReplica
 	}
 
 	return bar, nil
-}
-
-func (bar *BidirectionalActiveReplicator) Connect() error {
-	// if bar.push != nil {
-	// 	if err := bar.push.Connect(); err != nil {
-	// 		return err
-	// 	}
-	// }
-
-	if bar.pull != nil {
-		if err := bar.pull.Connect(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (bar *BidirectionalActiveReplicator) Start() error {

--- a/replicator/active_replicator.go
+++ b/replicator/active_replicator.go
@@ -27,15 +27,10 @@ type BidirectionalActiveReplicator struct {
 	pull *ActivePullReplicator
 }
 
-// Compile-time interface check.
 var _ ActiveReplicator = &BidirectionalActiveReplicator{}
 
 // NewBidirectionalActiveReplicator returns a bidirectional active replicator for the given config.
 func NewBidirectionalActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*BidirectionalActiveReplicator, error) {
-	if errs := config.Validate(); len(errs) > 0 {
-		return nil, fmt.Errorf("%v", errs)
-	}
-
 	bar := &BidirectionalActiveReplicator{}
 
 	// if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {

--- a/replicator/active_replicator.go
+++ b/replicator/active_replicator.go
@@ -1,0 +1,134 @@
+package replicator
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/couchbase/go-blip"
+	"golang.org/x/net/websocket"
+)
+
+// ActiveReplicator is a common interface used for the Bidirectional, Push, and Pull active replicators.
+type ActiveReplicator interface {
+	// Connect initiates a connection to the target, but does not send any replication instructions.
+	Connect() error
+	// Start will trigger the replicator to start its replication for the connection.
+	Start() error
+	// Close stops and closes any ongoing replications and connections.
+	Close() error
+}
+
+// BidirectionalActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
+type BidirectionalActiveReplicator struct {
+	// push *ActivePushReplicator // TODO: CBG-784
+	pull *ActivePullReplicator
+}
+
+// Compile-time interface check.
+var _ ActiveReplicator = &BidirectionalActiveReplicator{}
+
+// NewBidirectionalActiveReplicator returns a bidirectional active replicator for the given config.
+func NewBidirectionalActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*BidirectionalActiveReplicator, error) {
+	if errs := config.Validate(); len(errs) > 0 {
+		return nil, fmt.Errorf("%v", errs)
+	}
+
+	bar := &BidirectionalActiveReplicator{}
+
+	// if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {
+	// 	bar.Push = NewPushReplicator(config)
+	// }
+
+	if pullReplication := config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull; pullReplication {
+		bar.pull = NewPullReplicator(config)
+	}
+
+	return bar, nil
+}
+
+func (bar *BidirectionalActiveReplicator) Connect() error {
+	// if bar.push != nil {
+	// 	if err := bar.push.Connect(); err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	if bar.pull != nil {
+		if err := bar.pull.Connect(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (bar *BidirectionalActiveReplicator) Start() error {
+	// if bar.push != nil {
+	// 	if err := bar.push.Start(); err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	if bar.pull != nil {
+		if err := bar.pull.Start(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (bar *BidirectionalActiveReplicator) Close() error {
+	// if bar.push != nil {
+	// 	if err := bar.push.Close(); err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	if bar.pull != nil {
+		if err := bar.pull.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// blipSync opens a connection to the target, and returns a blip.Sender to send messages over.
+func blipSync(target url.URL, blipContext *blip.Context) (*blip.Sender, error) {
+	// GET target database endpoint to see if reachable for exit-early/clearer error message
+	resp, err := http.Get(target.String())
+	if err != nil {
+		return nil, err
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d from target database", resp.StatusCode)
+	}
+
+	// switch to websocket protocol scheme
+	if target.Scheme == "http" {
+		target.Scheme = "ws"
+	} else if target.Scheme == "https" {
+		target.Scheme = "wss"
+	}
+
+	config, err := websocket.NewConfig(target.String()+"/_blipsync", "http://localhost")
+	if err != nil {
+		return nil, err
+	}
+
+	if target.User != nil {
+		config.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(target.User.String())))
+	}
+
+	return blipContext.DialConfig(config)
+}

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -1,20 +1,19 @@
 package replicator
 
 import (
-	"fmt"
 	"net/url"
 )
 
 type ActiveReplicatorDirection uint8
 
 const (
-	activeReplicatorTypeUnset ActiveReplicatorDirection = iota
-	ActiveReplicatorTypePushAndPull
+	ActiveReplicatorTypePushAndPull ActiveReplicatorDirection = iota
 	ActiveReplicatorTypePush
 	ActiveReplicatorTypePull
-	activeReplicatorTypeCount
 )
 
+// ActiveReplicatorConfig controls the behaviour of the active replicator.
+// TODO: This might be replaced with ReplicatorConfig in the future.
 type ActiveReplicatorConfig struct {
 	ID string
 	// Type of replication: PushAndPull, Push, or Pull
@@ -25,38 +24,4 @@ type ActiveReplicatorConfig struct {
 	// ChangesBatchSize uint16 // Default: 200
 	// TargetDB represents the full Sync Gateway URL, including database path, and basic auth credentials
 	TargetDB *url.URL
-}
-
-// Validate returns a slice of validation errors for the given replicator config.
-// TODO: CBG-878 multierror util for this and other []error usages.
-func (arc *ActiveReplicatorConfig) Validate() (errors []error) {
-	if arc.Direction == activeReplicatorTypeUnset {
-		errors = append(errors, fmt.Errorf("unset ActiveReplicatorDirection"))
-	} else if arc.Direction < activeReplicatorTypeUnset || arc.Direction >= activeReplicatorTypeCount {
-		errors = append(errors, fmt.Errorf("unknown ActiveReplicatorDirection value: %v", arc.Direction))
-	}
-
-	// if arc.ChangesBatchSize == 0 {
-	// 	errors = append(errors, fmt.Errorf("unset ChangesBatchSize"))
-	// }
-
-	// if arc.CheckpointInterval == 0 {
-	// 	errors = append(errors, fmt.Errorf("unset CheckpointInterval"))
-	// }
-
-	if arc.TargetDB == nil {
-		errors = append(errors, fmt.Errorf("empty TargetDB URL"))
-	} else {
-		if arc.TargetDB.Host == "" {
-			errors = append(errors, fmt.Errorf("empty host for TargetDB URL: %v", arc.TargetDB))
-		}
-		if arc.TargetDB.Path == "" {
-			errors = append(errors, fmt.Errorf("empty database path for TargetDB URL: %v", arc.TargetDB))
-		}
-		if arc.TargetDB.Scheme != "http" && arc.TargetDB.Scheme != "https" {
-			errors = append(errors, fmt.Errorf("unknown protocol scheme for TargetDB URL: %v", arc.TargetDB))
-		}
-	}
-
-	return errors
 }

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -1,0 +1,62 @@
+package replicator
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type ActiveReplicatorDirection uint8
+
+const (
+	activeReplicatorTypeUnset ActiveReplicatorDirection = iota
+	ActiveReplicatorTypePushAndPull
+	ActiveReplicatorTypePush
+	ActiveReplicatorTypePull
+	activeReplicatorTypeCount
+)
+
+type ActiveReplicatorConfig struct {
+	ID string
+	// Type of replication: PushAndPull, Push, or Pull
+	Direction ActiveReplicatorDirection
+	// // CheckpointInterval controls many revisions to process before storing a checkpoint
+	// CheckpointInterval uint16 // Default: 200
+	// // ChangesBatchSize controls how many revisions may be batched per changes message
+	// ChangesBatchSize uint16 // Default: 200
+	// TargetDB represents the full Sync Gateway URL, including database path, and basic auth credentials
+	TargetDB *url.URL
+}
+
+// Validate returns a slice of validation errors for the given replicator config.
+// TODO: CBG-878 multierror util for this and other []error usages.
+func (arc *ActiveReplicatorConfig) Validate() (errors []error) {
+	if arc.Direction == activeReplicatorTypeUnset {
+		errors = append(errors, fmt.Errorf("unset ActiveReplicatorDirection"))
+	} else if arc.Direction < activeReplicatorTypeUnset || arc.Direction >= activeReplicatorTypeCount {
+		errors = append(errors, fmt.Errorf("unknown ActiveReplicatorDirection value: %v", arc.Direction))
+	}
+
+	// if arc.ChangesBatchSize == 0 {
+	// 	errors = append(errors, fmt.Errorf("unset ChangesBatchSize"))
+	// }
+
+	// if arc.CheckpointInterval == 0 {
+	// 	errors = append(errors, fmt.Errorf("unset CheckpointInterval"))
+	// }
+
+	if arc.TargetDB == nil {
+		errors = append(errors, fmt.Errorf("empty TargetDB URL"))
+	} else {
+		if arc.TargetDB.Host == "" {
+			errors = append(errors, fmt.Errorf("empty host for TargetDB URL: %v", arc.TargetDB))
+		}
+		if arc.TargetDB.Path == "" {
+			errors = append(errors, fmt.Errorf("empty database path for TargetDB URL: %v", arc.TargetDB))
+		}
+		if arc.TargetDB.Scheme != "http" && arc.TargetDB.Scheme != "https" {
+			errors = append(errors, fmt.Errorf("unknown protocol scheme for TargetDB URL: %v", arc.TargetDB))
+		}
+	}
+
+	return errors
+}

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -13,7 +13,6 @@ type ActivePullReplicator struct {
 	blipSender  *blip.Sender
 }
 
-// Compile-time interface check.
 var _ ActiveReplicator = &ActivePullReplicator{}
 
 func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
@@ -26,12 +25,11 @@ func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 // Connects to the target via BLIP and sets.
 func (apr *ActivePullReplicator) Connect() error {
 	if apr == nil {
-		// noop
-		return nil
+		return fmt.Errorf("nil ActivePullReplicator, can't connect")
 	}
 
 	if apr.blipSender != nil {
-		return fmt.Errorf("replicator already has a blipSender ... can't connect twice")
+		return fmt.Errorf("replicator already has a blipSender, can't connect twice")
 	}
 
 	s, err := blipSync(*apr.config.TargetDB, apr.blipContext)
@@ -59,8 +57,7 @@ func (apr *ActivePullReplicator) Close() error {
 
 func (apr *ActivePullReplicator) Start() error {
 	if apr == nil {
-		// noop
-		return nil
+		return fmt.Errorf("nil ActivePullReplicator, can't start")
 	}
 
 	if apr.blipSender == nil {

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -1,0 +1,71 @@
+package replicator
+
+import (
+	"fmt"
+
+	"github.com/couchbase/go-blip"
+)
+
+// ActivePullReplicator is a unidirectional pull active replicator.
+type ActivePullReplicator struct {
+	config      *ActiveReplicatorConfig
+	blipContext *blip.Context
+	blipSender  *blip.Sender
+}
+
+// Compile-time interface check.
+var _ ActiveReplicator = &ActivePullReplicator{}
+
+func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
+	return &ActivePullReplicator{
+		config:      config,
+		blipContext: blip.NewContextCustomID(config.ID+"-pull", blipCBMobileReplication),
+	}
+}
+
+// Connects to the target via BLIP and sets.
+func (apr *ActivePullReplicator) Connect() error {
+	if apr == nil {
+		// noop
+		return nil
+	}
+
+	if apr.blipSender != nil {
+		return fmt.Errorf("replicator already has a blipSender ... can't connect twice")
+	}
+
+	s, err := blipSync(*apr.config.TargetDB, apr.blipContext)
+	if err != nil {
+		return err
+	}
+
+	apr.blipSender = s
+	return nil
+}
+
+func (apr *ActivePullReplicator) Close() error {
+	if apr == nil {
+		// noop
+		return nil
+	}
+
+	if apr.blipSender != nil {
+		apr.blipSender.Close()
+		apr.blipSender = nil
+	}
+
+	return nil
+}
+
+func (apr *ActivePullReplicator) Start() error {
+	if apr == nil {
+		// noop
+		return nil
+	}
+
+	if apr.blipSender == nil {
+		return fmt.Errorf("ActiveReplicator not connected, call Connect() before starting replicator")
+	}
+
+	return nil
+}

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -22,8 +22,7 @@ func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 	}
 }
 
-// Connects to the target via BLIP and sets.
-func (apr *ActivePullReplicator) Connect() error {
+func (apr *ActivePullReplicator) connect() error {
 	if apr == nil {
 		return fmt.Errorf("nil ActivePullReplicator, can't connect")
 	}
@@ -60,8 +59,8 @@ func (apr *ActivePullReplicator) Start() error {
 		return fmt.Errorf("nil ActivePullReplicator, can't start")
 	}
 
-	if apr.blipSender == nil {
-		return fmt.Errorf("ActiveReplicator not connected, call Connect() before starting replicator")
+	if err := apr.connect(); err != nil {
+		return err
 	}
 
 	return nil

--- a/replicator/blip.go
+++ b/replicator/blip.go
@@ -1,0 +1,43 @@
+package replicator
+
+import (
+	"context"
+
+	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
+)
+
+const (
+	// blipCBMobileReplication is the AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore).
+	// At some point this will need to be able to support an array of protocols.  See go-blip/issues/27.
+	blipCBMobileReplication = "CBMobile_2"
+)
+
+// NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
+func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context) {
+	if id == "" {
+		bc = blip.NewContext(blipCBMobileReplication)
+	} else {
+		bc = blip.NewContextCustomID(id, blipCBMobileReplication)
+	}
+
+	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)
+	bc.LogFrames = base.LogDebugEnabled(base.KeyWebSocketFrame)
+	bc.Logger = defaultBlipLogger(ctx)
+
+	return bc
+}
+
+// defaultBlipLogger returns a function that can be set as the blip.Context.Logger for Sync Gateway integrated go-blip logging.
+func defaultBlipLogger(ctx context.Context) blip.LogFn {
+	return func(eventType blip.LogEventType, format string, params ...interface{}) {
+		switch eventType {
+		case blip.LogFrame:
+			base.DebugfCtx(ctx, base.KeyWebSocketFrame, format, params...)
+		case blip.LogMessage:
+			base.DebugfCtx(ctx, base.KeyWebSocket, format, params...)
+		default:
+			base.InfofCtx(ctx, base.KeyWebSocket, format, params...)
+		}
+	}
+}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1,0 +1,50 @@
+package rest
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/replicator"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSGR2Pull(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skip("need at least 2 usable buckets for this test")
+	}
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyReplicate)()
+
+	// 2 single-node clusters:
+	rt1 := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{
+		// active replicator config
+	}})
+	defer rt1.Close()
+	rt2 := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{
+		// passive node config
+	}})
+	defer rt2.Close()
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request.
+	srv := httptest.NewServer(rt2.TestAdminHandler())
+	defer srv.Close()
+
+	targetDB, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	bar, err := replicator.NewBidirectionalActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
+		ID:        t.Name(),
+		Direction: replicator.ActiveReplicatorTypePushAndPull,
+		TargetDB:  targetDB,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, bar.Connect())
+	require.NoError(t, bar.Start())
+
+	time.Sleep(time.Second)
+}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/replicator"
@@ -42,9 +41,8 @@ func TestSGR2Pull(t *testing.T) {
 		TargetDB:  targetDB,
 	})
 	require.NoError(t, err)
+	defer bar.Close()
 
 	require.NoError(t, bar.Connect())
 	require.NoError(t, bar.Start())
-
-	time.Sleep(time.Second)
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -7,33 +7,36 @@ import (
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/replicator"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSGR2Pull(t *testing.T) {
-	if base.GTestBucketPool.NumUsableBuckets() < 2 {
-		t.Skip("need at least 2 usable buckets for this test")
-	}
-
+// TestActiveReplicatorBlipsync starts a RestTester, and publishes the REST API on a httptest server, which the ActiveReplicator can call blipsync on.
+func TestActiveReplicatorBlipsync(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyReplicate)()
 
 	// 2 single-node clusters:
-	rt1 := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{
-		// active replicator config
-	}})
-	defer rt1.Close()
-	rt2 := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{
-		// passive node config
-	}})
-	defer rt2.Close()
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {Password: base.StringPtr("pass")},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt.Close()
 
-	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request.
-	srv := httptest.NewServer(rt2.TestAdminHandler())
+	// Make rt listen on an actual HTTP port, so it can receive the blipsync request.
+	srv := httptest.NewServer(rt.TestPublicHandler())
 	defer srv.Close()
 
 	targetDB, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	targetDB.User = url.UserPassword("alice", "pass")
 
 	bar, err := replicator.NewBidirectionalActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
 		ID:        t.Name(),
@@ -41,8 +44,8 @@ func TestSGR2Pull(t *testing.T) {
 		TargetDB:  targetDB,
 	})
 	require.NoError(t, err)
-	defer bar.Close()
 
-	require.NoError(t, bar.Connect())
-	require.NoError(t, bar.Start())
+	assert.NoError(t, bar.Connect())
+	assert.NoError(t, bar.Start())
+	assert.NoError(t, bar.Close())
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -17,7 +17,6 @@ import (
 func TestActiveReplicatorBlipsync(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyReplicate)()
 
-	// 2 single-node clusters:
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -21,6 +21,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/couchbase/sync_gateway/replicator"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
@@ -732,15 +733,7 @@ func NewBlipTesterFromSpec(tb testing.TB, spec BlipTesterSpec) (*BlipTester, err
 	u.Scheme = "ws"
 
 	// Make BLIP/Websocket connection
-	bt.blipContext = blip.NewContext(BlipCBMobileReplication)
-	bt.blipContext.Logger = DefaultBlipLogger(
-		context.WithValue(context.Background(), base.LogContextKey{},
-			base.LogContext{CorrelationID: base.FormatBlipContextID(bt.blipContext.ID)},
-		),
-	)
-
-	bt.blipContext.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)
-	bt.blipContext.LogFrames = base.LogDebugEnabled(base.KeyWebSocketFrame)
+	bt.blipContext = replicator.NewSGBlipContext(context.Background(), "")
 
 	origin := "http://localhost" // TODO: what should be used here?
 


### PR DESCRIPTION
- Moved some common BLIP code into new `replicator` package
- Added ActiveReplicator APIs/Config
- Perform initial blipsync via single node-loopback test