### PR TITLE
CBG-947 - Checkpoint revisions which are ignored by a peer

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -16,12 +16,12 @@ import (
 
 const (
 	// TODO: Not aligned these to any stats in the PRD yet, these are used for test assertions.
-	ActiveReplicatorStatsKeyPullExpectedSeqsTotal  = "sgr2_pull_expected_seqs_total"
-	ActiveReplicatorStatsKeyPullProcessedSeqsTotal = "sgr2_pull_processed_seqs_total"
-	ActiveReplicatorStatsKeyPullIgnoredSeqsTotal   = "sgr2_pull_ignored_seqs_total"
-	ActiveReplicatorStatsKeyPushExpectedSeqsTotal  = "sgr2_push_expected_seqs_total"
-	ActiveReplicatorStatsKeyPushProcessedSeqsTotal = "sgr2_push_processed_seqs_total"
-	ActiveReplicatorStatsKeyPushIgnoredSeqsTotal   = "sgr2_push_ignored_seqs_total"
+	ActiveReplicatorStatsKeyPullExpectedSeqsTotal     = "sgr2_pull_expected_seqs_total"
+	ActiveReplicatorStatsKeyPullProcessedSeqsTotal    = "sgr2_pull_processed_seqs_total"
+	ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal = "sgr2_pull_already_known_seqs_total"
+	ActiveReplicatorStatsKeyPushExpectedSeqsTotal     = "sgr2_push_expected_seqs_total"
+	ActiveReplicatorStatsKeyPushProcessedSeqsTotal    = "sgr2_push_processed_seqs_total"
+	ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal = "sgr2_push_already_known_seqs_total"
 )
 
 const (

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -16,10 +16,12 @@ import (
 
 const (
 	// TODO: Not aligned these to any stats in the PRD yet, these are used for test assertions.
-	ActiveReplicatorStatsKeyRevsReceivedTotal        = "revs_received_total"
-	ActiveReplicatorStatsKeyChangesRevsReceivedTotal = "changes_revs_received_total"
-	ActiveReplicatorStatsKeyRevsSentTotal            = "revs_sent_total"
-	ActiveReplicatorStatsKeyRevsRequestedTotal       = "revs_requested_total"
+	ActiveReplicatorStatsKeyExpectedSeqsTotal      = "sgr2_pull_expected_seqs_total"
+	ActiveReplicatorStatsKeyProcessedSeqsTotal     = "sgr2_pull_processed_seqs_total"
+	ActiveReplicatorStatsKeyPullIgnoredSeqsTotal   = "sgr2_pull_ignored_seqs_total"
+	ActiveReplicatorStatsKeyPushExpectedSeqsTotal  = "sgr2_push_expected_seqs_total"
+	ActiveReplicatorStatsKeyPushProcessedSeqsTotal = "sgr2_push_processed_seqs_total"
+	ActiveReplicatorStatsKeyPushIgnoredSeqsTotal   = "sgr2_push_ignored_seqs_total"
 )
 
 const (

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -16,8 +16,8 @@ import (
 
 const (
 	// TODO: Not aligned these to any stats in the PRD yet, these are used for test assertions.
-	ActiveReplicatorStatsKeyExpectedSeqsTotal      = "sgr2_pull_expected_seqs_total"
-	ActiveReplicatorStatsKeyProcessedSeqsTotal     = "sgr2_pull_processed_seqs_total"
+	ActiveReplicatorStatsKeyPullExpectedSeqsTotal  = "sgr2_pull_expected_seqs_total"
+	ActiveReplicatorStatsKeyPullProcessedSeqsTotal = "sgr2_pull_processed_seqs_total"
 	ActiveReplicatorStatsKeyPullIgnoredSeqsTotal   = "sgr2_pull_ignored_seqs_total"
 	ActiveReplicatorStatsKeyPushExpectedSeqsTotal  = "sgr2_push_expected_seqs_total"
 	ActiveReplicatorStatsKeyPushProcessedSeqsTotal = "sgr2_push_processed_seqs_total"

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -53,7 +53,7 @@ func NewCheckpointer(ctx context.Context, clientID string, blipSender *blip.Send
 	}
 }
 
-func (c *Checkpointer) AddIgnoredSeq(seq string) {
+func (c *Checkpointer) AddAlreadyKnownSeq(seq ...string) {
 	select {
 	case <-c.ctx.Done():
 		// replicator already closed, bail out of checkpointing work
@@ -62,8 +62,10 @@ func (c *Checkpointer) AddIgnoredSeq(seq string) {
 	}
 
 	c.lock.Lock()
-	c.processedSeqs[seq] = struct{}{}
-	c.expectedSeqs = append(c.expectedSeqs, seq)
+	c.expectedSeqs = append(c.expectedSeqs, seq...)
+	for _, seq := range seq {
+		c.processedSeqs[seq] = struct{}{}
+	}
 	c.lock.Unlock()
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -175,12 +175,12 @@ func (apr *ActivePullReplicator) reset() error {
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
-	apr.blipSyncContext.sgr2PullIgnoreSeqCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPullIgnoredSeqsTotal, 1)
-		apr.Checkpointer.AddIgnoredSeq(remoteSeq)
+	apr.blipSyncContext.sgr2PullAlreadyKnownSeqsCallback = func(alreadyKnownSeqs []string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal, int64(len(alreadyKnownSeqs)))
+		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
 	}
 
-	apr.blipSyncContext.sgr2PullAddExepectedSeqsCallback = func(changesSeqs []string) {
+	apr.blipSyncContext.sgr2PullAddExpectedSeqsCallback = func(changesSeqs []string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPullExpectedSeqsTotal, int64(len(changesSeqs)))
 		apr.Checkpointer.AddExpectedSeq(changesSeqs...)
 	}

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -182,13 +182,13 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 	}
 
 	apr.blipSyncContext.sgr2PullAddExepectedSeqsCallback = func(changesSeqs []string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyExpectedSeqsTotal, int64(len(changesSeqs)))
+		apr.Stats.Add(ActiveReplicatorStatsKeyPullExpectedSeqsTotal, int64(len(changesSeqs)))
 		apr.Checkpointer.AddExpectedSeq(changesSeqs...)
 	}
 
 	// TODO: Check whether we need to add a handleNoRev callback to remove expected sequences.
 	apr.blipSyncContext.sgr2PullProcessedSeqCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyProcessedSeqsTotal, 1)
+		apr.Stats.Add(ActiveReplicatorStatsKeyPullProcessedSeqsTotal, 1)
 		apr.Checkpointer.ProcessedSeq(remoteSeq)
 	}
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -177,8 +177,7 @@ func (apr *ActivePullReplicator) reset() error {
 func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 	apr.blipSyncContext.sgr2PullIgnoreSeqCallback = func(remoteSeq string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPullIgnoredSeqsTotal, 1)
-		apr.Checkpointer.AddExpectedSeq(remoteSeq)
-		apr.Checkpointer.ProcessedSeq(remoteSeq)
+		apr.Checkpointer.AddIgnoredSeq(remoteSeq)
 	}
 
 	apr.blipSyncContext.sgr2PullAddExepectedSeqsCallback = func(changesSeqs []string) {
@@ -189,7 +188,7 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 	// TODO: Check whether we need to add a handleNoRev callback to remove expected sequences.
 	apr.blipSyncContext.sgr2PullProcessedSeqCallback = func(remoteSeq string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPullProcessedSeqsTotal, 1)
-		apr.Checkpointer.ProcessedSeq(remoteSeq)
+		apr.Checkpointer.AddProcessedSeq(remoteSeq)
 	}
 
 	// Trigger complete for non-continuous replications when caught up

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -198,8 +198,7 @@ func (apr *ActivePushReplicator) reset() error {
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
 	apr.blipSyncContext.sgr2PushIgnoreSeqCallback = func(remoteSeq string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushIgnoredSeqsTotal, 1)
-		apr.Checkpointer.AddExpectedSeq(remoteSeq)
-		apr.Checkpointer.ProcessedSeq(remoteSeq)
+		apr.Checkpointer.AddIgnoredSeq(remoteSeq)
 	}
 	apr.blipSyncContext.sgr2PushAddExpectedSeqCallback = func(remoteSeq string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, 1)
@@ -208,7 +207,7 @@ func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
 
 	apr.blipSyncContext.sgr2PushProcessedSeqCallback = func(remoteSeq string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushProcessedSeqsTotal, 1)
-		apr.Checkpointer.ProcessedSeq(remoteSeq)
+		apr.Checkpointer.AddProcessedSeq(remoteSeq)
 	}
 }
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -196,9 +196,9 @@ func (apr *ActivePushReplicator) reset() error {
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
-	apr.blipSyncContext.sgr2PushIgnoreSeqCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPushIgnoredSeqsTotal, 1)
-		apr.Checkpointer.AddIgnoredSeq(remoteSeq)
+	apr.blipSyncContext.sgr2PushAlreadyKnownSeqCallback = func(remoteSeq string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal, 1)
+		apr.Checkpointer.AddAlreadyKnownSeq(remoteSeq)
 	}
 	apr.blipSyncContext.sgr2PushAddExpectedSeqCallback = func(remoteSeq string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, 1)

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -196,13 +196,18 @@ func (apr *ActivePushReplicator) reset() error {
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
-	apr.blipSyncContext.preSendRevisionResponseCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyRevsRequestedTotal, 1)
+	apr.blipSyncContext.sgr2PushIgnoreSeqCallback = func(remoteSeq string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPushIgnoredSeqsTotal, 1)
+		apr.Checkpointer.AddExpectedSeq(remoteSeq)
+		apr.Checkpointer.ProcessedSeq(remoteSeq)
+	}
+	apr.blipSyncContext.sgr2PushAddExpectedSeqCallback = func(remoteSeq string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, 1)
 		apr.Checkpointer.AddExpectedSeq(remoteSeq)
 	}
 
