### PR TITLE
CBG-839: Support self-signed cert for sg-replicate testing

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -27,7 +27,6 @@ package auth
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -315,7 +314,7 @@ func (op *OIDCProvider) FetchCustomProviderConfig(discoveryURL string) (*Provide
 		base.Debugf(base.KeyAuth, "Error building new request for URL %s: %v", base.UD(discoveryURL), err)
 		return nil, err
 	}
-	client := GetHttpClient(op.InsecureSkipVerify)
+	client := base.GetHttpClient(op.InsecureSkipVerify)
 	resp, err := client.Do(req)
 	if err != nil {
 		base.Debugf(base.KeyAuth, "Error invoking calling discovery URL %s: %v", base.UD(discoveryURL), err)
@@ -447,24 +446,10 @@ func SetURLQueryParam(strURL, name, value string) (string, error) {
 	return uri.String(), nil
 }
 
-// GetHttpClient returns a new HTTP client with TLS certificate verification
-// disabled when insecureSkipVerify is true and enabled otherwise.
-func GetHttpClient(insecureSkipVerify bool) *http.Client {
-	if insecureSkipVerify {
-		transport := base.DefaultHTTPTransport()
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = new(tls.Config)
-		}
-		transport.TLSClientConfig.InsecureSkipVerify = true
-		return &http.Client{Transport: transport}
-	}
-	return http.DefaultClient
-}
-
 // GetOIDCClientContext returns a new Context that carries the provided HTTP client
 // with TLS certificate verification disabled when insecureSkipVerify is true and
 // enabled otherwise.
 func GetOIDCClientContext(insecureSkipVerify bool) context.Context {
-	client := GetHttpClient(insecureSkipVerify)
+	client := base.GetHttpClient(insecureSkipVerify)
 	return oidc.ClientContext(context.Background(), client)
 }

--- a/base/util.go
+++ b/base/util.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha1"
+	"crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -1356,4 +1357,18 @@ func GetRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64,
 	}
 
 	return value
+}
+
+// GetHttpClient returns a new HTTP client with TLS certificate verification
+// disabled when insecureSkipVerify is true and enabled otherwise.
+func GetHttpClient(insecureSkipVerify bool) *http.Client {
+	if insecureSkipVerify {
+		transport := DefaultHTTPTransport()
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = new(tls.Config)
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+		return &http.Client{Transport: transport}
+	}
+	return http.DefaultClient
 }

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -56,8 +56,13 @@ type ActiveReplicatorConfig struct {
 	WebsocketPingInterval time.Duration
 	// Conflict resolver function
 	ConflictResolver ConflictResolverFunc
+
 	// Delta sync enabled
 	DeltasEnabled bool
+
+	// InsecureSkipVerify determines whether the TLS certificate verification should be
+	// disabled during replication. TLS certificate verification is enabled by default.
+	InsecureSkipVerify bool
 }
 
 // CheckpointHash returns a deterministic hash of the given config to be used as a checkpoint ID.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -72,8 +72,9 @@ func (apr *ActivePullReplicator) Close() error {
 	}
 
 	apr.checkpointerCtxCancel()
