### PR TITLE
CBG-1011 Use replicationID instead of configHash in checkpoint keys

### DIFF
--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -159,14 +159,14 @@ func (apr *ActivePushReplicator) _stop() error {
 }
 
 func (apr *ActivePushReplicator) _initCheckpointer() error {
-	checkpointID, err := apr.CheckpointID()
-	if err != nil {
-		return err
+
+	checkpointHash, hashErr := apr.config.CheckpointHash()
+	if hashErr != nil {
+		return hashErr
 	}
+	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, apr.CheckpointID(), checkpointHash, apr.blipSender, apr.config.ActiveDB, apr.config.CheckpointInterval)
 
-	apr.Checkpointer = NewCheckpointer(apr.checkpointerCtx, checkpointID, apr.blipSender, apr.config.ActiveDB, apr.config.CheckpointInterval)
-
-	err = apr.Checkpointer.fetchCheckpoints()
+	err := apr.Checkpointer.fetchCheckpoints()
 	if err != nil {
 		return err
 	}
@@ -178,12 +178,8 @@ func (apr *ActivePushReplicator) _initCheckpointer() error {
 }
 
 // CheckpointID returns a unique ID to be used for the checkpoint client (which is used as part of the checkpoint Doc ID on the recipient)
-func (apr *ActivePushReplicator) CheckpointID() (string, error) {
-	checkpointHash, err := apr.config.CheckpointHash()
-	if err != nil {
-		return "", err
-	}
-	return "sgr2cp:push:" + checkpointHash, nil
+func (apr *ActivePushReplicator) CheckpointID() string {
+	return "sgr2cp:push:" + apr.config.ID
 }
 
 // reset performs a reset on the replication by removing the local checkpoint document.
@@ -191,11 +187,7 @@ func (apr *ActivePushReplicator) reset() error {
 	if apr.state != ReplicationStateStopped {
 		return fmt.Errorf("reset invoked for replication %s when the replication was not stopped", apr.config.ID)
 	}
-	checkpointID, err := apr.CheckpointID()
-	if err != nil {
-		return err
-	}
-	return resetLocalCheckpoint(apr.config.ActiveDB, checkpointID)
+	return resetLocalCheckpoint(apr.config.ActiveDB, apr.CheckpointID())
 }
 
 // registerCheckpointerCallbacks registers appropriate callback functions for checkpointing.

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -62,16 +62,11 @@ func (rq *SubChangesRequest) marshalBLIPRequest() (*blip.Message, error) {
 	return msg, nil
 }
 
-// SGR2CheckpointDoc is the body of the checkpoint stored in the bucket.
-type SGR2CheckpointDoc struct {
-	LastSequence string `json:"last_sequence,omitempty"`
-}
-
 // SetSGR2CheckpointRequest is a strongly typed 'setCheckpoint' request for SG-Replicate 2.
 type SetSGR2CheckpointRequest struct {
-	Client     string            // Client is the unique ID of client checkpoint to retrieve
-	RevID      *string           // RevID of the previous checkpoint, if known.
-	Checkpoint SGR2CheckpointDoc // Checkpoint is the actual checkpoint we're sending.
+	Client     string  // Client is the unique ID of client checkpoint to retrieve
+	RevID      *string // RevID of the previous checkpoint, if known.
+	Checkpoint Body    // Checkpoint is the actual checkpoint body we're sending.
 
 	msg *blip.Message
 }
@@ -165,8 +160,8 @@ func (rq *GetSGR2CheckpointRequest) marshalBLIPRequest() *blip.Message {
 }
 
 type SGR2Checkpoint struct {
-	RevID   string // The RevID of the checkpoint.
-	LastSeq string // The last_sequence of the checkpoint.
+	RevID string // The RevID of the checkpoint.
+	Body  Body   // The checkpoint body
 }
 
 func (rq *GetSGR2CheckpointRequest) Response() (*SGR2Checkpoint, error) {
@@ -187,13 +182,13 @@ func (rq *GetSGR2CheckpointRequest) Response() (*SGR2Checkpoint, error) {
 		return nil, fmt.Errorf("unknown response type: %v - %s", respMsg.Type(), respBody)
 	}
 
-	var c SGR2CheckpointDoc
-	if err := respMsg.ReadJSONBody(&c); err != nil {
+	var checkpointBody Body
+	if err := respMsg.ReadJSONBody(&checkpointBody); err != nil {
 		return nil, err
 	}
 
 	return &SGR2Checkpoint{
-		RevID:   respMsg.Properties[GetCheckpointResponseRev],
-		LastSeq: c.LastSequence,
+		RevID: respMsg.Properties[GetCheckpointResponseRev],
+		Body:  checkpointBody,
 	}, nil
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -30,6 +30,20 @@ const (
 	ReplicationStateError     = "error"
 )
 
+// Replication config validation error messages
+const (
+	ConfigErrorIDTooLong            = "Replication ID must be less than 200 characters"
+	ConfigErrorUnknownFilter        = "Unknown replication filter; try sync_gateway/bychannel"
+	ConfigErrorMissingQueryParams   = "Replication specifies sync_gateway/bychannel filter but is missing query_params"
+	ConfigErrorMissingRemote        = "Replication remote must be specified"
+	ConfigErrorMissingDirection     = "Replication direction must be specified"
+	ConfigErrorDuplicateCredentials = "Auth credentials can be specified using username/password config properties or remote URL, but not both"
+	ConfigErrorConfigBasedAdhoc     = "adhoc=true is invalid for replication in Sync Gateway configuration"
+	ConfigErrorConfigBasedCancel    = "cancel=true is invalid for replication in Sync Gateway configuration"
+	ConfigErrorInvalidDirectionFmt  = "Invalid replication direction %q, valid values are %s/%s/%s"
+	ConfigErrorBadChannelsArray     = "Bad channels array in query_params for sync_gateway/bychannel filter"
+)
+
 // ClusterUpdateFunc is callback signature used when updating the cluster configuration
 type ClusterUpdateFunc func(cluster *SGRCluster) (cancel bool, err error)
 
@@ -123,15 +137,19 @@ type ReplicationUpsertConfig struct {
 
 func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 
+	if len(rc.ID) > 200 {
+		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorIDTooLong)
+	}
+
 	// Cancel is only supported via the REST API
 	if rc.Cancel && fromConfig {
-		return base.HTTPErrorf(http.StatusBadRequest, "cancel=true is invalid for replication in Sync Gateway configuration")
+		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorConfigBasedCancel)
 	}
 
 	if rc.Adhoc {
 		// Adhoc is only supported via the REST API
 		if fromConfig {
-			return base.HTTPErrorf(http.StatusBadRequest, "adhoc=true is invalid for replication in Sync Gateway configuration")
+			return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorConfigBasedAdhoc)
 		}
 
 		if rc.State == ReplicationStateStopped {
@@ -140,7 +158,7 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 	}
 
 	if rc.Remote == "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote must be specified.")
+		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorMissingRemote)
 	}
 
 	remoteURL, err := url.Parse(rc.Remote)
