### PR TITLE
CBG-912 - Put replicator into reconnecting state when initial connection fails

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -515,6 +515,21 @@ func CreateMaxDoublingSleeperFunc(maxNumAttempts, initialTimeToSleepMs int, maxS
 
 }
 
+// CreateIndefiniteMaxDoublingSleeperFunc is similar to CreateMaxDoublingSleeperFunc, with the exception that there is no number of maximum retries.
+func CreateIndefiniteMaxDoublingSleeperFunc(initialTimeToSleepMs int, maxSleepPerRetryMs int) RetrySleeper {
+	timeToSleepMs := initialTimeToSleepMs
+
+	sleeper := func(numAttempts int) (bool, int) {
+		timeToSleepMs *= 2
+		if timeToSleepMs > maxSleepPerRetryMs {
+			timeToSleepMs = maxSleepPerRetryMs
+		}
+		return true, timeToSleepMs
+	}
+
+	return sleeper
+}
+
 // SortedUint64Slice attaches the methods of sort.Interface to []uint64, sorting in increasing order.
 type SortedUint64Slice []uint64
 

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -455,7 +455,11 @@ func (c *Checkpointer) setLocalCheckpointWithRetry(checkpoint *replicationCheckp
 
 func resetLocalCheckpoint(activeDB *Database, checkpointID string) error {
 	key := RealSpecialDocID(DocTypeLocal, checkpointDocIDPrefix+checkpointID)
-	return activeDB.Bucket.Delete(key)
+	err := activeDB.Bucket.Delete(key)
+	if err == nil || base.IsDocNotFoundError(err) {
+		return nil
+	}
+	return err
 }
 
 // getRemoteCheckpoint returns the sequence and rev for the remote checkpoint.

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"expvar"
 	"sync"
+	"time"
 
 	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
+)
+
+const (
+	defaultInitialReconnectInterval = time.Second
+	defaultMaxReconnectInterval     = time.Minute * 5
 )
 
 // replicatorCommon defines the struct contents shared by ActivePushReplicator
