### PR TITLE
CBG-1020: Skip redacting username in SGReplicate-2 response

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -55,6 +55,18 @@ func RedactBasicAuthURL(url string) string {
 	return basicAuthURLRegexp.ReplaceAllLiteralString(url, "://****:****@")
 }
 
+// basicAuthURLPasswordRegexp is used to match the HTTP basic auth credentials component of a URL
+var basicAuthURLPasswordRegexp = regexp.MustCompile(`:\/\/(?P<username>[^:/]+):(?P<password>[^@/]+)@`)
+
+// RedactBasicAuthURL returns the given string, with a redacted HTTP basic auth password component.
+func RedactBasicAuthURLPassword(url string) string {
+	if basicAuthURLPasswordRegexp.MatchString(url) {
+		redacted := fmt.Sprintf("://${%s}:****@", basicAuthURLPasswordRegexp.SubexpNames()[1])
+		return basicAuthURLPasswordRegexp.ReplaceAllString(url, redacted)
+	}
+	return url
+}
+
 // GenerateRandomSecret returns a cryptographically-secure 160-bit random number encoded as a hex string.
 func GenerateRandomSecret() string {
 	val, err := randCryptoHex(160)

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -454,7 +454,7 @@ func (h *handler) handleGetStatus() error {
 			return err
 		}
 		for _, replication := range cluster.Replications {
-			replication.ReplicationConfig = *replication.Redact()
+			replication.ReplicationConfig = *replication.Redacted()
 		}
 
 		status.Databases[database.Name] = DatabaseStatus{
@@ -830,7 +830,7 @@ func (h *handler) getReplications() error {
 		} else {
 			replication.AssignedNode = replication.AssignedNode + " (non-local)"
 		}
-		replication.ReplicationConfig = *replication.Redact()
+		replication.ReplicationConfig = *replication.Redacted()
 	}
 
 	h.writeJSON(replications)
@@ -847,7 +847,7 @@ func (h *handler) getReplication() error {
 		return err
 	}
 
-	h.writeJSON(replication.Redact())
+	h.writeJSON(replication.Redacted())
 	return nil
 }
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -889,7 +889,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		assert.Equal(t, expected.Username, actual.Username, "Couldn't redact username")
 		assert.Equal(t, expected.Password, actual.Password, "Couldn't redact password")
 	}
-	replication1Config.Password = "xxxxx"
+	replication1Config.Password = "****"
 	checkReplicationConfig(&replication1Config, &configResponse)
 
 	// Create another replication with auth credentials defined in Remote URL
@@ -908,7 +908,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
-	replication2Config.Remote = "http://bob:xxxxx@remote:4984/db"
+	replication2Config.Remote = "http://bob:****@remote:4984/db"
 	//checkReplicationConfig(&replication2Config, &configResponse)
 
 	// Check whether auth are credentials redacted from all replications response
@@ -1102,7 +1102,7 @@ func TestValidateReplicationWithInvalidURL(t *testing.T) {
 	replicationConfig := db.ReplicationConfig{Remote: "http://user:foo{bar=pass@remote:4984/db"}
 	err := replicationConfig.ValidateReplication(false)
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
-	assert.Contains(t, err.Error(), "http://user:xxxxx@remote:4984/db")
+	assert.Contains(t, err.Error(), "http://user:****@remote:4984/db")
 	assert.NotContains(t, err.Error(), "user:foo{bar=pass")
 
 	// Replication config with no credentials in an invalid remote URL
@@ -1170,13 +1170,13 @@ func TestGetStatusWithReplication(t *testing.T) {
 	// Check replication1 details in cluster response
 	repl, ok := database.SGRCluster.Replications[config1.ID]
 	assert.True(t, ok, "Error getting replication")
-	config1.Password = "xxxxx"
+	config1.Password = "****"
 	assertReplication(config1, repl)
 
 	// Check replication2 details in cluster response
 	repl, ok = database.SGRCluster.Replications[config2.ID]
 	assert.True(t, ok, "Error getting replication")
-	config2.Remote = "http://bob:xxxxx@remote:4984/db"
+	config2.Remote = "http://bob:****@remote:4984/db"
 	assertReplication(config2, repl)
 
 	// Delete both replications

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -889,8 +889,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		assert.Equal(t, expected.Username, actual.Username, "Couldn't redact username")
 		assert.Equal(t, expected.Password, actual.Password, "Couldn't redact password")
 	}
-	replication1Config.Username = "****"
-	replication1Config.Password = "****"
+	replication1Config.Password = "xxxxx"
 	checkReplicationConfig(&replication1Config, &configResponse)
 
 	// Create another replication with auth credentials defined in Remote URL
@@ -909,7 +908,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
-	replication2Config.Remote = "http://****:****@remote:4984/db"
+	replication2Config.Remote = "http://bob:xxxxx@remote:4984/db"
 	//checkReplicationConfig(&replication2Config, &configResponse)
 
 	// Check whether auth are credentials redacted from all replications response
@@ -1103,7 +1102,7 @@ func TestValidateReplicationWithInvalidURL(t *testing.T) {
 	replicationConfig := db.ReplicationConfig{Remote: "http://user:foo{bar=pass@remote:4984/db"}
 	err := replicationConfig.ValidateReplication(false)
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
-	assert.Contains(t, err.Error(), "http://****:****@remote:4984/db")
+	assert.Contains(t, err.Error(), "http://user:xxxxx@remote:4984/db")
 	assert.NotContains(t, err.Error(), "user:foo{bar=pass")
 
 	// Replication config with no credentials in an invalid remote URL
@@ -1171,14 +1170,13 @@ func TestGetStatusWithReplication(t *testing.T) {
 	// Check replication1 details in cluster response
 	repl, ok := database.SGRCluster.Replications[config1.ID]
 	assert.True(t, ok, "Error getting replication")
-	config1.Username = "****"
-	config1.Password = "****"
+	config1.Password = "xxxxx"
 	assertReplication(config1, repl)
 
 	// Check replication2 details in cluster response
 	repl, ok = database.SGRCluster.Replications[config2.ID]
 	assert.True(t, ok, "Error getting replication")
-	config2.Remote = "http://****:****@remote:4984/db"
+	config2.Remote = "http://bob:xxxxx@remote:4984/db"
 	assertReplication(config2, repl)
 
 	// Delete both replications


### PR DESCRIPTION
Existing SGReplicate2 API response is presented with the remote database credentials (both username and password) redacted. But this behavior needs to be changed to redact just password alone and not username.

Initial presumption was that we can bring the new URL method `Redacted` from the standard library to bear the password redaction behavior and thus by avoiding touching the username. But the method `Redacted` from the standard library is not available for us at this point of  time - it is available only in [Go 1.15](https://golang.org/doc/go1.15#net/url) and later releases.

Changes included in the ReplicationCfg `Redacted` method to return the ReplicationCfg with password of the remote database redacted from both config and remote URL, i.e. any password will be replaced with xxxxx if found.

Why xxxxx is used to mask the password instead of ****, similar to what we’ve in `base.RedactBasicAuthURL()`?
This was intentional to keep the redaction behavior aligned with the URL method `Redacted` introduced in the standard library since [Go 1.15](https://golang.org/doc/go1.15#net/url); at a later point we might be upgrading SG code base to [Go 1.15](https://golang.org/doc/go1.15#net/url) or later releases.