### PR TITLE
Implement includeConfig on replicationStatus APIs

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -858,7 +858,8 @@ func (h *handler) deleteReplication() error {
 }
 
 func (h *handler) getReplicationsStatus() error {
-	replicationsStatus, err := h.db.SGReplicateMgr.GetReplicationStatusAll()
+	includeConfig, _ := h.getOptBoolQuery("includeConfig", false)
+	replicationsStatus, err := h.db.SGReplicateMgr.GetReplicationStatusAll(includeConfig)
 	if err != nil {
 		return err
 	}
@@ -869,7 +870,8 @@ func (h *handler) getReplicationsStatus() error {
 
 func (h *handler) getReplicationStatus() error {
 	replicationID := mux.Vars(h.rq)["replicationID"]
-	status, err := h.db.SGReplicateMgr.GetReplicationStatus(replicationID)
+	includeConfig, _ := h.getOptBoolQuery("includeConfig", false)
+	status, err := h.db.SGReplicateMgr.GetReplicationStatus(replicationID, includeConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Includes config definition in GET replicationStatus response when includeConfig=true query parameter is set.