### PR TITLE
CBG-911 Add replicationStatus actions

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -137,6 +137,9 @@ func (c *Checkpointer) Start() {
 
 // CheckpointNow forces the checkpointer to send a checkpoint, and blocks until it has finished.
 func (c *Checkpointer) CheckpointNow() {
+	if c == nil {
+		return
+	}
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"context"
+	"expvar"
+
+	"github.com/couchbase/go-blip"
+)
+
+// replicatorCommon defines the struct contents shared by ActivePushReplicator
+// and ActivePullReplicator
+type activeReplicatorCommon struct {
+	config                *ActiveReplicatorConfig
+	blipSyncContext       *BlipSyncContext
+	blipSender            *blip.Sender
+	Stats                 expvar.Map
+	Checkpointer          *Checkpointer
+	checkpointerCtx       context.Context
+	checkpointerCtxCancel context.CancelFunc
+	state                 string
+	lastError             error
+	replicationStats      *BlipSyncStats
+}
+
+// setErrorState updates state and lastError, and
+// returns the error provided
+func (a *activeReplicatorCommon) setError(err error) (passThrough error) {
+	a.state = ReplicationStateError
+	a.lastError = err
+	return err
+}
+
+// setState updates replicator state and resets lastError to nil
+func (a *activeReplicatorCommon) setState(state string) {
+	a.state = state
+	a.lastError = nil
+}
+
+func (a *activeReplicatorCommon) Reset() error {
+	// TODO: pending CBG-908
+	//  Since we require that a replication be stopped
+	//  prior to reset, it's expected that checkpointer
+	//  is unavailable.  This function will need to
+	//  remove local checkpoints for push and pull replications
+	//  using the config.ActiveDB
+	return nil
+}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -479,6 +479,11 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 	return bsc.sendRevisionWithProperties(sender, docID, revID, bodyBytes, attDigests, properties)
 }
 
+// InitializeStats must be run before replication is started - there is no synchronization on replicationStats
+func (bsc *BlipSyncContext) InitializeStats(stats *BlipSyncStats) {
+	bsc.replicationStats = stats
+}
+
 func toHistory(revisions Revisions, knownRevs map[string]bool, maxHistory int) []string {
 	// Get the revision's history as a descending array of ancestor revIDs:
 	history := revisions.ParseRevisions()[1:]

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -885,5 +885,10 @@ func (h *handler) putReplicationStatus() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Query parameter 'action' must be specified")
 	}
 
-	return h.db.SGReplicateMgr.PutReplicationStatus(replicationID, action)
+	updatedStatus, err := h.db.SGReplicateMgr.PutReplicationStatus(replicationID, action)
+	if err != nil {
+		return err
+	}
+	h.writeJSON(updatedStatus)
+	return nil
 }

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -146,7 +146,7 @@ func TestReplicationStatusAPI(t *testing.T) {
 	replicationConfig := db.ReplicationConfig{
 		ID:        "replication1",
 		Remote:    "http://remote:4984/db",
-		Direction: "Pull",
+		Direction: "pull",
 	}
 
 	// PUT replication1
@@ -159,7 +159,7 @@ func TestReplicationStatusAPI(t *testing.T) {
 	var statusResponse db.ReplicationStatus
 	err := json.Unmarshal(response.BodyBytes(), &statusResponse)
 	require.NoError(t, err)
-	assert.Equal(t, statusResponse.ID, "replication1")
+	assert.Equal(t, "replication1", statusResponse.ID)
 
 	// PUT replication2
 	replication2Config := db.ReplicationConfig{


### PR DESCRIPTION
A number of replication lifecycle features that were required to support replicationStatus actions:
- refactored activeReplicator to support existence in a stopped state
- initialize replication stats on the replicator, and support initializing blipSyncContext with non-empty stats
- persist state to config, and respond to state changes for local replication when updated config is detected
- improved error reporting for failed replications, inclusion of error status and message in replicationStatus

Additional changes:
- refactored some common push and pull ActiveReplicator functionality into activeReplicatorCommon
- fixed a bug in sg_cluster_cfg where local cfg changes were triggering FireEvent twice (once on local invocation, once on DCP event