### PR TITLE
CBG-948 - Update last known rev IDs when we encounter a conflict on checkpoint write

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -403,8 +403,8 @@ func (c *Checkpointer) waitForExpectedSequences() error {
 	return errors.New("checkpointer waitForExpectedSequences failed to complete after waiting 10s")
 }
 
-type setCheckpointFn func(seq, parentRevID string) (string, error)
-type getCheckpointFn func() (string, string, error)
+type setCheckpointFn func(seq, parentRevID string) (revID string, err error)
+type getCheckpointFn func() (seq string, revID string, err error)
 
 // setRetry is a retry loop for a setCheckpointFn, which will fetch a new RevID from a getCheckpointFn in the event of a write conflict.
 func (c *Checkpointer) setRetry(seq, existingRevID string, setFn setCheckpointFn, getFn getCheckpointFn) (newRevID string, err error) {

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/couchbase/go-blip"
@@ -123,7 +124,7 @@ func (rq *SetSGR2CheckpointRequest) Response() (*SetSGR2CheckpointResponse, erro
 			respMsg.Properties["Error-Domain"] == "HTTP" &&
 			respMsg.Properties["Error-Code"] == "409" {
 			// conflict writing checkpoint
-			return nil, fmt.Errorf("conflict writing checkpoint: %s", respBody)
+			return nil, base.HTTPErrorf(http.StatusConflict, "Document update conflict")
 		}
 		return nil, fmt.Errorf("unknown response type: %v - %s", respMsg.Type(), respBody)
 	}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2006,3 +2006,114 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
 	assert.NoError(t, ar.Stop())
 }
+
+// TestActiveReplicatorRecoverFromMismatchedRev:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates a document on rt1 which is pushed to rt2.
+//   - Modifies the checkpoint rev ID in the target bucket.
+//   - Checkpoints again to ensure it is retried on error.
+func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	// Build passiveDBURL with basic auth creds
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	arConfig := db.ActiveReplicatorConfig{
+		ID:           t.Name(),
+		Direction:    db.ActiveReplicatorTypePushAndPull,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous: true,
+		// test isn't long running enough to worry about time-based checkpoints,
+		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
+		CheckpointInterval: time.Minute * 5,
+	}
+
+	// Create the first active replicator to pull from seq:0
+	ar := db.NewActiveReplicator(&arConfig)
+	require.NoError(t, err)
+
+	assert.NoError(t, ar.Start())
+
+	pushCheckpointID, err := ar.Push.CheckpointID()
+	require.NoError(t, err)
+	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
+	err = rt2.Bucket().SetRaw(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	require.NoError(t, err)
+
+	pullCheckpointID, err := ar.Pull.CheckpointID()
+	require.NoError(t, err)
+	pullCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pullCheckpointID
+	err = rt1.Bucket().SetRaw(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	require.NoError(t, err)
+
+	// Create doc1 on rt1
+	docID := t.Name() + "rt1doc"
+	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	assert.NoError(t, rt1.WaitForPendingChanges())
+
+	// wait for document originally written to rt1 to arrive at rt2
+	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	assert.Equal(t, docID, changesResults.Results[0].ID)
+
+	// Create doc2 on rt2
+	docID = t.Name() + "rt2doc"
+	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	assert.NoError(t, rt2.WaitForPendingChanges())
+
+	// wait for document originally written to rt2 to arrive at rt1
+	changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since=1", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	assert.Equal(t, docID, changesResults.Results[0].ID)
+
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	ar.Push.Checkpointer.CheckpointNow()
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+
+	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	ar.Pull.Checkpointer.CheckpointNow()
+	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+
+	assert.NoError(t, ar.Stop())
+}


### PR DESCRIPTION
When the checkpointer attempts to write a checkpoint, and gets a conflict error back, goes and fetches the latest Rev ID and retries the write up to 10 times.