### PR TITLE
CBG-864: Use addJSON errors and detection change

### DIFF
--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -58,7 +58,10 @@ func (h *handler) handleRevsDiff() error {
 			}
 			first = false
 			_, _ = h.response.Write([]byte(fmt.Sprintf("%q:", docid)))
-			_ = h.addJSON(docOutput)
+			err = h.addJSON(docOutput)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	_, _ = h.response.Write([]byte("}"))

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -140,7 +140,10 @@ func (h *handler) handleGetDoc() error {
 				}
 				_, _ = h.response.Write(separator)
 				separator = []byte(",")
-				_ = h.addJSON(revBody)
+				err = h.addJSON(revBody)
+				if err != nil {
+					return err
+				}
 			}
 			_, _ = h.response.Write([]byte(`]`))
 			h.db.DbStats.StatsDatabase().Add(base.StatKeyNumDocReadsRest, 1)

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -666,7 +666,7 @@ func (h *handler) addJSON(value interface{}) error {
 	err := encoder.Encode(value)
 	if err != nil {
 		// If we get a broken pipe error
-		if errors.Is(err, syscall.EPIPE) {
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
 			base.Debugf(base.KeyCRUD, "Couldn't serialize document body, HTTP client closed connection")
 			return err
 		} else {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -29,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -665,8 +663,9 @@ func (h *handler) addJSON(value interface{}) error {
 	encoder := base.JSONEncoderCanonical(h.response)
 	err := encoder.Encode(value)
 	if err != nil {
-		// If we get a broken pipe error
-		if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
+		brokenPipeError := strings.Contains(err.Error(), "write: broken pipe")
+		connectionResetError := strings.Contains(err.Error(), "write: connection reset")
+		if brokenPipeError || connectionResetError {
 			base.Debugf(base.KeyCRUD, "Couldn't serialize document body, HTTP client closed connection")
 			return err
 		} else {


### PR DESCRIPTION
Don't log entire json body on error.
Added new error check
All uses check for error and will stop iterating if an error is encountered.