### PR TITLE
CBG-944 Update replication state on one-shot completion

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -28,23 +28,31 @@ const (
 
 // ActiveReplicator is a wrapper to encapsulate separate push and pull active replicators.
 type ActiveReplicator struct {
-	ID   string
-	Push *ActivePushReplicator
-	Pull *ActivePullReplicator
+	ID         string
+	Push       *ActivePushReplicator
+	Pull       *ActivePullReplicator
+	onComplete OnCompleteFunc
 }
 
 // NewActiveReplicator returns a bidirectional active replicator for the given config.
 func NewActiveReplicator(config *ActiveReplicatorConfig) *ActiveReplicator {
 	ar := &ActiveReplicator{
-		ID: config.ID,
+		ID:         config.ID,
+		onComplete: config.onComplete,
 	}
 
 	if pushReplication := config.Direction == ActiveReplicatorTypePush || config.Direction == ActiveReplicatorTypePushAndPull; pushReplication {
 		ar.Push = NewPushReplicator(config)
+		if ar.onComplete != nil {
+			ar.Push.onReplicatorComplete = ar.ReplicationComplete
+		}
 	}
 
 	if pullReplication := config.Direction == ActiveReplicatorTypePull || config.Direction == ActiveReplicatorTypePushAndPull; pullReplication {
 		ar.Pull = NewPullReplicator(config)
+		if ar.onComplete != nil {
+			ar.Pull.onReplicatorComplete = ar.ReplicationComplete
+		}
 	}
 
 	return ar
@@ -96,6 +104,21 @@ func (ar *ActiveReplicator) Reset() error {
 	}
 
 	return nil
+}
+
+func (ar *ActiveReplicator) ReplicationComplete() {
+	allReplicationsComplete := true
+	if ar.Push != nil && ar.Push.state != ReplicationStateStopped {
+		allReplicationsComplete = false
+	}
+	if ar.Pull != nil && ar.Pull.state != ReplicationStateStopped {
+		allReplicationsComplete = false
+	}
+
+	if allReplicationsComplete {
+		ar.onComplete(ar.ID)
+	}
+
 }
 
 func (ar *ActiveReplicator) State() (state string, errorMessage string) {

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -123,6 +123,7 @@ func (ar *ActiveReplicator) ReplicationComplete() {
 
 func (ar *ActiveReplicator) State() (state string, errorMessage string) {
 
+	state = ReplicationStateStopped
 	if ar.Push != nil {
 		state = ar.Push.state
 		if ar.Push.state == ReplicationStateError && ar.Push.lastError != nil {

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -108,10 +108,10 @@ func (ar *ActiveReplicator) Reset() error {
 
 func (ar *ActiveReplicator) ReplicationComplete() {
 	allReplicationsComplete := true
-	if ar.Push != nil && ar.Push.state != ReplicationStateStopped {
+	if ar.Push != nil && ar.Push.getState() != ReplicationStateStopped {
 		allReplicationsComplete = false
 	}
-	if ar.Pull != nil && ar.Pull.state != ReplicationStateStopped {
+	if ar.Pull != nil && ar.Pull.getState() != ReplicationStateStopped {
 		allReplicationsComplete = false
 	}
 
@@ -125,16 +125,14 @@ func (ar *ActiveReplicator) State() (state string, errorMessage string) {
 
 	state = ReplicationStateStopped
 	if ar.Push != nil {
-		state = ar.Push.state
-		if ar.Push.state == ReplicationStateError && ar.Push.lastError != nil {
-			errorMessage = ar.Push.lastError.Error()
-		}
+		state, errorMessage = ar.Push.getStateWithErrorMessage()
 	}
 
 	if ar.Pull != nil {
-		state = combinedState(state, ar.Pull.state)
-		if ar.Pull.state == ReplicationStateError && ar.Pull.lastError != nil {
-			errorMessage = ar.Pull.lastError.Error()
+		pullState, pullErrorMessage := ar.Pull.getStateWithErrorMessage()
+		state = combinedState(state, pullState)
+		if pullErrorMessage != "" {
+			errorMessage = pullErrorMessage
 		}
 	}
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"expvar"
+	"sync"
 
 	"github.com/couchbase/go-blip"
 )
@@ -10,17 +11,18 @@ import (
 // replicatorCommon defines the struct contents shared by ActivePushReplicator
 // and ActivePullReplicator
 type activeReplicatorCommon struct {
-	config                *ActiveReplicatorConfig
-	blipSyncContext       *BlipSyncContext
-	blipSender            *blip.Sender
-	Stats                 expvar.Map
-	Checkpointer          *Checkpointer
-	checkpointerCtx       context.Context
-	checkpointerCtxCancel context.CancelFunc
-	state                 string
-	lastError             error
-	replicationStats      *BlipSyncStats
-	onReplicatorComplete  ReplicatorCompleteFunc
+	config                  *ActiveReplicatorConfig
+	blipSyncContext         *BlipSyncContext
+	blipSender              *blip.Sender
+	Stats                   expvar.Map
+	Checkpointer            *Checkpointer
+	checkpointerCtx         context.Context
+	checkpointerCtxCancel   context.CancelFunc
+	state                   string
+	lastError               error
+	replicationStats        *BlipSyncStats
+	onReplicatorComplete    ReplicatorCompleteFunc
+	replicatorCompleteMutex sync.Mutex
 }
 
 type ReplicatorCompleteFunc func()

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -11,34 +11,58 @@ import (
 // replicatorCommon defines the struct contents shared by ActivePushReplicator
 // and ActivePullReplicator
 type activeReplicatorCommon struct {
-	config                  *ActiveReplicatorConfig
-	blipSyncContext         *BlipSyncContext
-	blipSender              *blip.Sender
-	Stats                   expvar.Map
-	Checkpointer            *Checkpointer
-	checkpointerCtx         context.Context
-	checkpointerCtxCancel   context.CancelFunc
-	state                   string
-	lastError               error
-	replicationStats        *BlipSyncStats
-	onReplicatorComplete    ReplicatorCompleteFunc
-	replicatorCompleteMutex sync.Mutex
+	config                *ActiveReplicatorConfig
+	blipSyncContext       *BlipSyncContext
+	blipSender            *blip.Sender
+	Stats                 expvar.Map
+	Checkpointer          *Checkpointer
+	checkpointerCtx       context.Context
+	checkpointerCtxCancel context.CancelFunc
+	state                 string
+	lastError             error
+	replicationStats      *BlipSyncStats
+	onReplicatorComplete  ReplicatorCompleteFunc
+	lock                  sync.RWMutex
 }
 
 type ReplicatorCompleteFunc func()
 
 // setErrorState updates state and lastError, and
-// returns the error provided
-func (a *activeReplicatorCommon) setError(err error) (passThrough error) {
+// returns the error provided.  Expects callers to be holding
+// a.lock
+func (a *activeReplicatorCommon) _setError(err error) (passThrough error) {
 	a.state = ReplicationStateError
 	a.lastError = err
 	return err
 }
 
-// setState updates replicator state and resets lastError to nil
-func (a *activeReplicatorCommon) setState(state string) {
+// setState updates replicator state and resets lastError to nil.  Expects callers
+// to be holding a.lock
+func (a *activeReplicatorCommon) _setState(state string) {
 	a.state = state
 	a.lastError = nil
+}
+
+func (a *activeReplicatorCommon) getState() string {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	return a.state
+}
+
+func (a *activeReplicatorCommon) getLastError() error {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	return a.lastError
+}
+
+func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastErrorMessage string) {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	if a.lastError == nil {
+		return a.state, ""
+	} else {
+		return a.state, a.lastError.Error()
+	}
 }
 
 func (a *activeReplicatorCommon) Reset() error {

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -20,7 +20,10 @@ type activeReplicatorCommon struct {
 	state                 string
 	lastError             error
 	replicationStats      *BlipSyncStats
+	onReplicatorComplete  ReplicatorCompleteFunc
 }
+
+type ReplicatorCompleteFunc func()
 
 // setErrorState updates state and lastError, and
 // returns the error provided

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -63,7 +63,12 @@ type ActiveReplicatorConfig struct {
 	// InsecureSkipVerify determines whether the TLS certificate verification should be
 	// disabled during replication. TLS certificate verification is enabled by default.
 	InsecureSkipVerify bool
+
+	// Callback to be invoked on replication completion
+	onComplete OnCompleteFunc
 }
+
+type OnCompleteFunc func(replicationID string)
 
 // CheckpointHash returns a deterministic hash of the given config to be used as a checkpoint ID.
 // TODO: Might be a way of caching this value? But need to be sure no config values wil change without clearing the cached hash.

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -70,12 +70,10 @@ func (apr *ActivePullReplicator) Start() error {
 // Complete gracefully shuts down a replication, waiting for all in-flight revisions to be processed
 // before stopping the replication
 func (apr *ActivePullReplicator) Complete() {
-	base.Infof(base.KeyReplicate, "Performing Complete for replication %s", apr.config.ID)
 	err := apr.Checkpointer.waitForExpectedSequences()
 	if err != nil {
-		base.Infof(base.KeyReplicate, "Timeout draining replication - stopping: %v", err)
+		base.Infof(base.KeyReplicate, "Timeout draining replication %s - stopping: %v", apr.config.ID, err)
 	}
-	base.Infof(base.KeyReplicate, "Drain done, stopping replication %s", apr.config.ID)
 
 	stopErr := apr.Stop()
 	if stopErr != nil {

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -17,6 +17,7 @@ func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 		activeReplicatorCommon: activeReplicatorCommon{
 			config:           config,
 			replicationStats: NewBlipSyncStats(),
+			state:            ReplicationStateStopped,
 		},
 	}
 }

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -182,6 +182,9 @@ func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
 func (apr *ActivePushReplicator) waitForPendingChangesResponse() error {
 	waitCount := 0
 	for waitCount < 100 {
+		if apr.blipSyncContext == nil {
+			return nil
+		}
 		pendingCount := atomic.LoadInt64(&apr.blipSyncContext.changesPendingResponseCount)
 		if pendingCount <= 0 {
 			return nil

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -20,6 +20,7 @@ func NewPushReplicator(config *ActiveReplicatorConfig) *ActivePushReplicator {
 		activeReplicatorCommon: activeReplicatorCommon{
 			config:           config,
 			replicationStats: NewBlipSyncStats(),
+			state:            ReplicationStateStopped,
 		},
 	}
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -365,6 +365,13 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 	bh.logEndpointEntry(rq.Profile(), fmt.Sprintf("#Changes:%d", len(changeList)))
 	if len(changeList) == 0 {
+		// An empty changeList is sent when a one-shot replication sends its final changes
+		// message, or a continuous replication catches up *for the first time*.
+		// Note that this doesn't mean that rev messages associated with previous changes
+		// messages have been fully processed
+		if bh.emptyChangesMessageCallback != nil {
+			bh.emptyChangesMessageCallback()
+		}
 		return nil
 	}
 	output := bytes.NewBuffer(make([]byte, 0, 100*len(changeList)))

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -96,6 +96,7 @@ type BlipSyncContext struct {
 	replicationStats                 *BlipSyncStats              // Replication stats
 	purgeOnRemoval                   bool                        // Purges the document when we pull a _removed:true revision.
 	conflictResolver                 ConflictResolverFunc        // Conflict resolver for active replications
+	changesPendingResponseCount      int64                       // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
 	sendRevNoConflicts bool // Whether to set noconflicts=true when sending revisions
 

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -92,6 +92,7 @@ type BlipSyncContext struct {
 	postHandleChangesCallback        func(expectedSeqs []string) // postHandleChangesCallback is called after successfully handling an incoming changes message
 	preSendRevisionResponseCallback  func(remoteSeq string)      // preSendRevisionResponseCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
 	postSendRevisionResponseCallback func(remoteSeq string)      // postSendRevisionResponseCallback is called after receiving acknowledgement of a sent revision
+	emptyChangesMessageCallback      func()                      // emptyChangesMessageCallback is called when an empty changes message is received
 	replicationStats                 *BlipSyncStats              // Replication stats
 	purgeOnRemoval                   bool                        // Purges the document when we pull a _removed:true revision.
 	conflictResolver                 ConflictResolverFunc        // Conflict resolver for active replications

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -476,7 +476,10 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 }
 
 func (m *sgReplicateManager) replicationComplete(replicationID string) {
-	m.UpdateReplicationState(replicationID, ReplicationStateStopped)
+	_, err := m.UpdateReplicationState(replicationID, ReplicationStateStopped)
+	if err != nil {
+		base.Warnf("Unable to update replication state to stopped on completion: %v", err)
+	}
 }
 
 func (m *sgReplicateManager) Stop() {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -106,6 +106,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 		ActiveDB:              &db.Database{DatabaseContext: rt.GetDatabase()},
 		PassiveDBURL:          passiveDBURL,
 		WebsocketPingInterval: time.Millisecond * 10,
+		Continuous:            true,
 	})
 
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count")))
@@ -278,7 +279,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous:       false,
+		Continuous:       true,
 		ChangesBatchSize: changesBatchSize,
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
@@ -622,7 +623,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous:       false,
+		Continuous:       true,
 		ChangesBatchSize: changesBatchSize,
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1597,7 +1597,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous: false,
+		Continuous: true,
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval: time.Minute * 5,
@@ -1752,7 +1752,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous: false,
+		Continuous: true,
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval: time.Minute * 5,

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -460,7 +460,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	assert.True(t, replicationStopped, "Replication status should be stopped")
+	assert.True(t, replicationStopped, "One-shot replication status should go to stopped on completion")
 
 	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
@@ -717,6 +717,99 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
 	ar.Push.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+}
+
+// TestActiveReplicatorPushOneshot:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates a document on rt1 which can be pushed by the replicator.
+//   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
+//   - Uses an ActiveReplicator configured for push to start pushing changes to rt2.
+func TestActiveReplicatorPushOneshot(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	defer tb2.Close()
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	defer tb1.Close()
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	docID := t.Name() + "rt1doc1"
+	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID := respRevID(t, resp)
+
+	localDoc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePush,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize: 200,
+	})
+	defer func() { assert.NoError(t, ar.Stop()) }()
+
+	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
+
+	// Start the replicator (implicit connect)
+	assert.NoError(t, ar.Start())
+
+	// wait for the replication to stop
+	replicationStopped := false
+	for i := 0; i < 100; i++ {
+		status := ar.GetStatus()
+		if status.Status == db.ReplicationStateStopped {
+			replicationStopped = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.True(t, replicationStopped, "One-shot replication status should go to stopped on completion")
+
+	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
 }
 
 // TestActiveReplicatorPullTombstone:


### PR DESCRIPTION
Adds Complete() action to activeReplicator implementations that is triggered on one-shot completion.  Complete() waits for any in-flight operations to complete, then closes the replication and invokes an optional callback to update the replication state to stopped.

Added race protection between Complete() and Stop(), which looks like it would also have been needed for concurrent Stops.

