### PR TITLE
CBG-895: Prevent headers being added to gzip

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -335,6 +335,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
                         sg_tasks.append(task)
                     else:
                         task = add_file_task(sourcefile_path=log_file_item_path)
+                        task.no_header = True
                         sg_tasks.append(task)
 
                 # Track which log file paths have been added so far


### PR DESCRIPTION
Changes were made in CBG-752 to directly place gzipped files into log zip, however, it added headers to the gzip file making them appear to be corrupt. This prevents those headers being added.