### PR TITLE
CBG-767-prereq Implement replication lifecycle features

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -139,7 +139,7 @@ var (
 	}
 
 	// Default warning thresholds
-	DefaultWarnThresholdXattrSize      = 0.9 * float64(couchbaseMaxSystemXattrSize)
+	DefaultWarnThresholdXattrSize      = uint32(0.9 * float64(couchbaseMaxSystemXattrSize))
 	DefaultWarnThresholdChannelsPerDoc = uint32(50)
 	DefaultWarnThresholdGrantsPerDoc   = uint32(50)
 

--- a/base/constants.go
+++ b/base/constants.go
@@ -116,6 +116,9 @@ const (
 
 	SyncPropertyName = "_sync"
 	SyncXattrName    = "_sync"
+
+	// Replication filter constants
+	ByChannelFilter = "sync_gateway/bychannel"
 )
 
 const (
@@ -139,7 +142,7 @@ var (
 	}
 
 	// Default warning thresholds
-	DefaultWarnThresholdXattrSize      = uint32(0.9 * float64(couchbaseMaxSystemXattrSize))
+	DefaultWarnThresholdXattrSize      = 0.9 * float64(couchbaseMaxSystemXattrSize)
 	DefaultWarnThresholdChannelsPerDoc = uint32(50)
 	DefaultWarnThresholdGrantsPerDoc   = uint32(50)
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -28,28 +28,28 @@ type ActiveReplicator struct {
 
 // NewActiveReplicator returns a bidirectional active replicator for the given config.
 func NewActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActiveReplicator, error) {
-	bar := &ActiveReplicator{}
+	ar := &ActiveReplicator{}
 
 	// if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {
-	// 	bar.Push = NewPushReplicator(config)
+	// 	ar.Push = NewPushReplicator(config)
 	// }
 
 	if pullReplication := config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull; pullReplication {
-		bar.Pull = NewPullReplicator(ctx, config)
+		ar.Pull = NewPullReplicator(ctx, config)
 	}
 
-	return bar, nil
+	return ar, nil
 }
 
-func (bar *ActiveReplicator) Start() error {
-	// if bar.push != nil {
-	// 	if err := bar.push.Start(); err != nil {
+func (ar *ActiveReplicator) Start() error {
+	// if ar.push != nil {
+	// 	if err := ar.push.Start(); err != nil {
 	// 		return err
 	// 	}
 	// }
 
-	if bar.Pull != nil {
-		if err := bar.Pull.Start(); err != nil {
+	if ar.Pull != nil {
+		if err := ar.Pull.Start(); err != nil {
 			return err
 		}
 	}
@@ -57,15 +57,15 @@ func (bar *ActiveReplicator) Start() error {
 	return nil
 }
 
-func (bar *ActiveReplicator) Close() error {
-	// if bar.push != nil {
-	// 	if err := bar.push.Close(); err != nil {
+func (ar *ActiveReplicator) Close() error {
+	// if ar.push != nil {
+	// 	if err := ar.push.Close(); err != nil {
 	// 		return err
 	// 	}
 	// }
 
-	if bar.Pull != nil {
-		if err := bar.Pull.Close(); err != nil {
+	if ar.Pull != nil {
+		if err := ar.Pull.Close(); err != nil {
 			return err
 		}
 	}

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -9,13 +9,22 @@ import (
 	"time"
 )
 
-type ActiveReplicatorDirection uint8
+type ActiveReplicatorDirection string
 
 const (
-	ActiveReplicatorTypePushAndPull ActiveReplicatorDirection = iota
-	ActiveReplicatorTypePush
-	ActiveReplicatorTypePull
+	ActiveReplicatorTypePushAndPull ActiveReplicatorDirection = "pushAndPull"
+	ActiveReplicatorTypePush                                  = "push"
+	ActiveReplicatorTypePull                                  = "pull"
 )
+
+func (d ActiveReplicatorDirection) IsValid() bool {
+	switch d {
+	case ActiveReplicatorTypePushAndPull, ActiveReplicatorTypePush, ActiveReplicatorTypePull:
+		return true
+	default:
+		return false
+	}
+}
 
 const (
 	defaultCheckpointInterval = time.Second * 30
@@ -69,7 +78,7 @@ func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
 	if _, err := hash.Write([]byte(strconv.FormatBool(arc.ActiveOnly))); err != nil {
 		return "", err
 	}
-	if _, err := hash.Write([]byte(strconv.FormatUint(uint64(arc.Direction), 10))); err != nil {
+	if _, err := hash.Write([]byte(arc.Direction)); err != nil {
 		return "", err
 	}
 	if _, err := hash.Write([]byte(arc.PassiveDBURL.String())); err != nil {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -167,7 +167,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	bh.continuous = subChangesParams.continuous()
 	bh.activeOnly = subChangesParams.activeOnly()
 
-	if filter := subChangesParams.filter(); filter == "sync_gateway/bychannel" {
+	if filter := subChangesParams.filter(); filter == base.ByChannelFilter {
 		var err error
 
 		bh.channels, err = subChangesParams.channelsExpandedSet()

--- a/db/database.go
+++ b/db/database.go
@@ -449,6 +449,8 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		}
 	}
 
+	dbContext.ExitChanges = make(chan struct{})
+
 	return dbContext, nil
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -300,7 +300,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	// Initialize sg-replicate manager
-	dbContext.SGReplicateMgr, err = NewSGReplicateManager(dbContext.CfgSG, dbName)
+	dbContext.SGReplicateMgr, err = NewSGReplicateManager(dbContext, dbContext.CfgSG)
 	if err != nil {
 		return nil, err
 	}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -651,7 +651,7 @@ func NewReplicationHeartbeatListener(mgr *sgReplicateManager) (*ReplicationHeart
 	}
 
 	// Subscribe to changes to the known node set key
-	err = listener.subscribeNodeChanges()
+	err = listener.subscribeNodeSetChanges()
 	if err != nil {
 		return nil, err
 	}
@@ -674,8 +674,8 @@ func (l *ReplicationHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
 }
 
 // subscribeNodeChanges registers with the manager's cfg implementation for notifications on changes to the
-// NODE_DEFS_KNOWN key.  When notified, refreshes the handlers nodeIDs.
-func (l *ReplicationHeartbeatListener) subscribeNodeChanges() error {
+// cfgKeySGRCluster key.  When notified, refreshes the handlers nodeIDs.
+func (l *ReplicationHeartbeatListener) subscribeNodeSetChanges() error {
 
 	cfgEvents := make(chan cbgt.CfgEvent)
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -116,7 +117,7 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 		return err
 	}
 
-	if rc.Filter == "sync_gateway/bychannel" {
+	if rc.Filter == base.ByChannelFilter {
 		if rc.QueryParams == nil {
 			err = base.HTTPErrorf(http.StatusBadRequest, "Replication specifies sync_gateway/bychannel filter but is missing query_params")
 			return
@@ -234,12 +235,17 @@ func (rc *ReplicationConfig) Equals(compareToCfg *ReplicationConfig) (bool, erro
 
 // sgReplicateManager should be used for all interactions with the stored cluster definition.
 type sgReplicateManager struct {
-	cfg               cbgt.Cfg                      // Key-value store implementation
-	loggingCtx        context.Context               // logging context for manager operations
-	heartbeatListener *ReplicationHeartbeatListener // node heartbeat listener for replication distribution
+	cfg                    cbgt.Cfg                      // Key-value store implementation
+	loggingCtx             context.Context               // logging context for manager operations
+	heartbeatListener      *ReplicationHeartbeatListener // node heartbeat listener for replication distribution
+	localNodeUUID          string                        // nodeUUID for this SG node
+	activeReplications     map[string]*ActiveReplicator  // currently active replications
+	activeReplicationsLock sync.RWMutex                  // Mutex for activeReplications
+	terminator             chan struct{}
+	dbContext              *DatabaseContext
 }
 
-func NewSGReplicateManager(cfg cbgt.Cfg, dbName string) (*sgReplicateManager, error) {
+func NewSGReplicateManager(dbContext *DatabaseContext, cfg *base.CfgSG) (*sgReplicateManager, error) {
 	if cfg == nil {
 		return nil, errors.New("Cfg must be provided for SGReplicateManager")
 	}
@@ -247,7 +253,10 @@ func NewSGReplicateManager(cfg cbgt.Cfg, dbName string) (*sgReplicateManager, er
 	return &sgReplicateManager{
 		cfg: cfg,
 		loggingCtx: context.WithValue(context.Background(), base.LogContextKey{},
-			base.LogContext{CorrelationID: sgrClusterMgrContextID + dbName}),
+			base.LogContext{CorrelationID: sgrClusterMgrContextID + dbContext.Name}),
+		terminator:         make(chan struct{}),
+		dbContext:          dbContext,
+		activeReplications: make(map[string]*ActiveReplicator),
 	}, nil
 
 }
@@ -266,12 +275,157 @@ func (m *sgReplicateManager) StartLocalNode(nodeUUID string, heartbeater base.He
 		return err
 	}
 
+	m.localNodeUUID = nodeUUID
+
 	m.heartbeatListener, err = NewReplicationHeartbeatListener(m)
 	if err != nil {
 		return err
 	}
 
 	return heartbeater.RegisterListener(m.heartbeatListener)
+}
+
+// StartReplications performs an initial retrieval of the cluster config, starts any replications
+// assigned to this node, and starts the process to monitor future changes to the cluster config.
+func (m *sgReplicateManager) StartReplications() error {
+
+	replications, err := m.GetReplications()
+	if err != nil {
+		return err
+	}
+
+	for replicationID, replication := range replications {
+		if replication.AssignedNode == m.localNodeUUID {
+			// TODO: retain replication reference for status
+			_, err := m.StartReplication(replication)
+			if err != nil {
+				return err
+			}
+			base.Infof(base.KeyReplicate, "Started replication %s", base.UD(replicationID))
+		}
+	}
+
+	return m.SubscribeCfgChanges()
+}
+
+func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicator *ActiveReplicator, err error) {
+	// TODO: the following properties on ActiveReplicator aren't currently supported in ReplicationCfg.  Some could be taken
+	//    out until they are implemented?
+	//    - docIDs  (future enhancement)
+	//    - activeOnly (P1)
+	//    - changesBatchSize (to be added only based on perf testing)
+	//    - checkpointInterval (not externally configurable)
+
+	base.Infof(base.KeyReplicate, "Starting replication %v (placeholder)", config.ID)
+
+	rc := &ActiveReplicatorConfig{
+		ID:         config.ID,
+		Continuous: config.Continuous,
+		ActiveDB:   &Database{DatabaseContext: m.dbContext}, // sg-replicate interacts with local as admin
+	}
+
+	if config.Filter == base.ByChannelFilter {
+		rc.Filter = base.ByChannelFilter
+		rc.FilterChannels, err = ChannelsFromQueryParams(config.QueryParams)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("Unknown replication filter: %v", config.Filter)
+	}
+
+	rc.Direction = ActiveReplicatorDirection(config.Direction)
+	if !rc.Direction.IsValid() {
+		return nil, fmt.Errorf("Unknown replication direction: %v", config.Direction)
+	}
+
+	if config.Remote == "" {
+		return nil, fmt.Errorf("Replication remote must not be empty")
+	}
+
+	rc.PassiveDBURL, err = url.Parse(config.Remote)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: review whether there's a more appropriate context to use here
+	replicator, err = NewActiveReplicator(context.Background(), rc)
+	if err != nil {
+		return nil, err
+	}
+
+	startErr := replicator.Start()
+	if startErr != nil {
+		return nil, err
+	}
+
+	return replicator, nil
+}
+
+func (m *sgReplicateManager) Stop() {
+	close(m.terminator)
+}
+
+// RefreshReplicationCfg is called when the cfg changes.  Checks whether replications
+// have been added to or removed from this node
+func (m *sgReplicateManager) RefreshReplicationCfg() error {
+	configReplications, err := m.GetReplications()
+	if err != nil {
+		return err
+	}
+
+	// check for active replications that should be stopped
+	m.activeReplicationsLock.Lock()
+	defer m.activeReplicationsLock.Unlock()
+	for replicationID, activeReplication := range m.activeReplications {
+		replicationCfg, ok := configReplications[replicationID]
+		if !ok || replicationCfg.AssignedNode != m.localNodeUUID {
+			err := activeReplication.Close()
+			if err != nil {
+				base.Warnf("Unable to gracefully close active replication: %v", err)
+			}
+			delete(m.activeReplications, replicationID)
+		}
+	}
+
+	// Check for replications assigned to this node that need to be started
+	for replicationID, replicationCfg := range configReplications {
+		if replicationCfg.AssignedNode == m.localNodeUUID {
+			_, exists := m.activeReplications[replicationID]
+			if !exists {
+				m.activeReplications[replicationID], err = m.StartReplication(replicationCfg)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m *sgReplicateManager) SubscribeCfgChanges() error {
+	cfgEvents := make(chan cbgt.CfgEvent)
+
+	err := m.cfg.Subscribe(cfgKeySGRCluster, cfgEvents)
+	if err != nil {
+		base.Debugf(base.KeyCluster, "Error subscribing to %s key changes: %v", cfgKeySGRCluster, err)
+		return err
+	}
+	go func() {
+		defer base.FatalPanicHandler()
+		for {
+			select {
+			case <-cfgEvents:
+				err := m.RefreshReplicationCfg()
+				if err != nil {
+					base.Warnf("Error while updating replications based on latest cfg: %v", err)
+				}
+			case <-m.terminator:
+				return
+			}
+		}
+	}()
+	return nil
 }
 
 // Loads the SGReplicate config from the config store

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -21,7 +21,7 @@ func TestReplicateManagerReplications(t *testing.T) {
 	testCfg, err := base.NewCfgSG(bucket)
 	require.NoError(t, err)
 
-	manager, err := NewSGReplicateManager(testCfg, "test")
+	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 
 	replication1_id := "replication1"
@@ -84,7 +84,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	testCfg, err := base.NewCfgSG(bucket)
 	require.NoError(t, err)
 
-	manager, err := NewSGReplicateManager(testCfg, "test")
+	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 
 	err = manager.RegisterNode("node1", "host1")
@@ -138,7 +138,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 
 	testCfg, err := base.NewCfgSG(bucket)
 	require.NoError(t, err)
-	manager, err := NewSGReplicateManager(testCfg, "test")
+	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 
 	var nodeWg sync.WaitGroup
@@ -181,7 +181,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 
 	testCfg, err := base.NewCfgSG(bucket)
 	require.NoError(t, err)
-	manager, err := NewSGReplicateManager(testCfg, "test")
+	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 
 	var replicationWg sync.WaitGroup

--- a/db/sg_replicate_util.go
+++ b/db/sg_replicate_util.go
@@ -1,0 +1,37 @@
+package db
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/couchbase/sync_gateway/base"
+)
+
+// QueryParams retrieves the channels associated with the byChannels a replication filter
+// from the generic queryParams interface{}.
+// The Channels may be passed as a JSON array of strings directly,
+// or embedded in a JSON object with the "channels" property and array value
+func ChannelsFromQueryParams(queryParams interface{}) (channels []string, err error) {
+
+	var chanarray []interface{}
+	if paramsmap, ok := queryParams.(map[string]interface{}); ok {
+		if chanarray, ok = paramsmap["channels"].([]interface{}); !ok {
+			return nil, errors.New("/_replicate sync_gateway/bychannel filter; query_params missing channels property")
+		}
+	} else if chanarray, ok = queryParams.([]interface{}); ok {
+		// query params is an array and chanarray has been set, now drop out of if-then-else for processing
+	} else {
+		return nil, base.HTTPErrorf(http.StatusBadRequest, "/_replicate sync_gateway/bychannel filter; Bad channels array")
+	}
+	if len(chanarray) > 0 {
+		channels = make([]string, len(chanarray))
+		for i := range chanarray {
+			if channel, ok := chanarray[i].(string); ok {
+				channels[i] = channel
+			} else {
+				return nil, errors.New("/_replicate sync_gateway/bychannel filter; Bad channel name")
+			}
+		}
+	}
+	return channels, nil
+}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1607,10 +1607,10 @@ func TestReplicateErrorConditions(t *testing.T) {
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"filter":"somefilter"}`), 400)
 
 	//Send JSON Object containing filter 'sync_gateway/bychannel' with non array query_params property
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"filter":"sync_gateway/bychannel", "query_params":{"someproperty":"somevalue"}}`), 400)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"filter":"`+base.ByChannelFilter+`", "query_params":{"someproperty":"somevalue"}}`), 400)
 
 	//Send JSON Object containing filter 'sync_gateway/bychannel' with non string array query_params property
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"filter":"sync_gateway/bychannel", "query_params":["someproperty",false]}`), 400)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"filter":"`+base.ByChannelFilter+`", "query_params":["someproperty",false]}`), 400)
 
 	//Send JSON Object containing proxy property
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"proxy":"http://myproxy/"}`), 400)
@@ -1665,22 +1665,22 @@ func TestDocumentChangeReplicate(t *testing.T) {
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db", "target":"http://myhost:4985/db", "continuous":true}`), 200)
 
 	//Initiate synchronous one shot replication with channel filter and JSON array of channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db2", "target":"http://myhost:4985/db2", "filter":"sync_gateway/bychannel", "query_params":["A"]}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db2", "target":"http://myhost:4985/db2", "filter":"`+base.ByChannelFilter+`", "query_params":["A"]}`), 500)
 
 	//Initiate synchronous one shot replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db3", "target":"http://myhost:4985/db3", "filter":"sync_gateway/bychannel", "query_params":{"channels":["A"]}}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db3", "target":"http://myhost:4985/db3", "filter":"`+base.ByChannelFilter+`", "query_params":{"channels":["A"]}}`), 500)
 
 	//Initiate synchronous one shot replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names and custom changes_feed_limit
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db4", "target":"http://myhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10}`), 500)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db4", "target":"http://myhost:4985/db4", "filter":"`+base.ByChannelFilter+`", "query_params":{"channels":["B"]}, "changes_feed_limit":10}`), 500)
 
 	//Initiate continuous replication with channel filter and JSON array of channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db2", "target":"http://myhost:4985/db2", "filter":"sync_gateway/bychannel", "query_params":["A"], "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db2", "target":"http://myhost:4985/db2", "filter":"`+base.ByChannelFilter+`", "query_params":["A"], "continuous":true}`), 200)
 
 	//Initiate continuous replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db3", "target":"http://myhost:4985/db3", "filter":"sync_gateway/bychannel", "query_params":{"channels":["A"]}, "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db3", "target":"http://myhost:4985/db3", "filter":"`+base.ByChannelFilter+`", "query_params":{"channels":["A"]}, "continuous":true}`), 200)
 
 	//Initiate continuous replication with channel filter and JSON object containing a property "channels" and value of JSON Array pf channel names and custom changes_feed_limit
-	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db4", "target":"http://myhost:4985/db4", "filter":"sync_gateway/bychannel", "query_params":{"channels":["B"]}, "changes_feed_limit":10, "continuous":true}`), 200)
+	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/db4", "target":"http://myhost:4985/db4", "filter":"`+base.ByChannelFilter+`", "query_params":{"channels":["B"]}, "changes_feed_limit":10, "continuous":true}`), 200)
 
 	//Send JSON Object containing source and target as absolute URL and a replication_id
 	assertStatus(t, rt.SendAdminRequest("POST", "/_replicate", `{"source":"http://myhost:4985/mysourcedb", "target":"http://myhost:4985/mytargetdb", "replication_id":"myreplicationid"}`), 500)

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -126,7 +126,7 @@ func TestChangesNotifyChannelFilter(t *testing.T) {
 					 "feed":"longpoll", 
 					 "limit":50, 
 					 "since":"%s",
-					 "filter":"sync_gateway/bychannel",
+					 "filter":"` + base.ByChannelFilter + `",
 					 "channels":"ABC,PBS"}`
 	sinceZeroJSON := fmt.Sprintf(changesJSON, "0")
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", sinceZeroJSON, "bernard"))

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -252,7 +252,7 @@ func (h *handler) handleChanges() error {
 	// The default is all channels the user can access.
 	userChannels := base.SetOf(ch.AllChannelWildcard)
 	if filter != "" {
-		if filter == "sync_gateway/bychannel" {
+		if filter == base.ByChannelFilter {
 			if channelsArray == nil {
 				return base.HTTPErrorf(http.StatusBadRequest, "Missing 'channels' filter parameter")
 			}

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -437,7 +437,7 @@ func postChangesChannelFilter(t *testing.T, rt *RestTester) {
 		Last_Seq interface{}
 	}
 
-	changesJSON := `{"filter":"sync_gateway/bychannel", "channels":"PBS"}`
+	changesJSON := `{"filter":"` + base.ByChannelFilter + `", "channels":"PBS"}`
 	changesResponse := rt.Send(requestByUser("POST", "/db/_changes", changesJSON, "bernard"))
 
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -184,7 +184,7 @@ func TestReplicationsFromConfig(t *testing.T) {
 		"delta_sync_enabled":true,
 		"max_backoff":100,
 		"state":"stopped",
-		"filter":"sync_gateway/bychannel",
+		"filter":"` + base.ByChannelFilter + `",
 		"query_params":["ABC"],
 		"cancel":false
 	}`
@@ -199,7 +199,7 @@ func TestReplicationsFromConfig(t *testing.T) {
 		"delta_sync_enabled":true,
 		"max_backoff":100,
 		"state":"stopped",
-		"filter":"sync_gateway/bychannel",
+		"filter":"` + base.ByChannelFilter + `",
 		"query_params":["ABC"],
 		"cancel":false
 	}`

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -110,7 +110,10 @@ func (sc *ServerContext) PostStartup() {
 	time.Sleep(5 * time.Second)
 	sc.lock.RLock()
 	for _, dbContext := range sc.databases_ {
-		dbContext.SGReplicateMgr.StartReplications()
+		err := dbContext.SGReplicateMgr.StartReplications()
+		if err != nil {
+			base.Errorf("Error starting sg-replicate replications: %v", err)
+		}
 	}
 	sc.lock.RUnlock()
 
@@ -375,7 +378,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	// Process unsupported config options
 	if config.Unsupported.WarningThresholds.XattrSize == nil {
-		config.Unsupported.WarningThresholds.XattrSize = &base.DefaultWarnThresholdXattrSize
+		config.Unsupported.WarningThresholds.XattrSize = base.Uint32Ptr(uint32(base.DefaultWarnThresholdXattrSize))
 	} else {
 		lowerLimit := 0.1 * 1024 * 1024 // 0.1 MB
 		upperLimit := 1 * 1024 * 1024   // 1 MB

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -95,13 +95,24 @@ func NewServerContext(config *ServerConfig) *ServerContext {
 
 // PostStartup runs anything that relies on SG being fully started (i.e. sgreplicate)
 func (sc *ServerContext) PostStartup() {
+
+	// Start sg-replicate 1.x replications.
 	// Introduce a minor delay if there are any replications
 	// (sc.startReplicators() might rely on SG being fully started)
 	if len(sc.config.Replications) > 0 {
 		time.Sleep(time.Second)
 	}
-
 	sc.startReplicators()
+
+	// Start sg-replicate2 replications per-database.  sg-replicate2 replications aren't
+	// started until at least 5 seconds after SG node start, to avoid replication reassignment churn
+	// when a Sync Gateway Cluster is being initialized
+	time.Sleep(5 * time.Second)
+	sc.lock.RLock()
+	for _, dbContext := range sc.databases_ {
+		dbContext.SGReplicateMgr.StartReplications()
+	}
+	sc.lock.RUnlock()
 
 }
 
@@ -300,9 +311,7 @@ func GetBucketSpec(config *DbConfig) (spec base.BucketSpec, err error) {
 // existing DatabaseContext or an error based on the useExisting flag.
 func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisting bool) (context *db.DatabaseContext, err error) {
 
-	oldRevExpirySeconds := base.DefaultOldRevExpirySeconds
-
-	// Connect to the bucket and add the database:
+	// Generate bucket spec and validate whether db already exists
 	spec, err := GetBucketSpec(config)
 	if err != nil {
 		return nil, err
@@ -311,15 +320,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	dbName := config.Name
 	if dbName == "" {
 		dbName = spec.BucketName
-	}
-
-	if config.OldRevExpirySeconds != nil {
-		oldRevExpirySeconds = *config.OldRevExpirySeconds
-	}
-
-	localDocExpirySecs := base.DefaultLocalDocExpirySecs
-	if config.LocalDocExpirySecs != nil {
-		localDocExpirySecs = *config.LocalDocExpirySecs
 	}
 
 	if sc.databases_[dbName] != nil {
@@ -331,11 +331,77 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
-	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
-		base.MD(dbName), base.MD(spec.BucketName), base.SD(spec.PoolName), base.SD(spec.Server))
-
 	if err := db.ValidateDatabaseName(dbName); err != nil {
 		return nil, err
+	}
+
+	// Connect to bucket
+	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
+		base.MD(dbName), base.MD(spec.BucketName), base.SD(spec.PoolName), base.SD(spec.Server))
+	bucket, err := db.ConnectToBucket(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	// If using a walrus bucket, force use of views
+	useViews := config.UseViews
+	if !useViews && spec.IsWalrusBucket() {
+		base.Warnf("Using GSI is not supported when using a walrus bucket - switching to use views.  Set 'use_views':true in Sync Gateway's database config to avoid this warning.")
+		useViews = true
+	}
+
+	// Initialize Views or GSI indexes for the bucket
+	if !useViews {
+		gsiSupported := bucket.IsSupported(sgbucket.BucketFeatureN1ql)
+		if !gsiSupported {
+			return nil, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
+		}
+
+		numReplicas := DefaultNumIndexReplicas
+		if config.NumIndexReplicas != nil {
+			numReplicas = *config.NumIndexReplicas
+		}
+
+		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
+		if indexErr != nil {
+			return nil, indexErr
+		}
+	} else {
+		viewErr := db.InitializeViews(bucket)
+		if viewErr != nil {
+			return nil, viewErr
+		}
+	}
+
+	// Process unsupported config options
+	if config.Unsupported.WarningThresholds.XattrSize == nil {
+		config.Unsupported.WarningThresholds.XattrSize = &base.DefaultWarnThresholdXattrSize
+	} else {
+		lowerLimit := 0.1 * 1024 * 1024 // 0.1 MB
+		upperLimit := 1 * 1024 * 1024   // 1 MB
+		if *config.Unsupported.WarningThresholds.XattrSize < uint32(lowerLimit) {
+			return nil, fmt.Errorf("xattr_size warning threshold cannot be lower than %d bytes", uint32(lowerLimit))
+		} else if *config.Unsupported.WarningThresholds.XattrSize > uint32(upperLimit) {
+			return nil, fmt.Errorf("xattr_size warning threshold cannot be higher than %d bytes", uint32(upperLimit))
+		}
+	}
+
+	if config.Unsupported.WarningThresholds.ChannelsPerDoc == nil {
+		config.Unsupported.WarningThresholds.ChannelsPerDoc = &base.DefaultWarnThresholdChannelsPerDoc
+	} else {
+		lowerLimit := 5
+		if *config.Unsupported.WarningThresholds.ChannelsPerDoc < uint32(lowerLimit) {
+			return nil, fmt.Errorf("channels_per_doc warning threshold cannot be lower than %d", lowerLimit)
+		}
+	}
+
+	if config.Unsupported.WarningThresholds.GrantsPerDoc == nil {
+		config.Unsupported.WarningThresholds.GrantsPerDoc = &base.DefaultWarnThresholdGrantsPerDoc
+	} else {
+		lowerLimit := 5
+		if *config.Unsupported.WarningThresholds.GrantsPerDoc < uint32(lowerLimit) {
+			return nil, fmt.Errorf("access_and_role_grants_per_doc warning threshold cannot be lower than %d", lowerLimit)
+		}
 	}
 
 	autoImport, err := config.AutoImportEnabled()
@@ -343,6 +409,104 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, err
 	}
 
+	// Generate database context options from config and server context
+	contextOptions, err := dbcOptionsFromConfig(sc, config, dbName)
+	if err != nil {
+		return nil, err
+	}
+	contextOptions.UseViews = useViews
+
+	// Create the DB Context
+	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, contextOptions)
+	if err != nil {
+		return nil, err
+	}
+	dbcontext.BucketSpec = spec
+
+	syncFn := ""
+	if config.Sync != nil {
+		syncFn = *config.Sync
+	}
+	if err := sc.applySyncFunction(dbcontext, syncFn); err != nil {
+		return nil, err
+	}
+
+	if config.RevsLimit != nil {
+		dbcontext.RevsLimit = *config.RevsLimit
+		if dbcontext.AllowConflicts() {
+			if dbcontext.RevsLimit < 20 {
+				return nil, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration cannot be set lower than 20.", dbcontext.RevsLimit)
+			}
+
+			if dbcontext.RevsLimit < db.DefaultRevsLimitConflicts {
+				base.Warnf("Setting the revs_limit (%v) to less than %d, whilst having allow_conflicts set to true, may have unwanted results when documents are frequently updated. Please see documentation for details.", dbcontext.RevsLimit, db.DefaultRevsLimitConflicts)
+			}
+		} else {
+			if dbcontext.RevsLimit <= 0 {
+				return nil, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", dbcontext.RevsLimit)
+			}
+		}
+	}
+
+	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
+
+	if dbcontext.ChannelMapper == nil {
+		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))
+	}
+
+	// Create default users & roles:
+	if err := sc.installPrincipals(dbcontext, config.Roles, "role"); err != nil {
+		return nil, err
+	} else if err := sc.installPrincipals(dbcontext, config.Users, "user"); err != nil {
+		return nil, err
+	}
+
+	// Initialize event handlers
+	if err := sc.initEventHandlers(dbcontext, config); err != nil {
+		return nil, err
+	}
+
+	// Validate replications
+	for replicationID, replicationConfig := range config.Replications {
+		if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
+			return nil, fmt.Errorf("replication_id %q does not match replications key %q in replication config", replicationConfig.ID, replicationID)
+		}
+		replicationConfig.ID = replicationID
+		if validateErr := replicationConfig.ValidateReplication(true); validateErr != nil {
+			return nil, validateErr
+		}
+	}
+
+	// Upsert replications
+	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
+	if replicationErr != nil {
+		return nil, replicationErr
+	}
+
+	// Register it so HTTP handlers can find it:
+	sc.databases_[dbcontext.Name] = dbcontext
+
+	// Save the config
+	sc.config.Databases[dbName] = config
+
+	if config.StartOffline {
+		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
+		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
+			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
+		}
+	} else {
+		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
+		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
+			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
+		}
+	}
+
+	return dbcontext, nil
+}
+
+func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (db.DatabaseContextOptions, error) {
+
+	// Identify import options
 	importOptions := db.ImportOptions{}
 	if config.ImportFilter != nil {
 		importOptions.ImportFilter = db.NewImportFilterFunction(*config.ImportFilter)
@@ -360,7 +524,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	for _, warnLog := range warnings {
 		base.Warnf(warnLog)
 	}
-
 	// Set cache properties, if present
 	cacheOptions := db.DefaultCacheOptions()
 	revCacheOptions := db.DefaultRevisionCacheOptions()
@@ -412,47 +575,15 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
-	bucket, err := db.ConnectToBucket(spec)
-	if err != nil {
-		return nil, err
-	}
-
-	// If using a walrus bucket, force use of views
-	useViews := config.UseViews
-	if !useViews && spec.IsWalrusBucket() {
-		base.Warnf("Using GSI is not supported when using a walrus bucket - switching to use views.  Set 'use_views':true in Sync Gateway's database config to avoid this warning.")
-		useViews = true
-	}
-
-	// Initialize Views or GSI indexes
-	if !useViews {
-
-		gsiSupported := bucket.IsSupported(sgbucket.BucketFeatureN1ql)
-
-		if !gsiSupported {
-			return nil, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
-		}
-
-		numReplicas := DefaultNumIndexReplicas
-		if config.NumIndexReplicas != nil {
-			numReplicas = *config.NumIndexReplicas
-		}
-
-		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
-		if indexErr != nil {
-			return nil, indexErr
-		}
-	} else {
-		viewErr := db.InitializeViews(bucket)
-		if viewErr != nil {
-			return nil, viewErr
-		}
-	}
-
 	// Create a callback function that will be invoked if the database goes offline and comes
 	// back online again
 	dbOnlineCallback := func(dbContext *db.DatabaseContext) {
 		sc.TakeDbOnline(dbContext)
+	}
+
+	oldRevExpirySeconds := base.DefaultOldRevExpirySeconds
+	if config.OldRevExpirySeconds != nil {
+		oldRevExpirySeconds = *config.OldRevExpirySeconds
 	}
 
 	deltaSyncOptions := db.DeltaSyncOptions{
@@ -469,62 +600,31 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 			if *revMaxAge == 0 {
 				// a setting of zero will fall back to the non-delta handling of revision body backups
 			} else if *revMaxAge < oldRevExpirySeconds {
-				return nil, fmt.Errorf("delta_sync.rev_max_age_seconds: %d must not be less than the configured old_rev_expiry_seconds: %d", *revMaxAge, oldRevExpirySeconds)
+				return db.DatabaseContextOptions{}, fmt.Errorf("delta_sync.rev_max_age_seconds: %d must not be less than the configured old_rev_expiry_seconds: %d", *revMaxAge, oldRevExpirySeconds)
 			}
 			deltaSyncOptions.RevMaxAgeSeconds = *revMaxAge
 		}
 	}
 	base.Infof(base.KeyAll, "delta_sync enabled=%t with rev_max_age_seconds=%d for database %s", deltaSyncOptions.Enabled, deltaSyncOptions.RevMaxAgeSeconds, dbName)
 
-	if config.Unsupported.WarningThresholds.XattrSize == nil {
-		val := uint32(base.DefaultWarnThresholdXattrSize)
-		config.Unsupported.WarningThresholds.XattrSize = &val
-	} else {
-		lowerLimit := 0.1 * 1024 * 1024 // 0.1 MB
-		upperLimit := 1 * 1024 * 1024   // 1 MB
-		if *config.Unsupported.WarningThresholds.XattrSize < uint32(lowerLimit) {
-			return nil, fmt.Errorf("xattr_size warning threshold cannot be lower than %d bytes", uint32(lowerLimit))
-		} else if *config.Unsupported.WarningThresholds.XattrSize > uint32(upperLimit) {
-			return nil, fmt.Errorf("xattr_size warning threshold cannot be higher than %d bytes", uint32(upperLimit))
-		}
+	compactIntervalSecs := db.DefaultCompactInterval
+	if config.CompactIntervalDays != nil {
+		compactIntervalSecs = uint32(*config.CompactIntervalDays * 60 * 60 * 24)
 	}
 
-	if config.Unsupported.WarningThresholds.ChannelsPerDoc == nil {
-		config.Unsupported.WarningThresholds.ChannelsPerDoc = &base.DefaultWarnThresholdChannelsPerDoc
-	} else {
-		lowerLimit := 5
-		if *config.Unsupported.WarningThresholds.ChannelsPerDoc < uint32(lowerLimit) {
-			return nil, fmt.Errorf("channels_per_doc warning threshold cannot be lower than %d", lowerLimit)
-		}
-	}
-
-	if config.Unsupported.WarningThresholds.GrantsPerDoc == nil {
-		config.Unsupported.WarningThresholds.GrantsPerDoc = &base.DefaultWarnThresholdGrantsPerDoc
-	} else {
-		lowerLimit := 5
-		if *config.Unsupported.WarningThresholds.GrantsPerDoc < uint32(lowerLimit) {
-			return nil, fmt.Errorf("access_and_role_grants_per_doc warning threshold cannot be lower than %d", lowerLimit)
-		}
-	}
-
-	compactIntervalDays := config.CompactIntervalDays
-	var compactIntervalSecs uint32
-	if compactIntervalDays == nil {
-		compactIntervalSecs = db.DefaultCompactInterval
-	} else {
-		compactIntervalSecs = uint32(*compactIntervalDays * 60 * 60 * 24)
-	}
-
-	var secureCookieOverride bool
+	secureCookieOverride := sc.config.SSLCert != nil
 	if config.SecureCookieOverride != nil {
 		secureCookieOverride = *config.SecureCookieOverride
-	} else {
-		secureCookieOverride = sc.config.SSLCert != nil
 	}
 
 	sgReplicateEnabled := db.DefaultSGReplicateEnabled
 	if config.SGReplicateEnabled != nil {
 		sgReplicateEnabled = *config.SGReplicateEnabled
+	}
+
+	localDocExpirySecs := base.DefaultLocalDocExpirySecs
+	if config.LocalDocExpirySecs != nil {
+		localDocExpirySecs = *config.LocalDocExpirySecs
 	}
 
 	contextOptions := db.DatabaseContextOptions{
@@ -543,103 +643,11 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		SessionCookieHttpOnly:     config.SessionCookieHTTPOnly,
 		AllowConflicts:            config.ConflictsAllowed(),
 		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
-		UseViews:                  useViews,
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
 		SgReplicateEnabled:        sgReplicateEnabled,
 	}
-
-	// Create the DB Context
-	dbcontext, err := db.NewDatabaseContext(dbName, bucket, autoImport, contextOptions)
-	if err != nil {
-		return nil, err
-	}
-	dbcontext.BucketSpec = spec
-
-	syncFn := ""
-	if config.Sync != nil {
-		syncFn = *config.Sync
-	}
-	if err := sc.applySyncFunction(dbcontext, syncFn); err != nil {
-		return nil, err
-	}
-
-	if config.RevsLimit != nil {
-		dbcontext.RevsLimit = *config.RevsLimit
-		if dbcontext.AllowConflicts() {
-			if dbcontext.RevsLimit < 20 {
-				return nil, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration cannot be set lower than 20.", dbcontext.RevsLimit)
-			}
-
-			if dbcontext.RevsLimit < db.DefaultRevsLimitConflicts {
-				base.Warnf("Setting the revs_limit (%v) to less than %d, whilst having allow_conflicts set to true, may have unwanted results when documents are frequently updated. Please see documentation for details.", dbcontext.RevsLimit, db.DefaultRevsLimitConflicts)
-			}
-		} else {
-			if dbcontext.RevsLimit <= 0 {
-				return nil, fmt.Errorf("The revs_limit (%v) value in your Sync Gateway configuration must be greater than zero.", dbcontext.RevsLimit)
-			}
-		}
-	}
-
-	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
-
-	if dbcontext.ChannelMapper == nil {
-		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))
-	}
-
-	// Create default users & roles:
-	if err := sc.installPrincipals(dbcontext, config.Roles, "role"); err != nil {
-		return nil, err
-	} else if err := sc.installPrincipals(dbcontext, config.Users, "user"); err != nil {
-		return nil, err
-	}
-
-	// Note: disabling access-related warnings, because they potentially block startup during view reindexing trying to query the principals view, which outweighs the usability benefit
-	//emitAccessRelatedWarnings(config, dbcontext)
-
-	// Initialize event handlers
-	if err := sc.initEventHandlers(dbcontext, config); err != nil {
-		return nil, err
-	}
-
-	// Validate all replications before updating any
-	for replicationID, replicationConfig := range config.Replications {
-		if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
-			return nil, fmt.Errorf("replication_id %q does not match replications key %q in replication config", replicationConfig.ID, replicationID)
-		}
-		replicationConfig.ID = replicationID
-		if validateErr := replicationConfig.ValidateReplication(true); validateErr != nil {
-			return nil, validateErr
-		}
-	}
-
-	// Validation was successful, can update replications
-	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
-	if replicationErr != nil {
-		return nil, replicationErr
-	}
-
-	dbcontext.ExitChanges = make(chan struct{})
-
-	// Register it so HTTP handlers can find it:
-	sc.databases_[dbcontext.Name] = dbcontext
-
-	// Save the config
-	sc.config.Databases[dbName] = config
-
-	if config.StartOffline {
-		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
-		}
-	} else {
-		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
-		}
-	}
-
-	return dbcontext, nil
+	return contextOptions, nil
 }
 
 func (sc *ServerContext) TakeDbOnline(database *db.DatabaseContext) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -208,21 +208,23 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.Error(t, err, "It should throw 400 Illegal database name")
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
 
+	// Get or add database from config with duplicate database name and useExisting as false.
+	server := "walrus:"
+	bucketName := "imbucket"
+	databaseName := "imdb"
+
 	// Get or add database from config with unrecognized value for import_docs.
 	dbConfig = &DbConfig{
 		Name:                "imdb",
 		OldRevExpirySeconds: &oldRevExpirySeconds,
 		LocalDocExpirySecs:  &localDocExpirySecs,
-		AutoImport:          "Unknown"}
+		AutoImport:          "Unknown",
+		BucketConfig:        BucketConfig{Server: &server, Bucket: &bucketName},
+	}
 
 	dbContext, err = serverContext._getOrAddDatabaseFromConfig(dbConfig, false)
 	assert.Nil(t, dbContext, "Can't create database context from config with unrecognized value for import_docs")
 	assert.Error(t, err, "It should throw Unrecognized value for import_docs")
-
-	// Get or add database from config with duplicate database name and useExisting as false.
-	server := "walrus:"
-	bucketName := "imbucket"
-	databaseName := "imdb"
 
 	bucketConfig := BucketConfig{Server: &server, Bucket: &bucketName}
 	dbConfig = &DbConfig{BucketConfig: bucketConfig, Name: databaseName, AllowEmptyPassword: true}


### PR DESCRIPTION
Implementation of additional replication lifecycle handling:
- Registers config file replications to replication cluster config on startup
- Subscribes to replication cluster config changes
- Starts activeReplication(s) when replications are assigned to node
- Stops activeReplication(s) when replications are unassigned from node

Includes some refactoring of getOrAddDatabaseFromConfig for readability.
