### PR TITLE
Refactor blip replication stats

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -153,10 +153,10 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 	if ar.Pull != nil {
 		pullStats := ar.Pull.replicationStats
 		status.DocsRead = pullStats.HandleRevCount.Value()
-		status.DocsPurged = pullStats.DocsPurgedCount.Value()
+		status.DocsPurged = pullStats.HandleRevDocsPurgedCount.Value()
 		status.RejectedLocal = pullStats.HandleRevErrorCount.Value()
-		status.DeltasRecv = pullStats.DeltaReceivedCount.Value()
-		status.DeltasRequested = pullStats.DeltaRequestedCount.Value()
+		status.DeltasRecv = pullStats.HandleRevDeltaRecvCount.Value()
+		status.DeltasRequested = pullStats.HandleChangesDeltaRequestedCount.Value()
 		if ar.Pull.Checkpointer != nil {
 			status.LastSeqPull = ar.Pull.Checkpointer.calculateSafeProcessedSeq()
 		}
@@ -168,7 +168,7 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		status.DocWriteFailures = pushStats.SendRevErrorTotal.Value()
 		status.DocWriteConflict = pushStats.SendRevErrorConflictCount.Value()
 		status.RejectedRemote = pushStats.SendRevErrorRejectedCount.Value()
-		status.DeltasSent = pushStats.DeltaSentCount.Value()
+		status.DeltasSent = pushStats.SendRevDeltaSentCount.Value()
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
 		}
@@ -183,11 +183,10 @@ func connect(idSuffix string, config *ActiveReplicatorConfig, replicationStats *
 
 	blipContext := NewSGBlipContext(context.TODO(), config.ID+idSuffix)
 	blipContext.WebsocketPingInterval = config.WebsocketPingInterval
-	bsc = NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID)
+	bsc = NewBlipSyncContext(blipContext, config.ActiveDB, blipContext.ID, replicationStats)
 	bsc.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
 		base.LogContext{CorrelationID: config.ID + idSuffix},
 	)
-	bsc.InitializeStats(replicationStats)
 
 	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.
 	// If deltas have been disabled in the replication config, override this value

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -15,16 +15,6 @@ import (
 )
 
 const (
-	// TODO: Not aligned these to any stats in the PRD yet, these are used for test assertions.
-	ActiveReplicatorStatsKeyPullExpectedSeqsTotal     = "sgr2_pull_expected_seqs_total"
-	ActiveReplicatorStatsKeyPullProcessedSeqsTotal    = "sgr2_pull_processed_seqs_total"
-	ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal = "sgr2_pull_already_known_seqs_total"
-	ActiveReplicatorStatsKeyPushExpectedSeqsTotal     = "sgr2_push_expected_seqs_total"
-	ActiveReplicatorStatsKeyPushProcessedSeqsTotal    = "sgr2_push_processed_seqs_total"
-	ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal = "sgr2_push_already_known_seqs_total"
-)
-
-const (
 	defaultCheckpointInterval = time.Second * 30
 )
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -66,3 +66,9 @@ func (a *activeReplicatorCommon) getStateWithErrorMessage() (state string, lastE
 		return a.state, a.lastError.Error()
 	}
 }
+
+func (a *activeReplicatorCommon) GetStats() *BlipSyncStats {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+	return a.replicationStats
+}

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -176,18 +176,15 @@ func (apr *ActivePullReplicator) reset() error {
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 	apr.blipSyncContext.sgr2PullAlreadyKnownSeqsCallback = func(alreadyKnownSeqs []string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal, int64(len(alreadyKnownSeqs)))
 		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
 	}
 
 	apr.blipSyncContext.sgr2PullAddExpectedSeqsCallback = func(changesSeqs []string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPullExpectedSeqsTotal, int64(len(changesSeqs)))
 		apr.Checkpointer.AddExpectedSeq(changesSeqs...)
 	}
 
 	// TODO: Check whether we need to add a handleNoRev callback to remove expected sequences.
 	apr.blipSyncContext.sgr2PullProcessedSeqCallback = func(remoteSeq string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPullProcessedSeqsTotal, 1)
 		apr.Checkpointer.AddProcessedSeq(remoteSeq)
 	}
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync/atomic"
 	"time"
 
@@ -206,6 +207,7 @@ func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
 	}
 
 	apr.blipSyncContext.sgr2PushProcessedSeqCallback = func(remoteSeq string) {
+		log.Printf("stats in sgr2PushProcessedSeqCallback: %T %+v", apr.Stats, apr.Stats)
 		apr.Stats.Add(ActiveReplicatorStatsKeyPushProcessedSeqsTotal, 1)
 		apr.Checkpointer.AddProcessedSeq(remoteSeq)
 	}

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync/atomic"
 	"time"
 
