### PR TITLE
Add unit tests for checkpointer seq calculations and fix off-by-one error

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -139,7 +139,7 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
 	safeSeq = c.expectedSeqs[maxI]
 
 	// removes to-be checkpointed sequences from processedSeqs list
-	for i := 0; i < maxI; i++ {
+	for i := 0; i <= maxI; i++ {
 		removeSeq := c.expectedSeqs[i]
 		delete(c.processedSeqs, removeSeq)
 		base.TracefCtx(c.ctx, base.KeyReplicate, "checkpointer: _updateCheckpointLists removed seq %v from processedSeqs map %v", removeSeq, c.processedSeqs)

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointerSafeSeq(t *testing.T) {
+	tests := []struct {
+		name                    string
+		c                       *Checkpointer
+		expectedSafeSeq         string
+		expectedExpectedSeqsIdx int
+		expectedExpectedSeqs    []string
+		expectedProcessedSeqs   map[string]struct{}
+	}{
+		{
+			name: "empty",
+			c: &Checkpointer{
+				expectedSeqs:  []string{},
+				processedSeqs: map[string]struct{}{},
+			},
+			expectedSafeSeq:         "",
+			expectedExpectedSeqsIdx: -1,
+			expectedExpectedSeqs:    []string{},
+			expectedProcessedSeqs:   map[string]struct{}{},
+		},
+		{
+			name: "none processed",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"1", "2", "3"},
+				processedSeqs: map[string]struct{}{},
+			},
+			expectedSafeSeq:         "",
+			expectedExpectedSeqsIdx: -1,
+			expectedExpectedSeqs:    []string{"1", "2", "3"},
+			expectedProcessedSeqs:   map[string]struct{}{},
+		},
+		{
+			name: "partial processed",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"1", "2", "3"},
+				processedSeqs: map[string]struct{}{"1": {}},
+			},
+			expectedSafeSeq:         "1",
+			expectedExpectedSeqsIdx: 0,
+			expectedExpectedSeqs:    []string{"2", "3"},
+			expectedProcessedSeqs:   map[string]struct{}{},
+		},
+		{
+			name: "partial processed with gap",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"1", "2", "3"},
+				processedSeqs: map[string]struct{}{"1": {}, "3": {}},
+			},
+			expectedSafeSeq:         "1",
+			expectedExpectedSeqsIdx: 0,
+			expectedExpectedSeqs:    []string{"2", "3"},
+			expectedProcessedSeqs:   map[string]struct{}{"3": {}},
+		},
+		{
+			name: "fully processed",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"1", "2", "3"},
+				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}},
+			},
+			expectedSafeSeq:         "3",
+			expectedExpectedSeqsIdx: 2,
+			expectedExpectedSeqs:    []string{},
+			expectedProcessedSeqs:   map[string]struct{}{},
+		},
+		{
+			name: "extra processed",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"1", "2", "3"},
+				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}, "4": {}, "5": {}},
+			},
+			expectedSafeSeq:         "3",
+			expectedExpectedSeqsIdx: 2,
+			expectedExpectedSeqs:    []string{},
+			expectedProcessedSeqs:   map[string]struct{}{"4": {}, "5": {}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("_calculateSafeExpectedSeqsIdx", func(t *testing.T) {
+				actualIdx := tt.c._calculateSafeExpectedSeqsIdx()
+				assert.Equal(t, tt.expectedExpectedSeqsIdx, actualIdx)
+			})
+
+			t.Run("_updateCheckpointLists", func(t *testing.T) {
+				actualSafeSeq := tt.c._updateCheckpointLists()
+				assert.Equal(t, tt.expectedSafeSeq, actualSafeSeq)
+				assert.Equal(t, tt.expectedExpectedSeqs, tt.c.expectedSeqs)
+				assert.Equal(t, tt.expectedProcessedSeqs, tt.c.processedSeqs)
+
+				// _updateCheckpointLists should be idempotent
+				// we'd expect no safe seq, and no further changes to either list, as long as c.processedSeqs hasn't been added to
+				actualSafeSeq2 := tt.c._updateCheckpointLists()
+				assert.Equal(t, "", actualSafeSeq2)
+				assert.Equal(t, tt.expectedExpectedSeqs, tt.c.expectedSeqs)
+				assert.Equal(t, tt.expectedProcessedSeqs, tt.c.processedSeqs)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Adds unit tests around `_calculateSafeExpectedSeqsIdx` and `_updateCheckpointLists` to ensure correctness for returned safeSeq and updated lists.

Fixes off-by-one error when removing items from the `processedSeqs` map.