### PR TITLE
CBG-783: Initial SGR2 pull replication implementation

### DIFF
--- a/replicator/active_replicator.go
+++ b/replicator/active_replicator.go
@@ -11,25 +11,15 @@ import (
 	"golang.org/x/net/websocket"
 )
 
-// ActiveReplicator is a common interface used for the Bidirectional, Push, and Pull active replicators.
-type ActiveReplicator interface {
-	// Start will trigger the replicator to connect to the target, and start replication.
-	Start() error
-	// Close stops and closes any ongoing replications and connections.
-	Close() error
-}
-
-// BidirectionalActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
-type BidirectionalActiveReplicator struct {
+// ActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
+type ActiveReplicator struct {
 	// push *ActivePushReplicator // TODO: CBG-784
 	pull *ActivePullReplicator
 }
 
-var _ ActiveReplicator = &BidirectionalActiveReplicator{}
-
-// NewBidirectionalActiveReplicator returns a bidirectional active replicator for the given config.
-func NewBidirectionalActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*BidirectionalActiveReplicator, error) {
-	bar := &BidirectionalActiveReplicator{}
+// NewActiveReplicator returns a bidirectional active replicator for the given config.
+func NewActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActiveReplicator, error) {
+	bar := &ActiveReplicator{}
 
 	// if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {
 	// 	bar.Push = NewPushReplicator(config)
@@ -42,7 +32,7 @@ func NewBidirectionalActiveReplicator(ctx context.Context, config *ActiveReplica
 	return bar, nil
 }
 
-func (bar *BidirectionalActiveReplicator) Start() error {
+func (bar *ActiveReplicator) Start() error {
 	// if bar.push != nil {
 	// 	if err := bar.push.Start(); err != nil {
 	// 		return err
@@ -58,7 +48,7 @@ func (bar *BidirectionalActiveReplicator) Start() error {
 	return nil
 }
 
-func (bar *BidirectionalActiveReplicator) Close() error {
+func (bar *ActiveReplicator) Close() error {
 	// if bar.push != nil {
 	// 	if err := bar.push.Close(); err != nil {
 	// 		return err

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -20,7 +20,7 @@ type ActiveReplicatorConfig struct {
 	ID     string
 	Filter string
 	// Since represents the sequence we're going to perform the replication from.
-	Since uint64
+	Since db.SequenceID
 	// ChangesBatchSize controls how many revisions may be batched per changes message.
 	ChangesBatchSize uint16
 	// Direction, otherwise known as the type of replication: PushAndPull, Push, or Pull.

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -17,18 +17,19 @@ const (
 // ActiveReplicatorConfig controls the behaviour of the active replicator.
 // TODO: This might be replaced with ReplicatorConfig in the future.
 type ActiveReplicatorConfig struct {
-	ID string
-	// Type of replication: PushAndPull, Push, or Pull
-	Direction ActiveReplicatorDirection
-	// PassiveDB represents the full Sync Gateway URL, including database path, and basic auth credentials
-	PassiveDB *url.URL
-	// ActiveDB is a reference to the active database context
-	ActiveDB *db.Database
-	// CheckpointInterval controls many revisions to process before storing a checkpoint
-	CheckpointInterval uint16
-	// ChangesBatchSize controls how many revisions may be batched per changes message
+	ID     string
+	Filter string
+	// Since represents the sequence we're going to perform the replication from.
+	Since uint64
+	// ChangesBatchSize controls how many revisions may be batched per changes message.
 	ChangesBatchSize uint16
-	Continuous       bool
-	Since            uint64
-	Filter           string
+	// Direction, otherwise known as the type of replication: PushAndPull, Push, or Pull.
+	Direction ActiveReplicatorDirection
+	// Continuous specifies whether the replication should be continuous or one-shot.
+	Continuous bool
+	// PassiveDB represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
+	PassiveDB *url.URL
+
+	// ActiveDB is a reference to the active database context.
+	ActiveDB *db.Database
 }

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -17,8 +17,15 @@ const (
 // ActiveReplicatorConfig controls the behaviour of the active replicator.
 // TODO: This might be replaced with ReplicatorConfig in the future.
 type ActiveReplicatorConfig struct {
-	ID     string
+	ID string
+	// Filter is a predetermined filter name (e.g. sync_gateway/bychannel)
 	Filter string
+	// FilterChannels are a set of channels to be used by the sync_gateway/bychannel filter.
+	FilterChannels []string
+	// DocIDs limits the changes to only those doc IDs specified.
+	DocIDs []string
+	// ActiveOnly when true prevents changes being sent for tombstones on the initial replication.
+	ActiveOnly bool
 	// Since represents the sequence we're going to perform the replication from.
 	Since db.SequenceID
 	// ChangesBatchSize controls how many revisions may be batched per changes message.

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -34,8 +34,8 @@ type ActiveReplicatorConfig struct {
 	Direction ActiveReplicatorDirection
 	// Continuous specifies whether the replication should be continuous or one-shot.
 	Continuous bool
-	// PassiveDB represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
-	PassiveDB *url.URL
+	// PassiveDBURL represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
+	PassiveDBURL *url.URL
 
 	// ActiveDB is a reference to the active database context.
 	ActiveDB *db.Database

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -2,6 +2,8 @@ package replicator
 
 import (
 	"net/url"
+
+	"github.com/couchbase/sync_gateway/db"
 )
 
 type ActiveReplicatorDirection uint8
@@ -18,10 +20,15 @@ type ActiveReplicatorConfig struct {
 	ID string
 	// Type of replication: PushAndPull, Push, or Pull
 	Direction ActiveReplicatorDirection
-	// // CheckpointInterval controls many revisions to process before storing a checkpoint
-	// CheckpointInterval uint16 // Default: 200
-	// // ChangesBatchSize controls how many revisions may be batched per changes message
-	// ChangesBatchSize uint16 // Default: 200
-	// TargetDB represents the full Sync Gateway URL, including database path, and basic auth credentials
-	TargetDB *url.URL
+	// PassiveDB represents the full Sync Gateway URL, including database path, and basic auth credentials
+	PassiveDB *url.URL
+	// ActiveDB is a reference to the active database context
+	ActiveDB *db.Database
+	// CheckpointInterval controls many revisions to process before storing a checkpoint
+	CheckpointInterval uint16
+	// ChangesBatchSize controls how many revisions may be batched per changes message
+	ChangesBatchSize uint16
+	Continuous       bool
+	Since            uint64
+	Filter           string
 }

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -13,8 +13,6 @@ type ActivePullReplicator struct {
 	blipSender      *blip.Sender
 }
 
-var _ ActiveReplicator = &ActivePullReplicator{}
-
 func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 	return &ActivePullReplicator{
 		config: config,
@@ -72,10 +70,13 @@ func (apr *ActivePullReplicator) Start() error {
 	}
 
 	subChangesRequest := SubChangesRequest{
-		Continuous: apr.config.Continuous,
-		Batch:      apr.config.ChangesBatchSize,
-		Since:      apr.config.Since,
-		Filter:     apr.config.Filter,
+		Continuous:     apr.config.Continuous,
+		Batch:          apr.config.ChangesBatchSize,
+		Since:          apr.config.Since,
+		Filter:         apr.config.Filter,
+		FilterChannels: apr.config.FilterChannels,
+		DocIDs:         apr.config.DocIDs,
+		ActiveOnly:     apr.config.ActiveOnly,
 	}
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -32,7 +32,7 @@ func (apr *ActivePullReplicator) connect() error {
 	bsc := NewBlipSyncContext(blipContext, apr.config.ActiveDB, blipContext.ID)
 	apr.blipSyncContext = bsc
 
-	s, err := blipSync(*apr.config.PassiveDB, apr.blipSyncContext.blipContext)
+	s, err := blipSync(*apr.config.PassiveDBURL, apr.blipSyncContext.blipContext)
 	if err != nil {
 		return err
 	}

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -38,7 +38,7 @@ func (apr *ActivePullReplicator) connect() error {
 	}
 	apr.blipSender = s
 
-	bsc := NewBlipSyncContext(apr.blipContext, apr.config.ActiveDB, "??")
+	bsc := NewBlipSyncContext(apr.blipContext, apr.config.ActiveDB, apr.blipContext.ID)
 	apr.blipSyncContext = bsc
 
 	return nil

--- a/replicator/blip_messages.go
+++ b/replicator/blip_messages.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/db"
 )
 
 type BLIPMessageSender interface {
@@ -12,10 +13,10 @@ type BLIPMessageSender interface {
 
 // SubChangesRequest is a strongly typed 'subChanges' request.
 type SubChangesRequest struct {
-	Continuous bool   // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
-	Batch      uint16 // Batch controls the maximum number of changes to send in a single change message (optional)
-	Since      uint64 // Since represents the latest sequence ID already known to the requester (optional) // TODO: Need a more complex sequence number type
-	Filter     string // Filter is the name of a filter function known to the recipient (optional)
+	Continuous bool          // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
+	Batch      uint16        // Batch controls the maximum number of changes to send in a single change message (optional)
+	Since      db.SequenceID // Since represents the latest sequence ID already known to the requester (optional)
+	Filter     string        // Filter is the name of a filter function known to the recipient (optional)
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}

--- a/replicator/blip_messages.go
+++ b/replicator/blip_messages.go
@@ -1,0 +1,41 @@
+package replicator
+
+import (
+	"fmt"
+
+	"github.com/couchbase/go-blip"
+)
+
+type BLIPMessageSender interface {
+	Send(s *blip.Sender) error
+}
+
+// SubChangesRequest is a strongly typed 'subChanges' request.
+type SubChangesRequest struct {
+	Continuous bool   // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
+	Batch      uint16 // Batch controls the maximum number of changes to send in a single change message (optional)
+	Since      uint64 // Since represents the latest sequence ID already known to the requester (optional) // TODO: Need a more complex sequence number type
+	Filter     string // Filter is the name of a filter function known to the recipient (optional)
+}
+
+var _ BLIPMessageSender = &SubChangesRequest{}
+
+func (scr *SubChangesRequest) Send(s *blip.Sender) error {
+	if ok := s.Send(scr.marshalBLIPRequest()); !ok {
+		return fmt.Errorf("closed blip sender")
+	}
+
+	return nil
+}
+
+func (scr *SubChangesRequest) marshalBLIPRequest() *blip.Message {
+	msg := blip.NewRequest()
+	msg.SetProfile("subChanges")
+
+	setOptionalProperty(msg.Properties, "continuous", scr.Continuous)
+	setOptionalProperty(msg.Properties, "since", scr.Since)
+	setOptionalProperty(msg.Properties, "filter", scr.Filter)
+	setOptionalProperty(msg.Properties, "batch", scr.Batch)
+
+	return msg
+}

--- a/replicator/blip_messages.go
+++ b/replicator/blip_messages.go
@@ -2,8 +2,10 @@ package replicator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 )
 
@@ -13,10 +15,13 @@ type BLIPMessageSender interface {
 
 // SubChangesRequest is a strongly typed 'subChanges' request.
 type SubChangesRequest struct {
-	Continuous bool          // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
-	Batch      uint16        // Batch controls the maximum number of changes to send in a single change message (optional)
-	Since      db.SequenceID // Since represents the latest sequence ID already known to the requester (optional)
-	Filter     string        // Filter is the name of a filter function known to the recipient (optional)
+	Continuous     bool          // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
+	Batch          uint16        // Batch controls the maximum number of changes to send in a single change message (optional)
+	Since          db.SequenceID // Since represents the latest sequence ID already known to the requester (optional)
+	Filter         string        // Filter is the name of a filter function known to the recipient (optional)
+	FilterChannels []string      // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
+	DocIDs         []string      // DocIDs specifies which doc IDs the recipient should send changes for (optional)
+	ActiveOnly     bool          // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}
@@ -34,9 +39,17 @@ func (scr *SubChangesRequest) marshalBLIPRequest() *blip.Message {
 	msg.SetProfile("subChanges")
 
 	setOptionalProperty(msg.Properties, "continuous", scr.Continuous)
+	setOptionalProperty(msg.Properties, "batch", scr.Batch)
 	setOptionalProperty(msg.Properties, "since", scr.Since)
 	setOptionalProperty(msg.Properties, "filter", scr.Filter)
-	setOptionalProperty(msg.Properties, "batch", scr.Batch)
+	setOptionalProperty(msg.Properties, "channels", strings.Join(scr.FilterChannels, ","))
+
+	if err := msg.SetJSONBody(map[string]interface{}{
+		"docIDs": scr.DocIDs,
+	}); err != nil {
+		base.Errorf("error marshalling docIDs slice into subChanges request: %v", err)
+		return nil
+	}
 
 	return msg
 }

--- a/replicator/blip_messages_utils.go
+++ b/replicator/blip_messages_utils.go
@@ -18,6 +18,8 @@ func setProperty(p blip.Properties, k string, v interface{}) {
 		p[k] = strconv.FormatUint(val, 10)
 	case uint16:
 		p[k] = strconv.FormatUint(uint64(val), 10)
+	case fmt.Stringer:
+		p[k] = val.String()
 	default:
 		panic(fmt.Sprintf("unknown setProperty value type: %T", val))
 	}
@@ -42,6 +44,8 @@ func setOptionalProperty(p blip.Properties, k string, v interface{}) {
 		if val != 0 {
 			p[k] = strconv.FormatUint(uint64(val), 10)
 		}
+	case fmt.Stringer:
+		p[k] = val.String()
 	default:
 		panic(fmt.Sprintf("unknown setOptionalProperty value type: %T", val))
 	}

--- a/replicator/blip_messages_utils.go
+++ b/replicator/blip_messages_utils.go
@@ -1,0 +1,48 @@
+package replicator
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/couchbase/go-blip"
+)
+
+// setProperty will set the given property value.
+func setProperty(p blip.Properties, k string, v interface{}) {
+	switch val := v.(type) {
+	case string:
+		p[k] = val
+	case bool:
+		p[k] = strconv.FormatBool(val)
+	case uint64:
+		p[k] = strconv.FormatUint(val, 10)
+	case uint16:
+		p[k] = strconv.FormatUint(uint64(val), 10)
+	default:
+		panic(fmt.Sprintf("unknown setProperty value type: %T", val))
+	}
+}
+
+// setOptionalProperty will set the given property value, if v is non-zero.
+func setOptionalProperty(p blip.Properties, k string, v interface{}) {
+	switch val := v.(type) {
+	case string:
+		if val != "" {
+			p[k] = val
+		}
+	case bool:
+		if val {
+			p[k] = strconv.FormatBool(val)
+		}
+	case uint64:
+		if val != 0 {
+			p[k] = strconv.FormatUint(val, 10)
+		}
+	case uint16:
+		if val != 0 {
+			p[k] = strconv.FormatUint(uint64(val), 10)
+		}
+	default:
+		panic(fmt.Sprintf("unknown setOptionalProperty value type: %T", val))
+	}
+}

--- a/replicator/blip_sync_context.go
+++ b/replicator/blip_sync_context.go
@@ -38,7 +38,7 @@ var (
 
 var ErrClosedBLIPSender = errors.New("use of closed BLIP sender")
 
-func NewBlipSyncContext(bc *blip.Context, db *db.Database, httpRequestSerialNumber string) *BlipSyncContext {
+func NewBlipSyncContext(bc *blip.Context, db *db.Database, contextID string) *BlipSyncContext {
 	bsc := &BlipSyncContext{
 		blipContext:      bc,
 		blipContextDb:    db,
@@ -54,7 +54,7 @@ func NewBlipSyncContext(bc *blip.Context, db *db.Database, httpRequestSerialNumb
 	// Register default handlers
 	bc.DefaultHandler = bsc.NotFoundHandler
 	bc.FatalErrorHandler = func(err error) {
-		base.InfofCtx(db.Ctx, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", httpRequestSerialNumber, err)
+		base.InfofCtx(db.Ctx, base.KeyHTTP, "%s:     --> BLIP+WebSocket connection error: %v", contextID, err)
 	}
 
 	// Register 2.x replicator handlers

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -39,10 +39,10 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 	targetDB.User = url.UserPassword("alice", "pass")
 
 	bar, err := replicator.NewActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
-		ID:        t.Name(),
-		Direction: replicator.ActiveReplicatorTypePushAndPull,
-		ActiveDB:  &db.Database{DatabaseContext: rt.GetDatabase()},
-		PassiveDB: targetDB,
+		ID:           t.Name(),
+		Direction:    replicator.ActiveReplicatorTypePushAndPull,
+		ActiveDB:     &db.Database{DatabaseContext: rt.GetDatabase()},
+		PassiveDBURL: targetDB,
 	})
 	require.NoError(t, err)
 
@@ -126,9 +126,9 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt1.Close()
 
 	bar, err := replicator.NewActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
-		ID:        t.Name(),
-		Direction: replicator.ActiveReplicatorTypePull,
-		PassiveDB: passiveDB,
+		ID:           t.Name(),
+		Direction:    replicator.ActiveReplicatorTypePull,
+		PassiveDBURL: passiveDB,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -132,8 +132,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		ChangesBatchSize:   200,
-		CheckpointInterval: 200,
+		ChangesBatchSize: 200,
 	})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, bar.Close()) }()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestActiveReplicatorBlipsync starts a RestTester, and publishes the REST API on a httptest server, which the ActiveReplicator can call blipsync on.
+// TestActiveReplicatorBlipsync uses an ActiveReplicator with another RestTester instance to connect and cleanly disconnect.
 func TestActiveReplicatorBlipsync(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg, base.KeyReplicate)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)()
 
 	rt := NewRestTester(t, &RestTesterConfig{
 		DatabaseConfig: &DbConfig{
@@ -38,7 +38,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 	// Add basic auth creds to target db URL
 	targetDB.User = url.UserPassword("alice", "pass")
 
-	bar, err := replicator.NewBidirectionalActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
+	bar, err := replicator.NewActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
 		ID:        t.Name(),
 		Direction: replicator.ActiveReplicatorTypePushAndPull,
 		ActiveDB:  &db.Database{DatabaseContext: rt.GetDatabase()},
@@ -85,7 +85,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges)()
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -125,7 +125,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	})
 	defer rt1.Close()
 
-	bar, err := replicator.NewBidirectionalActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
+	bar, err := replicator.NewActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
 		ID:        t.Name(),
 		Direction: replicator.ActiveReplicatorTypePull,
 		PassiveDB: passiveDB,


### PR DESCRIPTION
Implement basic pull replication on the ActiveReplicator by using existing BlipSyncContext code/handlers and sending a `subChanges` request.

TestActiveReplicatorPullBasic pulls a doc from one cluster to another as a user.