### PR TITLE
Log warning for panics that happen in BLIP handlers before passing back to go-blip

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -113,6 +113,14 @@ func (bsc *BlipSyncContext) register(profile string, handlerFn func(*blipHandler
 	// Wrap the handler function with a function that adds handling needed by all handlers
 	handlerFnWrapper := func(rq *blip.Message) {
 
+		// Recover to log panic from handlers and repanic for go-blip response handling
+		defer func() {
+			if err := recover(); err != nil {
+				base.WarnfCtx(bsc.loggingCtx, "PANIC handling BLIP request %v: %v\n%s", rq, err, debug.Stack())
+				panic(err)
+			}
+		}()
+
 		startTime := time.Now()
 		handler := blipHandler{
 			BlipSyncContext: bsc,


### PR DESCRIPTION
Related to test failure seen in #4679

go-blip recovers from handler panics, but it can only log at the normal info level before it sends a message response back if required.

https://github.com/couchbase/go-blip/blob/90436f91d5b8d3e2a988df91a138e59f69dad78c/context.go#L160-L173

We miss these logs in Sync Gateway without the WS log key enabled, so this wrapps all of our handlers with their own panic logging, before re-panicing to pass it back to go-blip for existing response handling.

![Screenshot 2020-07-22 at 13 02 39](https://user-images.githubusercontent.com/1525809/88174135-aa34ed00-cc1b-11ea-9d38-2345548aa64d.png)
