### PR TITLE
CBG-915 - Refactor blip.sendChanges for generic options parameter

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -99,6 +99,19 @@ func (ar *ActiveReplicator) GetStatus(replicationID string) *ReplicationStatus {
 	return status
 }
 
+func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.Sender, bsc *BlipSyncContext, err error) {
+
+	blipContext := blip.NewContextCustomID(config.ID+idSuffix, blipCBMobileReplication)
+	bsc = NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID)
+
+	blipSender, err = blipSync(*config.PassiveDBURL, blipContext)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return blipSender, bsc, nil
+}
+
 // blipSync opens a connection to the target, and returns a blip.Sender to send messages over.
 func blipSync(target url.URL, blipContext *blip.Context) (*blip.Sender, error) {
 	// GET target database endpoint to see if reachable for exit-early/clearer error message

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -250,6 +250,7 @@ func (apr *ActivePullReplicator) Start() error {
 		FilterChannels: apr.config.FilterChannels,
 		DocIDs:         apr.config.DocIDs,
 		ActiveOnly:     apr.config.ActiveOnly,
+		clientType:     clientTypeSGR2,
 	}
 
 	if err := apr.startCheckpointer(); err != nil {

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -232,7 +232,9 @@ func (apr *ActivePullReplicator) Start() error {
 		return fmt.Errorf("nil ActivePullReplicator, can't start")
 	}
 
-	if err := apr.connect(); err != nil {
+	var err error
+	apr.blipSender, apr.blipSyncContext, err = connect("-pull", apr.config)
+	if err != nil {
 		return err
 	}
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -33,27 +33,6 @@ func (apr *ActivePushReplicator) CheckpointID() (string, error) {
 	return "sgr2cp:push:" + checkpointHash, nil
 }
 
-func (apr *ActivePushReplicator) connect() (err error) {
-	if apr == nil {
-		return fmt.Errorf("nil ActivePushReplicator, can't connect")
-	}
-
-	if apr.blipSender != nil {
-		return fmt.Errorf("replicator already has a blipSender, can't connect twice")
-	}
-
-	blipContext := blip.NewContextCustomID(apr.config.ID+"-push", blipCBMobileReplication)
-	bsc := NewBlipSyncContext(blipContext, apr.config.ActiveDB, blipContext.ID)
-	apr.blipSyncContext = bsc
-
-	apr.blipSender, err = blipSync(*apr.config.PassiveDBURL, apr.blipSyncContext.blipContext)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // CheckpointNow forces the checkpointer to send a checkpoint, and blocks until it has finished.
 func (apr *ActivePushReplicator) CheckpointNow() {
 	// TODO: Implement push checkpointing (CBG-916)
@@ -98,7 +77,9 @@ func (apr *ActivePushReplicator) Start() error {
 		return fmt.Errorf("nil ActivePushReplicator, can't start")
 	}
 
-	if err := apr.connect(); err != nil {
+	var err error
+	apr.blipSender, apr.blipSyncContext, err = connect("-push", apr.config)
+	if err != nil {
 		return err
 	}
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -95,11 +95,6 @@ func (apr *ActivePushReplicator) Start() error {
 		serialNumber:    apr.blipSyncContext.incrementSerialNumber(),
 	}
 
-	// TODO: set bh.channels and these other options via sendChanges parameters (CBG-915)
-	bh.continuous = apr.config.Continuous
-	bh.batchSize = int(apr.config.ChangesBatchSize)
-	bh.activeOnly = apr.config.ActiveOnly
-
 	seq, err := apr.config.ActiveDB.ParseSequenceID(checkpoint.Checkpoint.LastSequence)
 	if err != nil {
 		base.Warnf("couldn't parse checkpointed sequence ID, starting push from seq:0")

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -112,6 +112,7 @@ func (apr *ActivePushReplicator) Start() error {
 		activeOnly: apr.config.ActiveOnly,
 		batchSize:  int(apr.config.ChangesBatchSize),
 		channels:   channels,
+		clientType: clientTypeSGR2,
 	})
 
 	return nil

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -105,10 +105,18 @@ func (apr *ActivePushReplicator) Start() error {
 		base.Warnf("couldn't parse checkpointed sequence ID, starting push from seq:0")
 	}
 
-	go bh.sendChanges(apr.blipSender, &SubChangesParams{
-		rq:      nil,
-		_since:  seq,
-		_docIDs: apr.config.DocIDs,
+	var channels base.Set
+	if apr.config.FilterChannels != nil {
+		channels = base.SetFromArray(apr.config.FilterChannels)
+	}
+
+	go bh.sendChanges(apr.blipSender, &sendChangesOptions{
+		docIDs:     apr.config.DocIDs,
+		since:      seq,
+		continuous: apr.config.Continuous,
+		activeOnly: apr.config.ActiveOnly,
+		batchSize:  int(apr.config.ChangesBatchSize),
+		channels:   channels,
 	})
 
 	return nil

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -21,6 +21,7 @@ type SubChangesRequest struct {
 	FilterChannels []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
 	DocIDs         []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
 	ActiveOnly     bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
+	clientType     clientType
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}
@@ -37,6 +38,7 @@ func (rq *SubChangesRequest) marshalBLIPRequest() *blip.Message {
 	msg := blip.NewRequest()
 	msg.SetProfile(MessageSubChanges)
 
+	setOptionalProperty(msg.Properties, "client_sgr2", rq.clientType == clientTypeSGR2)
 	setOptionalProperty(msg.Properties, SubChangesContinuous, rq.Continuous)
 	setOptionalProperty(msg.Properties, SubChangesBatch, rq.Batch)
 	setOptionalProperty(msg.Properties, SubChangesSince, rq.Since)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -71,11 +71,8 @@ type BlipSyncContext struct {
 	blipContext               *blip.Context
 	blipContextDb             *Database    // 'master' database instance for the replication, used as source when creating handler-specific databases
 	dbUserLock                sync.RWMutex // Must be held when refreshing the db user
-	batchSize                 int
 	gotSubChanges             bool
 	continuous                bool
-	activeOnly                bool
-	channels                  base.Set
 	lock                      sync.Mutex
 	allowedAttachments        map[string]int
 	handlerSerialNumber       uint64                      // Each handler within a context gets a unique serial number for logging

--- a/db/changes.go
+++ b/db/changes.go
@@ -26,18 +26,18 @@ import (
 // Options for changes-feeds.  ChangesOptions must not contain any mutable pointer references, as
 // changes processing currently assumes a deep copy when doing chanOpts := changesOptions.
 type ChangesOptions struct {
-	Since        SequenceID      // sequence # to start _after_
-	Limit        int             // Max number of changes to return, if nonzero
-	Conflicts    bool            // Show all conflicting revision IDs, not just winning one?
-	IncludeDocs  bool            // Include doc body of each change?
-	Wait         bool            // Wait for results, instead of immediately returning empty result?
-	Continuous   bool            // Run continuously until terminated?
-	Terminator   chan bool       // Caller can close this channel to terminate the feed
-	HeartbeatMs  uint64          // How often to send a heartbeat to the client
-	TimeoutMs    uint64          // After this amount of time, close the longpoll connection
-	ActiveOnly   bool            // If true, only return information on non-deleted, non-removed revisions
-	ClientIsCBL2 bool            // If the replication is being started from a CBL 2.x client
-	Ctx          context.Context // Used for adding context to logs
+	Since       SequenceID      // sequence # to start _after_
+	Limit       int             // Max number of changes to return, if nonzero
+	Conflicts   bool            // Show all conflicting revision IDs, not just winning one?
+	IncludeDocs bool            // Include doc body of each change?
+	Wait        bool            // Wait for results, instead of immediately returning empty result?
+	Continuous  bool            // Run continuously until terminated?
+	Terminator  chan bool       // Caller can close this channel to terminate the feed
+	HeartbeatMs uint64          // How often to send a heartbeat to the client
+	TimeoutMs   uint64          // After this amount of time, close the longpoll connection
+	ActiveOnly  bool            // If true, only return information on non-deleted, non-removed revisions
+	clientType  clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
+	Ctx         context.Context // Used for adding context to logs
 }
 
 // A changes entry; Database.GetChanges returns an array of these.
@@ -715,7 +715,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			output <- nil
 
 			// If this is an initial replication using CBL 2.x (active only), flip activeOnly now the client has caught up.
-			if options.ClientIsCBL2 && options.ActiveOnly {
+			if options.clientType == clientTypeCBL2 && options.ActiveOnly {
 				base.DebugfCtx(db.Ctx, base.KeyChanges, "%v MultiChangesFeed initial replication caught up - setting ActiveOnly to false... %s", options.Since, base.UD(to))
 				options.ActiveOnly = false
 			}


### PR DESCRIPTION
- [x] Rebase on #4623 
- Removed shared "connect" code into function for pull and push
- Refactor bh.sendChanges for generic options decoupled from subChanges
- Identify CBL2 and SGR2 clients instead of always assuming 2.x replication is CBL2