-	apr.Checkpointer.CheckpointNow()
-
+	if apr.Checkpointer != nil {
+		apr.Checkpointer.CheckpointNow()
+	}
 	if apr.blipSender != nil {
 		apr.blipSender.Close()
 		apr.blipSender = nil

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -84,8 +84,9 @@ func (apr *ActivePushReplicator) Close() error {
 	}
 
 	apr.checkpointerCtxCancel()
-	apr.Checkpointer.CheckpointNow()
-
+	if apr.Checkpointer != nil {
+		apr.Checkpointer.CheckpointNow()
+	}
 	if apr.blipSender != nil {
 		apr.blipSender.Close()
 		apr.blipSender = nil

--- a/db/database.go
+++ b/db/database.go
@@ -160,6 +160,7 @@ type UnsupportedOptions struct {
 	WarningThresholds        WarningThresholds       `json:"warning_thresholds,omitempty"`          // Warning thresholds related to _sync size
 	DisableCleanSkippedQuery bool                    `json:"disable_clean_skipped_query,omitempty"` // Clean skipped sequence processing bypasses final check
 	OidcTlsSkipVerify        bool                    `json:"oidc_tls_skip_verify"`                  // Config option to enable self-signed certs for OIDC testing.
+	SgrTlsSkipVerify         bool                    `json:"sgr_tls_skip_verify"`                   // Config option to enable self-signed certs for SG-Replicate testing.
 }
 
 type WarningThresholds struct {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -356,11 +356,12 @@ func (m *sgReplicateManager) StartReplication(config *ReplicationCfg) (replicato
 	base.Infof(base.KeyReplicate, "Starting replication %v (placeholder)", config.ID)
 
 	rc := &ActiveReplicatorConfig{
-		ID:             config.ID,
-		Continuous:     config.Continuous,
-		ActiveDB:       &Database{DatabaseContext: m.dbContext}, // sg-replicate interacts with local as admin
-		PurgeOnRemoval: config.PurgeOnRemoval,
-		DeltasEnabled:  false,
+		ID:                 config.ID,
+		Continuous:         config.Continuous,
+		ActiveDB:           &Database{DatabaseContext: m.dbContext}, // sg-replicate interacts with local as admin
+		PurgeOnRemoval:     config.PurgeOnRemoval,
+		DeltasEnabled:      false,
+		InsecureSkipVerify: m.dbContext.Options.UnsupportedOptions.SgrTlsSkipVerify,
 	}
 
 	rc.ChangesBatchSize = defaultChangesBatchSize

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -103,7 +103,7 @@ func TestProviderOIDCAuthWithTlsSkipVerifyEnabled(t *testing.T) {
 
 	// Set insecureSkipVerify on the test's HTTP client since both the _oidc and _oidc_testing
 	// endpoints are being run with the same TLSServer.
-	client := auth.GetHttpClient(true)
+	client := base.GetHttpClient(true)
 	client.Jar = jar
 	response, err := client.Do(request)
 	require.NoError(t, err, "Error sending request")
@@ -157,7 +157,7 @@ func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
 
 	// Set insecureSkipVerify on the test's HTTP client since both the _oidc and _oidc_testing
 	// endpoints are being run with the same TLSServer.
-	client := auth.GetHttpClient(true)
+	client := base.GetHttpClient(true)
 	client.Jar = jar
 	response, err := client.Do(request)
 	require.NoError(t, err, "Error sending request")

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1204,3 +1204,150 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 		})
 	}
 }
+
+// TestActiveReplicatorPushBasicWithInsecureSkipVerify:
+//   - Starts 2 RestTesters, one active (with InsecureSkipVerify), and one passive
+//   - Creates a document on rt1 which can be pushed by the replicator to rt2.
+//   - rt2 served using a self-signed TLS cert (via httptest)
+//   - Uses an ActiveReplicator configured for push to start pushing changes to rt2.
+func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	defer tb2.Close()
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	docID := t.Name() + "rt1doc1"
+	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID := respRevID(t, resp)
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	srv := httptest.NewTLSServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePush,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:   200,
+		InsecureSkipVerify: true,
+	})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, ar.Close()) }()
+
+	// Start the replicator (implicit connect)
+	require.NoError(t, ar.Start())
+
+	// wait for the document originally written to rt1 to arrive at rt2
+	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	assert.Equal(t, docID, changesResults.Results[0].ID)
+
+	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+}
+
+// TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled:
+//   - Starts 2 RestTesters, one active, and one passive
+//   - Creates a document on rt1 which can be pushed by the replicator to rt2.
+//   - rt2 served using a self-signed TLS cert (via httptest)
+//   - Uses an ActiveReplicator configured for push to start pushing changes to rt2.
+func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	defer tb2.Close()
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	docID := t.Name() + "rt1doc1"
+	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	srv := httptest.NewTLSServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	ar, err := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePush,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:   200,
+		InsecureSkipVerify: false,
+	})
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, ar.Close()) }()
+
+	// Start the replicator (implicit connect)
+	assert.Error(t, ar.Start(), "Error certificate signed by unknown authority")
+}


### PR DESCRIPTION
- Move GetHttpClient function from auth/oidc.go to base/util.go to make it reusable across both auth and db packages; this might require modifying the unit tests that accept self signed certificates during openid connect.
- Add a new property SgrTlsSkipVerify to UnsupportedOptions to accept the value of sgr_tls_skip_verify option from replicator configuration for testing.
- Add InsecureSkipVerify flag on ActiveReplicatorConfig and set the value from database context to replicator configuration during ActiveReplicatorConfig initialization.
- Add  InsecureSkipVerify flag on BlipContext and use that inside connect and blipSync methods to set the TLS configuration.
- Make sure the Checkpointer is not a nil reference before forcing it to send checkpoints.
- Add unit test cases that covers both sgr_tls_skip_verify enabled and disabled scenarios.
