### PR TITLE
CBG-802: Being able to configure OpenID Connect Test Provider with HTTPS

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -452,7 +452,10 @@ func SetURLQueryParam(strURL, name, value string) (string, error) {
 func GetHttpClient(insecureSkipVerify bool) *http.Client {
 	if insecureSkipVerify {
 		transport := base.DefaultHTTPTransport()
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = new(tls.Config)
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
 		return &http.Client{Transport: transport}
 	}
 	return http.DefaultClient

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -27,6 +27,7 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -126,6 +127,11 @@ type OIDCProvider struct {
 
 	// Name represents the name of this OpenID Connect provider.
 	Name string
+
+	// InsecureSkipVerify determines whether the TLS certificate verification
+	// should be disabled for this provider. TLS certificate verification is
+	// enabled by default.
+	InsecureSkipVerify bool
 }
 
 type OIDCProviderMap map[string]*OIDCProvider
@@ -272,14 +278,14 @@ func (op *OIDCProvider) DiscoverConfig() (verifier *oidc.IDTokenVerifier, endpoi
 		if err != nil {
 			return nil, nil, err
 		}
-		verifier = op.GenerateVerifier(metadata, context.Background())
+		verifier = op.GenerateVerifier(metadata, GetClientContext(op.InsecureSkipVerify))
 		endpoint = &oauth2.Endpoint{AuthURL: metadata.AuthorizationEndpoint, TokenURL: metadata.TokenEndpoint}
 	} else {
 		base.Infof(base.KeyAuth, "Fetching provider config from standard issuer-based discovery endpoint, issuer: %s", base.UD(op.Issuer))
 		var provider *oidc.Provider
 		maxRetryAttempts := 5
 		for i := 1; i <= maxRetryAttempts; i++ {
-			provider, err = oidc.NewProvider(context.Background(), op.Issuer)
+			provider, err = oidc.NewProvider(GetClientContext(op.InsecureSkipVerify), op.Issuer)
 			if err == nil && provider != nil {
 				providerEndpoint := provider.Endpoint()
 				endpoint = &providerEndpoint
@@ -309,7 +315,8 @@ func (op *OIDCProvider) FetchCustomProviderConfig(discoveryURL string) (*Provide
 		base.Debugf(base.KeyAuth, "Error building new request for URL %s: %v", base.UD(discoveryURL), err)
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := GetHttpClient(op.InsecureSkipVerify)
+	resp, err := client.Do(req)
 	if err != nil {
 		base.Debugf(base.KeyAuth, "Error invoking calling discovery URL %s: %v", base.UD(discoveryURL), err)
 		return nil, err
@@ -438,4 +445,24 @@ func SetURLQueryParam(strURL, name, value string) (string, error) {
 	rawQuery.Set(name, value)
 	uri.RawQuery = rawQuery.Encode()
 	return uri.String(), nil
+}
+
+// GetHttpClient returns a new HTTP client with TLS certificate verification
+// disabled when insecureSkipVerify is true and enabled otherwise.
+func GetHttpClient(insecureSkipVerify bool) *http.Client {
+	if insecureSkipVerify {
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		return &http.Client{Transport: transport}
+	}
+	return &http.Client{}
+}
+
+// GetClientContext returns a new Context that carries the provided HTTP client
+// with TLS certificate verification disabled when insecureSkipVerify is true and
+// enabled otherwise.
+func GetClientContext(insecureSkipVerify bool) context.Context {
+	client := GetHttpClient(insecureSkipVerify)
+	return oidc.ClientContext(context.Background(), client)
 }

--- a/db/database.go
+++ b/db/database.go
@@ -159,6 +159,7 @@ type UnsupportedOptions struct {
 	APIEndpoints             APIEndpoints            `json:"api_endpoints,omitempty"`               // Config settings for API endpoints
 	WarningThresholds        WarningThresholds       `json:"warning_thresholds,omitempty"`          // Warning thresholds related to _sync size
 	DisableCleanSkippedQuery bool                    `json:"disable_clean_skipped_query,omitempty"` // Clean skipped sequence processing bypasses final check
+	OidcTlsSkipVerify        bool                    `json:"oidc_tls_skip_verify"`                  // Config option to enable self-signed certs for OIDC testing.
 }
 
 type WarningThresholds struct {
@@ -390,6 +391,8 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 			if (options.OIDCOptions.DefaultProvider != nil && name == *options.OIDCOptions.DefaultProvider) || len(options.OIDCOptions.Providers) == 1 {
 				provider.IsDefault = true
 			}
+
+			provider.InsecureSkipVerify = options.UnsupportedOptions.OidcTlsSkipVerify
 
 			// If this isn't the default provider, add the provider to the callback URL (needed to identify provider to _oidc_callback)
 			if !provider.IsDefault && provider.CallbackURL != nil {

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -175,7 +175,7 @@ func (h *handler) handleOIDCCallback() error {
 	}
 
 	// Converts the authorization code into a token.
-	context := auth.GetClientContext(h.db.Options.UnsupportedOptions.OidcTlsSkipVerify)
+	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)
 	token, err := client.Config.Exchange(context, code)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Failed to exchange token: "+err.Error())
@@ -227,7 +227,7 @@ func (h *handler) handleOIDCRefresh() error {
 		return err
 	}
 
-	context := auth.GetClientContext(h.db.Options.UnsupportedOptions.OidcTlsSkipVerify)
+	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)
 	token, err := client.Config.TokenSource(context, &oauth2.Token{RefreshToken: refreshToken}).Token()
 	if err != nil {
 		base.Infof(base.KeyAuth, "Unsuccessful token refresh: %v", err)

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -10,7 +10,6 @@
 package rest
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -176,7 +175,8 @@ func (h *handler) handleOIDCCallback() error {
 	}
 
 	// Converts the authorization code into a token.
-	token, err := client.Config.Exchange(context.Background(), code)
+	context := auth.GetClientContext(h.db.Options.UnsupportedOptions.OidcTlsSkipVerify)
+	token, err := client.Config.Exchange(context, code)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Failed to exchange token: "+err.Error())
 	}
@@ -227,7 +227,8 @@ func (h *handler) handleOIDCRefresh() error {
 		return err
 	}
 
-	token, err := client.Config.TokenSource(context.Background(), &oauth2.Token{RefreshToken: refreshToken}).Token()
+	context := auth.GetClientContext(h.db.Options.UnsupportedOptions.OidcTlsSkipVerify)
+	token, err := client.Config.TokenSource(context, &oauth2.Token{RefreshToken: refreshToken}).Token()
 	if err != nil {
 		base.Infof(base.KeyAuth, "Unsuccessful token refresh: %v", err)
 		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to refresh token.")

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -123,10 +123,9 @@ func TestInsecureOpenIDConnectAuth(t *testing.T) {
 
 // parseAuthURL returns the authentication URL extracted from user consent form.
 func parseAuthURL(html string) string {
-	re := regexp.MustCompile(`<form action=".*?(.*)" method`)
-	submatch := re.FindAllStringSubmatch(html, -1)
-	for _, element := range submatch {
-		return element[1]
+	re := regexp.MustCompile(`<form action="(.+)" method`)
+	if submatch := re.FindStringSubmatch(html); submatch != nil {
+		return submatch[1]
 	}
 	return ""
 }

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -1,14 +1,23 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,4 +47,86 @@ func TestExtractSubjectFromRefreshToken(t *testing.T) {
 	sub, err = extractSubjectFromRefreshToken(refreshToken)
 	require.NoError(t, err, "invalid refresh token error")
 	assert.Equal(t, subject, sub)
+}
+
+func TestInsecureOpenIDConnectAuth(t *testing.T) {
+	providers := auth.OIDCProviderMap{
+		"test": &auth.OIDCProvider{
+			Register:      true,
+			Issuer:        "${baseURL}/db/_oidc_testing",
+			Name:          "test",
+			ClientID:      "sync_gateway",
+			ValidationKey: base.StringPtr("qux"),
+			CallbackURL:   base.StringPtr("${baseURL}/db/_oidc_callback"),
+		},
+	}
+	defaultProvider := "test"
+	opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
+	restTesterConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			OIDCConfig: &opts,
+			Unsupported: db.UnsupportedOptions{
+				OidcTestProvider: db.OidcTestProviderOptions{
+					Enabled: true,
+				},
+				OidcTlsSkipVerify: true,
+			},
+		}}
+	restTester := NewRestTester(t, &restTesterConfig)
+	restTester.SetAdminParty(false)
+	defer restTester.Close()
+
+	mockSyncGateway := httptest.NewTLSServer(restTester.TestPublicHandler())
+	defer mockSyncGateway.Close()
+	mockSyncGatewayURL := mockSyncGateway.URL
+	provider := restTesterConfig.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
+	provider.Issuer = mockSyncGateway.URL + "/db/_oidc_testing"
+	provider.CallbackURL = base.StringPtr(mockSyncGateway.URL + "/db/_oidc_callback")
+
+	// Send OpenID Connect request
+	authURL := "/db/_oidc?provider=test&offline=true"
+	requestURL := mockSyncGatewayURL + authURL
+	request, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	require.NoError(t, err, "Error creating new request")
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err, "Error creating new cookie jar")
+	client := auth.GetHttpClient(true)
+	client.Jar = jar
+	response, err := client.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	bodyBytes, err := ioutil.ReadAll(response.Body)
+	require.NoError(t, err, "Error reading response")
+	bodyString := string(bodyBytes)
+	require.NoError(t, response.Body.Close(), "Error closing response body")
+
+	// Send authentication request
+	requestURL = mockSyncGateway.URL + "/db/_oidc_testing/" + parseAuthURL(bodyString)
+	form := url.Values{}
+	form.Add("username", "alice")
+	form.Add("authenticated", "Return a valid authorization code for this user")
+	request, err = http.NewRequest(http.MethodPost, requestURL, bytes.NewBufferString(form.Encode()))
+	require.NoError(t, err, "Error creating new request")
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err = client.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	var authResponseActual OIDCTokenResponse
+	require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
+	require.NoError(t, response.Body.Close(), "Error closing response body")
+	assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
+	assert.NotEmpty(t, authResponseActual.Username, "session_id doesn't exist")
+	assert.NotEmpty(t, authResponseActual.IDToken, "id_token mismatch")
+	assert.NotEmpty(t, authResponseActual.RefreshToken, "refresh_token mismatch")
+}
+
+// parseAuthURL returns the authentication URL extracted from user consent form.
+func parseAuthURL(html string) string {
+	re := regexp.MustCompile(`<form action=".*?(.*)" method`)
+	submatch := re.FindAllStringSubmatch(html, -1)
+	for _, element := range submatch {
+		return element[1]
+	}
+	return ""
 }


### PR DESCRIPTION
- Add a boolean flag InsecureSkipVerify to OIDCProvider struct that determines whether the TLS certificate verification should be disabled for this provider.
- Add GetHttpClient function that returns a new HTTP client with TLS certificate verification disabled when insecureSkipVerify is true and enabled otherwise.
- Add GetClientContext function that returns a new Context that carries the provided HTTP client with TLS certificate verification disabled when insecureSkipVerify is true and enabled otherwise.
- Set the InsecureSkipVerify on the provider while initializing the database context.
- Use the background context that carries the provided HTTP client to generate ID token verifier during custom provider metadata discovery,  standard provider metadata discovery, token exchange, and token refresh.
- Add a unit test that covers the test provider OIDC auth flow.