@@ -198,17 +197,13 @@ func (apr *ActivePushReplicator) reset() error {
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
 	apr.blipSyncContext.sgr2PushAlreadyKnownSeqsCallback = func(alreadyKnownSeqs []string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal, int64(len(alreadyKnownSeqs)))
 		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
 	}
 	apr.blipSyncContext.sgr2PushAddExpectedSeqsCallback = func(expectedSeqs []string) {
-		apr.Stats.Add(ActiveReplicatorStatsKeyPushExpectedSeqsTotal, int64(len(expectedSeqs)))
 		apr.Checkpointer.AddExpectedSeq(expectedSeqs...)
 	}
 
 	apr.blipSyncContext.sgr2PushProcessedSeqCallback = func(remoteSeq string) {
-		log.Printf("stats in sgr2PushProcessedSeqCallback: %T %+v", apr.Stats, apr.Stats)
-		apr.Stats.Add(ActiveReplicatorStatsKeyPushProcessedSeqsTotal, 1)
 		apr.Checkpointer.AddProcessedSeq(remoteSeq)
 	}
 }

--- a/db/blip_sync_context_test.go
+++ b/db/blip_sync_context_test.go
@@ -37,10 +37,10 @@ func TestBlipSyncContextSetUseDeltas(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &BlipSyncContext{
-				dbStats:        NewDatabaseStats(),
-				blipContextDb:  &Database{Ctx: context.TODO()},
-				useDeltas:      tt.startingCtxDeltas,
-				sgCanUseDeltas: tt.sgCanUseDeltas,
+				blipContextDb:    &Database{Ctx: context.TODO()},
+				useDeltas:        tt.startingCtxDeltas,
+				sgCanUseDeltas:   tt.sgCanUseDeltas,
+				replicationStats: NewBlipSyncStats(),
 			}
 
 			ctx.setUseDeltas(tt.clientCanUseDeltas)
@@ -78,8 +78,8 @@ func BenchmarkBlipSyncContextSetUseDeltas(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			ctx := &BlipSyncContext{
-				dbStats:       NewDatabaseStats(),
-				blipContextDb: &Database{Ctx: context.TODO()},
+				blipContextDb:    &Database{Ctx: context.TODO()},
+				replicationStats: NewBlipSyncStats(),
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -1,33 +1,113 @@
 package db
 
-import "expvar"
+import (
+	"expvar"
+
+	"github.com/couchbase/sync_gateway/base"
+)
 
 type BlipSyncStats struct {
-	HandleRevCount            *expvar.Int
-	HandleRevErrorCount       *expvar.Int
-	SendRevCount              *expvar.Int
-	SendRevErrorTotal         *expvar.Int
-	SendRevErrorConflictCount *expvar.Int
-	SendRevErrorRejectedCount *expvar.Int
-	SendRevErrorOtherCount    *expvar.Int
-	DocsPurgedCount           *expvar.Int
-	DeltaSentCount            *expvar.Int
-	DeltaReceivedCount        *expvar.Int
-	DeltaRequestedCount       *expvar.Int
+	DeltaEnabledPullReplicationCount *expvar.Int // global
+	HandleRevCount                   *expvar.Int // handleRev
+	HandleRevErrorCount              *expvar.Int
+	HandleRevDeltaRecvCount          *expvar.Int
+	HandleRevBytes                   *expvar.Int
+	HandleRevProcessingTime          *expvar.Int
+	HandleRevDocsPurgedCount         *expvar.Int
+	SendRevCount                     *expvar.Int // sendRev
+	SendRevDeltaRequestedCount       *expvar.Int
+	SendRevDeltaSentCount            *expvar.Int
+	SendRevBytes                     *expvar.Int
+	SendRevErrorTotal                *expvar.Int
+	SendRevErrorConflictCount        *expvar.Int
+	SendRevErrorRejectedCount        *expvar.Int
+	SendRevErrorOtherCount           *expvar.Int
+	HandleChangesCount               *expvar.Int // handleChanges/handleProposeChanges
+	HandleChangesTime                *expvar.Int
+	HandleChangesDeltaRequestedCount *expvar.Int
+	GetAttachmentCount               *expvar.Int // getAttachment
+	GetAttachmentBytes               *expvar.Int
+	HandleChangesResponseCount       *expvar.Int // handleChangesResponse
+	HandleChangesResponseTime        *expvar.Int
+	HandleChangesSendRevCount        *expvar.Int //  - (duplicates SendRevCount, included for support of CBL expvars)
+	HandleChangesSendRevLatency      *expvar.Int
+	HandleChangesSendRevTime         *expvar.Int
+	SubChangesContinuousActive       *expvar.Int // subChanges
+	SubChangesContinuousTotal        *expvar.Int
+	SubChangesOneShotActive          *expvar.Int
+	SubChangesOneShotTotal           *expvar.Int
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
 	return &BlipSyncStats{
-		HandleRevCount:            &expvar.Int{},
-		HandleRevErrorCount:       &expvar.Int{},
-		SendRevCount:              &expvar.Int{},
-		SendRevErrorTotal:         &expvar.Int{},
-		SendRevErrorConflictCount: &expvar.Int{},
-		SendRevErrorRejectedCount: &expvar.Int{},
-		SendRevErrorOtherCount:    &expvar.Int{},
-		DocsPurgedCount:           &expvar.Int{},
-		DeltaSentCount:            &expvar.Int{},
-		DeltaReceivedCount:        &expvar.Int{},
-		DeltaRequestedCount:       &expvar.Int{},
+		DeltaEnabledPullReplicationCount: &expvar.Int{}, // global
+		HandleRevCount:                   &expvar.Int{}, // handleRev
+		HandleRevErrorCount:              &expvar.Int{},
+		HandleRevDeltaRecvCount:          &expvar.Int{},
+		HandleRevBytes:                   &expvar.Int{},
+		HandleRevProcessingTime:          &expvar.Int{},
+		HandleRevDocsPurgedCount:         &expvar.Int{},
+		SendRevCount:                     &expvar.Int{}, // sendRev
+		SendRevDeltaRequestedCount:       &expvar.Int{},
+		SendRevDeltaSentCount:            &expvar.Int{},
+		SendRevBytes:                     &expvar.Int{},
+		SendRevErrorTotal:                &expvar.Int{},
+		SendRevErrorConflictCount:        &expvar.Int{},
+		SendRevErrorRejectedCount:        &expvar.Int{},
+		SendRevErrorOtherCount:           &expvar.Int{},
+		HandleChangesCount:               &expvar.Int{}, // handleChanges/handleProposeChanges
+		HandleChangesTime:                &expvar.Int{},
+		HandleChangesDeltaRequestedCount: &expvar.Int{},
+		GetAttachmentCount:               &expvar.Int{}, // getAttachment
+		GetAttachmentBytes:               &expvar.Int{},
+		HandleChangesResponseCount:       &expvar.Int{}, // handleChangesResponse
+		HandleChangesResponseTime:        &expvar.Int{},
+		HandleChangesSendRevCount:        &expvar.Int{}, //  - (duplicates SendRevCount, included for support of CBL expvars)
+		HandleChangesSendRevLatency:      &expvar.Int{},
+		HandleChangesSendRevTime:         &expvar.Int{},
+		SubChangesContinuousActive:       &expvar.Int{}, // subChanges
+		SubChangesContinuousTotal:        &expvar.Int{},
+		SubChangesOneShotActive:          &expvar.Int{},
+		SubChangesOneShotTotal:           &expvar.Int{},
 	}
+}
+
+// Stats mappings
+// Create BlipSyncStats mapped to the corresponding CBL replication stats from DatabaseStats
+func BlipSyncStatsForCBL(dbStats *DatabaseStats) *BlipSyncStats {
+	blipStats := NewBlipSyncStats()
+
+	blipStats.HandleChangesCount = dbStats.StatsCblReplicationPush().Get(base.StatKeyProposeChangeCount).(*expvar.Int)
+	blipStats.HandleChangesTime = dbStats.StatsCblReplicationPush().Get(base.StatKeyProposeChangeTime).(*expvar.Int)
+
+	blipStats.SendRevDeltaSentCount = dbStats.StatsDeltaSync().Get(base.StatKeyDeltasSent).(*expvar.Int)
+
+	blipStats.SendRevDeltaRequestedCount = dbStats.StatsDeltaSync().Get(base.StatKeyDeltasRequested).(*expvar.Int)
+	blipStats.SendRevBytes = dbStats.StatsDatabase().Get(base.StatKeyDocReadsBytesBlip).(*expvar.Int)
+	blipStats.SendRevCount = dbStats.StatsDatabase().Get(base.StatKeyNumDocReadsBlip).(*expvar.Int)
+
+	blipStats.HandleRevBytes = dbStats.StatsDatabase().Get(base.StatKeyDocWritesBytesBlip).(*expvar.Int)
+	blipStats.HandleRevProcessingTime = dbStats.StatsCblReplicationPush().Get(base.StatKeyWriteProcessingTime).(*expvar.Int)
+
+	blipStats.HandleRevDeltaRecvCount = dbStats.StatsDeltaSync().Get(base.StatKeyDeltaPushDocCount).(*expvar.Int)
+	blipStats.HandleRevCount = dbStats.StatsCblReplicationPush().Get(base.StatKeyDocPushCount).(*expvar.Int)
+
+	blipStats.GetAttachmentCount = dbStats.StatsCblReplicationPull().Get(base.StatKeyAttachmentPullCount).(*expvar.Int)
+	blipStats.GetAttachmentBytes = dbStats.StatsCblReplicationPull().Get(base.StatKeyAttachmentPullBytes).(*expvar.Int)
+
+	blipStats.HandleChangesResponseCount = dbStats.StatsCblReplicationPull().Get(base.StatKeyRequestChangesCount).(*expvar.Int)
+	blipStats.HandleChangesResponseTime = dbStats.StatsCblReplicationPull().Get(base.StatKeyRequestChangesTime).(*expvar.Int)
+	blipStats.HandleChangesSendRevCount = dbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount).(*expvar.Int)
+	blipStats.HandleChangesSendRevLatency = dbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendLatency).(*expvar.Int)
+	blipStats.HandleChangesSendRevTime = dbStats.StatsCblReplicationPull().Get(base.StatKeyRevProcessingTime).(*expvar.Int)
+
+	// TODO: these are strictly cross-replication stats, maybe do elsewhere?
+	blipStats.SubChangesContinuousActive = dbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsActiveContinuous).(*expvar.Int)
+	blipStats.SubChangesContinuousTotal = dbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsTotalContinuous).(*expvar.Int)
+	blipStats.SubChangesOneShotActive = dbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsActiveOneShot).(*expvar.Int)
+	blipStats.SubChangesOneShotTotal = dbStats.StatsCblReplicationPull().Get(base.StatKeyPullReplicationsTotalOneShot).(*expvar.Int)
+
+	blipStats.DeltaEnabledPullReplicationCount = dbStats.StatsDeltaSync().Get(base.StatKeyDeltaPullReplicationCount).(*expvar.Int)
+
+	return blipStats
 }

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -32,7 +32,7 @@ func (h *handler) handleBLIPSync() error {
 	)
 
 	// Create a new BlipSyncContext attached to the given blipContext.