@@ -24,15 +30,145 @@ type activeReplicatorCommon struct {
 	replicationStats      *BlipSyncStats
 	onReplicatorComplete  ReplicatorCompleteFunc
 	lock                  sync.RWMutex
+	ctx                   context.Context
+	ctxCancel             context.CancelFunc
+}
+
+func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) *activeReplicatorCommon {
+
+	var replicationStats *BlipSyncStats
+	if direction == ActiveReplicatorTypePush {
+		replicationStats = BlipSyncStatsForSGRPush(config.ReplicationStatsMap)
+	} else {
+		replicationStats = BlipSyncStatsForSGRPull(config.ReplicationStatsMap)
+	}
+
+	return &activeReplicatorCommon{
+		config:           config,
+		state:            ReplicationStateStopped,
+		replicationStats: replicationStats,
+	}
+}
+
+// reconnect synchronously calls the given _connectFn until successful, or times out trying. Retry loop can be stopped by cancelling a.ctx
+func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
+	base.DebugfCtx(a.ctx, base.KeyReplicate, "starting reconnector")
+
+	initialReconnectInterval := defaultInitialReconnectInterval
+	if a.config.InitialReconnectInterval != 0 {
+		initialReconnectInterval = a.config.InitialReconnectInterval
+	}
+	maxReconnectInterval := defaultMaxReconnectInterval
+	if a.config.MaxReconnectInterval != 0 {
+		maxReconnectInterval = a.config.MaxReconnectInterval
+	}
+
+	// ctx causes the retry loop to stop if cancelled
+	ctx := a.ctx
+
+	// if a reconnect timeout is set, we'll wrap the existing so both can stop the retry loop
+	var deadlineCancel context.CancelFunc
+	if a.config.TotalReconnectTimeout != 0 {
+		ctx, deadlineCancel = context.WithDeadline(ctx, time.Now().Add(a.config.TotalReconnectTimeout))
+	}
+
+	sleeperFunc := base.SleeperFuncCtx(
+		base.CreateIndefiniteMaxDoublingSleeperFunc(
+			int(initialReconnectInterval.Milliseconds()),
+			int(maxReconnectInterval.Milliseconds())),
+		ctx)
+
+	retryFunc := func() (shouldRetry bool, err error, _ interface{}) {
+		select {
+		case <-a.ctx.Done():
+			return
+		default:
+		}
+
+		a.lock.Lock()
+
+		// preserve lastError from the previous connect attempt
+		a.state = ReplicationStateReconnecting
+
+		// disconnect no-ops if nothing is active, but will close any checkpointer processes, blip contexts, etc, if active.
+		err = a._disconnect()
+		if err != nil {
+			base.InfofCtx(a.ctx, base.KeyReplicate, "error stopping replicator on reconnect: %v", err)
+		}
+
+		// set lastError, but don't set an error state inside the reconnect loop
+		err = _connectFn()
+		a.lastError = err
+
+		a.lock.Unlock()
+
+		if err != nil {
+			base.InfofCtx(a.ctx, base.KeyReplicate, "error starting replicator on reconnect: %v", err)
+		}
+		return err != nil, err, nil
+	}
+
+	err, _ := base.RetryLoop("replicator reconnect", retryFunc, sleeperFunc)
+	// release timer associated with context deadline
+	if deadlineCancel != nil {
+		deadlineCancel()
+	}
+	if err != nil {
+		a.replicationStats.NumReconnectsAborted.Add(1)
+		base.WarnfCtx(a.ctx, "couldn't reconnect replicator: %v", err)
+	}
+}
+
+// Stop runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
+func (a *activeReplicatorCommon) Stop() error {
+	a.lock.Lock()
+	err := a._disconnect()
+	a._stop()
+	a._setState(ReplicationStateStopped)
+	a.lock.Unlock()
+	return err
+}
+
+// _disconnect aborts any replicator processes used during a connected/running replication (checkpointing, blip contexts, etc.)
+func (a *activeReplicatorCommon) _disconnect() error {
+	if a == nil {
+		// noop
+		return nil
+	}
+
+	if a.checkpointerCtx != nil {
+		a.checkpointerCtxCancel()
+		a.Checkpointer.CheckpointNow()
+	}
+	a.checkpointerCtx = nil
+
+	if a.blipSender != nil {
+		a.blipSender.Close()
+		a.blipSender = nil
+	}
+
+	if a.blipSyncContext != nil {
+		a.blipSyncContext.Close()
+		a.blipSyncContext = nil
+	}
+
+	return nil
+}
+
+// _stop aborts any replicator processes that run outside of a running replication (e.g: async reconnect handling)
+func (a *activeReplicatorCommon) _stop() {
+	if a.ctxCancel != nil {
+		a.ctxCancel()
+	}
 }
 
 type ReplicatorCompleteFunc func()
 
