### PR TITLE
CBG-1021 - Fall back to getAttachment when using SGR2

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -195,6 +195,8 @@ func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sen
 		base.LogContext{CorrelationID: arc.config.ID + idSuffix},
 	)
 
+	bsc.clientType = BLIPClientTypeSGR2
+
 	// NewBlipSyncContext has already set deltas as disabled/enabled based on config.ActiveDB.
 	// If deltas have been disabled in the replication config, override this value
 	if arc.config.DeltasEnabled == false {
@@ -238,7 +240,7 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 		target.Scheme = "wss"
 	}
 
-	config, err := websocket.NewConfig(target.String()+"/_blipsync", "http://localhost")
+	config, err := websocket.NewConfig(target.String()+"/_blipsync?"+BLIPSyncClientTypeQueryParam+"="+string(BLIPClientTypeSGR2), "http://localhost")
 	if err != nil {
 		return nil, err
 	}

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -73,7 +73,6 @@ func (apr *ActivePullReplicator) _connect() error {
 		FilterChannels: apr.config.FilterChannels,
 		DocIDs:         apr.config.DocIDs,
 		ActiveOnly:     apr.config.ActiveOnly,
-		clientType:     clientTypeSGR2,
 	}
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -92,7 +92,6 @@ func (apr *ActivePushReplicator) _connect() error {
 			activeOnly:        apr.config.ActiveOnly,
 			batchSize:         int(apr.config.ChangesBatchSize),
 			channels:          channels,
-			clientType:        clientTypeSGR2,
 			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.
 		})
 		// On a normal completion, call complete for the replication

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -22,7 +22,6 @@ type SubChangesRequest struct {
 	FilterChannels []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
 	DocIDs         []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
 	ActiveOnly     bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
-	clientType     clientType
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}
@@ -43,7 +42,6 @@ func (rq *SubChangesRequest) marshalBLIPRequest() (*blip.Message, error) {
 	msg := blip.NewRequest()
 	msg.SetProfile(MessageSubChanges)
 
-	setOptionalProperty(msg.Properties, "client_sgr2", rq.clientType == clientTypeSGR2)
 	setOptionalProperty(msg.Properties, SubChangesContinuous, rq.Continuous)
 	setOptionalProperty(msg.Properties, SubChangesBatch, rq.Batch)
 	setOptionalProperty(msg.Properties, SubChangesSince, rq.Since)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -102,8 +102,12 @@ type BlipSyncContext struct {
 	conflictResolver                 *ConflictResolver                         // Conflict resolver for active replications
 	changesPendingResponseCount      int64                                     // Number of changes messages pending changesResponse
 	// TODO: For review, whether sendRevAllConflicts needs to be per sendChanges invocation
-	sendRevNoConflicts bool // Whether to set noconflicts=true when sending revisions
+	sendRevNoConflicts bool                      // Whether to set noconflicts=true when sending revisions
+	clientType         BLIPSyncContextClientType // can perform client-specific replication behaviour based on this field
+}
 
+func (bsc *BlipSyncContext) SetClientType(clientType BLIPSyncContextClientType) {
+	bsc.clientType = clientType
 }
 
 // Registers a BLIP handler including the outer-level work of logging & error handling.

--- a/db/changes.go
+++ b/db/changes.go
@@ -26,18 +26,18 @@ import (
 // Options for changes-feeds.  ChangesOptions must not contain any mutable pointer references, as
 // changes processing currently assumes a deep copy when doing chanOpts := changesOptions.
 type ChangesOptions struct {
-	Since       SequenceID      // sequence # to start _after_
-	Limit       int             // Max number of changes to return, if nonzero
-	Conflicts   bool            // Show all conflicting revision IDs, not just winning one?
-	IncludeDocs bool            // Include doc body of each change?
-	Wait        bool            // Wait for results, instead of immediately returning empty result?
-	Continuous  bool            // Run continuously until terminated?
-	Terminator  chan bool       // Caller can close this channel to terminate the feed
-	HeartbeatMs uint64          // How often to send a heartbeat to the client
-	TimeoutMs   uint64          // After this amount of time, close the longpoll connection
-	ActiveOnly  bool            // If true, only return information on non-deleted, non-removed revisions
-	clientType  clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
-	Ctx         context.Context // Used for adding context to logs
+	Since                SequenceID      // sequence # to start _after_
+	Limit                int             // Max number of changes to return, if nonzero
+	Conflicts            bool            // Show all conflicting revision IDs, not just winning one?
+	IncludeDocs          bool            // Include doc body of each change?
+	Wait                 bool            // Wait for results, instead of immediately returning empty result?
+	Continuous           bool            // Run continuously until terminated?
+	Terminator           chan bool       // Caller can close this channel to terminate the feed
+	HeartbeatMs          uint64          // How often to send a heartbeat to the client
+	TimeoutMs            uint64          // After this amount of time, close the longpoll connection
+	ActiveOnly           bool            // If true, only return information on non-deleted, non-removed revisions
+	PersistentActiveOnly bool            // CBL 2.x clients expect ActiveOnly to flip to false after the initial replication has caught up, but this can be set to true to force ActiveOnly to stay enabled.
+	Ctx                  context.Context // Used for adding context to logs
 }
 
 // A changes entry; Database.GetChanges returns an array of these.
@@ -714,8 +714,8 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			base.DebugfCtx(db.Ctx, base.KeyChanges, "MultiChangesFeed waiting... %s", base.UD(to))
 			output <- nil
 
-			// If this is an initial replication using CBL 2.x (active only), flip activeOnly now the client has caught up.
-			if options.clientType == clientTypeCBL2 && options.ActiveOnly {
+			// If this is an initial replication flip activeOnly now the client has caught up.
+			if !options.PersistentActiveOnly && options.ActiveOnly {
 				base.DebugfCtx(db.Ctx, base.KeyChanges, "%v MultiChangesFeed initial replication caught up - setting ActiveOnly to false... %s", options.Since, base.UD(to))
 				options.ActiveOnly = false
 			}

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -40,6 +40,12 @@ func (h *handler) handleBLIPSync() error {
 	ctx := db.NewBlipSyncContext(blipContext, h.db, h.formatSerialNumber(), db.BlipSyncStatsForCBL(h.db.DbStats))
 	defer ctx.Close()
 
+	if string(db.BLIPClientTypeSGR2) == h.getQuery(db.BLIPSyncClientTypeQueryParam) {
+		ctx.SetClientType(db.BLIPClientTypeSGR2)
+	} else {
+		ctx.SetClientType(db.BLIPClientTypeCBL2)
+	}
+
 	// Create a BLIP WebSocket handler and have it handle the request:
 	server := blipContext.WebSocketServer()
 	defaultHandler := server.Handler

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -219,6 +219,114 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
 }
 
+// TestActiveReplicatorPullAttachments:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates a document with an attachment on rt2 which can be pulled by the replicator running in rt1.
+//   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
+//   - Uses an ActiveReplicator configured for pull to start pulling changes from rt2.
+//   - Creates a second doc which references the same attachment.
+func TestActiveReplicatorPullAttachments(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
+
+	docID := t.Name() + "rt2doc1"
+	resp := rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","doc_num":1,`+attachment+`,"channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID := respRevID(t, resp)
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		Continuous:          true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+	})
+	defer func() { assert.NoError(t, ar.Stop()) }()
+
+	assert.Equal(t, int64(0), ar.Pull.GetStats().GetAttachment.Value())
+
+	// Start the replicator (implicit connect)
+	assert.NoError(t, ar.Start())
+
+	// wait for the document originally written to rt2 to arrive at rt1
+	changesResults, err := rt1.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	assert.Equal(t, docID, changesResults.Results[0].ID)
+
+	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, int64(1), ar.Pull.GetStats().GetAttachment.Value())
+
+	docID = t.Name() + "rt2doc2"
+	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","doc_num":2,`+attachment+`,"channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID = respRevID(t, resp)
+
+	// wait for the new document written to rt2 to arrive at rt1
+	changesResults, err = rt1.WaitForChanges(2, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 2)
+	assert.Equal(t, docID, changesResults.Results[1].ID)
+
+	doc2, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
+	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, int64(2), ar.Pull.GetStats().GetAttachment.Value())
+}
+
 // TestActiveReplicatorPullFromCheckpoint:
 //   - Starts 2 RestTesters, one active, and one passive.
 //   - Creates enough documents on rt2 which can be pulled by a replicator running in rt1 to start setting checkpoints.
