### PR TITLE
CBG-920: SGR2 track pulled norev sequences for checkpointing

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -103,13 +103,12 @@ func (c *Checkpointer) AddProcessedSeqIDAndRev(seq string, idAndRev IDAndRev) {
 
 	c.lock.Lock()
 
-	// need to remove idAndRev from the lookup map even if we have a seq available
-	lookupSeq, _ := c.idAndRevLookup[idAndRev]
+	if seq == "" {
+		seq, _ = c.idAndRevLookup[idAndRev]
+	}
+	// should remove entry in the map even if we have a seq available
 	delete(c.idAndRevLookup, idAndRev)
 
-	if seq == "" {
-		seq = lookupSeq
-	}
 	c.processedSeqs[seq] = struct{}{}
 	c.stats.ProcessedSequenceCount++
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -24,6 +24,9 @@ type Checkpointer struct {
 	expectedSeqs []string
 	// processedSeqs is a map of sequence IDs we've processed revs for
 	processedSeqs map[string]struct{}
+	// idAndRevLookup is a temporary map of DocID/RevID pair to sequence number,
+	// to handle cases where we receive a message that doesn't contain a sequence.
+	idAndRevLookup map[IDAndRev]string
 	// ctx is used to stop the checkpointer goroutine
 	ctx context.Context
 	// lastRemoteCheckpointRevID is the last known remote checkpoint RevID.
@@ -52,6 +55,7 @@ func NewCheckpointer(ctx context.Context, clientID string, blipSender *blip.Send
 		activeDB:           activeDB,
 		expectedSeqs:       make([]string, 0),
 		processedSeqs:      make(map[string]struct{}),
+		idAndRevLookup:     make(map[IDAndRev]string),
 		checkpointInterval: checkpointInterval,
 		ctx:                ctx,
 		stats:              CheckpointerStats{},
@@ -89,8 +93,31 @@ func (c *Checkpointer) AddProcessedSeq(seq string) {
 	c.lock.Unlock()
 }
 
-func (c *Checkpointer) AddExpectedSeq(seq ...string) {
-	if len(seq) == 0 {
+func (c *Checkpointer) AddProcessedSeqIDAndRev(seq string, idAndRev IDAndRev) {
+	select {
+	case <-c.ctx.Done():
+		// replicator already closed, bail out of checkpointing work
+		return
+	default:
+	}
+
+	c.lock.Lock()
+
+	// need to remove idAndRev from the lookup map even if we have a seq available
+	lookupSeq, _ := c.idAndRevLookup[idAndRev]
+	delete(c.idAndRevLookup, idAndRev)
+
+	if seq == "" {
+		seq = lookupSeq
+	}
+	c.processedSeqs[seq] = struct{}{}
+	c.stats.ProcessedSequenceCount++
+
+	c.lock.Unlock()
+}
+
+func (c *Checkpointer) AddExpectedSeqs(seqs ...string) {
+	if len(seqs) == 0 {
 		// nothing to do
 		return
 	}
@@ -103,8 +130,30 @@ func (c *Checkpointer) AddExpectedSeq(seq ...string) {
 	}
 
 	c.lock.Lock()
-	c.expectedSeqs = append(c.expectedSeqs, seq...)
-	c.stats.ExpectedSequenceCount += int64(len(seq))
+	c.expectedSeqs = append(c.expectedSeqs, seqs...)
+	c.stats.ExpectedSequenceCount += int64(len(seqs))
+	c.lock.Unlock()
+}
+
+func (c *Checkpointer) AddExpectedSeqIDAndRevs(seqs map[IDAndRev]string) {
+	if len(seqs) == 0 {
+		// nothing to do
+		return
+	}
+
+	select {
+	case <-c.ctx.Done():
+		// replicator already closed, bail out of checkpointing work
+		return
+	default:
+	}
+
+	c.lock.Lock()
+	for idAndRev, seq := range seqs {
+		c.idAndRevLookup[idAndRev] = seq
+		c.expectedSeqs = append(c.expectedSeqs, seq)
+	}
+	c.stats.ExpectedSequenceCount += int64(len(seqs))
 	c.lock.Unlock()
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -175,19 +176,62 @@ func (apr *ActivePullReplicator) reset() error {
 	return resetLocalCheckpoint(apr.config.ActiveDB, checkpointID)
 }
 
+type pullCheckpointerLookup struct {
+	m map[IDAndRev]string
+	l sync.Mutex
+}
+
+func newPullCheckpointerLookup() *pullCheckpointerLookup {
+	return &pullCheckpointerLookup{
+		m: make(map[IDAndRev]string, 0),
+	}
+}
+
+func (p *pullCheckpointerLookup) AddSeqs(idRevAndSeq map[IDAndRev]string) (addedSeqs []string) {
+	addedSeqs = make([]string, 0, len(idRevAndSeq))
+	p.l.Lock()
+	for k, v := range idRevAndSeq {
+		p.m[k] = v
+		addedSeqs = append(addedSeqs, v)
+	}
+	p.l.Unlock()
+	return addedSeqs
+}
+
+// Pop a sequence by DocID+RevID
+func (p *pullCheckpointerLookup) PopSeq(idAndRev IDAndRev) (seq string) {
+	p.l.Lock()
+	seq, ok := p.m[idAndRev]
+	if ok {
+		delete(p.m, idAndRev)
+	}
+	p.l.Unlock()
+	return seq
+}
+
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
+	// noRevSeqLookup is required for sgr2PullNorevCallback because sequence isn't sent in norev messages like it is for everything else.
+	// For hydrogen-to-hydrogen replications, we do send seq in norev, but still need this handling for pre-hydrogen targets.
+	noRevSeqLookup := newPullCheckpointerLookup()
+
 	apr.blipSyncContext.sgr2PullAlreadyKnownSeqsCallback = func(alreadyKnownSeqs []string) {
 		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
 	}
 
-	apr.blipSyncContext.sgr2PullAddExpectedSeqsCallback = func(changesSeqs []string) {
-		apr.Checkpointer.AddExpectedSeq(changesSeqs...)
+	apr.blipSyncContext.sgr2PullAddExpectedSeqsCallback = func(changesSeqs map[IDAndRev]string) {
+		seqs := noRevSeqLookup.AddSeqs(changesSeqs)
+		apr.Checkpointer.AddExpectedSeq(seqs...)
 	}
 
-	// TODO: Check whether we need to add a handleNoRev callback to remove expected sequences.
-	apr.blipSyncContext.sgr2PullProcessedSeqCallback = func(remoteSeq string) {
+	apr.blipSyncContext.sgr2PullProcessedSeqCallback = func(idAndRev IDAndRev, remoteSeq string) {
+		_ = noRevSeqLookup.PopSeq(idAndRev)
 		apr.Checkpointer.AddProcessedSeq(remoteSeq)
+	}
+
+	apr.blipSyncContext.sgr2PullNorevCallback = func(docID, revID string) {
+		seq := noRevSeqLookup.PopSeq(IDAndRev{DocID: docID, RevID: revID})
+		apr.Checkpointer.AddProcessedSeq(seq)
 	}
 
 	// Trigger complete for non-continuous replications when caught up

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -196,16 +196,11 @@ func (apr *ActivePushReplicator) reset() error {
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.
 func (apr *ActivePushReplicator) registerCheckpointerCallbacks() {
-	apr.blipSyncContext.sgr2PushAlreadyKnownSeqsCallback = func(alreadyKnownSeqs []string) {
-		apr.Checkpointer.AddAlreadyKnownSeq(alreadyKnownSeqs...)
-	}
-	apr.blipSyncContext.sgr2PushAddExpectedSeqsCallback = func(expectedSeqs []string) {
-		apr.Checkpointer.AddExpectedSeq(expectedSeqs...)
-	}
+	apr.blipSyncContext.sgr2PushAlreadyKnownSeqsCallback = apr.Checkpointer.AddAlreadyKnownSeq
 
-	apr.blipSyncContext.sgr2PushProcessedSeqCallback = func(remoteSeq string) {
-		apr.Checkpointer.AddProcessedSeq(remoteSeq)
-	}
+	apr.blipSyncContext.sgr2PushAddExpectedSeqsCallback = apr.Checkpointer.AddExpectedSeqs
+
+	apr.blipSyncContext.sgr2PushProcessedSeqCallback = apr.Checkpointer.AddProcessedSeq
 }
 
 // waitForExpectedSequences waits for the pending changes response count

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -441,7 +441,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		bh.sgr2PullAddExpectedSeqsCallback(expectedSeqs)
 	}
 	if bh.sgr2PullAlreadyKnownSeqsCallback != nil {
-		bh.sgr2PullAlreadyKnownSeqsCallback(alreadyKnownSeqs)
+		bh.sgr2PullAlreadyKnownSeqsCallback(alreadyKnownSeqs...)
 	}
 
 	return nil
@@ -557,8 +557,8 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "%s: norev for doc %q / %q - error: %q - reason: %q",
 		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
-	if bh.sgr2PullNorevCallback != nil {
-		bh.sgr2PullNorevCallback(rq.Properties[NorevMessageId], rq.Properties[NorevMessageRev])
+	if bh.sgr2PullProcessedSeqCallback != nil {
+		bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
 	}
 
 	// Couchbase Lite always sends noreply=true for norev profiles
@@ -620,7 +620,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			}
 			bh.replicationStats.HandleRevDocsPurgedCount.Add(1)
 			if bh.sgr2PullProcessedSeqCallback != nil {
-				bh.sgr2PullProcessedSeqCallback(IDAndRev{DocID: docID, RevID: revID}, rq.Properties[RevMessageSequence])
+				bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
 			}
 			return nil
 		}
@@ -745,7 +745,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	}
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		bh.sgr2PullProcessedSeqCallback(IDAndRev{DocID: docID, RevID: revID}, rq.Properties[RevMessageSequence])
+		bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence], IDAndRev{DocID: docID, RevID: revID})
 	}
 
 	return nil

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -391,7 +391,8 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		bh.replicationStats.HandleChangesTime.Add(time.Since(startTime).Nanoseconds())
 	}()
 
-	expectedSeqs := make([]string, 0)
+	// DocID+RevID -> SeqNo
+	expectedSeqs := make(map[IDAndRev]string, 0)
 	alreadyKnownSeqs := make([]string, 0)
 
 	for _, change := range changeList {
@@ -421,7 +422,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 			// skip parsing seqno if we're not going to use it (no callback defined)
 			if bh.sgr2PullAddExpectedSeqsCallback != nil {
-				expectedSeqs = append(expectedSeqs, seqStr(change[0]))
+				expectedSeqs[IDAndRev{DocID: docID, RevID: revID}] = seqStr(change[0])
 			}
 		}
 		nWritten++
@@ -556,6 +557,10 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 	base.InfofCtx(bh.loggingCtx, base.KeySyncMsg, "%s: norev for doc %q / %q - error: %q - reason: %q",
 		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
+	if bh.sgr2PullNorevCallback != nil {
+		bh.sgr2PullNorevCallback(rq.Properties[NorevMessageId], rq.Properties[NorevMessageRev])
+	}
+
 	// Couchbase Lite always sends noreply=true for norev profiles
 	// but for testing purposes, it's useful to know which handler processed the message
 	if !rq.NoReply() && rq.Properties[SGShowHandler] == "true" {
@@ -615,7 +620,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			}
 			bh.replicationStats.HandleRevDocsPurgedCount.Add(1)
 			if bh.sgr2PullProcessedSeqCallback != nil {
-				bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence])
+				bh.sgr2PullProcessedSeqCallback(IDAndRev{DocID: docID, RevID: revID}, rq.Properties[RevMessageSequence])
 			}
 			return nil
 		}
