### PR TITLE
Remove node from cluster on SGReplicateManager.Stop()

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -514,6 +514,9 @@ func (m *sgReplicateManager) Stop() {
 		}
 	}
 	m.activeReplicatorsLock.Unlock()
+	if err := m.RemoveNode(m.localNodeUUID); err != nil {
+		base.WarnfCtx(m.loggingCtx, "Attempt to remove node %v from sg-replicate cfg got error: %v", m.localNodeUUID, err)
+	}
 	close(m.terminator)
 }
 


### PR DESCRIPTION
Prevents nodes from being temporarily part of the sg-replicate cluster until the heartbeat doc has expired, by removing the node on graceful shutdown.

## TODO:
- [x] Depends on PR to reorder bucket/dbContext close (#4710)