### PR TITLE
CBG-930 Enable delta sync flag for sg-replicate2

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -115,6 +115,12 @@ func connect(idSuffix string, config *ActiveReplicatorConfig) (blipSender *blip.
 		base.LogContext{CorrelationID: config.ID + idSuffix},
 	)
 
+	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.
+	// If deltas have been disabled in the replication config, override this value
+	if config.DeltasEnabled == false {
+		bsc.sgCanUseDeltas = false
+	}
+
 	blipSender, err = blipSync(*config.PassiveDBURL, blipContext)
 	if err != nil {
 		return nil, nil, err

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -56,6 +56,8 @@ type ActiveReplicatorConfig struct {
 	WebsocketPingInterval time.Duration
 	// Conflict resolver function
 	ConflictResolver ConflictResolverFunc
+	// Delta sync enabled
+	DeltasEnabled bool
 }
 
 // CheckpointHash returns a deterministic hash of the given config to be used as a checkpoint ID.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -421,6 +421,10 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}
 	output.Write([]byte("]"))
 	response := rq.Response()
+	if bh.sgCanUseDeltas {
+		base.DebugfCtx(bh.loggingCtx, base.KeyAll, "Setting deltas=true property on handleChanges response")
+		response.Properties[ChangesResponseDeltas] = "true"
+	}
 	response.SetCompressed(true)
 	response.SetBody(output.Bytes())
 


### PR DESCRIPTION
If delta sync is disabled for an sg-replicate replication, override the calculated sgCanUseDeltas value for the replication's blip sync context.

Note that this implies that pull replications from a remote that supports delta sync will still not use deltas unless deltas are enabled on the local node.  This matches CBL behaviour today (we don't accept deltas from CBL if deltas aren't enabled for the SG database).