-// setErrorState updates state and lastError, and
+// _setError updates state and lastError, and
 // returns the error provided.  Expects callers to be holding
 // a.lock
 func (a *activeReplicatorCommon) _setError(err error) (passThrough error) {
-	base.Infof(base.KeyReplicate, "ActiveReplicator had error state set with err: %v", err)
+	base.InfofCtx(a.ctx, base.KeyReplicate, "ActiveReplicator had error state set with err: %v", err)
 	a.state = ReplicationStateError
 	a.lastError = err
 	return err

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -57,6 +57,12 @@ type ActiveReplicatorConfig struct {
 	WebsocketPingInterval time.Duration
 	// Conflict resolver
 	ConflictResolverFunc ConflictResolverFunc
+	// InitialReconnectInterval is the initial time to wait for exponential backoff reconnects.
+	InitialReconnectInterval time.Duration
+	// MaxReconnectInterval is the maximum amount of time to wait between exponential backoff reconnect attempts.
+	MaxReconnectInterval time.Duration
+	// TotalReconnectTimeout, if non-zero, is the amount of time to wait before giving up trying to reconnect.
+	TotalReconnectTimeout time.Duration
 
 	// Delta sync enabled
 	DeltasEnabled bool

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -39,6 +39,8 @@ type BlipSyncStats struct {
 	SubChangesOneShotActive          *expvar.Int
 	SubChangesOneShotTotal           *expvar.Int
 	SendChangesCount                 *expvar.Int // sendChagnes
+	NumConnectAttempts               *expvar.Int
+	NumReconnectsAborted             *expvar.Int
 }
 
 func NewBlipSyncStats() *BlipSyncStats {
@@ -75,6 +77,8 @@ func NewBlipSyncStats() *BlipSyncStats {
 		SubChangesOneShotActive:          &expvar.Int{},
 		SubChangesOneShotTotal:           &expvar.Int{},
 		SendChangesCount:                 &expvar.Int{},
+		NumConnectAttempts:               &expvar.Int{},
+		NumReconnectsAborted:             &expvar.Int{},
 	}
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -511,7 +511,7 @@ func (context *DatabaseContext) GetServerUUID() string {
 	if context.serverUUID == "" {
 		b, ok := base.AsGoCBBucket(context.Bucket)
 		if !ok {
-			base.Warnf("Database %v: Unable to get server UUID. Bucket was type: %T, not GoCBBucket.", base.MD(context.Name), context.Bucket)
+			base.Warnf("Database %v: Unable to get server UUID. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
 			return ""
 		}
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -18,11 +18,10 @@ import (
 )
 
 const (
-	cfgKeySGRCluster            = "sgrCluster" // key used for sgrCluster information in a cbgt.Cfg-based key value store
-	maxSGRClusterCasRetries     = 100          // Maximum number of CAS retries when attempting to update the sgr cluster configuration
-	sgrClusterMgrContextID      = "sgr-mgr-"   // logging context ID prefix for sgreplicate manager
-	defaultChangesBatchSize     = 200          // default changes batch size if replication batch_size is unset
-	defaultMaxReconnectInterval = time.Minute * 5
+	cfgKeySGRCluster        = "sgrCluster" // key used for sgrCluster information in a cbgt.Cfg-based key value store
+	maxSGRClusterCasRetries = 100          // Maximum number of CAS retries when attempting to update the sgr cluster configuration
+	sgrClusterMgrContextID  = "sgr-mgr-"   // logging context ID prefix for sgreplicate manager
+	defaultChangesBatchSize = 200          // default changes batch size if replication batch_size is unset
 )
 
 const (
@@ -462,8 +461,11 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 		rc.MaxReconnectInterval = time.Duration(config.MaxBackoff) * time.Minute
 	}
 
-	// TODO: Calculate based on given max interval.
-	// rc.TotalReconnectTimeout =
+	// If maxBackoff is zero, retry up to ~MaxReconnectInterval and then give up.
+	// If non-zero, reconnect is indefinite.
+	if config.MaxBackoff == 0 {
+		rc.TotalReconnectTimeout = rc.MaxReconnectInterval * 2
+	}
 
 	rc.ChangesBatchSize = defaultChangesBatchSize
 	if config.BatchSize > 0 {

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -805,7 +805,7 @@ func (rt *RestTester) assertReplicationState(replicationID string, expectedState
 	assertStatus(rt.tb, resp, http.StatusOK)
 	var status db.ReplicationStatus
 	require.NoError(rt.tb, json.Unmarshal(resp.Body.Bytes(), &status))
-	assert.Equal(rt.tb, expectedState, status.Status)
+	assert.Equalf(rt.tb, expectedState, status.Status, "status: %v", status)
 }
 
 // createReplication creates a replication via the REST API with the specified ID, remoteURL, direction and channel filter

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2884,10 +2884,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	assert.NoError(t, ar.Stop())
 }
 
-// TestActiveReplicatorReconnectOnStart ensures ActiveReplicators retry their initial connection for cases like:
-// - Incorrect credentials
-// - Unroutable remote address
-// Will test both indefinite retry, and a timeout.
+// TestActiveReplicatorReconnectSendActions ensures ActiveReplicator reconnect retry loops exit when the replicator is stopped
 func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2884,6 +2884,105 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	assert.NoError(t, ar.Stop())
 }
 
+// TestActiveReplicatorReconnectOnStart ensures ActiveReplicators retry their initial connection for cases like:
+// - Incorrect credentials
+// - Unroutable remote address
+// Will test both indefinite retry, and a timeout.
+func TestActiveReplicatorReconnectSendActions(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	// Build passiveDBURL with basic auth creds
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add incorrect basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("bob", "pass")
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	arConfig := db.ActiveReplicatorConfig{
+		ID:           base.GenerateRandomID(),
+		Direction:    db.ActiveReplicatorTypePull,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous: true,
+		// test isn't long running enough to worry about time-based checkpoints,
+		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
+		CheckpointInterval: time.Minute * 5,
+		// aggressive reconnect intervals for testing purposes
+		InitialReconnectInterval: time.Millisecond,
+		MaxReconnectInterval:     time.Millisecond * 50,
+		TotalReconnectTimeout:    time.Second * 5,
+	}
+
+	// Create the first active replicator to pull from seq:0
+	ar := db.NewActiveReplicator(&arConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), ar.Pull.GetStats().NumConnectAttempts.Value())
+
+	err = ar.Start()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unexpected status code 401 from target database"))
+
+	// wait for an arbitrary number of reconnect attempts
+	waitForCondition(t, func() bool {
+		return ar.Pull.GetStats().NumConnectAttempts.Value() > 3
+	})
+
+	assert.NoError(t, ar.Stop())
+	reconnectAttempts := ar.Pull.GetStats().NumConnectAttempts.Value()
+
+	// wait for a bit to see if the reconnect loop has stopped
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(t, reconnectAttempts, ar.Pull.GetStats().NumConnectAttempts.Value())
+
+	assert.NoError(t, ar.Reset())
+
+	err = ar.Start()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unexpected status code 401 from target database"))
+
+	// wait for another set of reconnect attempts
+	waitForCondition(t, func() bool {
+		return ar.Pull.GetStats().NumConnectAttempts.Value() > 3
+	})
+
+	assert.NoError(t, ar.Stop())
+}
+
 func waitForCondition(t *testing.T, fn func() bool) {
 	for i := 0; i <= 20; i++ {
 		if i == 20 {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -2675,6 +2676,212 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	assert.Equal(t, int64(0), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
 	ar.Pull.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), ar.Pull.Checkpointer.Stats().SetCheckpointCount)
+}
+
+// TestActiveReplicatorReconnectOnStart ensures ActiveReplicators retry their initial connection for cases like:
+// - Incorrect credentials
+// - Unroutable remote address
+// Will test both indefinite retry, and a timeout.
+func TestActiveReplicatorReconnectOnStart(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	tests := []struct {
+		name                  string
+		usernameOverride      string
+		remoteURLHostOverride string
+		expectedErrorContains string
+	}{
+		{
+			name:                  "wrong user",
+			usernameOverride:      "bob",
+			expectedErrorContains: "unexpected status code 401 from target database",
+		},
+		{
+			name:                  "invalid port", // fails faster than unroutable address (connection refused vs. connect timeout)
+			remoteURLHostOverride: "127.0.0.1:1234",
+			expectedErrorContains: "connection refused",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// test cases with and without a timeout. Ensure replicator retry loop is stopped in both cases.
+			timeoutVals := []time.Duration{
+				0,
+				time.Millisecond * 100,
+			}
+
+			for _, timeoutVal := range timeoutVals {
+				t.Run(test.name+" with timeout "+timeoutVal.String(), func(t *testing.T) {
+
+					defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)()
+
+					// Passive
+					tb2 := base.GetTestBucket(t)
+					rt2 := NewRestTester(t, &RestTesterConfig{
+						TestBucket: tb2,
+						DatabaseConfig: &DbConfig{
+							Users: map[string]*db.PrincipalConfig{
+								"alice": {
+									Password:         base.StringPtr("pass"),
+									ExplicitChannels: base.SetOf("alice"),
+								},
+							},
+						},
+						noAdminParty: true,
+					})
+					defer rt2.Close()
+
+					// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+					srv := httptest.NewServer(rt2.TestPublicHandler())
+					defer srv.Close()
+
+					// Build passiveDBURL with basic auth creds
+					passiveDBURL, err := url.Parse(srv.URL + "/db")
+					require.NoError(t, err)
+
+					// Add basic auth creds to target db URL
+					username := "alice"
+					if test.usernameOverride != "" {
+						username = test.usernameOverride
+					}
+					passiveDBURL.User = url.UserPassword(username, "pass")
+
+					if test.remoteURLHostOverride != "" {
+						passiveDBURL.Host = test.remoteURLHostOverride
+					}
+
+					// Active
+					tb1 := base.GetTestBucket(t)
+					rt1 := NewRestTester(t, &RestTesterConfig{
+						TestBucket: tb1,
+					})
+					defer rt1.Close()
+
+					arConfig := db.ActiveReplicatorConfig{
+						ID:           base.GenerateRandomID(),
+						Direction:    db.ActiveReplicatorTypePushAndPull,
+						PassiveDBURL: passiveDBURL,
+						ActiveDB: &db.Database{
+							DatabaseContext: rt1.GetDatabase(),
+						},
+						Continuous: true,
+						// test isn't long running enough to worry about time-based checkpoints,
+						// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
+						CheckpointInterval: time.Minute * 5,
+						// aggressive reconnect intervals for testing purposes
+						InitialReconnectInterval: time.Millisecond,
+						MaxReconnectInterval:     time.Millisecond * 50,
+						TotalReconnectTimeout:    timeoutVal,
+					}
+
+					// Create the first active replicator to pull from seq:0
+					ar := db.NewActiveReplicator(&arConfig)
+					require.NoError(t, err)
+
+					assert.Equal(t, int64(0), ar.Push.GetStats().NumConnectAttempts.Value())
+
+					err = ar.Start()
+					assert.Error(t, err)
+					assert.True(t, strings.Contains(err.Error(), test.expectedErrorContains))
+
+					// wait for an arbitrary number of reconnect attempts
+					waitForCondition(t, func() bool {
+						return ar.Push.GetStats().NumConnectAttempts.Value() > 3
+					})
+
+					if timeoutVal > 0 {
+						// wait for the retry loop to hit the TotalReconnectTimeout and give up retrying
+						waitForCondition(t, func() bool {
+							return ar.Push.GetStats().NumReconnectsAborted.Value() > 0
+						})
+					}
+
+					assert.NoError(t, ar.Stop())
+				})
+			}
+		})
+	}
+}
+
+// TestActiveReplicatorReconnectOnStartEventualSuccess ensures an active replicator with invalid creds retries,
+// but succeeds once the user is created on the remote.
+func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket:   tb2,
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	// Build passiveDBURL with basic auth creds
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	arConfig := db.ActiveReplicatorConfig{
+		ID:           base.GenerateRandomID(),
+		Direction:    db.ActiveReplicatorTypePushAndPull,
+		PassiveDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous: true,
+		// test isn't long running enough to worry about time-based checkpoints,
+		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
+		CheckpointInterval: time.Minute * 5,
+		// aggressive reconnect intervals for testing purposes
+		InitialReconnectInterval: time.Millisecond,
+		MaxReconnectInterval:     time.Millisecond * 50,
+	}
+
+	// Create the first active replicator to pull from seq:0
+	ar := db.NewActiveReplicator(&arConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(0), ar.Push.GetStats().NumConnectAttempts.Value())
+
+	err = ar.Start()
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unexpected status code 401 from target database"))
+
+	// wait for an arbitrary number of reconnect attempts
+	waitForCondition(t, func() bool {
+		return ar.Push.GetStats().NumConnectAttempts.Value() > 3
+	})
+
+	resp := rt2.SendAdminRequest(http.MethodPut, "/db/_user/alice", `{"password":"pass"}`)
+	assertStatus(t, resp, http.StatusCreated)
+
+	waitForCondition(t, func() bool {
+		state, _ := ar.State()
+		return state == db.ReplicationStateRunning
+	})
+
+	assert.NoError(t, ar.Stop())
 }
 
 func waitForCondition(t *testing.T, fn func() bool) {


### PR DESCRIPTION
- When starting a replicator, error scenarios cause a goroutine to be kicked off which attempts to reconnect.
  - The replicator reconnect retry can be configured with 3 config properties, which are not yet set from the SGR config.
- Disconnection mid-replication does not currently cause the replicator to go into this reconnecting state. Requires more testing under CBG-954
- Sets context on a replicator used for log context, and cancellation of processes on close.