### PR TITLE
CBG-1041: Provide SGR2 stats with replicationID

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -61,7 +61,7 @@ func NewSyncGatewayStats() *SgwStats {
 
 	// This provides a stat for sgw_up where the value will be fixed to one. This is to allow backwards compatibility
 	// where the standalone exporter would export a value of 1 if it has contact with SGW.
-	NewIntStat("", "up", "", prometheus.GaugeValue, 1)
+	NewIntStat("", "up", nil, prometheus.GaugeValue, 1)
 
 	return &sgwStats
 }
@@ -84,25 +84,25 @@ type GlobalStat struct {
 
 func (g *GlobalStat) initResourceUtilizationStats() {
 	g.ResourceUtilization = &ResourceUtilization{
-		AdminNetworkInterfaceBytesReceived:  NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_recv", "", prometheus.CounterValue, 0),
-		AdminNetworkInterfaceBytesSent:      NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_sent", "", prometheus.CounterValue, 0),
-		ErrorCount:                          NewIntStat(ResourceUtilizationSubsystem, "error_count", "", prometheus.CounterValue, 0),
-		GoMemstatsHeapAlloc:                 NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapalloc", "", prometheus.GaugeValue, 0),
-		GoMemstatsHeapIdle:                  NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapidle", "", prometheus.GaugeValue, 0),
-		GoMemstatsHeapInUse:                 NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapinuse", "", prometheus.GaugeValue, 0),
-		GoMemstatsHeapReleased:              NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapreleased", "", prometheus.GaugeValue, 0),
-		GoMemstatsPauseTotalNS:              NewIntStat(ResourceUtilizationSubsystem, "go_memstats_pausetotalns", "", prometheus.GaugeValue, 0),
-		GoMemstatsStackInUse:                NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stackinuse", "", prometheus.GaugeValue, 0),
-		GoMemstatsStackSys:                  NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stacksys", "", prometheus.GaugeValue, 0),
-		GoMemstatsSys:                       NewIntStat(ResourceUtilizationSubsystem, "go_memstats_sys", "", prometheus.GaugeValue, 0),
-		GoroutinesHighWatermark:             NewIntStat(ResourceUtilizationSubsystem, "goroutines_high_watermark", "", prometheus.GaugeValue, 0),
-		NumGoroutines:                       NewIntStat(ResourceUtilizationSubsystem, "num_goroutines", "", prometheus.GaugeValue, 0),
-		ProcessMemoryResident:               NewIntStat(ResourceUtilizationSubsystem, "process_memory_resident", "", prometheus.GaugeValue, 0),
-		PublicNetworkInterfaceBytesReceived: NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_recv", "", prometheus.CounterValue, 0),
-		PublicNetworkInterfaceBytesSent:     NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_sent", "", prometheus.CounterValue, 0),
-		SystemMemoryTotal:                   NewIntStat(ResourceUtilizationSubsystem, "system_memory_total", "", prometheus.GaugeValue, 0),
-		WarnCount:                           NewIntStat(ResourceUtilizationSubsystem, "warn_count", "", prometheus.CounterValue, 0),
-		CpuPercentUtil:                      NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", "", prometheus.GaugeValue, 0),
+		AdminNetworkInterfaceBytesReceived:  NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_recv", nil, prometheus.CounterValue, 0),
+		AdminNetworkInterfaceBytesSent:      NewIntStat(ResourceUtilizationSubsystem, "admin_net_bytes_sent", nil, prometheus.CounterValue, 0),
+		ErrorCount:                          NewIntStat(ResourceUtilizationSubsystem, "error_count", nil, prometheus.CounterValue, 0),
+		GoMemstatsHeapAlloc:                 NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapalloc", nil, prometheus.GaugeValue, 0),
+		GoMemstatsHeapIdle:                  NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapidle", nil, prometheus.GaugeValue, 0),
+		GoMemstatsHeapInUse:                 NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapinuse", nil, prometheus.GaugeValue, 0),
+		GoMemstatsHeapReleased:              NewIntStat(ResourceUtilizationSubsystem, "go_memstats_heapreleased", nil, prometheus.GaugeValue, 0),
+		GoMemstatsPauseTotalNS:              NewIntStat(ResourceUtilizationSubsystem, "go_memstats_pausetotalns", nil, prometheus.GaugeValue, 0),
+		GoMemstatsStackInUse:                NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stackinuse", nil, prometheus.GaugeValue, 0),
+		GoMemstatsStackSys:                  NewIntStat(ResourceUtilizationSubsystem, "go_memstats_stacksys", nil, prometheus.GaugeValue, 0),
+		GoMemstatsSys:                       NewIntStat(ResourceUtilizationSubsystem, "go_memstats_sys", nil, prometheus.GaugeValue, 0),
+		GoroutinesHighWatermark:             NewIntStat(ResourceUtilizationSubsystem, "goroutines_high_watermark", nil, prometheus.GaugeValue, 0),
+		NumGoroutines:                       NewIntStat(ResourceUtilizationSubsystem, "num_goroutines", nil, prometheus.GaugeValue, 0),
+		ProcessMemoryResident:               NewIntStat(ResourceUtilizationSubsystem, "process_memory_resident", nil, prometheus.GaugeValue, 0),
+		PublicNetworkInterfaceBytesReceived: NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_recv", nil, prometheus.CounterValue, 0),
+		PublicNetworkInterfaceBytesSent:     NewIntStat(ResourceUtilizationSubsystem, "pub_net_bytes_sent", nil, prometheus.CounterValue, 0),
+		SystemMemoryTotal:                   NewIntStat(ResourceUtilizationSubsystem, "system_memory_total", nil, prometheus.GaugeValue, 0),
+		WarnCount:                           NewIntStat(ResourceUtilizationSubsystem, "warn_count", nil, prometheus.CounterValue, 0),
+		CpuPercentUtil:                      NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", nil, prometheus.GaugeValue, 0),
 	}
 }
 
@@ -393,14 +393,7 @@ func newSGWStat(subsystem string, key string, labels map[string]string, statValu
 	}
 }
 
