### PR TITLE
CBG-905: Support using custom OIDC claim as Sync Gateway username

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -655,7 +655,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -665,7 +665,8 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			IssuedAt: jwt.NewNumericDate(time.Now()),
 			Expiry:   jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
 		}
-		wantUsername := getOIDCUsername(provider, claims.Subject)
+		wantUsername, err := getOIDCUsername(provider, &Identity{Subject: claims.Subject})
+		assert.NoError(t, err, "Error retrieving OpenID Connect username")
 		builder := jwt.Signed(signer).Claims(claims)
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
@@ -683,7 +684,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -710,7 +711,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud4",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -737,7 +738,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud4",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -763,7 +764,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -790,7 +791,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:        "id0123456789",
@@ -801,7 +802,8 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Expiry:    jwt.NewNumericDate(time.Now().Add(1 * time.Minute)),
 			NotBefore: jwt.NewNumericDate(time.Now().Add(1 * time.Minute)),
 		}
-		wantUsername := getOIDCUsername(provider, claims.Subject)
+		wantUsername, err := getOIDCUsername(provider, &Identity{Subject: claims.Subject})
+		assert.NoError(t, err, "Error retrieving OpenID Connect username")
 		builder := jwt.Signed(signer).Claims(claims)
 		token, err := builder.CompactSerialize()
 		require.NoError(t, err, "Error serializing token using compact serialization format")
@@ -819,7 +821,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:        "id0123456789",
@@ -847,7 +849,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			Issuer:      issuerGoogleAccounts,
 			ClientID:    "aud1",
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -881,7 +883,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -919,7 +921,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -957,7 +959,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -989,7 +991,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 			UserPrefix:  strings.ToLower(providerGoogle.Name),
 		}
-		err = provider.initUserPrefix()
+		err = provider.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",
@@ -1214,7 +1216,7 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 			ClientID:    "aud1",
 		}
 		providers := OIDCProviderMap{providerGoogle.Name: providerGoogle, providerFacebook.Name: providerFacebook}
-		err = providerGoogle.initUserPrefix()
+		err = providerGoogle.InitUserPrefix()
 		assert.NoError(t, err, "Error initializing user prefix")
 		claims := jwt.Claims{
 			ID:       "id0123456789",

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -427,9 +427,9 @@ func formatUsername(value interface{}) (string, error) {
 	case string:
 		return valueType, nil
 	case json.Number:
-		return string(valueType), nil
+		return valueType.String(), nil
 	case float64:
-		return strconv.FormatFloat(valueType, 'e', -1, 64), nil
+		return strconv.FormatFloat(valueType, 'f', -1, 64), nil
 	default:
 		return "", fmt.Errorf("oidc: can't treat value of type: %T as valid username", valueType)
 	}

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -156,6 +156,8 @@ type OIDCProvider struct {
 	DisableCallbackState bool `json:"disable_callback_state,omitempty"`
 
 	// UsernameClaim allows to specify a claim other than subject to use as the Sync Gateway username.
+	// The specified claim must be a string - numeric claims may be unmarshalled inconsistently between 
+	// Sync Gateway and the underlying OIDC library.
 	UsernameClaim string `json:"username_claim"`
 
 	// client represents client configurations to authenticate end-users

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -156,7 +156,7 @@ type OIDCProvider struct {
 	DisableCallbackState bool `json:"disable_callback_state,omitempty"`
 
 	// UsernameClaim allows to specify a claim other than subject to use as the Sync Gateway username.
-	// The specified claim must be a string - numeric claims may be unmarshalled inconsistently between 
+	// The specified claim must be a string - numeric claims may be unmarshalled inconsistently between
 	// Sync Gateway and the underlying OIDC library.
 	UsernameClaim string `json:"username_claim"`
 

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"io"
 	"log"
@@ -894,6 +895,7 @@ func TestGetDiscoveryEndpoint(t *testing.T) {
 		})
 	}
 }
+
 func TestIsStandardDiscovery(t *testing.T) {
 	tests := []struct {
 		name                        string
@@ -936,6 +938,44 @@ func TestIsStandardDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			isStandardDiscoveryActual := tc.provider.isStandardDiscovery()
 			assert.Equal(t, tc.isStandardDiscoveryExpected, isStandardDiscoveryActual)
+		})
+	}
+}
+
+func TestFormatUsername(t *testing.T) {
+	tests := []struct {
+		name             string
+		username         interface{}
+		usernameExpected string
+		errorExpected    error
+	}{{
+		name:             "format username with valid username of type string",
+		username:         "80249751",
+		usernameExpected: "80249751",
+	}, {
+		name:             "format username with valid username of type int",
+		username:         80249751,
+		usernameExpected: "",
+		errorExpected:    errors.New("oidc: can't treat value of type: int as valid username"),
+	}, {
+		name:             "format username with valid username of type float64",
+		username:         float64(80249751),
+		usernameExpected: "8.0249751e+07",
+	}, {
+		name:             "format username with valid username of type json.Number",
+		username:         json.Number("80249751"),
+		usernameExpected: "80249751",
+	}, {
+		name:             "format username with valid username of type nil",
+		username:         nil,
+		usernameExpected: "",
+		errorExpected:    errors.New("oidc: can't treat value of type: <nil> as valid username"),
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			username, err := formatUsername(tc.username)
+			assert.Equal(t, tc.errorExpected, err)
+			assert.Equal(t, tc.usernameExpected, username)
 		})
 	}
 }

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -960,7 +960,7 @@ func TestFormatUsername(t *testing.T) {
 	}, {
 		name:             "format username with valid username of type float64",
 		username:         float64(80249751),
-		usernameExpected: "8.0249751e+07",
+		usernameExpected: "80249751",
 	}, {
 		name:             "format username with valid username of type json.Number",
 		username:         json.Number("80249751"),

--- a/auth/oidc_test.go
+++ b/auth/oidc_test.go
@@ -172,41 +172,43 @@ func TestOIDCProviderMap_GetProviderForIssuer(t *testing.T) {
 }
 
 func TestOIDCUsername(t *testing.T) {
-
 	provider := OIDCProvider{
 		Name:   "Some_Provider",
 		Issuer: "http://www.someprovider.com",
 	}
 
-	err := provider.initUserPrefix()
+	err := provider.InitUserPrefix()
 	assert.NoError(t, err)
 	assert.Equal(t, "www.someprovider.com", provider.UserPrefix)
 
 	// test username suffix
-	oidcUsername := getOIDCUsername(&provider, "bernard")
+	identity := Identity{Subject: "bernard"}
+	oidcUsername, err := getOIDCUsername(&provider, &identity)
+	assert.NoError(t, err, "Error retrieving OpenID Connect username")
 	assert.Equal(t, "www.someprovider.com_bernard", oidcUsername)
 	assert.Equal(t, true, IsValidPrincipalName(oidcUsername))
 
 	// test char escaping
-	oidcUsername = getOIDCUsername(&provider, "{bernard}")
+	identity.Subject = "{bernard}"
+	oidcUsername, err = getOIDCUsername(&provider, &identity)
+	assert.NoError(t, err, "Error retrieving OpenID Connect username")
 	assert.Equal(t, "www.someprovider.com_%7Bbernard%7D", oidcUsername)
 	assert.Equal(t, true, IsValidPrincipalName(oidcUsername))
 
 	// test URL with paths
 	provider.UserPrefix = ""
 	provider.Issuer = "http://www.someprovider.com/extra"
-	err = provider.initUserPrefix()
+	err = provider.InitUserPrefix()
 	assert.NoError(t, err)
 	assert.Equal(t, "www.someprovider.com%2Fextra", provider.UserPrefix)
 
 	// test invalid URL
 	provider.UserPrefix = ""
 	provider.Issuer = "http//www.someprovider.com"
-	err = provider.initUserPrefix()
+	err = provider.InitUserPrefix()
 	assert.NoError(t, err)
 	// falls back to provider name:
 	assert.Equal(t, "Some_Provider", provider.UserPrefix)
-
 }
 
 func TestInitOIDCClient(t *testing.T) {

--- a/auth/oidc_verify.go
+++ b/auth/oidc_verify.go
@@ -26,16 +26,36 @@ type Identity struct {
 	Expiry   time.Time
 	IssuedAt time.Time
 	Email    string
+	Claims   map[string]interface{}
 }
 
 type IdentityJson struct {
-	Issuer    string    `json:"iss"`
-	Subject   string    `json:"sub"`
-	Audience  audience  `json:"aud"`
-	Expiry    jsonTime  `json:"exp"`
-	IssuedAt  jsonTime  `json:"iat"`
-	NotBefore *jsonTime `json:"nbf"`
-	Email     string    `json:"email"`
+	Issuer    string                 `json:"iss"`
+	Subject   string                 `json:"sub"`
+	Audience  audience               `json:"aud"`
+	Expiry    jsonTime               `json:"exp"`
+	IssuedAt  jsonTime               `json:"iat"`
+	NotBefore *jsonTime              `json:"nbf"`
+	Email     string                 `json:"email"`
+	Claims    map[string]interface{} `json:"-"`
+}
+
+// UnmarshalIdentityJSON unmarshalls the raw claims into IdentityJson
+func UnmarshalIdentityJSON(claims []byte, identity *IdentityJson) error {
+	if err := json.Unmarshal(claims, &identity); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(claims, &identity.Claims); err != nil {
+		return err
+	}
+	delete(identity.Claims, "iss")
+	delete(identity.Claims, "sub")
+	delete(identity.Claims, "aud")
+	delete(identity.Claims, "exp")
+	delete(identity.Claims, "iat")
+	delete(identity.Claims, "nbf")
+	delete(identity.Claims, "email")
+	return nil
 }
 
 // VerifyClaims parses a raw ID Token and verifies the claim.
@@ -44,8 +64,8 @@ func VerifyClaims(rawIDToken, clientID, issuer string) (*Identity, error) {
 	if err != nil {
 		return nil, fmt.Errorf("oidc: malformed jwt: %v", err)
 	}
-	var identityJson IdentityJson
-	if err := json.Unmarshal(payload, &identityJson); err != nil {
+	identityJson := new(IdentityJson)
+	if err := UnmarshalIdentityJSON(payload, identityJson); err != nil {
 		return nil, fmt.Errorf("oidc: failed to unmarshal claims: %v", err)
 	}
 
@@ -56,6 +76,7 @@ func VerifyClaims(rawIDToken, clientID, issuer string) (*Identity, error) {
 		Expiry:   time.Time(identityJson.Expiry),
 		IssuedAt: time.Time(identityJson.IssuedAt),
 		Email:    identityJson.Email,
+		Claims:   identityJson.Claims,
 	}
 
 	// Check issuer. Google sometimes returns "accounts.google.com" as the issuer claim instead of the required
@@ -139,15 +160,10 @@ func (j *jsonTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func GetIdentity(idToken *oidc.IDToken) (identity *Identity, identityErr error) {
+// getIdentity returns identity claims extracted from an ID token.
+func getIdentity(idToken *oidc.IDToken) (identity *Identity, ok bool, identityErr error) {
 	if idToken == nil {
-		return nil, errors.New("can't extract identity from a nil token")
-	}
-	var claims struct {
-		Email string `json:"email"`
-	}
-	if err := idToken.Claims(&claims); err != nil {
-		identityErr = pkgerrors.Wrap(err, "failed to get email from token")
+		return nil, false, errors.New("can't extract identity claims from a nil token")
 	}
 	identity = &Identity{
 		Issuer:   idToken.Issuer,
@@ -155,7 +171,17 @@ func GetIdentity(idToken *oidc.IDToken) (identity *Identity, identityErr error) 
 		Subject:  idToken.Subject,
 		Expiry:   idToken.Expiry,
 		IssuedAt: idToken.IssuedAt,
-		Email:    claims.Email,
 	}
-	return identity, identityErr
+	claims := map[string]interface{}{}
+	if err := idToken.Claims(&claims); err != nil {
+		identityErr = pkgerrors.Wrap(err, "failed to extract identity claims from token")
+	}
+	identity.Claims = claims
+	if claim, found := claims["email"]; found {
+		var ok bool
+		if identity.Email, ok = claim.(string); !ok {
+			return identity, true, fmt.Errorf("oidc: can't cast claim %q as string", "email")
+		}
+	}
+	return identity, true, identityErr
 }

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -361,7 +361,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 			request.Header.Add("Authorization", BearerToken+" "+authResponseActual.IDToken)
 			response, err = http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
-			checkGoodAuthResponse(t, response)
+			checkGoodAuthResponse(t, response, "foo_noah")
 		})
 	}
 }


### PR DESCRIPTION
When authenticating incoming OIDC tokens, Sync Gateway currently treats the username as [user_prefix]_[subject].  By default user_prefix is the issuer, but can be customized in the Sync Gateway provider config.  Subject is always the sub claim in the token. In some OIDC implementations, users would like to specify a claim other than subject to use as the Sync Gateway username.  To support this, we add a new 'username_claim' config property to Sync Gateway's provider config, with the following behavior:

- If username_claim is set but user_prefix is not set, use that claim as the Sync Gateway username.
- If username_claim is set and user_prefix is also set, use [user_prefix]_[username_claim] as the Sync Gateway username.
- If username_claim is not set and user_prefix is set, use [user_prefix]_[subject] as the Sync Gateway username (existing behaviour).
- If neither username_claim nor user_prefix are set, use [issuer]_[subject] as the Sync Gateway username (existing behaviour).
- If username_claim is set but the specified claim property does not exist in the token, then reject the token
- If the username associated with an OIDC subject changes, Sync Gateway does not maintain any connection between the previous user and the current user.  If register=true, a new user will be created if it does not already exist.  If register=false, the user must be created prior to successful authentication with the token