### PR TITLE
Fix TestTombstoneCompaction assertion of mixed int/int64 types

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -244,7 +244,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 		dbStats.InitDeltaSyncStats()
 	}
 
-	if autoImport {
+	if autoImport || options.EnableXattr {
 		dbStats.InitSharedBucketImportStats()
 	}
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3604,7 +3604,7 @@ func TestTombstoneCompaction(t *testing.T) {
 		}
 
 		expectedBatches += numDocs/db.QueryTombstoneBatch + 1
-		assert.Equal(t, expectedBatches, actualBatches)
+		assert.Equal(t, expectedBatches, int(actualBatches))
 	}
 
 	// Multiples of Batch Size


### PR DESCRIPTION
Test is a Couchbase Server only test, and fails due to stat type assertion. @JRascagneres is running Couchbase Server tests locally to find any other instances.

```
--- FAIL: TestTombstoneCompaction (12.79s)
    changes_api_test.go:3607: 
        	Error Trace:	changes_api_test.go:3607
        	            				changes_api_test.go:3611
        	Error:      	Not equal: 
        	            	expected: int(2)
        	            	actual  : int64(2)
        	Test:       	TestTombstoneCompaction
    changes_api_test.go:3607: 
        	Error Trace:	changes_api_test.go:3607
        	            				changes_api_test.go:3612
        	Error:      	Not equal: 
        	            	expected: int(7)
        	            	actual  : int64(7)
        	Test:       	TestTombstoneCompaction
    changes_api_test.go:3607: 
        	Error Trace:	changes_api_test.go:3607
        	            				changes_api_test.go:3615
        	Error:      	Not equal: 
        	            	expected: int(8)
        	            	actual  : int64(8)
        	Test:       	TestTombstoneCompaction
    changes_api_test.go:3607: 
        	Error Trace:	changes_api_test.go:3607
        	            				changes_api_test.go:3616
        	Error:      	Not equal: 
        	            	expected: int(9)
        	            	actual  : int64(9)
        	Test:       	TestTombstoneCompaction
    changes_api_test.go:3607: 
        	Error Trace:	changes_api_test.go:3607
        	            				changes_api_test.go:3619
        	Error:      	Not equal: 
        	            	expected: int(11)
        	            	actual  : int64(11)
        	Test:       	TestTombstoneCompaction
```