### PR TITLE
CBG-835 - ActiveReplicator heartbeat mechanism (via websocket ping frames)

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -107,7 +107,11 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 
 func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.Sender, bsc *BlipSyncContext, err error) {
 
-	blipContext := blip.NewContextCustomID(config.ID+idSuffix, blipCBMobileReplication)
+	blipContext := NewSGBlipContext(context.TODO(), config.ID+idSuffix)
+	if config.WebsocketPingInterval == 0 {
+		config.WebsocketPingInterval = defaultWebsocketPingInterval
+	}
+	blipContext.WebsocketPingInterval = config.WebsocketPingInterval
 	bsc = NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID)
 
 	blipSender, err = blipSync(*config.PassiveDBURL, blipContext)

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -32,17 +32,17 @@ type ActiveReplicator struct {
 }
 
 // NewActiveReplicator returns a bidirectional active replicator for the given config.
-func NewActiveReplicator(ctx context.Context, config *ActiveReplicatorConfig) (*ActiveReplicator, error) {
+func NewActiveReplicator(config *ActiveReplicatorConfig) (*ActiveReplicator, error) {
 	ar := &ActiveReplicator{
 		ID: config.ID,
 	}
 
 	if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {
-		ar.Push = NewPushReplicator(ctx, config)
+		ar.Push = NewPushReplicator(config)
 	}
 
 	if pullReplication := config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull; pullReplication {
-		ar.Pull = NewPullReplicator(ctx, config)
+		ar.Pull = NewPullReplicator(config)
 	}
 
 	return ar, nil

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -108,9 +108,6 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.Sender, bsc *BlipSyncContext, err error) {
 
 	blipContext := NewSGBlipContext(context.TODO(), config.ID+idSuffix)
-	if config.WebsocketPingInterval == 0 {
-		config.WebsocketPingInterval = defaultWebsocketPingInterval
-	}
 	blipContext.WebsocketPingInterval = config.WebsocketPingInterval
 	bsc = NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID)
 

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -26,10 +26,6 @@ func (d ActiveReplicatorDirection) IsValid() bool {
 	}
 }
 
-const (
-	defaultWebsocketPingInterval = time.Minute * 5
-)
-
 // ActiveReplicatorConfig controls the behaviour of the active replicator.
 // TODO: This might be replaced with ReplicatorConfig in the future.
 type ActiveReplicatorConfig struct {

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -26,6 +26,10 @@ func (d ActiveReplicatorDirection) IsValid() bool {
 	}
 }
 
