### PR TITLE
CBG-931 Perform all config validation at creation time

### DIFF
--- a/db/sg_replicate_util.go
+++ b/db/sg_replicate_util.go
@@ -16,12 +16,12 @@ func ChannelsFromQueryParams(queryParams interface{}) (channels []string, err er
 	var chanarray []interface{}
 	if paramsmap, ok := queryParams.(map[string]interface{}); ok {
 		if chanarray, ok = paramsmap["channels"].([]interface{}); !ok {
-			return nil, errors.New("/_replicate sync_gateway/bychannel filter; query_params missing channels property")
+			return nil, errors.New("Replication specifies sync_gateway/bychannel filter, but query_params is missing channels property")
 		}
 	} else if chanarray, ok = queryParams.([]interface{}); ok {
 		// query params is an array and chanarray has been set, now drop out of if-then-else for processing
 	} else {
-		return nil, base.HTTPErrorf(http.StatusBadRequest, "/_replicate sync_gateway/bychannel filter; Bad channels array")
+		return nil, base.HTTPErrorf(http.StatusBadRequest, "Bad channels array in query_params for sync_gateway/bychannel filter")
 	}
 	if len(chanarray) > 0 {
 		channels = make([]string, len(chanarray))
@@ -29,7 +29,7 @@ func ChannelsFromQueryParams(queryParams interface{}) (channels []string, err er
 			if channel, ok := chanarray[i].(string); ok {
 				channels[i] = channel
 			} else {
-				return nil, errors.New("/_replicate sync_gateway/bychannel filter; Bad channel name")
+				return nil, errors.New("Bad channel name in query_params for sync_gateway/bychannel filter")
 			}
 		}
 	}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -166,7 +166,7 @@ func TestReplicationStatusAPI(t *testing.T) {
 	replication2Config := db.ReplicationConfig{
 		ID:        "replication2",
 		Remote:    "http://remote:4984/db",
-		Direction: "Pull",
+		Direction: "pull",
 	}
 	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", marshalConfig(t, replication2Config))
 	assertStatus(t, response, http.StatusCreated)
@@ -290,7 +290,7 @@ func TestReplicationStatusAPIIncludeConfig(t *testing.T) {
 	replication2Config := db.ReplicationConfig{
 		ID:        "replication2",
 		Remote:    "http://remote:4984/db",
-		Direction: "Pull",
+		Direction: "pull",
 	}
 	response = rt.SendAdminRequest("PUT", "/db/_replication/replication2", marshalConfig(t, replication2Config))
 	assertStatus(t, response, http.StatusCreated)


### PR DESCRIPTION
Added missing Direction validation to ValidateReplication, reused ValidateReplication on replication start.