### PR TITLE
Add logging to ActiveReplicator setError

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/couchbase/go-blip"
+	"github.com/couchbase/sync_gateway/base"
 )
 
 // replicatorCommon defines the struct contents shared by ActivePushReplicator
@@ -31,6 +32,7 @@ type ReplicatorCompleteFunc func()
 // returns the error provided.  Expects callers to be holding
 // a.lock
 func (a *activeReplicatorCommon) _setError(err error) (passThrough error) {
+	base.Infof(base.KeyReplicate, "ActiveReplicator had error state set with err: %v" ,err)
 	a.state = ReplicationStateError
 	a.lastError = err
 	return err

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -32,7 +32,7 @@ type ReplicatorCompleteFunc func()
 // returns the error provided.  Expects callers to be holding
 // a.lock
 func (a *activeReplicatorCommon) _setError(err error) (passThrough error) {
-	base.Infof(base.KeyReplicate, "ActiveReplicator had error state set with err: %v" ,err)
+	base.Infof(base.KeyReplicate, "ActiveReplicator had error state set with err: %v", err)
 	a.state = ReplicationStateError
 	a.lastError = err
 	return err


### PR DESCRIPTION
Add logging to the ActiveReplicator `_setError` function for diagnosis of a replicator error without a cluster manager.