### PR TITLE
Rename TestRemoveObsoleteIndexOnFail test to TestRemoveObsoleteIndexOnError

### DIFF
--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -220,7 +220,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 	assert.NoError(t, validateErr, "Error validating indexes online")
 }
 
-func TestRemoveObsoleteIndexOnFail(t *testing.T) {
+func TestRemoveObsoleteIndexOnError(t *testing.T) {
 
 	if base.TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")


### PR DESCRIPTION
Minor change, but prevents this test appearing in case-insensitive searches for `FAIL:` when looking at Go test output.

> === RUN   TestRemoveObsoleteIndexOnFail
>     TestRemoveObsoleteIndexOn**Fail:** indexes_test.go:226: This test only works with Couchbase Server and UseViews=false