### PR TITLE
CBG-1026 Restrict EE-only functionality

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -19,7 +19,7 @@ const DefaultImportPartitions = 16
 // CbgtContext holds the two handles we have for CBGT-related functionality.
 type CbgtContext struct {
 	Manager           *cbgt.Manager            // Manager is main entry point for initialization, registering indexes
-	Cfg               *CfgSG                   // Cfg manages storage of the current pindex set and node assignment
+	Cfg               cbgt.Cfg                 // Cfg manages storage of the current pindex set and node assignment
 	heartbeater       Heartbeater              // Heartbeater used for failed node detection
 	heartbeatListener *importHeartbeatListener // Listener subscribed to failed node alerts from heartbeater
 	loggingCtx        context.Context          // Context for cbgt logging
@@ -27,7 +27,7 @@ type CbgtContext struct {
 
 // StartShardedDCPFeed initializes and starts a CBGT Manager targeting the provided bucket.
 // dbName is used to define a unique path name for local file storage of pindex files
-func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket *CouchbaseBucketGoCB, numPartitions uint16, cfg *CfgSG) (*CbgtContext, error) {
+func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket *CouchbaseBucketGoCB, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
 
 	cbgtContext, err := initCBGTManager(bucket, bucket.Spec, cfg, uuid)
 	if err != nil {
@@ -202,7 +202,7 @@ func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (exists bool, pre
 // createCBGTManager creates a new manager for a given bucket and bucketSpec
 // Inline comments below provide additional detail on how cbgt uses each manager
 // parameter, and the implications for SG
-func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG *CfgSG, dbUUID string) (*CbgtContext, error) {
+func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string) (*CbgtContext, error) {
 
 	// uuid: Unique identifier for the node. Used to identify the node in the config.
 	//       Without UUID persistence across SG restarts, a restarted SG node relies on heartbeater to remove

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -20,6 +20,8 @@ type CfgSG struct {
 	lock          sync.Mutex                        // mutex for subscriptions
 }
 
+type CfgEventNotifyFunc func(docID string, cas uint64, err error)
+
 var ErrCfgCasError = &cbgt.CfgCASError{}
 
 // NewCfgSG returns a Cfg implementation that reads/writes its entries

--- a/db/database.go
+++ b/db/database.go
@@ -365,8 +365,8 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	importEnabled := dbContext.UseXattrs() && dbContext.autoImport
 	sgReplicateEnabled := dbContext.Options.SGReplicateOptions.Enabled
 
-	// Initialize node heartbeater if sg-replicate or import enabled on the node
-	if importEnabled || sgReplicateEnabled {
+	// Initialize node heartbeater in EE mode if sg-replicate or import enabled on the node
+	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
 		// Create heartbeater
 		heartbeater, err := base.NewCouchbaseHeartbeater(bucket, base.SyncPrefix, dbContext.UUID)
 		if err != nil {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -142,6 +142,19 @@ type ReplicationUpsertConfig struct {
 
 func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 
+	// Perform EE checks first, to avoid error messages related to EE functionality
+	if !base.IsEnterpriseEdition() {
+		if rc.ConflictResolutionType != "" && rc.ConflictResolutionType != ConflictResolverDefault {
+			return base.HTTPErrorf(http.StatusBadRequest, "Non-default conflict_resolution_type is only supported in enterprise edition")
+		}
+		if rc.DeltaSyncEnabled == true {
+			return base.HTTPErrorf(http.StatusBadRequest, "Delta sync for sg-replicate is only supported in enterprise edition")
+		}
+		if rc.BatchSize > 0 && rc.BatchSize != defaultChangesBatchSize {
+			return base.HTTPErrorf(http.StatusBadRequest, "Replication batch_size can only be configured in enterprise edition")
+		}
+	}
+
 	// Checkpoint keys are prefixed with 35 characters:  _sync:local:checkpoint/sgr2cp:pull:
 	// Setting length limit for replication ID to 160 characters to retain some room for future
 	// key-related enhancements
@@ -411,6 +424,11 @@ func (m *sgReplicateManager) StartLocalNode(nodeUUID string, heartbeater base.He
 	}
 
 	m.localNodeUUID = nodeUUID
+
+	// Heartbeat registration is EE-only, only register if heartbeater is non-nil
+	if heartbeater == nil {
+		return nil
+	}
 
 	m.heartbeatListener, err = NewReplicationHeartbeatListener(m)
 	if err != nil {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -379,7 +379,7 @@ func (ar *ActiveReplicator) alignState(targetState string) error {
 
 }
 
-func NewSGReplicateManager(dbContext *DatabaseContext, cfg *base.CfgSG) (*sgReplicateManager, error) {
+func NewSGReplicateManager(dbContext *DatabaseContext, cfg cbgt.Cfg) (*sgReplicateManager, error) {
 	if cfg == nil {
 		return nil, errors.New("Cfg must be provided for SGReplicateManager")
 	}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -635,6 +635,10 @@ func TestReplicationStatusActions(t *testing.T) {
 //   - Creates more documents, validates they are replicated
 func TestReplicationRebalancePull(t *testing.T) {
 
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only (replication rebalance)")
+	}
+
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
@@ -722,6 +726,10 @@ func TestReplicationRebalancePull(t *testing.T) {
 //   - adds another active node
 //   - Creates more documents, validates they are replicated
 func TestReplicationRebalancePush(t *testing.T) {
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only (replication rebalance)")
+	}
 
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {
 		t.Skipf("test requires at least 2 usable test buckets")


### PR DESCRIPTION
When running in CE mode, use an in-memory cluster config to provide the full replication management functionality, but isolated to that node.

Also includes config validation for EE-only customization options.