-	apr.blipSyncContext.postSendRevisionResponseCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyRevsSentTotal, 1)
+	apr.blipSyncContext.sgr2PushProcessedSeqCallback = func(remoteSeq string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPushProcessedSeqsTotal, 1)
 		apr.Checkpointer.ProcessedSeq(remoteSeq)
 	}
 }

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -196,11 +196,11 @@ func (apr *ActivePushReplicator) reset() error {
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
-	apr.blipSyncContext.sgr2PushAlreadyKnownSeqCallback = func(alreadyKnownSeqs []string) {
+	apr.blipSyncContext.sgr2PushAlreadyKnownSeqsCallback = func(alreadyKnownSeqs []string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal, int64(len(alreadyKnownSeqs)))
 		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
 	}
-	apr.blipSyncContext.sgr2PushAddExpectedSeqCallback = func(expectedSeqs []string) {
+	apr.blipSyncContext.sgr2PushAddExpectedSeqsCallback = func(expectedSeqs []string) {
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, int64(len(expectedSeqs)))
 		apr.Checkpointer.AddExpectedSeq(expectedSeqs...)
 	}

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -196,13 +196,13 @@ func (apr *ActivePushReplicator) reset() error {
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
-	apr.blipSyncContext.sgr2PushAlreadyKnownSeqCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal, 1)
-		apr.Checkpointer.AddAlreadyKnownSeq(remoteSeq)
+	apr.blipSyncContext.sgr2PushAlreadyKnownSeqCallback = func(alreadyKnownSeqs []string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal, int64(len(alreadyKnownSeqs)))
+		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
 	}
