### PR TITLE
CBG-945 Clear status on replication reset

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -706,6 +706,29 @@ func (d *DbStats) DBReplicatorStats(replicationID string) *DbReplicatorStats {
 	return d.DbReplicatorStats[replicationID]
 }
 
+// Reset replication stats to zero
+func (dbr *DbReplicatorStats) Reset() {
+	dbr.NumAttachmentBytesPushed.Set(0)
+	dbr.NumAttachmentPushed.Set(0)
+	dbr.NumDocPushed.Set(0)
+	dbr.NumDocsFailedToPush.Set(0)
+	dbr.PushConflictCount.Set(0)
+	dbr.PushRejectedCount.Set(0)
+	dbr.PushDeltaSentCount.Set(0)
+	dbr.DocsCheckedSent.Set(0)
+	dbr.NumAttachmentBytesPulled.Set(0)
+	dbr.NumAttachmentsPulled.Set(0)
+	dbr.PulledCount.Set(0)
+	dbr.PurgedCount.Set(0)
+	dbr.FailedToPullCount.Set(0)
+	dbr.DeltaReceivedCount.Set(0)
+	dbr.DeltaRequestedCount.Set(0)
+	dbr.DocsCheckedReceived.Set(0)
+	dbr.ConflictResolvedLocalCount.Set(0)
+	dbr.ConflictResolvedRemoteCount.Set(0)
+	dbr.ConflictResolvedMergedCount.Set(0)
+}
+
 func (d *DbStats) Security() *SecurityStats {
 	return d.SecurityStats
 }

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -123,6 +123,10 @@ func (ar *ActiveReplicator) Reset() error {
 		return pullErr
 	}
 
+	if ar.config.ReplicationStatsMap != nil {
+		ar.config.ReplicationStatsMap.Reset()
+	}
+
 	return nil
 }
 
@@ -170,16 +174,10 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 
 	if ar.Pull != nil {
 		status.PullReplicationStatus = ar.Pull.GetStatus().PullReplicationStatus
-		if ar.Pull.Checkpointer != nil {
-			status.LastSeqPull = ar.Pull.Checkpointer.calculateSafeProcessedSeq()
-		}
 	}
 
 	if ar.Push != nil {
 		status.PushReplicationStatus = ar.Push.GetStatus().PushReplicationStatus
-		if ar.Push.Checkpointer != nil {
-			status.LastSeqPush = ar.Push.Checkpointer.calculateSafeProcessedSeq()
-		}
 	}
 
 	return status

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -528,6 +528,70 @@ func TestPullReplicationAPI(t *testing.T) {
 	assert.Equal(t, "rt2", doc2Body["source"])
 }
 
+// TestPullReplicationAPI
+//   - Starts 2 RestTesters, one active, and one passive.
+//   - Creates a continuous pull replication on rt1 via the REST API
+//   - Validates stop/start/reset actions on the replicationStatus endpoint
+func TestReplicationStatusActions(t *testing.T) {
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+
+	rt1, rt2, remoteURLString, teardown := setupSGRPeers(t)
+	defer teardown()
+
+	// Create doc1 on rt2
+	docID1 := t.Name() + "rt2doc"
+	_ = rt2.putDoc(docID1, `{"source":"rt2","channels":["alice"]}`)
+
+	// Create pull replication, verify running
+	replicationID := t.Name()
+	rt1.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePull, nil, true)
+	rt1.assertReplicationState(replicationID, db.ReplicationStateRunning)
+
+	// wait for document originally written to rt2 to arrive at rt1
+	changesResults := rt1.RequireWaitChanges(1, "0")
+	changesResults.requireDocIDs(t, []string{docID1})
+
+	// Validate doc1 contents
+	doc1Body := rt1.getDoc(docID1)
+	assert.Equal(t, "rt2", doc1Body["source"])
+
+	// Create doc2 on rt2
+	docID2 := t.Name() + "rt2doc2"
+	_ = rt2.putDoc(docID2, `{"source":"rt2","channels":["alice"]}`)
+
+	// wait for new document to arrive at rt1
+	changesResults = rt1.RequireWaitChanges(1, changesResults.Last_Seq.(string))
+	changesResults.requireDocIDs(t, []string{docID2})
+
+	// Validate doc2 contents
+	doc2Body := rt1.getDoc(docID2)
+	assert.Equal(t, "rt2", doc2Body["source"])
+
+	// Stop replication
+	response := rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=stop", "")
+	assertStatus(t, response, http.StatusOK)
+
+	// Wait for stopped.  Non-instant as config change needs to arrive over DCP
+	rt1.WaitForCondition(func() bool {
+		status := rt1.GetReplicationStatus(replicationID)
+		return status.Status == db.ReplicationStateStopped
+	})
+
+	// Reset replication
+	response = rt1.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=reset", "")
+	assertStatus(t, response, http.StatusOK)
+
+	time.Sleep(1 * time.Second)
+	status := rt1.GetReplicationStatus(replicationID)
+	assert.Equal(t, db.ReplicationStateStopped, status.Status)
+	assert.Equal(t, 0, status.LastSeqPull)
+
+}
+
 // TestReplicationRebalancePull
 //   - Starts 2 RestTesters, one active, and one passive.
 //   - Creates documents on rt1 in two channels


### PR DESCRIPTION
Resets stats and invalidates checkpointer on replication reset.  Requires some additional locking around checkpointer nil checks.  Added test to validate no concurrent access locking.