### PR TITLE
CBG-973: Avoid collecting sensitive data during sgcollect

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -723,13 +723,10 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 			// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.
 			// SGCollect relies on this path to pick up the standard and rotated log files.
 			info, err := os.Stat(*config.Logging.DeprecatedDefaultLog.LogFilePath)
-			if err != nil {
-				base.Infof(base.KeyAll, "Detected error retrieving stats of logging.[\"default\"].LogFilePath %q, "+
-					"Error: %v", *config.Logging.DeprecatedDefaultLog.LogFilePath, err)
-			}
-			if !os.IsNotExist(err) && info.IsDir() {
+			if err == nil && info.IsDir() {
 				config.Logging.LogFilePath = *config.Logging.DeprecatedDefaultLog.LogFilePath
 			} else {
+				base.Infof(base.KeyAll, "Writing logs into the parent directory of the path specified")
 				config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
 			}
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -726,8 +726,9 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 			if err == nil && info.IsDir() {
 				config.Logging.LogFilePath = *config.Logging.DeprecatedDefaultLog.LogFilePath
 			} else {
-				base.Infof(base.KeyAll, "Using %v as log file path (parent directory of deprecated logging.["default"].LogFilePath)", config.Logging.LogFilePath)
 				config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
+				base.Infof(base.KeyAll, "Using %v as log file path (parent directory of deprecated logging."+
+					"[\"default\"].LogFilePath)", config.Logging.LogFilePath)
 			}
 		}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -725,10 +725,10 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 
 			// SGCollect relies on this directory path to pick up the standard and rotated log files.
 			// Enforce setting absolute or relative path on the filesystem to the log file, not directory.
-			if info, statErr := os.Stat(*config.Logging.DeprecatedDefaultLog.LogFilePath); statErr == nil && info.Mode().IsDir() {
-				err = fmt.Errorf("logging.[\"default\"].LogFilePath must not be a  directory, " +
-					"specify absolute or relative path on the filesystem to the log file instead")
-				return
+			logFilePath := *config.Logging.DeprecatedDefaultLog.LogFilePath
+			if info, statErr := os.Stat(logFilePath); statErr == nil && info.Mode().IsDir() {
+				return warnings, fmt.Errorf("logging.[\"default\"].LogFilePath %q must be a file, not directory. "+
+					"Specify absolute or relative path on the filesystem to the log file instead", logFilePath)
 			}
 
 			// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.

--- a/rest/config.go
+++ b/rest/config.go
@@ -726,7 +726,7 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 			if err == nil && info.IsDir() {
 				config.Logging.LogFilePath = *config.Logging.DeprecatedDefaultLog.LogFilePath
 			} else {
-				base.Infof(base.KeyAll, "Writing logs into the parent directory of the path specified")
+				base.Infof(base.KeyAll, "Using %v as log file path (parent directory of deprecated logging.["default"].LogFilePath)", config.Logging.LogFilePath)
 				config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
 			}
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -720,6 +720,7 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 				base.Warnf(warningMsgFmt, `logging.["default"].LogFilePath`, "logging.log_file_path")
 			})
 			// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.
+			// SGCollect relies on this directory path to pick up the standard and rotated log files.
 			config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
 		}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -726,23 +726,23 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 			// Ensures existence of the default logging.["default"].LogFilePath if specified.
 			// SGCollect relies on this path to pick up the standard and rotated log files.
 			info, err := os.Stat(*config.Logging.DeprecatedDefaultLog.LogFilePath)
-			if err != nil && os.IsNotExist(err) {
-				return warnings, fmt.Errorf("specified logging.[\"default\"].LogFilePath %q does not exist",
-					*config.Logging.DeprecatedDefaultLog.LogFilePath)
-			}
-
-			if err != nil && !os.IsNotExist(err) {
+			if os.IsNotExist(err) {
+				return warnings, fmt.Errorf("specified logging.[\"default\"].LogFilePath %q does not exist, Error: %v",
+					*config.Logging.DeprecatedDefaultLog.LogFilePath, err)
+			} else if err != nil {
 				warnings = append(warnings, func() {
-					base.Warnf("Unexpected error setting logging.log_file_path by using the " +
-						"path specified against logging.[\"default\"].LogFilePath")
+					base.Warnf("Unexpected error setting logging.log_file_path by using the "+
+						"path specified against logging.[\"default\"].LogFilePath, Error: %v", err)
 				})
 			}
 
 			// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.
-			if err == nil && info.IsDir() {
-				config.Logging.LogFilePath = *config.Logging.DeprecatedDefaultLog.LogFilePath
-			} else {
-				config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
+			if err == nil {
+				if info.IsDir() {
+					config.Logging.LogFilePath = *config.Logging.DeprecatedDefaultLog.LogFilePath
+				} else {
+					config.Logging.LogFilePath = filepath.Dir(*config.Logging.DeprecatedDefaultLog.LogFilePath)
+				}
 			}
 		}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -734,10 +734,8 @@ func (config *ServerConfig) deprecatedConfigLoggingFallback() (warnings []base.D
 					base.Warnf("Unexpected error setting logging.log_file_path by using the "+
 						"path specified against logging.[\"default\"].LogFilePath, Error: %v", err)
 				})
-			}
-
-			// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.
-			if err == nil {
+			} else {
+				// Set the new LogFilePath to be the directory containing the old logfile, instead of the full path.
 				if info.IsDir() {
 					config.Logging.LogFilePath = *config.Logging.DeprecatedDefaultLog.LogFilePath
 				} else {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -521,78 +521,95 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 	logKeys := []string{"Admin", "Access", "Auth", "Bucket", "Cache"}
 	deprecatedLog := []string{"Admin", "Access", "Auth", "Bucket", "Cache"}
 
-	// Create temp dirs for specifying logging config
-	logFilePath, err := ioutil.TempDir("", "logFilePath")
-	require.NoErrorf(t, err, "Error creating temp dir %q", logFilePath)
-	dlfPath, err := ioutil.TempDir("", "dlfPath")
-	require.NoErrorf(t, err, "Error creating temp dir %q", dlfPath)
-
-	defer func() {
-		require.NoErrorf(t, os.RemoveAll(logFilePath), "Error removing dir %q", logFilePath)
-		require.NoErrorf(t, os.RemoveAll(dlfPath), "Error removing dir %q", dlfPath)
-		_, err := os.Stat(logFilePath)
-		require.True(t, os.IsNotExist(err), "Deleted dir %q shouldn't exist", logFilePath)
-		_, err = os.Stat(logFilePath)
-		require.True(t, os.IsNotExist(err), "Deleted dir %q shouldn't exist", dlfPath)
-	}()
-
-	// Call deprecatedConfigLoggingFallback with specifying deprecated default log file path as a directory
-	ddl := &base.LogAppenderConfig{
-		LogFilePath: &logFilePath,
-		LogKeys:     logKeys,
-		LogLevel:    base.PanicLevel,
-	}
-	lc := &base.LoggingConfig{
-		DeprecatedDefaultLog: ddl,
-	}
-	sc := &ServerConfig{
-		Logging:               lc,
-		DeprecatedLogFilePath: &dlfPath,
-		DeprecatedLog:         deprecatedLog,
+	removeDirs := func(dirs ...string) {
+		for _, dir := range dirs {
+			require.NoErrorf(t, os.RemoveAll(dir), "Error removing dir %q", dir)
+			_, err := os.Stat(dir)
+			require.True(t, os.IsNotExist(err), "Removed dir %q shouldn't exist", dir)
+		}
 	}
 
-	warns, err := sc.deprecatedConfigLoggingFallback()
-	require.NoError(t, err, "Error setting up deprecated logging config")
-	assert.Equal(t, *sc.Logging.DeprecatedDefaultLog.LogFilePath, sc.Logging.LogFilePath)
-	assert.Equal(t, sc.Logging.DeprecatedDefaultLog.LogKeys, sc.Logging.Console.LogKeys)
-	assert.Equal(t, base.ToLogLevel(sc.Logging.DeprecatedDefaultLog.LogLevel), sc.Logging.Console.LogLevel)
-	assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
-	assert.Len(t, warns, 3)
-
-	// Call deprecatedConfigLoggingFallback with specifying deprecated default log file path as a file
-	dlfPathFile, err := ioutil.TempFile(dlfPath, "sg-trace-*.log")
-	require.NoErrorf(t, err, "Error creating temp file %q", dlfPathFile)
-	sc.Logging.DeprecatedDefaultLog.LogFilePath = base.StringPtr(dlfPathFile.Name())
-	sc.Logging.LogFilePath = ""
-
-	warns, err = sc.deprecatedConfigLoggingFallback()
-	require.NoError(t, err, "Error setting up deprecated logging config")
-	assert.Equal(t, filepath.Dir(*sc.Logging.DeprecatedDefaultLog.LogFilePath), sc.Logging.LogFilePath)
-	assert.Equal(t, sc.Logging.DeprecatedDefaultLog.LogKeys, sc.Logging.Console.LogKeys)
-	assert.Equal(t, base.ToLogLevel(sc.Logging.DeprecatedDefaultLog.LogLevel), sc.Logging.Console.LogLevel)
-	assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
-	assert.Len(t, warns, 1)
-
-	// Call deprecatedConfigLoggingFallback with specifying deprecated default log file path that doesn't exist.
-	sc.Logging.DeprecatedDefaultLog.LogFilePath = base.StringPtr(dlfPathFile.Name() + ".unknown")
-	sc.Logging.LogFilePath = ""
-
-	warns, err = sc.deprecatedConfigLoggingFallback()
-	require.Error(t, err, "Error setting up deprecated logging config")
-	require.Contains(t, err.Error(), "does not exist")
-
-	// Call deprecatedConfigLoggingFallback without specifying DeprecatedDefaultLog
-	sc = &ServerConfig{
-		Logging:               &base.LoggingConfig{},
-		DeprecatedLogFilePath: &dlfPath,
-		DeprecatedLog:         deprecatedLog,
+	serverConfig := func() *ServerConfig {
+		return &ServerConfig{
+			Logging: &base.LoggingConfig{
+				DeprecatedDefaultLog: &base.LogAppenderConfig{
+					LogKeys:  logKeys,
+					LogLevel: base.PanicLevel,
+				},
+			},
+			DeprecatedLog: deprecatedLog,
+		}
 	}
-	warns, err = sc.deprecatedConfigLoggingFallback()
-	require.NoError(t, err, "Error setting up deprecated logging config")
 
-	assert.Equal(t, *sc.DeprecatedLogFilePath, sc.Logging.LogFilePath)
-	assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
-	assert.Len(t, warns, 2)
+	t.Run("call deprecatedConfigLoggingFallback with default log file path as a directory", func(t *testing.T) {
+		logFilePath, err := ioutil.TempDir("", "logFilePath")
+		require.NoErrorf(t, err, "Error creating temp dir %q", logFilePath)
+		dlfPath, err := ioutil.TempDir("", "dlfPath")
+		require.NoErrorf(t, err, "Error creating temp dir %q", dlfPath)
+		defer removeDirs(logFilePath, dlfPath)
+
+		sc := serverConfig()
+		sc.Logging.DeprecatedDefaultLog.LogFilePath = &logFilePath
+		sc.DeprecatedLogFilePath = &dlfPath
+
+		warns, err := sc.deprecatedConfigLoggingFallback()
+		require.NoError(t, err, "Error setting up deprecated logging config")
+		assert.Equal(t, *sc.Logging.DeprecatedDefaultLog.LogFilePath, sc.Logging.LogFilePath)
+		assert.Equal(t, sc.Logging.DeprecatedDefaultLog.LogKeys, sc.Logging.Console.LogKeys)
+		assert.Equal(t, base.ToLogLevel(sc.Logging.DeprecatedDefaultLog.LogLevel), sc.Logging.Console.LogLevel)
+		assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
+		assert.Len(t, warns, 3)
+	})
+
+	t.Run("call deprecatedConfigLoggingFallback with default log file path as a file", func(t *testing.T) {
+		dlfPath, err := ioutil.TempDir("", "dlfPath")
+		require.NoErrorf(t, err, "Error creating temp dir %q", dlfPath)
+		dlfPathFile, err := ioutil.TempFile(dlfPath, "sg-trace-*.log")
+		require.NoErrorf(t, err, "Error creating temp file %q", dlfPathFile)
+		defer removeDirs(dlfPath)
+
+		sc := serverConfig()
+		sc.Logging.DeprecatedDefaultLog.LogFilePath = base.StringPtr(dlfPathFile.Name())
+
+		warns, err := sc.deprecatedConfigLoggingFallback()
+		require.NoError(t, err, "Error setting up deprecated logging config")
+		assert.Equal(t, filepath.Dir(*sc.Logging.DeprecatedDefaultLog.LogFilePath), sc.Logging.LogFilePath)
+		assert.Equal(t, sc.Logging.DeprecatedDefaultLog.LogKeys, sc.Logging.Console.LogKeys)
+		assert.Equal(t, base.ToLogLevel(sc.Logging.DeprecatedDefaultLog.LogLevel), sc.Logging.Console.LogLevel)
+		assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
+		assert.Len(t, warns, 3)
+	})
+
+	t.Run("call deprecatedConfigLoggingFallback with default log file path that doesn't exist", func(t *testing.T) {
+		dlfPath, err := ioutil.TempDir("", "dlfPath")
+		require.NoErrorf(t, err, "Error creating temp dir %q", dlfPath)
+		defer removeDirs(dlfPath)
+
+		sc := serverConfig()
+		sc.Logging.DeprecatedDefaultLog.LogFilePath = base.StringPtr(dlfPath + "unknown.log")
+
+		warns, err := sc.deprecatedConfigLoggingFallback()
+		require.Error(t, err, "Error setting up deprecated logging config")
+		require.Contains(t, err.Error(), "does not exist")
+		assert.Len(t, warns, 1)
+	})
+
+	t.Run("call deprecatedConfigLoggingFallback without specifying DeprecatedDefaultLog", func(t *testing.T) {
+		dlfPath, err := ioutil.TempDir("", "dlfPath")
+		require.NoErrorf(t, err, "Error creating temp dir %q", dlfPath)
+		defer removeDirs(dlfPath)
+		sc := &ServerConfig{
+			Logging:               &base.LoggingConfig{},
+			DeprecatedLogFilePath: &dlfPath,
+			DeprecatedLog:         deprecatedLog,
+		}
+
+		warns, err := sc.deprecatedConfigLoggingFallback()
+		require.NoError(t, err, "Error setting up deprecated logging config")
+		assert.Equal(t, *sc.DeprecatedLogFilePath, sc.Logging.LogFilePath)
+		assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)
+		assert.Len(t, warns, 2)
+	})
 }
 
 func TestSetupAndValidateLogging(t *testing.T) {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -527,7 +527,8 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 	lc := &base.LoggingConfig{DeprecatedDefaultLog: ddl}
 	sc := &ServerConfig{Logging: lc, DeprecatedLogFilePath: &dlfPath, DeprecatedLog: deprecatedLog}
 
-	warns := sc.deprecatedConfigLoggingFallback()
+	warns, err := sc.deprecatedConfigLoggingFallback()
+	require.NoError(t, err, "Error setting up deprecated logging config")
 	assert.Equal(t, filepath.Dir(*sc.Logging.DeprecatedDefaultLog.LogFilePath), sc.Logging.LogFilePath)
 	assert.Equal(t, sc.Logging.DeprecatedDefaultLog.LogKeys, sc.Logging.Console.LogKeys)
 	assert.Equal(t, base.ToLogLevel(sc.Logging.DeprecatedDefaultLog.LogLevel), sc.Logging.Console.LogLevel)
@@ -536,7 +537,8 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 
 	// Call deprecatedConfigLoggingFallback without DeprecatedDefaultLog
 	sc = &ServerConfig{Logging: &base.LoggingConfig{}, DeprecatedLogFilePath: &dlfPath, DeprecatedLog: deprecatedLog}
-	warns = sc.deprecatedConfigLoggingFallback()
+	warns, err = sc.deprecatedConfigLoggingFallback()
+	require.NoError(t, err, "Error setting up deprecated logging config")
 
 	assert.Equal(t, *sc.DeprecatedLogFilePath, sc.Logging.LogFilePath)
 	assert.Equal(t, sc.DeprecatedLog, sc.Logging.Console.LogKeys)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -278,7 +278,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
            log_file_pattern
         )
 
-        for log_file_item_name in glob.iglob(rotated_logs_pattern):
+        for log_file_item_name in glob.glob(rotated_logs_pattern) + glob.glob(rotated_logs_pattern + ".gz"):
             log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
             # As long as a task that monitors this log file path has not already been added, add a new task
             if log_file_item_path not in sg_log_file_paths:
@@ -288,6 +288,19 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
 
             # Track which log file paths have been added so far
             sg_log_file_paths[log_file_item_path] = log_file_item_path
+    elif guessed_logging_path and os.path.isdir(guessed_logging_path):
+        for _, sg_log_file in sg_log_files.items():
+            name, ext = os.path.splitext(sg_log_file)
+            log_file_pattern = "{0}*{1}".format(name, ext)
+            rotated_logs_pattern = os.path.join(guessed_logging_path, log_file_pattern)
+            for log_file_item_name in glob.glob(rotated_logs_pattern) + glob.glob(rotated_logs_pattern + ".gz"):
+                log_file_item_path = os.path.join(guessed_logging_path, log_file_item_name)
+                if log_file_item_path not in sg_log_file_paths:
+                    print('Capturing rotated log file {0}'.format(sg_log_file_path))
+                    task = add_file_task(sourcefile_path=log_file_item_path)
+                    task.no_header = True
+                    sg_tasks.append(task)
+                sg_log_file_paths[log_file_item_path] = log_file_item_path
 
     # Find log file path from SGW 2.1 style logging config
     guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -270,37 +270,41 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
         log_file_parent_dir = os.path.abspath(os.path.join(guessed_logging_path, os.pardir))
         log_file_name = os.path.basename(guessed_logging_path)
         name, ext = os.path.splitext(log_file_name)
-
-        # iterate over all log files, including those with a timestamp prefix
-        log_file_pattern = "{0}*{1}".format(name, ext)
-        rotated_logs_pattern = os.path.join(
-           log_file_parent_dir,
-           log_file_pattern
-        )
-
-        for log_file_item_name in glob.glob(rotated_logs_pattern) + glob.glob(rotated_logs_pattern + ".gz"):
-            log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
-            # As long as a task that monitors this log file path has not already been added, add a new task
-            if log_file_item_path not in sg_log_file_paths:
-                print('Capturing rotated log file {0}'.format(log_file_item_path))
-                task = add_file_task(sourcefile_path=log_file_item_path)
-                sg_tasks.append(task)
-
-            # Track which log file paths have been added so far
-            sg_log_file_paths[log_file_item_path] = log_file_item_path
+        # Iterate over all log files, including rotated log files with timestamp in file name.
+        rotated_logs_pattern = (
+            os.path.join(log_file_parent_dir, "{0}*{1}".format(name, ext)),
+            os.path.join(log_file_parent_dir, "{0}*{1}.gz".format(name, ext)))
+        print("Searching for patterns: ", rotated_logs_pattern)
+        iterators = [glob.iglob(pattern) for pattern in rotated_logs_pattern]
+        for iterator in iterators:
+            for log_file_item_name in iterator:
+                log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
+                # As long as a task that monitors this log file path has not already been added, add a new task
+                if log_file_item_path not in sg_log_file_paths:
+                    print('Capturing rotated log file {0}'.format(log_file_item_path))
+                    task = add_file_task(sourcefile_path=log_file_item_path)
+                    sg_tasks.append(task)
+                # Track which log file paths have been added so far.
+                sg_log_file_paths[log_file_item_path] = log_file_item_path
     elif guessed_logging_path and os.path.isdir(guessed_logging_path):
         for _, sg_log_file in sg_log_files.items():
             name, ext = os.path.splitext(sg_log_file)
-            log_file_pattern = "{0}*{1}".format(name, ext)
-            rotated_logs_pattern = os.path.join(guessed_logging_path, log_file_pattern)
-            for log_file_item_name in glob.glob(rotated_logs_pattern) + glob.glob(rotated_logs_pattern + ".gz"):
-                log_file_item_path = os.path.join(guessed_logging_path, log_file_item_name)
-                if log_file_item_path not in sg_log_file_paths:
-                    print('Capturing rotated log file {0}'.format(sg_log_file_path))
-                    task = add_file_task(sourcefile_path=log_file_item_path)
-                    task.no_header = True
-                    sg_tasks.append(task)
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
+            # Iterate over all log files, including rotated log files with timestamp in file name.
+            rotated_logs_pattern = (
+                os.path.join(guessed_logging_path, "{0}*{1}".format(name, ext)),
+                os.path.join(guessed_logging_path, "{0}*{1}.gz".format(name, ext)))
+            print("Searching for patterns: ", rotated_logs_pattern)
+            iterators = [glob.iglob(pattern) for pattern in rotated_logs_pattern]
+            for iterator in iterators:
+                for log_file_item_name in iterator:
+                    log_file_item_path = os.path.join(guessed_logging_path, log_file_item_name)
+                    if log_file_item_path not in sg_log_file_paths:
+                        print('Capturing rotated log file {0}'.format(sg_log_file_path))
+                        task = add_file_task(sourcefile_path=log_file_item_path)
+                        task.no_header = True
+                        sg_tasks.append(task)
+                    # Track which log file paths have been added so far.
+                    sg_log_file_paths[log_file_item_path] = log_file_item_path
 
     # Find log file path from SGW 2.1 style logging config
     guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -239,29 +239,29 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
     # Find log file path from old style top level config
     guessed_log_path = extract_element_from_config('LogFilePath', config_str)
     if guessed_log_path and os.path.isfile(guessed_log_path):
-        # Add the directory where the log file is so that it will be searched
+        # If the specified log path is a file, add filename to standard SG log files list
+        # and parent directory path of the file to standard SG log directories list to
+        # eventually look for all permutations of SG log files and directories.
         os_home_dirs.append(os.path.dirname(guessed_log_path))
-        # Add the filename, in case it's different
         sg_log_files[os.path.basename(guessed_log_path)] = os.path.basename(guessed_log_path)
     elif guessed_log_path and os.path.isdir(guessed_log_path):
-        os_home_dirs.append(os.path.dirname(guessed_log_path))
+        # If the specified log path is a directory, add that path to the standard
+        # SG log directories list to eventually look for the standard SG log files.
+        os_home_dirs.append(guessed_log_path)
 
     # Keep a dictionary of log file paths we've added, to avoid adding duplicates
     sg_log_file_paths = {}
 
     sg_tasks = []
 
-    for _, path in sg_log_files.items():
-        for os_home_dir in os_home_dirs:
-            sg_log_file_path = os.path.join(os_home_dir, path)
+    def lookup_std_log_files(files, dirs):
+        for std_log_file in [os.path.join(d, f) for f in files for d in dirs]:
+            if std_log_file not in sg_log_file_paths:
+                sg_tasks.append(add_file_task(sourcefile_path=std_log_file))
+                sg_log_file_paths[std_log_file] = std_log_file
 
-            # As long as a task that monitors this log file path has not already been added, add a new task
-            if sg_log_file_path not in sg_log_file_paths:
-                task = add_file_task(sourcefile_path=sg_log_file_path)
-                sg_tasks.append(task)
-
-            # Track which log file paths have been added so far
-            sg_log_file_paths[sg_log_file_path] = sg_log_file_path
+    # Lookup each standard SG log files in each standard SG log directories.
+    lookup_std_log_files(sg_log_files, os_home_dirs)
 
     # Find log file path from logging.["default"] style config
     guessed_logging_path = extract_element_from_default_logging_config('LogFilePath', config_str)
@@ -270,39 +270,34 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
         log_file_parent_dir = os.path.abspath(os.path.join(guessed_logging_path, os.pardir))
         log_file_name = os.path.basename(guessed_logging_path)
         name, ext = os.path.splitext(log_file_name)
-        # Iterate over all log files, including rotated log files with timestamp in file name.
-        rotated_logs_pattern = (
-            os.path.join(log_file_parent_dir, "{0}*{1}".format(name, ext)),
-            os.path.join(log_file_parent_dir, "{0}*{1}.gz".format(name, ext)))
-        print("Searching for patterns: ", rotated_logs_pattern)
-        iterators = [glob.iglob(pattern) for pattern in rotated_logs_pattern]
-        for iterator in iterators:
-            for log_file_item_name in iterator:
-                log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print('Capturing rotated log file {0}'.format(log_file_item_path))
-                    task = add_file_task(sourcefile_path=log_file_item_path)
-                    sg_tasks.append(task)
+
+        # Lookup SG log files inside the parent directory, including rotated log files.
+        rotated_logs_pattern = os.path.join(log_file_parent_dir, "{0}*{1}".format(name, ext))
+        for log_file_item_name in glob.iglob(rotated_logs_pattern):
+            log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
+            # As long as a task that monitors this log file path has not already been added, add a new task
+            if log_file_item_path not in sg_log_file_paths:
+                print('Capturing rotated log file {0}'.format(log_file_item_path))
+                task = add_file_task(sourcefile_path=log_file_item_path)
+                sg_tasks.append(task)
                 # Track which log file paths have been added so far.
                 sg_log_file_paths[log_file_item_path] = log_file_item_path
+
+        # Lookup standard SG log files inside the parent directory.
+        lookup_std_log_files(sg_log_files, [log_file_parent_dir])
     elif guessed_logging_path and os.path.isdir(guessed_logging_path):
         for _, sg_log_file in sg_log_files.items():
             name, ext = os.path.splitext(sg_log_file)
-            # Iterate over all log files, including rotated log files with timestamp in file name.
-            rotated_logs_pattern = (
-                os.path.join(guessed_logging_path, "{0}*{1}".format(name, ext)),
-                os.path.join(guessed_logging_path, "{0}*{1}.gz".format(name, ext)))
-            print("Searching for patterns: ", rotated_logs_pattern)
-            iterators = [glob.iglob(pattern) for pattern in rotated_logs_pattern]
-            for iterator in iterators:
-                for log_file_item_name in iterator:
-                    log_file_item_path = os.path.join(guessed_logging_path, log_file_item_name)
-                    if log_file_item_path not in sg_log_file_paths:
-                        print('Capturing rotated log file {0}'.format(sg_log_file_path))
-                        task = add_file_task(sourcefile_path=log_file_item_path)
-                        task.no_header = True
-                        sg_tasks.append(task)
+
+            # Lookup standard SG log files inside the directory, including rotated log files.
+            rotated_logs_pattern = os.path.join(guessed_logging_path, "{0}*{1}".format(name, ext))
+            for log_file_item_name in glob.iglob(rotated_logs_pattern):
+                log_file_item_path = os.path.join(guessed_logging_path, log_file_item_name)
+                if log_file_item_path not in sg_log_file_paths:
+                    print('Capturing rotated log file {0}'.format(log_file_item_path))
+                    task = add_file_task(sourcefile_path=log_file_item_path)
+                    task.no_header = True
+                    sg_tasks.append(task)
                     # Track which log file paths have been added so far.
                     sg_log_file_paths[log_file_item_path] = log_file_item_path
 
@@ -316,10 +311,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
             # e.g: sg_info-2018-12-31T13-33-41.055.log
             name, ext = os.path.splitext(log_file_name)
             log_file_pattern = "{0}*{1}".format(name, ext)
-            rotated_logs_pattern = os.path.join(
-               log_file_path,
-               log_file_pattern
-            )
+            rotated_logs_pattern = os.path.join(log_file_path, log_file_pattern)
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
@@ -329,16 +321,13 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
                     task = add_file_task(sourcefile_path=log_file_item_path)
                     sg_tasks.append(task)
 
-                # Track which log file paths have been added so far
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
+                    # Track which log file paths have been added so far
+                    sg_log_file_paths[log_file_item_path] = log_file_item_path
 
             # try gzipped logs too
             # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
             log_file_pattern = "{0}*{1}.gz".format(name, ext)
-            rotated_logs_pattern = os.path.join(
-               log_file_path,
-               log_file_pattern
-            )
+            rotated_logs_pattern = os.path.join(log_file_path, log_file_pattern)
 
             for log_file_item_name in glob.iglob(rotated_logs_pattern):
                 log_file_item_path = os.path.join(log_file_path, log_file_item_name)
@@ -355,8 +344,8 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
                         task.no_header = True
                         sg_tasks.append(task)
 
-                # Track which log file paths have been added so far
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
+                    # Track which log file paths have been added so far
+                    sg_log_file_paths[log_file_item_path] = log_file_item_path
 
     return sg_tasks
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -204,96 +204,142 @@ def extract_element_from_logging_config(element, config):
             return
 
 
-def fetch_config(url):
-    """Returns response from /_config endpoint.
-    """
-    if not url:
-        print("Can't fetch Sync Gateway server config without endpoint")
-        return ""
-    try:
-        endpoint = "{0}/_config".format(url)
-        print("Fetching Sync Gateway server config from: {0}".format(endpoint))
-        response = urllib.request.urlopen(endpoint)
-    except urllib.error.URLError:
-        return ""
-    return response.read().decode('utf-8')
-
-
-def discover_log_files(files, dirs):
-    """Discovers the log file names from the list of directory paths.
-    """
-    def discover(files, path):
-        patterns = []
-        for file in files:
-            name, ext = os.path.splitext(file)
-            patterns.append(os.path.join(path, "{0}*{1}".format(name, ext)))
-            patterns.append(os.path.join(path, "{0}*{1}.gz".format(name, ext)))
-        log_files = []
-        for pattern in patterns:
-            log_files.extend(glob.glob(pattern))
-        return log_files
-
-    log_files = []
-    if isinstance(dirs, list):
-        for path in dirs:
-            log_files.extend(discover(files, path))
-    elif isinstance(dirs, str):
-        log_files.extend(discover(files, dirs))
-    else:
-        raise TypeError("dirs must be valid directory path(s)")
-    return list(dict.fromkeys(log_files))
-
-
 def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
-    sg_log_files = [
-        "sg_error.log",
-        "sg_warn.log",
-        "sg_info.log",
-        "sg_debug.log",
-        "sg_stats.log",
-        "sync_gateway_access.log",
-        "sync_gateway_error.log",
-    ]
+
+    sg_log_files = {
+        "sg_error.log": "sg_error.log",
+        "sg_warn.log": "sg_warn.log",
+        "sg_info.log": "sg_info.log",
+        "sg_debug.log": "sg_debug.log",
+        "sg_stats.log": "sg_stats.log",
+        "sync_gateway_access.log": "sync_gateway_access.log",
+        "sync_gateway_error.log": "sync_gateway_error.log",
+    }
+
     os_home_dirs = [
         "/home/sync_gateway/logs",
         "/var/log/sync_gateway",
-        "/Users/sync_gateway/logs",                                        # OSX sync gateway
-        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',        # Windows (Pre-2.0)
-        R'C:\Program Files\Couchbase\var\lib\couchbase\logs',              # Windows (Post-2.0)
-        R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'  # Windows (Post-2.1) sync gateway
+        "/Users/sync_gateway/logs",                                                     # OSX sync gateway
+        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',                     # Windows (Pre-2.0)
+        R'C:\Program Files\Couchbase\var\lib\couchbase\logs',                           # Windows (Post-2.0)
+        R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'               # Windows (Post-2.1) sync gateway
     ]
+    # Try to find user-specified log path
+    if sg_url:
+        config_url = "{0}/_config".format(sg_url)
+        try:
+            response = urllib.request.urlopen(config_url)
+        except urllib.error.URLError:
+            config_str = ""
+        else:
+            config_str = response.read().decode('utf-8')
+    else:
+        config_str = ""
 
-    config = fetch_config(sg_url)
-    config_log_paths = [
-        extract_element_from_config('LogFilePath', config),
-        extract_element_from_default_logging_config('LogFilePath', config),
-        extract_element_from_logging_config('log_file_path', config),
-    ]
-    config_log_paths = list(filter(None, config_log_paths))
-    print("Extracted log paths from server config: {0}".format(config_log_paths))
+    # Find log file path from old style top level config
+    guessed_log_path = extract_element_from_config('LogFilePath', config_str)
+    if guessed_log_path and os.path.isfile(guessed_log_path):
+        # Add the directory where the log file is so that it will be searched
+        os_home_dirs.append(os.path.dirname(guessed_log_path))
+        # Add the filename, in case it's different
+        sg_log_files[os.path.basename(guessed_log_path)] = os.path.basename(guessed_log_path)
+    elif guessed_log_path and os.path.isdir(guessed_log_path):
+        os_home_dirs.append(os.path.dirname(guessed_log_path))
 
-    for path in config_log_paths:
-        if path and os.path.isfile(path):
-            os_home_dirs.append(os.path.dirname(path))
-            sg_log_files.append(os.path.basename(path))
-        elif path and os.path.isdir(path):
-            os_home_dirs.append(path)
-        elif path and os.path.isdir(os.path.dirname(path)):
-            os_home_dirs.append(os.path.dirname(path))
-            sg_log_files.append(os.path.basename(path))
+    # Keep a dictionary of log file paths we've added, to avoid adding duplicates
+    sg_log_file_paths = {}
 
-    log_files = discover_log_files(sg_log_files, os_home_dirs)
-    print("Discovered list of log files: {0}".format(log_files))
     sg_tasks = []
 
-    for log_file in log_files:
-        if should_redact and log_file.lower().endswith('.gz'):
-            task = add_gzip_file_task(sourcefile_path=log_file, salt=salt)
-            sg_tasks.append(task)
-        else:
-            task = add_file_task(sourcefile_path=log_file)
-            task.no_header = True
-            sg_tasks.append(task)
+    for _, path in sg_log_files.items():
+        for os_home_dir in os_home_dirs:
+            sg_log_file_path = os.path.join(os_home_dir, path)
+
+            # As long as a task that monitors this log file path has not already been added, add a new task
+            if sg_log_file_path not in sg_log_file_paths:
+                task = add_file_task(sourcefile_path=sg_log_file_path)
+                sg_tasks.append(task)
+
+            # Track which log file paths have been added so far
+            sg_log_file_paths[sg_log_file_path] = sg_log_file_path
+
+    # Find log file path from logging.["default"] style config
+    guessed_logging_path = extract_element_from_default_logging_config('LogFilePath', config_str)
+    if guessed_logging_path and os.path.isfile(guessed_logging_path):
+        # Get the parent directory and the log file name
+        log_file_parent_dir = os.path.abspath(os.path.join(guessed_logging_path, os.pardir))
+        log_file_name = os.path.basename(guessed_logging_path)
+        name, ext = os.path.splitext(log_file_name)
+
+        # iterate over all log files, including those with a timestamp prefix
+        log_file_pattern = "{0}*{1}".format(name, ext)
+        rotated_logs_pattern = os.path.join(
+           log_file_parent_dir,
+           log_file_pattern
+        )
+
+        for log_file_item_name in glob.iglob(rotated_logs_pattern):
+            log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
+            # As long as a task that monitors this log file path has not already been added, add a new task
+            if log_file_item_path not in sg_log_file_paths:
+                print('Capturing rotated log file {0}'.format(log_file_item_path))
+                task = add_file_task(sourcefile_path=log_file_item_path)
+                sg_tasks.append(task)
+
+            # Track which log file paths have been added so far
+            sg_log_file_paths[log_file_item_path] = log_file_item_path
+
+    # Find log file path from SGW 2.1 style logging config
+    guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)
+    if guessed_log_file_path:
+        log_file_path = os.path.abspath(guessed_log_file_path)
+
+        for log_file_name in sg_log_files:
+            # iterate over all log files, including those with a rotation timestamp
+            # e.g: sg_info-2018-12-31T13-33-41.055.log
+            name, ext = os.path.splitext(log_file_name)
+            log_file_pattern = "{0}*{1}".format(name, ext)
+            rotated_logs_pattern = os.path.join(
+               log_file_path,
+               log_file_pattern
+            )
+
+            for log_file_item_name in glob.iglob(rotated_logs_pattern):
+                log_file_item_path = os.path.join(log_file_path, log_file_item_name)
+                # As long as a task that monitors this log file path has not already been added, add a new task
+                if log_file_item_path not in sg_log_file_paths:
+                    print('Capturing rotated log file {0}'.format(log_file_item_path))
+                    task = add_file_task(sourcefile_path=log_file_item_path)
+                    sg_tasks.append(task)
+
+                # Track which log file paths have been added so far
+                sg_log_file_paths[log_file_item_path] = log_file_item_path
+
+            # try gzipped logs too
+            # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
+            log_file_pattern = "{0}*{1}.gz".format(name, ext)
+            rotated_logs_pattern = os.path.join(
+               log_file_path,
+               log_file_pattern
+            )
+
+            for log_file_item_name in glob.iglob(rotated_logs_pattern):
+                log_file_item_path = os.path.join(log_file_path, log_file_item_name)
+                # As long as a task that monitors this log file path has not already been added, add a new task
+                if log_file_item_path not in sg_log_file_paths:
+                    print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
+                    # If we're redacting a gzipped log file, we'll need to extract, redact and recompress it.
+                    # If we're not redacting, we can skip extraction entirely, and use the existing .gz log file.
+                    if should_redact:
+                        task = add_gzip_file_task(sourcefile_path=log_file_item_path, salt=salt)
+                        sg_tasks.append(task)
+                    else:
+                        task = add_file_task(sourcefile_path=log_file_item_path)
+                        task.no_header = True
+                        sg_tasks.append(task)
+
+                # Track which log file paths have been added so far
+                sg_log_file_paths[log_file_item_path] = log_file_item_path
 
     return sg_tasks
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -264,6 +264,11 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
     lookup_std_log_files(sg_log_files, os_home_dirs)
 
     # Find log file path from logging.["default"] style config
+    # When the log file path from the default style config is a directory, we need to look for all
+    # standard SG log files inside the directory including rotated log files. But that handling is
+    # not included here, it relies on the fall through to the 2.1 style handling to pick up those
+    # log files that were written to the directory path instead; SG exposes the log_file_path as
+    # the parent directory of the file specified against LogFilePath through /_config endpoint.
     guessed_logging_path = extract_element_from_default_logging_config('LogFilePath', config_str)
     if guessed_logging_path and os.path.isfile(guessed_logging_path):
         # Get the parent directory and the log file name
@@ -285,21 +290,6 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
 
         # Lookup standard SG log files inside the parent directory.
         lookup_std_log_files(sg_log_files, [log_file_parent_dir])
-    elif guessed_logging_path and os.path.isdir(guessed_logging_path):
-        for _, sg_log_file in sg_log_files.items():
-            name, ext = os.path.splitext(sg_log_file)
-
-            # Lookup standard SG log files inside the directory, including rotated log files.
-            rotated_logs_pattern = os.path.join(guessed_logging_path, "{0}*{1}".format(name, ext))
-            for log_file_item_name in glob.iglob(rotated_logs_pattern):
-                log_file_item_path = os.path.join(guessed_logging_path, log_file_item_name)
-                if log_file_item_path not in sg_log_file_paths:
-                    print('Capturing rotated log file {0}'.format(log_file_item_path))
-                    task = add_file_task(sourcefile_path=log_file_item_path)
-                    task.no_header = True
-                    sg_tasks.append(task)
-                    # Track which log file paths have been added so far.
-                    sg_log_file_paths[log_file_item_path] = log_file_item_path
 
     # Find log file path from SGW 2.1 style logging config
     guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -204,142 +204,96 @@ def extract_element_from_logging_config(element, config):
             return
 
 
+def fetch_config(url):
+    """Returns response from /_config endpoint.
+    """
+    if not url:
+        print("Can't fetch Sync Gateway server config without endpoint")
+        return ""
+    try:
+        endpoint = "{0}/_config".format(url)
+        print("Fetching Sync Gateway server config from: {0}".format(endpoint))
+        response = urllib.request.urlopen(endpoint)
+    except urllib.error.URLError:
+        return ""
+    return response.read().decode('utf-8')
+
+
+def discover_log_files(files, dirs):
+    """Discovers the log file names from the list of directory paths.
+    """
+    def discover(files, path):
+        patterns = []
+        for file in files:
+            name, ext = os.path.splitext(file)
+            patterns.append(os.path.join(path, "{0}*{1}".format(name, ext)))
+            patterns.append(os.path.join(path, "{0}*{1}.gz".format(name, ext)))
+        log_files = []
+        for pattern in patterns:
+            log_files.extend(glob.glob(pattern))
+        return log_files
+
+    log_files = []
+    if isinstance(dirs, list):
+        for path in dirs:
+            log_files.extend(discover(files, path))
+    elif isinstance(dirs, str):
+        log_files.extend(discover(files, dirs))
+    else:
+        raise TypeError("dirs must be valid directory path(s)")
+    return list(dict.fromkeys(log_files))
+
+
 def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
-
-    sg_log_files = {
-        "sg_error.log": "sg_error.log",
-        "sg_warn.log": "sg_warn.log",
-        "sg_info.log": "sg_info.log",
-        "sg_debug.log": "sg_debug.log",
-        "sg_stats.log": "sg_stats.log",
-        "sync_gateway_access.log": "sync_gateway_access.log",
-        "sync_gateway_error.log": "sync_gateway_error.log",
-    }
-
+    sg_log_files = [
+        "sg_error.log",
+        "sg_warn.log",
+        "sg_info.log",
+        "sg_debug.log",
+        "sg_stats.log",
+        "sync_gateway_access.log",
+        "sync_gateway_error.log",
+    ]
     os_home_dirs = [
         "/home/sync_gateway/logs",
         "/var/log/sync_gateway",
-        "/Users/sync_gateway/logs",                                                     # OSX sync gateway
-        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',                     # Windows (Pre-2.0)
-        R'C:\Program Files\Couchbase\var\lib\couchbase\logs',                           # Windows (Post-2.0)
-        R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'               # Windows (Post-2.1) sync gateway
+        "/Users/sync_gateway/logs",                                        # OSX sync gateway
+        R'C:\Program Files (x86)\Couchbase\var\lib\couchbase\logs',        # Windows (Pre-2.0)
+        R'C:\Program Files\Couchbase\var\lib\couchbase\logs',              # Windows (Post-2.0)
+        R'C:\Program Files\Couchbase\Sync Gateway\var\lib\couchbase\logs'  # Windows (Post-2.1) sync gateway
     ]
-    # Try to find user-specified log path
-    if sg_url:
-        config_url = "{0}/_config".format(sg_url)
-        try:
-            response = urllib.request.urlopen(config_url)
-        except urllib.error.URLError:
-            config_str = ""
-        else:
-            config_str = response.read().decode('utf-8')
-    else:
-        config_str = ""
 
-    # Find log file path from old style top level config
-    guessed_log_path = extract_element_from_config('LogFilePath', config_str)
-    if guessed_log_path and os.path.isfile(guessed_log_path):
-        # Add the directory where the log file is so that it will be searched
-        os_home_dirs.append(os.path.dirname(guessed_log_path))
-        # Add the filename, in case it's different
-        sg_log_files[os.path.basename(guessed_log_path)] = os.path.basename(guessed_log_path)
-    elif guessed_log_path and os.path.isdir(guessed_log_path):
-        os_home_dirs.append(os.path.dirname(guessed_log_path))
+    config = fetch_config(sg_url)
+    config_log_paths = [
+        extract_element_from_config('LogFilePath', config),
+        extract_element_from_default_logging_config('LogFilePath', config),
+        extract_element_from_logging_config('log_file_path', config),
+    ]
+    config_log_paths = list(filter(None, config_log_paths))
+    print("Extracted log paths from server config: {0}".format(config_log_paths))
 
-    # Keep a dictionary of log file paths we've added, to avoid adding duplicates
-    sg_log_file_paths = {}
+    for path in config_log_paths:
+        if path and os.path.isfile(path):
+            os_home_dirs.append(os.path.dirname(path))
+            sg_log_files.append(os.path.basename(path))
+        elif path and os.path.isdir(path):
+            os_home_dirs.append(path)
+        elif path and os.path.isdir(os.path.dirname(path)):
+            os_home_dirs.append(os.path.dirname(path))
+            sg_log_files.append(os.path.basename(path))
 
+    log_files = discover_log_files(sg_log_files, os_home_dirs)
+    print("Discovered list of log files: {0}".format(log_files))
     sg_tasks = []
 
-    for _, path in sg_log_files.items():
-        for os_home_dir in os_home_dirs:
-            sg_log_file_path = os.path.join(os_home_dir, path)
-
-            # As long as a task that monitors this log file path has not already been added, add a new task
-            if sg_log_file_path not in sg_log_file_paths:
-                task = add_file_task(sourcefile_path=sg_log_file_path)
-                sg_tasks.append(task)
-
-            # Track which log file paths have been added so far
-            sg_log_file_paths[sg_log_file_path] = sg_log_file_path
-
-    # Find log file path from logging.["default"] style config
-    guessed_logging_path = extract_element_from_default_logging_config('LogFilePath', config_str)
-    if guessed_logging_path and os.path.isfile(guessed_logging_path):
-        # Get the parent directory and the log file name
-        log_file_parent_dir = os.path.abspath(os.path.join(guessed_logging_path, os.pardir))
-        log_file_name = os.path.basename(guessed_logging_path)
-        name, ext = os.path.splitext(log_file_name)
-
-        # iterate over all log files, including those with a timestamp prefix
-        log_file_pattern = "{0}*{1}".format(name, ext)
-        rotated_logs_pattern = os.path.join(
-           log_file_parent_dir,
-           log_file_pattern
-        )
-
-        for log_file_item_name in glob.iglob(rotated_logs_pattern):
-            log_file_item_path = os.path.join(log_file_parent_dir, log_file_item_name)
-            # As long as a task that monitors this log file path has not already been added, add a new task
-            if log_file_item_path not in sg_log_file_paths:
-                print('Capturing rotated log file {0}'.format(log_file_item_path))
-                task = add_file_task(sourcefile_path=log_file_item_path)
-                sg_tasks.append(task)
-
-            # Track which log file paths have been added so far
-            sg_log_file_paths[log_file_item_path] = log_file_item_path
-
-    # Find log file path from SGW 2.1 style logging config
-    guessed_log_file_path = extract_element_from_logging_config('log_file_path', config_str)
-    if guessed_log_file_path:
-        log_file_path = os.path.abspath(guessed_log_file_path)
-
-        for log_file_name in sg_log_files:
-            # iterate over all log files, including those with a rotation timestamp
-            # e.g: sg_info-2018-12-31T13-33-41.055.log
-            name, ext = os.path.splitext(log_file_name)
-            log_file_pattern = "{0}*{1}".format(name, ext)
-            rotated_logs_pattern = os.path.join(
-               log_file_path,
-               log_file_pattern
-            )
-
-            for log_file_item_name in glob.iglob(rotated_logs_pattern):
-                log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print('Capturing rotated log file {0}'.format(log_file_item_path))
-                    task = add_file_task(sourcefile_path=log_file_item_path)
-                    sg_tasks.append(task)
-
-                # Track which log file paths have been added so far
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
-
-            # try gzipped logs too
-            # e.g: sg_info-2018-12-31T13-33-41.055.log.gz
-            log_file_pattern = "{0}*{1}.gz".format(name, ext)
-            rotated_logs_pattern = os.path.join(
-               log_file_path,
-               log_file_pattern
-            )
-
-            for log_file_item_name in glob.iglob(rotated_logs_pattern):
-                log_file_item_path = os.path.join(log_file_path, log_file_item_name)
-                # As long as a task that monitors this log file path has not already been added, add a new task
-                if log_file_item_path not in sg_log_file_paths:
-                    print('Capturing compressed rotated log file {0}'.format(log_file_item_path))
-                    # If we're redacting a gzipped log file, we'll need to extract, redact and recompress it.
-                    # If we're not redacting, we can skip extraction entirely, and use the existing .gz log file.
-                    if should_redact:
-                        task = add_gzip_file_task(sourcefile_path=log_file_item_path, salt=salt)
-                        sg_tasks.append(task)
-                    else:
-                        task = add_file_task(sourcefile_path=log_file_item_path)
-                        task.no_header = True
-                        sg_tasks.append(task)
-
-                # Track which log file paths have been added so far
-                sg_log_file_paths[log_file_item_path] = log_file_item_path
+    for log_file in log_files:
+        if should_redact and log_file.lower().endswith('.gz'):
+            task = add_gzip_file_task(sourcefile_path=log_file, salt=salt)
+            sg_tasks.append(task)
+        else:
+            task = add_file_task(sourcefile_path=log_file)
+            task.no_header = True
+            sg_tasks.append(task)
 
     return sg_tasks
 

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -238,11 +238,13 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
 
     # Find log file path from old style top level config
     guessed_log_path = extract_element_from_config('LogFilePath', config_str)
-    if guessed_log_path:
+    if guessed_log_path and os.path.isfile(guessed_log_path):
         # Add the directory where the log file is so that it will be searched
         os_home_dirs.append(os.path.dirname(guessed_log_path))
         # Add the filename, in case it's different
         sg_log_files[os.path.basename(guessed_log_path)] = os.path.basename(guessed_log_path)
+    elif guessed_log_path and os.path.isdir(guessed_log_path):
+        os_home_dirs.append(os.path.dirname(guessed_log_path))
 
     # Keep a dictionary of log file paths we've added, to avoid adding duplicates
     sg_log_file_paths = {}
@@ -263,7 +265,7 @@ def make_collect_logs_tasks(zip_dir, sg_url, salt, should_redact):
 
     # Find log file path from logging.["default"] style config
     guessed_logging_path = extract_element_from_default_logging_config('LogFilePath', config_str)
-    if guessed_logging_path:
+    if guessed_logging_path and os.path.isfile(guessed_logging_path):
         # Get the parent directory and the log file name
         log_file_parent_dir = os.path.abspath(os.path.join(guessed_logging_path, os.pardir))
         log_file_name = os.path.basename(guessed_logging_path)


### PR DESCRIPTION
It's been reported that `sgcollect_info` appears to pick up entire folder contents instead of targeting specific files; `sgcollect` doesn’t check whether the log file path extracted from the configuration is an existing file before identifying the parent directory of the log file. This leads in collecting all the files and directories recursively when the specified log file path is a directory. For example, when the log file path is specified as `/opt/couchbase-sync-gateway/logs` in the SG config, sgcollect identifies the parent directory `/opt/couchbase-sync-gateway` as usual and guess the filename pattern as `*` without any filename or extension and eventually the entire contents inside the parent directory `/opt/couchbase-sync-gateway` is being collected since `*` represents everything inside the directory. This behavior can be too risky when the directory contains sensitive information and it needs to be fixed.