### PR TITLE
Fix data race on global SlowQueryWarningThreshold

### DIFF
--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -16,8 +16,6 @@ const IndexStateDeferred = "deferred" // bucket state value, as returned by SELE
 const IndexStatePending = "pending"   // bucket state value, as returned by SELECT FROM system:indexes.  Index has been created, build is in progress
 const PrimaryIndexName = "#primary"
 
-var SlowQueryWarningThreshold time.Duration
-
 // IndexOptions used to build the 'with' clause
 type N1qlIndexOptions struct {
 	NumReplica      uint `json:"num_replica,omitempty"`          // Number of replicas
@@ -405,8 +403,8 @@ func isTransientIndexerError(err error) bool {
 	return false
 }
 
-func SlowQueryLog(startTime time.Time, messageFormat string, args ...interface{}) {
-	if elapsed := time.Now().Sub(startTime); elapsed > SlowQueryWarningThreshold {
+func SlowQueryLog(startTime time.Time, threshold time.Duration, messageFormat string, args ...interface{}) {
+	if elapsed := time.Now().Sub(startTime); elapsed > threshold {
 		Infof(KeyQuery, messageFormat+" took "+elapsed.String(), args...)
 	}
 }

--- a/db/database.go
+++ b/db/database.go
@@ -126,6 +126,7 @@ type DatabaseContextOptions struct {
 	DeltaSyncOptions          DeltaSyncOptions // Delta Sync Options
 	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
 	SGReplicateOptions        SGReplicateOptions
+	SlowQueryWarningThreshold time.Duration
 }
 
 type SGReplicateOptions struct {

--- a/db/query.go
+++ b/db/query.go
@@ -227,8 +227,8 @@ const (
 func (context *DatabaseContext) N1QLQueryWithStats(queryName string, statement string, params interface{}, consistency gocb.ConsistencyMode, adhoc bool) (results gocb.QueryResults, err error) {
 
 	startTime := time.Now()
-	if base.SlowQueryWarningThreshold > 0 {
-		defer base.SlowQueryLog(startTime, "N1QL Query(%q)", queryName)
+	if threshold := context.Options.SlowQueryWarningThreshold; threshold > 0 {
+		defer base.SlowQueryLog(startTime, threshold, "N1QL Query(%q)", queryName)
 	}
 
 	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
@@ -250,8 +250,8 @@ func (context *DatabaseContext) N1QLQueryWithStats(queryName string, statement s
 func (context *DatabaseContext) ViewQueryWithStats(ddoc string, viewName string, params map[string]interface{}) (results sgbucket.QueryResultIterator, err error) {
 
 	startTime := time.Now()
-	if base.SlowQueryWarningThreshold > 0 {
-		defer base.SlowQueryLog(startTime, "View Query (%s.%s)", ddoc, viewName)
+	if threshold := context.Options.SlowQueryWarningThreshold; threshold > 0 {
+		defer base.SlowQueryLog(startTime, threshold, "View Query (%s.%s)", ddoc, viewName)
 	}
 
 	results, err = context.Bucket.ViewQuery(ddoc, viewName, params)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -82,11 +82,9 @@ func NewServerContext(config *ServerConfig) *ServerContext {
 		couchbase.SetTcpKeepalive(true, *config.CouchbaseKeepaliveInterval)
 	}
 
-	slowQuery := kDefaultSlowQueryWarningThreshold
-	if config.SlowQueryWarningThreshold != nil {
-		slowQuery = *config.SlowQueryWarningThreshold
+	if config.SlowQueryWarningThreshold == nil {
+		config.SlowQueryWarningThreshold = base.IntPtr(kDefaultSlowQueryWarningThreshold)
 	}
-	base.SlowQueryWarningThreshold = time.Duration(slowQuery) * time.Millisecond
 
 	sc.startStatsLogger()
 
@@ -659,6 +657,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 			Enabled:               sgReplicateEnabled,
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,
 		},
+		SlowQueryWarningThreshold: time.Duration(*sc.config.SlowQueryWarningThreshold) * time.Millisecond,
 	}
 
 	return contextOptions, nil


### PR DESCRIPTION
The global `SlowQueryWarningThreshold` could be simultaneously read/written from two server contexts, which can be triggered when more than one SGR2 test runs in a quick enough succession.

The race goes away when you increase log level, or if I run with Walrus, so seems very sensitive to how fast the first test can close the changes feed, which I think is related to CBG-944.

In either case, I think this change still makes sense to do, even if it's not the root cause of the race.

```
=== RUN   TestActiveReplicatorBlipsync
2020-07-02T13:43:01.475+01:00 [INF] rest.TestActiveReplicatorBlipsync: Setup logging: level: info - keys: [HTTP HTTP+]
2020-07-02T13:43:01.499+01:00 [INF] Successfully opened bucket sg_int_0
2020-07-02T13:43:01.500+01:00 [INF] Successfully opened bucket sg_int_2
2020-07-02T13:43:01.503+01:00 [INF] Successfully opened bucket sg_int_1
2020-07-02T13:43:01.508+01:00 [INF] Set query timeouts for bucket sg_int_0 to cluster:1m15s, bucket:1m15s
2020-07-02T13:43:01.509+01:00 [INF] Set query timeouts for bucket sg_int_2 to cluster:1m15s, bucket:1m15s
2020-07-02T13:43:01.518+01:00 [INF] Set query timeouts for bucket sg_int_1 to cluster:1m15s, bucket:1m15s
2020-07-02T13:43:02.873+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2020-07-02T13:43:03.182+01:00 [INF] Design docs successfully created for view version 2.1.
2020-07-02T13:43:03.182+01:00 [INF] Verifying view availability for bucket sg_int_0...
2020-07-02T13:43:03.211+01:00 [INF] Views ready for bucket sg_int_0.
2020-07-02T13:43:03.211+01:00 [INF] Logging stats with frequency: 1m0s
2020-07-02T13:43:03.212+01:00 [INF] Opening db /db as bucket "sg_int_0", pool "default", server <couchbase://192.168.1.22>
2020-07-02T13:43:03.212+01:00 [INF] GoCBCustomSGTranscoder Opening Couchbase database sg_int_0 on <couchbase://192.168.1.22> as user "Administrator"
2020-07-02T13:43:03.254+01:00 [INF] Successfully opened bucket sg_int_0
2020-07-02T13:43:03.279+01:00 [INF] Set query timeouts for bucket sg_int_0 to cluster:1m15s, bucket:1m15s
2020-07-02T13:43:03.291+01:00 [INF] Design docs for current SG view version (2.1) found.
2020-07-02T13:43:03.291+01:00 [INF] Verifying view availability for bucket sg_int_0...
2020-07-02T13:43:03.314+01:00 [INF] Views ready for bucket sg_int_0.
2020-07-02T13:43:03.314+01:00 [INF] delta_sync enabled=false with rev_max_age_seconds=86400 for database db
2020-07-02T13:43:03.317+01:00 [INF] Created background task: "CleanAgedItems" with interval 1m0s
2020-07-02T13:43:03.318+01:00 [INF] Created background task: "InsertPendingEntries" with interval 2.5s
2020-07-02T13:43:03.318+01:00 [INF] Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
2020-07-02T13:43:03.610+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "db"
2020-07-02T13:43:03.798+01:00 [INF] CBGoUtilsLogger: Using plain authentication for user <ud>Administrator</ud>
2020-07-02T13:43:04.096+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2020-07-02T13:43:04.294+01:00 [INF] Design docs successfully created for view version 2.1.
2020-07-02T13:43:04.294+01:00 [INF] Verifying view availability for bucket sg_int_2...
2020/07/02 13:43:04 Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 500 Internal Server Error\r\nX-XSS-Protection: 1; mode=block\r\nX-Permitted-Cross-Domain-Policies: none\r\nX-Frame-Options: DENY\r\nX-Content-Type-Options: nosniff\r\nServer: MochiWeb/1.0 (Any of you quaids got a smint?)\r\nDate: Thu, 02 Jul 2020 12:43:04 GMT\r\nContent-Type: text/plain;charset=utf-8\r\nContent-Length: 41\r\nCache-Control: must-revalidate\r\n\r\n{\"error\":\"case_clause\",\"reason\":\"false\"}\n"; err=<nil>
2020-07-02T13:43:04.319+01:00 [INF] Views ready for bucket sg_int_2.
2020-07-02T13:43:04.676+01:00 [INF] Created user "alice"
2020-07-02T13:43:04.683+01:00 [INF] HTTP:  #001: GET /db/
2020-07-02T13:43:05.161+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2020-07-02T13:43:05.360+01:00 [INF] Design docs successfully created for view version 2.1.
2020-07-02T13:43:05.360+01:00 [INF] Verifying view availability for bucket sg_int_1...
2020-07-02T13:43:05.368+01:00 [INF] HTTP+: #001:     --> 200   (684.7 ms)
2020-07-02T13:43:05.370+01:00 [INF] HTTP:  #002: GET /db/_blipsync
2020-07-02T13:43:05.374+01:00 [INF] HTTP+: #002:     --> 101 [31003bc3] Upgraded to BLIP+WebSocket protocol (as alice)  (0.0 ms)
2020-07-02T13:43:05.399+01:00 [INF] Views ready for bucket sg_int_1.
2020-07-02T13:43:05.402+01:00 [INF] HTTP:  #003: GET /db/
2020-07-02T13:43:05.404+01:00 [INF] HTTP+: #003:     --> 200   (2.7 ms)
2020-07-02T13:43:05.408+01:00 [INF] HTTP:  #004: GET /db/_blipsync
2020-07-02T13:43:05.411+01:00 [INF] HTTP+: #004:     --> 101 [748d101d] Upgraded to BLIP+WebSocket protocol (as alice)  (0.0 ms)
2020-07-02T13:43:05.472+01:00 [INF] HTTP: c:[31003bc3] #002:    --> BLIP+WebSocket connection closed
2020-07-02T13:43:05.522+01:00 [INF] HTTP: c:[748d101d] #004:    --> BLIP+WebSocket connection closed
2020-07-02T13:43:05.625+01:00 [WRN] c:sg_int_0-SG Error processing DCP stream - will attempt to restart/reconnect if appropriate: pkt.Receive, err: read tcp 192.168.1.21:41806->192.168.1.22:11210: use of closed network connection. -- base.(*DCPReceiver).OnError() at dcp_receiver.go:61
2020-07-02T13:43:05.625+01:00 [INF] rest.TestActiveReplicatorBlipsync: Reset logging
--- PASS: TestActiveReplicatorBlipsync (4.15s)
=== RUN   TestActiveReplicatorHeartbeats
2020-07-02T13:43:05.626+01:00 [INF] rest.TestActiveReplicatorHeartbeats: Setup logging: level: debug - keys: [WS WSFrame]
==================
WARNING: DATA RACE
Write at 0x0000022129e8 by goroutine 216:
  github.com/couchbase/sync_gateway/rest.NewServerContext()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/server_context.go:89 +0x368
  github.com/couchbase/sync_gateway/rest.(*RestTester).Bucket()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:106 +0x49f
  github.com/couchbase/sync_gateway/rest.(*RestTester).ServerContext()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:162 +0x38
  github.com/couchbase/sync_gateway/rest.(*RestTester).TestPublicHandler.func1()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:284 +0x4a
  sync.(*Once).doSlow()
      /home/bbrks/go/go1.13.10/src/sync/once.go:66 +0x100
  sync.(*Once).Do()
      /home/bbrks/go/go1.13.10/src/sync/once.go:57 +0x68
  github.com/couchbase/sync_gateway/rest.(*RestTester).TestPublicHandler()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/utilities_testing.go:283 +0x65
  github.com/couchbase/sync_gateway/rest.TestActiveReplicatorHeartbeats()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/replicator_test.go:95 +0x4b5
  testing.tRunner()
      /home/bbrks/go/go1.13.10/src/testing/testing.go:909 +0x199

Previous read at 0x0000022129e8 by goroutine 243:
  github.com/couchbase/sync_gateway/base.SlowQueryLog()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/base/bucket_n1ql.go:409 +0x8a
  github.com/couchbase/sync_gateway/db.(*DatabaseContext).ViewQueryWithStats()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/query.go:264 +0x3e8
  github.com/couchbase/sync_gateway/db.(*DatabaseContext).QueryChannels()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/query.go:337 +0x506
  github.com/couchbase/sync_gateway/db.(*DatabaseContext).getChangesInChannelFromQuery()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/changes_view.go:96 +0x77f
  github.com/couchbase/sync_gateway/db.(*singleChannelCacheImpl).GetChanges()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/channel_cache_single.go:409 +0x5ea
  github.com/couchbase/sync_gateway/db.(*Database).changesFeed.func1()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/changes.go:208 +0x829

Goroutine 216 (running) created at:
  testing.(*T).Run()
      /home/bbrks/go/go1.13.10/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /home/bbrks/go/go1.13.10/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /home/bbrks/go/go1.13.10/src/testing/testing.go:909 +0x199
  testing.runTests()
      /home/bbrks/go/go1.13.10/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /home/bbrks/go/go1.13.10/src/testing/testing.go:1117 +0x2ff
  github.com/couchbase/sync_gateway/rest.TestMain()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/rest/main_test.go:14 +0xb1
  main.main()
      _testmain.go:754 +0x223

Goroutine 243 (finished) created at:
  github.com/couchbase/sync_gateway/db.(*Database).changesFeed()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/changes.go:189 +0x2fe
  github.com/couchbase/sync_gateway/db.(*Database).SimpleMultiChangesFeed.func1()
      /home/bbrks/dev/cb/sg/master/godeps/src/github.com/couchbase/sync_gateway/db/changes.go:578 +0x9b4
==================
2020-07-02T13:43:05.627+01:00 [INF] Logging stats with frequency: 1m0s
2020-07-02T13:43:05.627+01:00 [INF] Opening db /db as bucket "sg_int_2", pool "default", server <couchbase://192.168.1.22>
2020-07-02T13:43:05.628+01:00 [INF] GoCBCustomSGTranscoder Opening Couchbase database sg_int_2 on <couchbase://192.168.1.22> as user "Administrator"
2020-07-02T13:43:05.649+01:00 [INF] Successfully opened bucket sg_int_2
2020-07-02T13:43:05.654+01:00 [INF] Successfully opened bucket sg_int_0
2020-07-02T13:43:05.680+01:00 [INF] Set query timeouts for bucket sg_int_2 to cluster:1m15s, bucket:1m15s
2020-07-02T13:43:05.680+01:00 [INF] Set query timeouts for bucket sg_int_0 to cluster:1m15s, bucket:1m15s
2020-07-02T13:43:05.701+01:00 [INF] Design docs for current SG view version (2.1) found.
2020-07-02T13:43:05.701+01:00 [INF] Verifying view availability for bucket sg_int_2...
2020-07-02T13:43:05.726+01:00 [INF] Views ready for bucket sg_int_2.
2020-07-02T13:43:05.726+01:00 [INF] delta_sync enabled=false with rev_max_age_seconds=86400 for database db
2020-07-02T13:43:05.729+01:00 [INF] Created background task: "CleanAgedItems" with interval 1m0s
2020-07-02T13:43:05.730+01:00 [INF] Created background task: "InsertPendingEntries" with interval 2.5s
2020-07-02T13:43:05.730+01:00 [INF] Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
2020-07-02T13:43:05.891+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "db"
2020-07-02T13:43:06.074+01:00 [INF] CBGoUtilsLogger: Using plain authentication for user <ud>Administrator</ud>
2020-07-02T13:43:06.878+01:00 [INF] Design docs for current view version (2.1) do not exist - creating...
2020-07-02T13:43:07.004+01:00 [INF] Created user "alice"
2020-07-02T13:43:07.113+01:00 [INF] Design docs successfully created for view version 2.1.
2020-07-02T13:43:07.113+01:00 [INF] Verifying view availability for bucket sg_int_0...
2020/07/02 13:43:07 Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 500 Internal Server Error\r\nX-XSS-Protection: 1; mode=block\r\nX-Permitted-Cross-Domain-Policies: none\r\nX-Frame-Options: DENY\r\nX-Content-Type-Options: nosniff\r\nServer: MochiWeb/1.0 (Any of you quaids got a smint?)\r\nDate: Thu, 02 Jul 2020 12:43:07 GMT\r\nContent-Type: text/plain;charset=utf-8\r\nContent-Length: 41\r\nCache-Control: must-revalidate\r\n\r\n"; err=<nil>
2020-07-02T13:43:07.145+01:00 [INF] Views ready for bucket sg_int_0.
2020-07-02T13:43:07.775+01:00 [DBG] Database db: Got server UUID 5694f6f843c3073c0e033dafa762972b
2020-07-02T13:43:07.783+01:00 [INF] WS: c:#006 Start BLIP/Websocket handler
2020-07-02T13:43:07.784+01:00 [DBG] WSFrame+: c:#006 Sender starting
2020-07-02T13:43:07.784+01:00 [DBG] WSFrame+: Sender starting
2020-07-02T13:43:07.784+01:00 [DBG] WS+: Queued MSG#1
2020-07-02T13:43:07.786+01:00 [DBG] WSFrame+: Push MSG#1
2020-07-02T13:43:07.792+01:00 [DBG] WSFrame+: Sending frame: MSG#1 (flags=       0, size=   83)
2020-07-02T13:43:07.793+01:00 [DBG] WSFrame+: c:#006 Received frame: MSG#1 (flags=       0, length=83)
2020-07-02T13:43:07.793+01:00 [DBG] WS+: c:#006 Incoming BLIP Request: MSG#1
2020-07-02T13:43:07.794+01:00 [DBG] WSFrame+: c:#006 Push ERR#1
2020-07-02T13:43:07.794+01:00 [DBG] WSFrame+: Sender sent ping frame
2020-07-02T13:43:07.795+01:00 [DBG] WSFrame+: c:#006 Sending frame: ERR#1 (flags=      10, size=   41)
2020-07-02T13:43:07.795+01:00 [DBG] WSFrame+: Received frame: ERR#1 (flags=      10, length=41)
2020-07-02T13:43:07.805+01:00 [DBG] WSFrame+: Sender sent ping frame
2020-07-02T13:43:07.814+01:00 [DBG] WSFrame+: Sender sent ping frame
2020-07-02T13:43:07.824+01:00 [DBG] WSFrame+: Sender sent ping frame
2020-07-02T13:43:07.834+01:00 [DBG] WSFrame+: Sender sent ping frame
2020-07-02T13:43:07.844+01:00 [DBG] WSFrame+: Sender sent ping frame
2020-07-02T13:43:07.845+01:00 [DBG] WSFrame+: Sender stopped
2020-07-02T13:43:07.845+01:00 [INF] WS: Error: receiveLoop exiting with WebSocket error: read tcp 127.0.0.1:50104->127.0.0.1:43607: use of closed network connection
2020-07-02T13:43:07.845+01:00 [DBG] WSFrame+: c:#006 receiveLoop stopped
2020-07-02T13:43:07.846+01:00 [INF] WS: BLIP/Websocket receiveLoop exited: read tcp 127.0.0.1:50104->127.0.0.1:43607: use of closed network connection
2020-07-02T13:43:07.846+01:00 [DBG] WSFrame+: parseLoop stopped
2020-07-02T13:43:07.846+01:00 [DBG] WSFrame+: c:#006 Sender stopped
2020-07-02T13:43:07.846+01:00 [DBG] WSFrame+: c:#006 parseLoop stopped
2020-07-02T13:43:07.898+01:00 [DBG] Terminating background task: "CleanAgedItems"
2020-07-02T13:43:07.898+01:00 [DBG] Terminating background task: "CleanSkippedSequenceQueue"
2020-07-02T13:43:07.898+01:00 [DBG] Terminating background task: "InsertPendingEntries"
2020-07-02T13:43:07.899+01:00 [WRN] c:sg_int_2-SG Error processing DCP stream - will attempt to restart/reconnect if appropriate: pkt.Receive, err: read tcp 192.168.1.21:41878->192.168.1.22:11210: use of closed network connection. -- base.(*DCPReceiver).OnError() at dcp_receiver.go:61
2020-07-02T13:43:07.900+01:00 [INF] rest.TestActiveReplicatorHeartbeats: Reset logging
--- FAIL: TestActiveReplicatorHeartbeats (2.27s)
    testing.go:853: race detected during execution of test
FAIL
```