### PR TITLE
CBG-772 Heartbeat registration and dropped node handling for sg-replicate

### DIFF
--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -87,14 +87,14 @@ func TestReplicateManagerNodes(t *testing.T) {
 	manager, err := NewSGReplicateManager(testCfg, "test")
 	require.NoError(t, err)
 
-	err = manager.RegisterNode("node1")
+	err = manager.RegisterNode("node1", "host1")
 	require.NoError(t, err)
 
 	nodes, err := manager.getNodes()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(nodes))
 
-	err = manager.RegisterNode("node2")
+	err = manager.RegisterNode("node2", "host2")
 	require.NoError(t, err)
 
 	nodes, err = manager.getNodes()
@@ -102,7 +102,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	assert.Equal(t, 2, len(nodes))
 
 	// re-adding an existing node is a no-op
-	err = manager.RegisterNode("node1")
+	err = manager.RegisterNode("node1", "host1")
 	require.NoError(t, err)
 
 	nodes, err = manager.getNodes()
@@ -118,7 +118,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	require.Equal(t, 1, len(nodes))
 	node2, ok := nodes["node2"]
 	require.True(t, ok)
-	require.Equal(t, node2.Host, "node2")
+	require.Equal(t, node2.UUID, "node2")
 
 	// Removing an already removed node is a no-op
 	err = manager.RemoveNode("node1")
@@ -147,7 +147,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 		nodeWg.Add(1)
 		go func(i int) {
 			defer nodeWg.Done()
-			err := manager.RegisterNode(fmt.Sprintf("node_%d", i))
+			err := manager.RegisterNode(fmt.Sprintf("node_%d", i), fmt.Sprintf("host_%d", i))
 			assert.NoError(t, err)
 		}(i)
 	}
@@ -238,9 +238,9 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "new nodes",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
-				"n3": {Host: "n3"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
+				"n3": {UUID: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", "n1"),
@@ -254,9 +254,9 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "new replications",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
-				"n3": {Host: "n3"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
+				"n3": {UUID: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", ""),
@@ -270,8 +270,8 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "remove nodes",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", "n1"),
@@ -298,7 +298,7 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "single node",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
+				"n1": {UUID: "n1"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", "n1"),
@@ -312,8 +312,8 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "unbalanced distribution",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", "n1"),
@@ -327,9 +327,9 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "multiple reassignments new nodes",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
-				"n3": {Host: "n3"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
+				"n3": {UUID: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", "n1"),
@@ -346,9 +346,9 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "multiple reassignments new replications",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
-				"n3": {Host: "n3"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
+				"n3": {UUID: "n3"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", ""),
@@ -365,8 +365,8 @@ func TestRebalanceReplications(t *testing.T) {
 		{
 			name: "reassignment from unknown host",
 			nodes: map[string]*SGNode{
-				"n1": {Host: "n1"},
-				"n2": {Host: "n2"},
+				"n1": {UUID: "n1"},
+				"n2": {UUID: "n2"},
 			},
 			replications: map[string]*ReplicationCfg{
 				"r1": testReplicationCfg("r1", "n3"),

--- a/rest/config.go
+++ b/rest/config.go
@@ -197,6 +197,7 @@ type DbConfig struct {
 	BucketOpTimeoutMs         *uint32                          `json:"bucket_op_timeout_ms,omitempty"`         // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	DeltaSync                 *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                   // Config for delta sync
 	CompactIntervalDays       *float32                         `json:"compact_interval_days,omitempty"`        // Interval between scheduled compaction runs (in days) - 0 means don't run
+	SGReplicateEnabled        *bool                            `json:"sgreplicate_enabled,omitempty"`          // When false, node will not be assigned replications
 	Replications              map[string]*db.ReplicationConfig `json:"replications,omitempty"`                 // sg-replicate replication definitions
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -522,6 +522,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		secureCookieOverride = sc.config.SSLCert != nil
 	}
 
+	sgReplicateEnabled := db.DefaultSGReplicateEnabled
+	if config.SGReplicateEnabled != nil {
+		sgReplicateEnabled = *config.SGReplicateEnabled
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		RevisionCacheOptions:      revCacheOptions,
@@ -541,6 +546,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		UseViews:                  useViews,
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
+		SgReplicateEnabled:        sgReplicateEnabled,
 	}
 
 	// Create the DB Context

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -142,6 +142,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 		rt.DatabaseConfig.AllowConflicts = &boolVal
 	}
 
+	rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(false)
+
 	_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(rt.DatabaseConfig)
 	if err != nil {
 		rt.tb.Fatalf("Error from AddDatabaseFromConfig: %v", err)


### PR DESCRIPTION
Moves heartbeater initialization to database, and shares use between sg-replicate and import.  Includes addition of sgreplicate_enabled config property to allow nodes to opt out of sgreplicate.

http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/279/