### PR TITLE
CBG-773: Enhance sgcollect to retrieve/incorporate sg-replicate 2 information

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -718,6 +718,15 @@ func (m *sgReplicateManager) getNodes() (nodes map[string]*SGNode, err error) {
 	return sgrCluster.Nodes, nil
 }
 
+// GetSGRCluster returns SGReplicate configuration including nodes participating in
+// replication distribution, per database.
+func (m *sgReplicateManager) GetSGRCluster() (sgrCluster *SGRCluster, err error) {
+	if sgrCluster, _, err = m.loadSGRCluster(); err != nil {
+		return nil, err
+	}
+	return sgrCluster, nil
+}
+
 // GET _replication/{replicationID}
 func (m *sgReplicateManager) GetReplication(replicationID string) (*ReplicationCfg, error) {
 	sgrCluster, _, err := m.loadSGRCluster()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -919,3 +919,16 @@ func (h *handler) putReplicationStatus() error {
 	h.writeJSON(updatedStatus)
 	return nil
 }
+
+// getReplicationCluster responds to the request against _cluster endpoint.
+func (h *handler) getReplicationCluster() error {
+	cluster, err := h.db.SGReplicateMgr.GetSGRCluster()
+	if err != nil {
+		return err
+	}
+	for _, replication := range cluster.Replications {
+		replication.ReplicationConfig = *replication.Redact()
+	}
+	h.writeJSON(cluster)
+	return nil
+}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -445,8 +445,7 @@ func (h *handler) handleGetStatus() error {
 			lastSeq, _ = database.LastSequence()
 		}
 
-		// Add replication status and configuration to the status response, per database.
-		replicationsStatus, err := database.SGReplicateMgr.GetReplicationStatusAll(h.getReplicationStatusOptions())
+		replicationsStatus, err := database.SGReplicateMgr.GetReplicationStatusAll(db.DefaultReplicationStatusOptions())
 		if err != nil {
 			return err
 		}

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -206,8 +206,6 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_replication/{replicationID}",
 		makeHandler(sc, adminPrivs, (*handler).deleteReplication)).Methods("DELETE")
 
-	dbr.Handle("/_cluster/",
-		makeHandler(sc, adminPrivs, (*handler).getReplicationCluster)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/",
 		makeHandler(sc, adminPrivs, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -206,6 +206,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_replication/{replicationID}",
 		makeHandler(sc, adminPrivs, (*handler).deleteReplication)).Methods("DELETE")
 
+	dbr.Handle("/_cluster/",
+		makeHandler(sc, adminPrivs, (*handler).getReplicationCluster)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/",
 		makeHandler(sc, adminPrivs, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -518,23 +518,6 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
         ]
     )
 
-    databases = get_db_list(sg_url)
-    for database in databases:
-
-        # Collect replication status, per database.
-        sg_tasks.append(make_curl_task(
-            name="Collect replication status: {0}".format(database),
-            url="{0}/{1}/_replicationStatus".format(sg_url, database),
-            log_file="sync_gateway.log",
-            content_postprocessors=[password_remover.pretty_print_json]))
-
-        # Collect the set of nodes participating in replication distribution, per database.
-        sg_tasks.append(make_curl_task(
-            name="Collect replication distribution: {0}".format(database),
-            url="{0}/{1}/_cluster".format(sg_url, database),
-            log_file="sync_gateway.log",
-            content_postprocessors=[password_remover.pretty_print_json]))
-
     return sg_tasks
 
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -507,7 +507,7 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
                                   log_file="sync_gateway.log",
                                   content_postprocessors=[password_remover.pretty_print_json])
 
-    # Compbine all tasks into flattened list
+    # Combine all tasks into flattened list
     sg_tasks = flatten(
         [
             collect_logs_tasks,
@@ -517,6 +517,23 @@ def make_sg_tasks(zip_dir, sg_url, sync_gateway_config_path_option, sync_gateway
             status_tasks,
         ]
     )
+
+    databases = get_db_list(sg_url)
+    for database in databases:
+
+        # Collect replication status, per database.
+        sg_tasks.append(make_curl_task(
+            name="Collect replication status: {0}".format(database),
+            url="{0}/{1}/_replicationStatus".format(sg_url, database),
+            log_file="sync_gateway.log",
+            content_postprocessors=[password_remover.pretty_print_json]))
+
+        # Collect the set of nodes participating in replication distribution, per database.
+        sg_tasks.append(make_curl_task(
+            name="Collect replication distribution: {0}".format(database),
+            url="{0}/{1}/_cluster".format(sg_url, database),
+            log_file="sync_gateway.log",
+            content_postprocessors=[password_remover.pretty_print_json]))
 
     return sg_tasks
 


### PR DESCRIPTION
Information about which replications are running on a given node is available via the _replicationStatus endpoint.  To diagnose distribution and HA issues, it would be useful to be able to compare this to what’s in the SGR_NODES_KEY config. The following are proposed:

- Include the output of the _replicationStatus endpoint in sg_collect
- Introduce _cluster API to expose the replication config with participating nodes in replication per database
- Collect the replication config response from _cluster endpoint in sg_collect.

>At this time, the collected replication details are appended to the sync_gateway.log (with a separate section per database) that aligns with collecting other details such as run time server config, status collection etc. But the behavior can be twisted to write into separate log files if required.