+const (
+	defaultWebsocketPingInterval = time.Minute * 5
+)
+
 // ActiveReplicatorConfig controls the behaviour of the active replicator.
 // TODO: This might be replaced with ReplicatorConfig in the future.
 type ActiveReplicatorConfig struct {
@@ -52,6 +56,8 @@ type ActiveReplicatorConfig struct {
 	PurgeOnRemoval bool
 	// ActiveDB is a reference to the active database context.
 	ActiveDB *Database
+	// WebsocketPingInterval is the time between websocket heartbeats sent by the active replicator.
+	WebsocketPingInterval time.Duration
 }
 
 // CheckpointHash returns a deterministic hash of the given config to be used as a checkpoint ID.

--- a/db/database.go
+++ b/db/database.go
@@ -51,10 +51,11 @@ const (
 )
 
 const (
-	DefaultRevsLimitNoConflicts = 50
-	DefaultRevsLimitConflicts   = 100
-	DefaultPurgeInterval        = 30 // Default metadata purge interval, in days.  Used if server's purge interval is unavailable
-	DefaultSGReplicateEnabled   = true
+	DefaultRevsLimitNoConflicts             = 50
+	DefaultRevsLimitConflicts               = 100
+	DefaultPurgeInterval                    = 30 // Default metadata purge interval, in days.  Used if server's purge interval is unavailable
+	DefaultSGReplicateEnabled               = true
+	DefaultSGReplicateWebsocketPingInterval = time.Minute * 5
 )
 
 // Default values for delta sync
@@ -106,26 +107,30 @@ type DatabaseContext struct {
 }
 
 type DatabaseContextOptions struct {
-	CacheOptions                 *CacheOptions
-	RevisionCacheOptions         *RevisionCacheOptions
-	OldRevExpirySeconds          uint32
-	AdminInterface               *string
-	UnsupportedOptions           UnsupportedOptions
-	OIDCOptions                  *auth.OIDCOptions
-	DBOnlineCallback             DBOnlineCallback // Callback function to take the DB back online
-	ImportOptions                ImportOptions
-	EnableXattr                  bool             // Use xattr for _sync
-	LocalDocExpirySecs           uint32           // The _local doc expiry time in seconds
-	SecureCookieOverride         bool             // Pass-through DBConfig.SecureCookieOverride
-	SessionCookieName            string           // Pass-through DbConfig.SessionCookieName
-	SessionCookieHttpOnly        bool             // Pass-through DbConfig.SessionCookieHTTPOnly
-	AllowConflicts               *bool            // False forbids creating conflicts
-	SendWWWAuthenticateHeader    *bool            // False disables setting of 'WWW-Authenticate' header
-	UseViews                     bool             // Force use of views
-	DeltaSyncOptions             DeltaSyncOptions // Delta Sync Options
-	CompactInterval              uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
-	SgReplicateEnabled           bool             // Whether this node can be assigned sg-replicate replications
-	ActiveReplicatorPingInterval time.Duration    // BLIP Websocket Ping interval (for active replicators)
+	CacheOptions              *CacheOptions
+	RevisionCacheOptions      *RevisionCacheOptions
+	OldRevExpirySeconds       uint32
+	AdminInterface            *string
+	UnsupportedOptions        UnsupportedOptions
+	OIDCOptions               *auth.OIDCOptions
+	DBOnlineCallback          DBOnlineCallback // Callback function to take the DB back online
+	ImportOptions             ImportOptions
+	EnableXattr               bool             // Use xattr for _sync
+	LocalDocExpirySecs        uint32           // The _local doc expiry time in seconds
+	SecureCookieOverride      bool             // Pass-through DBConfig.SecureCookieOverride
+	SessionCookieName         string           // Pass-through DbConfig.SessionCookieName
+	SessionCookieHttpOnly     bool             // Pass-through DbConfig.SessionCookieHTTPOnly
+	AllowConflicts            *bool            // False forbids creating conflicts
+	SendWWWAuthenticateHeader *bool            // False disables setting of 'WWW-Authenticate' header
+	UseViews                  bool             // Force use of views
+	DeltaSyncOptions          DeltaSyncOptions // Delta Sync Options
+	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
+	SGReplicateOptions        SGReplicateOptions
+}
+
+type SGReplicateOptions struct {
+	Enabled               bool          // Whether this node can be assigned sg-replicate replications
+	WebsocketPingInterval time.Duration // BLIP Websocket Ping interval (for active replicators)
 }
 
 type OidcTestProviderOptions struct {
@@ -307,7 +312,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	importEnabled := dbContext.UseXattrs() && dbContext.autoImport
-	sgReplicateEnabled := dbContext.Options.SgReplicateEnabled
+	sgReplicateEnabled := dbContext.Options.SGReplicateOptions.Enabled
 
 	// Initialize node heartbeater if sg-replicate or import enabled on the node
 	if importEnabled || sgReplicateEnabled {

--- a/db/database.go
+++ b/db/database.go
@@ -106,25 +106,26 @@ type DatabaseContext struct {
 }
 
 type DatabaseContextOptions struct {
-	CacheOptions              *CacheOptions
-	RevisionCacheOptions      *RevisionCacheOptions
-	OldRevExpirySeconds       uint32
-	AdminInterface            *string
-	UnsupportedOptions        UnsupportedOptions
-	OIDCOptions               *auth.OIDCOptions
-	DBOnlineCallback          DBOnlineCallback // Callback function to take the DB back online
-	ImportOptions             ImportOptions
-	EnableXattr               bool             // Use xattr for _sync
-	LocalDocExpirySecs        uint32           // The _local doc expiry time in seconds
-	SecureCookieOverride      bool             // Pass-through DBConfig.SecureCookieOverride
-	SessionCookieName         string           // Pass-through DbConfig.SessionCookieName
-	SessionCookieHttpOnly     bool             // Pass-through DbConfig.SessionCookieHTTPOnly
-	AllowConflicts            *bool            // False forbids creating conflicts
-	SendWWWAuthenticateHeader *bool            // False disables setting of 'WWW-Authenticate' header
-	UseViews                  bool             // Force use of views
-	DeltaSyncOptions          DeltaSyncOptions // Delta Sync Options
-	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
-	SgReplicateEnabled        bool             // Whether this node can be assigned sg-replicate replications
+	CacheOptions                 *CacheOptions
+	RevisionCacheOptions         *RevisionCacheOptions
+	OldRevExpirySeconds          uint32
+	AdminInterface               *string
+	UnsupportedOptions           UnsupportedOptions
+	OIDCOptions                  *auth.OIDCOptions
+	DBOnlineCallback             DBOnlineCallback // Callback function to take the DB back online
+	ImportOptions                ImportOptions
+	EnableXattr                  bool             // Use xattr for _sync
+	LocalDocExpirySecs           uint32           // The _local doc expiry time in seconds
+	SecureCookieOverride         bool             // Pass-through DBConfig.SecureCookieOverride
+	SessionCookieName            string           // Pass-through DbConfig.SessionCookieName
+	SessionCookieHttpOnly        bool             // Pass-through DbConfig.SessionCookieHTTPOnly
+	AllowConflicts               *bool            // False forbids creating conflicts
+	SendWWWAuthenticateHeader    *bool            // False disables setting of 'WWW-Authenticate' header
+	UseViews                     bool             // Force use of views
+	DeltaSyncOptions             DeltaSyncOptions // Delta Sync Options
+	CompactInterval              uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
+	SgReplicateEnabled           bool             // Whether this node can be assigned sg-replicate replications
+	ActiveReplicatorPingInterval time.Duration    // BLIP Websocket Ping interval (for active replicators)
 }
 
 type OidcTestProviderOptions struct {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -366,7 +366,7 @@ func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicato
 		return nil, err
 	}
 
-	rc.WebsocketPingInterval = m.dbContext.Options.ActiveReplicatorPingInterval
+	rc.WebsocketPingInterval = m.dbContext.Options.SGReplicateOptions.WebsocketPingInterval
 
 	// TODO: review whether there's a more appropriate context to use here
 	replicator, err = NewActiveReplicator(rc)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -366,6 +366,8 @@ func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicato
 		return nil, err
 	}
 
+	rc.WebsocketPingInterval = m.dbContext.Options.ActiveReplicatorPingInterval
+
 	// TODO: review whether there's a more appropriate context to use here
 	replicator, err = NewActiveReplicator(context.Background(), rc)
 	if err != nil {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -369,7 +369,7 @@ func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicato
 	rc.WebsocketPingInterval = m.dbContext.Options.ActiveReplicatorPingInterval
 
 	// TODO: review whether there's a more appropriate context to use here
-	replicator, err = NewActiveReplicator(context.Background(), rc)
+	replicator, err = NewActiveReplicator(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="2bf53fab0c9b2f40be76ca61789620c8786ec904"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="f592f79219d62d53030e8832e0bd952ed0766e07"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="c3e3ff50deec093b64208e20786335f7597b2916"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="2bf53fab0c9b2f40be76ca61789620c8786ec904"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="ae070d43a6ec6dd8fb9ecfa7108c9fc811f22220"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="c3e3ff50deec093b64208e20786335f7597b2916"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="35c8cc6e82d381dca20ced33518807ac10735267"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="90436f91d5b8d3e2a988df91a138e59f69dad78c"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="f592f79219d62d53030e8832e0bd952ed0766e07"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="35c8cc6e82d381dca20ced33518807ac10735267"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -61,43 +62,46 @@ const (
 
 	// Default number of index replicas
 	DefaultNumIndexReplicas = uint(1)
+
+	DefaultActiveReplicatorPingInterval = time.Minute * 5
 )
 
 // JSON object that defines the server configuration.
 type ServerConfig struct {
-	TLSMinVersion              *string                  `json:"tls_minimum_version,omitempty"`    // Set TLS Version
-	Interface                  *string                  `json:",omitempty"`                       // Interface to bind REST API to, default ":4984"
-	SSLCert                    *string                  `json:",omitempty"`                       // Path to SSL cert file, or nil
-	SSLKey                     *string                  `json:",omitempty"`                       // Path to SSL private key file, or nil
-	ServerReadTimeout          *int                     `json:",omitempty"`                       // maximum duration.Second before timing out read of the HTTP(S) request
-	ServerWriteTimeout         *int                     `json:",omitempty"`                       // maximum duration.Second before timing out write of the HTTP(S) response
-	ReadHeaderTimeout          *int                     `json:",omitempty"`                       // The amount of time allowed to read request headers.
-	IdleTimeout                *int                     `json:",omitempty"`                       // The maximum amount of time to wait for the next request when keep-alives are enabled.
-	AdminInterface             *string                  `json:",omitempty"`                       // Interface to bind admin API to, default "localhost:4985"
-	AdminUI                    *string                  `json:",omitempty"`                       // Path to Admin HTML page, if omitted uses bundled HTML
-	ProfileInterface           *string                  `json:",omitempty"`                       // Interface to bind Go profile API to (no default)
-	ConfigServer               *string                  `json:",omitempty"`                       // URL of config server (for dynamic db discovery)
-	Facebook                   *FacebookConfig          `json:",omitempty"`                       // Configuration for Facebook validation
-	Google                     *GoogleConfig            `json:",omitempty"`                       // Configuration for Google validation
-	CORS                       *CORSConfig              `json:",omitempty"`                       // Configuration for allowing CORS
-	DeprecatedLog              []string                 `json:"log,omitempty"`                    // Log keywords to enable
-	DeprecatedLogFilePath      *string                  `json:"logFilePath,omitempty"`            // Path to log file, if missing write to stderr
-	Logging                    *base.LoggingConfig      `json:",omitempty"`                       // Configuration for logging with optional log file rotation
-	Pretty                     bool                     `json:",omitempty"`                       // Pretty-print JSON responses?
-	DeploymentID               *string                  `json:",omitempty"`                       // Optional customer/deployment ID for stats reporting
-	StatsReportInterval        *float64                 `json:",omitempty"`                       // Optional stats report interval (0 to disable)
-	CouchbaseKeepaliveInterval *int                     `json:",omitempty"`                       // TCP keep-alive interval between SG and Couchbase server
-	SlowQueryWarningThreshold  *int                     `json:",omitempty"`                       // Log warnings if N1QL queries take this many ms
-	MaxIncomingConnections     *int                     `json:",omitempty"`                       // Max # of incoming HTTP connections to accept
-	MaxFileDescriptors         *uint64                  `json:",omitempty"`                       // Max # of open file descriptors (RLIMIT_NOFILE)
-	CompressResponses          *bool                    `json:",omitempty"`                       // If false, disables compression of HTTP responses
-	Databases                  DbConfigMap              `json:",omitempty"`                       // Pre-configured databases, mapped by name
-	Replications               []*ReplicateV1Config     `json:",omitempty"`                       // sg-replicate replication definitions
-	MaxHeartbeat               uint64                   `json:",omitempty"`                       // Max heartbeat value for _changes request (seconds)
-	ClusterConfig              *ClusterConfig           `json:"cluster_config,omitempty"`         // Bucket and other config related to CBGT
-	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`            // Config for unsupported features
-	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"` // BLIP data compression level (0-9)
-	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`            // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
+	TLSMinVersion                *string                  `json:"tls_minimum_version,omitempty"`              // Set TLS Version
+	Interface                    *string                  `json:",omitempty"`                                 // Interface to bind REST API to, default ":4984"
+	SSLCert                      *string                  `json:",omitempty"`                                 // Path to SSL cert file, or nil
+	SSLKey                       *string                  `json:",omitempty"`                                 // Path to SSL private key file, or nil
+	ServerReadTimeout            *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out read of the HTTP(S) request
+	ServerWriteTimeout           *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out write of the HTTP(S) response
+	ReadHeaderTimeout            *int                     `json:",omitempty"`                                 // The amount of time allowed to read request headers.
+	IdleTimeout                  *int                     `json:",omitempty"`                                 // The maximum amount of time to wait for the next request when keep-alives are enabled.
+	AdminInterface               *string                  `json:",omitempty"`                                 // Interface to bind admin API to, default "localhost:4985"
+	AdminUI                      *string                  `json:",omitempty"`                                 // Path to Admin HTML page, if omitted uses bundled HTML
+	ProfileInterface             *string                  `json:",omitempty"`                                 // Interface to bind Go profile API to (no default)
+	ConfigServer                 *string                  `json:",omitempty"`                                 // URL of config server (for dynamic db discovery)
+	Facebook                     *FacebookConfig          `json:",omitempty"`                                 // Configuration for Facebook validation
+	Google                       *GoogleConfig            `json:",omitempty"`                                 // Configuration for Google validation
+	CORS                         *CORSConfig              `json:",omitempty"`                                 // Configuration for allowing CORS
+	DeprecatedLog                []string                 `json:"log,omitempty"`                              // Log keywords to enable
+	DeprecatedLogFilePath        *string                  `json:"logFilePath,omitempty"`                      // Path to log file, if missing write to stderr
+	Logging                      *base.LoggingConfig      `json:",omitempty"`                                 // Configuration for logging with optional log file rotation
+	Pretty                       bool                     `json:",omitempty"`                                 // Pretty-print JSON responses?
+	DeploymentID                 *string                  `json:",omitempty"`                                 // Optional customer/deployment ID for stats reporting
+	StatsReportInterval          *float64                 `json:",omitempty"`                                 // Optional stats report interval (0 to disable)
+	CouchbaseKeepaliveInterval   *int                     `json:",omitempty"`                                 // TCP keep-alive interval between SG and Couchbase server
+	SlowQueryWarningThreshold    *int                     `json:",omitempty"`                                 // Log warnings if N1QL queries take this many ms
+	MaxIncomingConnections       *int                     `json:",omitempty"`                                 // Max # of incoming HTTP connections to accept
+	MaxFileDescriptors           *uint64                  `json:",omitempty"`                                 // Max # of open file descriptors (RLIMIT_NOFILE)
+	CompressResponses            *bool                    `json:",omitempty"`                                 // If false, disables compression of HTTP responses
+	Databases                    DbConfigMap              `json:",omitempty"`                                 // Pre-configured databases, mapped by name
+	Replications                 []*ReplicateV1Config     `json:",omitempty"`                                 // sg-replicate replication definitions
+	MaxHeartbeat                 uint64                   `json:",omitempty"`                                 // Max heartbeat value for _changes request (seconds)
+	ClusterConfig                *ClusterConfig           `json:"cluster_config,omitempty"`                   // Bucket and other config related to CBGT
+	Unsupported                  *UnsupportedServerConfig `json:"unsupported,omitempty"`                      // Config for unsupported features
+	ReplicatorCompression        *int                     `json:"replicator_compression,omitempty"`           // BLIP data compression level (0-9)
+	ActiveReplicatorPingInterval *int                     `json:"replicator_ping_interval_seconds,omitempty"` // Websocket Ping interval (for active replicators). Defaults to 5 minutes. Set to 0 to disable pings.
+	BcryptCost                   int                      `json:"bcrypt_cost,omitempty"`                      // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
 }
 
 // Bucket configuration elements - used by db, index

--- a/rest/config.go
+++ b/rest/config.go
@@ -66,40 +66,39 @@ const (
 
 // JSON object that defines the server configuration.
 type ServerConfig struct {
-	TLSMinVersion                *string                  `json:"tls_minimum_version,omitempty"`              // Set TLS Version
-	Interface                    *string                  `json:",omitempty"`                                 // Interface to bind REST API to, default ":4984"
-	SSLCert                      *string                  `json:",omitempty"`                                 // Path to SSL cert file, or nil
-	SSLKey                       *string                  `json:",omitempty"`                                 // Path to SSL private key file, or nil
-	ServerReadTimeout            *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out read of the HTTP(S) request
-	ServerWriteTimeout           *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out write of the HTTP(S) response
-	ReadHeaderTimeout            *int                     `json:",omitempty"`                                 // The amount of time allowed to read request headers.
-	IdleTimeout                  *int                     `json:",omitempty"`                                 // The maximum amount of time to wait for the next request when keep-alives are enabled.
-	AdminInterface               *string                  `json:",omitempty"`                                 // Interface to bind admin API to, default "localhost:4985"
-	AdminUI                      *string                  `json:",omitempty"`                                 // Path to Admin HTML page, if omitted uses bundled HTML
-	ProfileInterface             *string                  `json:",omitempty"`                                 // Interface to bind Go profile API to (no default)
-	ConfigServer                 *string                  `json:",omitempty"`                                 // URL of config server (for dynamic db discovery)
-	Facebook                     *FacebookConfig          `json:",omitempty"`                                 // Configuration for Facebook validation
-	Google                       *GoogleConfig            `json:",omitempty"`                                 // Configuration for Google validation
-	CORS                         *CORSConfig              `json:",omitempty"`                                 // Configuration for allowing CORS
-	DeprecatedLog                []string                 `json:"log,omitempty"`                              // Log keywords to enable
-	DeprecatedLogFilePath        *string                  `json:"logFilePath,omitempty"`                      // Path to log file, if missing write to stderr
-	Logging                      *base.LoggingConfig      `json:",omitempty"`                                 // Configuration for logging with optional log file rotation
-	Pretty                       bool                     `json:",omitempty"`                                 // Pretty-print JSON responses?
-	DeploymentID                 *string                  `json:",omitempty"`                                 // Optional customer/deployment ID for stats reporting
-	StatsReportInterval          *float64                 `json:",omitempty"`                                 // Optional stats report interval (0 to disable)
-	CouchbaseKeepaliveInterval   *int                     `json:",omitempty"`                                 // TCP keep-alive interval between SG and Couchbase server
-	SlowQueryWarningThreshold    *int                     `json:",omitempty"`                                 // Log warnings if N1QL queries take this many ms
-	MaxIncomingConnections       *int                     `json:",omitempty"`                                 // Max # of incoming HTTP connections to accept
-	MaxFileDescriptors           *uint64                  `json:",omitempty"`                                 // Max # of open file descriptors (RLIMIT_NOFILE)
-	CompressResponses            *bool                    `json:",omitempty"`                                 // If false, disables compression of HTTP responses
-	Databases                    DbConfigMap              `json:",omitempty"`                                 // Pre-configured databases, mapped by name
-	Replications                 []*ReplicateV1Config     `json:",omitempty"`                                 // sg-replicate replication definitions
-	MaxHeartbeat                 uint64                   `json:",omitempty"`                                 // Max heartbeat value for _changes request (seconds)
-	ClusterConfig                *ClusterConfig           `json:"cluster_config,omitempty"`                   // Bucket and other config related to CBGT
-	Unsupported                  *UnsupportedServerConfig `json:"unsupported,omitempty"`                      // Config for unsupported features
-	ReplicatorCompression        *int                     `json:"replicator_compression,omitempty"`           // BLIP data compression level (0-9)
-	ActiveReplicatorPingInterval *int                     `json:"replicator_ping_interval_seconds,omitempty"` // Websocket Ping interval (for active replicators). Defaults to 5 minutes. Set to 0 to disable pings.
-	BcryptCost                   int                      `json:"bcrypt_cost,omitempty"`                      // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
+	TLSMinVersion              *string                  `json:"tls_minimum_version,omitempty"`    // Set TLS Version
+	Interface                  *string                  `json:",omitempty"`                       // Interface to bind REST API to, default ":4984"
+	SSLCert                    *string                  `json:",omitempty"`                       // Path to SSL cert file, or nil
+	SSLKey                     *string                  `json:",omitempty"`                       // Path to SSL private key file, or nil
+	ServerReadTimeout          *int                     `json:",omitempty"`                       // maximum duration.Second before timing out read of the HTTP(S) request
+	ServerWriteTimeout         *int                     `json:",omitempty"`                       // maximum duration.Second before timing out write of the HTTP(S) response
+	ReadHeaderTimeout          *int                     `json:",omitempty"`                       // The amount of time allowed to read request headers.
+	IdleTimeout                *int                     `json:",omitempty"`                       // The maximum amount of time to wait for the next request when keep-alives are enabled.
+	AdminInterface             *string                  `json:",omitempty"`                       // Interface to bind admin API to, default "localhost:4985"
+	AdminUI                    *string                  `json:",omitempty"`                       // Path to Admin HTML page, if omitted uses bundled HTML
+	ProfileInterface           *string                  `json:",omitempty"`                       // Interface to bind Go profile API to (no default)
+	ConfigServer               *string                  `json:",omitempty"`                       // URL of config server (for dynamic db discovery)
+	Facebook                   *FacebookConfig          `json:",omitempty"`                       // Configuration for Facebook validation
+	Google                     *GoogleConfig            `json:",omitempty"`                       // Configuration for Google validation
+	CORS                       *CORSConfig              `json:",omitempty"`                       // Configuration for allowing CORS
+	DeprecatedLog              []string                 `json:"log,omitempty"`                    // Log keywords to enable
+	DeprecatedLogFilePath      *string                  `json:"logFilePath,omitempty"`            // Path to log file, if missing write to stderr
+	Logging                    *base.LoggingConfig      `json:",omitempty"`                       // Configuration for logging with optional log file rotation
+	Pretty                     bool                     `json:",omitempty"`                       // Pretty-print JSON responses?
+	DeploymentID               *string                  `json:",omitempty"`                       // Optional customer/deployment ID for stats reporting
+	StatsReportInterval        *float64                 `json:",omitempty"`                       // Optional stats report interval (0 to disable)
+	CouchbaseKeepaliveInterval *int                     `json:",omitempty"`                       // TCP keep-alive interval between SG and Couchbase server
+	SlowQueryWarningThreshold  *int                     `json:",omitempty"`                       // Log warnings if N1QL queries take this many ms
+	MaxIncomingConnections     *int                     `json:",omitempty"`                       // Max # of incoming HTTP connections to accept
+	MaxFileDescriptors         *uint64                  `json:",omitempty"`                       // Max # of open file descriptors (RLIMIT_NOFILE)
+	CompressResponses          *bool                    `json:",omitempty"`                       // If false, disables compression of HTTP responses
+	Databases                  DbConfigMap              `json:",omitempty"`                       // Pre-configured databases, mapped by name
+	Replications               []*ReplicateV1Config     `json:",omitempty"`                       // sg-replicate replication definitions
+	MaxHeartbeat               uint64                   `json:",omitempty"`                       // Max heartbeat value for _changes request (seconds)
+	ClusterConfig              *ClusterConfig           `json:"cluster_config,omitempty"`         // Bucket and other config related to CBGT
+	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`            // Config for unsupported features
+	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"` // BLIP data compression level (0-9)
+	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`            // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
 }
 
 // Bucket configuration elements - used by db, index

--- a/rest/config.go
+++ b/rest/config.go
@@ -25,7 +25,6 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -166,41 +165,41 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                             string                           `json:"name,omitempty"`                                    // Database name in REST API (stored as key in JSON)
-	Sync                             *string                          `json:"sync,omitempty"`                                    // Sync function defines which users can see which data
-	Users                            map[string]*db.PrincipalConfig   `json:"users,omitempty"`                                   // Initial user accounts
-	Roles                            map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                                   // Initial roles
-	RevsLimit                        *uint32                          `json:"revs_limit,omitempty"`                              // Max depth a document's revision tree can grow to
-	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                             // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
-	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                       // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
-	ImportFilter                     *string                          `json:"import_filter,omitempty"`                           // Filter function (import)
-	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                             // Whether import should attempt to create a temporary backup of the previous revision body, when available.
-	EventHandlers                    interface{}                      `json:"event_handlers,omitempty"`                          // Event handlers (webhook)
-	FeedType                         string                           `json:"feed_type,omitempty"`                               // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                    // Allow empty passwords?  Defaults to false
-	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                                   // Cache settings
-	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                          // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
-	StartOffline                     bool                             `json:"offline,omitempty"`                                 // start the DB in the offline state, defaults to false
-	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                             // Config for unsupported features
-	Deprecated                       DeprecatedOptions                `json:"deprecated,omitempty"`                              // Config for Deprecated features
-	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                    // Config properties for OpenID Connect authentication
-	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`                  // The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs             *uint32                          `json:"view_query_timeout_secs,omitempty"`                 // The view query timeout in seconds
-	LocalDocExpirySecs               *uint32                          `json:"local_doc_expiry_secs,omitempty"`                   // The _local doc expiry time in seconds
-	EnableXattrs                     *bool                            `json:"enable_shared_bucket_access,omitempty"`             // Whether to use extended attributes to store _sync metadata
-	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`                   // Override cookie secure flag
-	SessionCookieName                string                           `json:"session_cookie_name"`                               // Custom per-database session cookie name
-	SessionCookieHTTPOnly            bool                             `json:"session_cookie_http_only"`                          // HTTP only cookies
-	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                         // False forbids creating conflicts
-	NumIndexReplicas                 *uint                            `json:"num_index_replicas"`                                // Number of GSI index replicas used for core indexes
-	UseViews                         bool                             `json:"use_views"`                                         // Force use of views instead of GSI
-	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`            // If false, disables setting of 'WWW-Authenticate' header in 401 responses
-	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                    // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                              // Config for delta sync
-	CompactIntervalDays              *float32                         `json:"compact_interval_days,omitempty"`                   // Interval between scheduled compaction runs (in days) - 0 means don't run
-	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                     // When false, node will not be assigned replications
-	SGReplicateWebsocketPingInterval *time.Duration                   `json:"sgreplicate_websocket_heartbeat_seconds,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
-	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                            // sg-replicate replication definitions
+	Name                             string                           `json:"name,omitempty"`                                 // Database name in REST API (stored as key in JSON)
+	Sync                             *string                          `json:"sync,omitempty"`                                 // Sync function defines which users can see which data
+	Users                            map[string]*db.PrincipalConfig   `json:"users,omitempty"`                                // Initial user accounts
+	Roles                            map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                                // Initial roles
+	RevsLimit                        *uint32                          `json:"revs_limit,omitempty"`                           // Max depth a document's revision tree can grow to
+	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                          // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
+	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                    // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
+	ImportFilter                     *string                          `json:"import_filter,omitempty"`                        // Filter function (import)
+	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                          // Whether import should attempt to create a temporary backup of the previous revision body, when available.
+	EventHandlers                    interface{}                      `json:"event_handlers,omitempty"`                       // Event handlers (webhook)
+	FeedType                         string                           `json:"feed_type,omitempty"`                            // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                 // Allow empty passwords?  Defaults to false
+	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                                // Cache settings
+	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                       // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
+	StartOffline                     bool                             `json:"offline,omitempty"`                              // start the DB in the offline state, defaults to false
+	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                          // Config for unsupported features
+	Deprecated                       DeprecatedOptions                `json:"deprecated,omitempty"`                           // Config for Deprecated features
+	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                 // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`               // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs             *uint32                          `json:"view_query_timeout_secs,omitempty"`              // The view query timeout in seconds
+	LocalDocExpirySecs               *uint32                          `json:"local_doc_expiry_secs,omitempty"`                // The _local doc expiry time in seconds
+	EnableXattrs                     *bool                            `json:"enable_shared_bucket_access,omitempty"`          // Whether to use extended attributes to store _sync metadata
+	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`                // Override cookie secure flag
+	SessionCookieName                string                           `json:"session_cookie_name"`                            // Custom per-database session cookie name
+	SessionCookieHTTPOnly            bool                             `json:"session_cookie_http_only"`                       // HTTP only cookies
+	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                      // False forbids creating conflicts
+	NumIndexReplicas                 *uint                            `json:"num_index_replicas"`                             // Number of GSI index replicas used for core indexes
+	UseViews                         bool                             `json:"use_views"`                                      // Force use of views instead of GSI
+	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                 // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                           // Config for delta sync
+	CompactIntervalDays              *float32                         `json:"compact_interval_days,omitempty"`                // Interval between scheduled compaction runs (in days) - 0 means don't run
+	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                  // When false, node will not be assigned replications
+	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
+	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -167,41 +167,41 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                             string                           `json:"name,omitempty"`                                // Database name in REST API (stored as key in JSON)
-	Sync                             *string                          `json:"sync,omitempty"`                                // Sync function defines which users can see which data
-	Users                            map[string]*db.PrincipalConfig   `json:"users,omitempty"`                               // Initial user accounts
-	Roles                            map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                               // Initial roles
-	RevsLimit                        *uint32                          `json:"revs_limit,omitempty"`                          // Max depth a document's revision tree can grow to
-	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                         // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
-	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                   // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
-	ImportFilter                     *string                          `json:"import_filter,omitempty"`                       // Filter function (import)
-	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                         // Whether import should attempt to create a temporary backup of the previous revision body, when available.
-	EventHandlers                    interface{}                      `json:"event_handlers,omitempty"`                      // Event handlers (webhook)
-	FeedType                         string                           `json:"feed_type,omitempty"`                           // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                // Allow empty passwords?  Defaults to false
-	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                               // Cache settings
-	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                      // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
-	StartOffline                     bool                             `json:"offline,omitempty"`                             // start the DB in the offline state, defaults to false
-	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                         // Config for unsupported features
-	Deprecated                       DeprecatedOptions                `json:"deprecated,omitempty"`                          // Config for Deprecated features
-	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                // Config properties for OpenID Connect authentication
-	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`              // The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs             *uint32                          `json:"view_query_timeout_secs,omitempty"`             // The view query timeout in seconds
-	LocalDocExpirySecs               *uint32                          `json:"local_doc_expiry_secs,omitempty"`               // The _local doc expiry time in seconds
-	EnableXattrs                     *bool                            `json:"enable_shared_bucket_access,omitempty"`         // Whether to use extended attributes to store _sync metadata
-	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`               // Override cookie secure flag
-	SessionCookieName                string                           `json:"session_cookie_name"`                           // Custom per-database session cookie name
-	SessionCookieHTTPOnly            bool                             `json:"session_cookie_http_only"`                      // HTTP only cookies
-	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                     // False forbids creating conflicts
-	NumIndexReplicas                 *uint                            `json:"num_index_replicas"`                            // Number of GSI index replicas used for core indexes
-	UseViews                         bool                             `json:"use_views"`                                     // Force use of views instead of GSI
-	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`        // If false, disables setting of 'WWW-Authenticate' header in 401 responses
-	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                          // Config for delta sync
-	CompactIntervalDays              *float32                         `json:"compact_interval_days,omitempty"`               // Interval between scheduled compaction runs (in days) - 0 means don't run
-	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                 // When false, node will not be assigned replications
-	SGReplicateWebsocketPingInterval *time.Duration                   `json:"sgreplicate_websocket_ping_interval,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
-	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                        // sg-replicate replication definitions
+	Name                             string                           `json:"name,omitempty"`                                    // Database name in REST API (stored as key in JSON)
+	Sync                             *string                          `json:"sync,omitempty"`                                    // Sync function defines which users can see which data
+	Users                            map[string]*db.PrincipalConfig   `json:"users,omitempty"`                                   // Initial user accounts
+	Roles                            map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                                   // Initial roles
+	RevsLimit                        *uint32                          `json:"revs_limit,omitempty"`                              // Max depth a document's revision tree can grow to
+	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                             // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
+	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                       // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
+	ImportFilter                     *string                          `json:"import_filter,omitempty"`                           // Filter function (import)
+	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                             // Whether import should attempt to create a temporary backup of the previous revision body, when available.
+	EventHandlers                    interface{}                      `json:"event_handlers,omitempty"`                          // Event handlers (webhook)
+	FeedType                         string                           `json:"feed_type,omitempty"`                               // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                    // Allow empty passwords?  Defaults to false
+	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                                   // Cache settings
+	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                          // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
+	StartOffline                     bool                             `json:"offline,omitempty"`                                 // start the DB in the offline state, defaults to false
+	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                             // Config for unsupported features
+	Deprecated                       DeprecatedOptions                `json:"deprecated,omitempty"`                              // Config for Deprecated features
+	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                    // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`                  // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs             *uint32                          `json:"view_query_timeout_secs,omitempty"`                 // The view query timeout in seconds
+	LocalDocExpirySecs               *uint32                          `json:"local_doc_expiry_secs,omitempty"`                   // The _local doc expiry time in seconds
+	EnableXattrs                     *bool                            `json:"enable_shared_bucket_access,omitempty"`             // Whether to use extended attributes to store _sync metadata
+	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`                   // Override cookie secure flag
+	SessionCookieName                string                           `json:"session_cookie_name"`                               // Custom per-database session cookie name
+	SessionCookieHTTPOnly            bool                             `json:"session_cookie_http_only"`                          // HTTP only cookies
+	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                         // False forbids creating conflicts
+	NumIndexReplicas                 *uint                            `json:"num_index_replicas"`                                // Number of GSI index replicas used for core indexes
+	UseViews                         bool                             `json:"use_views"`                                         // Force use of views instead of GSI
+	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`            // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                    // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                              // Config for delta sync
+	CompactIntervalDays              *float32                         `json:"compact_interval_days,omitempty"`                   // Interval between scheduled compaction runs (in days) - 0 means don't run
+	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                     // When false, node will not be assigned replications
+	SGReplicateWebsocketPingInterval *time.Duration                   `json:"sgreplicate_websocket_heartbeat_seconds,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
+	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                            // sg-replicate replication definitions
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -62,8 +62,6 @@ const (
 
 	// Default number of index replicas
 	DefaultNumIndexReplicas = uint(1)
-
-	DefaultActiveReplicatorPingInterval = time.Minute * 5
 )
 
 // JSON object that defines the server configuration.
@@ -169,40 +167,41 @@ func (c ClusterConfig) CBGTEnabled() bool {
 // JSON object that defines a database configuration within the ServerConfig.
 type DbConfig struct {
 	BucketConfig
-	Name                      string                           `json:"name,omitempty"`                         // Database name in REST API (stored as key in JSON)
-	Sync                      *string                          `json:"sync,omitempty"`                         // Sync function defines which users can see which data
-	Users                     map[string]*db.PrincipalConfig   `json:"users,omitempty"`                        // Initial user accounts
-	Roles                     map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                        // Initial roles
-	RevsLimit                 *uint32                          `json:"revs_limit,omitempty"`                   // Max depth a document's revision tree can grow to
-	AutoImport                interface{}                      `json:"import_docs,omitempty"`                  // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
-	ImportPartitions          *uint16                          `json:"import_partitions,omitempty"`            // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
-	ImportFilter              *string                          `json:"import_filter,omitempty"`                // Filter function (import)
-	ImportBackupOldRev        bool                             `json:"import_backup_old_rev"`                  // Whether import should attempt to create a temporary backup of the previous revision body, when available.
-	EventHandlers             interface{}                      `json:"event_handlers,omitempty"`               // Event handlers (webhook)
-	FeedType                  string                           `json:"feed_type,omitempty"`                    // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword        bool                             `json:"allow_empty_password,omitempty"`         // Allow empty passwords?  Defaults to false
-	CacheConfig               *CacheConfig                     `json:"cache,omitempty"`                        // Cache settings
-	DeprecatedRevCacheSize    *uint32                          `json:"rev_cache_size,omitempty"`               // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
-	StartOffline              bool                             `json:"offline,omitempty"`                      // start the DB in the offline state, defaults to false
-	Unsupported               db.UnsupportedOptions            `json:"unsupported,omitempty"`                  // Config for unsupported features
-	Deprecated                DeprecatedOptions                `json:"deprecated,omitempty"`                   // Config for Deprecated features
-	OIDCConfig                *auth.OIDCOptions                `json:"oidc,omitempty"`                         // Config properties for OpenID Connect authentication
-	OldRevExpirySeconds       *uint32                          `json:"old_rev_expiry_seconds,omitempty"`       // The number of seconds before old revs are removed from CBS bucket
-	ViewQueryTimeoutSecs      *uint32                          `json:"view_query_timeout_secs,omitempty"`      // The view query timeout in seconds
-	LocalDocExpirySecs        *uint32                          `json:"local_doc_expiry_secs,omitempty"`        // The _local doc expiry time in seconds
-	EnableXattrs              *bool                            `json:"enable_shared_bucket_access,omitempty"`  // Whether to use extended attributes to store _sync metadata
-	SecureCookieOverride      *bool                            `json:"session_cookie_secure,omitempty"`        // Override cookie secure flag
-	SessionCookieName         string                           `json:"session_cookie_name"`                    // Custom per-database session cookie name
-	SessionCookieHTTPOnly     bool                             `json:"session_cookie_http_only"`               // HTTP only cookies
-	AllowConflicts            *bool                            `json:"allow_conflicts,omitempty"`              // False forbids creating conflicts
-	NumIndexReplicas          *uint                            `json:"num_index_replicas"`                     // Number of GSI index replicas used for core indexes
-	UseViews                  bool                             `json:"use_views"`                              // Force use of views instead of GSI
-	SendWWWAuthenticateHeader *bool                            `json:"send_www_authenticate_header,omitempty"` // If false, disables setting of 'WWW-Authenticate' header in 401 responses
-	BucketOpTimeoutMs         *uint32                          `json:"bucket_op_timeout_ms,omitempty"`         // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	DeltaSync                 *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                   // Config for delta sync
-	CompactIntervalDays       *float32                         `json:"compact_interval_days,omitempty"`        // Interval between scheduled compaction runs (in days) - 0 means don't run
-	SGReplicateEnabled        *bool                            `json:"sgreplicate_enabled,omitempty"`          // When false, node will not be assigned replications
-	Replications              map[string]*db.ReplicationConfig `json:"replications,omitempty"`                 // sg-replicate replication definitions
+	Name                             string                           `json:"name,omitempty"`                                // Database name in REST API (stored as key in JSON)
+	Sync                             *string                          `json:"sync,omitempty"`                                // Sync function defines which users can see which data
+	Users                            map[string]*db.PrincipalConfig   `json:"users,omitempty"`                               // Initial user accounts
+	Roles                            map[string]*db.PrincipalConfig   `json:"roles,omitempty"`                               // Initial roles
+	RevsLimit                        *uint32                          `json:"revs_limit,omitempty"`                          // Max depth a document's revision tree can grow to
+	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                         // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
+	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                   // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
+	ImportFilter                     *string                          `json:"import_filter,omitempty"`                       // Filter function (import)
+	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                         // Whether import should attempt to create a temporary backup of the previous revision body, when available.
+	EventHandlers                    interface{}                      `json:"event_handlers,omitempty"`                      // Event handlers (webhook)
+	FeedType                         string                           `json:"feed_type,omitempty"`                           // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
+	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                // Allow empty passwords?  Defaults to false
+	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                               // Cache settings
+	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                      // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
+	StartOffline                     bool                             `json:"offline,omitempty"`                             // start the DB in the offline state, defaults to false
+	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                         // Config for unsupported features
+	Deprecated                       DeprecatedOptions                `json:"deprecated,omitempty"`                          // Config for Deprecated features
+	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                // Config properties for OpenID Connect authentication
+	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`              // The number of seconds before old revs are removed from CBS bucket
+	ViewQueryTimeoutSecs             *uint32                          `json:"view_query_timeout_secs,omitempty"`             // The view query timeout in seconds
+	LocalDocExpirySecs               *uint32                          `json:"local_doc_expiry_secs,omitempty"`               // The _local doc expiry time in seconds
+	EnableXattrs                     *bool                            `json:"enable_shared_bucket_access,omitempty"`         // Whether to use extended attributes to store _sync metadata
+	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`               // Override cookie secure flag
+	SessionCookieName                string                           `json:"session_cookie_name"`                           // Custom per-database session cookie name
+	SessionCookieHTTPOnly            bool                             `json:"session_cookie_http_only"`                      // HTTP only cookies
+	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                     // False forbids creating conflicts
+	NumIndexReplicas                 *uint                            `json:"num_index_replicas"`                            // Number of GSI index replicas used for core indexes
+	UseViews                         bool                             `json:"use_views"`                                     // Force use of views instead of GSI
+	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`        // If false, disables setting of 'WWW-Authenticate' header in 401 responses
+	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                          // Config for delta sync
+	CompactIntervalDays              *float32                         `json:"compact_interval_days,omitempty"`               // Interval between scheduled compaction runs (in days) - 0 means don't run
+	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                 // When false, node will not be assigned replications
+	SGReplicateWebsocketPingInterval *time.Duration                   `json:"sgreplicate_websocket_ping_interval,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
+	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                        // sg-replicate replication definitions
 }
 
 type DeltaSyncConfig struct {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"context"
 	"expvar"
 	"fmt"
 	"net/http"
@@ -41,7 +40,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
-	ar, err := db.NewActiveReplicator(context.Background(), &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:           t.Name(),
 		Direction:    db.ActiveReplicatorTypePushAndPull,
 		ActiveDB:     &db.Database{DatabaseContext: rt.GetDatabase()},
@@ -101,7 +100,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
-	ar, err := db.NewActiveReplicator(context.Background(), &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:                    t.Name(),
 		Direction:             db.ActiveReplicatorTypePush,
 		ActiveDB:              &db.Database{DatabaseContext: rt.GetDatabase()},
@@ -181,7 +180,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	})
 	defer rt1.Close()
 
-	ar, err := db.NewActiveReplicator(context.Background(), &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:           t.Name(),
 		Direction:    db.ActiveReplicatorTypePull,
 		PassiveDBURL: passiveDBURL,
@@ -282,7 +281,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	ar, err := db.NewActiveReplicator(context.Background(), &arConfig)
+	ar, err := db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
 	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
@@ -334,7 +333,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	ar, err = db.NewActiveReplicator(context.Background(), &arConfig)
+	ar, err = db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Close()) }()
 	assert.NoError(t, ar.Start())
@@ -429,7 +428,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	// Add basic auth creds to target db URL
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
-	ar, err := db.NewActiveReplicator(context.Background(), &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:           t.Name(),
 		Direction:    db.ActiveReplicatorTypePush,
 		PassiveDBURL: passiveDBURL,
@@ -530,7 +529,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	ar, err := db.NewActiveReplicator(context.Background(), &arConfig)
+	ar, err := db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
 	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
@@ -581,7 +580,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	ar, err = db.NewActiveReplicator(context.Background(), &arConfig)
+	ar, err = db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Close()) }()
 	assert.NoError(t, ar.Start())
@@ -677,7 +676,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	})
 	defer rt1.Close()
 
-	ar, err := db.NewActiveReplicator(context.Background(), &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:           t.Name(),
 		Direction:    db.ActiveReplicatorTypePull,
 		PassiveDBURL: passiveDBURL,
@@ -777,7 +776,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	})
 	defer rt1.Close()
 
-	ar, err := db.NewActiveReplicator(context.Background(), &db.ActiveReplicatorConfig{
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:           t.Name(),
 		Direction:    db.ActiveReplicatorTypePull,
 		PassiveDBURL: passiveDBURL,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -629,7 +629,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 
 	sgReplicateWebsocketPingInterval := db.DefaultSGReplicateWebsocketPingInterval
 	if config.SGReplicateWebsocketPingInterval != nil {
-		sgReplicateWebsocketPingInterval = *config.SGReplicateWebsocketPingInterval
+		sgReplicateWebsocketPingInterval = time.Second * time.Duration(*config.SGReplicateWebsocketPingInterval)
 	}
 
 	localDocExpirySecs := base.DefaultLocalDocExpirySecs

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -652,6 +652,13 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		CompactInterval:           compactIntervalSecs,
 		SgReplicateEnabled:        sgReplicateEnabled,
 	}
+
+	if sc.config.ActiveReplicatorPingInterval != nil {
+		contextOptions.ActiveReplicatorPingInterval = time.Duration(*sc.config.ActiveReplicatorPingInterval) * time.Second
+	} else {
+		contextOptions.ActiveReplicatorPingInterval = DefaultActiveReplicatorPingInterval
+	}
+
 	return contextOptions, nil
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -627,6 +627,11 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		sgReplicateEnabled = *config.SGReplicateEnabled
 	}
 
+	sgReplicateWebsocketPingInterval := db.DefaultSGReplicateWebsocketPingInterval
+	if config.SGReplicateWebsocketPingInterval != nil {
+		sgReplicateWebsocketPingInterval = *config.SGReplicateWebsocketPingInterval
+	}
+
 	localDocExpirySecs := base.DefaultLocalDocExpirySecs
 	if config.LocalDocExpirySecs != nil {
 		localDocExpirySecs = *config.LocalDocExpirySecs
@@ -650,13 +655,10 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
-		SgReplicateEnabled:        sgReplicateEnabled,
-	}
-
-	if sc.config.ActiveReplicatorPingInterval != nil {
-		contextOptions.ActiveReplicatorPingInterval = time.Duration(*sc.config.ActiveReplicatorPingInterval) * time.Second
-	} else {
-		contextOptions.ActiveReplicatorPingInterval = DefaultActiveReplicatorPingInterval
+		SGReplicateOptions: db.SGReplicateOptions{
+			Enabled:               sgReplicateEnabled,
+			WebsocketPingInterval: sgReplicateWebsocketPingInterval,
+		},
 	}
 
 	return contextOptions, nil


### PR DESCRIPTION
- [x] Requires https://github.com/couchbase/go-blip/pull/44

Adds a heartbeat mechanism to the ActiveReplicator for idle connections, via websocket ping frames in the go-blip library.
- Defaults to one ping every 5 minutes, to match lite-core's default value.
- Can be set to zero to disable the heartbeats.

Also added in this PR:
- Removed duplicated NewBlipSyncContext previously identified
- Cleaned up context for checkpointer cancellation