### PR TITLE
CBG-1051: Improve replicationStatus reporting prior to successful connection

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -392,6 +392,10 @@ func (r *RetryTimeoutError) Error() string {
 }
 
 func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (error, interface{}) {
+	return RetryLoopCtx(description, worker, sleeper, context.Background())
+}
+
+func RetryLoopCtx(description string, worker RetryWorker, sleeper RetrySleeper, ctx context.Context) (error, interface{}) {
 
 	numAttempts := 1
 
@@ -413,7 +417,12 @@ func RetryLoop(description string, worker RetryWorker, sleeper RetrySleeper) (er
 		}
 		Debugf(KeyAll, "RetryLoop retrying %v after %v ms.", description, sleepMs)
 
-		<-time.After(time.Millisecond * time.Duration(sleepMs))
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Retry loop for %v closed based on context", description), nil
+		case <-time.After(time.Millisecond * time.Duration(sleepMs)):
+			continue
+		}
 
 		numAttempts += 1
 

--- a/base/util.go
+++ b/base/util.go
@@ -421,7 +421,6 @@ func RetryLoopCtx(description string, worker RetryWorker, sleeper RetrySleeper, 
 		case <-ctx.Done():
 			return fmt.Errorf("Retry loop for %v closed based on context", description), nil
 		case <-time.After(time.Millisecond * time.Duration(sleepMs)):
-			continue
 		}
 
 		numAttempts += 1

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -35,6 +35,7 @@ type activeReplicatorCommon struct {
 	lock                  sync.RWMutex
 	ctx                   context.Context
 	ctxCancel             context.CancelFunc
+	reconnectActive       base.AtomicBool // Tracks whether reconnect goroutine is active
 }
 
 func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveReplicatorDirection) *activeReplicatorCommon {
@@ -60,6 +61,9 @@ func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveR
 // reconnect synchronously calls the given _connectFn until successful, or times out trying. Retry loop can be stopped by cancelling a.ctx
 func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 	base.DebugfCtx(a.ctx, base.KeyReplicate, "starting reconnector")
+	defer func() {
+		a.reconnectActive.Set(false)
+	}()
 
 	initialReconnectInterval := defaultInitialReconnectInterval
 	if a.config.InitialReconnectInterval != 0 {
@@ -116,7 +120,7 @@ func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 		return err != nil, err, nil
 	}
 
-	err, _ := base.RetryLoop("replicator reconnect", retryFunc, sleeperFunc)
+	err, _ := base.RetryLoopCtx("replicator reconnect", retryFunc, sleeperFunc, ctx)
 	// release timer associated with context deadline
 	if deadlineCancel != nil {
 		deadlineCancel()
@@ -135,6 +139,12 @@ func (a *activeReplicatorCommon) Stop() error {
 	a.setState(ReplicationStateStopped)
 	a._publishStatus()
 	a.lock.Unlock()
+
+	// Wait for up to 10s for reconnect goroutine to exit
+	teardownStart := time.Now()
+	for a.reconnectActive.IsTrue() && (time.Since(teardownStart) < time.Second*10) {
+		time.Sleep(10 * time.Millisecond)
+	}
 	return err
 }
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -106,6 +106,7 @@ func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 		// set lastError, but don't set an error state inside the reconnect loop
 		err = _connectFn()
 		a.setLastError(err)
+		a._publishStatus()
 
 		a.lock.Unlock()
 
@@ -195,7 +196,9 @@ func (a *activeReplicatorCommon) setLastError(err error) {
 func (a *activeReplicatorCommon) setState(state string) {
 	a.stateErrorLock.Lock()
 	a.state = state
-	a.lastError = nil
+	if state == ReplicationStateRunning {
+		a.lastError = nil
+	}
 	a.stateErrorLock.Unlock()
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -39,6 +39,7 @@ func (apr *ActivePullReplicator) Start() error {
 	if err != nil {
 		_ = apr.setError(err)
 		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
+		apr.reconnectActive.Set(true)
 		go apr.reconnect(apr._connect)
 	}
 	apr._publishStatus()

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -31,6 +31,7 @@ func (apr *ActivePullReplicator) Start() error {
 		return fmt.Errorf("ActivePullReplicator already running")
 	}
 
+	apr.state = ReplicationStateStarting
 	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
@@ -40,6 +41,7 @@ func (apr *ActivePullReplicator) Start() error {
 		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
 		go apr.reconnect(apr._connect)
 	}
+	apr._publishStatus()
 	return err
 }
 
@@ -86,7 +88,6 @@ func (apr *ActivePullReplicator) _connect() error {
 	}
 
 	apr.setState(ReplicationStateRunning)
-	apr._publishStatus()
 	return nil
 }
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -35,6 +35,7 @@ func (apr *ActivePushReplicator) Start() error {
 		return fmt.Errorf("ActivePushReplicator already running")
 	}
 
+	apr.state = ReplicationStateStarting
 	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 
@@ -44,6 +45,7 @@ func (apr *ActivePushReplicator) Start() error {
 		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
 		go apr.reconnect(apr._connect)
 	}
+	apr._publishStatus()
 	return err
 }
 
@@ -102,9 +104,6 @@ func (apr *ActivePushReplicator) _connect() error {
 	}(apr.blipSender)
 
 	apr.setState(ReplicationStateRunning)
-
-	apr._publishStatus()
-
 	return nil
 }
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -43,6 +43,7 @@ func (apr *ActivePushReplicator) Start() error {
 	if err != nil {
 		_ = apr.setError(err)
 		base.WarnfCtx(apr.ctx, "Couldn't connect. Attempting to reconnect in background: %v", err)
+		apr.reconnectActive.Set(true)
 		go apr.reconnect(apr._connect)
 	}
 	apr._publishStatus()

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -29,6 +29,7 @@ const (
 	ReplicationStateReconnecting = "reconnecting"
 	ReplicationStateResetting    = "resetting"
 	ReplicationStateError        = "error"
+	ReplicationStateStarting     = "starting"
 )
 
 // Replication config validation error messages


### PR DESCRIPTION
Replication status wasn't previously being persisted during retry, so reporting for non-local replications wasn't being properly displayed.  In addition, switched default replication status for an activeReplication to 'starting', since active replication isn't being created for initially stopped replications.