@@ -740,7 +745,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	}
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		bh.sgr2PullProcessedSeqCallback(rq.Properties[RevMessageSequence])
+		bh.sgr2PullProcessedSeqCallback(IDAndRev{DocID: docID, RevID: revID}, rq.Properties[RevMessageSequence])
 	}
 
 	return nil

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -82,25 +82,26 @@ type BlipSyncContext struct {
 	continuous                       bool
 	lock                             sync.Mutex
 	allowedAttachments               map[string]int
-	handlerSerialNumber              uint64                          // Each handler within a context gets a unique serial number for logging
-	terminatorOnce                   sync.Once                       // Used to ensure the terminator channel below is only ever closed once.
-	terminator                       chan bool                       // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
-	activeSubChanges                 base.AtomicBool                 // Flag for whether there is a subChanges subscription currently active.  Atomic access
-	useDeltas                        bool                            // Whether deltas can be used for this connection - This should be set via setUseDeltas()
-	sgCanUseDeltas                   bool                            // Whether deltas can be used by Sync Gateway for this connection
-	userChangeWaiter                 *ChangeWaiter                   // Tracks whether the users/roles associated with the replication have changed
-	userName                         string                          // Avoid contention on db.user during userChangeWaiter user lookup
-	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs []string)     // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
-	sgr2PullProcessedSeqCallback     func(remoteSeq string)          // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
-	sgr2PullAlreadyKnownSeqsCallback func(alreadyKnownSeqs []string) // sgr2PullAlreadyKnownSeqsCallback is called to mark the sequences as being immediately processed
-	sgr2PushAddExpectedSeqsCallback  func(expectedSeqs []string)     // sgr2PushAddExpectedSeqsCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
-	sgr2PushProcessedSeqCallback     func(remoteSeq string)          // sgr2PushProcessedSeqCallback is called after receiving acknowledgement of a sent revision
-	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs []string) // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
-	emptyChangesMessageCallback      func()                          // emptyChangesMessageCallback is called when an empty changes message is received
-	replicationStats                 *BlipSyncStats                  // Replication stats
-	purgeOnRemoval                   bool                            // Purges the document when we pull a _removed:true revision.
-	conflictResolver                 *ConflictResolver               // Conflict resolver for active replications
-	changesPendingResponseCount      int64                           // Number of changes messages pending changesResponse
+	handlerSerialNumber              uint64                                    // Each handler within a context gets a unique serial number for logging
+	terminatorOnce                   sync.Once                                 // Used to ensure the terminator channel below is only ever closed once.
+	terminator                       chan bool                                 // Closed during BlipSyncContext.close(). Ensures termination of async goroutines.
+	activeSubChanges                 base.AtomicBool                           // Flag for whether there is a subChanges subscription currently active.  Atomic access
+	useDeltas                        bool                                      // Whether deltas can be used for this connection - This should be set via setUseDeltas()
+	sgCanUseDeltas                   bool                                      // Whether deltas can be used by Sync Gateway for this connection
+	userChangeWaiter                 *ChangeWaiter                             // Tracks whether the users/roles associated with the replication have changed
+	userName                         string                                    // Avoid contention on db.user during userChangeWaiter user lookup
+	sgr2PullAddExpectedSeqsCallback  func(expectedSeqs map[IDAndRev]string)    // sgr2PullAddExpectedSeqsCallback is called after successfully handling an incoming changes message
+	sgr2PullProcessedSeqCallback     func(idAndRev IDAndRev, remoteSeq string) // sgr2PullProcessedSeqCallback is called after successfully handling an incoming rev message
+	sgr2PullAlreadyKnownSeqsCallback func(alreadyKnownSeqs []string)           // sgr2PullAlreadyKnownSeqsCallback is called to mark the sequences as being immediately processed
+	sgr2PullNorevCallback            func(docID, revID string)                 // sgr2PullNorevCallback is called when we receive a norev in response to a rev request
+	sgr2PushAddExpectedSeqsCallback  func(expectedSeqs []string)               // sgr2PushAddExpectedSeqsCallback is called after sync gateway has sent a revision, but is still awaiting an acknowledgement
+	sgr2PushProcessedSeqCallback     func(remoteSeq string)                    // sgr2PushProcessedSeqCallback is called after receiving acknowledgement of a sent revision
+	sgr2PushAlreadyKnownSeqsCallback func(alreadyKnownSeqs []string)           // sgr2PushAlreadyKnownSeqsCallback is called to mark the sequence as being immediately processed
+	emptyChangesMessageCallback      func()                                    // emptyChangesMessageCallback is called when an empty changes message is received
+	replicationStats                 *BlipSyncStats                            // Replication stats
+	purgeOnRemoval                   bool                                      // Purges the document when we pull a _removed:true revision.
+	conflictResolver                 *ConflictResolver                         // Conflict resolver for active replications
+	changesPendingResponseCount      int64                                     // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
 	sendRevNoConflicts bool // Whether to set noconflicts=true when sending revisions
 


### PR DESCRIPTION
Prior to hydrogen, Sync Gateway doesn't send sequences in norev messages, which means we have to use DocID+RevID pairs to lookup which sequence was sent originally in order to checkpoint it.