### PR TITLE
CBG-908 - ActiveReplicator checkpointing on both local and remote

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -126,7 +126,7 @@ func (c *Checkpointer) CheckpointNow() {
 		return
 	}
 
-	base.Tracef(base.KeyReplicate, "checkpointer: calculated seq: %v", seq)
+	base.Infof(base.KeyReplicate, "checkpointer: calculated seq: %v", seq)
 	err := c.setCheckpoints(seq)
 	if err != nil {
 		base.Warnf("couldn't set checkpoints: %v", err)

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -172,8 +172,7 @@ func calculateCheckpointSeq(expectedSeqs []string, processedSeqs map[string]stru
 const checkpointDocIDPrefix = "checkpoint/"
 
 // fetchCheckpoints tries to fetch since values for the given replication by requesting a checkpoint on the local and remote.
-// If we fail to fetch checkpoints, we remove any existing checkpoints, and start from zero.
-// If we fetch mismatched checkpoints, we'll pick the lower of the two, and remove the higher checkpoint.
+// If we fetch missing, or mismatched checkpoints, we'll pick the lower of the two, and roll back the higher checkpoint.
 func (c *Checkpointer) fetchCheckpoints() error {
 	base.TracefCtx(c.ctx, base.KeyReplicate, "fetchCheckpoints()")
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -104,7 +104,7 @@ func (c *Checkpointer) Start() {
 			c.CheckpointNow()
 
 			if exit {
-				base.Debugf(base.KeyReplicate, "checkpointer goroutine stopped")
+				base.DebugfCtx(c.ctx, base.KeyReplicate, "checkpointer goroutine stopped")
 				return
 			}
 		}
@@ -119,14 +119,14 @@ func (c *Checkpointer) CheckpointNow() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	base.Tracef(base.KeyReplicate, "checkpointer: running")
+	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: running")
 
 	seq := c.calculateCheckpointSeq()
 	if seq == "" {
 		return
 	}
 
-	base.Infof(base.KeyReplicate, "checkpointer: calculated seq: %v", seq)
+	base.InfofCtx(c.ctx, base.KeyReplicate, "checkpointer: calculated seq: %v", seq)
 	err := c.setCheckpoints(seq)
 	if err != nil {
 		base.Warnf("couldn't set checkpoints: %v", err)
@@ -134,7 +134,7 @@ func (c *Checkpointer) CheckpointNow() {
 }
 
 func (c *Checkpointer) calculateCheckpointSeq() (seq string) {
-	base.Tracef(base.KeyReplicate, "checkpointer: calculateCheckpointSeq(%v, %v)", c.expectedSeqs, c.processedSeqs)
+	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: calculateCheckpointSeq(%v, %v)", c.expectedSeqs, c.processedSeqs)
 
 	if len(c.expectedSeqs) == 0 {
 		// nothing to do
@@ -145,12 +145,12 @@ func (c *Checkpointer) calculateCheckpointSeq() (seq string) {
 	maxI := -1
 	for i, seq := range c.expectedSeqs {
 		if _, ok := c.processedSeqs[seq]; !ok {
-			base.Tracef(base.KeyReplicate, "checkpointer: couldn't find %v in processedSeqs", seq)
+			base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: couldn't find %v in processedSeqs", seq)
 			break
 		}
 
 		delete(c.processedSeqs, seq)
-		base.Tracef(base.KeyReplicate, "checkpointer: calculateCheckpointSeq removed seq %v from processedSeqs map %v", seq, c.processedSeqs)
+		base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: calculateCheckpointSeq removed seq %v from processedSeqs map %v", seq, c.processedSeqs)
 		maxI = i
 	}
 
@@ -268,7 +268,7 @@ func (c *Checkpointer) getLocalCheckpoint() (seq, rev string, err error) {
 		if !base.IsKeyNotFoundError(c.activeDB.Bucket, err) {
 			return "", "", err
 		}
-		base.Debugf(base.KeyReplicate, "couldn't find existing local checkpoint for client %q", c.clientID)
+		base.DebugfCtx(c.ctx, base.KeyReplicate, "couldn't find existing local checkpoint for client %q", c.clientID)
 		return "", "", nil
 	}
 
@@ -304,7 +304,7 @@ func (c *Checkpointer) getRemoteCheckpoint() (seq, rev string, err error) {
 	}
 
 	if resp == nil {
-		base.Debugf(base.KeyReplicate, "couldn't find existing remote checkpoint for client %q", c.clientID)
+		base.DebugfCtx(c.ctx, base.KeyReplicate, "couldn't find existing remote checkpoint for client %q", c.clientID)
 		return "", "", nil
 	}
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -210,7 +210,7 @@ func (c *Checkpointer) fetchCheckpoints() error {
 		// roll local/remote checkpoint back to lowest of the two
 		if remoteSeqVal.Before(localSeqVal) {
 			checkpointSeq = remoteSeq
-			c.lastLocalCheckpointRevID, err = c.setLocalCheckpoint(checkpointSeq, c.lastRemoteCheckpointRevID)
+			c.lastLocalCheckpointRevID, err = c.setLocalCheckpoint(checkpointSeq, c.lastLocalCheckpointRevID)
 			if err != nil {
 				return err
 			}

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -173,7 +173,7 @@ func (c *Checkpointer) calculateCheckpointSeq() (seq string) {
 }
 
 const (
-	checkpointDocIDPrefix = "checkpoint/"
+	checkpointDocIDPrefix   = "checkpoint/"
 	checkpointDocLastSeqKey = "last_sequence"
 )
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -99,7 +99,7 @@ func (apr *ActivePullReplicator) initCheckpointer() error {
 
 	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.CheckpointInterval)
 
-	checkpoint := apr.Checkpointer.GetCheckpoint()
+	checkpoint := apr.Checkpointer.getCheckpoint()
 	apr.Checkpointer.lastCheckpointRevID = checkpoint.RevID
 	apr.Checkpointer.lastCheckpointSeq = checkpoint.Checkpoint.LastSequence
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -97,11 +97,12 @@ func (apr *ActivePullReplicator) initCheckpointer() error {
 		return err
 	}
 
-	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.CheckpointInterval)
+	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.ActiveDB, apr.config.CheckpointInterval)
 
-	checkpoint := apr.Checkpointer.getCheckpoint()
-	apr.Checkpointer.lastCheckpointRevID = checkpoint.RevID
-	apr.Checkpointer.lastCheckpointSeq = checkpoint.Checkpoint.LastSequence
+	err = apr.Checkpointer.fetchCheckpoints()
+	if err != nil {
+		return err
+	}
 
 	apr.registerCheckpointerCallbacks()
 	apr.Checkpointer.Start()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -110,7 +110,7 @@ func (apr *ActivePushReplicator) initCheckpointer() error {
 
 	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.CheckpointInterval)
 
-	checkpoint := apr.Checkpointer.GetCheckpoint()
+	checkpoint := apr.Checkpointer.getCheckpoint()
 	apr.Checkpointer.lastCheckpointRevID = checkpoint.RevID
 	apr.Checkpointer.lastCheckpointSeq = checkpoint.Checkpoint.LastSequence
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -108,11 +108,12 @@ func (apr *ActivePushReplicator) initCheckpointer() error {
 		return err
 	}
 
-	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.CheckpointInterval)
+	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.ActiveDB, apr.config.CheckpointInterval)
 
-	checkpoint := apr.Checkpointer.getCheckpoint()
-	apr.Checkpointer.lastCheckpointRevID = checkpoint.RevID
-	apr.Checkpointer.lastCheckpointSeq = checkpoint.Checkpoint.LastSequence
+	err = apr.Checkpointer.fetchCheckpoints()
+	if err != nil {
+		return err
+	}
 
 	apr.registerCheckpointerCallbacks()
 	apr.Checkpointer.Start()

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -82,19 +82,18 @@ func (bh *blipHandler) refreshUser() error {
 
 //////// CHECKPOINTS
 
-// Received a "getCheckpoint" request
+// Received a "fetchCheckpoints" request
 func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 
 	client := rq.Properties[BlipClient]
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("Client:%s", client))
 
-	docID := fmt.Sprintf("checkpoint/%s", client)
 	response := rq.Response()
 	if response == nil {
 		return nil
 	}
 
-	value, err := bh.db.GetSpecial("local", docID)
+	value, err := bh.db.GetSpecial("local", checkpointDocIDPrefix+client)
 	if err != nil {
 		return err
 	}
@@ -115,8 +114,6 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 	checkpointMessage := SetCheckpointMessage{rq}
 	bh.logEndpointEntry(rq.Profile(), checkpointMessage.String())
 
-	docID := fmt.Sprintf("checkpoint/%s", checkpointMessage.client())
-
 	var checkpoint Body
 	if err := checkpointMessage.ReadJSONBody(&checkpoint); err != nil {
 		return err
@@ -124,7 +121,7 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 	if revID := checkpointMessage.rev(); revID != "" {
 		checkpoint[BodyRev] = revID
 	}
-	revID, err := bh.db.PutSpecial("local", docID, checkpoint)
+	revID, err := bh.db.PutSpecial("local", checkpointDocIDPrefix+checkpointMessage.client(), checkpoint)
 	if err != nil {
 		return err
 	}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -82,7 +82,7 @@ func (bh *blipHandler) refreshUser() error {
 
 //////// CHECKPOINTS
 
-// Received a "fetchCheckpoints" request
+// Received a "getCheckpoint" request
 func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 
 	client := rq.Properties[BlipClient]

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -133,7 +133,7 @@ func (rq *SetSGR2CheckpointRequest) Response() (*SetSGR2CheckpointResponse, erro
 	}, nil
 }
 
-// GetSGR2CheckpointRequest is a strongly typed 'fetchCheckpoints' request for SG-Replicate 2.
+// GetSGR2CheckpointRequest is a strongly typed 'getCheckpoint' request for SG-Replicate 2.
 type GetSGR2CheckpointRequest struct {
 	Client string // Client is the unique ID of client checkpoint to retrieve
 

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -15,7 +15,7 @@ import (
 // Message types
 const (
 	MessageSetCheckpoint   = "setCheckpoint"
-	MessageGetCheckpoint   = "getCheckpoint"
+	MessageGetCheckpoint   = "fetchCheckpoints"
 	MessageSubChanges      = "subChanges"
 	MessageChanges         = "changes"
 	MessageRev             = "rev"
@@ -38,7 +38,7 @@ const (
 	SetCheckpointClient      = "client"
 	SetCheckpointResponseRev = "rev"
 
-	// getCheckpoint message properties
+	// fetchCheckpoints message properties
 	GetCheckpointResponseRev = "rev"
 	GetCheckpointClient      = "client"
 

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -15,7 +15,7 @@ import (
 // Message types
 const (
 	MessageSetCheckpoint   = "setCheckpoint"
-	MessageGetCheckpoint   = "fetchCheckpoints"
+	MessageGetCheckpoint   = "getCheckpoint"
 	MessageSubChanges      = "subChanges"
 	MessageChanges         = "changes"
 	MessageRev             = "rev"
@@ -38,7 +38,7 @@ const (
 	SetCheckpointClient      = "client"
 	SetCheckpointResponseRev = "rev"
 
-	// fetchCheckpoints message properties
+	// getCheckpoint message properties
 	GetCheckpointResponseRev = "rev"
 	GetCheckpointClient      = "client"
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1573,7 +1573,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
@@ -1636,7 +1636,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err = rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1406,7 +1406,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	ar, err := db.NewActiveReplicator(&arConfig)
+	ar := db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
 	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
@@ -1442,7 +1442,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	ar.Pull.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
 
-	assert.NoError(t, ar.Close())
+	assert.NoError(t, ar.Stop())
 
 	gocbBucket, ok := base.AsGoCBBucket(tb1)
 	require.True(t, ok)
@@ -1463,7 +1463,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	arConfig.ActiveDB = &db.Database{
 		DatabaseContext: rt1.GetDatabase(),
 	}
-	ar, err = db.NewActiveReplicator(&arConfig)
+	ar = db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
 	assert.NoError(t, ar.Start())
@@ -1497,7 +1497,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	ar.Pull.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
 
-	assert.NoError(t, ar.Close())
+	assert.NoError(t, ar.Stop())
 }
 
 // TestActiveReplicatorRecoverFromRemoteFlush:
@@ -1568,7 +1568,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	ar, err := db.NewActiveReplicator(&arConfig)
+	ar := db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
 	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
@@ -1604,7 +1604,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	ar.Push.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
 
-	assert.NoError(t, ar.Close())
+	assert.NoError(t, ar.Stop())
 
 	gocbBucket, ok := base.AsGoCBBucket(tb2)
 	require.True(t, ok)
@@ -1636,7 +1636,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 	arConfig.PassiveDBURL = passiveDBURL
 
-	ar, err = db.NewActiveReplicator(&arConfig)
+	ar = db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
 	assert.NoError(t, ar.Start())
@@ -1670,5 +1670,5 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	ar.Push.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
 
-	assert.NoError(t, ar.Close())
+	assert.NoError(t, ar.Stop())
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1535,7 +1535,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 	srv := httptest.NewServer(rt2.TestPublicHandler())
-defer srv.Close()
+	defer srv.Close()
 
 	// Build passiveDBURL with basic auth creds
 	passiveDBURL, err := url.Parse(srv.URL + "/db")

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1346,8 +1346,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 //   - Starts the replication again, and ensures that documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
-	if base.GTestBucketPool.NumUsableBuckets() < 4 {
-		t.Skipf("test requires at least 4 usable test buckets")
+	if base.GTestBucketPool.NumUsableBuckets() < 3 {
+		t.Skipf("test requires at least 3 usable test buckets")
 	}
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
@@ -1501,8 +1501,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 //   - Starts the replication again, and ensures that post-flush, documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
-	if base.GTestBucketPool.NumUsableBuckets() < 4 {
-		t.Skipf("test requires at least 4 usable test buckets")
+	if base.GTestBucketPool.NumUsableBuckets() < 3 {
+		t.Skipf("test requires at least 3 usable test buckets")
 	}
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1342,13 +1342,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 //   - Starts 2 RestTesters, one active, and one passive.
 //   - Creates a document on rt2 which is pulled to rt1.
 //   - Checkpoints once finished.
-//   - Flushes the bucket behind rt1.
-//   - Starts the replication again, and ensures that post-flush, documents are re-replicated to it.
+//   - Recreates rt1 with a new bucket (to simulate a flush).
+//   - Starts the replication again, and ensures that documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
-
-	if base.UnitTestUrlIsWalrus() {
-		t.Skipf("test requires a flushable bucket (Couchbase Server)")
-	}
 
 	if base.GTestBucketPool.NumUsableBuckets() < 4 {
 		t.Skipf("test requires at least 4 usable test buckets")
@@ -1501,13 +1497,9 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 //   - Starts 2 RestTesters, one active, and one passive.
 //   - Creates a document on rt1 which is pushed to rt2.
 //   - Checkpoints once finished.
-//   - Flushes the bucket behind rt2.
+//   - Recreates rt2 with a new bucket (to simulate a flush).
 //   - Starts the replication again, and ensures that post-flush, documents are re-replicated to it.
 func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
-
-	if base.UnitTestUrlIsWalrus() {
-		t.Skipf("test requires a flushable bucket (Couchbase Server)")
-	}
 
 	if base.GTestBucketPool.NumUsableBuckets() < 4 {
 		t.Skipf("test requires at least 4 usable test buckets")

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1350,8 +1350,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 		t.Skipf("test requires a flushable bucket (Couchbase Server)")
 	}
 
-	if base.GTestBucketPool.NumUsableBuckets() < 2 {
-		t.Skipf("test requires at least 2 usable test buckets")
+	if base.GTestBucketPool.NumUsableBuckets() < 4 {
+		t.Skipf("test requires at least 4 usable test buckets")
 	}
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
@@ -1444,19 +1444,12 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 	assert.NoError(t, ar.Stop())
 
-	gocbBucket, ok := base.AsGoCBBucket(tb1)
-	require.True(t, ok)
-	require.NoError(t, gocbBucket.Flush())
-
-	fmt.Println("flushed bucket")
-
-	// prevent test bucket from being released back into pool upon close
-	rt1.testBucket = nil
+	// close rt1, and release the underlying bucket back to the pool.
 	rt1.Close()
 
-	// recreate rt1 with the now flushed tb1 bucket
+	// recreate rt1 with a new bucket
 	rt1 = NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 	defer rt1.Close()
 
@@ -1514,8 +1507,8 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 		t.Skipf("test requires a flushable bucket (Couchbase Server)")
 	}
 
-	if base.GTestBucketPool.NumUsableBuckets() < 2 {
-		t.Skipf("test requires at least 2 usable test buckets")
+	if base.GTestBucketPool.NumUsableBuckets() < 4 {
+		t.Skipf("test requires at least 4 usable test buckets")
 	}
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
@@ -1608,19 +1601,12 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	assert.NoError(t, ar.Stop())
 
-	gocbBucket, ok := base.AsGoCBBucket(tb2)
-	require.True(t, ok)
-	require.NoError(t, gocbBucket.Flush())
-
-	fmt.Println("flushed bucket")
-
-	// prevent test bucket from being released back into pool upon close
-	rt2.testBucket = nil
+	// close rt2, and release the underlying bucket back to the pool.
 	rt2.Close()
 
-	// recreate rt2, http server and update target URL in the replicator
+	// recreate rt2 with a new bucket, http server and update target URL in the replicator
 	rt2 = NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
 				"alice": {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1377,6 +1377,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	resp := rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","channels":["alice"]}`)
 	assertStatus(t, resp, http.StatusCreated)
 
+	assert.NoError(t, rt2.WaitForPendingChanges())
+
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
 	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
@@ -1548,6 +1550,8 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	docID := t.Name() + "rt1doc"
 	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
 	assertStatus(t, resp, http.StatusCreated)
+
+	assert.NoError(t, rt1.WaitForPendingChanges())
 
 	arConfig := db.ActiveReplicatorConfig{
 		ID:           t.Name(),

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1450,6 +1450,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 	fmt.Println("flushed bucket")
 
+	// prevent test bucket from being released back into pool upon close
+	rt1.testBucket = nil
 	rt1.Close()
 
 	// recreate rt1 with the now flushed tb1 bucket
@@ -1612,6 +1614,8 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	fmt.Println("flushed bucket")
 
+	// prevent test bucket from being released back into pool upon close
+	rt2.testBucket = nil
 	rt2.Close()
 
 	// recreate rt2, http server and update target URL in the replicator


### PR DESCRIPTION
The ActiveReplicator determines lowest checkpoint if checkpoints don't match.
Covers the case where buckets are flushed, or somehow rolled back (backup restore?)

TODO:
- [x] Test local flush
- [x] Test remote flush
- [x] Test remote rollback

Test:
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/339/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/342/
- [ ] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/343/