### PR TITLE
Prevent nil pointer in BlipTesterClient

### DIFF
--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -670,8 +670,9 @@ func (btc *BlipTesterClient) GetRev(docID, revID string) (data []byte, found boo
 	defer btc.docsLock.RUnlock()
 
 	if rev, ok := btc.docs[docID]; ok {
-		data, found := rev[revID]
-		return data.body, found
+		if data, ok := rev[revID]; ok && data != nil {
+			return data.body, true
+		}
 	}
 
 	return nil, false


### PR DESCRIPTION
When the BlipTesterClient has the DocID, but doesn't yet have the specific rev we're looking for, don't panic, but safely return nil/false.

This test failue seems to be uncovered by the test running slower than usual, resulting in the missing rev:

- http://mobile.jenkins.couchbase.com/blue/organizations/jenkins/sgw-windows-wix/detail/sgw-windows-wix/2739/pipeline 