### PR TITLE
CBG-1004: Avoid rendering attachments in browser

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -74,36 +74,37 @@ const (
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.
 type DatabaseContext struct {
-	Name               string                   // Database name
-	UUID               string                   // UUID for this database instance. Used by cbgt and sgr
-	Bucket             base.Bucket              // Storage
-	BucketSpec         base.BucketSpec          // The BucketSpec
-	BucketLock         sync.RWMutex             // Control Access to the underlying bucket object
-	mutationListener   changeListener           // Caching feed listener
-	ImportListener     *importListener          // Import feed listener
-	sequences          *sequenceAllocator       // Source of new sequence numbers
-	ChannelMapper      *channels.ChannelMapper  // Runs JS 'sync' function
-	StartTime          time.Time                // Timestamp when context was instantiated
-	RevsLimit          uint32                   // Max depth a document's revision tree can grow to
-	autoImport         bool                     // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
-	revisionCache      RevisionCache            // Cache of recently-accessed doc revisions
-	changeCache        *changeCache             // Cache of recently-access channels
-	EventMgr           *EventManager            // Manages notification events
-	AllowEmptyPassword bool                     // Allow empty passwords?  Defaults to false
-	Options            DatabaseContextOptions   // Database Context Options
-	AccessLock         sync.RWMutex             // Allows DB offline to block until synchronous calls have completed
-	State              uint32                   // The runtime state of the DB from a service perspective
-	ExitChanges        chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
-	OIDCProviders      auth.OIDCProviderMap     // OIDC clients
-	PurgeInterval      int                      // Metadata purge interval, in hours
-	serverUUID         string                   // UUID of the server, if available
-	DbStats            *DatabaseStats           // stats that correspond to this database context
-	CompactState       uint32                   // Status of database compaction
-	terminator         chan bool                // Signal termination of background goroutines
-	activeChannels     *channels.ActiveChannels // Tracks active replications by channel
-	CfgSG              *base.CfgSG              // Sync Gateway cluster shared config
-	SGReplicateMgr     *sgReplicateManager      // Manages interactions with sg-replicate replications
-	Heartbeater        base.Heartbeater         // Node heartbeater for SG cluster awareness
+	Name                          string                   // Database name
+	UUID                          string                   // UUID for this database instance. Used by cbgt and sgr
+	Bucket                        base.Bucket              // Storage
+	BucketSpec                    base.BucketSpec          // The BucketSpec
+	BucketLock                    sync.RWMutex             // Control Access to the underlying bucket object
+	mutationListener              changeListener           // Caching feed listener
+	ImportListener                *importListener          // Import feed listener
+	sequences                     *sequenceAllocator       // Source of new sequence numbers
+	ChannelMapper                 *channels.ChannelMapper  // Runs JS 'sync' function
+	StartTime                     time.Time                // Timestamp when context was instantiated
+	RevsLimit                     uint32                   // Max depth a document's revision tree can grow to
+	autoImport                    bool                     // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
+	revisionCache                 RevisionCache            // Cache of recently-accessed doc revisions
+	changeCache                   *changeCache             // Cache of recently-access channels
+	EventMgr                      *EventManager            // Manages notification events
+	AllowEmptyPassword            bool                     // Allow empty passwords?  Defaults to false
+	Options                       DatabaseContextOptions   // Database Context Options
+	AccessLock                    sync.RWMutex             // Allows DB offline to block until synchronous calls have completed
+	State                         uint32                   // The runtime state of the DB from a service perspective
+	ExitChanges                   chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
+	OIDCProviders                 auth.OIDCProviderMap     // OIDC clients
+	PurgeInterval                 int                      // Metadata purge interval, in hours
+	serverUUID                    string                   // UUID of the server, if available
+	DbStats                       *DatabaseStats           // stats that correspond to this database context
+	CompactState                  uint32                   // Status of database compaction
+	terminator                    chan bool                // Signal termination of background goroutines
+	activeChannels                *channels.ActiveChannels // Tracks active replications by channel
+	CfgSG                         *base.CfgSG              // Sync Gateway cluster shared config
+	SGReplicateMgr                *sgReplicateManager      // Manages interactions with sg-replicate replications
+	Heartbeater                   base.Heartbeater         // Node heartbeater for SG cluster awareness
+	ServeAllAttachmentContentType bool                     // Attachment content type will bypass the content-disposition handling, default false
 }
 
 type DatabaseContextOptions struct {

--- a/db/database.go
+++ b/db/database.go
@@ -74,37 +74,37 @@ const (
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.
 type DatabaseContext struct {
-	Name                          string                   // Database name
-	UUID                          string                   // UUID for this database instance. Used by cbgt and sgr
-	Bucket                        base.Bucket              // Storage
-	BucketSpec                    base.BucketSpec          // The BucketSpec
-	BucketLock                    sync.RWMutex             // Control Access to the underlying bucket object
-	mutationListener              changeListener           // Caching feed listener
-	ImportListener                *importListener          // Import feed listener
-	sequences                     *sequenceAllocator       // Source of new sequence numbers
-	ChannelMapper                 *channels.ChannelMapper  // Runs JS 'sync' function
-	StartTime                     time.Time                // Timestamp when context was instantiated
-	RevsLimit                     uint32                   // Max depth a document's revision tree can grow to
-	autoImport                    bool                     // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
-	revisionCache                 RevisionCache            // Cache of recently-accessed doc revisions
-	changeCache                   *changeCache             // Cache of recently-access channels
-	EventMgr                      *EventManager            // Manages notification events
-	AllowEmptyPassword            bool                     // Allow empty passwords?  Defaults to false
-	Options                       DatabaseContextOptions   // Database Context Options
-	AccessLock                    sync.RWMutex             // Allows DB offline to block until synchronous calls have completed
-	State                         uint32                   // The runtime state of the DB from a service perspective
-	ExitChanges                   chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
-	OIDCProviders                 auth.OIDCProviderMap     // OIDC clients
-	PurgeInterval                 int                      // Metadata purge interval, in hours
-	serverUUID                    string                   // UUID of the server, if available
-	DbStats                       *DatabaseStats           // stats that correspond to this database context
-	CompactState                  uint32                   // Status of database compaction
-	terminator                    chan bool                // Signal termination of background goroutines
-	activeChannels                *channels.ActiveChannels // Tracks active replications by channel
-	CfgSG                         *base.CfgSG              // Sync Gateway cluster shared config
-	SGReplicateMgr                *sgReplicateManager      // Manages interactions with sg-replicate replications
-	Heartbeater                   base.Heartbeater         // Node heartbeater for SG cluster awareness
-	ServeAllAttachmentContentType bool                     // Attachment content type will bypass the content-disposition handling, default false
+	Name                         string                   // Database name
+	UUID                         string                   // UUID for this database instance. Used by cbgt and sgr
+	Bucket                       base.Bucket              // Storage
+	BucketSpec                   base.BucketSpec          // The BucketSpec
+	BucketLock                   sync.RWMutex             // Control Access to the underlying bucket object
+	mutationListener             changeListener           // Caching feed listener
+	ImportListener               *importListener          // Import feed listener
+	sequences                    *sequenceAllocator       // Source of new sequence numbers
+	ChannelMapper                *channels.ChannelMapper  // Runs JS 'sync' function
+	StartTime                    time.Time                // Timestamp when context was instantiated
+	RevsLimit                    uint32                   // Max depth a document's revision tree can grow to
+	autoImport                   bool                     // Add sync data to new untracked couchbase server docs?  (Xattr mode specific)
+	revisionCache                RevisionCache            // Cache of recently-accessed doc revisions
+	changeCache                  *changeCache             // Cache of recently-access channels
+	EventMgr                     *EventManager            // Manages notification events
+	AllowEmptyPassword           bool                     // Allow empty passwords?  Defaults to false
+	Options                      DatabaseContextOptions   // Database Context Options
+	AccessLock                   sync.RWMutex             // Allows DB offline to block until synchronous calls have completed
+	State                        uint32                   // The runtime state of the DB from a service perspective
+	ExitChanges                  chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
+	OIDCProviders                auth.OIDCProviderMap     // OIDC clients
+	PurgeInterval                int                      // Metadata purge interval, in hours
+	serverUUID                   string                   // UUID of the server, if available
+	DbStats                      *DatabaseStats           // stats that correspond to this database context
+	CompactState                 uint32                   // Status of database compaction
+	terminator                   chan bool                // Signal termination of background goroutines
+	activeChannels               *channels.ActiveChannels // Tracks active replications by channel
+	CfgSG                        *base.CfgSG              // Sync Gateway cluster shared config
+	SGReplicateMgr               *sgReplicateManager      // Manages interactions with sg-replicate replications
+	Heartbeater                  base.Heartbeater         // Node heartbeater for SG cluster awareness
+	ServeInsecureAttachmentTypes bool                     // Attachment content type will bypass the content-disposition handling, default false
 }
 
 type DatabaseContextOptions struct {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5125,6 +5125,11 @@ func TestAttachmentContentType(t *testing.T) {
 		},
 		{
 			setContentType:                true,
+			putContentType:                "text/html; charset=utf-8",
+			expectedContentDispositionSet: true,
+		},
+		{
+			setContentType:                true,
 			putContentType:                "application/xhtml+xml",
 			expectedContentDispositionSet: true,
 		},
@@ -5164,7 +5169,7 @@ func TestAttachmentContentType(t *testing.T) {
 		contentDisposition := response.Header().Get("Content-Disposition")
 
 		if test.expectedContentDispositionSet {
-			assert.Equal(t, `attachment; filename="login.aspx"`, contentDisposition, fmt.Sprintf("Failed with doc_%d", index))
+			assert.Equal(t, `attachment`, contentDisposition, fmt.Sprintf("Failed with doc_%d", index))
 		} else {
 			assert.Equal(t, "", contentDisposition)
 		}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -639,7 +639,7 @@ func TestManualAttachment(t *testing.T) {
 	response = rt.SendAdminRequest("GET", "/db/doc1/attach1", "")
 	assertStatus(t, response, 200)
 	goassert.Equals(t, string(response.Body.Bytes()), attachmentBody)
-	goassert.True(t, response.Header().Get("Content-Disposition") == `attachment; filename="attach1"`)
+	goassert.True(t, response.Header().Get("Content-Disposition") == `attachment`)
 	goassert.True(t, response.Header().Get("Content-Type") == attachmentContentType)
 
 	// try to overwrite that attachment

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5130,12 +5130,7 @@ func TestAttachmentContentType(t *testing.T) {
 		},
 		{
 			setContentType:                true,
-			putContentType:                "application/xml",
-			expectedContentDispositionSet: true,
-		},
-		{
-			setContentType:                true,
-			putContentType:                "text/xml",
+			putContentType:                "image/svg+xml",
 			expectedContentDispositionSet: true,
 		},
 		{
@@ -5155,6 +5150,7 @@ func TestAttachmentContentType(t *testing.T) {
 		},
 	}
 
+	// Tests will be ran against default config
 	for index, test := range tests {
 		contentType := ""
 		if test.setContentType {
@@ -5172,5 +5168,14 @@ func TestAttachmentContentType(t *testing.T) {
 		} else {
 			assert.Equal(t, "", contentDisposition)
 		}
+	}
+
+	// Ran against allow insecure
+	rt.DatabaseConfig.ServeInsecureAttachmentTypes = true
+	for index, _ := range tests {
+		response := rt.SendRequest("GET", fmt.Sprintf("/db/doc_allow_insecure_%d/login.aspx", index), "")
+		contentDisposition := response.Header().Get("Content-Disposition")
+
+		assert.Equal(t, "", contentDisposition)
 	}
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -200,7 +200,7 @@ type DbConfig struct {
 	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                  // When false, node will not be assigned replications
 	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
-	ServeAllAttachmentContentType    bool                             `json:"serve_all_attachment_content_type, omitempty"`   // Attachment content type will bypass the content-disposition handling, default false
+	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -200,6 +200,7 @@ type DbConfig struct {
 	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                  // When false, node will not be assigned replications
 	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
+	ServeAllAttachmentContentType    bool                             `json:"serve_all_attachment_content_type, omitempty"`   // Attachment content type will bypass the content-disposition handling, default false
 }
 
 type DeltaSyncConfig struct {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -223,11 +223,19 @@ func (h *handler) handleGetAttachment() error {
 		h.setHeader("Content-Type", contentType)
 	}
 
-	if !h.db.ServeAllAttachmentContentType {
-		if contentTypeSet && (contentType == "text/html" || contentType == "application/xhtml+xml" || contentType == "application/xml" || contentType == "text/xml" || contentType == "") {
-			setContentDisposition = true
-		}
-		if !contentTypeSet {
+	if !h.db.ServeInsecureAttachmentTypes {
+
+		if contentTypeSet {
+			contentTypeFirst := strings.Split(contentType, ";")[0]
+			switch contentTypeFirst {
+			case
+				"",
+				"text/html",
+				"application/xhtml+xml",
+				"image/svg+xml":
+				setContentDisposition = true
+			}
+		} else {
 			setContentDisposition = true
 		}
 	}

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -254,7 +254,7 @@ func (h *handler) handleGetAttachment() error {
 		}
 	}
 	if setContentDisposition {
-		h.setHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", attachmentName))
+		h.setHeader("Content-Disposition", "attachment")
 
 	}
 	h.db.DatabaseContext.DbStats.StatsCblReplicationPull().Add(base.StatKeyAttachmentPullCount, 1)

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -226,6 +226,9 @@ func (h *handler) handleGetAttachment() error {
 	if !h.db.ServeInsecureAttachmentTypes {
 
 		if contentTypeSet {
+			// This split is required as the content type field can have other elements after a ; such as charset,
+			// however, we only care about checking the first part. In the event that there is no ';' strings.Split just
+			// takes the full contentType string
 			contentTypeFirst := strings.Split(contentType, ";")[0]
 			switch contentTypeFirst {
 			case

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -191,8 +191,8 @@ func (h *handler) handleGetAttachment() error {
 		return kNotFoundError
 	}
 
-	meta, contentTypeSet := rev.Attachments[attachmentName].(map[string]interface{})
-	if !contentTypeSet {
+	meta, ok := rev.Attachments[attachmentName].(map[string]interface{})
+	if !ok {
 		return base.HTTPErrorf(http.StatusNotFound, "missing attachment %s", attachmentName)
 	}
 	digest := meta["digest"].(string)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -453,7 +453,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
-	dbcontext.ServeAllAttachmentContentType = config.ServeAllAttachmentContentType
+	dbcontext.ServeInsecureAttachmentTypes = config.ServeInsecureAttachmentTypes
 
 	if dbcontext.ChannelMapper == nil {
 		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -453,6 +453,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
+	dbcontext.ServeAllAttachmentContentType = config.ServeAllAttachmentContentType
 
 	if dbcontext.ChannelMapper == nil {
 		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))


### PR DESCRIPTION
A number of content-types will have a content-disposition header added to it so when the attachment URL is visited the file is instead downloaded rather than displayed in the browser. This can be bypassed with a config option.

Content-Disposition was decided on as it is already used on the admin port, and to avoid any potential issues with changing content-type: 
Issues: https://github.com/couchbase/sync_gateway/issues/720
Commit: https://github.com/couchbase/sync_gateway/commit/266cf96de8b1be5d2e11bf3b87dcfa8d9bc9321c

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition