### PR TITLE
CBG-1053: Adhoc replicationStatus panic fix

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -328,7 +328,7 @@ func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (st
 		status.LastSeqPush = pushCheckpoint.Status.LastSeqPush
 	}
 
-	if pullCheckpoint == nil && pushCheckpoint == nil {
+	if (pullCheckpoint == nil || pullCheckpoint.Status == nil) && (pushCheckpoint == nil || pushCheckpoint.Status == nil) {
 		return nil, errors.New("Replication status not found")
 	}
 

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -313,7 +313,7 @@ func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (st
 	}
 
 	pullCheckpoint, _ := getLocalCheckpoint(dbContext, PullCheckpointID(replicationID))
-	if pullCheckpoint != nil {
+	if pullCheckpoint != nil && pullCheckpoint.Status != nil {
 		status.PullReplicationStatus = pullCheckpoint.Status.PullReplicationStatus
 		status.Status = pullCheckpoint.Status.Status
 		status.ErrorMessage = pullCheckpoint.Status.ErrorMessage
@@ -321,7 +321,7 @@ func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (st
 	}
 
 	pushCheckpoint, _ := getLocalCheckpoint(dbContext, PushCheckpointID(replicationID))
-	if pushCheckpoint != nil {
+	if pushCheckpoint != nil && pushCheckpoint.Status != nil {
 		status.PushReplicationStatus = pushCheckpoint.Status.PushReplicationStatus
 		status.Status = pushCheckpoint.Status.Status
 		status.ErrorMessage = pushCheckpoint.Status.ErrorMessage

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -313,19 +313,27 @@ func LoadReplicationStatus(dbContext *DatabaseContext, replicationID string) (st
 	}
 
 	pullCheckpoint, _ := getLocalCheckpoint(dbContext, PullCheckpointID(replicationID))
-	if pullCheckpoint != nil && pullCheckpoint.Status != nil {
-		status.PullReplicationStatus = pullCheckpoint.Status.PullReplicationStatus
-		status.Status = pullCheckpoint.Status.Status
-		status.ErrorMessage = pullCheckpoint.Status.ErrorMessage
-		status.LastSeqPull = pullCheckpoint.Status.LastSeqPull
+	if pullCheckpoint != nil {
+		if pullCheckpoint.Status != nil {
+			status.PullReplicationStatus = pullCheckpoint.Status.PullReplicationStatus
+			status.Status = pullCheckpoint.Status.Status
+			status.ErrorMessage = pullCheckpoint.Status.ErrorMessage
+			status.LastSeqPull = pullCheckpoint.Status.LastSeqPull
+		} else {
+			status.LastSeqPull = pullCheckpoint.LastSeq
+		}
 	}
 
 	pushCheckpoint, _ := getLocalCheckpoint(dbContext, PushCheckpointID(replicationID))
-	if pushCheckpoint != nil && pushCheckpoint.Status != nil {
-		status.PushReplicationStatus = pushCheckpoint.Status.PushReplicationStatus
-		status.Status = pushCheckpoint.Status.Status
-		status.ErrorMessage = pushCheckpoint.Status.ErrorMessage
-		status.LastSeqPush = pushCheckpoint.Status.LastSeqPush
+	if pushCheckpoint != nil {
+		if pushCheckpoint.Status != nil {
+			status.PushReplicationStatus = pushCheckpoint.Status.PushReplicationStatus
+			status.Status = pushCheckpoint.Status.Status
+			status.ErrorMessage = pushCheckpoint.Status.ErrorMessage
+			status.LastSeqPush = pushCheckpoint.Status.LastSeqPush
+		} else {
+			status.LastSeqPush = pushCheckpoint.LastSeq
+		}
 	}
 
 	if (pullCheckpoint == nil || pullCheckpoint.Status == nil) && (pushCheckpoint == nil || pushCheckpoint.Status == nil) {

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -134,10 +134,10 @@ func (ar *ActiveReplicator) Reset() error {
 // associated with the ActiveReplicator are complete, onComplete is invoked
 func (ar *ActiveReplicator) _onReplicationComplete() {
 	allReplicationsComplete := true
-	if ar.Push != nil && ar.Push.state != ReplicationStateStopped {
+	if ar.Push != nil && ar.Push.getState() != ReplicationStateStopped {
 		allReplicationsComplete = false
 	}
-	if ar.Pull != nil && ar.Pull.state != ReplicationStateStopped {
+	if ar.Pull != nil && ar.Pull.getState() != ReplicationStateStopped {
 		allReplicationsComplete = false
 	}
 


### PR DESCRIPTION
Status section of the checkpoint was nil and causing the panic. A simple nil check against that prevents the issue.