### PR TITLE
Wider detection of retry-style indexer errors

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -376,14 +376,20 @@ func IsIndexerRetryIndexError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "will be retried in background")
+	if strings.Contains(err.Error(), "will retry") || strings.Contains(err.Error(), "will be retried") {
+		return true
+	}
+	return false
 }
 
 func IsIndexerRetryBuildError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "will retry building in the background")
+	if strings.Contains(err.Error(), "will retry") || strings.Contains(err.Error(), "will be retried") {
+		return true
+	}
+	return false
 }
 
 // Check for transient indexer errors (can be retried)


### PR DESCRIPTION
Recent tests have failed on indexer errors like "Build index fails. Some index will be retried building in the background. For more details, please check index status.", which weren't treated as retry-style errors by our previous checking.

http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/305/