### PR TITLE
Stop sgReplicateManager on DatabaseContext Close

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -537,6 +537,9 @@ func (context *DatabaseContext) Close() {
 	if context.Heartbeater != nil {
 		context.Heartbeater.Stop()
 	}
+	if context.SGReplicateMgr != nil {
+		context.SGReplicateMgr.Stop()
+	}
 	context.Bucket.Close()
 	context.Bucket = nil
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -601,6 +601,13 @@ func (m *sgReplicateManager) loadSGRCluster() (sgrCluster *SGRCluster, cas uint6
 // updateCluster manages CAS retry for SGRCluster updates.
 func (m *sgReplicateManager) updateCluster(callback ClusterUpdateFunc) error {
 	for i := 1; i <= maxSGRClusterCasRetries; i++ {
+		select {
+		case <-m.terminator:
+			base.DebugfCtx(m.loggingCtx, base.KeyReplicate, "manager terminated, bailing out of update retry loop")
+			return nil
+		default:
+		}
+
 		sgrCluster, cas, err := m.loadSGRCluster()
 		if err != nil {
 			return err


### PR DESCRIPTION
Prevents use of bucket after close for things like the async onComplete callbacks.

```
2020-07-20T12:51:10.534+01:00 [INF] HTTP: c:[1c4dff88] #003:    --> BLIP+WebSocket connection closed
2020-07-20T12:51:10.534+01:00 [INF] SGCluster: c:sg_int_walrus_e0a9ff2e2ad2c24edc8c7dc28ca63f55-cfgSG cfg_sg: Get, key: sgrCluster, cas: 0
2020-07-20T12:51:10.534+01:00 [TRC] Bucket+: b:sg_int_walrus_e0a9ff2e2ad2c24edc8c7dc28ca63f55 runtime.gopanic([ _sync:cfgsgrCluster ]) [39.625µs]
panic: Accessing closed Walrus bucket "sg_int_walrus_e0a9ff2e2ad2c24edc8c7dc28ca63f55"

goroutine 165 [running]:
github.com/couchbaselabs/walrus.(*WalrusBucket).assertNotClosed(...)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbaselabs/walrus/crud.go:203
github.com/couchbaselabs/walrus.(*WalrusBucket).missingError(...)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbaselabs/walrus/crud.go:208
github.com/couchbaselabs/walrus.(*WalrusBucket).getRaw(0xc0004a4820, 0xc000036460, 0x13, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbaselabs/walrus/crud.go:230 +0x327
github.com/couchbaselabs/walrus.(*WalrusBucket).Get(0xc0004a4820, 0xc000036460, 0x13, 0x4a86f80, 0xc000324000, 0x403022a, 0x1fd70801, 0xc000182190)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbaselabs/walrus/crud.go:253 +0x43
github.com/couchbase/sync_gateway/base.(*LeakyBucket).Get(0xc0002e2180, 0xc000036460, 0x13, 0x4a86f80, 0xc000324000, 0x1, 0x1000000000013, 0x8)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/base/leaky_bucket.go:78 +0x5b
github.com/couchbase/sync_gateway/base.(*LoggingBucket).Get(0xc0004a6b40, 0xc000036460, 0x13, 0x4a86f80, 0xc000324000, 0x0, 0x0, 0x0)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/base/logging_bucket.go:37 +0x19f
github.com/couchbase/sync_gateway/base.(*CfgSG).Get(0xc00031ede0, 0x4c5b791, 0xa, 0x0, 0x5d56458, 0x0, 0x10, 0xc000182020, 0xc0003b4c00, 0x605972b28)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/base/sg_cluster_cfg.go:55 +0x1bb
github.com/couchbase/sync_gateway/db.(*sgReplicateManager).loadSGRCluster(0xc0000fa5b0, 0x5d56458, 0x1, 0x8, 0x10)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/sg_replicate_cfg.go:582 +0x66
github.com/couchbase/sync_gateway/db.(*sgReplicateManager).updateCluster(0xc0000fa5b0, 0xc00027dd60, 0xc000172c5c, 0xc000000001)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/sg_replicate_cfg.go:604 +0x114
github.com/couchbase/sync_gateway/db.(*sgReplicateManager).UpdateReplicationState(0xc0000fa5b0, 0xc0003683c8, 0x5, 0x4c5861e, 0x7, 0x0, 0xc0004bad60)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/sg_replicate_cfg.go:798 +0x9a
github.com/couchbase/sync_gateway/db.(*sgReplicateManager).replicationComplete(0xc0000fa5b0, 0xc0003683c8, 0x5)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/sg_replicate_cfg.go:476 +0x58
github.com/couchbase/sync_gateway/db.(*ActiveReplicator)._onReplicationComplete(0xc000176930)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/active_replicator.go:123 +0x99
github.com/couchbase/sync_gateway/db.(*ActivePushReplicator).Complete(0xc0004c21c0)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/active_replicator_push.go:120 +0x104
github.com/couchbase/sync_gateway/db.(*ActivePushReplicator).Start.func1(0xc0001863e0, 0xc0004c21c0, 0x0, 0x0, 0x0, 0x0)
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/active_replicator_push.go:82 +0xf3
created by github.com/couchbase/sync_gateway/db.(*ActivePushReplicator).Start
	/Users/benbrooks/dev/sync_gateway/master/godeps/src/github.com/couchbase/sync_gateway/db/active_replicator_push.go:72 +0x291
FAIL	github.com/couchbase/sync_gateway/rest	10.213s
```