### PR TITLE
CBG-1000 Wait for remote sequence allocation on cache start

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -193,22 +193,16 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 	return nil
 }
 
-func (c *changeCache) Start() error {
+func (c *changeCache) Start(initialSequence uint64) error {
 
 	// Unlock the cache after this function returns.
 	defer c.lock.Unlock()
 
-	// Find the current global doc sequence and use that for the initial sequence for the change cache
-	lastSequence, err := c.context.LastSequence()
-	if err != nil {
-		return err
-	}
-
 	// Set initial sequence for sequence buffering
-	c._setInitialSequence(lastSequence)
+	c._setInitialSequence(initialSequence)
 
 	// Set initial sequence for cache (validFrom)
-	c.channelCache.Init(lastSequence)
+	c.channelCache.Init(initialSequence)
 
 	return nil
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -1977,7 +1977,7 @@ func BenchmarkProcessEntry(b *testing.B) {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}
-			if err := changeCache.Start(); err != nil {
+			if err := changeCache.Start(0); err != nil {
 				log.Printf("Start error for changeCache: %v", err)
 				b.Fail()
 			}
@@ -2202,7 +2202,7 @@ func BenchmarkDocChanged(b *testing.B) {
 				log.Printf("Init failed for changeCache: %v", err)
 				b.Fail()
 			}
-			if err := changeCache.Start(); err != nil {
+			if err := changeCache.Start(0); err != nil {
 				log.Printf("Start error for changeCache: %v", err)
 				b.Fail()
 			}

--- a/db/sequence_allocator.go
+++ b/db/sequence_allocator.go
@@ -259,3 +259,16 @@ func (s *sequenceAllocator) releaseSequenceRange(fromSequence, toSequence uint64
 	base.Debugf(base.KeyCRUD, "Released unused sequences #%d-#%d", fromSequence, toSequence)
 	return nil
 }
+
+// waitForReleasedSequences blocks for 'releaseSequenceWait' past the provided startTime.
+// Used to guarantee assignment of allocated sequences on other nodes.
+func (s *sequenceAllocator) waitForReleasedSequences(startTime time.Time) (waitedFor time.Duration) {
+
+	requiredWait := s.releaseSequenceWait - time.Since(startTime)
+	if requiredWait < 0 {
+		return 0
+	}
+	base.Infof(base.KeyCache, "Waiting %v for sequence allocation...", requiredWait)
+	time.Sleep(requiredWait)
+	return requiredWait
+}


### PR DESCRIPTION
Ensure allocated sequences on remote nodes are used or released prior to cache start