### PR TITLE
CBG-783-prereq-1: Move getRestrictedInt helpers into base/util

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1310,3 +1310,60 @@ func MinInt(x, y int) int {
 	}
 	return y
 }
+
+// GetRestrictedIntQuery returns the integer value of a URL query, restricted to a min and max value,
+// but returning 0 if missing or unparseable.  If allowZero is true, values coming in
+// as zero will stay zero, instead of being set to the minValue.
+func GetRestrictedIntQuery(values url.Values, query string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
+	return GetRestrictedIntFromString(
+		values.Get(query),
+		defaultValue,
+		minValue,
+		maxValue,
+		allowZero,
+	)
+}
+
+func GetRestrictedIntFromString(rawValue string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
+	var value *uint64
+	if rawValue != "" {
+		intValue, err := strconv.ParseUint(rawValue, 10, 64)
+		if err != nil {
+			value = nil
+		} else {
+			value = &intValue
+		}
+	}
+
+	return GetRestrictedInt(
+		value,
+		defaultValue,
+		minValue,
+		maxValue,
+		allowZero,
+	)
+}
+
+func GetRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
+
+	var value uint64
+
+	// Only use the defaultValue if rawValue isn't specified.
+	if rawValue == nil {
+		value = defaultValue
+	} else {
+		value = *rawValue
+	}
+
+	// If value is zero and allowZero=true, leave value at zero rather than forcing it to the minimum value
+	validZero := (value == 0 && allowZero)
+	if value < minValue && !validZero {
+		value = minValue
+	}
+
+	if value > maxValue && maxValue > 0 {
+		value = maxValue
+	}
+
+	return value
+}

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1220,3 +1220,94 @@ func BenchmarkPanicRecover(b *testing.B) {
 		}
 	})
 }