@@ -151,21 +169,21 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 
 	if (remoteURL != nil && remoteURL.User.Username() != "") && rc.Username != "" {
 		return base.HTTPErrorf(http.StatusBadRequest,
-			"Auth credentials can be specified either in replication config or remote URL but not allowed in both")
+			ConfigErrorDuplicateCredentials)
 	}
 
 	if rc.Direction == "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "Replication direction must be specified")
+		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorMissingDirection)
 	}
 
 	if !rc.Direction.IsValid() {
-		return base.HTTPErrorf(http.StatusBadRequest, "Invalid replication direction %q, valid values are %s/%s/%s",
+		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorInvalidDirectionFmt,
 			rc.Direction, ActiveReplicatorTypePush, ActiveReplicatorTypePull, ActiveReplicatorTypePushAndPull)
 	}
 
 	if rc.Filter == base.ByChannelFilter {
 		if rc.QueryParams == nil {
-			return base.HTTPErrorf(http.StatusBadRequest, "Replication specifies sync_gateway/bychannel filter but is missing query_params")
+			return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorMissingQueryParams)
 		}
 
 		_, invalidChannelsErr := ChannelsFromQueryParams(rc.QueryParams)
@@ -174,7 +192,7 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 		}
 
 	} else if rc.Filter != "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "Unknown replication filter; try sync_gateway/bychannel")
