### PR TITLE
CBG-958 Delta sync config fix and stats

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -153,6 +153,8 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocsRead = pullStats.HandleRevCount.Value()
 		status.DocsPurged = pullStats.DocsPurgedCount.Value()
 		status.RejectedLocal = pullStats.HandleRevErrorCount.Value()
+		status.DeltasRecv = pullStats.DeltaReceivedCount.Value()
+		status.DeltasRequested = pullStats.DeltaRequestedCount.Value()
 		if ar.Pull.Checkpointer != nil {
 			status.LastSeqPull = ar.Pull.Checkpointer.calculateSafeProcessedSeq()
 		}
@@ -164,6 +166,7 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocWriteFailures = pushStats.SendRevErrorTotal.Value()
 		status.DocWriteConflict = pushStats.SendRevErrorConflictCount.Value()
 		status.RejectedRemote = pushStats.SendRevErrorRejectedCount.Value()
+		status.DeltasSent = pushStats.DeltaSentCount.Value()
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
 		}

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -11,6 +11,9 @@ type BlipSyncStats struct {
 	SendRevErrorRejectedCount *expvar.Int
 	SendRevErrorOtherCount    *expvar.Int
 	DocsPurgedCount           *expvar.Int
+	DeltaSentCount            *expvar.Int
+	DeltaReceivedCount        *expvar.Int
+	DeltaRequestedCount       *expvar.Int
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
@@ -23,5 +26,8 @@ func NewBlipSyncStats() *BlipSyncStats {
 		SendRevErrorRejectedCount: &expvar.Int{},
 		SendRevErrorOtherCount:    &expvar.Int{},
 		DocsPurgedCount:           &expvar.Int{},
+		DeltaSentCount:            &expvar.Int{},
+		DeltaReceivedCount:        &expvar.Int{},
+		DeltaRequestedCount:       &expvar.Int{},
 	}
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -456,8 +456,8 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 		return nil, fmt.Errorf("Replication remote must not be empty")
 	}
 
-	if config.DeltaSyncEnabled == false {
-		rc.DeltasEnabled = false
+	if config.DeltaSyncEnabled == true {
+		rc.DeltasEnabled = true
 	}
 
 	rc.PassiveDBURL, err = url.Parse(config.Remote)
@@ -945,6 +945,9 @@ type ReplicationStatus struct {
 	LastSeqPull      string             `json:"last_seq_pull,omitempty"`
 	LastSeqPush      string             `json:"last_seq_push,omitempty"`
 	ErrorMessage     string             `json:"error_message,omitempty"`
+	DeltasSent       int64              `json:"deltas_sent,omitempty"`
+	DeltasRecv       int64              `json:"deltas_recv,omitempty"`
+	DeltasRequested  int64              `json:"deltas_requested,omitempty"`
 	Config           *ReplicationConfig `json:"config,omitempty"`
 }
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -414,7 +414,7 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 		Continuous:         config.Continuous,
 		ActiveDB:           &Database{DatabaseContext: m.dbContext}, // sg-replicate interacts with local as admin
 		PurgeOnRemoval:     config.PurgeOnRemoval,
-		DeltasEnabled:      false,
+		DeltasEnabled:      config.DeltaSyncEnabled,
 		InsecureSkipVerify: m.dbContext.Options.UnsupportedOptions.SgrTlsSkipVerify,
 	}
 
@@ -454,10 +454,6 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 
 	if config.Remote == "" {
 		return nil, fmt.Errorf("Replication remote must not be empty")
-	}
-
-	if config.DeltaSyncEnabled == true {
-		rc.DeltasEnabled = true
 	}
 
 	rc.PassiveDBURL, err = url.Parse(config.Remote)


### PR DESCRIPTION
Fixes config validation that was forcing replications to run with delta sync disabled, and adds stats for deltas sent/received/requested.