### PR TITLE
CBG-774 ConflictResolverFunc definition and API

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -13,8 +13,8 @@ type ActiveReplicatorDirection string
 
 const (
 	ActiveReplicatorTypePushAndPull ActiveReplicatorDirection = "pushAndPull"
-	ActiveReplicatorTypePush                                  = "push"
-	ActiveReplicatorTypePull                                  = "pull"
+	ActiveReplicatorTypePush        ActiveReplicatorDirection = "push"
+	ActiveReplicatorTypePull        ActiveReplicatorDirection = "pull"
 )
 
 func (d ActiveReplicatorDirection) IsValid() bool {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -53,19 +53,19 @@ func NewSGNode(uuid string, host string) *SGNode {
 
 // ReplicationConfig is a replication definition as stored in the Sync Gateway config
 type ReplicationConfig struct {
-	ID                     string      `json:"replication_id"`
-	Remote                 string      `json:"remote"`
-	Direction              string      `json:"direction"`
-	ConflictResolutionType string      `json:"conflict_resolution_type,omitempty"`
-	ConflictResolutionFn   string      `json:"custom_conflict_resolver,omitempty"`
-	PurgeOnRemoval         bool        `json:"purge_on_removal,omitempty"`
-	DeltaSyncEnabled       bool        `json:"enable_delta_sync,omitempty"`
-	MaxBackoff             int         `json:"max_backoff_time,omitempty"`
-	State                  string      `json:"state,omitempty"`
-	Continuous             bool        `json:"continuous,omitempty"`
-	Filter                 string      `json:"filter,omitempty"`
-	QueryParams            interface{} `json:"query_params,omitempty"`
-	Cancel                 bool        `json:"cancel,omitempty"`
+	ID                     string                    `json:"replication_id"`
+	Remote                 string                    `json:"remote"`
+	Direction              ActiveReplicatorDirection `json:"direction"`
+	ConflictResolutionType ConflictResolverType      `json:"conflict_resolution_type,omitempty"`
+	ConflictResolutionFn   string                    `json:"custom_conflict_resolver,omitempty"`
+	PurgeOnRemoval         bool                      `json:"purge_on_removal,omitempty"`
+	DeltaSyncEnabled       bool                      `json:"enable_delta_sync,omitempty"`
+	MaxBackoff             int                       `json:"max_backoff_time,omitempty"`
+	State                  string                    `json:"state,omitempty"`
+	Continuous             bool                      `json:"continuous,omitempty"`
+	Filter                 string                    `json:"filter,omitempty"`
+	QueryParams            interface{}               `json:"query_params,omitempty"`
+	Cancel                 bool                      `json:"cancel,omitempty"`
 }
 
 // ReplicationCfg represents a replication definition as stored in the cluster config.
@@ -165,11 +165,11 @@ func (rc *ReplicationConfig) Upsert(c *ReplicationUpsertConfig) {
 	}
 
 	if c.Direction != nil {
-		rc.Direction = *c.Direction
+		rc.Direction = ActiveReplicatorDirection(*c.Direction)
 	}
 
 	if c.ConflictResolutionType != nil {
-		rc.ConflictResolutionType = *c.ConflictResolutionType
+		rc.ConflictResolutionType = ConflictResolverType(*c.ConflictResolutionType)
 	}
 	if c.ConflictResolutionFn != nil {
 		rc.ConflictResolutionFn = *c.ConflictResolutionFn

--- a/db/sg_replicate_conflict_resolver.go
+++ b/db/sg_replicate_conflict_resolver.go
@@ -1,0 +1,90 @@
+package db
+
+import "fmt"
+
+type ConflictResolverType string
+
+const (
+	ConflictResolverLocalWins  ConflictResolverType = "localWins"
+	ConflictResolverRemoteWins ConflictResolverType = "remoteWins"
+	ConflictResolverDefault    ConflictResolverType = "default"
+	ConflictResolverCustom     ConflictResolverType = "custom"
+)
+
+func (d ConflictResolverType) IsValid() bool {
+	switch d {
+	case ConflictResolverLocalWins, ConflictResolverRemoteWins, ConflictResolverDefault, ConflictResolverCustom:
+		return true
+	default:
+		return false
+	}
+}
+
+// Conflict is the input to all conflict resolvers.  LocalDocument and RemoteDocument
+// are expected to be document bodies with metadata injected into the body following
+// the same approach used for doc and oldDoc in the Sync Function
+type Conflict struct {
+	LocalDocument  Body `json:"LocalDocument"`
+	RemoteDocument Body `json:"RemoteDocument"`
+}
+
+// Definition of the ConflictResolverFunc API.  Winner may be one of
+// conflict.LocalDocument or conflict.RemoteDocument, or a new Body
+// based on a merge of the two.
+//   - In the merge case, winner[revid] must be empty.
+//   - If an nil Body is returned, the conflict should be resolved as a deletion/tombstone.
+type ConflictResolverFunc func(conflict Conflict) (winner Body, err error)
+
+// DefaultConflictResolver uses the same logic as revTree.WinningRevision:
+// the revision whose (!deleted, generation, hash) tuple compares the highest.
+func DefaultConflictResolver(conflict Conflict) (result Body, err error) {
+	localDeleted, _ := conflict.LocalDocument[BodyDeleted].(bool)
+	remoteDeleted, _ := conflict.RemoteDocument[BodyDeleted].(bool)
+	if localDeleted && !remoteDeleted {
+		return conflict.RemoteDocument, nil
+	}
+
+	if remoteDeleted && !localDeleted {
+		return conflict.LocalDocument, nil
+	}
+
+	localRevID, _ := conflict.LocalDocument[BodyRev].(string)
+	remoteRevID, _ := conflict.RemoteDocument[BodyRev].(string)
+	if compareRevIDs(localRevID, remoteRevID) >= 0 {
+		return conflict.LocalDocument, nil
+	} else {
+		return conflict.RemoteDocument, nil
+	}
+}
+
+// LocalWinsConflictResolver returns the local document as winner
+func LocalWinsConflictResolver(conflict Conflict) (winner Body, err error) {
+	return conflict.LocalDocument, nil
+}
+
+// RemoteWinsConflictResolver returns the local document as-is
+func RemoteWinsConflictResolver(conflict Conflict) (winner Body, err error) {
+	return conflict.RemoteDocument, nil
+}
+
+func NewConflictResolverFunc(resolverType ConflictResolverType, customResolverSource string) (ConflictResolverFunc, error) {
+	switch resolverType {
+	case ConflictResolverLocalWins:
+		return LocalWinsConflictResolver, nil
+	case ConflictResolverRemoteWins:
+		return RemoteWinsConflictResolver, nil
+	case ConflictResolverDefault:
+		return DefaultConflictResolver, nil
+	case ConflictResolverCustom:
+		return NewCustomConflictResolver(customResolverSource)
+	default:
+		return nil, fmt.Errorf("Unknown Conflict Resolver type: %s", resolverType)
+	}
+}
+
+// NewCustomConflictResolver returns a ConflictResolverFunc that executes the
+// javascript conflict resolver specified by source
+func NewCustomConflictResolver(source string) (ConflictResolverFunc, error) {
+	// TODO: CBG-777
+	return nil, nil
+}

--- a/db/sg_replicate_conflict_resolver_test.go
+++ b/db/sg_replicate_conflict_resolver_test.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test node operations on SGReplicateManager
+func TestDefaultConflictResolver(t *testing.T) {
+
+	defaultConflictResolverTests := []struct {
+		name           string
+		localDocument  Body
+		remoteDocument Body
+		expectedWinner Body
+	}{
+		{
+			name:           "generation",
+			localDocument:  Body{"_rev": "2-abc"},
+			remoteDocument: Body{"_rev": "1-abc"},
+			expectedWinner: Body{"_rev": "2-abc"},
+		},
+		{
+			name:           "digest",
+			localDocument:  Body{"_rev": "1-abc"},
+			remoteDocument: Body{"_rev": "1-def"},
+			expectedWinner: Body{"_rev": "1-def"},
+		},
+		{
+			name:           "localDeleted",
+			localDocument:  Body{"_rev": "2-abc", "_deleted": true},
+			remoteDocument: Body{"_rev": "1-abc"},
+			expectedWinner: Body{"_rev": "1-abc"},
+		},
+		{
+			name:           "remoteDeleted",
+			localDocument:  Body{"_rev": "1-abc"},
+			remoteDocument: Body{"_rev": "2-abc", "_deleted": true},
+			expectedWinner: Body{"_rev": "1-abc"},
+		},
+		{
+			name:           "bothDeleted",
+			localDocument:  Body{"_rev": "1-abc", "_deleted": true},
+			remoteDocument: Body{"_rev": "2-abc", "_deleted": true},
+			expectedWinner: Body{"_rev": "2-abc", "_deleted": true},
+		},
+	}
+
+	for _, test := range defaultConflictResolverTests {
+		t.Run(test.name, func(tt *testing.T) {
+			conflict := Conflict{
+				LocalDocument:  test.localDocument,
+				RemoteDocument: test.remoteDocument,
+			}
+			result, err := DefaultConflictResolver(conflict)
+			assert.NoError(tt, err)
+			assert.Equal(tt, test.expectedWinner, result)
+		})
+	}
+}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -21,7 +21,7 @@ func TestReplicationAPI(t *testing.T) {
 	replicationConfig := db.ReplicationConfig{
 		ID:        "replication1",
 		Remote:    "http://remote:4984/db",
-		Direction: "Pull",
+		Direction: "pull",
 	}
 
 	// PUT replication
@@ -33,10 +33,11 @@ func TestReplicationAPI(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	var configResponse db.ReplicationConfig
 	err := json.Unmarshal(response.BodyBytes(), &configResponse)
+	log.Printf("configResponse direction type: %T", configResponse.Direction)
 	require.NoError(t, err)
-	assert.Equal(t, configResponse.ID, "replication1")
-	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
-	assert.Equal(t, configResponse.Direction, "Pull")
+	assert.Equal(t, "replication1", configResponse.ID)
+	assert.Equal(t, "http://remote:4984/db", configResponse.Remote)
+	assert.Equal(t, db.ActiveReplicatorTypePull, configResponse.Direction)
 
 	// POST replication
 	replicationConfig.ID = "replication2"
@@ -49,9 +50,9 @@ func TestReplicationAPI(t *testing.T) {
 	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err)
-	assert.Equal(t, configResponse.ID, "replication2")
-	assert.Equal(t, configResponse.Remote, "http://remote:4984/db")
-	assert.Equal(t, configResponse.Direction, "Pull")
+	assert.Equal(t, "replication2", configResponse.ID)
+	assert.Equal(t, "http://remote:4984/db", configResponse.Remote)
+	assert.Equal(t, db.ActiveReplicatorTypePull, configResponse.Direction)
 
 	// GET all replications
 	response = rt.SendAdminRequest("GET", "/db/_replication/", "")
@@ -191,7 +192,7 @@ func TestReplicationsFromConfig(t *testing.T) {
 	replicationConfig2String := `{
 		"replication_id": "replication2",
 		"remote": "http://remote:4985/db",
-		"direction":"Pull",
+		"direction":"pull",
 		"continuous":true,
 		"conflict_resolution_type":"foo",
 		"conflict_resolution_fn":"func()",


### PR DESCRIPTION
Adds ConflictResolverFunc API, implementations of default/localWins/RemoteWins, and constructor to return function based on config value.

Aligns with Couchbase Lite's conflict resolution API.

Addresses CBG-774, CBG-775 and CBG-776.