### PR TITLE
CBG-803: Support for OpenID Connect provider config refresh

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -436,7 +436,7 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(token string, providers OIDC
 
 		// Extract issuer and audience(s) from JSON Web Token.
 		var audiences []string
-		issuer, audiences, err = GetIssuerWithAudience(jwt)
+		issuer, audiences, err = getIssuerWithAudience(jwt)
 		base.Debugf(base.KeyAuth, "JWT issuer: %v, audiences: %v", base.UD(issuer), base.UD(audiences))
 		if err != nil {
 			base.Debugf(base.KeyAuth, "Error getting issuer and audience from token: %v", err)
@@ -458,8 +458,8 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(token string, providers OIDC
 		return nil, fmt.Errorf("OIDC client was not initialized")
 	}
 
-	// VerifyJWT validates the claims and signature on the JWT
-	idToken, err := client.VerifyJWT(token)
+	// verifyJWT validates the claims and signature on the JWT
+	idToken, err := client.verifyJWT(token)
 	if err != nil {
 		base.Debugf(base.KeyAuth, "Client %v could not verify JWT. Error: %v", base.UD(client), err)
 		return nil, err
@@ -496,7 +496,7 @@ func (auth *Authenticator) authenticateOIDCIdentity(identity *Identity, provider
 		base.Debugf(base.KeyAuth, "Empty subject found in OIDC identity: %v", base.UD(identity))
 		return nil, time.Time{}, errors.New("subject not found in OIDC identity")
 	}
-	username := GetOIDCUsername(provider, identity.Subject)
+	username := getOIDCUsername(provider, identity.Subject)
 	base.Debugf(base.KeyAuth, "OIDCUsername: %v", base.UD(username))
 
 	user, err = auth.GetUser(username)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -655,7 +655,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -665,7 +665,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			IssuedAt: jwt.NewNumericDate(time.Now()),
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
-		wantUsername := GetOIDCUsername(provider, claims.Subject)
+		wantUsername := getOIDCUsername(provider, claims.Subject)
 		builder := jwt.Signed(signer).Claims(claims)
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
@@ -683,7 +683,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -710,7 +710,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud4",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -737,7 +737,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud4",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -763,7 +763,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -790,7 +790,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:        "id0123456789",
@@ -801,7 +801,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:    jwt.NewNumericDate(time.Now().Add(1 * time.Minute)),
 			NotBefore: jwt.NewNumericDate(time.Now().Add(1 * time.Minute)),
 		}
-		wantUsername := GetOIDCUsername(provider, claims.Subject)
+		wantUsername := getOIDCUsername(provider, claims.Subject)
 		builder := jwt.Signed(signer).Claims(claims)
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
@@ -819,7 +819,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:        "id0123456789",
@@ -847,7 +847,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -881,7 +881,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -919,7 +919,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -957,7 +957,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -989,7 +989,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.InitUserPrefix()
+		err = provider.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1214,7 +1214,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 		}
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
-		err = providerGoogle.InitUserPrefix()
+		err = providerGoogle.initUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",

--- a/db/database.go
+++ b/db/database.go
@@ -528,6 +528,7 @@ func (context *DatabaseContext) Close() {
 	context.BucketLock.Lock()
 	defer context.BucketLock.Unlock()
 
+	context.OIDCProviders.Stop()
 	close(context.terminator)
 	context.sequences.Stop()
 	context.mutationListener.Stop()

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -116,9 +116,9 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 	offline := h.getBoolQuery(requestParamOffline)
 	if offline {
 		// Set access type to offline and prompt to consent in auth code request URL.
-		redirectURL, err = url.Parse(client.Config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce))
+		redirectURL, err = url.Parse(client.Config().AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce))
 	} else {
-		redirectURL, err = url.Parse(client.Config.AuthCodeURL(state))
+		redirectURL, err = url.Parse(client.Config().AuthCodeURL(state))
 	}
 
 	if err != nil {
@@ -176,7 +176,7 @@ func (h *handler) handleOIDCCallback() error {
 
 	// Converts the authorization code into a token.
 	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)
-	token, err := client.Config.Exchange(context, code)
+	token, err := client.Config().Exchange(context, code)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Failed to exchange token: "+err.Error())
 	}
@@ -228,7 +228,7 @@ func (h *handler) handleOIDCRefresh() error {
 	}
 
 	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)
-	token, err := client.Config.TokenSource(context, &oauth2.Token{RefreshToken: refreshToken}).Token()
+	token, err := client.Config().TokenSource(context, &oauth2.Token{RefreshToken: refreshToken}).Token()
 	if err != nil {
 		base.Infof(base.KeyAuth, "Unsuccessful token refresh: %v", err)
 		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to refresh token.")

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -175,7 +175,7 @@ func (s *mockAuthServer) setupSignerWithKeys() error {
 // The caller should call Shutdown when finished, to shut it down.
 func (s *mockAuthServer) Start() {
 	router := mux.NewRouter()
-	router.HandleFunc("/{provider}"+auth.OIDCDiscoveryConfigPath, s.discoveryHandler).Methods(http.MethodGet)
+	router.HandleFunc(auth.GetStandardDiscoveryEndpoint("/{provider}"), s.discoveryHandler).Methods(http.MethodGet)
 	router.HandleFunc("/{provider}/auth", s.authHandler).Methods(http.MethodGet, http.MethodPost)
 	router.HandleFunc("/{provider}/token", s.tokenHandler).Methods(http.MethodPost)
 	router.HandleFunc("/{provider}/keys", s.keysHandler).Methods(http.MethodGet)
@@ -896,7 +896,7 @@ func assertHttpResponse(t *testing.T, response *http.Response, forceError forceE
 func refreshProviderConfig(providers auth.OIDCProviderMap, issuer string) {
 	for name, provider := range providers {
 		provider.Issuer = issuer + "/" + name
-		provider.DiscoveryURI = provider.Issuer + auth.OIDCDiscoveryConfigPath
+		provider.DiscoveryURI = auth.GetStandardDiscoveryEndpoint(provider.Issuer)
 	}
 }
 


### PR DESCRIPTION
Poll OpenID Connect provider configuration as background task and refresh the the ID Token verifier if the provider metadata has modified.