-	apr.blipSyncContext.sgr2PushAddExpectedSeqCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, 1)
-		apr.Checkpointer.AddExpectedSeq(remoteSeq)
+	apr.blipSyncContext.sgr2PushAddExpectedSeqCallback = func(expectedSeqs []string) {
+		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, int64(len(expectedSeqs)))
+		apr.Checkpointer.AddExpectedSeq(expectedSeqs...)
 	}
 
 	apr.blipSyncContext.sgr2PushProcessedSeqCallback = func(remoteSeq string) {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -391,7 +391,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 	}()
 
 	expectedSeqs := make([]string, 0)
-	ignoredSeqs := make([]string, 0)
+	alreadyKnownSeqs := make([]string, 0)
 
 	for _, change := range changeList {
 		docID := change[1].(string)
@@ -404,7 +404,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {
-				ignoredSeqs = append(ignoredSeqs, seqStr(change[0]))
+				alreadyKnownSeqs = append(alreadyKnownSeqs, seqStr(change[0]))
 			}
 		} else {
 			// we want this rev, send possible ancestors to the peer
@@ -439,7 +439,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		bh.sgr2PullAddExpectedSeqsCallback(expectedSeqs)
 	}
 	if bh.sgr2PullAlreadyKnownSeqsCallback != nil {
-		bh.sgr2PullAlreadyKnownSeqsCallback(ignoredSeqs)
+		bh.sgr2PullAlreadyKnownSeqsCallback(alreadyKnownSeqs)
 	}
 
 	return nil

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -318,8 +318,8 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT2DocsInitial, numRevsSentTotal)
-	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
-	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -368,8 +368,8 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT2DocsTotal, numRevsSentTotal)
-	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
-	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -490,8 +490,8 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, int64(0), numRevsSentTotal)
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -531,8 +531,8 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, int64(0), numRevsSentTotal)
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -1937,8 +1937,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -1989,8 +1989,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+2, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -318,8 +318,8 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT2DocsInitial, numRevsSentTotal)
-	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyRevsReceivedTotal)))
-	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyChangesRevsReceivedTotal)))
+	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -368,8 +368,171 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT2DocsTotal, numRevsSentTotal)
-	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyRevsReceivedTotal)))
-	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyChangesRevsReceivedTotal)))
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+
+	// assert the second active replicator stats
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	ar.Pull.Checkpointer.CheckpointNow()
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+}
+
+// TestActiveReplicatorPullFromCheckpointIgnored:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates identical documents on rt1 and rt2.
+//   - Starts a pull replication to ensure that even ignored revisions are checkpointed.
+func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+
+	const (
+		changesBatchSize  = 10
+		numRT2DocsInitial = 13 // 2 batches of changes
+		numRT2DocsTotal   = 24 // 2 more batches
+	)
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	// Create first batch of docs
+	docIDPrefix := t.Name() + "doc"
+	for i := 0; i < numRT2DocsInitial; i++ {
+		resp := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt1RevID := respRevID(t, resp)
+		resp = rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt2RevID := respRevID(t, resp)
+		require.Equal(t, rt1RevID, rt2RevID)
+	}
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	// Build passiveDBURL with basic auth creds
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	arConfig := db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePull,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous:       true,
+		ChangesBatchSize: changesBatchSize,
+		// test isn't long running enough to worry about time-based checkpoints,
+		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
+		CheckpointInterval: time.Minute * 5,
+	}
+
+	// Create the first active replicator to pull from seq:0
+	ar := db.NewActiveReplicator(&arConfig)
+
+	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+
+	assert.NoError(t, ar.Start())
+
+	_, ok := base.WaitForStat(func() int64 {
+		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullIgnoredSeqsTotal))
+	}, numRT2DocsInitial)
+	assert.True(t, ok)
+
+	// wait for all of the documents originally written to rt2 to arrive at rt1
+	changesResults, err := rt1.WaitForChanges(numRT2DocsInitial, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, numRT2DocsInitial)
+	docIDsSeen := make(map[string]bool, numRT2DocsInitial)
+	for _, result := range changesResults.Results {
+		docIDsSeen[result.ID] = true
+	}
+	for i := 0; i < numRT2DocsInitial; i++ {
+		docID := fmt.Sprintf("%s%d", docIDPrefix, i)
+		assert.True(t, docIDsSeen[docID])
+
+		_, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+		assert.NoError(t, err)
+	}
+
+	// one _changes from seq:0 with initial number of docs sent
+	numChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	assert.Equal(t, startNumChangesRequestedFromZeroTotal+1, numChangesRequestedFromZeroTotal)
+
+	// rev assertions
+	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+	assert.Equal(t, int64(0), numRevsSentTotal)
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
+
+	// checkpoint assertions
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
+	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	ar.Pull.Checkpointer.CheckpointNow()
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+
+	assert.NoError(t, ar.Stop())
+
+	// Second batch of docs
+	for i := numRT2DocsInitial; i < numRT2DocsTotal; i++ {
+		resp := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt1RevID := respRevID(t, resp)
+		resp = rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt2RevID := respRevID(t, resp)
+		require.Equal(t, rt1RevID, rt2RevID)
+	}
+
+	// Create a new replicator using the same config, which should use the checkpoint set from the first.
+	ar = db.NewActiveReplicator(&arConfig)
+	defer func() { assert.NoError(t, ar.Stop()) }()
+	assert.NoError(t, ar.Start())
+
+	_, ok = base.WaitForStat(func() int64 {
+		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullIgnoredSeqsTotal))
+	}, numRT2DocsTotal-numRT2DocsInitial)
+	assert.True(t, ok)
+
+	// Make sure we've not started any more since:0 replications on rt2 since the first one
+	endNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	assert.Equal(t, numChangesRequestedFromZeroTotal, endNumChangesRequestedFromZeroTotal)
+
+	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
+	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+	assert.Equal(t, int64(0), numRevsSentTotal)
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -662,8 +825,8 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT1DocsInitial, numRevsSentTotal)
-	assert.Equal(t, int64(numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsSentTotal)))
-	assert.Equal(t, int64(numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsRequestedTotal)))
+	assert.Equal(t, int64(numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
+	assert.Equal(t, int64(numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
@@ -709,8 +872,153 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	// make sure rt1 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT1DocsTotal, numRevsSentTotal)
-	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsSentTotal)))
-	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsRequestedTotal)))
+	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
+	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+
+	// assert the second active replicator stats
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	ar.Push.Checkpointer.CheckpointNow()
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+}
+
+// TestActiveReplicatorPushFromCheckpointIgnored:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates enough documents on rt1 which can be pushed by a replicator running in rt1 to start setting checkpoints.
+//   - Insert the second batch of docs into rt1.
+//   - Starts the push replication again and asserts that the checkpoint is used.
+func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+
+	const (
+		changesBatchSize  = 10
+		numRT1DocsInitial = 13 // 2 batches of changes
+		numRT1DocsTotal   = 24 // 2 more batches
+	)
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Create first batch of docs
+	docIDPrefix := t.Name() + "doc"
+	for i := 0; i < numRT1DocsInitial; i++ {
+		resp := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt1RevID := respRevID(t, resp)
+		resp = rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt2RevID := respRevID(t, resp)
+		require.Equal(t, rt1RevID, rt2RevID)
+	}
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	// Build passiveDBURL with basic auth creds
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	arConfig := db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePush,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous:       true,
+		ChangesBatchSize: changesBatchSize,
+		// test isn't long running enough to worry about time-based checkpoints,
+		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
+		CheckpointInterval: time.Minute * 5,
+	}
+
+	// Create the first active replicator to pull from seq:0
+	ar := db.NewActiveReplicator(&arConfig)
+
+	startNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+
+	assert.NoError(t, ar.Start())
+
+	_, ok := base.WaitForStat(func() int64 {
+		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushIgnoredSeqsTotal))
+	}, numRT1DocsInitial)
+	assert.True(t, ok)
+
+	// one _changes from seq:0 with initial number of docs sent
+	numChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	assert.Equal(t, startNumChangesRequestedFromZeroTotal+1, numChangesRequestedFromZeroTotal)
+
+	// rev assertions
+	numRevsSentTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+	assert.Equal(t, int64(0), numRevsSentTotal)
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+
+	// checkpoint assertions
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+
+	assert.NoError(t, ar.Stop())
+
+	// Second batch of docs
+	for i := numRT1DocsInitial; i < numRT1DocsTotal; i++ {
+		resp := rt1.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt1RevID := respRevID(t, resp)
+		resp = rt2.SendAdminRequest(http.MethodPut, fmt.Sprintf("/db/%s%d", docIDPrefix, i), `{"channels":["alice"]}`)
+		assertStatus(t, resp, http.StatusCreated)
+		rt2RevID := respRevID(t, resp)
+		require.Equal(t, rt1RevID, rt2RevID)
+	}
+
+	// Create a new replicator using the same config, which should use the checkpoint set from the first.
+	ar = db.NewActiveReplicator(&arConfig)
+	defer func() { assert.NoError(t, ar.Stop()) }()
+	assert.NoError(t, ar.Start())
+
+	_, ok = base.WaitForStat(func() int64 {
+		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushIgnoredSeqsTotal))
+	}, numRT1DocsTotal-numRT1DocsInitial)
+	assert.True(t, ok)
+
+	// Make sure we've not started any more since:0 replications on rt1 since the first one
+	endNumChangesRequestedFromZeroTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsSinceZero))
+	assert.Equal(t, numChangesRequestedFromZeroTotal, endNumChangesRequestedFromZeroTotal)
+
+	// make sure rt1 thinks it has sent all of the revs via a 2.x replicator
+	numRevsSentTotal = base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
+	assert.Equal(t, int64(0), numRevsSentTotal)
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
@@ -1629,8 +1937,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyRevsReceivedTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyChangesRevsReceivedTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
@@ -1681,8 +1989,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+2, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyRevsReceivedTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyChangesRevsReceivedTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyProcessedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
@@ -1784,8 +2092,8 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsSentTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsRequestedTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
 
 	// checkpoint assertions
 	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