+		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorUnknownFilter)
 	}
 	return nil
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -32,7 +32,7 @@ const (
 
 // Replication config validation error messages
 const (
-	ConfigErrorIDTooLong            = "Replication ID must be less than 200 characters"
+	ConfigErrorIDTooLong            = "Replication ID must be less than 160 characters"
 	ConfigErrorUnknownFilter        = "Unknown replication filter; try sync_gateway/bychannel"
 	ConfigErrorMissingQueryParams   = "Replication specifies sync_gateway/bychannel filter but is missing query_params"
 	ConfigErrorMissingRemote        = "Replication remote must be specified"
@@ -137,7 +137,10 @@ type ReplicationUpsertConfig struct {
 
 func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 
-	if len(rc.ID) > 200 {
+	// Checkpoint keys are prefixed with 35 characters:  _sync:local:checkpoint/sgr2cp:pull:
+	// Setting length limit for replication ID to 160 characters to retain some room for future
+	// key-related enhancements
+	if len(rc.ID) > 160 {
 		return base.HTTPErrorf(http.StatusBadRequest, ConfigErrorIDTooLong)
 	}
 

--- a/db/sg_replicate_util.go
+++ b/db/sg_replicate_util.go
@@ -21,7 +21,7 @@ func ChannelsFromQueryParams(queryParams interface{}) (channels []string, err er
 	} else if chanarray, ok = queryParams.([]interface{}); ok {
 		// query params is an array and chanarray has been set, now drop out of if-then-else for processing
 	} else {
-		return nil, base.HTTPErrorf(http.StatusBadRequest, "Bad channels array in query_params for sync_gateway/bychannel filter")
+		return nil, base.HTTPErrorf(http.StatusBadRequest, ConfigErrorBadChannelsArray)
 	}
 	if len(chanarray) > 0 {
 		channels = make([]string, len(chanarray))

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1081,6 +1081,8 @@ func TestValidateReplication(t *testing.T) {
 					Message: tc.expectedErrorMsg,
 				}
 				assert.Equal(t, expectedError, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2261,7 +2261,6 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
 	cID := ar.Push.CheckpointID()
-	require.NoError(t, err)
 	checkpointDocID := base.SyncPrefix + "local:checkpoint/" + cID
 
 	firstCheckpoint, _, err := rt2.Bucket().GetRaw(checkpointDocID)
@@ -2382,7 +2381,6 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 	assert.NoError(t, ar.Start())
 
 	pushCheckpointID := ar.Push.CheckpointID()
-	require.NoError(t, err)
 	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
 	err = rt2.Bucket().SetRaw(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
 	require.NoError(t, err)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2260,7 +2260,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	ar.Push.Checkpointer.CheckpointNow()
 	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 
-	cID, err := ar.Push.CheckpointID()
+	cID := ar.Push.CheckpointID()
 	require.NoError(t, err)
 	checkpointDocID := base.SyncPrefix + "local:checkpoint/" + cID
 
@@ -2381,13 +2381,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 	assert.NoError(t, ar.Start())
 
-	pushCheckpointID, err := ar.Push.CheckpointID()
+	pushCheckpointID := ar.Push.CheckpointID()
 	require.NoError(t, err)
 	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
 	err = rt2.Bucket().SetRaw(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
 	require.NoError(t, err)
 
-	pullCheckpointID, err := ar.Pull.CheckpointID()
+	pullCheckpointID := ar.Pull.CheckpointID()
 	require.NoError(t, err)
 	pullCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pullCheckpointID
 	err = rt1.Bucket().SetRaw(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))


### PR DESCRIPTION
Modifies checkpoint key format to be based on replicationID instead of configHash.  Includes the following changes (left as separate commits for review):
- enforce max length of 200 for replicationIDs
- store configHash in checkpoint 
- reset replication checkpoint if configHash doesn't match on checkpointer init