### PR TITLE
CBG-785 SGR2 conflict resolution

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -114,7 +114,6 @@ func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.
 	bsc.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
 		base.LogContext{CorrelationID: config.ID + idSuffix},
 	)
-	bsc.conflictResolver = config.ConflictResolver
 
 	blipSender, err = blipSync(*config.PassiveDBURL, blipContext)
 	if err != nil {

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -114,6 +114,7 @@ func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.
 	bsc.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
 		base.LogContext{CorrelationID: config.ID + idSuffix},
 	)
+	bsc.conflictResolver = config.ConflictResolver
 
 	blipSender, err = blipSync(*config.PassiveDBURL, blipContext)
 	if err != nil {

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -54,6 +54,8 @@ type ActiveReplicatorConfig struct {
 	ActiveDB *Database
 	// WebsocketPingInterval is the time between websocket heartbeats sent by the active replicator.
 	WebsocketPingInterval time.Duration
+	// Conflict resolver function
+	ConflictResolver ConflictResolverFunc
 }
 
 // CheckpointHash returns a deterministic hash of the given config to be used as a checkpoint ID.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -34,6 +34,7 @@ func (apr *ActivePullReplicator) Start() error {
 	}
 
 	var err error
+
 	apr.blipSender, apr.blipSyncContext, err = connect("-pull", apr.config)
 	if err != nil {
 		return err

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -40,6 +40,7 @@ func (apr *ActivePullReplicator) Start() error {
 		return err
 	}
 
+	apr.blipSyncContext.conflictResolver = apr.config.ConflictResolver
 	apr.blipSyncContext.purgeOnRemoval = apr.config.PurgeOnRemoval
 
 	if err := apr.initCheckpointer(); err != nil {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -40,6 +40,10 @@ func (apr *ActivePushReplicator) Start() error {
 		return err
 	}
 
+	// TODO: If this were made a config option, and the default conflict resolver not enforced on
+	// 	the pull side, it would be feasible to run sgr-2 in 'manual conflict resolution' mode
+	apr.blipSyncContext.sendRevNoConflicts = true
+
 	if err := apr.initCheckpointer(); err != nil {
 		return err
 	}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -718,14 +718,6 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	return nil
 }
 
-func isConflictError(err error) bool {
-	httpError, ok := err.(*base.HTTPError)
-	if ok && httpError.Status == http.StatusConflict {
-		return true
-	}
-	return false
-}
-
 //////// ATTACHMENTS:
 
 // Received a "getAttachment" request

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log"
 	"regexp"
 	"runtime/debug"
 	"strconv"
@@ -60,6 +61,7 @@ func NewBlipSyncContext(bc *blip.Context, db *Database, contextID string) *BlipS
 	}
 
 	// Register 2.x replicator handlers
+	log.Printf("registering replication handlers: %v", contextID)
 	for profile, handlerFn := range kHandlersByProfile {
 		bsc.register(profile, handlerFn)
 	}
@@ -93,6 +95,7 @@ type BlipSyncContext struct {
 	postSendRevisionResponseCallback func(remoteSeq string)      // postSendRevisionResponseCallback is called after receiving acknowledgement of a sent revision
 	replicationStats                 *BlipSyncStats              // Replication stats
 	purgeOnRemoval                   bool                        // Purges the document when we pull a _removed:true revision.
+	conflictResolver                 ConflictResolverFunc        // Conflict resolver for active replications
 }
 
 // Registers a BLIP handler including the outer-level work of logging & error handling.

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -332,6 +332,14 @@ func (rm *RevMessage) SetRev(rev string) {
 	rm.Properties[RevMessageRev] = rev
 }
 