-func NewIntStat(subsystem string, key string, dbName string, statValueType prometheus.ValueType, initialValue int64) *SgwIntStat {
-	var labels map[string]string
-	if dbName != "" {
-		// It would be possible to supply labels directly into the constructor but as we will only take dbName for now
-		// we can do this to make the constructor more convenient to use.
-		labels = map[string]string{"database": dbName}
-	}
-
+func NewIntStat(subsystem string, key string, labels map[string]string, statValueType prometheus.ValueType, initialValue int64) *SgwIntStat {
 	stat := &SgwIntStat{
 		SgwStat: *newSGWStat(subsystem, key, labels, statValueType),
 		Val:     initialValue,
@@ -447,14 +440,7 @@ func (s *SgwIntStat) Value() int64 {
 	return atomic.LoadInt64(&s.Val)
 }
 
-func NewFloatStat(subsystem string, key string, dbName string, statValueType prometheus.ValueType, initialValue float64) *SgwFloatStat {
-	var labels map[string]string
-	if dbName != "" {
-		// It would be possible to supply labels directly into the constructor but as we will only take dbName for now
-		// we can do this to make the constructor more convenient to use.
-		labels = map[string]string{"database": dbName}
-	}
-
+func NewFloatStat(subsystem string, key string, labels map[string]string, statValueType prometheus.ValueType, initialValue float64) *SgwFloatStat {
 	stat := &SgwFloatStat{
 		SgwStat: *newSGWStat(subsystem, key, labels, statValueType),
 		Val:     math.Float64bits(initialValue),
@@ -541,32 +527,32 @@ func (s *SgwStats) ClearDBStats(name string) {
 }
 
 func (d *DbStats) initCacheStats() {
-	dbName := d.dbName
+	labels := map[string]string{"database": d.dbName}
 	d.CacheStats = &CacheStats{
-		AbandonedSeqs:                       NewIntStat(SubsystemCacheKey, "abandoned_seqs", dbName, prometheus.CounterValue, 0),
-		ChannelCacheRevsActive:              NewIntStat(SubsystemCacheKey, "chan_cache_active_revs", dbName, prometheus.GaugeValue, 0),
-		ChannelCacheBypassCount:             NewIntStat(SubsystemCacheKey, "chan_cache_bypass_count", dbName, prometheus.CounterValue, 0),
-		ChannelCacheChannelsAdded:           NewIntStat(SubsystemCacheKey, "chan_cache_channels_added", dbName, prometheus.CounterValue, 0),
-		ChannelCacheChannelsEvictedInactive: NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_inactive", dbName, prometheus.CounterValue, 0),
-		ChannelCacheChannelsEvictedNRU:      NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_nru", dbName, prometheus.CounterValue, 0),
-		ChannelCacheCompactCount:            NewIntStat(SubsystemCacheKey, "chan_cache_compact_count", dbName, prometheus.CounterValue, 0),
-		ChannelCacheCompactTime:             NewIntStat(SubsystemCacheKey, "chan_cache_compact_time", dbName, prometheus.CounterValue, 0),
-		ChannelCacheHits:                    NewIntStat(SubsystemCacheKey, "chan_cache_hits", dbName, prometheus.CounterValue, 0),
-		ChannelCacheMaxEntries:              NewIntStat(SubsystemCacheKey, "chan_cache_max_entries", dbName, prometheus.GaugeValue, 0),
-		ChannelCacheMisses:                  NewIntStat(SubsystemCacheKey, "chan_cache_misses", dbName, prometheus.CounterValue, 0),
-		ChannelCacheNumChannels:             NewIntStat(SubsystemCacheKey, "chan_cache_num_channels", dbName, prometheus.GaugeValue, 0),
-		ChannelCachePendingQueries:          NewIntStat(SubsystemCacheKey, "chan_cache_pending_queries", dbName, prometheus.GaugeValue, 0),
-		ChannelCacheRevsRemoval:             NewIntStat(SubsystemCacheKey, "chan_cache_removal_revs", dbName, prometheus.GaugeValue, 0),
-		ChannelCacheRevsTombstone:           NewIntStat(SubsystemCacheKey, "chan_cache_tombstone_revs", dbName, prometheus.GaugeValue, 0),
-		HighSeqCached:                       NewIntStat(SubsystemCacheKey, "high_seq_cached", dbName, prometheus.CounterValue, 0),
-		HighSeqStable:                       NewIntStat(SubsystemCacheKey, "high_seq_stable", dbName, prometheus.CounterValue, 0),
-		NumActiveChannels:                   NewIntStat(SubsystemCacheKey, "num_active_channels", dbName, prometheus.GaugeValue, 0),
-		NumSkippedSeqs:                      NewIntStat(SubsystemCacheKey, "num_skipped_seqs", dbName, prometheus.CounterValue, 0),
-		PendingSeqLen:                       NewIntStat(SubsystemCacheKey, "pending_seq_len", dbName, prometheus.GaugeValue, 0),
-		RevisionCacheBypass:                 NewIntStat(SubsystemCacheKey, "rev_cache_bypass", dbName, prometheus.GaugeValue, 0),
-		RevisionCacheHits:                   NewIntStat(SubsystemCacheKey, "rev_cache_hits", dbName, prometheus.CounterValue, 0),
-		RevisionCacheMisses:                 NewIntStat(SubsystemCacheKey, "rev_cache_misses", dbName, prometheus.CounterValue, 0),
-		SkippedSeqLen:                       NewIntStat(SubsystemCacheKey, "skipped_seq_len", dbName, prometheus.GaugeValue, 0),
+		AbandonedSeqs:                       NewIntStat(SubsystemCacheKey, "abandoned_seqs", labels, prometheus.CounterValue, 0),
+		ChannelCacheRevsActive:              NewIntStat(SubsystemCacheKey, "chan_cache_active_revs", labels, prometheus.GaugeValue, 0),
+		ChannelCacheBypassCount:             NewIntStat(SubsystemCacheKey, "chan_cache_bypass_count", labels, prometheus.CounterValue, 0),
+		ChannelCacheChannelsAdded:           NewIntStat(SubsystemCacheKey, "chan_cache_channels_added", labels, prometheus.CounterValue, 0),
+		ChannelCacheChannelsEvictedInactive: NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_inactive", labels, prometheus.CounterValue, 0),
+		ChannelCacheChannelsEvictedNRU:      NewIntStat(SubsystemCacheKey, "chan_cache_channels_evicted_nru", labels, prometheus.CounterValue, 0),
+		ChannelCacheCompactCount:            NewIntStat(SubsystemCacheKey, "chan_cache_compact_count", labels, prometheus.CounterValue, 0),
+		ChannelCacheCompactTime:             NewIntStat(SubsystemCacheKey, "chan_cache_compact_time", labels, prometheus.CounterValue, 0),
+		ChannelCacheHits:                    NewIntStat(SubsystemCacheKey, "chan_cache_hits", labels, prometheus.CounterValue, 0),
+		ChannelCacheMaxEntries:              NewIntStat(SubsystemCacheKey, "chan_cache_max_entries", labels, prometheus.GaugeValue, 0),
+		ChannelCacheMisses:                  NewIntStat(SubsystemCacheKey, "chan_cache_misses", labels, prometheus.CounterValue, 0),
+		ChannelCacheNumChannels:             NewIntStat(SubsystemCacheKey, "chan_cache_num_channels", labels, prometheus.GaugeValue, 0),
+		ChannelCachePendingQueries:          NewIntStat(SubsystemCacheKey, "chan_cache_pending_queries", labels, prometheus.GaugeValue, 0),
+		ChannelCacheRevsRemoval:             NewIntStat(SubsystemCacheKey, "chan_cache_removal_revs", labels, prometheus.GaugeValue, 0),
+		ChannelCacheRevsTombstone:           NewIntStat(SubsystemCacheKey, "chan_cache_tombstone_revs", labels, prometheus.GaugeValue, 0),
+		HighSeqCached:                       NewIntStat(SubsystemCacheKey, "high_seq_cached", labels, prometheus.CounterValue, 0),
+		HighSeqStable:                       NewIntStat(SubsystemCacheKey, "high_seq_stable", labels, prometheus.CounterValue, 0),
+		NumActiveChannels:                   NewIntStat(SubsystemCacheKey, "num_active_channels", labels, prometheus.GaugeValue, 0),
+		NumSkippedSeqs:                      NewIntStat(SubsystemCacheKey, "num_skipped_seqs", labels, prometheus.CounterValue, 0),
+		PendingSeqLen:                       NewIntStat(SubsystemCacheKey, "pending_seq_len", labels, prometheus.GaugeValue, 0),
+		RevisionCacheBypass:                 NewIntStat(SubsystemCacheKey, "rev_cache_bypass", labels, prometheus.GaugeValue, 0),
+		RevisionCacheHits:                   NewIntStat(SubsystemCacheKey, "rev_cache_hits", labels, prometheus.CounterValue, 0),
+		RevisionCacheMisses:                 NewIntStat(SubsystemCacheKey, "rev_cache_misses", labels, prometheus.CounterValue, 0),
+		SkippedSeqLen:                       NewIntStat(SubsystemCacheKey, "skipped_seq_len", labels, prometheus.GaugeValue, 0),
 	}
 }
 
@@ -575,23 +561,23 @@ func (d *DbStats) Cache() *CacheStats {
 }
 
 func (d *DbStats) initCBLReplicationPullStats() {
-	dbName := d.dbName
+	labels := map[string]string{"database": d.dbName}
 	d.CBLReplicationPullStats = &CBLReplicationPullStats{
-		AttachmentPullBytes:         NewIntStat(SubsystemReplicationPull, "attachment_pull_bytes", dbName, prometheus.CounterValue, 0),
-		AttachmentPullCount:         NewIntStat(SubsystemReplicationPull, "attachment_pull_count", dbName, prometheus.CounterValue, 0),
-		MaxPending:                  NewIntStat(SubsystemReplicationPull, "max_pending", dbName, prometheus.GaugeValue, 0),
-		NumReplicationsActive:       NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_continuous", dbName, prometheus.GaugeValue, 0),
-		NumPullReplActiveContinuous: NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_one_shot", dbName, prometheus.GaugeValue, 0),
-		NumPullReplActiveOneShot:    NewIntStat(SubsystemReplicationPull, "num_replications_active", dbName, prometheus.GaugeValue, 0),
-		NumPullReplCaughtUp:         NewIntStat(SubsystemReplicationPull, "num_pull_repl_caught_up", dbName, prometheus.GaugeValue, 0),
-		NumPullReplSinceZero:        NewIntStat(SubsystemReplicationPull, "num_pull_repl_since_zero", dbName, prometheus.CounterValue, 0),
-		NumPullReplTotalContinuous:  NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_continuous", dbName, prometheus.GaugeValue, 0),
-		NumPullReplTotalOneShot:     NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_one_shot", dbName, prometheus.GaugeValue, 0),
-		RequestChangesCount:         NewIntStat(SubsystemReplicationPull, "request_changes_count", dbName, prometheus.CounterValue, 0),
-		RequestChangesTime:          NewIntStat(SubsystemReplicationPull, "request_changes_time", dbName, prometheus.CounterValue, 0),
-		RevProcessingTime:           NewIntStat(SubsystemReplicationPull, "rev_processing_time", dbName, prometheus.GaugeValue, 0),
-		RevSendCount:                NewIntStat(SubsystemReplicationPull, "rev_send_count", dbName, prometheus.CounterValue, 0),
-		RevSendLatency:              NewIntStat(SubsystemReplicationPull, "rev_send_latency", dbName, prometheus.CounterValue, 0),
+		AttachmentPullBytes:         NewIntStat(SubsystemReplicationPull, "attachment_pull_bytes", labels, prometheus.CounterValue, 0),
+		AttachmentPullCount:         NewIntStat(SubsystemReplicationPull, "attachment_pull_count", labels, prometheus.CounterValue, 0),
+		MaxPending:                  NewIntStat(SubsystemReplicationPull, "max_pending", labels, prometheus.GaugeValue, 0),
+		NumReplicationsActive:       NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_continuous", labels, prometheus.GaugeValue, 0),
+		NumPullReplActiveContinuous: NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_one_shot", labels, prometheus.GaugeValue, 0),
+		NumPullReplActiveOneShot:    NewIntStat(SubsystemReplicationPull, "num_replications_active", labels, prometheus.GaugeValue, 0),
+		NumPullReplCaughtUp:         NewIntStat(SubsystemReplicationPull, "num_pull_repl_caught_up", labels, prometheus.GaugeValue, 0),
+		NumPullReplSinceZero:        NewIntStat(SubsystemReplicationPull, "num_pull_repl_since_zero", labels, prometheus.CounterValue, 0),
+		NumPullReplTotalContinuous:  NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_continuous", labels, prometheus.GaugeValue, 0),
+		NumPullReplTotalOneShot:     NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_one_shot", labels, prometheus.GaugeValue, 0),
+		RequestChangesCount:         NewIntStat(SubsystemReplicationPull, "request_changes_count", labels, prometheus.CounterValue, 0),
+		RequestChangesTime:          NewIntStat(SubsystemReplicationPull, "request_changes_time", labels, prometheus.CounterValue, 0),
+		RevProcessingTime:           NewIntStat(SubsystemReplicationPull, "rev_processing_time", labels, prometheus.GaugeValue, 0),
+		RevSendCount:                NewIntStat(SubsystemReplicationPull, "rev_send_count", labels, prometheus.CounterValue, 0),
+		RevSendLatency:              NewIntStat(SubsystemReplicationPull, "rev_send_latency", labels, prometheus.CounterValue, 0),
 	}
 }
 
@@ -600,16 +586,16 @@ func (d *DbStats) CBLReplicationPull() *CBLReplicationPullStats {
 }
 
 func (d *DbStats) initCBLReplicationPushStats() {
-	dbName := d.dbName
+	labels := map[string]string{"database": d.dbName}
 	d.CBLReplicationPushStats = &CBLReplicationPushStats{
-		AttachmentPushBytes: NewIntStat(SubsystemReplicationPush, "attachment_push_bytes", dbName, prometheus.CounterValue, 0),
-		AttachmentPushCount: NewIntStat(SubsystemReplicationPush, "attachment_push_count", dbName, prometheus.CounterValue, 0),
-		DocPushCount:        NewIntStat(SubsystemReplicationPush, "doc_push_count", dbName, prometheus.GaugeValue, 0),
-		ProposeChangeCount:  NewIntStat(SubsystemReplicationPush, "propose_change_count", dbName, prometheus.CounterValue, 0),
-		ProposeChangeTime:   NewIntStat(SubsystemReplicationPush, "propose_change_time", dbName, prometheus.CounterValue, 0),
-		SyncFunctionCount:   NewIntStat(SubsystemReplicationPush, "sync_function_count", dbName, prometheus.CounterValue, 0),
-		SyncFunctionTime:    NewIntStat(SubsystemReplicationPush, "sync_function_time", dbName, prometheus.CounterValue, 0),
-		WriteProcessingTime: NewIntStat(SubsystemReplicationPush, "write_processing_time", dbName, prometheus.GaugeValue, 0),
+		AttachmentPushBytes: NewIntStat(SubsystemReplicationPush, "attachment_push_bytes", labels, prometheus.CounterValue, 0),
+		AttachmentPushCount: NewIntStat(SubsystemReplicationPush, "attachment_push_count", labels, prometheus.CounterValue, 0),
+		DocPushCount:        NewIntStat(SubsystemReplicationPush, "doc_push_count", labels, prometheus.GaugeValue, 0),
+		ProposeChangeCount:  NewIntStat(SubsystemReplicationPush, "propose_change_count", labels, prometheus.CounterValue, 0),
+		ProposeChangeTime:   NewIntStat(SubsystemReplicationPush, "propose_change_time", labels, prometheus.CounterValue, 0),
+		SyncFunctionCount:   NewIntStat(SubsystemReplicationPush, "sync_function_count", labels, prometheus.CounterValue, 0),
+		SyncFunctionTime:    NewIntStat(SubsystemReplicationPush, "sync_function_time", labels, prometheus.CounterValue, 0),
+		WriteProcessingTime: NewIntStat(SubsystemReplicationPush, "write_processing_time", labels, prometheus.GaugeValue, 0),
 	}
 }
 
@@ -618,34 +604,34 @@ func (d *DbStats) CBLReplicationPush() *CBLReplicationPushStats {
 }
 
 func (d *DbStats) initDatabaseStats() {
-	dbName := d.dbName
+	labels := map[string]string{"database": d.dbName}
 	d.DatabaseStats = &DatabaseStats{
-		AbandonedSeqs:           NewIntStat(SubsystemDatabaseKey, "abandoned_seqs", dbName, prometheus.CounterValue, 0),
-		ConflictWriteCount:      NewIntStat(SubsystemDatabaseKey, "conflict_write_count", dbName, prometheus.CounterValue, 0),
-		Crc32MatchCount:         NewIntStat(SubsystemDatabaseKey, "crc32c_match_count", dbName, prometheus.GaugeValue, 0),
-		DCPCachingCount:         NewIntStat(SubsystemDatabaseKey, "dcp_caching_count", dbName, prometheus.GaugeValue, 0),
-		DCPCachingTime:          NewIntStat(SubsystemDatabaseKey, "dcp_caching_time", dbName, prometheus.GaugeValue, 0),
-		DCPReceivedCount:        NewIntStat(SubsystemDatabaseKey, "dcp_received_count", dbName, prometheus.GaugeValue, 0),
-		DCPReceivedTime:         NewIntStat(SubsystemDatabaseKey, "dcp_received_time", dbName, prometheus.GaugeValue, 0),
-		DocReadsBytesBlip:       NewIntStat(SubsystemDatabaseKey, "doc_reads_bytes_blip", dbName, prometheus.CounterValue, 0),
-		DocWritesBytes:          NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes", dbName, prometheus.CounterValue, 0),
-		DocWritesXattrBytes:     NewIntStat(SubsystemDatabaseKey, "doc_writes_xattr_bytes", dbName, prometheus.CounterValue, 0),
-		HighSeqFeed:             NewIntStat(SubsystemDatabaseKey, "high_seq_feed", dbName, prometheus.CounterValue, 0),
-		DocWritesBytesBlip:      NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes_blip", dbName, prometheus.CounterValue, 0),
-		NumDocReadsBlip:         NewIntStat(SubsystemDatabaseKey, "num_doc_reads_blip", dbName, prometheus.CounterValue, 0),
-		NumDocReadsRest:         NewIntStat(SubsystemDatabaseKey, "num_doc_reads_rest", dbName, prometheus.CounterValue, 0),
-		NumDocWrites:            NewIntStat(SubsystemDatabaseKey, "num_doc_writes", dbName, prometheus.CounterValue, 0),
-		NumReplicationsActive:   NewIntStat(SubsystemDatabaseKey, "num_replications_active", dbName, prometheus.GaugeValue, 0),
-		NumReplicationsTotal:    NewIntStat(SubsystemDatabaseKey, "num_replications_total", dbName, prometheus.CounterValue, 0),
-		NumTombstonesCompacted:  NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", dbName, prometheus.CounterValue, 0),
-		SequenceAssignedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", dbName, prometheus.CounterValue, 0),
-		SequenceGetCount:        NewIntStat(SubsystemDatabaseKey, "sequence_get_count", dbName, prometheus.CounterValue, 0),
-		SequenceIncrCount:       NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", dbName, prometheus.CounterValue, 0),
-		SequenceReleasedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_released_count", dbName, prometheus.CounterValue, 0),
-		SequenceReservedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", dbName, prometheus.CounterValue, 0),
-		WarnChannelsPerDocCount: NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", dbName, prometheus.CounterValue, 0),
-		WarnGrantsPerDocCount:   NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", dbName, prometheus.CounterValue, 0),
-		WarnXattrSizeCount:      NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", dbName, prometheus.CounterValue, 0),
+		AbandonedSeqs:           NewIntStat(SubsystemDatabaseKey, "abandoned_seqs", labels, prometheus.CounterValue, 0),
+		ConflictWriteCount:      NewIntStat(SubsystemDatabaseKey, "conflict_write_count", labels, prometheus.CounterValue, 0),
+		Crc32MatchCount:         NewIntStat(SubsystemDatabaseKey, "crc32c_match_count", labels, prometheus.GaugeValue, 0),
+		DCPCachingCount:         NewIntStat(SubsystemDatabaseKey, "dcp_caching_count", labels, prometheus.GaugeValue, 0),
+		DCPCachingTime:          NewIntStat(SubsystemDatabaseKey, "dcp_caching_time", labels, prometheus.GaugeValue, 0),
+		DCPReceivedCount:        NewIntStat(SubsystemDatabaseKey, "dcp_received_count", labels, prometheus.GaugeValue, 0),
+		DCPReceivedTime:         NewIntStat(SubsystemDatabaseKey, "dcp_received_time", labels, prometheus.GaugeValue, 0),
+		DocReadsBytesBlip:       NewIntStat(SubsystemDatabaseKey, "doc_reads_bytes_blip", labels, prometheus.CounterValue, 0),
+		DocWritesBytes:          NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes", labels, prometheus.CounterValue, 0),
+		DocWritesXattrBytes:     NewIntStat(SubsystemDatabaseKey, "doc_writes_xattr_bytes", labels, prometheus.CounterValue, 0),
+		HighSeqFeed:             NewIntStat(SubsystemDatabaseKey, "high_seq_feed", labels, prometheus.CounterValue, 0),
+		DocWritesBytesBlip:      NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes_blip", labels, prometheus.CounterValue, 0),
+		NumDocReadsBlip:         NewIntStat(SubsystemDatabaseKey, "num_doc_reads_blip", labels, prometheus.CounterValue, 0),
+		NumDocReadsRest:         NewIntStat(SubsystemDatabaseKey, "num_doc_reads_rest", labels, prometheus.CounterValue, 0),
+		NumDocWrites:            NewIntStat(SubsystemDatabaseKey, "num_doc_writes", labels, prometheus.CounterValue, 0),
+		NumReplicationsActive:   NewIntStat(SubsystemDatabaseKey, "num_replications_active", labels, prometheus.GaugeValue, 0),
+		NumReplicationsTotal:    NewIntStat(SubsystemDatabaseKey, "num_replications_total", labels, prometheus.CounterValue, 0),
+		NumTombstonesCompacted:  NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", labels, prometheus.CounterValue, 0),
+		SequenceAssignedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", labels, prometheus.CounterValue, 0),
+		SequenceGetCount:        NewIntStat(SubsystemDatabaseKey, "sequence_get_count", labels, prometheus.CounterValue, 0),
+		SequenceIncrCount:       NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", labels, prometheus.CounterValue, 0),
+		SequenceReleasedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_released_count", labels, prometheus.CounterValue, 0),
+		SequenceReservedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", labels, prometheus.CounterValue, 0),
+		WarnChannelsPerDocCount: NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", labels, prometheus.CounterValue, 0),
+		WarnGrantsPerDocCount:   NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", labels, prometheus.CounterValue, 0),
+		WarnXattrSizeCount:      NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", labels, prometheus.CounterValue, 0),
 		ImportFeedMapStats:      &ExpVarMapWrapper{new(expvar.Map).Init()},
 		CacheFeedMapStats:       &ExpVarMapWrapper{new(expvar.Map).Init()},
 	}
@@ -656,14 +642,14 @@ func (d *DbStats) Database() *DatabaseStats {
 }
 
 func (d *DbStats) InitDeltaSyncStats() {
-	dbName := d.dbName
+	labels := map[string]string{"database": d.dbName}
 	d.DeltaSyncStats = &DeltaSyncStats{
-		DeltasRequested:           NewIntStat(SubsystemDeltaSyncKey, "deltas_requested", dbName, prometheus.CounterValue, 0),
-		DeltasSent:                NewIntStat(SubsystemDeltaSyncKey, "deltas_sent", dbName, prometheus.CounterValue, 0),
-		DeltaPullReplicationCount: NewIntStat(SubsystemDeltaSyncKey, "delta_pull_replication_count", dbName, prometheus.CounterValue, 0),
-		DeltaCacheHit:             NewIntStat(SubsystemDeltaSyncKey, "delta_cache_hit", dbName, prometheus.CounterValue, 0),
-		DeltaCacheMiss:            NewIntStat(SubsystemDeltaSyncKey, "delta_sync_miss", dbName, prometheus.CounterValue, 0),
-		DeltaPushDocCount:         NewIntStat(SubsystemDeltaSyncKey, "delta_push_doc_count", dbName, prometheus.CounterValue, 0),
+		DeltasRequested:           NewIntStat(SubsystemDeltaSyncKey, "deltas_requested", labels, prometheus.CounterValue, 0),
+		DeltasSent:                NewIntStat(SubsystemDeltaSyncKey, "deltas_sent", labels, prometheus.CounterValue, 0),
+		DeltaPullReplicationCount: NewIntStat(SubsystemDeltaSyncKey, "delta_pull_replication_count", labels, prometheus.CounterValue, 0),
+		DeltaCacheHit:             NewIntStat(SubsystemDeltaSyncKey, "delta_cache_hit", labels, prometheus.CounterValue, 0),
+		DeltaCacheMiss:            NewIntStat(SubsystemDeltaSyncKey, "delta_sync_miss", labels, prometheus.CounterValue, 0),
+		DeltaPushDocCount:         NewIntStat(SubsystemDeltaSyncKey, "delta_push_doc_count", labels, prometheus.CounterValue, 0),
 	}
 }
 
@@ -673,13 +659,13 @@ func (d *DbStats) DeltaSync() *DeltaSyncStats {
 
 func (d *DbStats) initSecurityStats() {
 	if d.SecurityStats == nil {
-		dbName := d.dbName
+		labels := map[string]string{"database": d.dbName}
 		d.SecurityStats = &SecurityStats{
-			AuthFailedCount:  NewIntStat(SubsystemSecurity, "auth_failed_count", dbName, prometheus.CounterValue, 0),
-			AuthSuccessCount: NewIntStat(SubsystemSecurity, "auth_success_count", dbName, prometheus.CounterValue, 0),
-			NumAccessErrors:  NewIntStat(SubsystemSecurity, "num_access_errors", dbName, prometheus.CounterValue, 0),
-			NumDocsRejected:  NewIntStat(SubsystemSecurity, "num_docs_rejected", dbName, prometheus.CounterValue, 0),
-			TotalAuthTime:    NewIntStat(SubsystemSecurity, "total_auth_time", dbName, prometheus.GaugeValue, 0),
+			AuthFailedCount:  NewIntStat(SubsystemSecurity, "auth_failed_count", labels, prometheus.CounterValue, 0),
+			AuthSuccessCount: NewIntStat(SubsystemSecurity, "auth_success_count", labels, prometheus.CounterValue, 0),
+			NumAccessErrors:  NewIntStat(SubsystemSecurity, "num_access_errors", labels, prometheus.CounterValue, 0),
+			NumDocsRejected:  NewIntStat(SubsystemSecurity, "num_docs_rejected", labels, prometheus.CounterValue, 0),
+			TotalAuthTime:    NewIntStat(SubsystemSecurity, "total_auth_time", labels, prometheus.GaugeValue, 0),
 		}
 	}
 }
@@ -690,26 +676,27 @@ func (d *DbStats) DBReplicatorStats(replicationID string) *DbReplicatorStats {
 	}
 
 	if _, ok := d.DbReplicatorStats[replicationID]; !ok {
+		labels := map[string]string{"database": d.dbName, "replication": replicationID}
 		d.DbReplicatorStats[replicationID] = &DbReplicatorStats{
-			NumAttachmentBytesPushed:    NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pushed", d.dbName, prometheus.CounterValue, 0),
-			NumAttachmentPushed:         NewIntStat(SubsystemReplication, "sgr_num_attachments_pushed", d.dbName, prometheus.CounterValue, 0),
-			NumDocPushed:                NewIntStat(SubsystemReplication, "sgr_num_docs_pushed", d.dbName, prometheus.CounterValue, 0),
-			NumDocsFailedToPush:         NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_push", d.dbName, prometheus.CounterValue, 0),
-			PushConflictCount:           NewIntStat(SubsystemReplication, "sgr_push_conflict_count", d.dbName, prometheus.CounterValue, 0),
-			PushRejectedCount:           NewIntStat(SubsystemReplication, "sgr_push_rejected_count", d.dbName, prometheus.CounterValue, 0),
-			PushDeltaSentCount:          NewIntStat(SubsystemReplication, "sgr_deltas_sent", d.dbName, prometheus.CounterValue, 0),
-			DocsCheckedSent:             NewIntStat(SubsystemReplication, "sgr_docs_checked_sent", d.dbName, prometheus.CounterValue, 0),
-			NumAttachmentBytesPulled:    NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pulled", d.dbName, prometheus.CounterValue, 0),
-			NumAttachmentsPulled:        NewIntStat(SubsystemReplication, "sgr_num_attachments_pulled", d.dbName, prometheus.CounterValue, 0),
-			PulledCount:                 NewIntStat(SubsystemReplication, "sgr_num_docs_pulled", d.dbName, prometheus.CounterValue, 0),
-			PurgedCount:                 NewIntStat(SubsystemReplication, "sgr_num_docs_purged", d.dbName, prometheus.CounterValue, 0),
-			FailedToPullCount:           NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_pull", d.dbName, prometheus.CounterValue, 0),
-			DeltaReceivedCount:          NewIntStat(SubsystemReplication, "sgr_deltas_recv", d.dbName, prometheus.CounterValue, 0),
-			DeltaRequestedCount:         NewIntStat(SubsystemReplication, "sgr_deltas_requested", d.dbName, prometheus.CounterValue, 0),
-			DocsCheckedReceived:         NewIntStat(SubsystemReplication, "sgr_docs_checked_recv", d.dbName, prometheus.CounterValue, 0),
-			ConflictResolvedLocalCount:  NewIntStat(SubsystemReplication, "sgr_conflict_resolved_local_count", d.dbName, prometheus.CounterValue, 0),
-			ConflictResolvedRemoteCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_remote_count", d.dbName, prometheus.CounterValue, 0),
-			ConflictResolvedMergedCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_merge_count", d.dbName, prometheus.CounterValue, 0),
+			NumAttachmentBytesPushed:    NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pushed", labels, prometheus.CounterValue, 0),
+			NumAttachmentPushed:         NewIntStat(SubsystemReplication, "sgr_num_attachments_pushed", labels, prometheus.CounterValue, 0),
+			NumDocPushed:                NewIntStat(SubsystemReplication, "sgr_num_docs_pushed", labels, prometheus.CounterValue, 0),
+			NumDocsFailedToPush:         NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_push", labels, prometheus.CounterValue, 0),
+			PushConflictCount:           NewIntStat(SubsystemReplication, "sgr_push_conflict_count", labels, prometheus.CounterValue, 0),
+			PushRejectedCount:           NewIntStat(SubsystemReplication, "sgr_push_rejected_count", labels, prometheus.CounterValue, 0),
+			PushDeltaSentCount:          NewIntStat(SubsystemReplication, "sgr_deltas_sent", labels, prometheus.CounterValue, 0),
+			DocsCheckedSent:             NewIntStat(SubsystemReplication, "sgr_docs_checked_sent", labels, prometheus.CounterValue, 0),
+			NumAttachmentBytesPulled:    NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pulled", labels, prometheus.CounterValue, 0),
+			NumAttachmentsPulled:        NewIntStat(SubsystemReplication, "sgr_num_attachments_pulled", labels, prometheus.CounterValue, 0),
+			PulledCount:                 NewIntStat(SubsystemReplication, "sgr_num_docs_pulled", labels, prometheus.CounterValue, 0),
+			PurgedCount:                 NewIntStat(SubsystemReplication, "sgr_num_docs_purged", labels, prometheus.CounterValue, 0),
+			FailedToPullCount:           NewIntStat(SubsystemReplication, "sgr_num_docs_failed_to_pull", labels, prometheus.CounterValue, 0),
+			DeltaReceivedCount:          NewIntStat(SubsystemReplication, "sgr_deltas_recv", labels, prometheus.CounterValue, 0),
+			DeltaRequestedCount:         NewIntStat(SubsystemReplication, "sgr_deltas_requested", labels, prometheus.CounterValue, 0),
+			DocsCheckedReceived:         NewIntStat(SubsystemReplication, "sgr_docs_checked_recv", labels, prometheus.CounterValue, 0),
+			ConflictResolvedLocalCount:  NewIntStat(SubsystemReplication, "sgr_conflict_resolved_local_count", labels, prometheus.CounterValue, 0),
+			ConflictResolvedRemoteCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_remote_count", labels, prometheus.CounterValue, 0),
+			ConflictResolvedMergedCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_merge_count", labels, prometheus.CounterValue, 0),
 		}
 	}
 
@@ -722,14 +709,14 @@ func (d *DbStats) Security() *SecurityStats {
 
 func (d *DbStats) InitSharedBucketImportStats() {
 	if d.SharedBucketImportStats == nil {
-		dbName := d.dbName
+		labels := map[string]string{"database": d.dbName}
 		d.SharedBucketImportStats = &SharedBucketImportStats{
-			ImportCount:          NewIntStat(SubsystemSharedBucketImport, "import_count", dbName, prometheus.CounterValue, 0),
-			ImportCancelCAS:      NewIntStat(SubsystemSharedBucketImport, "import_cancel_cas", dbName, prometheus.CounterValue, 0),
-			ImportErrorCount:     NewIntStat(SubsystemSharedBucketImport, "import_error_count", dbName, prometheus.CounterValue, 0),
-			ImportProcessingTime: NewIntStat(SubsystemSharedBucketImport, "import_processing_time", dbName, prometheus.GaugeValue, 0),
-			ImportHighSeq:        NewIntStat(SubsystemSharedBucketImport, "import_high_seq", dbName, prometheus.CounterValue, 0),
-			ImportPartitions:     NewIntStat(SubsystemSharedBucketImport, "import_partitions", dbName, prometheus.GaugeValue, 0),
+			ImportCount:          NewIntStat(SubsystemSharedBucketImport, "import_count", labels, prometheus.CounterValue, 0),
+			ImportCancelCAS:      NewIntStat(SubsystemSharedBucketImport, "import_cancel_cas", labels, prometheus.CounterValue, 0),
+			ImportErrorCount:     NewIntStat(SubsystemSharedBucketImport, "import_error_count", labels, prometheus.CounterValue, 0),
+			ImportProcessingTime: NewIntStat(SubsystemSharedBucketImport, "import_processing_time", labels, prometheus.GaugeValue, 0),
+			ImportHighSeq:        NewIntStat(SubsystemSharedBucketImport, "import_high_seq", labels, prometheus.CounterValue, 0),
+			ImportPartitions:     NewIntStat(SubsystemSharedBucketImport, "import_partitions", labels, prometheus.GaugeValue, 0),
 		}
 	}
 }
@@ -751,7 +738,7 @@ func (d *DbStats) InitQueryStats(useViews bool, queryNames ...string) {
 
 func (d *DbStats) _initQueryStat(useViews bool, queryName string) {
 	if _, ok := d.QueryStats.Stats[queryName]; !ok {
-		dbName := d.dbName
+		labels := map[string]string{"database": d.dbName}
 
 		// Prometheus isn't happy with '.'s in the name and the '.'s come from the design doc version. Design doc isn't
 		// reported to prometheus. Only the view name.
@@ -762,9 +749,9 @@ func (d *DbStats) _initQueryStat(useViews bool, queryName string) {
 		}
 
 		d.QueryStats.Stats[queryName] = &QueryStat{
-			QueryCount:      NewIntStat(SubsystemGSIViews, prometheusKey+"_count", dbName, prometheus.CounterValue, 0),
-			QueryErrorCount: NewIntStat(SubsystemGSIViews, prometheusKey+"_error_count", dbName, prometheus.CounterValue, 0),
-			QueryTime:       NewIntStat(SubsystemGSIViews, prometheusKey+"_time", dbName, prometheus.CounterValue, 0),
+			QueryCount:      NewIntStat(SubsystemGSIViews, prometheusKey+"_count", labels, prometheus.CounterValue, 0),
+			QueryErrorCount: NewIntStat(SubsystemGSIViews, prometheusKey+"_error_count", labels, prometheus.CounterValue, 0),
+			QueryTime:       NewIntStat(SubsystemGSIViews, prometheusKey+"_time", labels, prometheus.CounterValue, 0),
 		}
 	}
 }

--- a/base/stats.go
+++ b/base/stats.go
@@ -26,6 +26,9 @@ const (
 	SubsystemReplicationPush    = "replication_push"
 	SubsystemSecurity           = "security"
 	SubsystemSharedBucketImport = "shared_bucket_import"
+
+	DatabaseLabelKey    = "database"
+	ReplicationLabelKey = "replication"
 )
 
 var (
@@ -50,11 +53,11 @@ func NewSyncGatewayStats() *SgwStats {
 		DbStats:     map[string]*DbStats{},
 	}
 
-	checkedSentDesc = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_docs_checked_sent"), "sgr_docs_checked_sent", []string{"replication"}, nil)
-	numAttachmentBytesTransferred = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_attachment_bytes_transferred"), "sgr_num_attachment_bytes_transferred", []string{"replication"}, nil)
-	numAttachmentsTransferred = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_attachments_transferred"), "sgr_num_attachments_transferred", []string{"replication"}, nil)
-	numDocsFailedToPush = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_docs_failed_to_push"), "sgr_num_docs_failed_to_push", []string{"replication"}, nil)
-	numDocsPushed = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_docs_pushed"), "sgr_num_docs_pushed", []string{"replication"}, nil)
+	checkedSentDesc = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_docs_checked_sent"), "sgr_docs_checked_sent", []string{ReplicationLabelKey}, nil)
+	numAttachmentBytesTransferred = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_attachment_bytes_transferred"), "sgr_num_attachment_bytes_transferred", []string{ReplicationLabelKey}, nil)
+	numAttachmentsTransferred = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_attachments_transferred"), "sgr_num_attachments_transferred", []string{ReplicationLabelKey}, nil)
+	numDocsFailedToPush = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_docs_failed_to_push"), "sgr_num_docs_failed_to_push", []string{ReplicationLabelKey}, nil)
+	numDocsPushed = prometheus.NewDesc(prometheus.BuildFQName(NamespaceKey, SubsystemReplication, "sgr_num_docs_pushed"), "sgr_num_docs_pushed", []string{ReplicationLabelKey}, nil)
 
 	sgwStats.GlobalStats.initResourceUtilizationStats()
 	sgwStats.initReplicationStats()
@@ -527,7 +530,7 @@ func (s *SgwStats) ClearDBStats(name string) {
 }
 
 func (d *DbStats) initCacheStats() {
-	labels := map[string]string{"database": d.dbName}
+	labels := map[string]string{DatabaseLabelKey: d.dbName}
 	d.CacheStats = &CacheStats{
 		AbandonedSeqs:                       NewIntStat(SubsystemCacheKey, "abandoned_seqs", labels, prometheus.CounterValue, 0),
 		ChannelCacheRevsActive:              NewIntStat(SubsystemCacheKey, "chan_cache_active_revs", labels, prometheus.GaugeValue, 0),
@@ -561,7 +564,7 @@ func (d *DbStats) Cache() *CacheStats {
 }
 
 func (d *DbStats) initCBLReplicationPullStats() {
-	labels := map[string]string{"database": d.dbName}
+	labels := map[string]string{DatabaseLabelKey: d.dbName}
 	d.CBLReplicationPullStats = &CBLReplicationPullStats{
 		AttachmentPullBytes:         NewIntStat(SubsystemReplicationPull, "attachment_pull_bytes", labels, prometheus.CounterValue, 0),
 		AttachmentPullCount:         NewIntStat(SubsystemReplicationPull, "attachment_pull_count", labels, prometheus.CounterValue, 0),
@@ -586,7 +589,7 @@ func (d *DbStats) CBLReplicationPull() *CBLReplicationPullStats {
 }
 
 func (d *DbStats) initCBLReplicationPushStats() {
-	labels := map[string]string{"database": d.dbName}
+	labels := map[string]string{DatabaseLabelKey: d.dbName}
 	d.CBLReplicationPushStats = &CBLReplicationPushStats{
 		AttachmentPushBytes: NewIntStat(SubsystemReplicationPush, "attachment_push_bytes", labels, prometheus.CounterValue, 0),
 		AttachmentPushCount: NewIntStat(SubsystemReplicationPush, "attachment_push_count", labels, prometheus.CounterValue, 0),
@@ -604,7 +607,7 @@ func (d *DbStats) CBLReplicationPush() *CBLReplicationPushStats {
 }
 
 func (d *DbStats) initDatabaseStats() {
-	labels := map[string]string{"database": d.dbName}
+	labels := map[string]string{DatabaseLabelKey: d.dbName}
 	d.DatabaseStats = &DatabaseStats{
 		AbandonedSeqs:           NewIntStat(SubsystemDatabaseKey, "abandoned_seqs", labels, prometheus.CounterValue, 0),
 		ConflictWriteCount:      NewIntStat(SubsystemDatabaseKey, "conflict_write_count", labels, prometheus.CounterValue, 0),
@@ -642,7 +645,7 @@ func (d *DbStats) Database() *DatabaseStats {
 }
 
 func (d *DbStats) InitDeltaSyncStats() {
-	labels := map[string]string{"database": d.dbName}
+	labels := map[string]string{DatabaseLabelKey: d.dbName}
 	d.DeltaSyncStats = &DeltaSyncStats{
 		DeltasRequested:           NewIntStat(SubsystemDeltaSyncKey, "deltas_requested", labels, prometheus.CounterValue, 0),
 		DeltasSent:                NewIntStat(SubsystemDeltaSyncKey, "deltas_sent", labels, prometheus.CounterValue, 0),
@@ -659,7 +662,7 @@ func (d *DbStats) DeltaSync() *DeltaSyncStats {
 
 func (d *DbStats) initSecurityStats() {
 	if d.SecurityStats == nil {
-		labels := map[string]string{"database": d.dbName}
+		labels := map[string]string{DatabaseLabelKey: d.dbName}
 		d.SecurityStats = &SecurityStats{
 			AuthFailedCount:  NewIntStat(SubsystemSecurity, "auth_failed_count", labels, prometheus.CounterValue, 0),
 			AuthSuccessCount: NewIntStat(SubsystemSecurity, "auth_success_count", labels, prometheus.CounterValue, 0),
@@ -676,7 +679,7 @@ func (d *DbStats) DBReplicatorStats(replicationID string) *DbReplicatorStats {
 	}
 
 	if _, ok := d.DbReplicatorStats[replicationID]; !ok {
-		labels := map[string]string{"database": d.dbName, "replication": replicationID}
+		labels := map[string]string{DatabaseLabelKey: d.dbName, ReplicationLabelKey: replicationID}
 		d.DbReplicatorStats[replicationID] = &DbReplicatorStats{
 			NumAttachmentBytesPushed:    NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pushed", labels, prometheus.CounterValue, 0),
 			NumAttachmentPushed:         NewIntStat(SubsystemReplication, "sgr_num_attachments_pushed", labels, prometheus.CounterValue, 0),
@@ -709,7 +712,7 @@ func (d *DbStats) Security() *SecurityStats {
 
 func (d *DbStats) InitSharedBucketImportStats() {
 	if d.SharedBucketImportStats == nil {
-		labels := map[string]string{"database": d.dbName}
+		labels := map[string]string{DatabaseLabelKey: d.dbName}
 		d.SharedBucketImportStats = &SharedBucketImportStats{
 			ImportCount:          NewIntStat(SubsystemSharedBucketImport, "import_count", labels, prometheus.CounterValue, 0),
 			ImportCancelCAS:      NewIntStat(SubsystemSharedBucketImport, "import_cancel_cas", labels, prometheus.CounterValue, 0),
@@ -738,7 +741,7 @@ func (d *DbStats) InitQueryStats(useViews bool, queryNames ...string) {
 
 func (d *DbStats) _initQueryStat(useViews bool, queryName string) {
 	if _, ok := d.QueryStats.Stats[queryName]; !ok {
-		labels := map[string]string{"database": d.dbName}
+		labels := map[string]string{DatabaseLabelKey: d.dbName}
 
 		// Prometheus isn't happy with '.'s in the name and the '.'s come from the design doc version. Design doc isn't
 		// reported to prometheus. Only the view name.


### PR DESCRIPTION
Need to provide replicationID as well as database ID for SGR2 stats. Switched the stat initializers to take the full map[string]{string} of labels so multiple can be easily provided.