### PR TITLE
CBG-917: Unit tests for internal properties in custom conflict resolver

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1045,7 +1045,7 @@ func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, doc
 	remoteAttachments := remoteDoc.DocAttachments
 
 	// TODO: Make doc expiry (_exp) available over replication.
-	remoteExpiry := remoteDoc.Expiry
+	// remoteExpiry := remoteDoc.Expiry
 
 	localDocBody := localDoc.GetDeepMutableBody()
 	localDocBody[BodyId] = localDoc.ID
@@ -1058,7 +1058,7 @@ func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, doc
 	remoteDocBody[BodyId] = remoteDoc.ID
 	remoteDocBody[BodyRev] = remoteRevID
 	remoteDocBody[BodyAttachments] = remoteAttachments
-	remoteDocBody[BodyExpiry] = remoteExpiry
+	// remoteDocBody[BodyExpiry] = remoteExpiry
 	remoteDocBody[BodyDeleted] = remoteDoc.Deleted
 
 	conflict := Conflict{

--- a/db/crud.go
+++ b/db/crud.go
@@ -838,7 +838,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		}
 
 		// Process the attachments, and populate _sync with metadata. This alters 'body' so it has to
-		// be done before calling createRevID (the ID is based on the digest of the body.)
+		// be done before calling CreateRevID (the ID is based on the digest of the body.)
 		newAttachments, err := db.storeAttachments(doc, newDoc.DocAttachments, generation, matchRev, nil)
 		if err != nil {
 			return nil, nil, nil, err
@@ -1157,7 +1157,7 @@ func (db *Database) resolveDocMerge(localDoc *Document, remoteDoc *Document, con
 
 	remoteRevID := conflict.RemoteDocument.ExtractRev()
 	remoteGeneration, _ := ParseRevID(remoteRevID)
-	mergedRevID, err := createRevID(remoteGeneration+1, remoteRevID, mergedBody)
+	mergedRevID, err := CreateRevID(remoteGeneration+1, remoteRevID, mergedBody)
 	if err != nil {
 		return "", nil, err
 	}

--- a/db/revision.go
+++ b/db/revision.go
@@ -333,7 +333,7 @@ func (body Body) FixJSONNumbers() {
 	}
 }
 
-func createRevID(generation int, parentRevID string, body Body) (string, error) {
+func CreateRevID(generation int, parentRevID string, body Body) (string, error) {
 	// This should produce the same results as TouchDB.
 	strippedBody, _ := stripSpecialProperties(body)
 	encoding, err := base.JSONMarshalCanonical(strippedBody)
@@ -450,6 +450,7 @@ func containsUserSpecialProperties(b Body) bool {
 				BodyDeleted,
 				BodyAttachments,
 				BodyRevisions,
+				BodyExpiry,
 			}, k) {
 			// body contains special property that isn't one of the above... must be user's
 			return true

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3103,11 +3103,15 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 		expectedLocalRevID string
 	}{
 		{
-			name:               "mergeReadWriteIntlProps",
-			localRevisionBody:  db.Body{"source": "local"},
-			localRevID:         "1-a",
-			remoteRevisionBody: db.Body{"source": "remote"},
-			remoteRevID:        "1-b",
+			name: "mergeReadWriteIntlProps",
+			localRevisionBody: db.Body{
+				"source": "local",
+			},
+			localRevID: "1-a",
+			remoteRevisionBody: db.Body{
+				"source": "remote",
+			},
+			remoteRevID: "1-b",
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -3115,15 +3119,15 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				mergedDoc.remoteRevId = conflict.RemoteDocument._rev;
 				mergedDoc.localDocId = conflict.LocalDocument._id;
 				mergedDoc.localRevId = conflict.LocalDocument._rev;
-                mergedDoc._id = "foo";
-                mergedDoc._rev = "2-c";
-                mergedDoc._exp = 100;
+				mergedDoc._id = "foo";
+				mergedDoc._rev = "2-c";
+				mergedDoc._exp = 100;
 				return mergedDoc;
 			}`,
 			expectedLocalBody: db.Body{
-				"_id":         "foo",
-				"_rev":        "2-c",
-				"_exp":        json.Number("100"),
+				db.BodyId:     "foo",
+				db.BodyRev:    "2-c",
+				db.BodyExpiry: json.Number("100"),
 				"localDocId":  "mergeReadWriteIntlProps",
 				"localRevId":  "1-a",
 				"remoteDocId": "mergeReadWriteIntlProps",
@@ -3131,9 +3135,9 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				"source":      "merged",
 			},
 			expectedLocalRevID: createRevID(2, "1-b", db.Body{
-				"_id":         "foo",
-				"_rev":        "2-c",
-				"_exp":        json.Number("100"),
+				db.BodyId:     "foo",
+				db.BodyRev:    "2-c",
+				db.BodyExpiry: json.Number("100"),
 				"localDocId":  "mergeReadWriteIntlProps",
 				"localRevId":  "1-a",
 				"remoteDocId": "mergeReadWriteIntlProps",
@@ -3144,13 +3148,19 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 		{
 			name: "mergeReadWriteAttachments",
 			localRevisionBody: map[string]interface{}{
-				"_attachments": map[string]interface{}{"A": map[string]interface{}{"data": "QQo="}},
-				"source":       "local",
+				db.BodyAttachments: map[string]interface{}{
+					"A": map[string]interface{}{
+						"data": "QQo=",
+					}},
+				"source": "local",
 			},
 			localRevID: "1-a",
 			remoteRevisionBody: map[string]interface{}{
-				"_attachments": map[string]interface{}{"B": map[string]interface{}{"data": "Qgo="}},
-				"source":       "remote",
+				db.BodyAttachments: map[string]interface{}{
+					"B": map[string]interface{}{
+						"data": "Qgo=",
+					}},
+				"source": "remote",
 			},
 			remoteRevID: "1-b",
 			conflictResolver: `function(conflict) {
@@ -3170,7 +3180,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				return mergedDoc;
 			}`,
 			expectedLocalBody: map[string]interface{}{
-				"_attachments": map[string]interface{}{
+				db.BodyAttachments: map[string]interface{}{
 					"A": map[string]interface{}{
 						"digest": "sha1-fRV9fAAK4n2xRldcCM4w34k9OmQ=",
 						"length": json.Number("2"),
@@ -3187,7 +3197,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				"source": "merged",
 			},
 			expectedLocalRevID: createRevID(2, "1-b", db.Body{
-				"_attachments": map[string]interface{}{
+				db.BodyAttachments: map[string]interface{}{
 					"A": map[string]interface{}{
 						"digest": "sha1-fRV9fAAK4n2xRldcCM4w34k9OmQ=",
 						"length": 2,
@@ -3205,8 +3215,11 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			}),
 		},
 		{
-			name:               "mergeReadIntlPropsLocalExpiry",
-			localRevisionBody:  db.Body{"source": "local", db.BodyExpiry: "2020-08-24T17:08:29-07:00"},
+			name: "mergeReadIntlPropsLocalExpiry",
+			localRevisionBody: db.Body{
+				"source":      "local",
+				db.BodyExpiry: "2020-08-24T17:08:29-07:00",
+			},
 			localRevID:         "1-a",
 			remoteRevisionBody: db.Body{"source": "remote"},
 			remoteRevID:        "1-b",
@@ -3226,11 +3239,16 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			}),
 		},
 		{
-			name:               "mergeWriteIntlPropsLocalExpiry",
-			localRevisionBody:  db.Body{"source": "local", db.BodyExpiry: "2020-08-24T17:08:29-07:00"},
-			localRevID:         "1-a",
-			remoteRevisionBody: db.Body{"source": "remote"},
-			remoteRevID:        "1-b",
+			name: "mergeWriteIntlPropsLocalExpiry",
+			localRevisionBody: db.Body{
+				"source":      "local",
+				db.BodyExpiry: "2020-08-24T17:08:29-07:00",
+			},
+			localRevID: "1-a",
+			remoteRevisionBody: db.Body{
+				"source": "remote",
+			},
+			remoteRevID: "1-b",
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -3247,11 +3265,16 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			}),
 		},
 		{
-			name:               "mergeReadIntlPropsDeletedWithLocalTombstone",
-			localRevisionBody:  db.Body{"source": "local", db.BodyDeleted: true},
-			localRevID:         "1-a",
-			remoteRevisionBody: db.Body{"source": "remote"},
-			remoteRevID:        "1-b",
+			name: "mergeReadIntlPropsDeletedWithLocalTombstone",
+			localRevisionBody: db.Body{
+				"source":       "local",
+				db.BodyDeleted: true,
+			},
+			localRevID: "1-a",
+			remoteRevisionBody: db.Body{
+				"source": "remote",
+			},
+			remoteRevID: "1-b",
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
@@ -3383,7 +3406,6 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 				}
 			}
 			assert.Equal(t, 1, activeCount)
-
 		})
 	}
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3239,7 +3239,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			}),
 		},
 		{
-			name: "mergeWriteIntlPropsLocalExpiry",
+			name: "mergeWriteIntlPropsExpiry",
 			localRevisionBody: db.Body{
 				"source":      "local",
 				db.BodyExpiry: "2020-08-24T17:08:29-07:00",
@@ -3252,15 +3252,15 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 			conflictResolver: `function(conflict) {
 				var mergedDoc = new Object();
 				mergedDoc.source = "merged";
-				mergedDoc.localDocExp = "2021-08-24T17:08:29-07:00";
+				mergedDoc._exp = "2021-08-24T17:08:29-07:00";
 				return mergedDoc;
 			}`,
 			expectedLocalBody: db.Body{
-				"localDocExp": "2021-08-24T17:08:29-07:00",
+				db.BodyExpiry: "2021-08-24T17:08:29-07:00",
 				"source":      "merged",
 			},
 			expectedLocalRevID: createRevID(2, "1-b", db.Body{
-				"localDocExp": "2021-08-24T17:08:29-07:00",
+				db.BodyExpiry: "2021-08-24T17:08:29-07:00",
 				"source":      "merged",
 			}),
 		},


### PR DESCRIPTION
Ensure unit test coverage for custom conflict resolver includes functions that read the internal properties from both localDocument and remoteDocument: