### PR TITLE
CBG-1040: Add missing reconnect stats to expvars & prometheus

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -329,8 +329,8 @@ type DbReplicatorStats struct {
 	PushRejectedCount        *SgwIntStat `json:"sgr_push_rejected_count"`
 	PushDeltaSentCount       *SgwIntStat `json:"sgr_deltas_sent"`
 	DocsCheckedSent          *SgwIntStat `json:"sgr_docs_checked_sent" `
-	NumConnectAttemptsPull   *SgwIntStat `json:"num_connects_pull"`
-	NumReconnectsAbortedPull *SgwIntStat `json:"num_reconnects_aborted_pull"`
+	NumConnectAttemptsPull   *SgwIntStat `json:"sgr_num_connects_pull"`
+	NumReconnectsAbortedPull *SgwIntStat `json:"sgr_num_reconnects_aborted_pull"`
 
 	NumAttachmentBytesPulled *SgwIntStat `json:"sgr_num_attachment_bytes_pulled"`
 	NumAttachmentsPulled     *SgwIntStat `json:"sgr_num_attachments_pulled"`
@@ -340,8 +340,8 @@ type DbReplicatorStats struct {
 	DeltaReceivedCount       *SgwIntStat `json:"sgr_deltas_recv"`
 	DeltaRequestedCount      *SgwIntStat `json:"sgr_deltas_requested"`
 	DocsCheckedReceived      *SgwIntStat `json:"sgr_docs_checked_recv"`
-	NumConnectAttemptsPush   *SgwIntStat `json:"num_connects_push"`
-	NumReconnectsAbortedPush *SgwIntStat `json:"num_reconnects_aborted_push"`
+	NumConnectAttemptsPush   *SgwIntStat `json:"sgr_num_connects_push"`
+	NumReconnectsAbortedPush *SgwIntStat `json:"sgr_num_reconnects_aborted_push"`
 
 	ConflictResolvedLocalCount  *SgwIntStat `json:"sgr_conflict_resolved_local_count"`
 	ConflictResolvedRemoteCount *SgwIntStat `json:"sgr_conflict_resolved_remote_count"`

--- a/base/stats.go
+++ b/base/stats.go
@@ -329,7 +329,7 @@ type DbReplicatorStats struct {
 	PushRejectedCount        *SgwIntStat `json:"sgr_push_rejected_count"`
 	PushDeltaSentCount       *SgwIntStat `json:"sgr_deltas_sent"`
 	DocsCheckedSent          *SgwIntStat `json:"sgr_docs_checked_sent" `
-	NumConnectAttemptsPull   *SgwIntStat `json:"sgr_num_connects_pull"`
+	NumConnectAttemptsPull   *SgwIntStat `json:"sgr_num_connect_attempts_pull"`
 	NumReconnectsAbortedPull *SgwIntStat `json:"sgr_num_reconnects_aborted_pull"`
 
 	NumAttachmentBytesPulled *SgwIntStat `json:"sgr_num_attachment_bytes_pulled"`
@@ -340,7 +340,7 @@ type DbReplicatorStats struct {
 	DeltaReceivedCount       *SgwIntStat `json:"sgr_deltas_recv"`
 	DeltaRequestedCount      *SgwIntStat `json:"sgr_deltas_requested"`
 	DocsCheckedReceived      *SgwIntStat `json:"sgr_docs_checked_recv"`
-	NumConnectAttemptsPush   *SgwIntStat `json:"sgr_num_connects_push"`
+	NumConnectAttemptsPush   *SgwIntStat `json:"sgr_num_connect_attempts_push"`
 	NumReconnectsAbortedPush *SgwIntStat `json:"sgr_num_reconnects_aborted_push"`
 
 	ConflictResolvedLocalCount  *SgwIntStat `json:"sgr_conflict_resolved_local_count"`

--- a/base/stats.go
+++ b/base/stats.go
@@ -329,6 +329,8 @@ type DbReplicatorStats struct {
 	PushRejectedCount        *SgwIntStat `json:"sgr_push_rejected_count"`
 	PushDeltaSentCount       *SgwIntStat `json:"sgr_deltas_sent"`
 	DocsCheckedSent          *SgwIntStat `json:"sgr_docs_checked_sent" `
+	NumConnectAttemptsPull   *SgwIntStat `json:"num_connects_pull"`
+	NumReconnectsAbortedPull *SgwIntStat `json:"num_reconnects_aborted_pull"`
 
 	NumAttachmentBytesPulled *SgwIntStat `json:"sgr_num_attachment_bytes_pulled"`
 	NumAttachmentsPulled     *SgwIntStat `json:"sgr_num_attachments_pulled"`
@@ -338,6 +340,8 @@ type DbReplicatorStats struct {
 	DeltaReceivedCount       *SgwIntStat `json:"sgr_deltas_recv"`
 	DeltaRequestedCount      *SgwIntStat `json:"sgr_deltas_requested"`
 	DocsCheckedReceived      *SgwIntStat `json:"sgr_docs_checked_recv"`
+	NumConnectAttemptsPush   *SgwIntStat `json:"num_connects_push"`
+	NumReconnectsAbortedPush *SgwIntStat `json:"num_reconnects_aborted_push"`
 
 	ConflictResolvedLocalCount  *SgwIntStat `json:"sgr_conflict_resolved_local_count"`
 	ConflictResolvedRemoteCount *SgwIntStat `json:"sgr_conflict_resolved_remote_count"`
@@ -689,6 +693,8 @@ func (d *DbStats) DBReplicatorStats(replicationID string) *DbReplicatorStats {
 			PushRejectedCount:           NewIntStat(SubsystemReplication, "sgr_push_rejected_count", labels, prometheus.CounterValue, 0),
 			PushDeltaSentCount:          NewIntStat(SubsystemReplication, "sgr_deltas_sent", labels, prometheus.CounterValue, 0),
 			DocsCheckedSent:             NewIntStat(SubsystemReplication, "sgr_docs_checked_sent", labels, prometheus.CounterValue, 0),
+			NumConnectAttemptsPush:      NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_push", labels, prometheus.CounterValue, 0),
+			NumReconnectsAbortedPush:    NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_push", labels, prometheus.CounterValue, 0),
 			NumAttachmentBytesPulled:    NewIntStat(SubsystemReplication, "sgr_num_attachment_bytes_pulled", labels, prometheus.CounterValue, 0),
 			NumAttachmentsPulled:        NewIntStat(SubsystemReplication, "sgr_num_attachments_pulled", labels, prometheus.CounterValue, 0),
 			PulledCount:                 NewIntStat(SubsystemReplication, "sgr_num_docs_pulled", labels, prometheus.CounterValue, 0),
@@ -700,6 +706,8 @@ func (d *DbStats) DBReplicatorStats(replicationID string) *DbReplicatorStats {
 			ConflictResolvedLocalCount:  NewIntStat(SubsystemReplication, "sgr_conflict_resolved_local_count", labels, prometheus.CounterValue, 0),
 			ConflictResolvedRemoteCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_remote_count", labels, prometheus.CounterValue, 0),
 			ConflictResolvedMergedCount: NewIntStat(SubsystemReplication, "sgr_conflict_resolved_merge_count", labels, prometheus.CounterValue, 0),
+			NumConnectAttemptsPull:      NewIntStat(SubsystemReplication, "sgr_num_connect_attempts_pull", labels, prometheus.CounterValue, 0),
+			NumReconnectsAbortedPull:    NewIntStat(SubsystemReplication, "sgr_num_reconnects_aborted_pull", labels, prometheus.CounterValue, 0),
 		}
 	}
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -1,11 +1,11 @@
 package db
 
 import (
-	"expvar"
-
 	"github.com/couchbase/sync_gateway/base"
 )
 
+// Note: To have any of these appear in expvars they must be connected to a stat inside of stats.go - This is done via
+// the BlipSyncStatsForCBL, BlipSyncStatsForSGRPush and BlipSyncStatsForSGRPull functions.
 type BlipSyncStats struct {
 	DeltaEnabledPullReplicationCount *base.SgwIntStat // global
 	HandleRevCount                   *base.SgwIntStat // handleRev
@@ -123,17 +123,6 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 	return blipStats
 }
 
-func initReplicationStat(statMap *expvar.Map, key string) (stat *expvar.Int) {
-	expvarVar := statMap.Get(key)
-	if expvarVar == nil {
-		stat = base.ExpvarIntVal(0)
-		statMap.Set(key, stat)
-	} else {
-		stat = expvarVar.(*expvar.Int)
-	}
-	return stat
-}
-
 func BlipSyncStatsForSGRPush(replicationStats *base.DbReplicatorStats) *BlipSyncStats {
 	blipStats := NewBlipSyncStats()
 
@@ -146,6 +135,9 @@ func BlipSyncStatsForSGRPush(replicationStats *base.DbReplicatorStats) *BlipSync
 	blipStats.SendRevErrorRejectedCount = replicationStats.PushRejectedCount
 	blipStats.SendRevDeltaSentCount = replicationStats.PushDeltaSentCount
 	blipStats.SendChangesCount = replicationStats.DocsCheckedSent
+	blipStats.NumConnectAttempts = replicationStats.NumConnectAttemptsPush
+	blipStats.NumReconnectsAborted = replicationStats.NumReconnectsAbortedPush
+
 	return blipStats
 }
 
@@ -160,6 +152,8 @@ func BlipSyncStatsForSGRPull(replicationStats *base.DbReplicatorStats) *BlipSync
 	blipStats.HandleRevDeltaRecvCount = replicationStats.DeltaReceivedCount
 	blipStats.HandleChangesDeltaRequestedCount = replicationStats.DeltaRequestedCount
 	blipStats.HandleChangesCount = replicationStats.DocsCheckedReceived
+	blipStats.NumConnectAttempts = replicationStats.NumConnectAttemptsPull
+	blipStats.NumReconnectsAborted = replicationStats.NumReconnectsAbortedPull
 
 	return blipStats
 }


### PR DESCRIPTION
A couple of the recently added reconnect stats weren't present in the expvars or metrics endpoints. They were added to BlipSyncStats however needed to be connected to the main stats with the BlipSyncStatsForCBL, BlipSyncStatsForSGRPush and BlipSyncStatsForSGRPull functions. Added a comment to make sure this isn't missed in future.

Also removed an unused function at the same time...