### PR TITLE
CBG-937 - More accurately track last_seq stats, and move old stat to last_seq_checkpointed

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -131,7 +131,6 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.RejectedLocal = pullStats.HandleRevErrorCount.Value()
 		if ar.Pull.Checkpointer != nil {
 			status.LastSeqPull = ar.Pull.Checkpointer.calculateSafeProcessedSeq()
-			status.LastSeqCheckpointedPull = ar.Pull.Checkpointer.lastCheckpointSeq
 		}
 	}
 
@@ -141,7 +140,6 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocWriteFailures = pushStats.SendRevErrorCount.Value()
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
-			status.LastSeqCheckpointedPush = ar.Push.Checkpointer.lastCheckpointSeq
 		}
 		// TODO: This is another scenario where we need to send a rev without noreply set to get the returned error
 		// status.RejectedRemote = pushStats.SendRevSyncFunctionErrorCount.Value()

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -130,7 +130,8 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocsPurged = pullStats.DocsPurgedCount.Value()
 		status.RejectedLocal = pullStats.HandleRevErrorCount.Value()
 		if ar.Pull.Checkpointer != nil {
-			status.LastSeqPull = ar.Pull.Checkpointer.lastCheckpointSeq
+			status.LastSeqPull = ar.Pull.Checkpointer.calculateSafeProcessedSeq()
+			status.LastSeqPullCheckpointed = ar.Pull.Checkpointer.lastCheckpointSeq
 		}
 	}
 
@@ -139,7 +140,8 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocsWritten = pushStats.SendRevCount.Value()
 		status.DocWriteFailures = pushStats.SendRevErrorCount.Value()
 		if ar.Push.Checkpointer != nil {
-			status.LastSeqPush = ar.Push.Checkpointer.lastCheckpointSeq
+			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
+			status.LastSeqPushCheckpointed = ar.Push.Checkpointer.lastCheckpointSeq
 		}
 		// TODO: This is another scenario where we need to send a rev without noreply set to get the returned error
 		// status.RejectedRemote = pushStats.SendRevSyncFunctionErrorCount.Value()

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -131,7 +131,7 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.RejectedLocal = pullStats.HandleRevErrorCount.Value()
 		if ar.Pull.Checkpointer != nil {
 			status.LastSeqPull = ar.Pull.Checkpointer.calculateSafeProcessedSeq()
-			status.LastSeqPullCheckpointed = ar.Pull.Checkpointer.lastCheckpointSeq
+			status.LastSeqCheckpointedPull = ar.Pull.Checkpointer.lastCheckpointSeq
 		}
 	}
 
@@ -141,7 +141,7 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocWriteFailures = pushStats.SendRevErrorCount.Value()
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
-			status.LastSeqPushCheckpointed = ar.Push.Checkpointer.lastCheckpointSeq
+			status.LastSeqCheckpointedPush = ar.Push.Checkpointer.lastCheckpointSeq
 		}
 		// TODO: This is another scenario where we need to send a rev without noreply set to get the returned error
 		// status.RejectedRemote = pushStats.SendRevSyncFunctionErrorCount.Value()

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -172,14 +172,14 @@ func (c *Checkpointer) _calculateSafeExpectedSeqsIdx() int {
 	return safeIdx
 }
 
-// calculateSafeProcessedSeq returns the sequence last processed that is able to be checkpointed.
+// calculateSafeProcessedSeq returns the sequence last processed that is able to be checkpointed, or the last checkpointed sequence.
 func (c *Checkpointer) calculateSafeProcessedSeq() string {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	idx := c._calculateSafeExpectedSeqsIdx()
 	if idx == -1 {
-		return ""
+		return c.lastCheckpointSeq
 	}
 
 	return c.expectedSeqs[idx]

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -145,13 +145,8 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
 		base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: _updateCheckpointLists removed seq %v from processedSeqs map %v", removeSeq, c.processedSeqs)
 	}
 
