### PR TITLE
SGR2: Support marking sequences as processed when pushing a norev

### DIFF
--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -62,6 +62,7 @@ const (
 	// norev message properties
 	NorevMessageId     = "id"
 	NorevMessageRev    = "rev"
+	NorevMessageSeq    = "seq"
 	NorevMessageError  = "error"
 	NorevMessageReason = "reason"
 
@@ -391,6 +392,10 @@ func (nrm *noRevMessage) SetId(id string) {
 
 func (nrm *noRevMessage) SetRev(rev string) {
 	nrm.Properties[NorevMessageRev] = rev
+}
+
+func (nrm *noRevMessage) SetSeq(seq SequenceID) {
+	nrm.Properties[NorevMessageSeq] = seq.String()
 }
 
 func (nrm *noRevMessage) SetReason(reason string) {


### PR DESCRIPTION
Half of CBG-920, but want to split push and pull because they're having to use different approaches.

- Marks sequences as processed whenever we need to send a norev in a push replication instead of the actual rev.
- Includes the optional sequence number in the norev messages sent by Sync Gateway, which would've been useful in SGR2, but can't be used for the pre-Hydrogen compatibility reasons.