### PR TITLE
CBG-926: User name not being logged for initial HTTP request

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -169,22 +169,22 @@ func (h *handler) invoke(method handlerMethod) error {
 	if dbContext != nil {
 		if !h.runOffline {
 
-			//get a read lock on the dbContext
-			//When the lock is returned we know that the db state will not be changed by
-			//any other call
+			// get a read lock on the dbContext
+			// When the lock is returned we know that the db state will not be changed by
+			// any other call
 			dbContext.AccessLock.RLock()
 
-			//defer releasing the dbContext until after the handler method returns
+			// defer releasing the dbContext until after the handler method returns
 			defer dbContext.AccessLock.RUnlock()
 
 			dbState := atomic.LoadUint32(&dbContext.State)
 
-			//if dbState == db.DBOnline, continue flow and invoke the handler method
+			// if dbState == db.DBOnline, continue flow and invoke the handler method
 			if dbState == db.DBOffline {
 				// DB is offline, only handlers with runOffline true can run in this state
 				return base.HTTPErrorf(http.StatusServiceUnavailable, "DB is currently under maintenance")
 			} else if dbState != db.DBOnline {
-				//DB is in transition state, no calls will be accepted until it is Online or Offline state
+				// DB is in transition state, no calls will be accepted until it is Online or Offline state
 				return base.HTTPErrorf(http.StatusServiceUnavailable, fmt.Sprintf("DB is %v - try again later", db.RunStateString[dbState]))
 			}
 		}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -132,17 +132,17 @@ func (h *handler) invoke(method handlerMethod) error {
 		}
 	}
 
-	h.logRequestLine()
-
 	switch h.rq.Header.Get("Content-Encoding") {
 	case "":
 		h.requestBody = h.rq.Body
 	case "gzip":
 		if h.requestBody, err = gzip.NewReader(h.rq.Body); err != nil {
+			h.logRequestLine()
 			return err
 		}
 		h.rq.Header.Del("Content-Encoding") // to prevent double decoding later on
 	default:
+		h.logRequestLine()
 		return base.HTTPErrorf(http.StatusUnsupportedMediaType, "Unsupported Content-Encoding; use gzip")
 	}
 
@@ -156,6 +156,7 @@ func (h *handler) invoke(method handlerMethod) error {
 	var dbContext *db.DatabaseContext
 	if dbname := h.PathVar("db"); dbname != "" {
 		if dbContext, err = h.server.GetDatabase(dbname); err != nil {
+			h.logRequestLine()
 			return err
 		}
 	}
@@ -176,9 +177,11 @@ func (h *handler) invoke(method handlerMethod) error {
 
 			//if dbState == db.DBOnline, continue flow and invoke the handler method
 			if dbState == db.DBOffline {
-				//DB is offline, only handlers with runOffline true can run in this state
+				h.logRequestLine()
+				// DB is offline, only handlers with runOffline true can run in this state
 				return base.HTTPErrorf(http.StatusServiceUnavailable, "DB is currently under maintenance")
 			} else if dbState != db.DBOnline {
+				h.logRequestLine()
 				//DB is in transition state, no calls will be accepted until it is Online or Offline state
 				return base.HTTPErrorf(http.StatusServiceUnavailable, fmt.Sprintf("DB is %v - try again later", db.RunStateString[dbState]))
 			}
@@ -188,9 +191,12 @@ func (h *handler) invoke(method handlerMethod) error {
 	// Authenticate, if not on admin port:
 	if h.privs != adminPrivs {
 		if err = h.checkAuth(dbContext); err != nil {
+			h.logRequestLine()
 			return err
 		}
 	}
+
+	h.logRequestLine()
 
 	// Now set the request's Database (i.e. context + user)
 	if dbContext != nil {


### PR DESCRIPTION
The change in https://github.com/couchbase/sync_gateway/pull/4200 to address missed logging in some scenarios introduced a regression - we're attempting to log before authentication has been completed, so the user associated with the request is no longer being logged for public API calls. Need to restore this functionality while still addressing the issue that the previous change was intending to fix.

### Log verification results

**Create user**
```
http --verbose PUT localhost:4985/default/_user/alice name=alice password=1234
2020-07-22T13:21:02.913-07:00 [INF] HTTP:  #001: PUT /default/_user/alice (as ADMIN)
2020-07-22T13:21:02.918-07:00 [INF] Access: Recomputed channels for "alice": !:1
2020-07-22T13:21:02.920-07:00 [INF] Access: Computed roles for "alice": 
2020-07-22T13:21:02.985-07:00 [INF] Auth: Saved principal w/ name:alice, seq: #2
2020-07-22T13:21:02.985-07:00 [INF] HTTP+: #001:     --> 201 Created  (72.1 ms)
2020-07-22T13:21:02.985-07:00 [INF] DCP: Received #2 ("_user/alice")
```

**Grant user access to channel**
```
http --verbose PUT localhost:4985/default/_user/alice admin_channels:='["channel1"]'
2020-07-22T13:21:51.211-07:00 [INF] HTTP:  #002: PUT /default/_user/alice (as ADMIN)
2020-07-22T13:21:51.212-07:00 [INF] Auth: Saved principal w/ name:alice, seq: #3
2020-07-22T13:21:51.212-07:00 [INF] HTTP+: #002:     --> 200 OK  (0.8 ms)
2020-07-22T13:21:51.212-07:00 [INF] DCP: Received #3 ("_user/alice")
```

```
http --verbose PUT localhost:4985/default/_user/alice admin_channels:='["*"]'
2020-07-22T13:22:13.702-07:00 [INF] HTTP:  #003: PUT /default/_user/alice (as ADMIN)
2020-07-22T13:22:13.707-07:00 [INF] Access: Recomputed channels for "alice": !:1,channel1:3
2020-07-22T13:22:13.707-07:00 [INF] DCP: Received #3 ("_user/alice")
2020-07-22T13:22:13.708-07:00 [INF] Auth: Saved principal w/ name:alice, seq: #4
2020-07-22T13:22:13.708-07:00 [INF] HTTP+: #003:     --> 200 OK  (6.0 ms)
2020-07-22T13:22:13.708-07:00 [INF] DCP: Received #4 ("_user/alice")
```

**Put a document to channel**
```
http --verbose -a alice:1234 PUT localhost:4984/default/doc0 Content-Encoding: channels:='["channel1"]' k1="v1"
2020-07-22T13:22:42.471-07:00 [INF] HTTP:  #004: PUT /default/doc0 (as alice)
2020-07-22T13:22:42.472-07:00 [INF] CRUD:       Doc "doc0" / "1-c55cac1accd4e833c16ed4534d6328ab" in channels "{channel1}"
2020-07-22T13:22:42.473-07:00 [INF] HTTP+: #004:     --> 201   (69.5 ms)
```

**Check Unsupported header case**
```
http --verbose -a alice:1234 PUT localhost:4984/default/doc1 Content-Encoding:text channels:='["channel1"]' k1="v1"
2020-07-22T13:23:07.283-07:00 [INF] HTTP:  #005: PUT /default/doc1
2020-07-22T13:23:07.283-07:00 [INF] HTTP: #005:     --> 415 Unsupported Content-Encoding; use gzip  (0.1 ms)
```

**Check invalid header flow**
```
http --verbose -a alice:1234 PUT localhost:4984/default/doc2 Content-Encoding:gzip channels:='["channel1"]' k1="v1"
2020-07-22T13:23:26.993-07:00 [INF] HTTP:  #006: PUT /default/doc2
2020-07-22T13:23:26.993-07:00 [ERR] #006: gzip: invalid header -- rest.(*handler).writeError() at handler.go:732
2020-07-22T13:23:26.994-07:00 [INF] HTTP: #006:     --> 500 Internal error: gzip: invalid header  (0.2 ms)
```

**Try to put a doc in an unknown database**
```
http --verbose -a alice:1234 PUT localhost:4984/unknown/doc3 channels:='["channel1"]' k1="v1"
2020-07-22T13:23:48.621-07:00 [INF] HTTP:  #007: PUT /unknown/doc3
2020-07-22T13:23:48.621-07:00 [INF] HTTP: #007:     --> 404 no such database "unknown"  (0.1 ms)
```