### PR TITLE
CBG-1059 - Fix unlocked state change causing race on replicator Start

### DIFF
--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -31,7 +31,7 @@ func (apr *ActivePullReplicator) Start() error {
 		return fmt.Errorf("ActivePullReplicator already running")
 	}
 
-	apr.state = ReplicationStateStarting
+	apr.setState(ReplicationStateStarting)
 	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePull)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -35,7 +35,7 @@ func (apr *ActivePushReplicator) Start() error {
 		return fmt.Errorf("ActivePushReplicator already running")
 	}
 
-	apr.state = ReplicationStateStarting
+	apr.setState(ReplicationStateStarting)
 	logCtx := context.WithValue(context.Background(), base.LogContextKey{}, base.LogContext{CorrelationID: apr.config.ID + "-" + string(ActiveReplicatorTypePush)})
 	apr.ctx, apr.ctxCancel = context.WithCancel(logCtx)
 


### PR DESCRIPTION
This race was being caught by `TestReplicationStatusActions` when run on Jenkins.