### PR TITLE
Add project-wide golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,3 +51,10 @@ linters:
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
     - whitespace # Tool for detection of leading and trailing whitespace
     - wsl # Whitespace Linter - Forces you to use empty lines!
+
+# Disable goconst in test files, often we have duplicated strings across tests, but don't make sense as constants.
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - goconst

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,53 @@
+# config file for golangci-lint
+
+linters:
+  enable:
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - deadcode # Finds unused code
+    - dupl # Tool for code clone detection
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
+    - goconst # Finds repeated strings that could be replaced by a constant
+    - gocritic # The most opinionated Go source code linter
+    - golint # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
+    - gosec # (gas) Inspects source code for security problems
+    - gosimple # (megacheck) Linter for Go source code that specializes in simplifying a code
+    - govet # (vet, vetshadow) Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # Detects when assignments to existing variables are not used
+    - maligned # Tool to detect Go structs that would take less memory if their fields were sorted
+    - nakedret # Finds naked returns in functions greater than a specified function length
+    - nestif # Reports deeply nested if statements
+    - prealloc # Finds slice declarations that could potentially be preallocated
+    - staticcheck # (megacheck) Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - structcheck # Finds unused struct fields
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unconvert # Remove unnecessary type conversions
+    - unparam # Reports unused function parameters
+    - varcheck # Finds unused global variables and constants
+  disable:
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    - dogsled # Checks assignments with too many blank identifiers # (e.g. x, _, _, _, := f())
+    - funlen # Tool for detection of long functions
+    - gochecknoglobals # Checks that no globals are present in Go code
+    - gochecknoinits # Checks that no init functions are present in Go code
+    - gocognit # Computes and checks the cognitive complexity of functions
+    - gocyclo # Computes and checks the cyclomatic complexity of functions
+    - godot # Check if comments end in a period
+    - godox # Tool for detection of FIXME, TODO and other comment keywords
+    - goerr113 # Golang linter to check the errors handling expressions
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
+    - gomnd # An analyzer to detect magic numbers.
+    - gomodguard # Allow and block list linter for direct Go module dependencies.
+    - interfacer # Linter that suggests narrower interface types
+    - lll # Reports long lines
+    - misspell # Finds commonly misspelled English words in comments
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - scopelint # Scopelint checks for unpinned variables in go programs
+    - stylecheck # Stylecheck is a replacement for golint
+    - testpackage # linter that makes you use a separate _test package
+    - unused # (megacheck) Checks Go code for unused constants, variables, functions and types
+    - whitespace # Tool for detection of leading and trailing whitespace
+    - wsl # Whitespace Linter - Forces you to use empty lines!


### PR DESCRIPTION
Would be good to get consensus on the set of linters we all run locally.

I'm up for discussion to change the list in this PR, it's just my personal settings, which strikes a balance in favour of **_functional_** warnings, rather than stylistic.

- Explicitly defines all available linters as either enabled or disabled for clarity.
- Skip `goconst` in test files, because of the large amount of false-positives (e.g.: `"doc1"`)