-	if len(c.expectedSeqs)-1 == maxI {
-		// received full set, empty expectedSeqs list
-		c.expectedSeqs = c.expectedSeqs[0:0]
-	} else {
-		// trim expectedSeqs list for partially received set
-		c.expectedSeqs = c.expectedSeqs[maxI+1:]
-	}
+	// trim expectedSeqs list for all processed seqs
+	c.expectedSeqs = c.expectedSeqs[maxI+1:]
 
 	return safeSeq
 }

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -86,7 +86,6 @@ func (c *Checkpointer) AddExpectedSeq(seq ...string) {
 func (c *Checkpointer) Start() {
 	// Start a time-based checkpointer goroutine
 	go func() {
-		var exit bool
 		checkpointInterval := defaultCheckpointInterval
 		if c.checkpointInterval > 0 {
 			checkpointInterval = c.checkpointInterval
@@ -96,14 +95,8 @@ func (c *Checkpointer) Start() {
 		for {
 			select {
 			case <-ticker.C:
+				c.CheckpointNow()
 			case <-c.ctx.Done():
-				exit = true
-				// parent context stopped stopped, set a final checkpoint before stopping this goroutine
-			}
-
-			c.CheckpointNow()
-
-			if exit {
 				base.DebugfCtx(c.ctx, base.KeyReplicate, "checkpointer goroutine stopped")
 				return
 			}
@@ -121,7 +114,7 @@ func (c *Checkpointer) CheckpointNow() {
 
 	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: running")
 
-	seq := c.calculateCheckpointSeq()
+	seq := c._updateCheckpointLists()
 	if seq == "" {
 		return
 	}
@@ -133,43 +126,63 @@ func (c *Checkpointer) CheckpointNow() {
 	}
 }
 
-func (c *Checkpointer) calculateCheckpointSeq() (seq string) {
-	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: calculateCheckpointSeq(%v, %v)", c.expectedSeqs, c.processedSeqs)
+// _updateCheckpointLists determines the highest checkpointable sequence, and trims the processedSeqs/expectedSeqs lists up to this point.
+func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
+	base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: _updateCheckpointLists(expectedSeqs: %v, procssedSeqs: %v)", c.expectedSeqs, c.processedSeqs)
 
-	if len(c.expectedSeqs) == 0 {
+	maxI := c._calculateSafeExpectedSeqsIdx()
+	if maxI == -1 {
 		// nothing to do
 		return ""
 	}
 
-	// iterates over each (ordered) expected sequence and stops when we find the first sequence we've yet to process a rev message for
-	maxI := -1
-	for i, seq := range c.expectedSeqs {
-		if _, ok := c.processedSeqs[seq]; !ok {
-			base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: couldn't find %v in processedSeqs", seq)
-			break
-		}
+	safeSeq = c.expectedSeqs[maxI]
 
-		delete(c.processedSeqs, seq)
-		base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: calculateCheckpointSeq removed seq %v from processedSeqs map %v", seq, c.processedSeqs)
-		maxI = i
+	// removes to-be checkpointed sequences from processedSeqs list
+	for i := 0; i < maxI; i++ {
+		removeSeq := c.expectedSeqs[i]
+		delete(c.processedSeqs, removeSeq)
+		base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: _updateCheckpointLists removed seq %v from processedSeqs map %v", removeSeq, c.processedSeqs)
 	}
-
-	// the first seq we expected hasn't arrived yet, so can't checkpoint anything
-	if maxI < 0 {
-		return
-	}
-
-	seq = c.expectedSeqs[maxI]
 
 	if len(c.expectedSeqs)-1 == maxI {
-		// received full set, empty list
+		// received full set, empty expectedSeqs list
 		c.expectedSeqs = c.expectedSeqs[0:0]
 	} else {
-		// trim sequence list for partially received set
+		// trim expectedSeqs list for partially received set
 		c.expectedSeqs = c.expectedSeqs[maxI+1:]
 	}
 
-	return seq
+	return safeSeq
+}
+
+// _calculateSafeExpectedSeqsIdx returns an index into expectedSeqs which is safe to checkpoint.
+// Returns -1 if no sequence in the list is able to be checkpointed.
+func (c *Checkpointer) _calculateSafeExpectedSeqsIdx() int {
+	safeIdx := -1
+
+	// iterates over each (ordered) expected sequence and stops when we find the first sequence we've yet to process a rev message for
+	for i, seq := range c.expectedSeqs {
+		if _, ok := c.processedSeqs[seq]; !ok {
+			break
+		}
+		safeIdx = i
+	}
+
+	return safeIdx
+}
+
+// calculateSafeProcessedSeq returns the sequence last processed that is able to be checkpointed.
+func (c *Checkpointer) calculateSafeProcessedSeq() string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	idx := c._calculateSafeExpectedSeqsIdx()
+	if idx == -1 {
+		return ""
+	}
+
+	return c.expectedSeqs[idx]
 }
 
 const (

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -914,9 +914,9 @@ type ReplicationStatus struct {
 	RejectedRemote          int64  `json:"rejected_by_remote"`
 	RejectedLocal           int64  `json:"rejected_by_local"`
 	LastSeqPull             string `json:"last_seq_pull,omitempty"`
-	LastSeqPullCheckpointed string `json:"last_seq_pull_checkpointed,omitempty"`
+	LastSeqCheckpointedPull string `json:"last_seq_checkpointed_pull,omitempty"`
 	LastSeqPush             string `json:"last_seq_push,omitempty"`
-	LastSeqPushCheckpointed string `json:"last_seq_push_checkpointed,omitempty"`
+	LastSeqCheckpointedPush string `json:"last_seq_checkpointed_push,omitempty"`
 	ErrorMessage            string `json:"error_message,omitempty"`
 }
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -905,19 +905,17 @@ func (a NodesByReplicationCount) Less(i, j int) bool {
 
 // ReplicationStatus is used by the _replicationStatus REST API endpoints
 type ReplicationStatus struct {
-	ID                      string `json:"replication_id"`
-	DocsRead                int64  `json:"docs_read"`
-	DocsWritten             int64  `json:"docs_written"`
-	DocsPurged              int64  `json:"docs_purged,omitempty"`
-	DocWriteFailures        int64  `json:"doc_write_failures"`
-	Status                  string `json:"status"`
-	RejectedRemote          int64  `json:"rejected_by_remote"`
-	RejectedLocal           int64  `json:"rejected_by_local"`
-	LastSeqPull             string `json:"last_seq_pull,omitempty"`
-	LastSeqCheckpointedPull string `json:"last_seq_checkpointed_pull,omitempty"`
-	LastSeqPush             string `json:"last_seq_push,omitempty"`
-	LastSeqCheckpointedPush string `json:"last_seq_checkpointed_push,omitempty"`
-	ErrorMessage            string `json:"error_message,omitempty"`
+	ID               string `json:"replication_id"`
+	DocsRead         int64  `json:"docs_read"`
+	DocsWritten      int64  `json:"docs_written"`
+	DocsPurged       int64  `json:"docs_purged,omitempty"`
+	DocWriteFailures int64  `json:"doc_write_failures"`
+	Status           string `json:"status"`
+	RejectedRemote   int64  `json:"rejected_by_remote"`
+	RejectedLocal    int64  `json:"rejected_by_local"`
+	LastSeqPull      string `json:"last_seq_pull,omitempty"`
+	LastSeqPush      string `json:"last_seq_push,omitempty"`
+	ErrorMessage     string `json:"error_message,omitempty"`
 }
 
 func (m *sgReplicateManager) GetReplicationStatus(replicationID string) (*ReplicationStatus, error) {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -905,17 +905,19 @@ func (a NodesByReplicationCount) Less(i, j int) bool {
 
 // ReplicationStatus is used by the _replicationStatus REST API endpoints
 type ReplicationStatus struct {
-	ID               string `json:"replication_id"`
-	DocsRead         int64  `json:"docs_read"`
-	DocsWritten      int64  `json:"docs_written"`
-	DocsPurged       int64  `json:"docs_purged,omitempty"`
-	DocWriteFailures int64  `json:"doc_write_failures"`
-	Status           string `json:"status"`
-	RejectedRemote   int64  `json:"rejected_by_remote"`
-	RejectedLocal    int64  `json:"rejected_by_local"`
-	LastSeqPull      string `json:"last_seq_pull,omitempty"`
-	LastSeqPush      string `json:"last_seq_push,omitempty"`
-	ErrorMessage     string `json:"error_message,omitempty"`
+	ID                      string `json:"replication_id"`
+	DocsRead                int64  `json:"docs_read"`
+	DocsWritten             int64  `json:"docs_written"`
+	DocsPurged              int64  `json:"docs_purged,omitempty"`
+	DocWriteFailures        int64  `json:"doc_write_failures"`
+	Status                  string `json:"status"`
+	RejectedRemote          int64  `json:"rejected_by_remote"`
+	RejectedLocal           int64  `json:"rejected_by_local"`
+	LastSeqPull             string `json:"last_seq_pull,omitempty"`
+	LastSeqPullCheckpointed string `json:"last_seq_pull_checkpointed,omitempty"`
+	LastSeqPush             string `json:"last_seq_push,omitempty"`
+	LastSeqPushCheckpointed string `json:"last_seq_push_checkpointed,omitempty"`
+	ErrorMessage            string `json:"error_message,omitempty"`
 }
 
 func (m *sgReplicateManager) GetReplicationStatus(replicationID string) (*ReplicationStatus, error) {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -194,7 +194,6 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
 	assert.Equal(t, "", ar.GetStatus().LastSeqPull)
-	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPull)
 
 	// Start the replicator (implicit connect)
 	assert.NoError(t, ar.Start())
@@ -212,12 +211,6 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
 
 	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
-	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPull)
-
-	ar.Pull.Checkpointer.CheckpointNow()
-
-	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
-	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqCheckpointedPull)
 }
 
 // TestActiveReplicatorPullBasic:
@@ -453,7 +446,6 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
 	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
-	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPush)
 
 	// Start the replicator (implicit connect)
 	assert.NoError(t, ar.Start())
@@ -471,12 +463,6 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
 	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
-	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPush)
-
-	ar.Push.Checkpointer.CheckpointNow()
-
-	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
-	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqCheckpointedPush)
 }
 
 // TestActiveReplicatorPushFromCheckpoint:

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -161,6 +161,9 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
+	remoteDoc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
@@ -190,6 +193,9 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
+	assert.Equal(t, "", ar.GetStatus().LastSeqPull)
+	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPull)
+
 	// Start the replicator (implicit connect)
 	assert.NoError(t, ar.Start())
 
@@ -204,6 +210,14 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
 	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
+	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPull)
+
+	ar.Pull.Checkpointer.CheckpointNow()
+
+	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
+	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqCheckpointedPull)
 }
 
 // TestActiveReplicatorPullBasic:
@@ -414,6 +428,9 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
+	localDoc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
@@ -435,6 +452,9 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
+	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
+	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPush)
+
 	// Start the replicator (implicit connect)
 	assert.NoError(t, ar.Start())
 
@@ -444,11 +464,19 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
+	assert.Equal(t, "", ar.GetStatus().LastSeqCheckpointedPush)
+
+	ar.Push.Checkpointer.CheckpointNow()
+
+	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
+	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqCheckpointedPush)
 }
 
 // TestActiveReplicatorPushFromCheckpoint:


### PR DESCRIPTION
- Remove `CheckpointNow()` on context close. Already explicitly called as part of `Stop()`
- `last_seq_...` stats now report last safe seq which is yet to be checkpointed, or the last checkpointed seq if none pending