### PR TITLE
CBG-923 - Add rev response callback

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -137,7 +137,8 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 	if ar.Push != nil {
 		pushStats := ar.Push.replicationStats
 		status.DocsWritten = pushStats.SendRevCount.Value()
-		status.DocWriteFailures = pushStats.SendRevErrorCount.Value()
+		status.DocWriteFailures = pushStats.SendRevErrorTotal.Value()
+		status.RejectedRemote = pushStats.SendRevErrorRejectedCount.Value()
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
 		}

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -138,6 +138,7 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		pushStats := ar.Push.replicationStats
 		status.DocsWritten = pushStats.SendRevCount.Value()
 		status.DocWriteFailures = pushStats.SendRevErrorTotal.Value()
+		status.DocWriteConflict = pushStats.SendRevErrorConflictCount.Value()
 		status.RejectedRemote = pushStats.SendRevErrorRejectedCount.Value()
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -261,13 +261,11 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 			var responseCallback func(resp *blip.Message)
 			if bsc.postSendRevisionResponseCallback != nil {
 				responseCallback = func(resp *blip.Message) {
-					if resp.Type() == blip.ResponseType {
-						bsc.postSendRevisionResponseCallback(seq.String())
-					} else {
+					if resp.Type() != blip.ResponseType {
 						respBody, _ := response.Body()
 						base.WarnfCtx(bsc.loggingCtx, "error %s in response to rev: %s", response.Properties["Error-Code"], respBody)
-						// TODO: What do we want to do with SGR2 checkpointing in this case? By never calling the callback, we're effectively preventing all future sequences from being checkpointed, but don't have a way to retry or recover.
 					}
+					bsc.postSendRevisionResponseCallback(seq.String())
 				}
 			}
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -3,19 +3,25 @@ package db
 import "expvar"
 
 type BlipSyncStats struct {
-	HandleRevCount      *expvar.Int
-	HandleRevErrorCount *expvar.Int
-	SendRevCount        *expvar.Int
-	SendRevErrorCount   *expvar.Int
-	DocsPurgedCount     *expvar.Int
+	HandleRevCount            *expvar.Int
+	HandleRevErrorCount       *expvar.Int
+	SendRevCount              *expvar.Int
+	SendRevErrorTotal         *expvar.Int
+	SendRevErrorConflictCount *expvar.Int
+	SendRevErrorRejectedCount *expvar.Int
+	SendRevErrorOtherCount    *expvar.Int
+	DocsPurgedCount           *expvar.Int
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
 	return &BlipSyncStats{
-		HandleRevCount:      &expvar.Int{},
-		HandleRevErrorCount: &expvar.Int{},
-		SendRevCount:        &expvar.Int{},
-		SendRevErrorCount:   &expvar.Int{},
-		DocsPurgedCount:     &expvar.Int{},
+		HandleRevCount:            &expvar.Int{},
+		HandleRevErrorCount:       &expvar.Int{},
+		SendRevCount:              &expvar.Int{},
+		SendRevErrorTotal:         &expvar.Int{},
+		SendRevErrorConflictCount: &expvar.Int{},
+		SendRevErrorRejectedCount: &expvar.Int{},
+		SendRevErrorOtherCount:    &expvar.Int{},
+		DocsPurgedCount:           &expvar.Int{},
 	}
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -910,6 +910,7 @@ type ReplicationStatus struct {
 	DocsWritten      int64  `json:"docs_written"`
 	DocsPurged       int64  `json:"docs_purged,omitempty"`
 	DocWriteFailures int64  `json:"doc_write_failures"`
+	DocWriteConflict int64  `json:"doc_write_conflict"`
 	Status           string `json:"status"`
 	RejectedRemote   int64  `json:"rejected_by_remote"`
 	RejectedLocal    int64  `json:"rejected_by_local"`


### PR DESCRIPTION
Invoke a callback when a response is received for a rev message triggered by SGR2 push, so that we're able to verify a successful response before checkpointing the sequence.

Uses the same goroutine as the existing attachment verification to prevent additional overhead.

## Open question:
- [x] What do we do with an error response? By not invoking the callback, we're preventing all future sequences from being checkpointed, and we have no mechanism currently to retry sending a rev.