### PR TITLE
CBG-951: Deleted documents should set _deleted:true for import filter function

### DIFF
--- a/db/import.go
+++ b/db/import.go
@@ -221,8 +221,12 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 			var shouldImport bool
 			var importErr error
 
-			if isDelete {
+			if isDelete && body == nil {
 				deleteBody := Body{BodyDeleted: true}
+				shouldImport, importErr = db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(deleteBody)
+			} else if isDelete && body != nil {
+				deleteBody := body.ShallowCopy()
+				deleteBody[BodyDeleted] = true
 				shouldImport, importErr = db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(deleteBody)
 			} else {
 				shouldImport, importErr = db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(body)

--- a/db/import.go
+++ b/db/import.go
@@ -221,7 +221,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 			var shouldImport bool
 			var importErr error
 
-			if len(body) == 0 && isDelete {
+			if isDelete {
 				deleteBody := Body{BodyDeleted: true}
 				shouldImport, importErr = db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(deleteBody)
 			} else {

--- a/db/import.go
+++ b/db/import.go
@@ -218,12 +218,21 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 		// If there's a filter function defined, evaluate to determine whether we should import this doc
 		if db.DatabaseContext.Options.ImportOptions.ImportFilter != nil {
-			shouldImport, err := db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(body)
-			if err != nil {
+			var shouldImport bool
+			var importErr error
+
+			if len(body) == 0 && isDelete {
+				deleteBody := Body{BodyDeleted: true}
+				shouldImport, importErr = db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(deleteBody)
+			} else {
+				shouldImport, importErr = db.DatabaseContext.Options.ImportOptions.ImportFilter.EvaluateFunction(body)
+			}
+
+			if importErr != nil {
 				base.Debugf(base.KeyImport, "Error returned for doc %s while evaluating import function - will not be imported.", base.UD(docid))
 				return nil, nil, updatedExpiry, base.ErrImportCancelledFilter
 			}
-			if shouldImport == false {
+			if !shouldImport {
 				base.Debugf(base.KeyImport, "Doc %s excluded by document import function - will not be imported.", base.UD(docid))
 				// TODO: If this document has a current revision (this is a document that was previously mobile-enabled), do additional opt-out processing
 				// pending https://github.com/couchbase/sync_gateway/issues/2750

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2167,9 +2167,8 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 	var respBody db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
-	syncMeta := respBody["_sync"].(map[string]interface{})
+	syncMeta := respBody[base.SyncPropertyName].(map[string]interface{})
 	assert.NotEmpty(t, syncMeta["rev"].(string))
-	log.Printf("Imported: %s", response.Body.Bytes())
 
 	// Delete the document via SDK
 	err = bucket.Delete(key)
@@ -2180,7 +2179,6 @@ func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
 	assert.True(t, respBody[db.BodyDeleted].(bool))
-	log.Printf("Imported Post-delete: %v", respBody)
-	syncMeta = respBody["_sync"].(map[string]interface{})
+	syncMeta = respBody[base.SyncPropertyName].(map[string]interface{})
 	assert.NotEmpty(t, syncMeta["rev"].(string))
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -128,89 +128,6 @@ func TestXattrImportOldDoc(t *testing.T) {
 	assert.True(t, HasActiveChannel(rawDeleteResponse.Sync.Channels, "docDeleted"), "doc did not set _deleted:true for SDK delete")
 }
 
-// Test import of an SDK delete with ImportFilter .
-func TestXattrImportOldDocWithImportFilter(t *testing.T) {
-	SkipImportTestsIfNotEnabled(t)
-	rtConfig := RestTesterConfig{
-		SyncFn: `function(doc, oldDoc) {
-			if (oldDoc == null) {
-				channel("oldDocNil")
-			} 
-			if (doc._deleted) {
-				channel("docDeleted")
-			}
-		}`,
-		DatabaseConfig: &DbConfig{
-			AutoImport: false,
-			ImportFilter: base.StringPtr(`function (doc) {
-				console.log("Doc in Import Filter:" + JSON.stringify(doc));
-				if (doc.channels || doc._deleted) {
-					return true
-				}
-				return false
-			}`),
-		},
-	}
-	rt := NewRestTester(t, &rtConfig)
-	defer rt.Close()
-	bucket := rt.Bucket()
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyJavascript)()
-
-	// 1. Test oldDoc behaviour during SDK insert
-	key := "doc1"
-	docBody := db.Body{"key": key, "channels": "ABC"}
-	_, err := bucket.Add(key, 0, docBody)
-	assert.NoErrorf(t, err, "Unable to insert doc %s", key)
-
-	// Attempt to get the document via Sync Gateway, to trigger import. On import of a create, oldDoc should be nil.
-	endpoint := "/db/_raw/" + key + "?redact=false"
-	response := rt.SendAdminRequest(http.MethodGet, endpoint, "")
-	assert.Equal(t, response.Code, http.StatusOK)
-	var rawInsertResponse RawResponse
-	err = base.JSONUnmarshal(response.Body.Bytes(), &rawInsertResponse)
-	assert.NoError(t, err, "Unable to unmarshal raw response")
-	assert.True(t, rawInsertResponse.Sync.Channels != nil, "Expected channels not returned for SDK insert")
-	log.Printf("insert channels: %+v", rawInsertResponse.Sync.Channels)
-	assert.True(t, HasActiveChannel(rawInsertResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK insert")
-
-	// 2. Test oldDoc behaviour during SDK update
-	updatedBody := db.Body{"key": key, "channels": "HBO"}
-	err = bucket.Set(key, 0, updatedBody)
-	assert.NoErrorf(t, err, "Unable to update doc %s", key)
-
-	// Attempt to get the document via Sync Gateway, to trigger import. On import of a create, oldDoc should be nil.
-	response = rt.SendAdminRequest(http.MethodGet, endpoint, "")
-	assert.Equal(t, response.Code, http.StatusOK)
-	var rawUpdateResponse RawResponse
-	err = base.JSONUnmarshal(response.Body.Bytes(), &rawUpdateResponse)
-	assert.NoError(t, err, "Unable to unmarshal raw response")
-
-	// If delta sync is enabled, old doc may be available based on the backup used for delta generation, if it hasn't already
-	// been converted to a delta
-	if !rt.GetDatabase().DeltaSyncEnabled() {
-		assert.True(t, rawUpdateResponse.Sync.Channels != nil, "Expected channels not returned for SDK update")
-		log.Printf("update channels: %+v", rawUpdateResponse.Sync.Channels)
-		assert.True(t, HasActiveChannel(rawUpdateResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK update")
-	}
-
-	// 3. Test oldDoc behaviour during SDK delete
-	err = bucket.Delete(key)
-	assert.NoErrorf(t, err, "Unable to delete doc %s", key)
-
-	response = rt.SendAdminRequest(http.MethodGet, endpoint, "")
-	assert.Equal(t, response.Code, http.StatusOK)
-	var rawDeleteResponse RawResponse
-	err = base.JSONUnmarshal(response.Body.Bytes(), &rawDeleteResponse)
-	log.Printf("Post-delete: %s", response.Body.Bytes())
-	assert.NoError(t, err, "Unable to unmarshal raw response")
-	assert.True(t, rawUpdateResponse.Sync.Channels != nil, "Expected channels not returned for SDK update")
-	log.Printf("update channels: %+v", rawDeleteResponse.Sync.Channels)
-	if !rt.GetDatabase().DeltaSyncEnabled() {
-		assert.True(t, HasActiveChannel(rawDeleteResponse.Sync.Channels, "oldDocNil"), "oldDoc was not nil during import of SDK delete")
-	}
-	assert.True(t, HasActiveChannel(rawDeleteResponse.Sync.Channels, "docDeleted"), "doc did not set _deleted:true for SDK delete")
-}
-
 // Validate tombstone w/ xattrs
 func TestXattrSGTombstone(t *testing.T) {
 
@@ -2214,4 +2131,56 @@ func TestDeletedEmptyDocumentImport(t *testing.T) {
 	assert.True(t, rawResponse[db.BodyDeleted].(bool))
 	syncMeta := rawResponse["_sync"].(map[string]interface{})
 	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", syncMeta["rev"])
+}
+
+// Check deleted document via SDK is getting imported if it is included in through ImportFilter function.
+func TestDeletedDocumentImportWithImportFilter(t *testing.T) {
+	SkipImportTestsIfNotEnabled(t)
+	rtConfig := RestTesterConfig{
+		SyncFn: `function(doc) {console.log("Doc in Sync Fn:" + JSON.stringify(doc))}`,
+		DatabaseConfig: &DbConfig{
+			AutoImport: false,
+			ImportFilter: base.StringPtr(`function (doc) {
+				console.log("Doc in Import Filter:" + JSON.stringify(doc));
+				if (doc.channels || doc._deleted) {
+					return true
+				}
+				return false
+			}`),
+		},
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+	bucket := rt.Bucket()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport, base.KeyCRUD, base.KeyJavascript)()
+
+	// Create document via SDK
+	key := "doc1"
+	docBody := db.Body{"key": key, "channels": "ABC"}
+	expiry := time.Now().Add(time.Second * 30)
+	_, err := bucket.Add(key, uint32(expiry.Unix()), docBody)
+	assert.NoErrorf(t, err, "Unable to insert doc %s", key)
+
+	// Trigger import and check whether created document is getting imported
+	endpoint := "/db/_raw/" + key + "?redact=false"
+	response := rt.SendAdminRequest(http.MethodGet, endpoint, "")
+	assert.Equal(t, http.StatusOK, response.Code)
+	var respBody db.Body
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
+	syncMeta := respBody["_sync"].(map[string]interface{})
+	assert.NotEmpty(t, syncMeta["rev"].(string))
+	log.Printf("Imported: %s", response.Body.Bytes())
+
+	// Delete the document via SDK
+	err = bucket.Delete(key)
+	assert.NoErrorf(t, err, "Unable to delete doc %s", key)
+
+	// Trigger import and check whether deleted document is getting imported
+	response = rt.SendAdminRequest(http.MethodGet, endpoint, "")
+	assert.Equal(t, http.StatusOK, response.Code)
+	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &respBody))
+	assert.True(t, respBody[db.BodyDeleted].(bool))
+	log.Printf("Imported Post-delete: %v", respBody)
+	syncMeta = respBody["_sync"].(map[string]interface{})
+	assert.NotEmpty(t, syncMeta["rev"].(string))
 }


### PR DESCRIPTION
Prior to 2.7, deleted docs included _deleted:true in the body passed to the import filter function. This was removed as part of the changes to reduce document marshalling, but should be restored.