### PR TITLE
Rely on dbContext/serverContext close to call bucket teardown

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -38,9 +38,8 @@ func canSeeAllChannels(princ Principal, channels base.Set) bool {
 
 func TestValidateGuestUser(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	bucket := gTestBucket.Bucket
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil)
 	user, err := auth.NewUser("", "", nil)
 	assert.True(t, user != nil)
@@ -49,9 +48,9 @@ func TestValidateGuestUser(t *testing.T) {
 
 func TestValidateUser(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, err := auth.NewUser("invalid:name", "", nil)
 	assert.Equal(t, user, (User)(nil))
 	assert.True(t, err != nil)
@@ -65,9 +64,9 @@ func TestValidateUser(t *testing.T) {
 
 func TestValidateRole(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	role, err := auth.NewRole("invalid:name", nil)
 	assert.Equal(t, (User)(nil), role)
 	assert.True(t, err != nil)
@@ -81,9 +80,9 @@ func TestValidateRole(t *testing.T) {
 
 func TestValidateUserEmail(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	badEmails := []string{"", "foo", "foo@", "@bar", "foo @bar", "foo@.bar"}
 	for _, e := range badEmails {
 		assert.False(t, IsValidEmail(e))
@@ -99,9 +98,9 @@ func TestValidateUserEmail(t *testing.T) {
 
 func TestUserPasswords(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, _ := auth.NewUser("me", "letmein", nil)
 	assert.True(t, user.Authenticate("letmein"))
 	assert.False(t, user.Authenticate("password"))
@@ -121,9 +120,9 @@ func TestUserPasswords(t *testing.T) {
 
 func TestSerializeUser(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, _ := auth.NewUser("me", "letmein", ch.SetOf(t, "me", "public"))
 	require.NoError(t, user.SetEmail("foo@example.com"))
 	encoded, _ := base.JSONMarshal(user)
@@ -142,9 +141,9 @@ func TestSerializeUser(t *testing.T) {
 
 func TestSerializeRole(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	role, _ := auth.NewRole("froods", ch.SetOf(t, "hoopy", "public"))
 	encoded, _ := base.JSONMarshal(role)
 	assert.True(t, encoded != nil)
@@ -160,9 +159,9 @@ func TestSerializeRole(t *testing.T) {
 func TestUserAccess(t *testing.T) {
 
 	// User with no access:
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, _ := auth.NewUser("foo", "password", nil)
 	goassert.DeepEquals(t, user.ExpandWildCardChannel(ch.SetOf(t, "*")), ch.SetOf(t, "!"))
 	assert.False(t, user.CanSeeChannel("x"))
@@ -231,9 +230,9 @@ func TestUserAccess(t *testing.T) {
 
 func TestGetMissingUser(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, err := auth.GetUser("noSuchUser")
 	assert.Equal(t, nil, err)
 	assert.True(t, user == nil)
@@ -244,9 +243,9 @@ func TestGetMissingUser(t *testing.T) {
 
 func TestGetMissingRole(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	role, err := auth.GetRole("noSuchRole")
 	assert.Equal(t, nil, err)
 	assert.True(t, role == nil)
@@ -254,9 +253,9 @@ func TestGetMissingRole(t *testing.T) {
 
 func TestGetGuestUser(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, err := auth.GetUser("")
 	assert.Equal(t, nil, err)
 	goassert.DeepEquals(t, user, auth.defaultGuestUser())
@@ -264,9 +263,9 @@ func TestGetGuestUser(t *testing.T) {
 
 func TestSaveUsers(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "test"))
 	err := auth.Save(user)
 	assert.Equal(t, nil, err)
@@ -278,9 +277,9 @@ func TestSaveUsers(t *testing.T) {
 
 func TestSaveRoles(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	role, _ := auth.NewRole("testRole", ch.SetOf(t, "test"))
 	err := auth.Save(role)
 	assert.Equal(t, nil, err)
@@ -318,10 +317,10 @@ func (self *mockComputer) UseGlobalSequence() bool {
 
 func TestRebuildUserChannels(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 	computer := mockComputer{channels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
-	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
+	auth := NewAuthenticator(bucket, &computer)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "explicit1"))
 	user.setChannels(nil)
 	err := auth.Save(user)
@@ -334,10 +333,10 @@ func TestRebuildUserChannels(t *testing.T) {
 
 func TestRebuildRoleChannels(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 	computer := mockComputer{roleChannels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
-	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
+	auth := NewAuthenticator(bucket, &computer)
 	role, err := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
 	assert.NoError(t, err)
 	err = auth.InvalidateChannels(role)
@@ -350,10 +349,10 @@ func TestRebuildRoleChannels(t *testing.T) {
 
 func TestRebuildChannelsError(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 	computer := mockComputer{}
-	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
+	auth := NewAuthenticator(bucket, &computer)
 	role, err := auth.NewRole("testRole2", ch.SetOf(t, "explicit1"))
 	assert.NoError(t, err)
 	assert.Equal(t, nil, auth.InvalidateChannels(role))
@@ -367,10 +366,10 @@ func TestRebuildChannelsError(t *testing.T) {
 
 func TestRebuildUserRoles(t *testing.T) {
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 	computer := mockComputer{roles: ch.AtSequence(base.SetOf("role1", "role2"), 3)}
-	auth := NewAuthenticator(gTestBucket.Bucket, &computer)
+	auth := NewAuthenticator(bucket, &computer)
 	user, _ := auth.NewUser("testUser", "letmein", nil)
 	user.SetExplicitRoles(ch.TimedSet{"role3": ch.NewVbSimpleSequence(1), "role1": ch.NewVbSimpleSequence(1)})
 	err := auth.Save(user)
@@ -396,9 +395,9 @@ func TestRebuildUserRoles(t *testing.T) {
 
 func TestRoleInheritance(t *testing.T) {
 	// Create some roles:
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+	auth := NewAuthenticator(bucket, nil)
 	role, _ := auth.NewRole("square", ch.SetOf(t, "dull", "duller", "dullest"))
 	assert.Equal(t, nil, auth.Save(role))
 	role, _ = auth.NewRole("frood", ch.SetOf(t, "hoopy", "hoopier", "hoopiest"))
@@ -422,11 +421,11 @@ func TestRoleInheritance(t *testing.T) {
 }
 
 func TestRegisterUser(t *testing.T) {
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 
 	// Register user based on name, email
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	auth := NewAuthenticator(bucket, nil)
 	user, err := auth.RegisterNewUser("ValidName", "foo@example.com")
 	require.NoError(t, err)
 	assert.Equal(t, "ValidName", user.Name())
@@ -480,8 +479,8 @@ func TestRegisterUser(t *testing.T) {
 }
 
 func TestConcurrentUserWrites(t *testing.T) {
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 
 	username := "foo"
 	password := "password"
@@ -491,7 +490,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 	require.Error(t, SetBcryptCost(5))
 
 	// Create user
-	auth := NewAuthenticator(gTestBucket.Bucket, nil)
+	auth := NewAuthenticator(bucket, nil)
 	user, _ := auth.NewUser(username, password, ch.SetOf(t, "123", "456"))
 	user.SetExplicitRoles(ch.TimedSet{"role1": ch.NewVbSimpleSequence(1), "role2": ch.NewVbSimpleSequence(1)})
 	createErr := auth.Save(user)
@@ -597,7 +596,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 func TestAuthenticateTrustedJWT(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 
 	callbackURL := base.StringPtr("http://comcast:4984/_callback")
 	providerGoogle := &OIDCProvider{
@@ -1018,7 +1017,7 @@ func TestAuthenticateTrustedJWT(t *testing.T) {
 func TestGetPrincipal(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 
 	const (
 		channelRead       = "read"
@@ -1088,7 +1087,7 @@ func ToBase64String(key string) string {
 func TestAuthenticateUntrustedJWT(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 
 	issuerFacebookAccounts := "https://accounts.facebook.com"
 	issuerAmazonAccounts := "https://accounts.amazon.com"

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -28,7 +28,7 @@ func TestInitRole(t *testing.T) {
 func TestAuthorizeChannelsRole(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 
 	role, err := auth.NewRole("root", channels.SetOf(t, "superuser"))
 	assert.NoError(t, err)

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -15,10 +15,9 @@ func TestCreateSession(t *testing.T) {
 	const invalidSessionTTLError = "400 Invalid session time-to-live"
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 	testBucket := base.GetTestBucket(t)
-
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
-	auth := NewAuthenticator(bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	// Create session with a username and valid TTL of 2 hours.
 	session, err := auth.CreateSession(username, 2*time.Hour)
@@ -56,10 +55,9 @@ func TestDeleteSession(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 	var username string = "Alice"
 	testBucket := base.GetTestBucket(t)
-
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
-	auth := NewAuthenticator(bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	mockSession := &LoginSession{
 		ID:         base.GenerateRandomSecret(),
@@ -68,7 +66,7 @@ func TestDeleteSession(t *testing.T) {
 		Ttl:        24 * time.Hour,
 	}
 	const noSessionExpiry = 0
-	assert.NoError(t, bucket.Set(DocIDForSession(mockSession.ID), noSessionExpiry, mockSession))
+	assert.NoError(t, testBucket.Set(DocIDForSession(mockSession.ID), noSessionExpiry, mockSession))
 	assert.NoError(t, auth.DeleteSession(mockSession.ID))
 
 	// Just to verify the session has been deleted gracefully.
@@ -83,16 +81,14 @@ func TestDeleteSession(t *testing.T) {
 func TestMakeSessionCookie(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 	testBucket := base.GetTestBucket(t)
-	var username string = "Alice"
-
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
-	auth := NewAuthenticator(bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	sessionID := base.GenerateRandomSecret()
 	mockSession := &LoginSession{
 		ID:         sessionID,
-		Username:   username,
+		Username:   "Alice",
 		Expiration: time.Now().Add(2 * time.Hour),
 		Ttl:        24 * time.Hour,
 	}
@@ -112,8 +108,7 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	bucket := testBucket.Bucket
-	auth := NewAuthenticator(bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 
 	sessionID := base.GenerateRandomSecret()
 	mockSession := &LoginSession{
@@ -145,10 +140,9 @@ func TestDeleteSessionForCookie(t *testing.T) {
 	const defaultEndpoint = "http://localhost/"
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 	testBucket := base.GetTestBucket(t)
-
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
-	auth := NewAuthenticator(bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	sessionID := base.GenerateRandomSecret()
 	body := strings.NewReader("?")

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -152,7 +152,7 @@ func TestCanSeeChannelSince(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 	freeChannels := base.SetFromArray([]string{"ESPN", "HBO", "FX", "AMC"})
 	user, err := auth.NewUser("user", "password", freeChannels)
 	assert.Nil(t, err)
@@ -180,7 +180,7 @@ func TestGetAddedChannels(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket, nil)
 
 	role, err := auth.NewRole("music", channels.SetOf(t, "Spotify", "Youtube"))
 	assert.Nil(t, err)
@@ -222,7 +222,8 @@ func TestUserAuthenticateWithDisabledUserAccount(t *testing.T) {
 	)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -243,7 +244,8 @@ func TestUserAuthenticateWithOldPasswordHash(t *testing.T) {
 	)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -263,7 +265,8 @@ func TestUserAuthenticateWithBadPasswordHash(t *testing.T) {
 	)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -282,7 +285,8 @@ func TestUserAuthenticateWithNoHashAndBadPassword(t *testing.T) {
 	)
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+
+	auth := NewAuthenticator(testBucket, nil)
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -19,9 +19,8 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	bucket := gTestBucket.Bucket
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
@@ -55,9 +54,8 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAuth)()
 
-	gTestBucket := base.GetTestBucket(t)
-	defer gTestBucket.Close()
-	bucket := gTestBucket.Bucket
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
 
 	// Reset bcrypt cost after test
 	defer func() { require.NoError(t, SetBcryptCost(bcryptDefaultCost)) }()

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -58,9 +58,8 @@ func TestTranscoder(t *testing.T) {
 
 func TestSetGetRaw(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 	val := []byte("bar")
@@ -87,9 +86,8 @@ func TestSetGetRaw(t *testing.T) {
 
 func TestAddRaw(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 	val := []byte("bar")
@@ -129,11 +127,10 @@ func TestAddRaw(t *testing.T) {
 //   (see CBG-463)
 func TestAddRawTimeoutRetry(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
-	gocbBucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	gocbBucket, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
 	if ok {
 		gocbBucket.Bucket.SetOperationTimeout(250 * time.Millisecond)
 	}
@@ -164,9 +161,8 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 
 func TestBulkGetRaw(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	keySet := make([]string, 1000)
 	valueSet := make(map[string][]byte, 1000)
@@ -189,7 +185,7 @@ func TestBulkGetRaw(t *testing.T) {
 		valueSet[key] = val
 
 		_, _, err := bucket.GetRaw(key)
-		require.Truef(t, IsKeyNotFoundError(testBucket.Bucket, err), "Key [%s] should not exist yet, expected error but didn't get one.", key)
+		require.Truef(t, IsKeyNotFoundError(bucket, err), "Key [%s] should not exist yet, expected error but didn't get one.", key)
 		require.NoError(t, bucket.SetRaw(key, 0, val))
 	}
 
@@ -230,9 +226,8 @@ func TestBulkGetRaw(t *testing.T) {
 
 func TestWriteCasBasic(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 	val := []byte("bar2")
@@ -272,9 +267,8 @@ func TestWriteCasBasic(t *testing.T) {
 
 func TestWriteCasAdvanced(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 
@@ -316,9 +310,8 @@ func TestSetBulk(t *testing.T) {
 	// However, there's no commented code in isRecoverableGoCBError()
 	t.Skip("TestSetBulk is currently not passing against both walrus and couchbase server.  Error logs: https://gist.github.com/tleyden/22d69ff9e627d7ad37043200614a3cc5")
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key1 := t.Name() + "1"
 	key2 := t.Name() + "2"
@@ -418,9 +411,8 @@ func numNonNilErrors(entries []*sgbucket.BulkSetEntry) int {
 
 func TestUpdate(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 	valInitial := []byte("initial")
@@ -474,9 +466,8 @@ func TestUpdate(t *testing.T) {
 
 func TestIncrCounter(t *testing.T) {
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 
@@ -520,9 +511,8 @@ func TestGetAndTouchRaw(t *testing.T) {
 	key := t.Name()
 	val := []byte("bar")
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	defer func() {
 		err := bucket.Delete(key)
@@ -627,9 +617,8 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 	xattrName := SyncXattrName
@@ -761,9 +750,8 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	key := t.Name()
 	xattrName := SyncXattrName
@@ -2062,9 +2050,8 @@ func TestCouchbaseServerVersion(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
 	major, _, _ := bucket.CouchbaseServerVersion()
 	assert.NotZero(t, major)
@@ -2076,11 +2063,10 @@ func TestCouchbaseServerMaxTTL(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
-	gocbBucket := bucket.(*CouchbaseBucketGoCB)
+	gocbBucket := bucket.Bucket.(*CouchbaseBucketGoCB)
 	maxTTL, err := gocbBucket.GetMaxTTL()
 	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, maxTTL, 0)
@@ -2271,10 +2257,10 @@ func verifyDocDeletedXattrExists(bucket *CouchbaseBucketGoCB, key, xattrName str
 func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
-	testBucket := GetTestBucket(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
-	defer testBucket.Close()
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	bucketGoCB, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
 	require.True(t, ok, "Can't cast to bucket")
 
 	// Create a document with extended attributes
@@ -2297,9 +2283,9 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 	updatedXattrVal["rev"] = "2-EmDC"
 
 	// Attempt to delete the document body (deleteBody = true); isDelete is true to mark this doc as a tombstone.
-	_, errDelete := bucket.UpdateXattr(key, xattrKey, 0, cas, &updatedXattrVal, true, true)
+	_, errDelete := bucketGoCB.UpdateXattr(key, xattrKey, 0, cas, &updatedXattrVal, true, true)
 	assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-	assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
+	assert.True(t, verifyDocDeletedXattrExists(bucketGoCB, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
 
 	var docResult map[string]interface{}
 	var xattrResult map[string]interface{}
@@ -2312,10 +2298,10 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 func TestUpdateXattrWithDeleteBodyAndIsNotDelete(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
-	testBucket := GetTestBucket(t)
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
 
-	defer testBucket.Close()
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	bucketGoCB, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
 	require.True(t, ok, "Can't cast to bucket")
 
 	// Create a document with extended attributes
@@ -2338,9 +2324,9 @@ func TestUpdateXattrWithDeleteBodyAndIsNotDelete(t *testing.T) {
 	updatedXattrVal["rev"] = "2-EmDC"
 
 	// Attempt to delete the document body (deleteBody = true); isDelete is false
-	_, errDelete := bucket.UpdateXattr(key, xattrKey, 0, cas, &updatedXattrVal, true, false)
+	_, errDelete := bucketGoCB.UpdateXattr(key, xattrKey, 0, cas, &updatedXattrVal, true, false)
 	assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-	assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
+	assert.True(t, verifyDocDeletedXattrExists(bucketGoCB, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
 
 	var docResult map[string]interface{}
 	var xattrResult map[string]interface{}

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -288,6 +288,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 
 	// Initialize cfgCB
 	cfgCB, err := initCfgCB(testBucket, testBucket.BucketSpec)
+	require.NoError(t, err)
 
 	// Simulate the three nodes self-registering into the cfg
 	nodeDefs := cbgt.NewNodeDefs("1.0.0")

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -287,7 +287,7 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	defer testBucket.Close()
 
 	// Initialize cfgCB
-	cfgCB, err := initCfgCB(testBucket.Bucket, testBucket.BucketSpec)
+	cfgCB, err := initCfgCB(testBucket, testBucket.BucketSpec)
 
 	// Simulate the three nodes self-registering into the cfg
 	nodeDefs := cbgt.NewNodeDefs("1.0.0")

--- a/base/util.go
+++ b/base/util.go
@@ -743,16 +743,15 @@ func BoolPtr(b bool) *bool {
 func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string, connSpec *gocbconnstr.ConnSpec) (httpUrls []string, err error) {
 
 	// If we're using a gocb bucket, use the bucket to retrieve the mgmt endpoints.  Note that incoming bucket may be CouchbaseBucketGoCB or *CouchbaseBucketGoCB.
-	switch typedBucket := bucket.(type) {
-	case *CouchbaseBucketGoCB:
+	typedBucket, ok := AsGoCBBucket(bucket)
+	if ok {
 		if typedBucket.IoRouter() != nil {
 			mgmtEps := typedBucket.IoRouter().MgmtEps()
 			return mgmtEps, nil
 		}
-	default:
-		// No bucket-based handling, fall back to URI parsing
-
 	}
+
+	// No bucket-based handling, fall back to URI parsing
 
 	// First try to do a simple URL parse, which will only work for http:// and https:// urls where there
 	// is a single host.  If that works, return the result

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -45,10 +45,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 	deltasEnabled := base.IsEnterpriseEdition()
 	xattrsEnabled := base.TestUseXattrs()
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext(
 		"db",
 		bucket,
@@ -111,10 +108,7 @@ func TestBackupOldRevisionWithAttachments(t *testing.T) {
 
 func TestAttachments(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
@@ -226,10 +220,7 @@ func TestAttachments(t *testing.T) {
 
 func TestAttachmentForRejectedDocument(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
@@ -256,10 +247,7 @@ func TestAttachmentForRejectedDocument(t *testing.T) {
 
 func TestAttachmentRetrievalUsingRevCache(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
@@ -341,9 +329,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket *base.TestBucket
-	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer testBucket.Close()
+	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close()
 
 	// Test creating & updating a document:
@@ -402,9 +388,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 		WriteUpdateCallback: writeUpdateCallback,
 	}
 
-	var testBucket *base.TestBucket
-	db, testBucket = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer testBucket.Close()
+	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	defer db.Close()
 
 	// Test creating & updating a document:
@@ -441,10 +425,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 }
 
 func TestForEachStubAttachmentErrors(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
@@ -569,10 +550,7 @@ func TestDecodeAttachmentError(t *testing.T) {
 }
 
 func TestSetAttachment(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "The database context should be created for database 'db'")
 	defer context.Close()
@@ -590,10 +568,7 @@ func TestSetAttachment(t *testing.T) {
 }
 
 func TestRetrieveAncestorAttachments(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "The database context should be created for database 'db'")
 	defer context.Close()
@@ -662,10 +637,7 @@ func TestRetrieveAncestorAttachments(t *testing.T) {
 }
 
 func TestStoreAttachments(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	assert.NoError(t, err, "The database context should be created for database 'db'")
 	defer context.Close()
@@ -780,9 +752,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 	const docKey = "TestAttachmentMigrate"
 
 	setupFn := func(t *testing.T) (db *Database, teardownFn func()) {
-		testBucket := base.GetTestBucket(t)
-		bucket := testBucket.Bucket
-
+		bucket := base.GetTestBucket(t)
 		context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{
 			EnableXattr: base.TestUseXattrs(),
 		})
@@ -886,7 +856,6 @@ func TestMigrateBodyAttachments(t *testing.T) {
 
 		return db, func() {
 			context.Close()
-			testBucket.Close()
 		}
 	}
 
@@ -1062,18 +1031,15 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 
 	const docKey = "TestAttachmentMigrate"
 
-	testBucket := base.GetTestBucket(t)
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{
 		EnableXattr: base.TestUseXattrs(),
 	})
 	require.NoError(t, err, "The database context should be created for database 'db'")
+	defer context.Close()
 
 	db, err := CreateDatabase(context)
 	require.NoError(t, err, "The database 'db' should be created")
-	defer testBucket.Close()
-	defer context.Close()
 
 	// Put a document 2 attachments, to write attachment to the bucket
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},"bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`
@@ -1228,18 +1194,15 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 
 	const docKey = "TestAttachmentMigrate"
 
-	testBucket := base.GetTestBucket(t)
-	bucket := testBucket.Bucket
-
+	bucket := base.GetTestBucket(t)
 	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{
 		EnableXattr: base.TestUseXattrs(),
 	})
 	require.NoError(t, err, "The database context should be created for database 'db'")
+	defer context.Close()
 
 	db, err := CreateDatabase(context)
 	require.NoError(t, err, "The database 'db' should be created")
-	defer testBucket.Close()
-	defer context.Close()
 
 	// Put a document with 3 attachments, to write attachments to the bucket
 	rev1input := `{"_attachments": {"hello.txt": {"data":"aGVsbG8gd29ybGQ="},"bye.txt": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="},"new.txt": {"data":"bmV3IGRhdGE="}}}`

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -117,8 +117,7 @@ func TestSkippedSequenceList(t *testing.T) {
 
 func TestLateSequenceHandling(t *testing.T) {
 
-	context, testBucket := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
-	defer testBucket.Close()
+	context := setupTestDBWithCacheOptions(t, DefaultCacheOptions())
 	defer context.Close()
 
 	cacheStats := &expvar.Map{}
@@ -185,8 +184,7 @@ func TestLateSequenceHandling(t *testing.T) {
 func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 
 	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", b, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
@@ -246,10 +244,8 @@ func TestLateSequenceErrorRecovery(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer testBucket.Close()
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Create a user with access to channel ABC
@@ -368,8 +364,7 @@ func TestLateSequenceHandlingDuringCompact(t *testing.T) {
 
 	cacheOptions := shortWaitCache()
 	cacheOptions.ChannelCacheOptions.MaxNumChannels = 100
-	db, testBucket := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer testBucket.Close()
+	db := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -547,8 +542,7 @@ func TestChannelCacheBufferingWithUserDoc(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyDCP)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -586,8 +580,7 @@ func TestChannelCacheBackfill(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
-	defer testBucket.Close()
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -652,9 +645,8 @@ func TestContinuousChangesBackfill(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyChanges, base.KeyDCP)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -753,9 +745,8 @@ func TestLowSequenceHandling(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -819,9 +810,8 @@ func TestLowSequenceHandlingAcrossChannels(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges, base.KeyQuery)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -877,9 +867,8 @@ func TestLowSequenceHandlingWithAccessGrant(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyQuery)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -985,8 +974,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 		PostQueryCallback: postQueryCallback,
 	}
 
-	db, testBucket := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
-	defer testBucket.Close()
+	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 	defer db.Close()
 
@@ -1079,9 +1067,8 @@ func TestLowSequenceHandlingNoDuplicates(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyCache)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1172,9 +1159,8 @@ func TestChannelRace(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges)()
 
-	db, testBucket := setupTestDBWithCacheOptions(t, shortWaitCache())
+	db := setupTestDBWithCacheOptions(t, shortWaitCache())
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1276,8 +1262,7 @@ func TestSkippedViewRetrieval(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		TapFeedMissingDocs: []string{"doc-3", "doc-7", "doc-10", "doc-13", "doc-14"},
 	}
-	db, testBucket := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	defer testBucket.Close()
+	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
 	defer db.Close()
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1351,8 +1336,7 @@ func TestStopChangeCache(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		TapFeedMissingDocs: []string{"doc-3"},
 	}
-	db, testBucket := setupTestLeakyDBWithCacheOptions(t, cacheOptions, leakyConfig)
-	defer testBucket.Close()
+	db := setupTestLeakyDBWithCacheOptions(t, cacheOptions, leakyConfig)
 
 	// Write sequences direct
 	WriteDirect(db, []string{"ABC"}, 1)
@@ -1364,7 +1348,7 @@ func TestStopChangeCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// tear down the DB.  Should stop the cache before view retrieval of the skipped sequence is attempted.
-	tearDownTestDB(t, db)
+	db.Close()
 
 	// Hang around a while to see if the housekeeping tasks fire and panic
 	time.Sleep(1 * time.Second)
@@ -1385,9 +1369,8 @@ func TestChannelCacheSize(t *testing.T) {
 	options.ChannelCacheOptions.ChannelCacheMaxLength = 600
 
 	log.Printf("Options in test:%+v", options)
-	db, testBucket := setupTestDBWithCacheOptions(t, options)
+	db := setupTestDBWithCacheOptions(t, options)
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -1606,9 +1589,8 @@ func TestLateArrivingSequenceTriggersOnChange(t *testing.T) {
 	options.ChannelCacheOptions.ChannelCacheMinLength = 600
 	options.ChannelCacheOptions.ChannelCacheMaxLength = 600
 
-	db, testBucket := setupTestDBWithCacheOptions(t, options)
+	db := setupTestDBWithCacheOptions(t, options)
 	defer db.Close()
-	defer testBucket.Close()
 
 	// -------- Setup notifyChange callback ----------------
 
@@ -1691,10 +1673,8 @@ func TestInitializeEmptyCache(t *testing.T) {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.ChannelCacheMaxLength = 50
 
-	db, testBucket := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer testBucket.Close()
+	db := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close()
-
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	cacheWaiter := db.NewDCPCachingCountWaiter(t)
@@ -1744,10 +1724,8 @@ func TestInitializeCacheUnderLoad(t *testing.T) {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.ChannelCacheMaxLength = 50
 
-	db, testBucket := setupTestDBWithCacheOptions(t, cacheOptions)
-	defer testBucket.Close()
+	db := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close()
-
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
 	// Writes [docCount] documents.  Use wait group (writesDone)to identify when all docs have been written.
@@ -1800,9 +1778,8 @@ func TestNotifyForInactiveChannel(t *testing.T) {
 	// Enable relevant logging
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache, base.KeyDCP)()
 
-	db, testBucket := setupTestDB(t)
+	db := setupTestDB(t)
 	defer db.Close()
-	defer testBucket.Close()
 
 	// -------- Setup notifyChange callback ----------------
 
@@ -1848,10 +1825,9 @@ func TestMaxChannelCacheConfig(t *testing.T) {
 	for _, val := range channelCacheMaxChannels {
 		options := DefaultCacheOptions()
 		options.ChannelCacheOptions.MaxNumChannels = val
-		db, testBucket := setupTestDBWithCacheOptions(t, options)
+		db := setupTestDBWithCacheOptions(t, options)
 		assert.Equal(t, val, db.DatabaseContext.Options.CacheOptions.MaxNumChannels)
-		testBucket.Close()
-		tearDownTestDB(t, db)
+		db.Close()
 	}
 }
 
@@ -1867,9 +1843,8 @@ func TestChangeCache_InsertPendingEntries(t *testing.T) {
 	cacheOptions := DefaultCacheOptions()
 	cacheOptions.CachePendingSeqMaxWait = 100 * time.Millisecond
 
-	db, testBucket := setupTestDBWithCacheOptions(t, cacheOptions)
+	db := setupTestDBWithCacheOptions(t, cacheOptions)
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1970,8 +1970,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 	for _, bm := range processEntryBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			b.StopTimer()
-			testBucket := base.GetTestBucket(b)
-			context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+			context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			changeCache := &changeCache{}
 			if err := changeCache.Init(context, nil, nil); err != nil {
@@ -2196,8 +2195,7 @@ func BenchmarkDocChanged(b *testing.B) {
 	for _, bm := range processEntryBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			b.StopTimer()
-			testBucket := base.GetTestBucket(b)
-			context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+			context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 			require.NoError(b, err)
 			changeCache := &changeCache{}
 			if err := changeCache.Init(context, nil, nil); err != nil {

--- a/db/change_listener_test.go
+++ b/db/change_listener_test.go
@@ -14,8 +14,7 @@ func TestUserWaiter(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// Create user
@@ -58,8 +57,7 @@ func TestUserWaiterForRoleChange(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// Create role

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -30,8 +30,7 @@ func TestChangesAfterChannelAdded(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyCache, base.KeyChanges)()
@@ -131,8 +130,7 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -216,8 +214,7 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 		t.Skip("This test is known to be failing against couchbase server with XATTRS enabled.  Same error as TestDocDeletionFromChannelCoalescedRemoved")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
@@ -289,9 +286,8 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 
 func TestActiveOnlyCacheUpdate(t *testing.T) {
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	db := setupTestDB(t)
+	defer db.Close()
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyChanges, base.KeyCache)()
 	// Create 10 documents
@@ -354,8 +350,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 func BenchmarkChangesFeedDocUnmarshalling(b *testing.B) {
 	defer base.SetUpBenchmarkLogging(base.LevelWarn, base.KeyHTTP)()
 
-	db, testBucket := setupTestDB(b)
-	defer testBucket.Close()
+	db := setupTestDB(b)
 	defer db.Close()
 
 	fieldVal := func(valSizeBytes int) string {

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -630,9 +630,8 @@ func TestBypassSingleChannelCache(t *testing.T) {
 func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
@@ -650,9 +649,8 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
@@ -668,9 +666,8 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
@@ -686,9 +683,8 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
@@ -704,9 +700,8 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
@@ -723,9 +718,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 
 	defer base.SetUpBenchmarkLogging(base.LevelInfo, base.KeyHTTP)()
 
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})
@@ -741,9 +734,8 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 
 	defer base.DisableTestLogging()()
-	testBucket := base.GetTestBucket(b)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+
+	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Benchmark", 0, &expvar.Map{})

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -18,9 +18,7 @@ func TestDuplicateDocID(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 
@@ -67,9 +65,7 @@ func TestLateArrivingSequence(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
@@ -101,9 +97,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
@@ -135,9 +129,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
@@ -210,9 +202,7 @@ func TestPrependChanges(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	// 1. Test prepend to empty cache
@@ -395,9 +385,7 @@ func TestChannelCacheRemove(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	cache := newSingleChannelCache(context, "Test1", 0, &expvar.Map{})
@@ -436,9 +424,7 @@ func TestChannelCacheStats(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	testStats := &expvar.Map{}
@@ -508,9 +494,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	testStats := &expvar.Map{}
@@ -540,9 +524,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	b := base.GetTestBucket(t)
-	defer b.Close()
-	context, err := NewDatabaseContext("db", b.Bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	testStats := &expvar.Map{}

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -29,9 +29,9 @@ func TestChannelCacheMaxSize(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	context, err := NewDatabaseContext("db", testBucket.Bucket, false, DatabaseContextOptions{})
+	bucket := base.GetTestBucket(t)
+
+	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
 	cache := context.changeCache.getChannelCache()

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -54,8 +54,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
-	db, testBucket := setupTestDBWithViewsEnabled(t)
-	defer testBucket.Close()
+	db := setupTestDBWithViewsEnabled(t)
 	defer db.Close()
 
 	base.TestExternalRevStorage = true
@@ -98,8 +97,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	base.TestExternalRevStorage = true
@@ -282,8 +280,7 @@ func TestRevisionStorageConflictAndTombstones(t *testing.T) {
 // TestRevisionStoragePruneTombstone - tests cleanup of external tombstone bodies when pruned.
 func TestRevisionStoragePruneTombstone(t *testing.T) {
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	base.TestExternalRevStorage = true
@@ -440,8 +437,7 @@ func TestRevisionStoragePruneTombstone(t *testing.T) {
 // Checks for unwanted interaction between old revision body backups and revision cache
 func TestOldRevisionStorage(t *testing.T) {
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	prop_1000_bytes := base.CreateProperty(1000)
@@ -602,8 +598,7 @@ func TestOldRevisionStorageError(t *testing.T) {
 	leakyConfig := base.LeakyBucketConfig{
 		ForceErrorSetRawKeys: []string{forceErrorKey},
 	}
-	db, testBucket := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
-	defer testBucket.Close()
+	db := setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), leakyConfig)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`)
@@ -731,9 +726,8 @@ func TestOldRevisionStorageError(t *testing.T) {
 // Validate JSON number handling for large sequence values
 func TestLargeSequence(t *testing.T) {
 
-	db, testBucket := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
+	db := setupTestDBWithCustomSyncSeq(t, 9223372036854775807)
 	defer db.Close()
-	defer testBucket.Close()
 
 	db.ChannelMapper = channels.NewDefaultChannelMapper()
 
@@ -771,8 +765,7 @@ const rawDocMalformedRevisionStorage = `
     }`
 
 func TestMalformedRevisionStorageRecovery(t *testing.T) {
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {channel(doc.channels);}`)
@@ -822,8 +815,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 func BenchmarkDatabaseGet1xRev(b *testing.B) {
 	defer base.DisableTestLogging()()
 
-	db, testBucket := setupTestDB(b)
-	defer testBucket.Close()
+	db := setupTestDB(b)
 	defer db.Close()
 
 	body := Body{"foo": "bar", "rev": "1-a"}
@@ -879,8 +871,7 @@ func BenchmarkDatabaseGet1xRev(b *testing.B) {
 func BenchmarkDatabaseGetRev(b *testing.B) {
 	defer base.DisableTestLogging()()
 
-	db, testBucket := setupTestDB(b)
-	defer testBucket.Close()
+	db := setupTestDB(b)
 	defer db.Close()
 
 	body := Body{"foo": "bar", "rev": "1-a"}
@@ -937,8 +928,7 @@ func BenchmarkDatabaseGetRev(b *testing.B) {
 func BenchmarkHandleRevDelta(b *testing.B) {
 	defer base.DisableTestLogging()()
 
-	db, testBucket := setupTestDB(b)
-	defer testBucket.Close()
+	db := setupTestDB(b)
 	defer db.Close()
 
 	body := Body{"foo": "bar"}
@@ -985,11 +975,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 }
 
 func TestGetAvailableRevAttachments(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
-	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
 	db, err := CreateDatabase(context)
@@ -1029,11 +1015,7 @@ func TestGetAvailableRevAttachments(t *testing.T) {
 }
 
 func TestGet1xRevAndChannels(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
-	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
 	db, err := CreateDatabase(context)
@@ -1096,11 +1078,7 @@ func TestGet1xRevAndChannels(t *testing.T) {
 }
 
 func TestGet1xRevFromDoc(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
-
-	context, err := NewDatabaseContext("db", bucket, false, DatabaseContextOptions{})
+	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	defer context.Close()
 	db, err := CreateDatabase(context)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1683,7 +1683,7 @@ func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
 			}
 			AddOptionsFromEnvironmentVariables(&options)
 
-			context, err := NewDatabaseContext("db", testBucket.Bucket, false, options)
+			context, err := NewDatabaseContext("db", testBucket, false, options)
 			assert.Error(t, err, "Couldn't create context for database 'db'")
 			assert.Contains(t, err.Error(), tc.expectedError)
 			assert.Nil(t, context, "Database context shouldn't be created")
@@ -1694,7 +1694,6 @@ func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
 }
 
 func TestNewDatabaseContextWithOIDCProviderOptions(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
 	tests := []struct {
 		name          string
 		inputOptions  *auth.OIDCOptions
@@ -1736,8 +1735,9 @@ func TestNewDatabaseContextWithOIDCProviderOptions(t *testing.T) {
 				OIDCOptions: tc.inputOptions,
 			}
 			AddOptionsFromEnvironmentVariables(&options)
-			context, err := NewDatabaseContext("db", testBucket.Bucket, false, options)
+			context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, options)
 			assert.NoError(t, err, "Couldn't create context for database 'db'")
+			defer context.Close()
 			assert.NotNil(t, context, "Database context should be created")
 
 			database, err := CreateDatabase(context)
@@ -1745,7 +1745,6 @@ func TestNewDatabaseContextWithOIDCProviderOptions(t *testing.T) {
 			assert.NoError(t, err, "Couldn't create database 'db'")
 		})
 	}
-	testBucket.Close()
 }
 
 func TestGetOIDCProvider(t *testing.T) {

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -20,8 +20,7 @@ func TestQueryChannelsStatsView(t *testing.T) {
 		t.Skip("This test is Walrus and UseViews=true only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// docID -> Sequence
@@ -72,8 +71,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 		t.Skip("This test is Couchbase Server only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// docID -> Sequence
@@ -120,8 +118,7 @@ func TestQueryChannelsStatsN1ql(t *testing.T) {
 // Validate query and stats for sequence view query
 func TestQuerySequencesStatsView(t *testing.T) {
 
-	db, testBucket := setupTestDBWithViewsEnabled(t)
-	defer testBucket.Close()
+	db := setupTestDBWithViewsEnabled(t)
 	defer db.Close()
 
 	// docID -> Sequence
@@ -217,8 +214,7 @@ func TestQuerySequencesStatsN1ql(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// docID -> Sequence
@@ -314,11 +310,10 @@ func TestCoveringQueries(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(testBucket)
+	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
 	if !ok {
 		t.Errorf("Unable to get gocbBucket for testBucket")
 	}
@@ -369,8 +364,7 @@ func TestAllDocsQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// Add docs with channel assignment
@@ -432,8 +426,7 @@ func TestAccessQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
@@ -483,8 +476,7 @@ func TestRoleAccessQuery(t *testing.T) {
 		t.Skip("This test is Couchbase Server only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc, oldDoc) {
@@ -575,9 +567,8 @@ func TestQueryChannelsActiveOnlyWithLimit(t *testing.T) {
 		t.Skip("This test is Couchbase Server and UseViews=false only")
 	}
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
-	defer tearDownTestDB(t, db)
+	db := setupTestDB(t)
+	defer db.Close()
 
 	docIdFlagMap := make(map[string]uint8)
 	var startSeq, endSeq uint64

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -16,11 +16,10 @@ const (
 	docIdProblematicRevTree2 = "docIdProblematicRevTree2"
 )
 
-func testBucketWithViewsAndBrokenDoc(t testing.TB) (tBucket *base.TestBucket, numDocs int) {
+func testBucketWithViewsAndBrokenDoc(t testing.TB) (bucket *base.TestBucket, numDocs int) {
 
 	numDocsAdded := 0
-	tBucket = base.GetTestBucket(t)
-	bucket := tBucket.Bucket
+	bucket = base.GetTestBucket(t)
 
 	err := installViews(bucket)
 	require.NoError(t, err)
@@ -51,7 +50,7 @@ func testBucketWithViewsAndBrokenDoc(t testing.TB) (tBucket *base.TestBucket, nu
 	require.NoError(t, err)
 	numDocsAdded++
 
-	return tBucket, numDocsAdded
+	return bucket, numDocsAdded
 
 }
 

--- a/db/repair_bucket_test.go
+++ b/db/repair_bucket_test.go
@@ -62,9 +62,8 @@ func TestRepairBucket(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
-	testBucket, numDocs := testBucketWithViewsAndBrokenDoc(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket, numDocs := testBucketWithViewsAndBrokenDoc(t)
+	defer bucket.Close()
 
 	repairJob := func(docId string, originalCBDoc []byte) (transformedCBDoc []byte, transformed bool, err error) {
 		log.Printf("repairJob called back")
@@ -94,9 +93,8 @@ func TestRepairBucketRevTreeCycles(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
-	testBucket, _ := testBucketWithViewsAndBrokenDoc(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket, _ := testBucketWithViewsAndBrokenDoc(t)
+	defer bucket.Close()
 
 	repairBucket := NewRepairBucket(bucket)
 
@@ -144,9 +142,8 @@ func TestRepairBucketDryRun(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCRUD)()
 
-	testBucket, _ := testBucketWithViewsAndBrokenDoc(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket, _ := testBucketWithViewsAndBrokenDoc(t)
+	defer bucket.Close()
 
 	repairBucket := NewRepairBucket(bucket)
 

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -167,8 +167,7 @@ func TestBackingStore(t *testing.T) {
 // Ensure internal properties aren't being incorrectly stored in revision cache
 func TestRevisionCacheInternalProperties(t *testing.T) {
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	// Invalid _revisions property will be stripped.  Should also not be present in the rev cache.
@@ -181,7 +180,7 @@ func TestRevisionCacheInternalProperties(t *testing.T) {
 
 	// Get the raw document directly from the bucket, validate _revisions property isn't found
 	var bucketBody Body
-	_, err = testBucket.Bucket.Get("doc1", &bucketBody)
+	_, err = db.Bucket.Get("doc1", &bucketBody)
 	require.NoError(t, err)
 	_, ok := bucketBody[BodyRevisions]
 	if ok {
@@ -216,8 +215,7 @@ func TestBypassRevisionCache(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	docBody := Body{
@@ -278,8 +276,7 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	rev1body := Body{
@@ -292,7 +289,7 @@ func TestPutRevisionCacheAttachmentProperty(t *testing.T) {
 
 	// Get the raw document directly from the bucket, validate _attachments property isn't found
 	var bucketBody Body
-	_, err = testBucket.Bucket.Get(rev1key, &bucketBody)
+	_, err = db.Bucket.Get(rev1key, &bucketBody)
 	assert.NoError(t, err, "Unexpected error calling bucket.Get")
 	_, ok := bucketBody[BodyAttachments]
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)
@@ -320,8 +317,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
-	db, testBucket := setupTestDB(t)
-	defer testBucket.Close()
+	db := setupTestDB(t)
 	defer db.Close()
 
 	docKey := "doc1"
@@ -341,7 +337,7 @@ func TestPutExistingRevRevisionCacheAttachmentProperty(t *testing.T) {
 
 	// Get the raw document directly from the bucket, validate _attachments property isn't found
 	var bucketBody Body
-	_, err = testBucket.Bucket.Get(docKey, &bucketBody)
+	_, err = db.Bucket.Get(docKey, &bucketBody)
 	assert.NoError(t, err, "Unexpected error calling bucket.Get")
 	_, ok := bucketBody[BodyAttachments]
 	assert.False(t, ok, "_attachments property still present in document body retrieved from bucket: %#v", bucketBody)

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestSequenceAllocator(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+
 	testStats := new(expvar.Map).Init()
 
 	// Create a sequence allocator without using constructor, to test without a releaseSequenceMonitor
@@ -77,9 +77,9 @@ func TestSequenceAllocator(t *testing.T) {
 
 func TestReleaseSequencesOnStop(t *testing.T) {
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := testBucket.Bucket
+	bucket := base.GetTestBucket(t)
+	defer bucket.Close()
+
 	testStats := new(expvar.Map).Init()
 
 	oldFrequency := MaxSequenceIncrFrequency
@@ -150,9 +150,8 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 		}
 	}
 
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	bucket := base.NewLeakyBucket(testBucket.Bucket, base.LeakyBucketConfig{IncrCallback: incrCallback})
+	bucket := base.NewLeakyBucket(base.GetTestBucket(t), base.LeakyBucketConfig{IncrCallback: incrCallback})
+	defer bucket.Close()
 
 	testStats := new(expvar.Map).Init()
 

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -16,9 +16,8 @@ func TestReplicateManagerReplications(t *testing.T) {
 
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
 
-	testCfg, err := base.NewCfgSG(bucket)
+	testCfg, err := base.NewCfgSG(testBucket)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
@@ -79,9 +78,8 @@ func TestReplicateManagerNodes(t *testing.T) {
 
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
 
-	testCfg, err := base.NewCfgSG(bucket)
+	testCfg, err := base.NewCfgSG(testBucket)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
@@ -134,9 +132,8 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
 
-	testCfg, err := base.NewCfgSG(bucket)
+	testCfg, err := base.NewCfgSG(testBucket)
 	require.NoError(t, err)
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
@@ -177,9 +174,8 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	bucket := testBucket.Bucket
 
-	testCfg, err := base.NewCfgSG(bucket)
+	testCfg, err := base.NewCfgSG(testBucket)
 	require.NoError(t, err)
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -143,7 +143,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -178,7 +178,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -558,7 +558,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -593,7 +593,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -650,7 +650,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -667,7 +667,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -1044,7 +1044,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -1061,7 +1061,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -1138,7 +1138,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -1170,7 +1170,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -1237,7 +1237,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
@@ -1269,7 +1269,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 
 	// Active
 	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
+
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb1,
 	})
@@ -1387,7 +1387,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			// Passive
 			tb2 := base.GetTestBucket(t)
-			defer tb2.Close()
+
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: tb2,
 				DatabaseConfig: &DbConfig{
@@ -1422,7 +1422,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			// Active
 			tb1 := base.GetTestBucket(t)
-			defer tb1.Close()
+
 			rt1 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: tb1,
 			})
@@ -1575,10 +1575,8 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD)()
 
 			// Passive
-			tb2 := base.GetTestBucket(t)
-			defer tb2.Close()
 			rt2 := NewRestTester(t, &RestTesterConfig{
-				TestBucket: tb2,
+				TestBucket: base.GetTestBucket(t),
 				DatabaseConfig: &DbConfig{
 					Users: map[string]*db.PrincipalConfig{
 						"alice": {
@@ -1610,10 +1608,8 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 			passiveDBURL.User = url.UserPassword("alice", "pass")
 
 			// Active
-			tb1 := base.GetTestBucket(t)
-			defer tb1.Close()
 			rt1 := NewRestTester(t, &RestTesterConfig{
-				TestBucket: tb1,
+				TestBucket: base.GetTestBucket(t),
 			})
 			defer rt1.Close()
 
@@ -1730,10 +1726,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
 				"alice": {
@@ -1747,10 +1741,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 	defer rt1.Close()
 
@@ -1810,10 +1802,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
 				"alice": {
@@ -1827,10 +1817,8 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 	defer rt1.Close()
 
@@ -1880,9 +1868,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
 				"alice": {
@@ -1912,9 +1899,8 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 
 	arConfig := db.ActiveReplicatorConfig{
@@ -2203,9 +2189,8 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
 				"alice": {
@@ -2228,9 +2213,8 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 	defer rt1.Close()
 
@@ -2349,9 +2333,8 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
 				"alice": {
@@ -2374,9 +2357,8 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 
 	// Active
-	tb1 := base.GetTestBucket(t)
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 	defer rt1.Close()
 
@@ -2456,10 +2438,8 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
 
 	// Passive
-	tb2 := base.GetTestBucket(t)
-	defer tb2.Close()
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb2,
+		TestBucket: base.GetTestBucket(t),
 		DatabaseConfig: &DbConfig{
 			AllowConflicts: base.BoolPtr(false),
 			Users: map[string]*db.PrincipalConfig{
@@ -2474,10 +2454,8 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	defer rt2.Close()
 
 	// Active
-	tb1 := base.GetTestBucket(t)
-	defer tb1.Close()
 	rt1 := NewRestTester(t, &RestTesterConfig{
-		TestBucket: tb1,
+		TestBucket: base.GetTestBucket(t),
 	})
 	defer rt1.Close()
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -232,12 +232,12 @@ func (rt *RestTester) Close() {
 	if rt.tb == nil {
 		panic("RestTester not properly initialized please use NewRestTester function")
 	}
+	if rt.RestTesterServerContext != nil {
+		rt.RestTesterServerContext.Close()
+	}
 	if rt.testBucket != nil {
 		rt.testBucket.Close()
 		rt.testBucket = nil
-	}
-	if rt.RestTesterServerContext != nil {
-		rt.RestTesterServerContext.Close()
 	}
 }
 


### PR DESCRIPTION
Avoids the incorrect order of closing a bucket before dbContext, which is causing problems for tests in #4707 

- Make most tests rely on dbContext close to close the bucket. Simplified some util functions to only return database, to avoid future accidental bucket close.
- For tests that explicitly create a test bucket, and then add a database from config using bucketspec, both still require closing.
- Added handling in TestBucketPool to log warnings for each test that doesn't close all buckets.