### PR TITLE
CBG-1052: Redact config endpoints

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -99,13 +99,31 @@ func (h *handler) handleDbOffline() error {
 
 // Get admin database info
 func (h *handler) handleGetDbConfig() error {
-	h.writeJSON(h.server.GetDatabaseConfig(h.db.Name))
+	redact, _ := h.getOptBoolQuery("redact", true)
+	if redact {
+		cfg, err := h.server.GetDatabaseConfig(h.db.Name).Redacted()
+		if err != nil {
+			return err
+		}
+		h.writeJSON(cfg)
+	} else {
+		h.writeJSON(h.server.GetDatabaseConfig(h.db.Name))
+	}
 	return nil
 }
 
 // Get admin config info
 func (h *handler) handleGetConfig() error {
-	h.writeJSON(h.server.GetConfig())
+	redact, _ := h.getOptBoolQuery("redact", true)
+	if redact {
+		cfg, err := h.server.GetConfig().Redacted()
+		if err != nil {
+			return err
+		}
+		h.writeJSON(cfg)
+	} else {
+		h.writeJSON(h.server.GetConfig())
+	}
 	return nil
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1839,7 +1839,7 @@ func TestHandleDBConfig(t *testing.T) {
 	assert.Equal(t, "Online", respBody["state"].(string))
 
 	// Put database config
-	resource = fmt.Sprintf("/%v/_config", bucket)
+	resource = fmt.Sprintf("/%v/_config?redact=false", bucket)
 
 	bucketConfig := BucketConfig{
 		Server:     &server,

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2155,7 +2155,7 @@ func TestConfigRedaction(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "password", unmarshaledConfig.Password)
+	assert.Equal(t, base.TestClusterPassword(), unmarshaledConfig.Password)
 	assert.Equal(t, "password", *unmarshaledConfig.Users["alice"].Password)
 
 	// Test default server config redaction
@@ -2172,6 +2172,6 @@ func TestConfigRedaction(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "password", unmarshaledServerConfig.Databases["db"].Password)
+	assert.Equal(t, base.TestClusterPassword(), unmarshaledServerConfig.Databases["db"].Password)
 	assert.Equal(t, "password", *unmarshaledServerConfig.Databases["db"].Users["alice"].Password)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2136,3 +2136,42 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &responseBody))
 }
+
+func TestConfigRedaction(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{Users: map[string]*db.PrincipalConfig{"alice": {Password: base.StringPtr("password")}}}})
+	defer rt.Close()
+
+	// Test default db config redaction
+	var unmarshaledConfig DbConfig
+	response := rt.SendAdminRequest("GET", "/db/_config", "")
+	err := json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, "****", unmarshaledConfig.Password)
+	assert.Equal(t, "****", *unmarshaledConfig.Users["alice"].Password)
+
+	// Test default db config redaction when redaction disabled
+	response = rt.SendAdminRequest("GET", "/db/_config?redact=false", "")
+	err = json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, "password", unmarshaledConfig.Password)
+	assert.Equal(t, "password", *unmarshaledConfig.Users["alice"].Password)
+
+	// Test default server config redaction
+	var unmarshaledServerConfig ServerConfig
+	response = rt.SendAdminRequest("GET", "/_config", "")
+	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, "****", unmarshaledServerConfig.Databases["db"].Password)
+	assert.Equal(t, "****", *unmarshaledServerConfig.Databases["db"].Users["alice"].Password)
+
+	// Test default server config redaction when redaction disabled
+	response = rt.SendAdminRequest("GET", "/_config?redact=false", "")
+	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, "password", unmarshaledServerConfig.Databases["db"].Password)
+	assert.Equal(t, "password", *unmarshaledServerConfig.Databases["db"].Users["alice"].Password)
+}

--- a/rest/config.go
+++ b/rest/config.go
@@ -613,6 +613,10 @@ func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
 		config.Users[i].Password = base.StringPtr("****")
 	}
 
+	for i, _ := range config.Replications {
+		config.Replications[i] = config.Replications[i].Redacted()
+	}
+
 	return &config, nil
 }
 
@@ -841,9 +845,6 @@ func (sc *ServerConfig) Redacted() (*ServerConfig, error) {
 		config.Databases[i], err = config.Databases[i].Redacted()
 		if err != nil {
 			return nil, err
-		}
-		for j, _ := range config.Databases[i].Replications {
-			config.Databases[i].Replications[j] = config.Databases[i].Replications[j].Redacted()
 		}
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -599,6 +599,23 @@ func (dbConfig *DbConfig) UseXattrs() bool {
 	return base.DefaultUseXattrs
 }
 
+func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
+	var config DbConfig
+
+	err := base.DeepCopyInefficient(&config, dbConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	config.Password = "****"
+
+	for i := range config.Users {
+		config.Users[i].Password = base.StringPtr("****")
+	}
+
+	return &config, nil
+}
+
 // Implementation of AuthHandler interface for ClusterConfig
 func (clusterConfig *ClusterConfig) GetCredentials() (string, string, string) {
 	return base.TransformBucketCredentials(clusterConfig.Username, clusterConfig.Password, *clusterConfig.Bucket)
@@ -810,6 +827,27 @@ func (self *ServerConfig) MergeWith(other *ServerConfig) error {
 		self.Databases[name] = db
 	}
 	return nil
+}
+
+func (sc *ServerConfig) Redacted() (*ServerConfig, error) {
+	var config ServerConfig
+
+	err := base.DeepCopyInefficient(&config, sc)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range config.Databases {
+		config.Databases[i], err = config.Databases[i].Redacted()
+		if err != nil {
+			return nil, err
+		}
+		for j, _ := range config.Databases[i].Replications {
+			config.Databases[i].Replications[j] = config.Databases[i].Replications[j].Redacted()
+		}
+	}
+
+	return &config, nil
 }
 
 // Reads the command line flags and the optional config file.


### PR DESCRIPTION
Added redact query to _config endpoints which is true by default. This redacts the bucket password, user passwords and replications config on the /db/_config and /_config endpoints.
Added unit tests to verify this.

---

- [x] Test fix