### PR TITLE
CBG-980 Use context cfgSG to fire change events instead of routing through import listener

### DIFF
--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/couchbase/cbgt"
@@ -114,7 +115,9 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 	return nil
 }
 
-func (c *CfgSG) FireEvent(cfgKey string, cas uint64, err error) {
+func (c *CfgSG) FireEvent(docID string, cas uint64, err error) {
+
+	cfgKey := strings.TrimPrefix(docID, SGCfgPrefix)
 	c.lock.Lock()
 	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: FireEvent, key: %s, cas %d", cfgKey, cas)
 	for _, ch := range c.subscriptions[cfgKey] {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -403,8 +403,8 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 	}
 
 	if strings.HasPrefix(docID, base.SGCfgPrefix) {
-		if c.context.ImportListener != nil {
-			c.context.ImportListener.NotifyCfg(docID, event.Cas)
+		if c.context.CfgSG != nil {
+			c.context.CfgSG.FireEvent(docID, event.Cas, nil)
 		}
 	}
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -160,10 +160,3 @@ func (il *importListener) Stop() {
 		close(il.terminator)
 	}
 }
-
-func (il *importListener) NotifyCfg(key string, cas uint64) {
-	if il.cbgtContext != nil && il.cbgtContext.Cfg != nil {
-		cfgKey := strings.TrimPrefix(key, base.SGCfgPrefix)
-		il.cbgtContext.Cfg.FireEvent(cfgKey, cas, nil)
-	}
-}


### PR DESCRIPTION
Removed obsolete importListener.NotifyCfg, moved prefix removal into FireEvent.