+func (rm *RevMessage) SetNoConflicts(noConflicts bool) {
+	if noConflicts {
+		rm.Properties[RevMessageNoConflicts] = "true"
+	} else {
+		rm.Properties[RevMessageNoConflicts] = "false"
+	}
+}
+
 // setProperties will add the given properties to the blip message, overwriting any that already exist.
 func (rm *RevMessage) SetProperties(properties blip.Properties) {
 	for k, v := range properties {

--- a/db/crud.go
+++ b/db/crud.go
@@ -1166,7 +1166,7 @@ func (db *Database) tombstoneActiveRevision(doc *Document, revID string) error {
 	// Backup previous revision body, then remove the current body from the doc
 	bodyBytes, err := doc.BodyBytes()
 	if err == nil {
-		db.setOldRevisionJSON(doc.ID, revID, bodyBytes, db.Options.OldRevExpirySeconds)
+		_ = db.setOldRevisionJSON(doc.ID, revID, bodyBytes, db.Options.OldRevExpirySeconds)
 	}
 	doc.RemoveBody()
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1091,9 +1091,6 @@ func (db *Database) resolveDocLocalWins(localDoc *Document, remoteDoc *Document,
 	remoteRevID := conflict.RemoteDocument.ExtractRev()
 	remoteGeneration, _ := ParseRevID(remoteRevID)
 	newRevID := CreateRevIDWithBytes(remoteGeneration+1, remoteRevID, docBodyBytes)
-	if err != nil {
-		return "", nil, err
-	}
 
 	// Set the incoming document's rev and body to the cloned local revision
 	remoteDoc.RevID = newRevID

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -358,7 +358,7 @@ func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicato
 	}
 
 	// Set conflict resolver for pull replications
-	if rc.Direction == ActiveReplicatorTypePull {
+	if rc.Direction == ActiveReplicatorTypePull || rc.Direction == ActiveReplicatorTypePushAndPull {
 		if config.ConflictResolutionType == "" {
 			rc.ConflictResolver, err = NewConflictResolverFunc(ConflictResolverDefault, "")
 		} else {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -826,90 +826,170 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 //   - Create the same document id with different content on rt1 and rt2
 //   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
 //   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
+// TODO: extend test cases to include conflicts with common ancestors (i.e. update conflict instead of insert conflict)
 func TestActiveReplicatorPullConflict(t *testing.T) {
 
-	if base.GTestBucketPool.NumUsableBuckets() < 2 {
-		t.Skipf("test requires at least 2 usable test buckets")
+	// scenarios
+	conflictResolutionTests := []struct {
+		name                    string
+		localRevisionBody       db.Body
+		localRevID              string
+		remoteRevisionBody      db.Body
+		remoteRevID             string
+		conflictResolver        string
+		expectedLocalBody       db.Body
+		expectedLocalRevID      string
+		expectedTombstonedRevID string
+	}{
+		{
+			name:               "remoteWins",
+			localRevisionBody:  db.Body{"source": "local"},
+			localRevID:         "1-a",
+			remoteRevisionBody: db.Body{"source": "remote"},
+			remoteRevID:        "1-b",
+			conflictResolver:   `function(conflict) {return conflict.RemoteDocument;}`,
+			expectedLocalBody:  db.Body{"source": "remote"},
+			expectedLocalRevID: "1-b",
+		},
+		{
+			name:               "merge",
+			localRevisionBody:  db.Body{"source": "local"},
+			localRevID:         "1-a",
+			remoteRevisionBody: db.Body{"source": "remote"},
+			remoteRevID:        "1-b",
+			conflictResolver: `function(conflict) {
+					var mergedDoc = new Object();
+					mergedDoc.source = "merged";
+					return mergedDoc;
+				}`,
+			expectedLocalBody:  db.Body{"source": "merged"},
+			expectedLocalRevID: db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"merged"}`)), // rev for merged body, with parent 1-b
+		},
+		{
+			name:               "localWins",
+			localRevisionBody:  db.Body{"source": "local"},
+			localRevID:         "1-a",
+			remoteRevisionBody: db.Body{"source": "remote"},
+			remoteRevID:        "1-b",
+			conflictResolver:   `function(conflict) {return conflict.LocalDocument;}`,
+			expectedLocalBody:  db.Body{"source": "local"},
+			expectedLocalRevID: db.CreateRevIDWithBytes(2, "1-b", []byte(`{"source":"local"}`)), // rev for local body, transposed under parent 1-b
+		},
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
 
-	// Passive
-	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
-	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
-		DatabaseConfig: &DbConfig{
-			Users: map[string]*db.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+	for _, test := range conflictResolutionTests {
+		t.Run(test.name, func(t *testing.T) {
+			if base.GTestBucketPool.NumUsableBuckets() < 2 {
+				t.Skipf("test requires at least 2 usable test buckets")
+			}
+			defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
+
+			// Passive
+			tb2 := base.GetTestBucket(t)
+			defer tb2.Close()
+			rt2 := NewRestTester(t, &RestTesterConfig{
+				TestBucket: tb2,
+				DatabaseConfig: &DbConfig{
+					Users: map[string]*db.PrincipalConfig{
+						"alice": {
+							Password:         base.StringPtr("pass"),
+							ExplicitChannels: base.SetOf("*"),
+						},
+					},
 				},
-			},
-		},
-		noAdminParty: true,
-	})
-	defer rt2.Close()
+				noAdminParty: true,
+			})
+			defer rt2.Close()
 
-	// Create revision on rt2 (creates rev 1-7f11ae86eabce724274a7f18f06f8bf5)
-	docID := t.Name() + "conflictdoc1"
-	resp := rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","channels":["alice"]}`)
-	assertStatus(t, resp, http.StatusCreated)
-	rt2revID := respRevID(t, resp)
-	// assert revID, as test depends on rt2 being winner under default conflict resolution
-	assert.Equal(t, "1-7f11ae86eabce724274a7f18f06f8bf5", rt2revID)
+			// Create revision on rt2 (remote)
+			docID := test.name
+			resp, err := rt2.PutDocumentWithRevID(docID, test.remoteRevID, "", test.remoteRevisionBody)
+			assert.NoError(t, err)
+			assertStatus(t, resp, http.StatusCreated)
+			rt2revID := respRevID(t, resp)
+			assert.Equal(t, test.remoteRevID, rt2revID)
 
-	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
-	srv := httptest.NewServer(rt2.TestPublicHandler())
-	defer srv.Close()
+			// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+			srv := httptest.NewServer(rt2.TestPublicHandler())
+			defer srv.Close()
 
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
-	require.NoError(t, err)
+			passiveDBURL, err := url.Parse(srv.URL + "/db")
+			require.NoError(t, err)
 
-	// Add basic auth creds to target db URL
-	passiveDBURL.User = url.UserPassword("alice", "pass")
+			// Add basic auth creds to target db URL
+			passiveDBURL.User = url.UserPassword("alice", "pass")
 
-	// Active
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
-	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
-	})
-	defer rt1.Close()
+			// Active
+			tb1 := base.GetTestBucket(t)
+			defer tb1.Close()
+			rt1 := NewRestTester(t, &RestTesterConfig{
+				TestBucket: tb1,
+			})
+			defer rt1.Close()
 
-	// Create conflicting revision on rt1 (creates rev 1-568d6718699d196555298dd8bde69a2a)
-	resp = rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
-	assertStatus(t, resp, http.StatusCreated)
-	rt1revID := respRevID(t, resp)
-	assert.Equal(t, "1-568d6718699d196555298dd8bde69a2a", rt1revID)
+			// Create revision on rt1 (local)
+			resp, err = rt1.PutDocumentWithRevID(docID, test.localRevID, "", test.localRevisionBody)
+			assert.NoError(t, err)
+			assertStatus(t, resp, http.StatusCreated)
+			rt1revID := respRevID(t, resp)
+			assert.Equal(t, test.localRevID, rt1revID)
 
-	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
-		ActiveDB: &db.Database{
-			DatabaseContext: rt1.GetDatabase(),
-		},
-		ChangesBatchSize: 200,
-		ConflictResolver: db.DefaultConflictResolver,
-	})
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, ar.Close()) }()
+			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver)
+			require.NoError(t, err)
+			ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+				ID:           t.Name(),
+				Direction:    db.ActiveReplicatorTypePull,
+				PassiveDBURL: passiveDBURL,
+				ActiveDB: &db.Database{
+					DatabaseContext: rt1.GetDatabase(),
+				},
+				ChangesBatchSize: 200,
+				ConflictResolver: customConflictResolver,
+			})
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, ar.Close()) }()
 
