### PR TITLE
CBG-909 Persist replication status for non-local access

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -117,6 +117,8 @@ const (
 	SyncPropertyName = "_sync"
 	SyncXattrName    = "_sync"
 
+	SGRStatusPrefix = SyncPrefix + "sgrStatus:"
+
 	// Prefix for transaction metadata documents
 	TxnPrefix = "_txn:"
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1008,33 +1008,42 @@ func (m *sgReplicateManager) GetReplicationStatus(replicationID string, options 
 	replication, isLocal := m.activeReplicators[replicationID]
 	m.activeReplicatorsLock.RUnlock()
 
+	if options.LocalOnly && !isLocal {
+		return nil, nil
+	}
+
 	var status *ReplicationStatus
+	var remoteCfg *ReplicationCfg
 	if isLocal {
 		status = replication.GetStatus()
-		if options.IncludeConfig {
-			config, err := m.GetReplication(replicationID)
+	} else {
+		// Attempt to retrieve persisted status
+		var loadErr error
+		status, loadErr = LoadReplicationStatus(m.dbContext, replicationID)
+		if loadErr != nil {
+			// Unable to load persisted status.  Create status stub based on config
+			var err error
+			remoteCfg, err = m.GetReplication(replicationID)
 			if err != nil {
 				return nil, err
 			}
-			status.Config = &config.ReplicationConfig
+			status = &ReplicationStatus{
+				ID:     replicationID,
+				Status: remoteCfg.State,
+			}
 		}
-	} else {
-		// Check if replication is remote
-		if options.LocalOnly {
-			return nil, nil
+	}
+
+	// Add the replicaiton config if requested
+	if options.IncludeConfig {
+		if remoteCfg == nil {
+			var err error
+			remoteCfg, err = m.GetReplication(replicationID)
+			if err != nil {
+				return nil, err
+			}
 		}
-		// TODO: generation of remote status pending CBG-909
-		remoteCfg, err := m.GetReplication(replicationID)
-		if err != nil {
-			return nil, err
-		}
-		status = &ReplicationStatus{
-			ID:     replicationID,
-			Status: remoteCfg.State,
-		}
-		if options.IncludeConfig {
-			status.Config = &remoteCfg.ReplicationConfig
-		}
+		status.Config = &remoteCfg.ReplicationConfig
 	}
 
 	if !options.IncludeError && status.Status == ReplicationStateError {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -46,6 +46,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 		Direction:    db.ActiveReplicatorTypePushAndPull,
 		ActiveDB:     &db.Database{DatabaseContext: rt.GetDatabase()},
 		PassiveDBURL: passiveDBURL,
+		Continuous:   true,
 	})
 
 	startNumReplicationsTotal := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDatabase().Get(base.StatKeyNumReplicationsTotal))


### PR DESCRIPTION
Persists status for running replications to the bucket every 10s, and uses this for non-local replications when serving _replicationStatus responses.