### PR TITLE
Fix race for allowed attachment processing

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -356,6 +356,7 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docI
 
 	// send the rev
 	if !bsc.sendBLIPMessage(sender, outrq.Message) {
+		bsc.removeAllowedAttachments(attDigests)
 		return ErrClosedBLIPSender
 	}
 


### PR DESCRIPTION
Not seen this manifest in the real world, but there's a gap between
sending the rev message, and adding the allowed attachments that the
client will ask for. If the response gets back to us quick enough, the
attachments won't be marked as allowed.