-	// Start the replicator (implicit connect)
-	assert.NoError(t, ar.Start())
+			// Start the replicator (implicit connect)
+			assert.NoError(t, ar.Start())
 
-	time.Sleep(1 * time.Second)
-	log.Printf("========================Replication should be done, checking with changes")
-	// wait for the document originally written to rt2 to arrive at rt1.  Should end up as winner under default conflict resolution
+			// TODO: Use replication stats to wait for replication to complete
+			time.Sleep(1 * time.Second)
+			log.Printf("========================Replication should be done, checking with changes")
+			// wait for the document originally written to rt2 to arrive at rt1.  Should end up as winner under default conflict resolution
 
-	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
-	require.NoError(t, err)
-	require.Len(t, changesResults.Results, 1)
-	assert.Equal(t, docID, changesResults.Results[0].ID)
+			changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			require.NoError(t, err)
+			require.Len(t, changesResults.Results, 1)
+			assert.Equal(t, docID, changesResults.Results[0].ID)
+			assert.Equal(t, test.expectedLocalRevID, changesResults.Results[0].Changes[0]["rev"])
+			log.Printf("Changes response is %+v", changesResults)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
-	assert.NoError(t, err)
+			doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedLocalRevID, doc.SyncData.CurrentRev)
+			assert.Equal(t, test.expectedLocalBody, doc.Body())
+			log.Printf("Doc %s is %+v", docID, doc)
+			for revID, revInfo := range doc.SyncData.History {
+				log.Printf("doc revision [%s]: %+v", revID, revInfo)
+			}
 
