### PR TITLE
Fix reconnect ctx race

### DIFF
--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -87,7 +87,7 @@ func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 
 	retryFunc := func() (shouldRetry bool, err error, _ interface{}) {
 		select {
-		case <-a.ctx.Done():
+		case <-ctx.Done():
 			return
 		default:
 		}

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -122,7 +122,7 @@ func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 	}
 	if err != nil {
 		a.replicationStats.NumReconnectsAborted.Add(1)
-		base.WarnfCtx(a.ctx, "couldn't reconnect replicator: %v", err)
+		base.WarnfCtx(ctx, "couldn't reconnect replicator: %v", err)
 	}
 }
 

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -88,7 +88,7 @@ func (a *activeReplicatorCommon) reconnect(_connectFn func() error) {
 	retryFunc := func() (shouldRetry bool, err error, _ interface{}) {
 		select {
 		case <-ctx.Done():
-			return
+			return false, ctx.Err(), nil
 		default:
 		}
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3040,7 +3040,7 @@ func waitAndRequireCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...
 func waitAndAssertCondition(t *testing.T, fn func() bool, failureMsgAndArgs ...interface{}) {
 	for i := 0; i <= 20; i++ {
 		if i == 20 {
-			require.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
+			assert.Fail(t, "Condition failed to be satisfied", failureMsgAndArgs...)
 		}
 		if fn() {
 			break


### PR DESCRIPTION
We take a copy of a.ctx earlier and wrap it with a deadline, but accidentally using the original context.

- Added optional test messages in `waitAnd...Condition` helpers for easier test diagnosis.

http://mobile.jenkins.couchbase.com/job/sgw-unix-build/14146/consoleText