### PR TITLE
Fix invalid filter error when SGR2 filter is unset

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -348,7 +348,7 @@ func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicato
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	} else if config.Filter != "" {
 		return nil, fmt.Errorf("Unknown replication filter: %v", config.Filter)
 	}
 


### PR DESCRIPTION
SGR2 fails when running with a config without a filter specified, but more generally, it looks like we're doing some level of config validation in 2 separate areas:

- `StartReplication()`
- `ValidateReplication()`

Need to review whether validation is required in Start, or if we can rely on the ValidateReplication method being called.

```json
      "replications": {
        "repl1": {
          "remote": "http://localhost:4985/db2/",
          "direction": "pushAndPull",
          "continuous": true
        }
      }
```

```
2020-06-26T14:19:51.276+01:00 [INF] Replicate: Starting sg-replicate replications...
2020-06-26T14:19:51.277+01:00 [INF] Replicate: Starting replication repl1 (placeholder)
2020-06-26T14:19:51.277+01:00 [WRN] Unable to start replication repl1: Unknown replication filter:  -- db.(*sgReplicateManager).StartReplications() at sg_replicate_cfg.go:316
2020-06-26T14:19:51.277+01:00 [ERR] Error starting sg-replicate replications: Unknown replication filter:  -- rest.(*ServerContext).PostStartup() at server_context.go:117
```