### PR TITLE
CBG-909 Persist replication status for non-local access

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -117,6 +117,8 @@ const (
 	SyncPropertyName = "_sync"
 	SyncXattrName    = "_sync"
 
+	SGRStatusPrefix = SyncPrefix + "sgrStatus:"
+
 	// Prefix for transaction metadata documents
 	TxnPrefix = "_txn:"
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -130,7 +130,10 @@ func (ar *ActiveReplicator) Reset() error {
 		return pullErr
 	}
 
-	_ = ar.purgeStatus()
+	err := ar.purgeStatus()
+	if err != nil {
+		base.Warnf("Unable to purge replication status for reset replication: %v", err)
+	}
 	return nil
 }
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -127,7 +127,7 @@ func (ar *ActiveReplicator) Reset() error {
 		return pullErr
 	}
 
-	_ = ar.publishStatus()
+	_ = ar.purgeStatus()
 	return nil
 }
 
@@ -305,6 +305,15 @@ func (ar *ActiveReplicator) publishStatus() error {
 	base.Debugf(base.KeyReplicate, "Persisting replication status for replicationID %v", ar.ID)
 	err := ar.config.ActiveDB.Bucket.Set(replicationStatusKey(ar.ID), 0, status)
 	return err
+}
+
+func (ar *ActiveReplicator) purgeStatus() error {
+	base.Debugf(base.KeyReplicate, "Purging replication status for replicationID %v", ar.ID)
+	err := ar.config.ActiveDB.Bucket.Delete(replicationStatusKey(ar.ID))
+	if !base.IsKeyNotFoundError(ar.config.ActiveDB.Bucket, err) {
+		return err
+	}
+	return nil
 }
 
 func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (status *ReplicationStatus, err error) {

--- a/db/database.go
+++ b/db/database.go
@@ -345,6 +345,14 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		if registerNodeErr != nil {
 			return nil, registerNodeErr
 		}
+		// Start background task to publish replication status
+		err := NewBackgroundTask("ReplicaitonStatus", dbContext.Name, func(ctx context.Context) error {
+			dbContext.SGReplicateMgr.PublishReplicationStatus()
+			return nil
+		}, defaultPublishStatusInterval, dbContext.terminator)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Start DCP feed

--- a/db/database.go
+++ b/db/database.go
@@ -346,7 +346,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 			return nil, registerNodeErr
 		}
 		// Start background task to publish replication status
-		err := NewBackgroundTask("ReplicaitonStatus", dbContext.Name, func(ctx context.Context) error {
+		err := NewBackgroundTask("ReplicationStatus", dbContext.Name, func(ctx context.Context) error {
 			dbContext.SGReplicateMgr.PublishReplicationStatus()
 			return nil
 		}, defaultPublishStatusInterval, dbContext.terminator)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -493,7 +493,10 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 				base.Warnf("Unable to gracefully close active replication: %v", err)
 			}
 			if !ok {
-				activeReplicator.purgeStatus()
+				purgeErr := activeReplicator.purgeStatus()
+				if purgeErr != nil {
+					base.Warnf("Unable to purge replication status for removed replication: %v", err)
+				}
 			}
 			delete(m.activeReplicators, replicationID)
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -492,7 +492,11 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 			if err != nil {
 				base.Warnf("Unable to gracefully close active replication: %v", err)
 			}
+			if !ok {
+				activeReplicator.purgeStatus()
+			}
 			delete(m.activeReplicators, replicationID)
+
 		} else {
 			// Check for replications assigned to this node with updated state
 			base.Debugf(base.KeyReplicate, "Aligning state for existing replication %s", replicationID)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -980,33 +980,42 @@ func (m *sgReplicateManager) GetReplicationStatus(replicationID string, options 
 	replication, isLocal := m.activeReplicators[replicationID]
 	m.activeReplicatorsLock.RUnlock()
 
+	if options.LocalOnly && !isLocal {
+		return nil, nil
+	}
+
 	var status *ReplicationStatus
+	var remoteCfg *ReplicationCfg
 	if isLocal {
 		status = replication.GetStatus()
-		if options.IncludeConfig {
-			config, err := m.GetReplication(replicationID)
+	} else {
+		// Attempt to retrieve persisted status
+		var loadErr error
+		status, loadErr = LoadReplicationStatus(m.dbContext, replicationID)
+		if loadErr != nil {
+			// Unable to load persisted status.  Create status stub based on config
+			var err error
+			remoteCfg, err = m.GetReplication(replicationID)
 			if err != nil {
 				return nil, err
 			}
-			status.Config = &config.ReplicationConfig
+			status = &ReplicationStatus{
+				ID:     replicationID,
+				Status: remoteCfg.State,
+			}
 		}
-	} else {
-		// Check if replication is remote
-		if options.LocalOnly {
-			return nil, nil
+	}
+
+	// Add the replicaiton config if requested
+	if options.IncludeConfig {
+		if remoteCfg == nil {
+			var err error
+			remoteCfg, err = m.GetReplication(replicationID)
+			if err != nil {
+				return nil, err
+			}
 		}
-		// TODO: generation of remote status pending CBG-909
-		remoteCfg, err := m.GetReplication(replicationID)
-		if err != nil {
-			return nil, err
-		}
-		status = &ReplicationStatus{
-			ID:     replicationID,
-			Status: remoteCfg.State,
-		}
-		if options.IncludeConfig {
-			status.Config = &remoteCfg.ReplicationConfig
-		}
+		status.Config = &remoteCfg.ReplicationConfig
 	}
 
 	if !options.IncludeError && status.Status == ReplicationStateError {
@@ -1079,6 +1088,20 @@ func (m *sgReplicateManager) GetReplicationStatusAll(options ReplicationStatusOp
 	}
 
 	return statuses, nil
+}
+
+func (m *sgReplicateManager) PublishReplicationStatus() {
+	m.activeReplicatorsLock.RLock()
+	defer m.activeReplicatorsLock.RUnlock()
+	for replicationID, replicator := range m.activeReplicators {
+		state, _ := replicator.State()
+		if state == ReplicationStateRunning {
+			err := replicator.publishStatus()
+			if err != nil {
+				base.WarnfCtx(m.loggingCtx, "Unable to publish replication status for replication %q: %v", replicationID, err)
+			}
+		}
+	}
 }
 
 // ImportHeartbeatListener uses replication cfg to manage node list

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -46,6 +46,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 		Direction:    db.ActiveReplicatorTypePushAndPull,
 		ActiveDB:     &db.Database{DatabaseContext: rt.GetDatabase()},
 		PassiveDBURL: passiveDBURL,
+		Continuous:   true,
 	})
 
 	startNumReplicationsTotal := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDatabase().Get(base.StatKeyNumReplicationsTotal))


### PR DESCRIPTION
Persists status for running replications to the bucket every 10s, and uses this for non-local replications when serving _replicationStatus responses.