### PR TITLE
CBG-961 Conflict resolution outcome stats

### DIFF
--- a/base/replicator_test.go
+++ b/base/replicator_test.go
@@ -42,7 +42,7 @@ func TestReplicator(t *testing.T) {
 }
 
 func waitForActiveTasks(t *testing.T, r *Replicator, taskCount int) {
-	for i := 0; i < 20; i++ {
+	for i := 0; i <= 20; i++ {
 		if i == 20 {
 			t.Fatalf("failed to find active task")
 		}

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -55,8 +55,8 @@ type ActiveReplicatorConfig struct {
 	ActiveDB *Database
 	// WebsocketPingInterval is the time between websocket heartbeats sent by the active replicator.
 	WebsocketPingInterval time.Duration
-	// Conflict resolver function
-	ConflictResolver ConflictResolverFunc
+	// Conflict resolver
+	ConflictResolverFunc ConflictResolverFunc
 
 	// Delta sync enabled
 	DeltasEnabled bool
@@ -68,9 +68,9 @@ type ActiveReplicatorConfig struct {
 	// Callback to be invoked on replication completion
 	onComplete OnCompleteFunc
 
-	// Map corresponding to db.replications.[replicationID] in Sync Gateway's expvars.  Mapped to
+	// Map corresponding to db.replications.[replicationID] in Sync Gateway's expvars.  Populated with
 	// replication stats in blip_sync_stats.go
-	ReplicationStats *expvar.Map
+	ReplicationStatsMap *expvar.Map
 }
 
 type OnCompleteFunc func(replicationID string)

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -16,7 +16,7 @@ func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
 	return &ActivePullReplicator{
 		activeReplicatorCommon: activeReplicatorCommon{
 			config:           config,
-			replicationStats: BlipSyncStatsForSGRPull(config.ReplicationStats),
+			replicationStats: BlipSyncStatsForSGRPull(config.ReplicationStatsMap),
 			state:            ReplicationStateStopped,
 		},
 	}
@@ -41,7 +41,9 @@ func (apr *ActivePullReplicator) Start() error {
 		return apr._setError(err)
 	}
 
-	apr.blipSyncContext.conflictResolver = apr.config.ConflictResolver
+	if apr.config.ConflictResolverFunc != nil {
+		apr.blipSyncContext.conflictResolver = NewConflictResolver(apr.config.ConflictResolverFunc, apr.config.ReplicationStatsMap)
+	}
 	apr.blipSyncContext.purgeOnRemoval = apr.config.PurgeOnRemoval
 
 	apr.checkpointerCtx, apr.checkpointerCtxCancel = context.WithCancel(context.Background())

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -19,7 +19,7 @@ func NewPushReplicator(config *ActiveReplicatorConfig) *ActivePushReplicator {
 	return &ActivePushReplicator{
 		activeReplicatorCommon: activeReplicatorCommon{
 			config:           config,
-			replicationStats: BlipSyncStatsForSGRPush(config.ReplicationStats),
+			replicationStats: BlipSyncStatsForSGRPush(config.ReplicationStatsMap),
 			state:            ReplicationStateStopped,
 		},
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -99,7 +99,7 @@ type BlipSyncContext struct {
 	emptyChangesMessageCallback      func()                          // emptyChangesMessageCallback is called when an empty changes message is received
 	replicationStats                 *BlipSyncStats                  // Replication stats
 	purgeOnRemoval                   bool                            // Purges the document when we pull a _removed:true revision.
-	conflictResolver                 ConflictResolverFunc            // Conflict resolver for active replications
+	conflictResolver                 *ConflictResolver               // Conflict resolver for active replications
 	changesPendingResponseCount      int64                           // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
 	sendRevNoConflicts bool // Whether to set noconflicts=true when sending revisions

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -444,9 +444,9 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	// Set conflict resolver for pull replications
 	if rc.Direction == ActiveReplicatorTypePull || rc.Direction == ActiveReplicatorTypePushAndPull {
 		if config.ConflictResolutionType == "" {
-			rc.ConflictResolver, err = NewConflictResolverFunc(ConflictResolverDefault, "")
+			rc.ConflictResolverFunc, err = NewConflictResolverFunc(ConflictResolverDefault, "")
 		} else {
-			rc.ConflictResolver, err = NewConflictResolverFunc(config.ConflictResolutionType, config.ConflictResolutionFn)
+			rc.ConflictResolverFunc, err = NewConflictResolverFunc(config.ConflictResolutionType, config.ConflictResolutionFn)
 		}
 		if err != nil {
 			return nil, err
@@ -476,7 +476,7 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	} else {
 		statsMap = statsVar.(*expvar.Map)
 	}
-	rc.ReplicationStats = statsMap
+	rc.ReplicationStatsMap = statsMap
 
 	// TODO: review whether there's a more appropriate context to use here
 	replicator = NewActiveReplicator(rc)


### PR DESCRIPTION
Adds stats for conflict resolution outcome (sgr_conflict_resolved_local_count, sgr_conflict_resolved_remote_count, sgr_conflict_resolved_merge_count).

Required wrapping ConflictResolutionFunc in ConflictResolver in order to maintain reference to stats.  Stats are managed internally as ConflictResolverStats, and can be associated with an expvar.map container if specified in the constructor. (+1 squashed commit)