### PR TITLE
CBG-940 Only invoke Complete() for completion of one-shot replications

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -42,6 +42,17 @@ func (tb TestBucket) Close() {
 	tb.closeFn()
 }
 
+// NoCloseClone returns a new test bucket referencing the same underlying bucket and bucketspec, but
+// with an IgnoreClose leaky bucket, and a no-op close function.  Used when multiple references to the same bucket are needed.
+func (tb *TestBucket) NoCloseClone() *TestBucket {
+	noCloseBucket := NewLeakyBucket(tb.Bucket, LeakyBucketConfig{IgnoreClose: true})
+	return &TestBucket{
+		Bucket:     noCloseBucket,
+		BucketSpec: tb.BucketSpec,
+		closeFn:    func() {},
+	}
+}
+
 func GetTestBucket(t testing.TB) *TestBucket {
 	bucket, spec, closeFn := GTestBucketPool.GetTestBucketAndSpec(t)
 	return &TestBucket{

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -70,7 +70,7 @@ func (apr *ActivePushReplicator) Start() error {
 	}
 
 	go func() {
-		bh.sendChanges(apr.blipSender, &sendChangesOptions{
+		isComplete := bh.sendChanges(apr.blipSender, &sendChangesOptions{
 			docIDs:            apr.config.DocIDs,
 			since:             seq,
 			continuous:        apr.config.Continuous,
@@ -80,7 +80,10 @@ func (apr *ActivePushReplicator) Start() error {
 			clientType:        clientTypeSGR2,
 			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.
 		})
-		apr.Complete()
+		// On a normal completion, call complete for the replication
+		if isComplete {
+			apr.Complete()
+		}
 	}()
 
 	apr._setState(ReplicationStateRunning)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -198,7 +198,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		}()
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()
-		bh.sendChanges(rq.Sender, &sendChangesOptions{
+		_ = bh.sendChanges(rq.Sender, &sendChangesOptions{
 			docIDs:     subChangesParams.docIDs(),
 			since:      subChangesParams.Since(),
 			continuous: continuous,
@@ -232,7 +232,7 @@ type sendChangesOptions struct {
 }
 
 // Sends all changes since the given sequence
-func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions) {
+func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions) (isComplete bool) {
 	defer func() {
 		if panicked := recover(); panicked != nil {
 			base.Warnf("[%s] PANIC sending changes: %v\n%s", bh.blipContext.ID, panicked, debug.Stack())
@@ -307,6 +307,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	if forceClose && bh.db.User() != nil {
 		bh.db.DatabaseContext.NotifyTerminatedChanges(bh.db.User().Name())
 	}
+	return !forceClose
 
 }
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -465,6 +465,15 @@ func (m *sgReplicateManager) replicationComplete(replicationID string) {
 }
 
 func (m *sgReplicateManager) Stop() {
+	// Stop active replications
+	m.activeReplicatorsLock.Lock()
+	for _, repl := range m.activeReplicators {
+		err := repl.Stop()
+		if err != nil {
+			base.WarnfCtx(m.loggingCtx, "Error stopping replication %s during manager stop: %v", repl.ID, err)
+		}
+	}
+	m.activeReplicatorsLock.Unlock()
 	close(m.terminator)
 }
 

--- a/rest/api_test_helpers_test.go
+++ b/rest/api_test_helpers_test.go
@@ -1,0 +1,36 @@
+package rest
+
+import (
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
+)
+
+type putDocResponse struct {
+	ID  string
+	Ok  bool
+	Rev string
+}
+
+func (rt *RestTester) getDoc(docID string) (body db.Body) {
+	rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
+	assertStatus(rt.tb, rawResponse, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
+	return body
+}
+
+func (rt *RestTester) putDoc(docID string, body string) (response putDocResponse) {
+	rawResponse := rt.SendAdminRequest("PUT", "/db/"+docID, body)
+	assertStatus(rt.tb, rawResponse, 201)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
+	require.True(rt.tb, response.Ok)
+	require.NotEmpty(rt.tb, response.Rev)
+	return response
+}
+
+func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) changesResults {
+	changesResults, err := rt.WaitForChanges(numChangesExpected, "/db/_changes?since="+since, "", true)
+	require.NoError(rt.tb, err)
+	require.Len(rt.tb, changesResults.Results, numChangesExpected)
+	return changesResults
+}


### PR DESCRIPTION
Avoids replications going to a stopped state when they are rebalanced to another node.