### PR TITLE
Send 'ignoreNoConflicts' flag for SGR2 push replications

### DIFF
--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -71,13 +71,14 @@ func (apr *ActivePushReplicator) Start() error {
 
 	go func() {
 		bh.sendChanges(apr.blipSender, &sendChangesOptions{
-			docIDs:     apr.config.DocIDs,
-			since:      seq,
-			continuous: apr.config.Continuous,
-			activeOnly: apr.config.ActiveOnly,
-			batchSize:  int(apr.config.ChangesBatchSize),
-			channels:   channels,
-			clientType: clientTypeSGR2,
+			docIDs:            apr.config.DocIDs,
+			since:             seq,
+			continuous:        apr.config.Continuous,
+			activeOnly:        apr.config.ActiveOnly,
+			batchSize:         int(apr.config.ChangesBatchSize),
+			channels:          channels,
+			clientType:        clientTypeSGR2,
+			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.
 		})
 		apr.Complete()
 	}()

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -200,13 +200,13 @@ func (bsc *BlipSyncContext) _copyContextDatabase() *Database {
 func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response *blip.Message, changeArray [][]interface{}, requestSent time.Time, handleChangesResponseDb *Database) error {
 	defer func() {
 		if panicked := recover(); panicked != nil {
-			base.Warnf("[%s] PANIC handling 'changes' response: %v\n%s", bsc.blipContext.ID, panicked, debug.Stack())
+			base.WarnfCtx(bsc.loggingCtx, "PANIC handling 'changes' response: %v\n%s", panicked, debug.Stack())
 		}
 	}()
 
 	if response.Type() == blip.ErrorType {
 		errorBody, _ := response.Body()
-		base.Infof(base.KeyAll, "[%s] Client returned error in changesResponse: %s", bsc.blipContext.ID, errorBody)
+		base.InfofCtx(bsc.loggingCtx, base.KeyAll, "Client returned error in changesResponse: %s", errorBody)
 		return nil
 	}
 
@@ -359,7 +359,7 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docI
 		go func() {
 			defer func() {
 				if panicked := recover(); panicked != nil {
-					base.Warnf("[%s] PANIC handling 'sendRevision' response: %v\n%s", bsc.blipContext.ID, panicked, debug.Stack())
+					base.WarnfCtx(bsc.loggingCtx, "PANIC handling 'sendRevision' response: %v\n%s", panicked, debug.Stack())
 					bsc.Close()
 				}
 			}()

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -67,6 +67,9 @@ const (
 	NorevMessageReason = "reason"
 
 	// changes message properties
+	ChangesMessageIgnoreNoConflicts = "ignoreNoConflicts"
+
+	// changes response properties
 	ChangesResponseMaxHistory = "maxHistory"
 	ChangesResponseDeltas     = "deltas"
 


### PR DESCRIPTION
Allows for Hydrogen to Hydrogen push replication to a peer running in no conflicts mode.