### PR TITLE
Use replicator-specific logging context for active replications

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
 	"golang.org/x/net/websocket"
 )
 
@@ -110,6 +111,9 @@ func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.
 	blipContext := NewSGBlipContext(context.TODO(), config.ID+idSuffix)
 	blipContext.WebsocketPingInterval = config.WebsocketPingInterval
 	bsc = NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID)
+	bsc.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
+		base.LogContext{CorrelationID: config.ID + idSuffix},
+	)
 
 	blipSender, err = blipSync(*config.PassiveDBURL, blipContext)
 	if err != nil {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -86,7 +86,7 @@ type ReplicationUpsertConfig struct {
 	DeltaSyncEnabled       *bool       `json:"enable_delta_sync,omitempty"`
 	MaxBackoff             *int        `json:"max_backoff_time,omitempty"`
 	State                  *string     `json:"state,omitempty"`
-	Continuous             *bool       `json:"continuous,omitempty"`
+	Continuous             *bool       `json:"continuous"`
 	Filter                 *string     `json:"filter,omitempty"`
 	QueryParams            interface{} `json:"query_params,omitempty"`
 	Cancel                 *bool       `json:"cancel,omitempty"`


### PR DESCRIPTION
Passive replication continues to use the database's context, active replication uses a replication-specific context for additional logging context.

Also removes omitempty to always display continuous=true/false in _replication response.