-	ctx := db.NewBlipSyncContext(blipContext, h.db, h.formatSerialNumber())
+	ctx := db.NewBlipSyncContext(blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
 	defer ctx.Close()
 
 	// Create a BLIP WebSocket handler and have it handle the request:

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -225,7 +225,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	const (
 		changesBatchSize  = 10
@@ -318,16 +318,16 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT2DocsInitial, numRevsSentTotal)
-	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
-	assert.Equal(t, int64(numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsInitial), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(numRT2DocsInitial), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().GetCheckpointMissCount)
 	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -368,15 +368,15 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+numRT2DocsTotal, numRevsSentTotal)
-	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
-	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(numRT2DocsTotal-numRT2DocsInitial), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// assert the second active replicator stats
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 }
 
 // TestActiveReplicatorPullFromCheckpointIgnored:
@@ -463,7 +463,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok := base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal))
+		return ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount
 	}, numRT2DocsInitial)
 	assert.True(t, ok)
 
@@ -490,16 +490,16 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, int64(0), numRevsSentTotal)
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().GetCheckpointMissCount)
 	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -520,7 +520,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok = base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullAlreadyKnownSeqsTotal))
+		return ar.Pull.Checkpointer.Stats().AlreadyKnownSequenceCount
 	}, numRT2DocsTotal-numRT2DocsInitial)
 	assert.True(t, ok)
 
