### PR TITLE
CBG-1021 (v2) - Add fallback for getAttachment when proveAttachment not available

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -862,7 +862,7 @@ func (bh *blipHandler) sendGetAttachment(sender *blip.Sender, docID string, name
 }
 
 // sendProveAttachment asks the peer to prove they have the attachment, without actually sending it.
-// This is to prevent clients from creating a doc with a digest for an attachment they don't otherwise can't access to download it.
+// This is to prevent clients from creating a doc with a digest for an attachment they otherwise can't access, in order to download it.
 func (bh *blipHandler) sendProveAttachment(sender *blip.Sender, docID, name, digest string, knownData []byte) error {
 	base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Verifying attachment %q for doc %s (digest %s)", base.UD(name), base.UD(docID), digest)
 	nonce, proof := GenerateProofOfAttachment(knownData)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -18,14 +18,15 @@ import (
 
 // kHandlersByProfile defines the routes for each message profile (verb) of an incoming request to the function that handles it.
 var kHandlersByProfile = map[string]blipHandlerFunc{
-	MessageGetCheckpoint:  (*blipHandler).handleGetCheckpoint,
-	MessageSetCheckpoint:  (*blipHandler).handleSetCheckpoint,
-	MessageSubChanges:     userBlipHandler((*blipHandler).handleSubChanges),
-	MessageChanges:        userBlipHandler((*blipHandler).handleChanges),
-	MessageRev:            userBlipHandler((*blipHandler).handleRev),
-	MessageNoRev:          (*blipHandler).handleNoRev,
-	MessageGetAttachment:  userBlipHandler((*blipHandler).handleGetAttachment),
-	MessageProposeChanges: (*blipHandler).handleProposeChanges,
+	MessageGetCheckpoint:   (*blipHandler).handleGetCheckpoint,
+	MessageSetCheckpoint:   (*blipHandler).handleSetCheckpoint,
+	MessageSubChanges:      userBlipHandler((*blipHandler).handleSubChanges),
+	MessageChanges:         userBlipHandler((*blipHandler).handleChanges),
+	MessageRev:             userBlipHandler((*blipHandler).handleRev),
+	MessageNoRev:           (*blipHandler).handleNoRev,
+	MessageGetAttachment:   userBlipHandler((*blipHandler).handleGetAttachment),
+	MessageProveAttachment: userBlipHandler((*blipHandler).handleProveAttachment),
+	MessageProposeChanges:  (*blipHandler).handleProposeChanges,
 }
 
 type blipHandler struct {
@@ -764,6 +765,36 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 
 //////// ATTACHMENTS:
 
+func (bh *blipHandler) handleProveAttachment(rq *blip.Message) error {
+	nonce, err := rq.Body()
+	if err != nil {
+		return err
+	}
+
+	if len(nonce) == 0 {
+		return base.HTTPErrorf(http.StatusBadRequest, "no nonce sent with proveAttachment")
+	}
+
+	digest, ok := rq.Properties[ProveAttachmentDigest]
+	if !ok {
+		return base.HTTPErrorf(http.StatusBadRequest, "no digest sent with proveAttachment")
+	}
+
+	attData, err := bh.db.GetAttachment(AttachmentKey(digest))
+	if err != nil {
+		panic(fmt.Sprintf("error getting client attachment: %v", err))
+	}
+
+	proof := ProveAttachment(attData, nonce)
+
+	resp := rq.Response()
+	resp.SetBody([]byte(proof))
+
+	bh.replicationStats.HandleProveAttachment.Add(1)
+
+	return nil
+}
+
 // Received a "getAttachment" request
 func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
 
@@ -792,65 +823,107 @@ func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
 	return nil
 }
 
+var NoBLIPHandlerError = fmt.Errorf("404 - No handler for BLIP request")
+
+func (bh *blipHandler) sendGetAttachment(sender *blip.Sender, docID string, name string, digest string, meta map[string]interface{}) ([]byte, error) {
+	// If I don't have the attachment, I will request it from the client:
+	base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Asking for attachment %q for doc %s (digest %s)", base.UD(name), base.UD(docID), digest)
+	outrq := blip.NewRequest()
+	outrq.Properties = map[string]string{BlipProfile: MessageGetAttachment, GetAttachmentDigest: digest}
+	if isCompressible(name, meta) {
+		outrq.Properties[BlipCompress] = "true"
+	}
+	if !bh.sendBLIPMessage(sender, outrq) {
+		return nil, ErrClosedBLIPSender
+	}
+
+	resp := outrq.Response()
+
+	respBody, err := resp.Body()
+	if err != nil {
+		return nil, err
+	}
+
+	lNum, metaLengthOK := meta["length"].(json.Number)
+	metaLength, err := lNum.Int64()
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify that the attachment we received matches the metadata stored in the document
+	if !metaLengthOK || len(respBody) != int(metaLength) || Sha1DigestKey(respBody) != digest {
+		return nil, base.HTTPErrorf(http.StatusBadRequest, "Incorrect data sent for attachment with digest: %s", digest)
+	}
+
+	bh.replicationStats.GetAttachment.Add(1)
+	bh.replicationStats.GetAttachmentBytes.Add(metaLength)
+
+	return respBody, nil
+}
+
+func (bh *blipHandler) sendProveAttachment(sender *blip.Sender, docID, name, digest string, knownData []byte) error {
+	// If I have the attachment already I don't need the client to send it, but for
+	// security purposes I do need the client to _prove_ it has the data, otherwise if
+	// it knew the digest it could acquire the data by uploading a document with the
+	// claimed attachment, then downloading it.
+	base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Verifying attachment %q for doc %s (digest %s)", base.UD(name), base.UD(docID), digest)
+	nonce, proof := GenerateProofOfAttachment(knownData)
+	outrq := blip.NewRequest()
+	outrq.Properties = map[string]string{BlipProfile: MessageProveAttachment, ProveAttachmentDigest: digest}
+	outrq.SetBody(nonce)
+	if !bh.sendBLIPMessage(sender, outrq) {
+		return ErrClosedBLIPSender
+	}
+
+	resp := outrq.Response()
+
+	body, err := resp.Body()
+	if err != nil {
+		base.WarnfCtx(bh.loggingCtx, "Error returned for proveAttachment message for doc %s (digest %s).  Error: %v", base.UD(docID), digest, err)
+		return err
+	}
+
+	if resp.Type() == blip.ErrorType &&
+		resp.Properties["Error-Domain"] == blip.BLIPErrorDomain &&
+		resp.Properties["Error-Code"] == "404" {
+		return NoBLIPHandlerError
+	}
+
+	if string(body) != proof {
+		base.WarnfCtx(bh.loggingCtx, "Incorrect proof for attachment %s : I sent nonce %x, expected proof %q, got %q", digest, base.MD(nonce), base.MD(proof), base.MD(string(body)))
+		return base.HTTPErrorf(http.StatusForbidden, "Incorrect proof for attachment %s", digest)
+	}
+
+	bh.replicationStats.ProveAttachment.Add(1)
+
+	base.InfofCtx(bh.loggingCtx, base.KeySync, "proveAttachment successful for doc %s (digest %s)", base.UD(docID), digest)
+	return nil
+}
+
 // For each attachment in the revision, makes sure it's in the database, asking the client to
 // upload it if necessary. This method blocks until all the attachments have been processed.
 func (bh *blipHandler) downloadOrVerifyAttachments(sender *blip.Sender, body Body, minRevpos int, docID string) error {
 	return bh.db.ForEachStubAttachment(body, minRevpos,
 		func(name string, digest string, knownData []byte, meta map[string]interface{}) ([]byte, error) {
-			if knownData != nil {
-				// If I have the attachment already I don't need the client to send it, but for
-				// security purposes I do need the client to _prove_ it has the data, otherwise if
-				// it knew the digest it could acquire the data by uploading a document with the
-				// claimed attachment, then downloading it.
-				base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Verifying attachment %q for doc %s (digest %s)", base.UD(name), base.UD(docID), digest)
-				nonce, proof := GenerateProofOfAttachment(knownData)
-				outrq := blip.NewRequest()
-				outrq.Properties = map[string]string{BlipProfile: MessageProveAttachment, ProveAttachmentDigest: digest}
-				outrq.SetBody(nonce)
-				if !bh.sendBLIPMessage(sender, outrq) {
-					return nil, ErrClosedBLIPSender
-				}
-				if body, err := outrq.Response().Body(); err != nil {
-					base.WarnfCtx(bh.loggingCtx, "Error returned for proveAttachment message for doc %s (digest %s).  Error: %v", base.UD(docID), digest, err)
-					return nil, err
-				} else if string(body) != proof {
-					base.WarnfCtx(bh.loggingCtx, "Incorrect proof for attachment %s : I sent nonce %x, expected proof %q, got %q", digest, base.MD(nonce), base.MD(proof), base.MD(string(body)))
-					return nil, base.HTTPErrorf(http.StatusForbidden, "Incorrect proof for attachment %s", digest)
-				} else {
-					base.InfofCtx(bh.loggingCtx, base.KeySync, "proveAttachment successful for doc %s (digest %s)", base.UD(docID), digest)
-				}
-				return nil, nil
-			} else {
-				// If I don't have the attachment, I will request it from the client:
-				base.DebugfCtx(bh.loggingCtx, base.KeySync, "    Asking for attachment %q for doc %s (digest %s)", base.UD(name), base.UD(docID), digest)
-				outrq := blip.NewRequest()
-				outrq.Properties = map[string]string{BlipProfile: MessageGetAttachment, GetAttachmentDigest: digest}
-				if isCompressible(name, meta) {
-					outrq.Properties[BlipCompress] = "true"
-				}
-				if !bh.sendBLIPMessage(sender, outrq) {
-					return nil, ErrClosedBLIPSender
-				}
-				attBody, err := outrq.Response().Body()
-				if err != nil {
-					return nil, err
-				}
 
-				lNum, metaLengthOK := meta["length"].(json.Number)
-				metaLength, err := lNum.Int64()
-				if err != nil {
-					return nil, err
-				}
+			haveAttachment := knownData != nil
 
-				// Verify that the attachment we received matches the metadata stored in the document
-				if !metaLengthOK || len(attBody) != int(metaLength) || Sha1DigestKey(attBody) != digest {
-					return nil, base.HTTPErrorf(http.StatusBadRequest, "Incorrect data sent for attachment with digest: %s", digest)
-				}
-
-				bh.replicationStats.GetAttachment.Add(1)
-				bh.replicationStats.GetAttachmentBytes.Add(metaLength)
-				return attBody, nil
+			if !haveAttachment {
+				return bh.sendGetAttachment(sender, docID, name, digest, meta)
 			}
+
+			proveAttErr := bh.sendProveAttachment(sender, docID, name, digest, knownData)
+			if proveAttErr == NoBLIPHandlerError {
+				// fall back to getAttachment (we're probably replicating with a pre-Hydrogen SG, which doesn't support proveAttachment)
+				_, getAttErr := bh.sendGetAttachment(sender, docID, name, digest, meta)
+				if getAttErr != nil {
+					return nil, getAttErr
+				}
+			} else if proveAttErr != nil {
+				return nil, proveAttErr
+			}
+
+			return nil, nil
 		})
 }
 

--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -25,9 +25,11 @@ type BlipSyncStats struct {
 	HandleChangesCount               *base.SgwIntStat // handleChanges/handleProposeChanges
 	HandleChangesTime                *base.SgwIntStat
 	HandleChangesDeltaRequestedCount *base.SgwIntStat
+	HandleProveAttachment            *base.SgwIntStat // handleProveAttachment
 	HandleGetAttachment              *base.SgwIntStat // handleGetAttachment
 	HandleGetAttachmentBytes         *base.SgwIntStat
-	GetAttachment                    *base.SgwIntStat // getAttachment
+	ProveAttachment                  *base.SgwIntStat // sendProveAttachment
+	GetAttachment                    *base.SgwIntStat // sendGetAttachment
 	GetAttachmentBytes               *base.SgwIntStat
 	HandleChangesResponseCount       *base.SgwIntStat // handleChangesResponse
 	HandleChangesResponseTime        *base.SgwIntStat
@@ -63,9 +65,11 @@ func NewBlipSyncStats() *BlipSyncStats {
 		HandleChangesCount:               &base.SgwIntStat{}, // handleChanges/handleProposeChanges
 		HandleChangesTime:                &base.SgwIntStat{},
 		HandleChangesDeltaRequestedCount: &base.SgwIntStat{},
+		HandleProveAttachment:            &base.SgwIntStat{}, // handleProveAttachment
 		HandleGetAttachment:              &base.SgwIntStat{}, // handleGetAttachment
 		HandleGetAttachmentBytes:         &base.SgwIntStat{},
-		GetAttachment:                    &base.SgwIntStat{}, // getAttachment
+		ProveAttachment:                  &base.SgwIntStat{}, // sendProveAttachment
+		GetAttachment:                    &base.SgwIntStat{}, // sendGetAttachment
 		GetAttachmentBytes:               &base.SgwIntStat{},
 		HandleChangesResponseCount:       &base.SgwIntStat{}, // handleChangesResponse
 		HandleChangesResponseTime:        &base.SgwIntStat{},


### PR DESCRIPTION
Closing the original PR (#4744) in favour of this, as it's a simpler approach, and avoids all of the changes to "clientType" that aren't needed for this approach.

Prior to Hydrogen, Sync Gateway had no handler for `proveAttachment`,
so replications targeting those nodes failed with a "No handler" error.

This allows for Hydrogen+ nodes to replicate using the more efficient
`proveAttachment` mechanism, but still allow replication of already known
attachments with nodes where the peer can't handle proveAttachment
requests by using `getAttachment`.

## Changes
- Split the two if/else `getAttachment`/`proveAttachment` sections of `downloadOrVerifyAttachments` into separate methods for easier fallback handling.
- Added stats for proveAttachment/handleProveAttachment for testing purposes.
- Added tests for Hydrogen-Hydrogen attachment replication.

## Manual testing
Active Hydrogen with passive pre-Hydrogen, demonstrating fallback logging:
![Screenshot 2020-09-02 at 13 19 36](https://user-images.githubusercontent.com/1525809/91980980-0c573680-ed20-11ea-9b9e-0304f264db62.png)
