### PR TITLE
CBG-921 Skip _txn: prefixed documents during DCP processing

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -117,6 +117,9 @@ const (
 	SyncPropertyName = "_sync"
 	SyncXattrName    = "_sync"
 
+	// Prefix for transaction metadata documents
+	TxnPrefix = "_txn:"
+
 	// Replication filter constants
 	ByChannelFilter = "sync_gateway/bychannel"
 )

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -498,8 +498,12 @@ func (b *backfillStatus) purgeBackfillSequences(bucket Bucket) error {
 // Only a subset of Sync Gateway's internal documents need to be included during DCP processing: user, role, and
 // unused sequence documents.  Any other documents with the leading '_sync' prefix can be ignored.
 // dcpKeyFilter returns true for documents that should be processed, false for those that do not need processing.
-//  TODO: The hardcoded strings here should be changed to constants (CBG-274)
 func dcpKeyFilter(key []byte) bool {
+
+	// If it's a _txn doc, don't process
+	if bytes.HasPrefix(key, []byte(TxnPrefix)) {
+		return false
+	}
 
 	// If it's not a _sync doc, process
 	if !bytes.HasPrefix(key, []byte(SyncPrefix)) {

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -52,6 +52,7 @@ func TestDCPKeyFilter(t *testing.T) {
 	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq")))
 	assert.False(t, dcpKeyFilter([]byte(SyncDataKey)))
 	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
+	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData")))
 }
 
 // Compare Atoi vs map lookup for partition conversion


### PR DESCRIPTION
Avoids SG interaction with transaction metadata documents.

No additional handling is needed for on-demand import scenarios, as the underscore-prefixed metadata documents are not have valid SG docIDs and already can't be accessed through SG's REST API.