### PR TITLE
CBG-977 - Tweak logging levels for SGCluster/sg-replicate/import logging

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -420,7 +420,7 @@ func (l *importHeartbeatListener) Name() string {
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
 func (l *importHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
 
-	Debugf(KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
+	Infof(KeyCluster, "StaleHeartbeatDetected by import listener for node: %v", nodeUUID)
 	err := cbgt.UnregisterNodes(l.cfg, l.mgrVersion, []string{nodeUUID})
 	if err != nil {
 		Warnf("Attempt to unregister %v from CBGT got error: %v", nodeUUID, err)

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -432,7 +432,7 @@ func (dh *documentBackedListener) updateNodeList(nodeID string, remove bool) err
 			dh.nodeIDs = append(dh.nodeIDs, nodeID)
 		}
 
-		Tracef(KeyCluster, "Updating nodeList document (%s) with node IDs: %v", dh.nodeListKey, dh.nodeIDs)
+		Infof(KeyCluster, "Updating nodeList document (%s) with node IDs: %v", dh.nodeListKey, dh.nodeIDs)
 
 		casOut, err := dh.bucket.WriteCas(dh.nodeListKey, 0, 0, dh.cas, dh.nodeIDs, 0)
 

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -50,7 +50,7 @@ func sgCfgBucketKey(cfgKey string) string {
 func (c *CfgSG) Get(cfgKey string, cas uint64) (
 	[]byte, uint64, error) {
 
-	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: Get, key: %s, cas: %d", cfgKey, cas)
+	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Get, key: %s, cas: %d", cfgKey, cas)
 	bucketKey := sgCfgBucketKey(cfgKey)
 	var value []byte
 	casOut, err := c.bucket.Get(bucketKey, &value)
@@ -69,7 +69,7 @@ func (c *CfgSG) Get(cfgKey string, cas uint64) (
 
 func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 
-	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: Set, key: %s, cas: %d", cfgKey, cas)
+	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Set, key: %s, cas: %d", cfgKey, cas)
 	var err error
 	bucketKey := sgCfgBucketKey(cfgKey)
 
@@ -88,7 +88,7 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 
 func (c *CfgSG) Del(cfgKey string, cas uint64) error {
 
-	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: Del, key: %s, cas: %d", cfgKey, cas)
+	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Del, key: %s, cas: %d", cfgKey, cas)
 	bucketKey := sgCfgBucketKey(cfgKey)
 	_, err := c.bucket.Remove(bucketKey, cas)
 	if IsCasMismatch(err) {
@@ -102,7 +102,7 @@ func (c *CfgSG) Del(cfgKey string, cas uint64) error {
 
 func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 
-	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: Subscribe, key: %s", cfgKey)
+	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Subscribe, key: %s", cfgKey)
 	c.lock.Lock()
 	a, exists := c.subscriptions[cfgKey]
 	if !exists || a == nil {
@@ -119,7 +119,7 @@ func (c *CfgSG) FireEvent(docID string, cas uint64, err error) {
 
 	cfgKey := strings.TrimPrefix(docID, SGCfgPrefix)
 	c.lock.Lock()
-	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: FireEvent, key: %s, cas %d", cfgKey, cas)
+	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: FireEvent, key: %s, cas %d", cfgKey, cas)
 	for _, ch := range c.subscriptions[cfgKey] {
 		go func(ch chan<- cbgt.CfgEvent) {
 			ch <- cbgt.CfgEvent{
@@ -132,7 +132,7 @@ func (c *CfgSG) FireEvent(docID string, cas uint64, err error) {
 
 func (c *CfgSG) Refresh() error {
 
-	InfofCtx(c.loggingCtx, KeyCluster, "cfg_sg: Refresh")
+	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Refresh")
 	c.lock.Lock()
 	for cfgKey, cs := range c.subscriptions {
 		event := cbgt.CfgEvent{Key: cfgKey}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1207,7 +1207,7 @@ func (l *ReplicationHeartbeatListener) Name() string {
 // When we detect other nodes have stopped pushing heartbeats, use manager to remove from cfg
 func (l *ReplicationHeartbeatListener) StaleHeartbeatDetected(nodeUUID string) {
 
-	base.Debugf(base.KeyCluster, "StaleHeartbeatDetected by sg-replicate listener for node: %v", nodeUUID)
+	base.Infof(base.KeyCluster, "StaleHeartbeatDetected by sg-replicate listener for node: %v", nodeUUID)
 	err := l.mgr.RemoveNode(nodeUUID)
 	if err != nil {
 		base.Warnf("Attempt to remove node %v from sg-replicate cfg got error: %v", nodeUUID, err)


### PR DESCRIPTION
- Raised Stale heartbeat detection logging to info, the same as replication rebalance logging.
- Lowered happy-path CRUD style cfgSG logging to debug.
- Kept DCP logging as-is, because of the limitations of current CBGT log levels.

Example:

```
2020-08-17T14:07:06.060+01:00 [DBG] SGCluster+: Checking heartbeats for node set: [51e41c2994ba1bc4 61dfbf695127f0b6]
2020-08-17T14:07:08.060+01:00 [DBG] SGCluster+: Checking heartbeats for node set: [51e41c2994ba1bc4 61dfbf695127f0b6]
2020-08-17T14:07:08.068+01:00 [INF] SGCluster: StaleHeartbeatDetected by sg-replicate listener for node: 61dfbf695127f0b6
2020-08-17T14:07:08.068+01:00 [DBG] SGCluster+: c:db2-cfgSG cfg_sg: Get, key: sgrCluster, cas: 0
2020-08-17T14:07:08.071+01:00 [DBG] Replicate+: c:sgr-mgr-db2 Initiating replication rebalance.  Nodes: 1  Replications: 0
2020-08-17T14:07:08.071+01:00 [DBG] Replicate+: c:sgr-mgr-db2 Replication rebalance complete, persistence is pending...
2020-08-17T14:07:08.071+01:00 [DBG] SGCluster+: c:db2-cfgSG cfg_sg: Set, key: sgrCluster, cas: 1597669591878008832
2020-08-17T14:07:08.074+01:00 [DBG] Replicate+: c:sgr-mgr-db2 Successfully persisted sg-replicate cluster definition.
2020-08-17T14:07:08.076+01:00 [DBG] SGCluster+: c:db2-cfgSG cfg_sg: FireEvent, key: sgrCluster, cas 1597669627999682560
2020-08-17T14:07:08.076+01:00 [INF] SGCluster: Replication definitions changed - refreshing...
2020-08-17T14:07:08.076+01:00 [DBG] SGCluster+: c:db2-cfgSG cfg_sg: Get, key: sgrCluster, cas: 0
2020-08-17T14:07:08.077+01:00 [DBG] SGCluster+: c:db2-cfgSG cfg_sg: Get, key: sgrCluster, cas: 0
```