### PR TITLE
CBG-805: Update test OIDC provider to simulate real-world token

### DIFF
--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -40,7 +40,7 @@ const (
 	formKeyUsername      = "username"
 	formKeyTokenTTL      = "tokenttl"
 	formKeyAuthenticated = "authenticated"
-	formKeyRefreshToken  = "refresh_token"
+	formKeyIdTokenFormat = "identity-token-formats"
 
 	// Headers
 	headerLocation = "Location"
@@ -49,11 +49,24 @@ const (
 type TokenRequestType uint8
 
 const (
-	TokenRequest_AuthCode TokenRequestType = iota
-	TokenRequest_Refresh
+	TokenRequestAuthCode TokenRequestType = iota
+	TokenRequestRefresh
 )
 
 var testProviderAudiences = []string{testProviderAud} // Audiences in array format for test provider validation
+
+// identityTokenFormat represents a specific token format supported by an OpenID Connect provider.
+type identityTokenFormat string
+
+const (
+
+	// defaultFormat represents the common format of ID token supported by most of the providers.
+	defaultFormat identityTokenFormat = "defaultFormat"
+
+	// ibmCloudAppIDFormat represents a specific identity token format supported by IBM Cloud App ID.
+	// It contains a version value and key id in token header in addition to token type and algorithm.
+	ibmCloudAppIDFormat identityTokenFormat = "ibmCloudAppIDFormat"
+)
 
 // This is the HTML template used to display the testing OP internal authentication form
 const loginHtml = `
@@ -87,6 +100,13 @@ const loginHtml = `
    <div>Username:<input type="text" name="username" cols="80"></div>
    <div>ID Token TTL (seconds):<input type="text" name="tokenttl" cols="30" value="3600"></div>
    <div>
+      <label>Identity Token Format:</label>
+      <select id="identity-token-formats" name="identity-token-formats">
+         <option name="identity-token-format" value="defaultFormat" selected="">Default</option>
+         <option name="identity-token-format" value="ibmCloudAppIDFormat">IBM Cloud AppID</option>
+      </select>
+   </div>
+   <div>
    <input type="checkbox" name="offline" value="offlineAccess">Allow Offline Access
    <div>
    <div><input type="submit" name="authenticated" value="Return a valid authorization code for this user"></div>
@@ -100,9 +120,10 @@ type Page struct {
 }
 
 type AuthState struct {
-	CallbackURL string
-	TokenTTL    time.Duration
-	Scopes      map[string]struct{}
+	CallbackURL         string
+	TokenTTL            time.Duration
+	Scopes              map[string]struct{}
+	IdentityTokenFormat identityTokenFormat
 }
 
 var authCodeTokenMap = make(map[string]AuthState)
@@ -132,6 +153,7 @@ func (h *handler) handleOidcProviderConfiguration() error {
 	}
 
 	if bytes, err := base.JSONMarshal(config); err == nil {
+		h.response.Header().Set("Expires", "0")
 		_, _ = h.response.Write(bytes)
 	}
 
@@ -277,12 +299,14 @@ func (h *handler) handleOidcTestProviderAuthenticate() error {
 
 	requestParams := h.getQueryValues()
 	username := h.rq.FormValue(formKeyUsername)
-	tokenttl, err := strconv.Atoi(h.rq.FormValue(formKeyTokenTTL))
+	tokenTtl, err := strconv.Atoi(h.rq.FormValue(formKeyTokenTTL))
+	idTokenFormat := h.rq.FormValue(formKeyIdTokenFormat)
+
 	if err != nil {
-		tokenttl = defaultIdTokenTTL
+		tokenTtl = defaultIdTokenTTL
 	}
 
-	tokenDuration := time.Duration(tokenttl) * time.Second
+	tokenDuration := time.Duration(tokenTtl) * time.Second
 	authenticated := h.rq.FormValue(formKeyAuthenticated)
 	redirectURI := requestParams.Get(requestParamRedirectURI)
 	base.Debugf(base.KeyAuth, "handleOidcTestProviderAuthenticate() called.  username: %s authenticated: %s", username, authenticated)
@@ -300,7 +324,12 @@ func (h *handler) handleOidcTestProviderAuthenticate() error {
 
 	// Generate the return code by base64 encoding the username
 	code := base64.StdEncoding.EncodeToString([]byte(username))
-	authCodeTokenMap[username] = AuthState{CallbackURL: redirectURI, TokenTTL: tokenDuration, Scopes: scopeMap}
+	authCodeTokenMap[username] = AuthState{
+		CallbackURL:         redirectURI,
+		TokenTTL:            tokenDuration,
+		Scopes:              scopeMap,
+		IdentityTokenFormat: identityTokenFormat(idTokenFormat),
+	}
 
 	locationURL, err := url.Parse(redirectURI)
 	if err != nil {
@@ -329,15 +358,25 @@ func scopeStringToMap(scope string) map[string]struct{} {
 }
 
 // Creates a signed JWT for the requesting subject and issuer URL
-func createJWT(subject string, issuerUrl string, ttl time.Duration, scopesMap map[string]struct{}) (token string,
-	err error) {
+func createJWT(subject string, issuerUrl string, authState AuthState) (token string, err error) {
 
 	key, err := privateKey()
 	if err != nil {
 		return "", base.HTTPErrorf(http.StatusInternalServerError, "Error getting private RSA Key: %v", err)
 	}
+	signingKey := jose.SigningKey{
+		Algorithm: jose.RS256,
+		Key:       key,
+	}
+	signerOptions := jose.SignerOptions{}
+	signerOptions.WithType("JWT")
 
-	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
+	if authState.IdentityTokenFormat == ibmCloudAppIDFormat {
+		signerOptions.WithHeader("kid", testProviderKeyIdentifier)
+		signerOptions.WithHeader("ver", 4)
+	}
+	signer, err := jose.NewSigner(signingKey, &signerOptions)
+
 	if err != nil {
 		return "", base.HTTPErrorf(http.StatusInternalServerError, "Error creating signer: %v", err)
 	}
@@ -347,21 +386,21 @@ func createJWT(subject string, issuerUrl string, ttl time.Duration, scopesMap ma
 		Subject:  subject,
 		Issuer:   issuerUrl,
 		IssuedAt: jwt.NewNumericDate(now),
-		Expiry:   jwt.NewNumericDate(now.Add(ttl)),
+		Expiry:   jwt.NewNumericDate(now.Add(authState.TokenTTL)),
 		Audience: jwt.Audience{testProviderAud},
 	}
 
 	var customClaims CustomClaims
 
-	if _, ok := scopesMap["email"]; ok {
+	if _, ok := authState.Scopes["email"]; ok {
 		customClaims.Email = subject + "@syncgatewayoidctesting.com"
 	}
 
-	if _, ok := scopesMap["profile"]; ok {
+	if _, ok := authState.Scopes["profile"]; ok {
 		customClaims.Nickname = "slim jim"
 	}
 
-	token, err = jwt.Signed(sig).Claims(claims).Claims(customClaims).CompactSerialize()
+	token, err = jwt.Signed(signer).Claims(claims).Claims(customClaims).CompactSerialize()
 	if err != nil {
 		return "", err
 	}
@@ -373,9 +412,9 @@ type CustomClaims struct {
 	Nickname string `json:"nickname,omitempty"`
 }
 
-//Generates the issuer URL based on the scheme and host in the client request
-//this should ensure that the testing provider works for local clients and
-//clients in front of a load balancer.
+// Generates the issuer URL based on the scheme and host in the client request
+// this should ensure that the testing provider works for local clients and
+// clients in front of a load balancer.
 func issuerUrl(h *handler) string {
 	return issuerUrlForDB(h, h.db.Name)
 }
@@ -411,22 +450,22 @@ func handleAuthCodeRequest(h *handler) error {
 		return base.HTTPErrorf(http.StatusBadRequest, "OIDC Invalid Auth Token: %v", code)
 	}
 
-	//Check for subject in map of known authenticated users
+	// Check for subject in map of known authenticated users
 	authState, ok := authCodeTokenMap[string(subject)]
 	if !ok {
 		return base.HTTPErrorf(http.StatusBadRequest, "OIDC Invalid Auth Token: %v", code)
 	}
-	return writeTokenResponse(h, string(subject), issuerUrl(h), authState.TokenTTL, authState.Scopes, TokenRequest_AuthCode)
+	return writeTokenResponse(h, string(subject), issuerUrl(h), authState, TokenRequestAuthCode)
 }
 
 func handleRefreshTokenRequest(h *handler) error {
-	//Validate the refresh request
+	// Validate the refresh request
 	refreshToken := h.rq.FormValue("refresh_token")
 
-	//extract the subject from the refresh token
+	// extract the subject from the refresh token
 	subject, err := extractSubjectFromRefreshToken(refreshToken)
 
-	//Check for subject in map of known authenticated users
+	// Check for subject in map of known authenticated users
 	authState, ok := authCodeTokenMap[subject]
 	if !ok {
 		return base.HTTPErrorf(http.StatusBadRequest, "OIDC Invalid Refresh Token: %v", refreshToken)
@@ -435,19 +474,19 @@ func handleRefreshTokenRequest(h *handler) error {
 	if err != nil {
 		return err
 	}
-	return writeTokenResponse(h, subject, issuerUrl(h), authState.TokenTTL, authState.Scopes, TokenRequest_Refresh)
+	return writeTokenResponse(h, subject, issuerUrl(h), authState, TokenRequestRefresh)
 }
 
-func writeTokenResponse(h *handler, subject string, issuerUrl string, tokenttl time.Duration, scopesMap map[string]struct{}, requestType TokenRequestType) error {
+func writeTokenResponse(h *handler, subject string, issuerUrl string, authState AuthState, requestType TokenRequestType) error {
 
 	accessToken := base64.StdEncoding.EncodeToString([]byte(subject))
 
 	var refreshToken string
-	if requestType == TokenRequest_AuthCode {
+	if requestType == TokenRequestAuthCode {
 		refreshToken = base64.StdEncoding.EncodeToString([]byte(subject + ":::" + accessToken))
 	}
 
-	idToken, err := createJWT(subject, issuerUrl, tokenttl, scopesMap)
+	idToken, err := createJWT(subject, issuerUrl, authState)
 	if err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Unable to generate OIDC Auth Token")
 	}
@@ -459,7 +498,7 @@ func writeTokenResponse(h *handler, subject string, issuerUrl string, tokenttl t
 		AccessToken:  accessToken,
 		TokenType:    "Bearer",
 		RefreshToken: refreshToken,
-		ExpiresIn:    int(tokenttl.Seconds()),
+		ExpiresIn:    int(authState.TokenTTL.Seconds()),
 		IdToken:      idToken,
 	}
 

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -5,31 +5,88 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/coreos/go-oidc"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
+type jwtHeader struct {
+	Algorithm string `json:"alg"`
+	KeyID     string `json:"kid"`
+	Type      string `json:"typ"`
+	Version   int    `json:"ver"`
+}
+
 func TestCreateJWTToken(t *testing.T) {
-	subject := "alice"
-	issueURL := "http://localhost:4984/default/_oidc_testing"
-	ttl := 5 * time.Minute
-	scopes := make(map[string]struct{})
-	token, err := createJWT(subject, issueURL, ttl, scopes)
-	assert.NoError(t, err, "Couldn't to create JSON Web Token for OpenID Connect")
-	log.Printf("Token: %s", token)
+	tests := []struct {
+		name           string
+		idTokenFormat  identityTokenFormat
+		headerExpected jwtHeader
+	}{{
+		name:          "create token in default format",
+		idTokenFormat: defaultFormat,
+		headerExpected: jwtHeader{
+			Algorithm: oidc.RS256,
+			Type:      "JWT",
+		},
+	}, {
+		name:          "create token in IBM Cloud App ID format",
+		idTokenFormat: ibmCloudAppIDFormat,
+		headerExpected: jwtHeader{
+			Algorithm: oidc.RS256,
+			KeyID:     testProviderKeyIdentifier,
+			Type:      "JWT",
+			Version:   4,
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subject := "alice"
+			issueURL := "http://localhost:4984/db/_oidc_testing"
+			scopes := make(map[string]struct{})
+			scopes["email"] = struct{}{}
+			scopes["profile"] = struct{}{}
+			authState := AuthState{
+				CallbackURL:         "http://localhost:4984/db/_oidc_callback",
+				TokenTTL:            5 * time.Minute,
+				Scopes:              scopes,
+				IdentityTokenFormat: test.idTokenFormat,
+			}
+			token, err := createJWT(subject, issueURL, authState)
+			assert.NoError(t, err, "Couldn't to create JSON Web Token")
+			assert.NotEmpty(t, token, "Empty token received")
+			tok, err := jwt.ParseSigned(token)
+			require.NoError(t, err, "Error parsing signed token")
+			claims := &jwt.Claims{}
+			customClaims := &CustomClaims{}
+			err = tok.UnsafeClaimsWithoutVerification(claims, customClaims)
+			require.NoError(t, err, "Error parsing signed token")
+			assert.Equal(t, subject, claims.Subject, "Subject mismatch")
+			assert.Equal(t, issueURL, claims.Issuer, "Issuer mismatch")
+			assert.Equal(t, "slim jim", customClaims.Nickname, "Nickname mismatch")
+			assert.Equal(t, subject+"@syncgatewayoidctesting.com", customClaims.Email, "Email mismatch")
+			headerBytes, err := base64.StdEncoding.DecodeString(strings.Split(token, ".")[0])
+			require.NoError(t, err, "Error extracting header from token")
+			var jwtHeaderActual jwtHeader
+			require.NoError(t, json.Unmarshal(headerBytes, &jwtHeaderActual), "Header unmarshal error")
+			require.True(t, reflect.DeepEqual(test.headerExpected, jwtHeaderActual), "Token header mismatch")
+		})
+	}
 }
 
 func TestExtractSubjectFromRefreshToken(t *testing.T) {
@@ -167,6 +224,121 @@ func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
 	bodyString := string(bodyBytes)
 	assert.Contains(t, bodyString, "Unable to obtain client for provider")
 	require.NoError(t, response.Body.Close(), "Error closing response body")
+}
+
+func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
+	tests := []struct {
+		name           string
+		idTokenFormat  identityTokenFormat
+		headerExpected jwtHeader
+	}{{
+		name:          "obtain session with bearer token in default format",
+		idTokenFormat: defaultFormat,
+		headerExpected: jwtHeader{
+			Algorithm: oidc.RS256,
+			Type:      "JWT",
+		},
+	}, {
+		name:          "obtain session with bearer token in IBM Cloud App ID format",
+		idTokenFormat: ibmCloudAppIDFormat,
+		headerExpected: jwtHeader{
+			Algorithm: oidc.RS256,
+			KeyID:     testProviderKeyIdentifier,
+			Type:      "JWT",
+			Version:   4,
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			providers := auth.OIDCProviderMap{
+				"test": &auth.OIDCProvider{
+					Register:      true,
+					Issuer:        "${baseURL}/db/_oidc_testing",
+					Name:          "test",
+					ClientID:      "sync_gateway",
+					ValidationKey: base.StringPtr("qux"),
+					CallbackURL:   base.StringPtr("${baseURL}/db/_oidc_callback"),
+					UserPrefix:    "foo",
+				},
+			}
+			defaultProvider := "test"
+			opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
+			restTesterConfig := RestTesterConfig{
+				DatabaseConfig: &DbConfig{
+					OIDCConfig: &opts,
+					Unsupported: db.UnsupportedOptions{
+						OidcTestProvider: db.OidcTestProviderOptions{
+							Enabled: true,
+						},
+					},
+				}}
+			restTester := NewRestTester(t, &restTesterConfig)
+			restTester.SetAdminParty(false)
+			defer restTester.Close()
+
+			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
+			defer mockSyncGateway.Close()
+			mockSyncGatewayURL := mockSyncGateway.URL
+			provider := restTesterConfig.DatabaseConfig.OIDCConfig.Providers.GetDefaultProvider()
+			provider.Issuer = mockSyncGateway.URL + "/db/_oidc_testing"
+			provider.CallbackURL = base.StringPtr(mockSyncGateway.URL + "/db/_oidc_callback")
+			createUser(t, restTester, "foo_noah")
+
+			// Send OpenID Connect request
+			authURL := "/db/_oidc?provider=test&offline=true"
+			requestURL := mockSyncGatewayURL + authURL
+			request, err := http.NewRequest(http.MethodGet, requestURL, nil)
+			require.NoError(t, err, "Error creating new request")
+			jar, err := cookiejar.New(nil)
+			require.NoError(t, err, "Error creating new cookie jar")
+			client := http.DefaultClient
+			client.Jar = jar
+			response, err := client.Do(request)
+			require.NoError(t, err, "Error sending request")
+			require.Equal(t, http.StatusOK, response.StatusCode)
+			bodyBytes, err := ioutil.ReadAll(response.Body)
+			require.NoError(t, err, "Error reading response")
+			bodyString := string(bodyBytes)
+			require.NoError(t, response.Body.Close(), "Error closing response body")
+
+			// Send authentication request
+			requestURL = mockSyncGateway.URL + "/db/_oidc_testing/" + parseAuthURL(bodyString)
+			form := url.Values{}
+			form.Add(formKeyUsername, "noah")
+			form.Add(formKeyAuthenticated, "Return a valid authorization code for this user")
+			form.Add(formKeyIdTokenFormat, string(test.idTokenFormat))
+			request, err = http.NewRequest(http.MethodPost, requestURL, bytes.NewBufferString(form.Encode()))
+			require.NoError(t, err, "Error creating new request")
+			request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			response, err = client.Do(request)
+			require.NoError(t, err, "Error sending request")
+			require.Equal(t, http.StatusOK, response.StatusCode)
+
+			var authResponseActual OIDCTokenResponse
+			require.NoError(t, err, json.NewDecoder(response.Body).Decode(&authResponseActual))
+			require.NoError(t, response.Body.Close(), "Error closing response body")
+			assert.NotEmpty(t, authResponseActual.SessionID, "session_id doesn't exist")
+			assert.NotEmpty(t, authResponseActual.Username, "session_id doesn't exist")
+			assert.NotEmpty(t, authResponseActual.IDToken, "id_token mismatch")
+			assert.NotEmpty(t, authResponseActual.RefreshToken, "refresh_token mismatch")
+
+			// Check token header
+			headerBytes, err := base64.StdEncoding.DecodeString(strings.Split(authResponseActual.IDToken, ".")[0])
+			require.NoError(t, err, "Error extracting header from token")
+			var jwtHeaderActual jwtHeader
+			require.NoError(t, json.Unmarshal(headerBytes, &jwtHeaderActual), "Header unmarshal error")
+			require.True(t, reflect.DeepEqual(test.headerExpected, jwtHeaderActual), "Token header mismatch")
+
+			// Obtain session with Bearer token
+			sessionEndpoint := mockSyncGatewayURL + "/" + restTester.DatabaseConfig.Name + "/_session"
+			request, err = http.NewRequest(http.MethodPost, sessionEndpoint, strings.NewReader(`{}`))
+			require.NoError(t, err, "Error creating new request")
+			request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
+			response, err = http.DefaultClient.Do(request)
+			require.NoError(t, err, "Error sending request with bearer token")
+			checkGoodAuthResponse(t, response)
+		})
+	}
 }
 
 // parseAuthURL returns the authentication URL extracted from user consent form.


### PR DESCRIPTION
- Provide an option for selecting JWT format in the user consent screen.
- Modify the token creation logic a bit to accept the format and create token based on that format.
- Additional unit test cases to cover the real world token format.
- Provide a default token format supported by most of the OpenID Connect providers.
- Provide token format of IBM Cloud App ID.
