### PR TITLE
CBG-954 - Invoke reconnect loop when BLIP/Websocket connection closes

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -190,7 +190,7 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.
-		if arc.ctx.Err() != nil {
+		if arc.ctx.Err() == nil {
 			go arc.reconnectLoop()
 		}
 	}

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -189,7 +189,10 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 	blipContext := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix)
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
-		go arc.reconnectLoop()
+		// fall into a reconnect loop only if the connection is unexpectedly closed.
+		if arc.ctx.Err() != nil {
+			go arc.reconnectLoop()
+		}
 	}
 
 	bsc = NewBlipSyncContext(blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats)

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -188,6 +188,10 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 
 	blipContext := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix)
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
+	blipContext.OnExitCallback = func() {
+		go arc.reconnectLoop()
+	}
+
 	bsc = NewBlipSyncContext(blipContext, arc.config.ActiveDB, blipContext.ID, arc.replicationStats)
 	bsc.loggingCtx = context.WithValue(context.Background(), base.LogContextKey{},
 		base.LogContext{CorrelationID: arc.config.ID + idSuffix},

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -36,6 +36,7 @@ type activeReplicatorCommon struct {
 	ctx                   context.Context
 	ctxCancel             context.CancelFunc
 	reconnectActive       base.AtomicBool // Tracks whether reconnect goroutine is active
+	replicatorConnectFn   func() error    // the function called inside reconnectLoop.
 }
 
 func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) *activeReplicatorCommon {
@@ -58,8 +59,8 @@ func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveR
 	}
 }
 
