### PR TITLE
CBG-975: SG-Replicate 2: Support basic auth credentials (username/password) as separate config options

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -49,6 +49,10 @@ type ActiveReplicatorConfig struct {
 	Continuous bool
 	// PassiveDBURL represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
 	PassiveDBURL *url.URL
+	// PassiveDBUsername is the name of the user who has access to the remote Sync gateway database.
+	PassiveDBUsername string
+	// PassiveDBPassword is the password for accessing the remote Sync gateway database.
+	PassiveDBPassword string
 	// PurgeOnRemoval will purge the document on the active side if we pull a removal from the remote.
 	PurgeOnRemoval bool
 	// ActiveDB is a reference to the active database context.

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -49,10 +49,6 @@ type ActiveReplicatorConfig struct {
 	Continuous bool
 	// PassiveDBURL represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
 	PassiveDBURL *url.URL
-	// PassiveDBUsername is the name of the user who has access to the remote Sync gateway database.
-	PassiveDBUsername string
-	// PassiveDBPassword is the password for accessing the remote Sync gateway database.
-	PassiveDBPassword string
 	// PurgeOnRemoval will purge the document on the active side if we pull a removal from the remote.
 	PurgeOnRemoval bool
 	// ActiveDB is a reference to the active database context.

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -145,8 +145,8 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 
 	remoteURL, err := url.Parse(rc.Remote)
 	if err != nil {
-		base.Debugf(base.KeyReplicate, "Failed to parse replication remote URL [%s]: %v", remoteURL, err)
-		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote URL is invalid")
+		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote URL [%s] is invalid: %v",
+			base.RedactBasicAuthURL(rc.Remote), base.RedactBasicAuthURL(err.Error()))
 	}
 
 	if (remoteURL != nil && remoteURL.User.Username() != "") && rc.Username != "" {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -814,6 +814,7 @@ func (h *handler) getReplications() error {
 		} else {
 			replication.AssignedNode = replication.AssignedNode + " (non-local)"
 		}
+		replication = replication.Redact()
 	}
 
 	h.writeJSON(replications)
@@ -830,7 +831,7 @@ func (h *handler) getReplication() error {
 		return err
 	}
 
-	h.writeJSON(replication)
+	h.writeJSON(replication.Redact())
 	return nil
 }
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -814,7 +814,7 @@ func (h *handler) getReplications() error {
 		} else {
 			replication.AssignedNode = replication.AssignedNode + " (non-local)"
 		}
-		replication = replication.Redact()
+		replication.ReplicationConfig = *replication.Redact()
 	}
 
 	h.writeJSON(replications)

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1041,4 +1041,3 @@ func TestValidateReplication(t *testing.T) {
 		})
 	}
 }
-

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -803,7 +803,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	replication1Config := db.ReplicationConfig{
 		ID:        "replication1",
 		Remote:    "http://remote:4984/db",
-		Username:  "bob",
+		Username:  "alice",
 		Password:  "pass",
 		Direction: db.ActiveReplicatorTypePull,
 		Adhoc:     true,
@@ -811,7 +811,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_replication/replication1", marshalConfig(t, replication1Config))
 	assertStatus(t, response, http.StatusCreated)
 
-	// Check whether auth are credentials redacted from the first replication response
+	// Check whether auth are credentials redacted from replication response
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication1", "")
 	assertStatus(t, response, http.StatusOK)
 	var configResponse db.ReplicationConfig
@@ -824,10 +824,12 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		assert.Equal(t, expected.ID, actual.ID, "Replication ID mismatch")
 		assert.Equal(t, expected.Adhoc, actual.Adhoc, "Replication type mismatch")
 		assert.Equal(t, expected.Direction, actual.Direction, "Replication direction mismatch")
-		assert.Equal(t, "http://remote:4984/db", actual.Remote, "Couldn't redact auth credentials")
-		assert.Empty(t, actual.Username, "Couldn't redact username")
-		assert.Empty(t, actual.Password, "Couldn't redact password")
+		assert.Equal(t, expected.Remote, actual.Remote, "Couldn't redact auth credentials")
+		assert.Equal(t, expected.Username, actual.Username, "Couldn't redact username")
+		assert.Equal(t, expected.Password, actual.Password, "Couldn't redact password")
 	}
+	replication1Config.Username = "****"
+	replication1Config.Password = "****"
 	checkReplicationConfig(&replication1Config, &configResponse)
 
 	// Create another replication with auth credentials defined in Remote URL
@@ -840,12 +842,14 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodPost, "/db/_replication/", marshalConfig(t, replication2Config))
 	assertStatus(t, response, http.StatusCreated)
 
-	// Check whether auth are credentials redacted from the second replication response
+	// Check whether auth are credentials redacted from replication response
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication2", "")
 	assertStatus(t, response, http.StatusOK)
+	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
-	checkReplicationConfig(&replication2Config, &configResponse)
+	replication2Config.Remote = "http://****:****@remote:4984/db"
+	//checkReplicationConfig(&replication2Config, &configResponse)
 
 	// Check whether auth are credentials redacted from all replications response
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/", "")
@@ -887,3 +891,154 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	response = rt.SendAdminRequest(http.MethodGet, "/db/_replication/replication2", "")
 	assertStatus(t, response, http.StatusNotFound)
 }