@@ -531,15 +531,15 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, int64(0), numRevsSentTotal)
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// assert the second active replicator stats
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 }
 
 // TestActiveReplicatorPullOneshot:
@@ -825,13 +825,13 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := ar.Push.GetStats().SendRevCount.Value()
 	assert.Equal(t, startNumRevsSentTotal+numRT1DocsInitial, numRevsSentTotal)
-	assert.Equal(t, int64(numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
-	assert.Equal(t, int64(numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+	assert.Equal(t, int64(numRT1DocsInitial), ar.Push.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(numRT1DocsInitial), ar.Push.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -872,15 +872,15 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	// make sure the new replicator has only sent new mutations
 	numRevsSentNewReplicator := ar.Push.GetStats().SendRevCount.Value()
 	assert.Equal(t, numRT1DocsTotal-numRT1DocsInitial, int(numRevsSentNewReplicator))
-	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
-	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), ar.Push.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(numRT1DocsTotal-numRT1DocsInitial), ar.Push.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// assert the second active replicator stats
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 }
 
 // TestActiveReplicatorPushFromCheckpointIgnored:
@@ -968,7 +968,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok := base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal))
+		return ar.Push.Checkpointer.Stats().AlreadyKnownSequenceCount
 	}, numRT1DocsInitial)
 	assert.True(t, ok)
 