+
+func TestGetRestrictedIntQuery(t *testing.T) {
+
+	defaultValue := uint64(42)
+	minValue := uint64(20)
+	maxValue := uint64(100)
+
+	// make sure it returns default value when passed empty Values
+	values := make(url.Values)
+	restricted := GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equal(t, defaultValue, restricted)
+
+	// make sure it returns default value when passed Values that doesn't contain key
+	values.Set("bar", "99")
+	restricted = GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equal(t, defaultValue, restricted)
+
+	// make sure it returns appropriate value from Values
+	values.Set("foo", "99")
+	restricted = GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equal(t, uint64(99), restricted)
+
+	// make sure it is limited to max when value value is over max
+	values.Set("foo", "200")
+	restricted = GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equal(t, maxValue, restricted)
+
+	// make sure it is limited to min when value value is under min
+	values.Set("foo", "1")
+	restricted = GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equal(t, minValue, restricted)
+
+	// Return zero when allowZero=true
+	values.Set("foo", "0")
+	restricted = GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		true,
+	)
+	assert.Equal(t, uint64(0), restricted)
+
+	// Return minValue when allowZero=false
+	values.Set("foo", "0")
+	restricted = GetRestrictedIntQuery(
+		values,
+		"foo",
+		defaultValue,
+		minValue,
+		maxValue,
+		false,
+	)
+	assert.Equal(t, minValue, restricted)
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -488,7 +488,7 @@ func (h *handler) handleSetLogging() error {
 		setLogLevel = true
 	} else if level := h.getIntQuery("level", 0); level != 0 {
 		base.Warnf("Using deprecated query parameter: %q. Use %q instead.", "level", "logLevel")
-		switch getRestrictedInt(&level, 0, 1, 3, false) {
+		switch base.GetRestrictedInt(&level, 0, 1, 3, false) {
 		case 1:
 			newLogLevel = base.LevelInfo
 		case 2:

--- a/rest/blip_sync_messages.go
+++ b/rest/blip_sync_messages.go
@@ -153,7 +153,7 @@ func readDocIDsFromRequest(rq *blip.Message) (docIDs []string, err error) {
 }
 
 func (s *subChangesParams) batchSize() int {
-	return int(getRestrictedIntFromString(s.rq.Properties["batch"], BlipDefaultBatchSize, BlipMinimumBatchSize, math.MaxUint64, true))
+	return int(base.GetRestrictedIntFromString(s.rq.Properties["batch"], BlipDefaultBatchSize, BlipMinimumBatchSize, math.MaxUint64, true))
 }
 
 func (s *subChangesParams) continuous() bool {

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -132,7 +132,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 	}
 
 	if _, ok := values["heartbeat"]; ok {
-		options.HeartbeatMs = getRestrictedIntQuery(
+		options.HeartbeatMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
@@ -143,7 +143,7 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 	}
 
 	if _, ok := values["timeout"]; ok {
-		options.TimeoutMs = getRestrictedIntQuery(
+		options.TimeoutMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"timeout",
 			kDefaultTimeoutMS,
@@ -198,7 +198,7 @@ func (h *handler) handleChanges() error {
 			}
 		}
 
-		options.HeartbeatMs = getRestrictedIntQuery(
+		options.HeartbeatMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
@@ -206,7 +206,7 @@ func (h *handler) handleChanges() error {
 			h.server.config.MaxHeartbeat*1000,
 			true,
 		)
-		options.TimeoutMs = getRestrictedIntQuery(
+		options.TimeoutMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"timeout",
 			kDefaultTimeoutMS,
@@ -763,7 +763,7 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 
 	docIdsArray = input.DocIds
 
-	options.HeartbeatMs = getRestrictedInt(
+	options.HeartbeatMs = base.GetRestrictedInt(
 		input.HeartbeatMs,
 		kDefaultHeartbeatMS,
 		kMinHeartbeatMS,
@@ -771,7 +771,7 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 		true,
 	)
 
-	options.TimeoutMs = getRestrictedInt(
+	options.TimeoutMs = base.GetRestrictedInt(
 		input.TimeoutMs,
 		kDefaultTimeoutMS,
 		0,

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -425,7 +425,7 @@ func (h *handler) getOptBoolQuery(query string, defaultValue bool) (result, isSe
 
 // Returns the integer value of a URL query, defaulting to 0 if unparseable
 func (h *handler) getIntQuery(query string, defaultValue uint64) (value uint64) {
-	return getRestrictedIntQuery(h.getQueryValues(), query, defaultValue, 0, 0, false)
+	return base.GetRestrictedIntQuery(h.getQueryValues(), query, defaultValue, 0, 0, false)
 }
 
 func (h *handler) getJSONQuery(query string) (value interface{}, err error) {
@@ -849,63 +849,6 @@ func parseHTTPRangeHeader(rangeStr string, contentLength uint64) (status int, st
 	// OK, it's a subrange:
 	status = http.StatusPartialContent
 	return
-}
-
-// Returns the integer value of a URL query, restricted to a min and max value,
-// but returning 0 if missing or unparseable.  If allowZero is true, values coming in
-// as zero will stay zero, instead of being set to the minValue.
-func getRestrictedIntQuery(values url.Values, query string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
-	return getRestrictedIntFromString(
-		values.Get(query),
-		defaultValue,
-		minValue,
-		maxValue,
-		allowZero,
-	)
-}
-
-func getRestrictedIntFromString(rawValue string, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
-	var value *uint64
-	if rawValue != "" {
-		intValue, err := strconv.ParseUint(rawValue, 10, 64)
-		if err != nil {
-			value = nil
-		} else {
-			value = &intValue
-		}
-	}
-
-	return getRestrictedInt(
-		value,
-		defaultValue,
-		minValue,
-		maxValue,
-		allowZero,
-	)
-}
-
-func getRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64, allowZero bool) uint64 {
-
-	var value uint64
-
-	// Only use the defaultValue if rawValue isn't specified.
-	if rawValue == nil {
-		value = defaultValue
-	} else {
-		value = *rawValue
-	}
-
-	// If value is zero and allowZero=true, leave value at zero rather than forcing it to the minimum value
-	validZero := (value == 0 && allowZero)
-	if value < minValue && !validZero {
-		value = minValue
-	}
-
-	if value > maxValue && maxValue > 0 {
-		value = maxValue
-	}
-
-	return value
 }
 
 // formatSerialNumber returns the formatted serial number

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -2,102 +2,10 @@ package rest
 
 import (
 	"net/http"
-	"net/url"
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
 )
-
-func TestGetRestrictedIntQuery(t *testing.T) {
-
-	defaultValue := uint64(42)
-	minValue := uint64(20)
-	maxValue := uint64(100)
-
-	// make sure it returns default value when passed empty Values
-	values := make(url.Values)
-	restricted := getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		false,
-	)
-	goassert.Equals(t, restricted, defaultValue)
-
-	// make sure it returns default value when passed Values that doesn't contain key
-	values.Set("bar", "99")
-	restricted = getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		false,
-	)
-	goassert.Equals(t, restricted, defaultValue)
-
-	// make sure it returns appropriate value from Values
-	values.Set("foo", "99")
-	restricted = getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		false,
-	)
-	goassert.Equals(t, restricted, uint64(99))
-
-	// make sure it is limited to max when value value is over max
-	values.Set("foo", "200")
-	restricted = getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		false,
-	)
-	goassert.Equals(t, restricted, maxValue)
-
-	// make sure it is limited to min when value value is under min
-	values.Set("foo", "1")
-	restricted = getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		false,
-	)
-	goassert.Equals(t, restricted, minValue)
-
-	// Return zero when allowZero=true
-	values.Set("foo", "0")
-	restricted = getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		true,
-	)
-	goassert.Equals(t, restricted, uint64(0))
-
-	// Return minValue when allowZero=false
-	values.Set("foo", "0")
-	restricted = getRestrictedIntQuery(
-		values,
-		"foo",
-		defaultValue,
-		minValue,
-		maxValue,
-		false,
-	)
-	goassert.Equals(t, restricted, minValue)
-}
 
 func TestParseHTTPRangeHeader(t *testing.T) {
 	// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35


### PR DESCRIPTION
Has no `rest` specific behavior, and will need to use it from `replicator` package.