@@ -728,6 +836,112 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
 	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
+}
+
+// TestActiveReplicatorPushAttachments:
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates a document with an attachment on rt1 which can be pushed by the replicator running in rt1.
+//   - Publishes the REST API on a httptest server for the passive node (so the active can connect to it)
+//   - Uses an ActiveReplicator configured for pull to start pushing changes to rt2.
+//   - Creates a second doc which references the same attachment.
+func TestActiveReplicatorPushAttachments(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+
+	// Active
+	tb1 := base.GetTestBucket(t)
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb1,
+	})
+	defer rt1.Close()
+
+	// Passive
+	tb2 := base.GetTestBucket(t)
+	rt2 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: tb2,
+		DatabaseConfig: &DbConfig{
+			Users: map[string]*db.PrincipalConfig{
+				"alice": {
+					Password:         base.StringPtr("pass"),
+					ExplicitChannels: base.SetOf("alice"),
+				},
+			},
+		},
+		noAdminParty: true,
+	})
+	defer rt2.Close()
+
+	attachment := `"_attachments":{"hi.txt":{"data":"aGk=","content_type":"text/plain"}}`
+
+	docID := t.Name() + "rt1doc1"
+	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","doc_num":1,`+attachment+`,"channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID := respRevID(t, resp)
+
+	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	// Add basic auth creds to target db URL
+	passiveDBURL.User = url.UserPassword("alice", "pass")
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		Continuous:          true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+	})
+	defer func() { assert.NoError(t, ar.Stop()) }()
+
+	assert.Equal(t, int64(0), ar.Push.GetStats().HandleGetAttachment.Value())
+
+	// Start the replicator (implicit connect)
+	assert.NoError(t, ar.Start())
+
+	// wait for the document originally written to rt1 to arrive at rt2
+	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 1)
+	assert.Equal(t, docID, changesResults.Results[0].ID)
+
+	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, int64(1), ar.Push.GetStats().HandleGetAttachment.Value())
+
+	docID = t.Name() + "rt1doc2"
+	resp = rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","doc_num":2,`+attachment+`,"channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID = respRevID(t, resp)
+
+	// wait for the new document written to rt1 to arrive at rt2
+	changesResults, err = rt2.WaitForChanges(2, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 2)
+	assert.Equal(t, docID, changesResults.Results[1].ID)
+
+	doc2, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
+	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	assert.Equal(t, int64(2), ar.Push.GetStats().HandleGetAttachment.Value())
 }
 
 // TestActiveReplicatorPushFromCheckpoint:


### PR DESCRIPTION
- Rearranged the "ClientType" code in BlipSyncContext to determine SGR2/CBL2 specific behaviour, because it was previously scoped to a changes request instead of the entire blipsync context.
- Falls back to sending getAttachment requests instead of proveAttachments when SGR2 is being used.
- Implement proveAttachments (for push replications targeting pre-Hydrogen) - manually tested with a replication from this PR targeting master.
- Adds tests for push and pull of new and duplicated attachments.