-// reconnect synchronously calls the given _connectFn until successful, or times out trying. Retry loop can be stopped by cancelling a.ctx
-func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
+// reconnectLoop synchronously calls replicatorConnectFn until successful, or times out trying. Retry loop can be stopped by cancelling ctx
+func (a *activeReplicatorCommon) reconnectLoop() {
 	base.DebugfCtx(a.ctx, base.KeyReplicate, "starting reconnector")
 	defer func() {
 		a.reconnectActive.Set(false)
@@ -108,7 +109,7 @@ func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 		}
 
 		// set lastError, but don't set an error state inside the reconnect loop
-		err = _connectFn()
+		err = a.replicatorConnectFn()
 		a.setLastError(err)
 		a._publishStatus()
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -135,8 +135,8 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 // Stop runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
 func (a *activeReplicatorCommon) Stop() error {
 	a.lock.Lock()
-	err := a._disconnect()
 	a._stop()
+	err := a._disconnect()
 	a.setState(ReplicationStateStopped)
 	a._publishStatus()
 	a.lock.Unlock()

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -107,6 +107,8 @@ func (apr *ActivePullReplicator) Complete() {
 		base.InfofCtx(apr.ctx, base.KeyReplicate, "Timeout draining replication %s - stopping: %v", apr.config.ID, err)
 	}
 
+	apr._stop()
+
 	stopErr := apr._disconnect()
 	if stopErr != nil {
 		base.InfofCtx(apr.ctx, base.KeyReplicate, "Error attempting to stop replication %s: %v", apr.config.ID, stopErr)

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -13,10 +13,11 @@ type ActivePullReplicator struct {
 }
 
 func NewPullReplicator(config *ActiveReplicatorConfig) *ActivePullReplicator {
-	arc := newActiveReplicatorCommon(config, ActiveReplicatorTypePull)
-	return &ActivePullReplicator{
-		activeReplicatorCommon: arc,
+	apr := ActivePullReplicator{
+		activeReplicatorCommon: newActiveReplicatorCommon(config, ActiveReplicatorTypePull),
 	}
+	apr.replicatorConnectFn = apr._connect
+	return &apr
 }
 
 func (apr *ActivePullReplicator) Start() error {
@@ -40,7 +41,7 @@ func (apr *ActivePullReplicator) Start() error {
 		_ = apr.setError(err)
 		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
 		apr.reconnectActive.Set(true)
-		go apr.reconnect(apr._connect)
+		go apr.reconnectLoop()
 	}
 	apr._publishStatus()
 	return err

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -129,6 +129,8 @@ func (apr *ActivePushReplicator) Complete() {
 		base.InfofCtx(apr.ctx, base.KeyReplicate, "Timeout draining replication %s - stopping: %v", apr.config.ID, err)
 	}
 
+	apr._stop()
+
 	stopErr := apr._disconnect()
 	if stopErr != nil {
 		base.InfofCtx(apr.ctx, base.KeyReplicate, "Error attempting to stop replication %s: %v", apr.config.ID, stopErr)

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -17,10 +17,11 @@ type ActivePushReplicator struct {
 }
 
 func NewPushReplicator(config *ActiveReplicatorConfig) *ActivePushReplicator {
-	arc := newActiveReplicatorCommon(config, ActiveReplicatorTypePush)
-	return &ActivePushReplicator{
-		activeReplicatorCommon: arc,
+	apr := ActivePushReplicator{
+		activeReplicatorCommon: newActiveReplicatorCommon(config, ActiveReplicatorTypePush),
 	}
+	apr.replicatorConnectFn = apr._connect
+	return &apr
 }
 
 func (apr *ActivePushReplicator) Start() error {
@@ -44,7 +45,7 @@ func (apr *ActivePushReplicator) Start() error {
 		_ = apr.setError(err)
 		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
 		apr.reconnectActive.Set(true)
-		go apr.reconnect(apr._connect)
+		go apr.reconnectLoop()
 	}
 	apr._publishStatus()
 	return err

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"regexp"
 	"runtime/debug"
 	"strconv"
@@ -216,13 +215,13 @@ func (bsc *BlipSyncContext) handleChangesResponse(sender *blip.Sender, response 
 	}
 
 	var answer []interface{}
-	if err := base.JSONUnmarshal(respBody, &answer); err != nil {
-		if err == io.EOF {
-			base.DebugfCtx(bsc.loggingCtx, base.KeyAll, "Invalid response to 'changes' message: %s -- %s.  Body: %s", response, err, respBody)
-		} else {
+	if len(respBody) > 0 {
+		if err := base.JSONUnmarshal(respBody, &answer); err != nil {
 			base.ErrorfCtx(bsc.loggingCtx, "Invalid response to 'changes' message: %s -- %s.  Body: %s", response, err, respBody)
+			return nil
 		}
-		return nil
+	} else {
+		base.DebugfCtx(bsc.loggingCtx, base.KeyAll, "Empty response to 'changes' message: %s", response)
 	}
 	changesResponseReceived := time.Now()
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -564,6 +564,9 @@ func (m *sgReplicateManager) Stop() {
 	if err := m.RemoveNode(m.localNodeUUID); err != nil {
 		base.WarnfCtx(m.loggingCtx, "Attempt to remove node %v from sg-replicate cfg got error: %v", m.localNodeUUID, err)
 	}
+	if m.heartbeatListener != nil {
+		m.heartbeatListener.Stop()
+	}
 	close(m.clusterUpdateTerminator)
 }
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3b193cb05da904d5dcf5da8c8452ee5a9278c1cf"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="73600c7628b2f93657bfa60083289a6b403615b3"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="90436f91d5b8d3e2a988df91a138e59f69dad78c"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="352ceb41f221ae87e8214ce3af2ab992586d69e7"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -94,7 +94,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="352ceb41f221ae87e8214ce3af2ab992586d69e7"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3b193cb05da904d5dcf5da8c8452ee5a9278c1cf"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -708,6 +708,11 @@ func TestReplicationRebalancePull(t *testing.T) {
 	waitAndAssertCondition(t, func() bool { return activeRT2.GetReplicationStatus("rep_ABC").DocsRead == 2 })
 	waitAndAssertCondition(t, func() bool { return activeRT2.GetReplicationStatus("rep_DEF").DocsRead == 2 })
 
+	// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
+	activeRT.GetDatabase().SGReplicateMgr.Stop()
+	activeRT.GetDatabase().SGReplicateMgr = nil
+	activeRT2.GetDatabase().SGReplicateMgr.Stop()
+	activeRT2.GetDatabase().SGReplicateMgr = nil
 }
 
 // TestReplicationRebalancePush
@@ -790,6 +795,12 @@ func TestReplicationRebalancePush(t *testing.T) {
 	waitAndAssertCondition(t, func() bool { return activeRT.GetReplicationStatus("rep_DEF").DocsCheckedPush == 2 })
 	waitAndAssertCondition(t, func() bool { return activeRT2.GetReplicationStatus("rep_ABC").DocsCheckedPush == 2 })
 	waitAndAssertCondition(t, func() bool { return activeRT2.GetReplicationStatus("rep_DEF").DocsCheckedPush == 2 })
+
+	// explicitly stop the SGReplicateMgrs on the active nodes, to prevent a node rebalance during test teardown.
+	activeRT.GetDatabase().SGReplicateMgr.Stop()
+	activeRT.GetDatabase().SGReplicateMgr = nil
+	activeRT2.GetDatabase().SGReplicateMgr.Stop()
+	activeRT2.GetDatabase().SGReplicateMgr = nil
 }
 
 // TestPullReplicationAPI

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -115,22 +115,23 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 		ReplicationStatsMap:   base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
 	})
 
-	assert.Equal(t, int64(0), base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count")))
+	pingCountStart := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count"))
+	pingGoroutinesStart := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("goroutines_sender_ping"))
 
 	assert.NoError(t, ar.Start())
 
 	time.Sleep(time.Millisecond * 50)
 
 	pingGoroutines := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("goroutines_sender_ping"))
-	assert.Equal(t, int64(1), pingGoroutines)
+	assert.Equal(t, 1+pingGoroutinesStart, pingGoroutines, "Expected ping sender goroutine to be 1 more than start")
 
 	pingCount := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count"))
-	assert.Truef(t, pingCount > 0, "Expected ping count to be >0")
+	assert.Truef(t, pingCount > pingCountStart, "Expected ping count to be > pingCountStart")
 
 	assert.NoError(t, ar.Stop())
 
 	pingGoroutines = base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("goroutines_sender_ping"))
-	assert.Equal(t, int64(0), pingGoroutines)
+	assert.Equal(t, pingGoroutinesStart, pingGoroutines, "Expected ping sender goroutine to return to start count after stop")
 }
 
 // TestActiveReplicatorPullBasic:


### PR DESCRIPTION
- [x] Prereq: https://github.com/couchbase/go-blip/pull/45 

## Implementation detail:
- Reworked activeReplicatorCommon to add connectFn, to avoid circular reference.

## Manual testing:
- Started replication with another SG cluster, shut down target SG node (using Ctrl+c) to ensure reconnect loop is started
- Start target SG node back up, and ensure connection is reestablished and reconnect loop stops.
