### PR TITLE
CBG-913: Migrate SGR1 checkpoints when a matching SGR2 replication ID is in the config

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -223,7 +223,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 		bsc.sgCanUseDeltas = false
 	}
 
-	blipSender, err = blipSync(*arc.config.PassiveDBURL, blipContext, arc.config.InsecureSkipVerify)
+	blipSender, err = blipSync(*arc.config.RemoteDBURL, blipContext, arc.config.InsecureSkipVerify)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -47,8 +47,8 @@ type ActiveReplicatorConfig struct {
 	Direction ActiveReplicatorDirection
 	// Continuous specifies whether the replication should be continuous or one-shot.
 	Continuous bool
-	// PassiveDBURL represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
-	PassiveDBURL *url.URL
+	// RemoteDBURL represents the full Sync Gateway URL, including database path, and basic auth credentials of the target.
+	RemoteDBURL *url.URL
 	// PurgeOnRemoval will purge the document on the active side if we pull a removal from the remote.
 	PurgeOnRemoval bool
 	// ActiveDB is a reference to the active database context.
@@ -57,6 +57,8 @@ type ActiveReplicatorConfig struct {
 	WebsocketPingInterval time.Duration
 	// Conflict resolver
 	ConflictResolverFunc ConflictResolverFunc
+	// SGR1CheckpointID can be used as a fallback when SGR2 checkpoints can't be found.
+	SGR1CheckpointID string
 	// InitialReconnectInterval is the initial time to wait for exponential backoff reconnects.
 	InitialReconnectInterval time.Duration
 	// MaxReconnectInterval is the maximum amount of time to wait between exponential backoff reconnect attempts.
@@ -110,7 +112,7 @@ func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
 	if _, err := hash.Write([]byte(arc.Direction)); err != nil {
 		return "", err
 	}
-	if _, err := hash.Write([]byte(arc.PassiveDBURL.String())); err != nil {
+	if _, err := hash.Write([]byte(arc.RemoteDBURL.String())); err != nil {
 		return "", err
 	}
 	bucketUUID, err := arc.ActiveDB.Bucket.UUID()

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -126,7 +126,7 @@ func (apr *ActivePullReplicator) _initCheckpointer() error {
 		return hashErr
 	}
 
-	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, apr.CheckpointID(), checkpointHash, apr.blipSender, apr.config.ActiveDB, apr.config.CheckpointInterval)
+	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, apr.CheckpointID(), checkpointHash, apr.blipSender, apr.config)
 	err := apr.Checkpointer.fetchCheckpoints()
 	if err != nil {
 		return err

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -144,7 +144,7 @@ func (apr *ActivePushReplicator) _initCheckpointer() error {
 	if hashErr != nil {
 		return hashErr
 	}
-	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, apr.CheckpointID(), checkpointHash, apr.blipSender, apr.config.ActiveDB, apr.config.CheckpointInterval)
+	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, apr.CheckpointID(), checkpointHash, apr.blipSender, apr.config)
 
 	err := apr.Checkpointer.fetchCheckpoints()
 	if err != nil {

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -294,3 +294,12 @@ func (db *DatabaseContext) GetChannelQueryCount() int64 {
 	return base.ExpvarVar2Int(db.DbStats.StatsGsiViews().Get(queryCountExpvar))
 
 }
+
+// GetLocalActiveReplicatorForTest is a test util for retrieving an Active Replicator for deeper introspection/assertions.
+func (m *sgReplicateManager) GetLocalActiveReplicatorForTest(t testing.TB, replicationID string) (ar *ActiveReplicator, ok bool) {
+	// Check if replication is assigned locally
+	m.activeReplicatorsLock.RLock()
+	replication, isLocal := m.activeReplicators[replicationID]
+	m.activeReplicatorsLock.RUnlock()
+	return replication, isLocal
+}

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -72,7 +72,7 @@
 
   <project name="crypto" path="godeps/src/golang.org/x/crypto" remote="couchbasedeps" revision="release-branch.go1.11"/>
 
-  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="d6eb45633e5784f5161973b04317e192931972a3"/>
+  <project name="sg-replicate" path="godeps/src/github.com/couchbaselabs/sg-replicate" remote="couchbaselabs" revision="6fb5493d6168e70813dd27208456cc36f1394cfd"/>
 
   <project name="clog" path="godeps/src/github.com/couchbase/clog" remote="couchbase" revision="dcae66272b24600ae0005fa06b511cfae8914d3d"/>
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -217,6 +217,7 @@ type ReplicateV1Config struct {
 	Async            bool        `json:"async"`
 	ChangesFeedLimit *int        `json:"changes_feed_limit"`
 	ReplicationId    string      `json:"replication_id"`
+	upgradedToSGR2   bool        // upgradedToSGR2 is set to true when an equivalent SGR2 replication is found, which prevents this v1 replication from starting.
 }
 
 func (h *handler) readReplicateV1ParametersFromJSON(jsonData []byte) (params sgreplicate.ReplicationParameters, cancel bool, localdb bool, err error) {

--- a/rest/api_benchmark_test.go
+++ b/rest/api_benchmark_test.go
@@ -2,13 +2,13 @@ package rest
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"strings"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/require"
 )
 
 var doc_1k_format = `{%s

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -43,11 +43,11 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePushAndPull,
-		ActiveDB:     &db.Database{DatabaseContext: rt.GetDatabase()},
-		PassiveDBURL: passiveDBURL,
-		Continuous:   true,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePushAndPull,
+		ActiveDB:    &db.Database{DatabaseContext: rt.GetDatabase()},
+		RemoteDBURL: passiveDBURL,
+		Continuous:  true,
 	})
 
 	startNumReplicationsTotal := base.ExpvarVar2Int(rt.GetDatabase().DbStats.StatsDatabase().Get(base.StatKeyNumReplicationsTotal))
@@ -106,7 +106,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 		ID:                    t.Name(),
 		Direction:             db.ActiveReplicatorTypePush,
 		ActiveDB:              &db.Database{DatabaseContext: rt.GetDatabase()},
-		PassiveDBURL:          passiveDBURL,
+		RemoteDBURL:           passiveDBURL,
 		WebsocketPingInterval: time.Millisecond * 10,
 		Continuous:            true,
 	})
@@ -186,9 +186,9 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt1.Close()
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -275,9 +275,9 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 	defer rt1.Close()
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -444,9 +444,9 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -601,9 +601,9 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	defer rt1.Close()
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -693,9 +693,9 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -782,9 +782,9 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -949,9 +949,9 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -1087,9 +1087,9 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -1178,9 +1178,9 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	defer rt1.Close()
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -1277,9 +1277,9 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	defer rt1.Close()
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -1440,9 +1440,9 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 			require.NoError(t, err)
 			replicationStats := new(expvar.Map).Init()
 			ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-				ID:           t.Name(),
-				Direction:    db.ActiveReplicatorTypePull,
-				PassiveDBURL: passiveDBURL,
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePull,
+				RemoteDBURL: passiveDBURL,
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
@@ -1624,9 +1624,9 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver)
 			require.NoError(t, err)
 			ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-				ID:           t.Name(),
-				Direction:    db.ActiveReplicatorTypePushAndPull,
-				PassiveDBURL: passiveDBURL,
+				ID:          t.Name(),
+				Direction:   db.ActiveReplicatorTypePushAndPull,
+				RemoteDBURL: passiveDBURL,
 				ActiveDB: &db.Database{
 					DatabaseContext: rt1.GetDatabase(),
 				},
@@ -1763,9 +1763,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -1838,9 +1838,9 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -1905,9 +1905,9 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	})
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2060,9 +2060,9 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	assert.NoError(t, rt1.WaitForPendingChanges())
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2135,7 +2135,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	passiveDBURL, err = url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
-	arConfig.PassiveDBURL = passiveDBURL
+	arConfig.RemoteDBURL = passiveDBURL
 
 	ar = db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
@@ -2227,9 +2227,9 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.NoError(t, rt1.WaitForPendingChanges())
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2363,9 +2363,9 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	defer rt1.Close()
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePushAndPull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePushAndPull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2477,9 +2477,9 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePush,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2567,9 +2567,9 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 	defer rt1.Close()
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           t.Name(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2738,8 +2738,8 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					srv := httptest.NewServer(rt2.TestPublicHandler())
 					defer srv.Close()
 
-					// Build passiveDBURL with basic auth creds
-					passiveDBURL, err := url.Parse(srv.URL + "/db")
+					// Build remoteDBURL with basic auth creds
+					remoteDBURL, err := url.Parse(srv.URL + "/db")
 					require.NoError(t, err)
 
 					// Add basic auth creds to target db URL
@@ -2747,10 +2747,10 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					if test.usernameOverride != "" {
 						username = test.usernameOverride
 					}
-					passiveDBURL.User = url.UserPassword(username, "pass")
+					remoteDBURL.User = url.UserPassword(username, "pass")
 
 					if test.remoteURLHostOverride != "" {
-						passiveDBURL.Host = test.remoteURLHostOverride
+						remoteDBURL.Host = test.remoteURLHostOverride
 					}
 
 					// Active
@@ -2761,9 +2761,9 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 					defer rt1.Close()
 
 					arConfig := db.ActiveReplicatorConfig{
-						ID:           base.GenerateRandomID(),
-						Direction:    db.ActiveReplicatorTypePushAndPull,
-						PassiveDBURL: passiveDBURL,
+						ID:          base.GenerateRandomID(),
+						Direction:   db.ActiveReplicatorTypePushAndPull,
+						RemoteDBURL: remoteDBURL,
 						ActiveDB: &db.Database{
 							DatabaseContext: rt1.GetDatabase(),
 						},
@@ -2828,12 +2828,12 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
 
-	// Build passiveDBURL with basic auth creds
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	// Build remoteDBURL with basic auth creds
+	remoteDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 
 	// Add basic auth creds to target db URL
-	passiveDBURL.User = url.UserPassword("alice", "pass")
+	remoteDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
 	tb1 := base.GetTestBucket(t)
@@ -2843,9 +2843,9 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	defer rt1.Close()
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           base.GenerateRandomID(),
-		Direction:    db.ActiveReplicatorTypePushAndPull,
-		PassiveDBURL: passiveDBURL,
+		ID:          base.GenerateRandomID(),
+		Direction:   db.ActiveReplicatorTypePushAndPull,
+		RemoteDBURL: remoteDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
@@ -2913,12 +2913,12 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
 
-	// Build passiveDBURL with basic auth creds
-	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	// Build remoteDBURL with basic auth creds
+	remoteDBURL, err := url.Parse(srv.URL + "/db")
 	require.NoError(t, err)
 
 	// Add incorrect basic auth creds to target db URL
-	passiveDBURL.User = url.UserPassword("bob", "pass")
+	remoteDBURL.User = url.UserPassword("bob", "pass")
 
 	// Active
 	tb1 := base.GetTestBucket(t)
@@ -2928,9 +2928,9 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 	defer rt1.Close()
 
 	arConfig := db.ActiveReplicatorConfig{
-		ID:           base.GenerateRandomID(),
-		Direction:    db.ActiveReplicatorTypePull,
-		PassiveDBURL: passiveDBURL,
+		ID:          base.GenerateRandomID(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: remoteDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -26,6 +26,7 @@ import (
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	sgreplicate "github.com/couchbaselabs/sg-replicate"
 	pkgerrors "github.com/pkg/errors"
 )
 
@@ -124,6 +125,10 @@ func (sc *ServerContext) PostStartup() {
 func (sc *ServerContext) startReplicators() {
 
 	for _, replicationConfig := range sc.config.Replications {
+		if replicationConfig.upgradedToSGR2 {
+			base.Infof(base.KeyReplicate, "Replication %q was upgraded, preventing startup of v1 replication.", replicationConfig.ReplicationId)
+			continue
+		}
 
 		params, _, _, err := validateReplicateV1Parameters(*replicationConfig, true, *sc.config.AdminInterface)
 		if err != nil {
@@ -471,7 +476,9 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, err
 	}
 
-	// Validate replications
+	sgr1CheckpointIDs := make(map[string]string, len(config.Replications))
+
+	// Validate replications and fetch SGR1 checkpoint IDs, if any match.
 	for replicationID, replicationConfig := range config.Replications {
 		if replicationConfig.ID != "" && replicationConfig.ID != replicationID {
 			return nil, fmt.Errorf("replication_id %q does not match replications key %q in replication config", replicationConfig.ID, replicationID)
@@ -480,10 +487,77 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		if validateErr := replicationConfig.ValidateReplication(true); validateErr != nil {
 			return nil, validateErr
 		}
+
+		// Only support SGR1 checkpoint upgrade if the replication is unidirectional.
+		if replicationConfig.Direction == db.ActiveReplicatorTypePush || replicationConfig.Direction == db.ActiveReplicatorTypePull {
+			// SGR1 checkpoint fallback:
+			// If we match based on replication ID, we'll generate the SGR1 checkpoint ID and use it as a fallback in the event that no
+			// SGR2 checkpoints can be found. This needs to be persisted cluster-wide so that an assigned node that is not running SGR1 replications can still utilise the existing checkpoint.
+			// SGR1 replications were unidirectional only, and so we can't match replication IDs for SGR1 checkpoints in the event of a pushAndPull SGR2 replication.
+			for _, sgr1ReplicationConfig := range sc.config.Replications {
+				if sgr1ReplicationConfig.ReplicationId != replicationID {
+					continue
+				}
+				base.Debugf(base.KeyReplicate, "Matched replication IDs for SGR1 checkpoint fallback: %v %v", replicationConfig, sgr1ReplicationConfig)
+
+				// don't have running replications available before startup, so regenerate the params in this case for us to generate a checkpoint ID.
+				params, _, localdb, err := validateReplicateV1Parameters(*sgr1ReplicationConfig, true, *sc.config.AdminInterface)
+				if err != nil {
+					base.Warnf("Couldn't build SGR1 replication parameters for replication config: %v", err)
+					break
+				}
+
+				if !localdb {
+					base.Warnf("SGR1 replication was not a local replication, no equivalent SGR2 replication.")
+					break
+				}
+
+				// Verify source/target of SGR1 matches SGR2.
+				if replicationConfig.Direction == db.ActiveReplicatorTypePush {
+					if params.SourceDb != dbName {
+						base.Warnf("SGR1 replication SourceDB did not match SGR2 database... Can't use SGR1 checkpoints")
+						break
+					}
+					if params.GetTargetDbUrl() != replicationConfig.Remote {
+						base.Warnf("SGR1 replication TargetDB did not match SGR2 remote... Can't use SGR1 checkpoints")
+						break
+					}
+				} else if replicationConfig.Direction == db.ActiveReplicatorTypePull {
+					if params.TargetDb != dbName {
+						base.Warnf("SGR1 replication TargetDB did not match SGR2 database... Can't use SGR1 checkpoints")
+						break
+					}
+					if params.GetSourceDbUrl() != replicationConfig.Remote {
+						base.Warnf("SGR1 replication SourceDB did not match SGR2 remote... Can't use SGR1 checkpoints")
+						break
+					}
+				}
+
+				// TODO: We don't ensure further SGR1 and SGR2 params match (Filter, Channels, etc.)
+				// It's possible for users to change replication filters when moving to SGR2 and have an invalid SGR1 checkpoint used.
+
+				// replications derived from the SG config have Async forced to true, so we'll do that here to generate the same checkpoint ID.
+				params.Async = true
+				// sg-replicate itself forces a one-shot lifecycle due to the implementation of continuous,
+				// but not something we're concerned about for checkpoint ID purposes.
+				params.Lifecycle = sgreplicate.ONE_SHOT
+
+				sgr1CheckpointID, err := params.TargetCheckpointAddress()
+				if err != nil {
+					base.Warnf("Couldn't generate SGR1 checkpoint ID from replication parameters: %v", err)
+					break
+				}
+
+				base.Infof(base.KeyReplicate, "Got SGR1 checkpoint for fallback in replication %q: %v", replicationID, sgr1CheckpointID)
+				sgr1CheckpointIDs[replicationID] = sgr1CheckpointID
+				sgr1ReplicationConfig.upgradedToSGR2 = true
+			}
+		}
 	}
 
 	// Upsert replications
-	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications)
+	// TODO: Include sgr1CheckpointID from above
+	replicationErr := dbcontext.SGReplicateMgr.PutReplications(config.Replications, sgr1CheckpointIDs)
 	if replicationErr != nil {
 		return nil, replicationErr
 	}


### PR DESCRIPTION
## TODO
- [x] Rebase after #4707 

- Stores a new "SGR1CheckpointID" field on a replication config, which is set if a SG node detects a matching replication on startup using the config.
- The SGR1 checkpoint ID is used as a fallback to bootstrap the initial replication when no SGR2 checkpoints are found.
- Replication parameters are **_not_** checked for consistency between SGR1 and SGR2 (e.g. push/pull, filters, etc.)
  - This might be something to do for filters, but is tricky to do correctly for direction due to SGR1's source/target config.
- Upon replication reset, the sequence is explicitly set to zero, rather than deleted, to prevent the SGR1 checkpoint from being picked up again post-reset.