### PR TITLE
Clean up local doc expiry handling

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -353,7 +353,7 @@ func (c *Checkpointer) _setCheckpoints(seq string) (err error) {
 func (c *Checkpointer) getLocalCheckpoint() (seq, rev string, err error) {
 	base.TracefCtx(c.ctx, base.KeyReplicate, "getLocalCheckpoint")
 
-	checkpointBody, err := c.activeDB.GetSpecial("local", checkpointDocIDPrefix+c.clientID)
+	checkpointBody, err := c.activeDB.GetSpecial(DocTypeLocal, checkpointDocIDPrefix+c.clientID)
 	if err != nil {
 		if !base.IsKeyNotFoundError(c.activeDB.Bucket, err) {
 			return "", "", err
@@ -368,7 +368,7 @@ func (c *Checkpointer) getLocalCheckpoint() (seq, rev string, err error) {
 func (c *Checkpointer) setLocalCheckpoint(seq, parentRev string) (newRev string, err error) {
 	base.TracefCtx(c.ctx, base.KeyReplicate, "setLocalCheckpoint(%v, %v)", seq, parentRev)
 
-	newRev, err = c.activeDB.putSpecial("local", checkpointDocIDPrefix+c.clientID, parentRev, Body{checkpointDocLastSeqKey: seq})
+	newRev, err = c.activeDB.putSpecial(DocTypeLocal, checkpointDocIDPrefix+c.clientID, parentRev, Body{checkpointDocLastSeqKey: seq})
 	if err != nil {
 		return "", err
 	}
@@ -384,7 +384,7 @@ func (c *Checkpointer) setLocalCheckpointWithRetry(seq, existingRevID string) (n
 }
 
 func resetLocalCheckpoint(activeDB *Database, checkpointID string) error {
-	key := activeDB.realSpecialDocID("local", checkpointDocIDPrefix+checkpointID)
+	key := RealSpecialDocID(DocTypeLocal, checkpointDocIDPrefix+checkpointID)
 	return activeDB.Bucket.Delete(key)
 }
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -93,7 +93,7 @@ func (bh *blipHandler) handleGetCheckpoint(rq *blip.Message) error {
 		return nil
 	}
 
-	value, err := bh.db.GetSpecial("local", checkpointDocIDPrefix+client)
+	value, err := bh.db.GetSpecial(DocTypeLocal, checkpointDocIDPrefix+client)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (bh *blipHandler) handleSetCheckpoint(rq *blip.Message) error {
 	if revID := checkpointMessage.rev(); revID != "" {
 		checkpoint[BodyRev] = revID
 	}
-	revID, err := bh.db.PutSpecial("local", checkpointDocIDPrefix+checkpointMessage.client(), checkpoint)
+	revID, err := bh.db.PutSpecial(DocTypeLocal, checkpointDocIDPrefix+checkpointMessage.client(), checkpoint)
 	if err != nil {
 		return err
 	}

--- a/rest/bulk_api.go
+++ b/rest/bulk_api.go
@@ -537,7 +537,7 @@ func (h *handler) handleBulkDocs() error {
 		offset := len("_local/")
 		docid, _ := doc[db.BodyId].(string)
 		idslug := docid[offset:]
-		revid, err = h.db.PutSpecial("local", idslug, doc)
+		revid, err = h.db.PutSpecial(db.DocTypeLocal, idslug, doc)
 		status := db.Body{}
 		status["id"] = docid
 		if err != nil {

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -477,7 +477,7 @@ func (h *handler) handleDeleteDoc() error {
 // HTTP handler for a GET of a _local document
 func (h *handler) handleGetLocalDoc() error {
 	docid := h.PathVar("docid")
-	value, err := h.db.GetSpecial("local", docid)
+	value, err := h.db.GetSpecial(db.DocTypeLocal, docid)
 	if err != nil {
 		return err
 	}
@@ -495,7 +495,7 @@ func (h *handler) handlePutLocalDoc() error {
 	body, err := h.readJSON()
 	if err == nil {
 		var revid string
-		revid, err = h.db.PutSpecial("local", docid, body)
+		revid, err = h.db.PutSpecial(db.DocTypeLocal, docid, body)
 		if err == nil {
 			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"_local/`+docid+`","ok":true,"rev":"`+revid+`"}`))
 		}
@@ -506,5 +506,5 @@ func (h *handler) handlePutLocalDoc() error {
 // HTTP handler for a DELETE of a _local document
 func (h *handler) handleDelLocalDoc() error {
 	docid := h.PathVar("docid")
-	return h.db.DeleteSpecial("local", docid, h.getQuery("rev"))
+	return h.db.DeleteSpecial(db.DocTypeLocal, docid, h.getQuery("rev"))
 }


### PR DESCRIPTION
Remove unused code attempting to reference body["_exp"] after special properties had already been stripped from the document.  Removed _exp handling altogether as it's incompatible with GetAndTouch on subsequent local doc access.

Added test to validate LocalDocExpirySecs behaviour, and defined constant for "local" doctype.