### PR TITLE
Remove hard-coded state parameter value from test provider

### DIFF
--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -309,7 +309,9 @@ func (h *handler) handleOidcTestProviderAuthenticate() error {
 
 	query := locationURL.Query()
 	query.Set(requestParamCode, code)
-	query.Set(requestParamState, "af0ifjsldkj")
+	if state := requestParams.Get(requestParamState); state != "" {
+		query.Set(requestParamState, state)
+	}
 	locationURL.RawQuery = query.Encode()
 	h.setHeader(headerLocation, locationURL.String())
 	h.response.WriteHeader(http.StatusFound)


### PR DESCRIPTION
Remove hard-coded state parameter value from test provider and return the actual state value along with authorization code.