-	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+			// Validate only one active leaf node remains after conflict resolution, and that all parents
+			// of leaves have empty bodies
+			activeCount := 0
+			for _, revID := range doc.SyncData.History.GetLeaves() {
+				revInfo, ok := doc.SyncData.History[revID]
+				require.True(t, ok)
+				if !revInfo.Deleted {
+					activeCount++
+				}
+				if revInfo.Parent != "" {
+					parentRevInfo, ok := doc.SyncData.History[revInfo.Parent]
+					require.True(t, ok)
+					assert.True(t, parentRevInfo.Body == nil)
+				}
+			}
+			assert.Equal(t, 1, activeCount)
+
+		})
+	}
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"expvar"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -818,4 +819,97 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, base.IsDocNotFoundError(err), "Error returned wasn't a DocNotFound error")
 	assert.Nil(t, doc)
+}
+
+// TestActiveReplicatorPullConflict:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Create the same document id with different content on rt1 and rt2
+//   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
+//   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
+func TestActiveReplicatorPullConflict(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	defer tb2.Close()
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Create revision on rt2 (creates rev 1-7f11ae86eabce724274a7f18f06f8bf5)
+	docID := t.Name() + "conflictdoc1"
+	resp := rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	rt2revID := respRevID(t, resp)
+	// assert revID, as test depends on rt2 being winner under default conflict resolution
+	assert.Equal(t, "1-7f11ae86eabce724274a7f18f06f8bf5", rt2revID)
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	// Create conflicting revision on rt1 (creates rev 1-568d6718699d196555298dd8bde69a2a)
+	resp = rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	rt1revID := respRevID(t, resp)
+	assert.Equal(t, "1-568d6718699d196555298dd8bde69a2a", rt1revID)
+
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePull,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize: 200,
+		ConflictResolver: db.DefaultConflictResolver,
+	})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, ar.Close()) }()
+
+	// Start the replicator (implicit connect)
+	assert.NoError(t, ar.Start())
+
+	time.Sleep(1 * time.Second)
+	log.Printf("========================Replication should be done, checking with changes")
+	// wait for the document originally written to rt2 to arrive at rt1.  Should end up as winner under default conflict resolution
+
+	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	assert.Equal(t, docID, changesResults.Results[0].ID)
+
+	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
 }


### PR DESCRIPTION
Enables conflict resolution for active pull replications:
- Adds a variation of PutExistingRev that performs conflict resolution when a conflictResolverFunc is provided
- Modifies handleRev to use this variation when a conflict resolver is defined on the blipSyncContext
- Modifies activePullReplicator to pass through conflict resolver
- Modifies activePushReplicator to set noConflicts flag on pushed revisions
 
Initial conflict resolution implementation follows the CBL model to determine the impact on the revision tree after conflict is resolved.  This approach does not require tombstones to be pushed to the remote (not currently supported for non-active revisions in the 2.x replication protocol).

Remote revision wins
- losing local revision is tombstoned
- remote revision is added to the rev tree

Local revision wins
- remote revision is added to the rev tree
- local revision is cloned as child of remote revision
- original local revision is tombstoned

Merge
- remote revision is added to the rev tree
- local revision is tombstoned
- merged revision is added to the rev tree as a child of the remote revision
