### PR TITLE
CBG-838: Add sync_gateway user check

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -674,7 +674,7 @@ def make_os_tasks(processes):
         UnixTask("couchbase user definition", "getent passwd couchbase"),
         UnixTask("couchbase user limits", "su couchbase -c \"ulimit -a\"",
                  privileged=True),
-        UnixTask("couchbase user limits", "su couchbase -c \"ulimit -a\"",
+        UnixTask("sync_gateway user limits", "su sync_gateway -c \"ulimit -a\"",
                  privileged=True),
         UnixTask("Interrupt status", "intrstat 1 10"),
         UnixTask("Processor status", "mpstat 1 10"),

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -674,6 +674,7 @@ def make_os_tasks(processes):
         UnixTask("couchbase user definition", "getent passwd couchbase"),
         UnixTask("couchbase user limits", "su couchbase -c \"ulimit -a\"",
                  privileged=True),
+        UnixTask("sync_gateway user definition", "getent passwd sync_gateway"),
         UnixTask("sync_gateway user limits", "su sync_gateway -c \"ulimit -a\"",
                  privileged=True),
         UnixTask("Interrupt status", "intrstat 1 10"),


### PR DESCRIPTION
Appears like we currently have two checks the exact same which both check couchbase user limits. I believe that the intention was to have one check for couchbase user and the second was meant to be changed to check for sync_gateway user.
I have therefore changed the second check to sync_gateway.