+
+func TestValidateReplication(t *testing.T) {
+	testCases := []struct {
+		name              string
+		replicationConfig db.ReplicationConfig
+		fromConfig        bool
+		errExpected       error
+	}{
+		{
+			name: "replication config unsupported Cancel option",
+			replicationConfig: db.ReplicationConfig{
+				Cancel: true,
+			},
+			fromConfig: true,
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "cancel=true is invalid for replication in Sync Gateway configuration",
+			},
+		},
+		{
+			name: "replication config unsupported Adhoc option",
+			replicationConfig: db.ReplicationConfig{
+				Adhoc: true,
+			},
+			fromConfig: true,
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "adhoc=true is invalid for replication in Sync Gateway configuration",
+			},
+		},
+		{
+			name: "replication config with no remote URL specified",
+			replicationConfig: db.ReplicationConfig{
+				Remote: "",
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Replication remote must be specified.",
+			},
+		},
+		{
+			name: "replication config with invalid remote URL specified",
+			replicationConfig: db.ReplicationConfig{
+				Remote: "http://user:foo{bar=pass@remote:4984/db",
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Replication remote URL is invalid",
+			},
+		},
+		{
+			name: "auth credentials specified in both replication config and remote URL",
+			replicationConfig: db.ReplicationConfig{
+				Remote:   "http://bob:pass@remote:4984/db",
+				Username: "alice",
+				Password: "pass",
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Auth credentials can be specified either in replication config or remote URL but not allowed in both",
+			},
+		},
+		{
+			name: "auth credentials specified in replication config",
+			replicationConfig: db.ReplicationConfig{
+				Remote:      "http://remote:4984/db",
+				Username:    "alice",
+				Password:    "pass",
+				Filter:      base.ByChannelFilter,
+				QueryParams: map[string]interface{}{"channels": []interface{}{"E", "A", "D", "G", "B", "e"}},
+				Direction:   db.ActiveReplicatorTypePull,
+			},
+		},
+		{
+			name: "auth credentials specified in remote URL",
+			replicationConfig: db.ReplicationConfig{
+				Remote:      "http://bob:pass@remote:4984/db",
+				Filter:      base.ByChannelFilter,
+				QueryParams: map[string]interface{}{"channels": []interface{}{"E", "A", "D", "G", "B", "e"}},
+				Direction:   db.ActiveReplicatorTypePull,
+			},
+		},
+		{
+			name: "replication config with no direction",
+			replicationConfig: db.ReplicationConfig{
+				Remote: "http://bob:pass@remote:4984/db",
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Replication direction must be specified",
+			},
+		},
+		{
+			name: "replication config with invalid direction",
+			replicationConfig: db.ReplicationConfig{
+				Remote:    "http://bob:pass@remote:4984/db",
+				Direction: "UpAndDown",
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Invalid replication direction \"UpAndDown\", valid values are push/pull/pushAndPull",
+			},
+		},
+		{
+			name: "replication config with unknown filter",
+			replicationConfig: db.ReplicationConfig{
+				Remote:      "http://bob:pass@remote:4984/db",
+				QueryParams: map[string]interface{}{"channels": []interface{}{"E", "A", "D", "G", "B", "e"}},
+				Direction:   db.ActiveReplicatorTypePull,
+				Filter:      "unknownFilter",
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Unknown replication filter; try sync_gateway/bychannel",
+			},
+		},
+		{
+			name: "replication config with channel filter but no query params",
+			replicationConfig: db.ReplicationConfig{
+				Remote:    "http://bob:pass@remote:4984/db",
+				Filter:    base.ByChannelFilter,
+				Direction: db.ActiveReplicatorTypePull,
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Replication specifies sync_gateway/bychannel filter but is missing query_params",
+			},
+		},
+		{
+			name: "replication config with channel filter and invalid query params",
+			replicationConfig: db.ReplicationConfig{
+				Remote:      "http://bob:pass@remote:4984/db",
+				Filter:      base.ByChannelFilter,
+				QueryParams: []string{"E", "A", "D", "G", "B", "e"},
+				Direction:   db.ActiveReplicatorTypePull,
+			},
+			errExpected: &base.HTTPError{
+				Status:  http.StatusBadRequest,
+				Message: "Bad channels array in query_params for sync_gateway/bychannel filter",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.replicationConfig.ValidateReplication(tc.fromConfig)
+			assert.Equal(t, tc.errExpected, err)
+		})
+	}
+}
+

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"testing"
 	"time"
 
@@ -874,8 +875,12 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 	var allStatusResponse []*db.ReplicationStatus
 	require.NoError(t, json.Unmarshal(response.BodyBytes(), &allStatusResponse))
-
 	require.Equal(t, 2, len(allStatusResponse), "Replication count mismatch")
+
+	// Sort replications by replication ID before assertion
+	sort.Slice(allStatusResponse[:], func(i, j int) bool {
+		return allStatusResponse[i].Config.ID < allStatusResponse[j].Config.ID
+	})
 	checkReplicationConfig(&replication1Config, allStatusResponse[0].Config)
 	checkReplicationConfig(&replication2Config, allStatusResponse[1].Config)
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -938,7 +938,7 @@ func TestValidateReplication(t *testing.T) {
 			},
 			errExpected: &base.HTTPError{
 				Status:  http.StatusBadRequest,
-				Message: "Replication remote URL is invalid",
+				Message: "Replication remote URL [http://****:****@remote:4984/db] is invalid: parse http://****:****@remote:4984/db: net/url: invalid userinfo",
 			},
 		},
 		{


### PR DESCRIPTION
Allow users to specify basic auth credentials (username and password) in config in addition to passing them via passive database URL connection string in SG Replicate 2, i.e the remote URL format that is consistent with SG-Replicate 1 should be available to existing users who would like to retain the old way of configuration. Update _replication and _replicationStatus (when includeConfig is enabled) endpoints to filter out both username and password from the response . 