### PR TITLE
CBG-957 expvar stats for SGR2 replications

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -180,13 +180,33 @@ const (
 	StatKeyViewQueryErrorCountExpvarFormat = "%s.%s_error_count" // Design doc, view
 	StatKeyViewQueryTimeExpvarFormat       = "%s.%s_time"        // Design doc, view
 
-	// StatsReplication
+	// StatsReplication (1.x)
 	StatKeySgrActive                     = "sgr_active"
-	StatKeySgrNumDocsPushed              = "sgr_num_docs_pushed"
-	StatKeySgrNumDocsFailedToPush        = "sgr_num_docs_failed_to_push"
 	StatKeySgrNumAttachmentsTransferred  = "sgr_num_attachments_transferred"
 	StatKeySgrAttachmentBytesTransferred = "sgr_num_attachment_bytes_transferred"
-	StatKeySgrDocsCheckedSent            = "sgr_docs_checked_sent"
+
+	// StatsReplication (SGR 1.x and 2.x)
+	StatKeySgrNumDocsPushed       = "sgr_num_docs_pushed"
+	StatKeySgrNumDocsFailedToPush = "sgr_num_docs_failed_to_push"
+	StatKeySgrDocsCheckedSent     = "sgr_docs_checked_sent"
+
+	// StatsReplication (SGR 2.x)
+	StatKeySgrNumAttachmentsPushed     = "sgr_num_attachments_pushed"
+	StatKeySgrNumAttachmentBytesPushed = "sgr_num_attachment_bytes_pushed"
+	StatKeySgrNumAttachmentsPulled     = "sgr_num_attachments_pulled"
+	StatKeySgrNumAttachmentBytesPulled = "sgr_num_attachment_bytes_pulled"
+	StatKeySgrPulledCount              = "sgr_num_docs_pulled"
+	StatKeySgrPurgedCount              = "sgr_num_docs_purged"
+	StatKeySgrFailedToPullCount        = "sgr_num_docs_failed_to_pull"
+	StatKeySgrPushConflictCount        = "sgr_push_conflict_count"
+	StatKeySgrPushRejectedCount        = "sgr_push_rejected_count"
+	StatKeySgrDocsCheckedRecv          = "sgr_docs_checked_recv"
+	StatKeySgrDeltaRecvCount           = "sgr_deltas_recv"
+	StatKeySgrDeltaRequestedCount      = "sgr_deltas_requested"
+	StatKeySgrPushDeltaSentCount       = "sgr_deltas_sent"
+	StatKeySgrConflictResolvedLocal    = "sgr_conflict_resolved_local_count"
+	StatKeySgrConflictResolvedRemote   = "sgr_conflict_resolved_remote_count"
+	StatKeySgrConflictResolvedMerge    = "sgr_conflict_resolved_merge_count"
 )
 
 const (
@@ -200,6 +220,7 @@ const (
 	StatsGroupKeyCblReplicationPull  = "cbl_replication_pull"
 	StatsGroupKeySecurity            = "security"
 	StatsGroupKeyGsiViews            = "gsi_views"
+	StatsGroupKeyReplications        = "replications"
 )
 
 func init() {

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -162,8 +162,6 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 		if ar.Push.Checkpointer != nil {
 			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
 		}
-		// TODO: This is another scenario where we need to send a rev without noreply set to get the returned error
-		// status.RejectedRemote = pushStats.SendRevSyncFunctionErrorCount.Value()
 	}
 
 	return status

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"crypto/sha1"
+	"expvar"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -66,6 +67,10 @@ type ActiveReplicatorConfig struct {
 
 	// Callback to be invoked on replication completion
 	onComplete OnCompleteFunc
+
+	// Map corresponding to db.replications.[replicationID] in Sync Gateway's expvars.  Mapped to
+	// replication stats in blip_sync_stats.go
+	ReplicationStats *expvar.Map
 }
 
 type OnCompleteFunc func(replicationID string)

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -16,7 +16,7 @@ func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 	return &ActivePullReplicator{
 		activeReplicatorCommon: activeReplicatorCommon{
 			config:           config,
-			replicationStats: NewBlipSyncStats(),
+			replicationStats: BlipSyncStatsForSGRPull(config.ReplicationStats),
 			state:            ReplicationStateStopped,
 		},
 	}

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -19,7 +19,7 @@ func NewPushReplicator(config *ActiveReplicatorConfig) *ActivePushReplicator {
 	return &ActivePushReplicator{
 		activeReplicatorCommon: activeReplicatorCommon{
 			config:           config,
-			replicationStats: NewBlipSyncStats(),
+			replicationStats: BlipSyncStatsForSGRPush(config.ReplicationStats),
 			state:            ReplicationStateStopped,
 		},
 	}

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -61,8 +61,10 @@ func NewBlipSyncStats() *BlipSyncStats {
 		HandleChangesCount:               &expvar.Int{}, // handleChanges/handleProposeChanges
 		HandleChangesTime:                &expvar.Int{},
 		HandleChangesDeltaRequestedCount: &expvar.Int{},
-		HandleGetAttachment:              &expvar.Int{}, // getAttachment
+		HandleGetAttachment:              &expvar.Int{}, // handleGetAttachment
 		HandleGetAttachmentBytes:         &expvar.Int{},
+		GetAttachment:                    &expvar.Int{}, // getAttachment
+		GetAttachmentBytes:               &expvar.Int{},
 		HandleChangesResponseCount:       &expvar.Int{}, // handleChangesResponse
 		HandleChangesResponseTime:        &expvar.Int{},
 		HandleChangesSendRevCount:        &expvar.Int{}, //  - (duplicates SendRevCount, included for support of CBL expvars)
@@ -129,6 +131,10 @@ func initReplicationStat(statMap *expvar.Map, key string) (stat *expvar.Int) {
 
 func BlipSyncStatsForSGRPush(statsMap *expvar.Map) *BlipSyncStats {
 	blipStats := NewBlipSyncStats()
+	if statsMap == nil {
+		base.Warnf("statsMap not provided for SGRPush initialization - replication stats will not be published")
+		statsMap = new(expvar.Map).Init()
+	}
 
 	blipStats.HandleGetAttachmentBytes = initReplicationStat(statsMap, base.StatKeySgrNumAttachmentBytesPushed)
 	blipStats.HandleGetAttachment = initReplicationStat(statsMap, base.StatKeySgrNumAttachmentsPushed)
@@ -144,6 +150,10 @@ func BlipSyncStatsForSGRPush(statsMap *expvar.Map) *BlipSyncStats {
 
 func BlipSyncStatsForSGRPull(statsMap *expvar.Map) *BlipSyncStats {
 	blipStats := NewBlipSyncStats()
+	if statsMap == nil {
+		base.Warnf("statsMap not provided for SGRPull initialization - replication stats will not be published")
+		statsMap = new(expvar.Map).Init()
+	}
 
 	blipStats.GetAttachmentBytes = initReplicationStat(statsMap, base.StatKeySgrNumAttachmentBytesPulled)
 	blipStats.GetAttachment = initReplicationStat(statsMap, base.StatKeySgrNumAttachmentsPulled)

--- a/db/database_stats.go
+++ b/db/database_stats.go
@@ -24,7 +24,8 @@ type DatabaseStats struct {
 	cblReplicationPushSync,
 	cblReplicationPullSync,
 	statsSecuritySync,
-	statsGsiViewsSync sync.Once
+	statsGsiViewsSync,
+	statsReplicationsSync sync.Once
 
 	statsCacheMap,
 	statsDatabaseMap,
@@ -33,7 +34,8 @@ type DatabaseStats struct {
 	cblReplicationPush,
 	cblReplicationPull,
 	statsSecurity,
-	statsGsiViews *expvar.Map
+	statsGsiViews,
+	statsReplications *expvar.Map
 }
 
 func NewDatabaseStats() *DatabaseStats {
@@ -103,6 +105,13 @@ func (d *DatabaseStats) StatsGsiViews() (stats *expvar.Map) {
 		d.StatsByKey(base.StatsGroupKeyGsiViews)
 	})
 	return d.statsGsiViews
+}
+
+func (d *DatabaseStats) StatsReplications() (stats *expvar.Map) {
+	d.statsReplicationsSync.Do(func() {
+		d.StatsByKey(base.StatsGroupKeyReplications)
+	})
+	return d.statsReplications
 }
 
 func (d *DatabaseStats) StatsByKey(key string) (stats *expvar.Map) {
@@ -228,6 +237,9 @@ func initEmptyStatsMap(key string, d *DatabaseStats) *expvar.Map {
 	case base.StatsGroupKeyGsiViews:
 		// GsiView stat keys are dynamically generated based on query names - see query.go
 		d.statsGsiViews = result
+	case base.StatsGroupKeyReplications:
+		// Replications stat keys are generated per replication, see blip_sync_stats.go
+		d.statsReplications = result
 	}
 
 	return result


### PR DESCRIPTION
Adds expvars under db.replications.replicationID for SGR2 replications.  Push and pull replication expvar values are mapped to blip ReplicationStats.