@@ -1847,8 +2155,8 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	// make sure rt1 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt1.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+2, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsSentTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyRevsRequestedTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
 
 	// assert the second active replicator stats
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -463,7 +463,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok := base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullIgnoredSeqsTotal))
+		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal))
 	}, numRT2DocsInitial)
 	assert.True(t, ok)
 
@@ -520,7 +520,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok = base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullIgnoredSeqsTotal))
+		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal))
 	}, numRT2DocsTotal-numRT2DocsInitial)
 	assert.True(t, ok)
 
@@ -968,7 +968,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok := base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushIgnoredSeqsTotal))
+		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal))
 	}, numRT1DocsInitial)
 	assert.True(t, ok)
 
@@ -1006,7 +1006,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok = base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushIgnoredSeqsTotal))
+		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal))
 	}, numRT1DocsTotal-numRT1DocsInitial)
 	assert.True(t, ok)
 


### PR DESCRIPTION
- Renames the existing SGR2 callbacks to something a bit more specific and consistent (`AddExpectedSeq`/`AddProcessedSeq`)
- Adds a new `AlreadyKnownSeq` callback for revisions which a peer does not need to be sent, but can still be checkpointed. This immediately marks the sequence as being both expected and processed for the purposes of the existing checkpointing logic.
- Adds push and pull tests for scenarios where a replication target already has the full set of documents, but still needs to checkpoint the replication.