### PR TITLE
CBG-782 - Add pull replicator checkpointing

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="53b1ec0f0cb08b38fe3f7b12621ca452bd9f21c8"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b1349276dedea51b9aec41dc86dd6598bcfc5e01"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="74d1ca0181faec13d8c00e9cde9ca6252abb31d0"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="53b1ec0f0cb08b38fe3f7b12621ca452bd9f21c8"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
 

--- a/replicator/active_replicator.go
+++ b/replicator/active_replicator.go
@@ -11,10 +11,19 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+const (
+	// TODO: Not aligned these to any stats in the PRD yet, these are used for test assertions.
+	ActiveReplicatorStatsKeyGetCheckpointHitTotal    = "get_checkpoint_hit_total"
+	ActiveReplicatorStatsKeyGetCheckpointMissTotal   = "get_checkpoint_miss_total"
+	ActiveReplicatorStatsKeySetCheckpointTotal       = "set_checkpoint_total"
+	ActiveReplicatorStatsKeyRevsReceivedTotal        = "revs_received_total"
+	ActiveReplicatorStatsKeyChangesRevsReceivedTotal = "changes_revs_received_total"
+)
+
 // ActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
 type ActiveReplicator struct {
 	// push *ActivePushReplicator // TODO: CBG-784
-	pull *ActivePullReplicator
+	Pull *ActivePullReplicator
 }
 
 // NewActiveReplicator returns a bidirectional active replicator for the given config.
@@ -26,7 +35,7 @@ func NewActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*
 	// }
 
 	if pullReplication := config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull; pullReplication {
-		bar.pull = NewPullReplicator(config)
+		bar.Pull = NewPullReplicator(ctx, config)
 	}
 
 	return bar, nil
