### PR TITLE
CBG-922: Standardize text file processing across all platforms by using 'latin-1' encoding

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -23,19 +23,15 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-
-# The 'latin-1' encoding to map byte values directly to the first 256 Unicode code points.
-# This is the closest equivalent Python 3 offers to the permissive Python 2 text handling model.
-# While the Windows cp1252 encoding is also sometimes referred to as 'latin-1', it doesn't map
-# all possible byte values, and thus needs to be used in combination with the 'surrogateescape'
-# error handler to ensure it never throws UnicodeDecodeError.
+# The 'latin-1' encoding is being used since we can't guarantee that all bytes that will be
+# processed through sgcollect will be decodable from 'utf-8' (which is the default in Python)
+# and the decoder may fail if it encounters any such byte sequence whilst decoding byte strings.
+# The 'latin-1' encoding belongs to the ISO-8859 family and is capable of decoding any byte sequence.
 ENCODING_LATIN1 = 'latin-1'
 
-# This is the error handler that Python uses for most OS facing APIs to gracefully cope with encoding
-# problems in the data supplied by the OS. It handles decoding errors by squirreling the data away in
-# a little used part of the Unicode code point space. When encoding, it translates those hidden away
-# values back into the exact original byte sequence that failed to decode correctly.
-SURROGATE_ESCAPE = 'surrogateescape'
+# Error handler is being used to handle special cases on Windows platforms when the cp1252
+# encoding is  referred to as 'latin-1',  it does not map all possible byte values.
+BACKSLASH_REPLACE = 'backslashreplace'
 
 class LogRedactor:
     def __init__(self, salt, tmpdir):
@@ -47,8 +43,8 @@ class LogRedactor:
 
     def _process_file(self, ifile, ofile, processor):
         try:
-            with open(ifile, 'r', newline='', encoding=ENCODING_LATIN1, errors=SURROGATE_ESCAPE) as inp:
-                with open(ofile, 'w+', newline='', encoding=ENCODING_LATIN1, errors=SURROGATE_ESCAPE) as out:
+            with open(ifile, 'r', newline='', encoding=ENCODING_LATIN1, errors=BACKSLASH_REPLACE) as inp:
+                with open(ofile, 'w+', newline='', encoding=ENCODING_LATIN1, errors=BACKSLASH_REPLACE) as out:
                     # Write redaction header
                     out.write(self.couchbase_log.do("RedactLevel"))
                     for line in inp:

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -24,6 +24,19 @@ import urllib.parse
 import urllib.request
 
 
+# The 'latin-1' encoding to map byte values directly to the first 256 Unicode code points.
+# This is the closest equivalent Python 3 offers to the permissive Python 2 text handling model.
+# While the Windows cp1252 encoding is also sometimes referred to as 'latin-1', it doesn't map
+# all possible byte values, and thus needs to be used in combination with the 'surrogateescape'
+# error handler to ensure it never throws UnicodeDecodeError.
+ENCODING_LATIN1 = 'latin-1'
+
+# This is the error handler that Python uses for most OS facing APIs to gracefully cope with encoding
+# problems in the data supplied by the OS. It handles decoding errors by squirreling the data away in
+# a little used part of the Unicode code point space. When encoding, it translates those hidden away
+# values back into the exact original byte sequence that failed to decode correctly.
+SURROGATE_ESCAPE = 'surrogateescape'
+
 class LogRedactor:
     def __init__(self, salt, tmpdir):
         self.target_dir = os.path.join(tmpdir, "redacted")
@@ -34,8 +47,8 @@ class LogRedactor:
 
     def _process_file(self, ifile, ofile, processor):
         try:
-            with open(ifile, 'r') as inp:
-                with open(ofile, 'w+') as out:
+            with open(ifile, 'r', newline='', encoding=ENCODING_LATIN1, errors=SURROGATE_ESCAPE) as inp:
+                with open(ofile, 'w+', newline='', encoding=ENCODING_LATIN1, errors=SURROGATE_ESCAPE) as out:
                     # Write redaction header
                     out.write(self.couchbase_log.do("RedactLevel"))
                     for line in inp:


### PR DESCRIPTION
When opening text files using `open()` function for reading and writing with no encoding format is specified, Python 3 does use the default encoding format of the target environment (whatever `locale.getpreferredencoding()` returns) which is platform dependent. This may end up in UnicodeEncode error when reading a file that has code points which are not actually in the specified encoding of target environment; similarly when attempting write out code points which have no representation in the target encoding can lead to UnicodeDecode error. In general, open the file in text mode with the appropriate encoding that is consistent across platforms with appropriate error handler. The `surrogateescape` error handler can be used to be more tolerant of encoding errors if it is necessary to make a best effort attempt to process files that contain such errors instead of rejecting them outright as invalid input.