### PR TITLE
CBG-1047 Re-initialize replication when config is upserted

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,10 @@ type ActiveReplicatorConfig struct {
 	WebsocketPingInterval time.Duration
 	// Conflict resolver
 	ConflictResolverFunc ConflictResolverFunc
+	// Conflict resolution type.  Required for Equals comparison only
+	ConflictResolutionType ConflictResolverType
+	// Conflict resolver source, for custom conflict resolver.  Required for Equals comparison only
+	ConflictResolverFuncSrc string
 	// SGR1CheckpointID can be used as a fallback when SGR2 checkpoints can't be found.
 	SGR1CheckpointID string
 	// InitialReconnectInterval is the initial time to wait for exponential backoff reconnects.
@@ -125,4 +130,81 @@ func (arc ActiveReplicatorConfig) CheckpointHash() (string, error) {
 	}
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func (arc *ActiveReplicatorConfig) Equals(other *ActiveReplicatorConfig) bool {
+
+	if arc.ID != other.ID {
+		return false
+	}
+
+	if arc.Filter != other.Filter {
+		return false
+	}
+
+	if !reflect.DeepEqual(arc.FilterChannels, other.FilterChannels) {
+		return false
+	}
+
+	if !reflect.DeepEqual(arc.DocIDs, other.DocIDs) {
+		return false
+	}
+
+	if arc.ActiveOnly != other.ActiveOnly {
+		return false
+	}
+
+	if arc.ChangesBatchSize != other.ChangesBatchSize {
+		return false
+	}
+
+	if arc.CheckpointInterval != other.CheckpointInterval {
+		return false
+	}
+
+	if arc.Direction != other.Direction {
+		return false
+	}
+
+	if arc.Continuous != other.Continuous {
+		return false
+	}
+
+	if !reflect.DeepEqual(arc.RemoteDBURL, other.RemoteDBURL) {
+		return false
+	}
+
+	if arc.PurgeOnRemoval != other.PurgeOnRemoval {
+		return false
+	}
+
+	if arc.WebsocketPingInterval != other.WebsocketPingInterval {
+		return false
+	}
+
+	if arc.ConflictResolutionType != other.ConflictResolutionType {
+		return false
+	}
+
+	if arc.ConflictResolverFuncSrc != other.ConflictResolverFuncSrc {
+		return false
+	}
+
+	if arc.InitialReconnectInterval != other.InitialReconnectInterval {
+		return false
+	}
+
+	if arc.MaxReconnectInterval != other.MaxReconnectInterval {
+		return false
+	}
+
+	if arc.TotalReconnectTimeout != other.TotalReconnectTimeout {
+		return false
+	}
+
+	if arc.DeltasEnabled != other.DeltasEnabled {
+		return false
+	}
+
+	return true
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -641,10 +641,8 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 		} else {
 			// Check for replications assigned to this node with updated state
 			base.Debugf(base.KeyReplicate, "Aligning state for existing replication %s", replicationID)
-			// TODO: need to compare full hash here to see if replicator needs to be updated
-			//      not just checkpointer hash, as things like continuous true/false need to be considered
-			// if update required and active replicator state is not stopped, need to stop then update
-			// should all happen prior to align state
+
+			// If the config has changed, re-initialize the replication
 			isChanged, err := m.isCfgChanged(replicationCfg, activeReplicator.config)
 			if err != nil {
 				base.Warnf("Error evaluating whether cfg has changed, potential changes not applied: %v", err)

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -322,8 +322,8 @@ func (rc *ReplicationConfig) Equals(compareToCfg *ReplicationConfig) (bool, erro
 
 // Redacted returns the ReplicationCfg with password of the remote database redacted from
 // both replication config and remote URL, i.e., any password will be replaced with xxxxx.
-func (r *ReplicationConfig) Redacted() *ReplicationConfig {
-	config := *r
+func (rc *ReplicationConfig) Redacted() *ReplicationConfig {
+	config := *rc
 	if config.Password != "" {
 		config.Password = "****"
 	}
@@ -468,18 +468,9 @@ func (m *sgReplicateManager) StartReplications() error {
 	return m.SubscribeCfgChanges()
 }
 
-func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (replicator *ActiveReplicator, err error) {
-
-	base.Infof(base.KeyReplicate, "Initializing replication %v", base.UD(config.ID))
-
-	// Re-validate replication.  Replication config should have already been validated on creation/update, but
-	// re-checking here in case of issues during persistence/load.
-	configValidationError := config.ValidateReplication(false)
-	if configValidationError != nil {
-		return nil, fmt.Errorf("Validation failure for replication config when initializing replication %s: %v", base.UD(config.ID), configValidationError)
-	}
-
-	rc := &ActiveReplicatorConfig{
+// NewActiveReplicatorConfig converts an incoming ReplicationCfg to an ActiveReplicatorConfig
+func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (rc *ActiveReplicatorConfig, err error) {
+	rc = &ActiveReplicatorConfig{
 		ID:                 config.ID,
 		Continuous:         config.Continuous,
 		ActiveDB:           &Database{DatabaseContext: m.dbContext}, // sg-replicate interacts with local as admin
@@ -519,12 +510,15 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	if rc.Direction == ActiveReplicatorTypePull || rc.Direction == ActiveReplicatorTypePushAndPull {
 		if config.ConflictResolutionType == "" {
 			rc.ConflictResolverFunc, err = NewConflictResolverFunc(ConflictResolverDefault, "")
+
 		} else {
 			rc.ConflictResolverFunc, err = NewConflictResolverFunc(config.ConflictResolutionType, config.ConflictResolutionFn)
+			rc.ConflictResolverFuncSrc = config.ConflictResolutionFn
 		}
 		if err != nil {
 			return nil, err
 		}
+		rc.ConflictResolutionType = config.ConflictResolutionType
 	}
 
 	if config.Remote == "" {
@@ -545,6 +539,33 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 	rc.WebsocketPingInterval = m.dbContext.Options.SGReplicateOptions.WebsocketPingInterval
 
 	rc.onComplete = m.replicationComplete
+
+	return rc, nil
+}
+
+func (m *sgReplicateManager) isCfgChanged(newCfg *ReplicationCfg, activeCfg *ActiveReplicatorConfig) (bool, error) {
+	newConfig, err := m.NewActiveReplicatorConfig(newCfg)
+	if err != nil {
+		return true, err
+	}
+	return !newConfig.Equals(activeCfg), nil
+}
+
+func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (replicator *ActiveReplicator, err error) {
+
+	base.Infof(base.KeyReplicate, "Initializing replication %v", base.UD(config.ID))
+
+	// Re-validate replication.  Replication config should have already been validated on creation/update, but
+	// re-checking here in case of issues during persistence/load.
+	configValidationError := config.ValidateReplication(false)
+	if configValidationError != nil {
+		return nil, fmt.Errorf("Validation failure for replication config when initializing replication %s: %v", base.UD(config.ID), configValidationError)
+	}
+
+	rc, cfgErr := m.NewActiveReplicatorConfig(config)
+	if cfgErr != nil {
+		return nil, cfgErr
+	}
 
 	// Retrieve or create an entry in db.replications expvar for this replication
 	allReplicationsStatsMap := m.dbContext.DbStats.DBReplicatorStats(rc.ID)
@@ -620,6 +641,24 @@ func (m *sgReplicateManager) RefreshReplicationCfg() error {
 		} else {
 			// Check for replications assigned to this node with updated state
 			base.Debugf(base.KeyReplicate, "Aligning state for existing replication %s", replicationID)
+			// TODO: need to compare full hash here to see if replicator needs to be updated
+			//      not just checkpointer hash, as things like continuous true/false need to be considered
+			// if update required and active replicator state is not stopped, need to stop then update
+			// should all happen prior to align state
+			isChanged, err := m.isCfgChanged(replicationCfg, activeReplicator.config)
+			if err != nil {
+				base.Warnf("Error evaluating whether cfg has changed, potential changes not applied: %v", err)
+			}
+			if isChanged {
+				replicator, initError := m.InitializeReplication(replicationCfg)
+				if initError != nil {
+					base.Warnf("Error initializing upserted replication %s: %v", initError)
+				} else {
+					m.activeReplicators[replicationID] = replicator
+					activeReplicator = replicator
+				}
+			}
+
 			stateErr := activeReplicator.alignState(replicationCfg.TargetState)
 			if stateErr != nil {
 				base.Warnf("Error updating active replication %s to state %s: %v", replicationID, replicationCfg.TargetState, stateErr)


### PR DESCRIPTION
When receiving an updated cluster config, check whether the config for locally assigned replications has changed.  If changed, remove and re-initialize the replication.