### PR TITLE
CBG-960 Delete local replication checkpoint on reset

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -92,13 +92,13 @@ func (ar *ActiveReplicator) Stop() error {
 
 func (ar *ActiveReplicator) Reset() error {
 	if ar.Push != nil {
-		if err := ar.Push.Reset(); err != nil {
+		if err := ar.Push.reset(); err != nil {
 			return err
 		}
 	}
 
 	if ar.Pull != nil {
-		if err := ar.Pull.Reset(); err != nil {
+		if err := ar.Pull.reset(); err != nil {
 			return err
 		}
 	}

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -297,6 +297,11 @@ func (c *Checkpointer) setLocalCheckpoint(seq, parentRev string) (newRev string,
 	return newRev, nil
 }
 
+func resetLocalCheckpoint(activeDB *Database, checkpointID string) error {
+	key := activeDB.realSpecialDocID("local", checkpointDocIDPrefix+checkpointID)
+	return activeDB.Bucket.Delete(key)
+}
+
 // getRemoteCheckpoint returns the sequence and rev for the remote checkpoint.
 // if the checkpoint does not exist, returns empty sequence and rev.
 func (c *Checkpointer) getRemoteCheckpoint() (seq, rev string, err error) {

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -64,13 +64,3 @@ func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastE
 		return a.state, a.lastError.Error()
 	}
 }
-
-func (a *activeReplicatorCommon) Reset() error {
-	// TODO: pending CBG-908
-	//  Since we require that a replication be stopped
-	//  prior to reset, it's expected that checkpointer
-	//  is unavailable.  This function will need to
-	//  remove local checkpoints for push and pull replications
-	//  using the config.ActiveDB
-	return nil
-}

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -162,6 +162,17 @@ func (apr *ActivePullReplicator) CheckpointID() (string, error) {
 	return "sgr2cp:pull:" + checkpointHash, nil
 }
 
+func (apr *ActivePullReplicator) reset() error {
+	if apr.state != ReplicationStateStopped {
+		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)
+	}
+	checkpointID, err := apr.CheckpointID()
+	if err != nil {
+		return err
+	}
+	return resetLocalCheckpoint(apr.config.ActiveDB, checkpointID)
+}
+
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 	apr.blipSyncContext.postHandleChangesCallback = func(changesSeqs []string) {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -182,7 +182,7 @@ func (apr *ActivePushReplicator) CheckpointID() (string, error) {
 	return "sgr2cp:push:" + checkpointHash, nil
 }
 
-// Reset performs a reset on the replication by removing the local checkpoint document.
+// reset performs a reset on the replication by removing the local checkpoint document.
 func (apr *ActivePushReplicator) reset() error {
 	if apr.state != ReplicationStateStopped {
 		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -182,6 +182,18 @@ func (apr *ActivePushReplicator) CheckpointID() (string, error) {
 	return "sgr2cp:push:" + checkpointHash, nil
 }
 
+// Reset performs a reset on the replication by removing the local checkpoint document.
+func (apr *ActivePushReplicator) reset() error {
+	if apr.state != ReplicationStateStopped {
+		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)
+	}
+	checkpointID, err := apr.CheckpointID()
+	if err != nil {
+		return err
+	}
+	return resetLocalCheckpoint(apr.config.ActiveDB, checkpointID)
+}
+
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
 	apr.blipSyncContext.preSendRevisionResponseCallback = func(remoteSeq string) {


### PR DESCRIPTION
Checkpointer is not expected to be available/running when reset is invoked, so local checkpoint is removed via direct local doc operation.