### PR TITLE
Remove unsigned_id_token option that is no longer in use after OpenID Connect library upgrade

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -123,8 +123,7 @@ type DatabaseContextOptions struct {
 }
 
 type OidcTestProviderOptions struct {
-	Enabled         bool `json:"enabled,omitempty"`           // Whether the oidc_test_provider endpoints should be exposed on the public API
-	UnsignedIDToken bool `json:"unsigned_id_token,omitempty"` // Whether the internal test provider returns a signed ID token on a refresh request.  Used to simulate Azure behaviour
+	Enabled bool `json:"enabled,omitempty"` // Whether the oidc_test_provider endpoints should be exposed on the public API
 }
 
 type UserViewsOptions struct {


### PR DESCRIPTION
Prior to OpenID Connect library upgrade unsigned_id_token option was used to determine whether  a signed or unsigned token should be returned in both authorization and refresh token response from Test Provider. But as per the OpenID Connect library upgrade, the authorization server will always return a signed token and an unsigned token will never be authenticated.