@@ -39,8 +48,8 @@ func (bar *ActiveReplicator) Start() error {
 	// 	}
 	// }
 
-	if bar.pull != nil {
-		if err := bar.pull.Start(); err != nil {
+	if bar.Pull != nil {
+		if err := bar.Pull.Start(); err != nil {
 			return err
 		}
 	}
@@ -55,8 +64,8 @@ func (bar *ActiveReplicator) Close() error {
 	// 	}
 	// }
 
-	if bar.pull != nil {
-		if err := bar.pull.Close(); err != nil {
+	if bar.Pull != nil {
+		if err := bar.Pull.Close(); err != nil {
 			return err
 		}
 	}

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -33,13 +33,9 @@ type ActiveReplicatorConfig struct {
 	ActiveOnly bool
 	// ChangesBatchSize controls how many revisions may be batched per changes message.
 	ChangesBatchSize uint16
-	// CheckpointMinInterval throttles checkpointing to be at most, once this often.
-	CheckpointMinInterval time.Duration
-	// CheckpointMaxInterval limits the maximum time to go between setting a checkpoint.
-	CheckpointMaxInterval time.Duration
+	// CheckpointInterval triggers a checkpoint to be set this often.
+	CheckpointInterval time.Duration
 	// CheckpointRevCount controls how many revs to store before attempting to save a checkpoint.
-	CheckpointRevCount uint16
-	// Direction, otherwise known as the type of replication: PushAndPull, Push, or Pull.
 	Direction ActiveReplicatorDirection
 	// Continuous specifies whether the replication should be continuous or one-shot.
 	Continuous bool

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -2,6 +2,7 @@ package replicator
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/couchbase/sync_gateway/db"
 )
@@ -26,12 +27,14 @@ type ActiveReplicatorConfig struct {
 	DocIDs []string
 	// ActiveOnly when true prevents changes being sent for tombstones on the initial replication.
 	ActiveOnly bool
-	// Since represents the sequence we're going to perform the replication from.
-	Since db.SequenceID
 	// ChangesBatchSize controls how many revisions may be batched per changes message.
 	ChangesBatchSize uint16
-	// CheckpointInterval controls how often checkpoints are set by number of revisions processed.
-	CheckpointInterval uint16
+	// CheckpointMinInterval throttles checkpointing to be at most, once this often.
+	CheckpointMinInterval time.Duration
+	// CheckpointMaxInterval limits the maximum time to go between setting a checkpoint.
+	CheckpointMaxInterval time.Duration
+	// CheckpointRevCount controls how many revs to store before attempting to save a checkpoint.
+	CheckpointRevCount uint16
 	// Direction, otherwise known as the type of replication: PushAndPull, Push, or Pull.
 	Direction ActiveReplicatorDirection
 	// Continuous specifies whether the replication should be continuous or one-shot.

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -19,6 +19,10 @@ const (
 	ActiveReplicatorTypePull
 )
 
+const (
+	defaultCheckpointInterval = time.Second * 30
+)
+
 // ActiveReplicatorConfig controls the behaviour of the active replicator.
 // TODO: This might be replaced with ReplicatorConfig in the future.
 type ActiveReplicatorConfig struct {

--- a/replicator/active_replicator_config.go
+++ b/replicator/active_replicator_config.go
@@ -30,6 +30,8 @@ type ActiveReplicatorConfig struct {
 	Since db.SequenceID
 	// ChangesBatchSize controls how many revisions may be batched per changes message.
 	ChangesBatchSize uint16
+	// CheckpointInterval controls how often checkpoints are set by number of revisions processed.
+	CheckpointInterval uint16
 	// Direction, otherwise known as the type of replication: PushAndPull, Push, or Pull.
 	Direction ActiveReplicatorDirection
 	// Continuous specifies whether the replication should be continuous or one-shot.

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -2,8 +2,11 @@ package replicator
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 )
 
 // ActivePullReplicator is a unidirectional pull active replicator.
@@ -11,6 +14,7 @@ type ActivePullReplicator struct {
 	config          *ActiveReplicatorConfig
 	blipSyncContext *BlipSyncContext
 	blipSender      *blip.Sender
+	checkpointRevID string // checkpointRev is the last known checkpoint RevID.
 }
 
 func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
@@ -62,6 +66,39 @@ func (apr *ActivePullReplicator) Close() error {
 	return nil
 }
 
+// getCheckpoint tries to fetch a since value for the given replication by requesting a checkpoint.
+// If this fails, the function returns a zero value.
+func (apr *ActivePullReplicator) getCheckpoint() GetSGR2CheckpointResponse {
+	// TODO: apr.config.CheckpointHash() ?
+	client := apr.blipSyncContext.blipContext.ID
+
+	rq := GetSGR2CheckpointRequest{
+		Client: client,
+	}
+
+	if err := rq.Send(apr.blipSender); err != nil {
+		base.Warnf("couldn't send GetCheckpoint request, starting from 0: %v", err)
+		return GetSGR2CheckpointResponse{}
+	}
+
+	resp, err := rq.Response()
+	if err != nil {
+		base.Warnf("couldn't get response for GetCheckpoint request, starting from 0: %v", err)
+		return GetSGR2CheckpointResponse{}
+	}
+
+	if resp == nil {
+		base.Debugf(base.KeyReplicate, "couldn't find existing checkpoint for client %q, starting from 0", client)
+		return GetSGR2CheckpointResponse{}
+	}
+
+	return *resp
+}
+
+func (apr *ActivePullReplicator) setCheckpoint(seq uint64, revID string) {
+
+}
+
 func (apr *ActivePullReplicator) Start() error {
 	if apr == nil {
 		return fmt.Errorf("nil ActivePullReplicator, can't start")
@@ -71,31 +108,13 @@ func (apr *ActivePullReplicator) Start() error {
 		return err
 	}
 
-	rq := GetSGR2CheckpointRequest{
-		// TODO: apr.config.CheckpointHash() ?
-		Client: apr.blipSyncContext.blipContext.ID,
-	}
-
-	if err := rq.Send(apr.blipSender); err != nil {
-		return err
-	}
-
-	resp, err := rq.Response()
-	if err != nil {
-		return err
-	}
-
-	// TODO: Send String version via subChanges, or safeseq??
-	since := apr.config.Since
-	if resp != nil {
-		// since = resp.Checkpoint.LastSequence
-		since = resp.Checkpoint.LastSequence
-	}
+	checkpoint := apr.getCheckpoint()
+	apr.checkpointRevID = checkpoint.RevID
 
 	subChangesRequest := SubChangesRequest{
 		Continuous:     apr.config.Continuous,
 		Batch:          apr.config.ChangesBatchSize,
-		Since:          since,
+		Since:          checkpoint.Checkpoint.LastSequence,
 		Filter:         apr.config.Filter,
 		FilterChannels: apr.config.FilterChannels,
 		DocIDs:         apr.config.DocIDs,
@@ -104,6 +123,41 @@ func (apr *ActivePullReplicator) Start() error {
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {
 		return err
+	}
+
+	if apr.config.CheckpointInterval > 0 {
+		// keep track of how many revs we've finished processing to know when to set checkpoints.
+		var revsHandled uint64
+		apr.blipSyncContext.postHandleRevCallback = func() {
+			if val := atomic.AddUint64(&revsHandled, 1); val%uint64(apr.config.CheckpointInterval) != 0 {
+				// not at a checkpoint interval, noop
+				return
+			}
+
+			rq := SetSGR2CheckpointRequest{
+				// TODO: apr.config.CheckpointHash() ?
+				Client: apr.blipSyncContext.blipContext.ID,
+				Checkpoint: SGR2Checkpoint{
+					// TODO: use actual value
+					LastSequence: db.SequenceID{Seq: 10},
+				},
+			}
+			if apr.checkpointRevID != "" {
+				rq.RevID = &apr.checkpointRevID
+			}
+
+			if err := rq.Send(apr.blipSender); err != nil {
+				base.Warnf("couldn't send SetCheckpoint request: %v", err)
+				return
+			}
+
+			resp, err := rq.Response()
+			if err != nil {
+				base.Warnf("couldn't get response for SetCheckpoint request: %v", err)
+				return
+			}
+			apr.checkpointRevID = resp.RevID
+		}
 	}
 
 	return nil

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -1,8 +1,11 @@
 package replicator
 
 import (
+	"context"
+	"expvar"
 	"fmt"
-	"sync/atomic"
+	"sync"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
@@ -14,15 +17,19 @@ type ActivePullReplicator struct {
 	config          *ActiveReplicatorConfig
 	blipSyncContext *BlipSyncContext
 	blipSender      *blip.Sender
+	ctx             context.Context
 	checkpointRevID string // checkpointRev is the last known checkpoint RevID.
+	checkpointerWg  sync.WaitGroup
+	Stats           expvar.Map
 }
 
-func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
+func NewPullReplicator(ctx context.Context, config *ActiveReplicatorConfig) *ActivePullReplicator {
 	blipContext := blip.NewContextCustomID(config.ID+"-pull", blipCBMobileReplication)
 	bsc := NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID)
 	return &ActivePullReplicator{
 		config:          config,
 		blipSyncContext: bsc,
+		ctx:             ctx,
 	}
 }
 
@@ -52,6 +59,8 @@ func (apr *ActivePullReplicator) Close() error {
 		// noop
 		return nil
 	}
+
+	apr.checkpointerWg.Wait()
 
 	if apr.blipSender != nil {
 		apr.blipSender.Close()
@@ -89,14 +98,41 @@ func (apr *ActivePullReplicator) getCheckpoint() GetSGR2CheckpointResponse {
 
 	if resp == nil {
 		base.Debugf(base.KeyReplicate, "couldn't find existing checkpoint for client %q, starting from 0", client)
+		apr.Stats.Add(ActiveReplicatorStatsKeyGetCheckpointMissTotal, 1)
 		return GetSGR2CheckpointResponse{}
 	}
+
+	apr.Stats.Add(ActiveReplicatorStatsKeyGetCheckpointHitTotal, 1)
 
 	return *resp
 }
 
-func (apr *ActivePullReplicator) setCheckpoint(seq uint64, revID string) {
+func (apr *ActivePullReplicator) setCheckpoint(seq db.SequenceID) {
+	rq := SetSGR2CheckpointRequest{
+		// TODO: apr.config.CheckpointHash() ?
+		Client: apr.blipSyncContext.blipContext.ID,
+		Checkpoint: SGR2Checkpoint{
+			LastSequence: seq,
+		},
+	}
+	if apr.checkpointRevID != "" {
+		rq.RevID = &apr.checkpointRevID
+	}
 
+	if err := rq.Send(apr.blipSender); err != nil {
+		base.Warnf("couldn't send SetCheckpoint request: %v", err)
+		return
+	}
+
+	resp, err := rq.Response()
+	if err != nil {
+		base.Warnf("couldn't get response for SetCheckpoint request: %v", err)
+		return
+	}
+
+	apr.Stats.Add(ActiveReplicatorStatsKeySetCheckpointTotal, 1)
+
+	apr.checkpointRevID = resp.RevID
 }
 
 func (apr *ActivePullReplicator) Start() error {
@@ -121,44 +157,150 @@ func (apr *ActivePullReplicator) Start() error {
 		ActiveOnly:     apr.config.ActiveOnly,
 	}
 
+	if err := apr.startCheckpointer(); err != nil {
+		return err
+	}
+
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {
 		return err
 	}
 
-	if apr.config.CheckpointInterval > 0 {
-		// keep track of how many revs we've finished processing to know when to set checkpoints.
-		var revsHandled uint64
-		apr.blipSyncContext.postHandleRevCallback = func() {
-			if val := atomic.AddUint64(&revsHandled, 1); val%uint64(apr.config.CheckpointInterval) != 0 {
-				// not at a checkpoint interval, noop
-				return
-			}
+	return nil
+}
 
-			rq := SetSGR2CheckpointRequest{
-				// TODO: apr.config.CheckpointHash() ?
-				Client: apr.blipSyncContext.blipContext.ID,
-				Checkpoint: SGR2Checkpoint{
-					// TODO: use actual value
-					LastSequence: db.SequenceID{Seq: 10},
-				},
-			}
-			if apr.checkpointRevID != "" {
-				rq.RevID = &apr.checkpointRevID
-			}
+// startCheckpointer registers appropriate callback functions for checkpointing, and starts a time-based checkpointer goroutine.
+func (apr *ActivePullReplicator) startCheckpointer() error {
+	if apr.config.CheckpointMinInterval == 0 {
+		apr.config.CheckpointMinInterval = time.Second * 10
+	}
+	if apr.config.CheckpointMaxInterval == 0 {
+		apr.config.CheckpointMaxInterval = time.Second * 30
+	}
+	if apr.config.CheckpointRevCount == 0 {
+		apr.config.CheckpointRevCount = apr.config.ChangesBatchSize
+	}
 
-			if err := rq.Send(apr.blipSender); err != nil {
-				base.Warnf("couldn't send SetCheckpoint request: %v", err)
-				return
-			}
+	// checkpointerLock guards the expectedSeqs slice, and receivedSeqs map
+	checkpointerLock := sync.Mutex{}
 
-			resp, err := rq.Response()
-			if err != nil {
-				base.Warnf("couldn't get response for SetCheckpoint request: %v", err)
-				return
-			}
-			apr.checkpointRevID = resp.RevID
+	// An ordered list of sequence IDs we expect to receive revs for.
+	expectedSeqs := []db.SequenceID{}
+	// A map of sequence IDs we've received revs for.
+	receivedSeqs := map[db.SequenceID]struct{}{}
+
+	checkpointNow := make(chan struct{})
+
+	apr.blipSyncContext.postHandleChangesCallback = func(changesSeqs []db.SequenceID) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyChangesRevsReceivedTotal, int64(len(changesSeqs)))
+
+		if len(changesSeqs) == 0 {
+			// nothing to do
+			return
+		}
+
+		select {
+		case <-apr.ctx.Done():
+			// replicator already closed, bail out of checkpointing work
+			return
+		default:
+		}
+
+		checkpointerLock.Lock()
+		expectedSeqs = append(expectedSeqs, changesSeqs...)
+		checkpointerLock.Unlock()
+	}
+
+	revCounter := uint16(0)
+	apr.blipSyncContext.postHandleRevCallback = func(remoteSeq db.SequenceID) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyRevsReceivedTotal, 1)
+
+		select {
+		case <-apr.ctx.Done():
+			// replicator already closed, bail out of checkpointing work
+			return
+		default:
+		}
+
+		checkpointerLock.Lock()
+		revCounter++
+		receivedSeqs[remoteSeq] = struct{}{}
+
+		shouldCheckpoint := revCounter >= apr.config.CheckpointRevCount
+		if !shouldCheckpoint {
+			checkpointerLock.Unlock()
+			return
+		}
+
+		revCounter = uint16(0)
+		checkpointerLock.Unlock()
+
+		select {
+		case checkpointNow <- struct{}{}:
+		case <-time.After(apr.config.CheckpointMinInterval):
+			// Blocked trying to send a checkpointNow signal
+			base.Tracef(base.KeyReplicate, "checkpointer: skipping sending blocked checkpointNow signal")
 		}
 	}
+
+	// Start a time-based checkpointer goroutine
+	go func() {
+		timeout := time.NewTimer(apr.config.CheckpointMaxInterval)
+		defer timeout.Stop()
+		for {
+			select {
+			case <-checkpointNow:
+				base.Tracef(base.KeyReplicate, "checkpointer: got checkpointNow signal")
+				// fall out of select to set the checkpoint
+			case <-timeout.C:
+				base.Tracef(base.KeyReplicate, "checkpointer: got timeout signal")
+				// timed out waiting for number of revs to reach CheckpointRevCount
+				// fall out of select to set the checkpoint
+			case <-apr.ctx.Done():
+				// replicator stopped, set a final checkpoint
+			}
+
+			apr.checkpointerWg.Add(1)
+			if !timeout.Stop() {
+				<-timeout.C
+			}
+
+			checkpointerLock.Lock()
+
+			// find the highest contiguous sequence we've received
+			if len(expectedSeqs) > 0 {
+				var lowSeq db.SequenceID
+
+				// iterates over each (ordered) expected sequence and stops when we find the first sequence we've yet to receive a rev message for
+				var maxI int
+				for i, seq := range expectedSeqs {
+					if _, ok := receivedSeqs[seq]; !ok {
+						base.Tracef(base.KeyReplicate, "checkpointer: couldn't find %v in receivedSeqs", seq)
+						break
+					}
+
+					delete(receivedSeqs, seq)
+					maxI = i
+				}
+
+				lowSeq = expectedSeqs[maxI]
+
+				if len(expectedSeqs)-1 == maxI {
+					// received full set, empty list
+					expectedSeqs = expectedSeqs[0:0]
+				} else {
+					// trim sequence list for partially received set
+					expectedSeqs = expectedSeqs[maxI+1:]
+				}
+
+				base.Tracef(base.KeyReplicate, "checkpointer got lowSeq: %v", lowSeq)
+				apr.setCheckpoint(lowSeq)
+			}
+
+			checkpointerLock.Unlock()
+			timeout.Reset(apr.config.CheckpointMinInterval)
+			apr.checkpointerWg.Done()
+		}
+	}()
 
 	return nil
 }

--- a/replicator/active_replicator_pull.go
+++ b/replicator/active_replicator_pull.go
@@ -298,7 +298,11 @@ func (apr *ActivePullReplicator) startCheckpointer() error {
 	// Start a time-based checkpointer goroutine
 	go func() {
 		var exit bool
-		ticker := time.NewTicker(apr.config.CheckpointInterval)
+		checkpointInterval := defaultCheckpointInterval
+		if apr.config.CheckpointInterval > 0 {
+			checkpointInterval = apr.config.CheckpointInterval
+		}
+		ticker := time.NewTicker(checkpointInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/replicator/blip_handler.go
+++ b/replicator/blip_handler.go
@@ -624,8 +624,15 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	bh.dbStats.CblReplicationPush().Add(base.StatKeyDocPushCount, 1)
 
 	_, _, err = bh.db.PutExistingRev(newDoc, history, noConflicts)
+	if err != nil {
+		return err
+	}
 
-	return err
+	if bh.postHandleRevCallback != nil {
+		bh.postHandleRevCallback()
+	}
+
+	return nil
 }
 
 //////// ATTACHMENTS:

--- a/replicator/blip_handler.go
+++ b/replicator/blip_handler.go
@@ -354,7 +354,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		bh.dbStats.CblReplicationPush().Add(base.StatKeyProposeChangeTime, time.Since(startTime).Nanoseconds())
 	}()
 
-	expectedSeqs := make([]db.SequenceID, 0)
+	expectedSeqs := make([]string, 0)
 
 	for _, change := range changeList {
 		docID := change[1].(string)
@@ -386,11 +386,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 				case json.Number:
 					seqStr = seq.String()
 				}
-				seq, err := bh.db.DatabaseContext.ParseSequenceID(seqStr)
-				if err != nil {
-					return base.HTTPErrorf(http.StatusBadRequest, "invalid sequence number %q for rev: %s / %s", seqStr, docID, revID)
-				}
-				expectedSeqs = append(expectedSeqs, seq)
+				expectedSeqs = append(expectedSeqs, seqStr)
 			}
 		}
 		nWritten++
@@ -656,11 +652,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	}
 
 	if bh.postHandleRevCallback != nil {
-		remoteSeq, err := bh.db.ParseSequenceID(rq.Properties[RevMessageSequence])
-		if err != nil {
-			return err
-		}
-		bh.postHandleRevCallback(remoteSeq)
+		bh.postHandleRevCallback(rq.Properties[RevMessageSequence])
 	}
 
 	return nil

--- a/replicator/blip_handler.go
+++ b/replicator/blip_handler.go
@@ -354,6 +354,8 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		bh.dbStats.CblReplicationPush().Add(base.StatKeyProposeChangeTime, time.Since(startTime).Nanoseconds())
 	}()
 
+	expectedSeqs := make([]db.SequenceID, 0)
+
 	for _, change := range changeList {
 		docID := change[1].(string)
 		revID := change[2].(string)
@@ -362,13 +364,33 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			output.Write([]byte(","))
 		}
 		if missing == nil {
+			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
-		} else if len(possible) == 0 {
-			output.Write([]byte("[]"))
 		} else {
-			err := jsonOutput.Encode(possible)
-			if err != nil {
-				base.InfofCtx(bh.blipContextDb.Ctx, base.KeyAll, "Error encoding json: %v", err)
+			// we want this rev, send possible ancestors to the peer
+			if len(possible) == 0 {
+				output.Write([]byte("[]"))
+			} else {
+				err := jsonOutput.Encode(possible)
+				if err != nil {
+					base.InfofCtx(bh.blipContextDb.Ctx, base.KeyAll, "Error encoding json: %v", err)
+				}
+			}
+
+			// skip parsing seqno if we're not going to use it (no callback defined)
+			if bh.postHandleChangesCallback != nil {
+				var seqStr string
+				switch seq := change[0].(type) {
+				case string:
+					seqStr = seq
+				case json.Number:
+					seqStr = seq.String()
+				}
+				seq, err := bh.db.DatabaseContext.ParseSequenceID(seqStr)
+				if err != nil {
+					return base.HTTPErrorf(http.StatusBadRequest, "invalid sequence number %q for rev: %s / %s", seqStr, docID, revID)
+				}
+				expectedSeqs = append(expectedSeqs, seq)
 			}
 		}
 		nWritten++
@@ -377,6 +399,11 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	response := rq.Response()
 	response.SetCompressed(true)
 	response.SetBody(output.Bytes())
+
+	if bh.postHandleChangesCallback != nil {
+		bh.postHandleChangesCallback(expectedSeqs)
+	}
+
 	return nil
 }
 
@@ -629,7 +656,11 @@ func (bh *blipHandler) handleRev(rq *blip.Message) error {
 	}
 
 	if bh.postHandleRevCallback != nil {
-		bh.postHandleRevCallback()
+		remoteSeq, err := bh.db.ParseSequenceID(rq.Properties[RevMessageSequence])
+		if err != nil {
+			return err
+		}
+		bh.postHandleRevCallback(remoteSeq)
 	}
 
 	return nil

--- a/replicator/blip_messages.go
+++ b/replicator/blip_messages.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 )
 
 type BLIPMessageSender interface {
@@ -15,13 +14,13 @@ type BLIPMessageSender interface {
 
 // SubChangesRequest is a strongly typed 'subChanges' request.
 type SubChangesRequest struct {
-	Continuous     bool          // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
-	Batch          uint16        // Batch controls the maximum number of changes to send in a single change message (optional)
-	Since          db.SequenceID // Since represents the latest sequence ID already known to the requester (optional)
-	Filter         string        // Filter is the name of a filter function known to the recipient (optional)
-	FilterChannels []string      // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
-	DocIDs         []string      // DocIDs specifies which doc IDs the recipient should send changes for (optional)
-	ActiveOnly     bool          // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
+	Continuous     bool     // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
+	Batch          uint16   // Batch controls the maximum number of changes to send in a single change message (optional)
+	Since          string   // Since represents the latest sequence ID already known to the requester (optional)
+	Filter         string   // Filter is the name of a filter function known to the recipient (optional)
+	FilterChannels []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
+	DocIDs         []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
+	ActiveOnly     bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}
@@ -56,7 +55,7 @@ func (rq *SubChangesRequest) marshalBLIPRequest() *blip.Message {
 
 // TODO: Checkpoint format? Local/Remote?
 type SGR2Checkpoint struct {
-	LastSequence db.SequenceID `json:"last_sequence,omitempty"`
+	LastSequence string `json:"last_sequence,omitempty"`
 }
 
 // SetSGR2CheckpointRequest is a strongly typed 'setCheckpoint' request for SG-Replicate 2.

--- a/replicator/blip_messages_utils.go
+++ b/replicator/blip_messages_utils.go
@@ -28,6 +28,10 @@ func setProperty(p blip.Properties, k string, v interface{}) {
 // setOptionalProperty will set the given property value, if v is non-zero.
 func setOptionalProperty(p blip.Properties, k string, v interface{}) {
 	switch val := v.(type) {
+	case *string:
+		if val != nil {
+			p[k] = *val
+		}
 	case string:
 		if val != "" {
 			p[k] = val

--- a/replicator/blip_sync_context.go
+++ b/replicator/blip_sync_context.go
@@ -87,6 +87,8 @@ type BlipSyncContext struct {
 	userChangeWaiter    *db.ChangeWaiter  // Tracks whether the users/roles associated with the replication have changed
 	userName            string            // Avoid contention on db.user during userChangeWaiter user lookup
 	dbStats             *db.DatabaseStats // Direct stats access to support reloading db while stats are being updated
+
+	postHandleRevCallback func() // postHandleRevCallback is called after successfully handling an incoming rev message
 }
 
 // Registers a BLIP handler including the outer-level work of logging & error handling.

--- a/replicator/blip_sync_context.go
+++ b/replicator/blip_sync_context.go
@@ -88,7 +88,8 @@ type BlipSyncContext struct {
 	userName            string            // Avoid contention on db.user during userChangeWaiter user lookup
 	dbStats             *db.DatabaseStats // Direct stats access to support reloading db while stats are being updated
 
-	postHandleRevCallback func() // postHandleRevCallback is called after successfully handling an incoming rev message
+	postHandleRevCallback     func(remoteSeq db.SequenceID)      // postHandleRevCallback is called after successfully handling an incoming rev message
+	postHandleChangesCallback func(expectedSeqs []db.SequenceID) // postHandleChangesCallback is called after successfully handling an incoming changes message
 }
 
 // Registers a BLIP handler including the outer-level work of logging & error handling.

--- a/replicator/blip_sync_context.go
+++ b/replicator/blip_sync_context.go
@@ -68,28 +68,27 @@ func NewBlipSyncContext(bc *blip.Context, db *db.Database, contextID string) *Bl
 // BlipSyncContext represents one BLIP connection (socket) opened by a client.
 // This connection remains open until the client closes it, and can receive any number of requests.
 type BlipSyncContext struct {
-	blipContext         *blip.Context
-	blipContextDb       *db.Database // 'master' database instance for the replication, used as source when creating handler-specific databases
-	dbUserLock          sync.RWMutex // Must be held when refreshing the db user
-	batchSize           int
-	gotSubChanges       bool
-	continuous          bool
-	activeOnly          bool
-	channels            base.Set
-	lock                sync.Mutex
-	allowedAttachments  map[string]int
-	handlerSerialNumber uint64            // Each handler within a context gets a unique serial number for logging
-	terminatorOnce      sync.Once         // Used to ensure the terminator channel below is only ever closed once.
-	terminator          chan bool         // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
-	activeSubChanges    base.AtomicBool   // Flag for whether there is a subChanges subscription currently active.  Atomic access
-	useDeltas           bool              // Whether deltas can be used for this connection - This should be set via setUseDeltas()
-	sgCanUseDeltas      bool              // Whether deltas can be used by Sync Gateway for this connection
-	userChangeWaiter    *db.ChangeWaiter  // Tracks whether the users/roles associated with the replication have changed
-	userName            string            // Avoid contention on db.user during userChangeWaiter user lookup
-	dbStats             *db.DatabaseStats // Direct stats access to support reloading db while stats are being updated
-
-	postHandleRevCallback     func(remoteSeq db.SequenceID)      // postHandleRevCallback is called after successfully handling an incoming rev message
-	postHandleChangesCallback func(expectedSeqs []db.SequenceID) // postHandleChangesCallback is called after successfully handling an incoming changes message
+	blipContext               *blip.Context
+	blipContextDb             *db.Database // 'master' database instance for the replication, used as source when creating handler-specific databases
+	dbUserLock                sync.RWMutex // Must be held when refreshing the db user
+	batchSize                 int
+	gotSubChanges             bool
+	continuous                bool
+	activeOnly                bool
+	channels                  base.Set
+	lock                      sync.Mutex
+	allowedAttachments        map[string]int
+	handlerSerialNumber       uint64                      // Each handler within a context gets a unique serial number for logging
+	terminatorOnce            sync.Once                   // Used to ensure the terminator channel below is only ever closed once.
+	terminator                chan bool                   // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
+	activeSubChanges          base.AtomicBool             // Flag for whether there is a subChanges subscription currently active.  Atomic access
+	useDeltas                 bool                        // Whether deltas can be used for this connection - This should be set via setUseDeltas()
+	sgCanUseDeltas            bool                        // Whether deltas can be used by Sync Gateway for this connection
+	userChangeWaiter          *db.ChangeWaiter            // Tracks whether the users/roles associated with the replication have changed
+	userName                  string                      // Avoid contention on db.user during userChangeWaiter user lookup
+	dbStats                   *db.DatabaseStats           // Direct stats access to support reloading db while stats are being updated
+	postHandleRevCallback     func(remoteSeq string)      // postHandleRevCallback is called after successfully handling an incoming rev message
+	postHandleChangesCallback func(expectedSeqs []string) // postHandleChangesCallback is called after successfully handling an incoming changes message
 }
 
 // Registers a BLIP handler including the outer-level work of logging & error handling.

--- a/replicator/blip_sync_messages.go
+++ b/replicator/blip_sync_messages.go
@@ -35,10 +35,13 @@ const (
 	BlipProfile  = "Profile"
 
 	// setCheckpoint message properties
-	SetCheckpointRev = "rev"
+	SetCheckpointRev         = "rev"
+	SetCheckpointClient      = "client"
+	SetCheckpointResponseRev = "rev"
 
 	// getCheckpoint message properties
 	GetCheckpointResponseRev = "rev"
+	GetCheckpointClient      = "client"
 
 	// subChanges message properties
 	SubChangesActiveOnly = "activeOnly"
@@ -46,6 +49,7 @@ const (
 	SubChangesChannels   = "channels"
 	SubChangesSince      = "since"
 	SubChangesContinuous = "continuous"
+	SubChangesBatch      = "batch"
 
 	// rev message properties
 	RevMessageId          = "id"

--- a/rest/blip_sync_messages_test.go
+++ b/rest/blip_sync_messages_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/couchbase/sync_gateway/replicator"
-	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddRevision(t *testing.T) {
@@ -55,7 +56,7 @@ func TestAddRevision(t *testing.T) {
 		revMessage := &replicator.RevMessage{
 			Message: &blipMessage,
 		}
-		goassert.Equals(t, revMessage.Deleted(), testCase.expectedDeletedVal)
+		assert.Equal(t, testCase.expectedDeletedVal, revMessage.Deleted())
 	}
 
 }
@@ -72,12 +73,10 @@ func TestSubChangesSince(t *testing.T) {
 	rq := blip.NewRequest()
 	rq.Properties["since"] = `"1"`
 
-	zeroSinceVal := db.SequenceID{}
+	subChangesParams, err := replicator.NewSubChangesParams(context.TODO(), rq, db.SequenceID{}, testDb.ParseSequenceID)
+	require.NoError(t, err)
 
-	subChangesParams, err := replicator.NewSubChangesParams(context.TODO(), rq, zeroSinceVal, testDb.ParseSequenceID)
-	goassert.True(t, err == nil)
-
-	seqId := subChangesParams.Since()
-	goassert.True(t, seqId.Seq == 1)
+	seqID := subChangesParams.Since()
+	assert.Equal(t, uint64(1), seqID.Seq)
 
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -86,10 +87,11 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
+	defer tb2.Close()
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -121,6 +123,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -156,22 +159,22 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 // TestActiveReplicatorPullBasic:
 //   - Starts 2 RestTesters, one active, and one passive.
-//   - Creates a document on rt2 which can be pulled by the replicator running in rt1.
-//   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
-//   - Uses an ActiveReplicator configured for pull to pull changes from rt2.
-//   - SetCheckpoint on the active replicator.
-//   - Starts the pull replication again.
+//   - Creates enough documents on rt2 which can be pulled by a replicator running in rt1 to start setting checkpoints.
+//   - Insert the second batch of docs into rt2.
+//   - Starts the pull replication again and asserts that the checkpoint is used.
 func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	const (
-		numRT2Docs         = 25
-		checkpointInterval = 10
+		checkpointRevCount = 5
+		changesBatchSize   = 10
+		numRT2DocsInitial  = 13 // 2 batches of changes
+		numRT2DocsTotal    = 24 // 2 more batches
 	)
 
 	// Passive
@@ -190,20 +193,20 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	})
 	defer rt2.Close()
 
+	// Create first batch of docs
 	docIDPrefix := t.Name() + "rt2doc"
-	for i := 0; i < numRT2Docs; i++ {
+	for i := 0; i < numRT2DocsInitial; i++ {
 		resp := rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"source":"rt2","channels":["alice"]}`)
 		assertStatus(t, resp, http.StatusCreated)
 	}
 
-	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
 
+	// Build passiveDBURL with basic auth creds
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
-
-	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
@@ -213,34 +216,40 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	})
 	defer rt1.Close()
 
-	ar, err := replicator.NewActiveReplicator(context.Background(), &replicator.ActiveReplicatorConfig{
+	arConfig := replicator.ActiveReplicatorConfig{
 		ID:           t.Name(),
 		Direction:    replicator.ActiveReplicatorTypePull,
 		PassiveDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		ChangesBatchSize:   5,
-		CheckpointInterval: checkpointInterval,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Close()) }()
+		Continuous:         false,
+		ChangesBatchSize:   changesBatchSize,
+		CheckpointRevCount: checkpointRevCount,
+		// test isn't long running enough to worry about time-based checkpoints,
+		// to keep testing simple, bumped these up for deterministic checkpointing
+		CheckpointMinInterval: time.Minute,
+		CheckpointMaxInterval: time.Minute,
+	}
 
-	// Start the replicator (implicit connect)
+	// Create the first active replicator to pull from seq:0
+	ar, err := replicator.NewActiveReplicator(context.Background(), &arConfig)
+	require.NoError(t, err)
+
+	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	startNumRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+
 	assert.NoError(t, ar.Start())
 
 	// wait for all of the documents originally written to rt2 to arrive at rt1
-	changesResults, err := rt1.WaitForChanges(numRT2Docs, "/db/_changes?since=0", "", true)
+	changesResults, err := rt1.WaitForChanges(numRT2DocsInitial, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
-
-	require.Len(t, changesResults.Results, numRT2Docs)
-
-	docIDsSeen := make(map[string]bool, numRT2Docs)
+	require.Len(t, changesResults.Results, numRT2DocsInitial)
+	docIDsSeen := make(map[string]bool, numRT2DocsInitial)
 	for _, result := range changesResults.Results {
 		docIDsSeen[result.ID] = true
 	}
-
-	for i := 0; i < numRT2Docs; i++ {
+	for i := 0; i < numRT2DocsInitial; i++ {
 		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
 		assert.True(t, docIDsSeen[docID])
 
@@ -248,4 +257,69 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
 	}
+
+	// one _changes from seq:0 with initial number of docs sent
+	numChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	assert.Equal(t, startNumChangesRequestedFromZeroTotal+1, numChangesRequestedFromZeroTotal)
+
+	// rev assertions
+	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+	assert.Equal(t, startNumRevsSentTotal+numRT2DocsInitial, numRevsSentTotal)
+	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyRevsReceivedTotal)))
+	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyChangesRevsReceivedTotal)))
+
+	// checkpoint assertions
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyGetCheckpointHitTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyGetCheckpointMissTotal)))
+	// The number of checkpoints set is non-deterministic, as more revs can arrive between the time checkpointing was started, and whilst waiting for checkpointing to run
+	// Make sure we set at least one checkpoint for the initial set of revs
+	assert.True(t, 1 <= base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeySetCheckpointTotal)))
+
+	assert.NoError(t, ar.Close())
+
+	// Second batch of docs
+	for i := numRT2DocsInitial; i < numRT2DocsTotal; i++ {
+		resp := rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"source":"rt2","channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+	}
+
+	// Create a new replicator using the same config, which should use the checkpoint set from the first.
+	ar, err = replicator.NewActiveReplicator(context.Background(), &arConfig)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, ar.Close()) }()
+	assert.NoError(t, ar.Start())
+
+	// wait for all of the documents originally written to rt2 to arrive at rt1
+	changesResults, err = rt1.WaitForChanges(numRT2DocsTotal, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, numRT2DocsTotal)
+
+	docIDsSeen = make(map[string]bool, numRT2DocsTotal)
+	for _, result := range changesResults.Results {
+		docIDsSeen[result.ID] = true
+	}
+
+	for i := 0; i < numRT2DocsTotal; i++ {
+		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
+		assert.True(t, docIDsSeen[docID])
+
+		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		assert.NoError(t, err)
+		assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+	}
+
+	// Make sure we've not started any more since:0 replications on rt2 since the first one
+	endNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	assert.Equal(t, numChangesRequestedFromZeroTotal, endNumChangesRequestedFromZeroTotal)
+
+	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
+	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+	assert.Equal(t, startNumRevsSentTotal+numRT2DocsTotal, numRevsSentTotal)
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyRevsReceivedTotal)))
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyChangesRevsReceivedTotal)))
+
+	// assert the second active replicator stats
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyGetCheckpointHitTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeyGetCheckpointMissTotal)))
+	assert.True(t, int64(1) <= base.ExpvarVar2Int(ar.Pull.Stats.Get(replicator.ActiveReplicatorStatsKeySetCheckpointTotal)))
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/couchbaselabs/walrus/pull/51

- Adds test that performs 2 pull replications using the same config to ensure checkpoints are being set and used.
- Added callback functions to handleChanges and handleRev to invoke from the ActiveReplicator for tracking pending/received sequences for checkpointing
- Start checkpointer goroutine which waits for number of revs to pass a configured threshold, or the configured checkpoint timeout to pass.