### PR TITLE
CBG-949: Improve error when non-upgradable HTTP request is sent to _b…

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -14,10 +14,15 @@ import (
 
 // HTTP handler for incoming BLIP sync WebSocket request (/db/_blipsync)
 func (h *handler) handleBLIPSync() error {
-
 	h.db.DatabaseContext.DbStats.StatsDatabase().Add(base.StatKeyNumReplicationsActive, 1)
 	h.db.DatabaseContext.DbStats.StatsDatabase().Add(base.StatKeyNumReplicationsTotal, 1)
 	defer h.db.DatabaseContext.DbStats.StatsDatabase().Add(base.StatKeyNumReplicationsActive, -1)
+
+	// Exits early when the connection can't be switched to websocket protocol.
+	if _, ok := h.response.(http.Hijacker); !ok {
+		base.DebugfCtx(h.db.Ctx, base.KeyHTTP, "Non-upgradable request received for BLIP+WebSocket protocol")
+		return base.HTTPErrorf(http.StatusForbidden, "Can't upgrade this request to websocket connection")
+	}
 
 	if c := h.server.GetConfig().ReplicatorCompression; c != nil {
 		blip.CompressionLevel = *c

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2482,5 +2482,5 @@ func TestBlipSyncNonUpgradableConnection(t *testing.T) {
 
 	response, err := http.DefaultClient.Do(request)
 	require.NoError(t, err, "Error sending request")
-	require.Equal(t, http.StatusForbidden, response.StatusCode)
+	require.Equal(t, http.StatusUpgradeRequired, response.StatusCode)
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2456,3 +2456,31 @@ func waitForCondition(t *testing.T, fn func() bool) {
 		time.Sleep(time.Millisecond * 100)
 	}
 }
+
+func TestBlipSyncNonUpgradableConnection(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeyHTTPResp)()
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {Password: base.StringPtr("pass")},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt.Close()
+
+	// Make rt listen on an actual HTTP port, so it can receive the blipsync request.
+	server := httptest.NewServer(rt.TestPublicHandler())
+	defer server.Close()
+	dbURL, err := url.Parse(server.URL + "/db/_blipsync")
+	require.NoError(t, err)
+
+	// Add basic auth credentials to target db URL
+	dbURL.User = url.UserPassword("alice", "pass")
+	request, err := http.NewRequest(http.MethodGet, dbURL.String(), nil)
+	require.NoError(t, err, "Error creating new request")
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err, "Error sending request")
+	require.Equal(t, http.StatusForbidden, response.StatusCode)
+}


### PR DESCRIPTION
Avoid panicking when a non-upgradable plain HTTP request is sent to `/_blipsync` endpoint and return more sensible status code with appropriate error message 