@@ -979,13 +979,13 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := ar.Push.GetStats().SendRevCount.Value()
 	assert.Equal(t, int64(0), numRevsSentTotal)
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -1006,7 +1006,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	_, ok = base.WaitForStat(func() int64 {
-		return base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushAlreadyKnownSeqsTotal))
+		return ar.Push.Checkpointer.Stats().AlreadyKnownSequenceCount
 	}, numRT1DocsTotal-numRT1DocsInitial)
 	assert.True(t, ok)
 
@@ -1017,15 +1017,15 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	// make sure rt1 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = ar.Push.GetStats().SendRevCount.Value()
 	assert.Equal(t, int64(0), numRevsSentTotal)
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// assert the second active replicator stats
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 }
 
 // TestActiveReplicatorPushOneshot:
@@ -1937,16 +1937,16 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().GetCheckpointMissCount)
 	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -1970,7 +1970,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// we pulled the remote checkpoint, but the local checkpoint wasn't there to match it.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointHitTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().GetCheckpointHitCount)
 
 	// wait for document originally written to rt2 to arrive at rt1
 	changesResults, err = rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
@@ -1989,14 +1989,14 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	// make sure rt2 thinks it has sent all of the revs via a 2.x replicator
 	numRevsSentTotal = base.ExpvarVar2Int(rt2.GetDatabase().DbStats.StatsCblReplicationPull().Get(base.StatKeyRevSendCount))
 	assert.Equal(t, startNumRevsSentTotal+2, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullProcessedSeqsTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Stats.Get(db.ActiveReplicatorStatsKeyPullExpectedSeqsTotal)))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// assert the second active replicator stats
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 }
@@ -2093,16 +2093,16 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	// rev assertions
 	numRevsSentTotal := ar.Push.GetStats().SendRevCount.Value()
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// checkpoint assertions
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().GetCheckpointMissCount)
 	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -2137,7 +2137,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	// we pulled the remote checkpoint, but the local checkpoint wasn't there to match it.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointHitTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().GetCheckpointHitCount)
 
 	// wait for document originally written to rt1 to arrive at rt2
 	changesResults, err = rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
@@ -2156,14 +2156,14 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	// make sure the replicator has resent the rev
 	numRevsSentTotal = ar.Push.GetStats().SendRevCount.Value()
 	assert.Equal(t, startNumRevsSentTotal+1, numRevsSentTotal)
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushProcessedSeqsTotal)))
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Stats.Get(db.ActiveReplicatorStatsKeyPushExpectedSeqsTotal)))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().ProcessedSequenceCount)
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().ExpectedSequenceCount)
 
 	// assert the second active replicator stats
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatGetCheckpointMissTotal))
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().GetCheckpointMissCount)
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 }
@@ -2253,9 +2253,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
 	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	cID, err := ar.Push.CheckpointID()
 	require.NoError(t, err)
@@ -2280,9 +2280,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(2), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(2), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 
@@ -2310,9 +2310,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	assert.NoError(t, ar.Stop())
 }
 
@@ -2416,13 +2416,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	require.Len(t, changesResults.Results, 1)
 	assert.Equal(t, docID, changesResults.Results[0].ID)
 
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Push.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
-	assert.Equal(t, int64(1), base.ExpvarVar2Int(ar.Pull.Checkpointer.StatSetCheckpointTotal))
+	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 
 	assert.NoError(t, ar.Stop())
 }


### PR DESCRIPTION
Refactoring of blip-related stats to support different usage for CBL vs. sg-replicate replications.  Tracks internal stats as 2.0 replicator specific events, and supports mapping of these stats to database stats for use by CBL. 

Also refactors checkpointer stats into the checkpointer.

This is a prereq to several enhancements to sgr2 replication stats in expvars.