### PR TITLE
Prevent activeSubChanges flag race when client is rapidly issuing requests

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1139,6 +1139,17 @@ func (ab *AtomicBool) CompareAndSwap(old bool, new bool) bool {
 	return atomic.CompareAndSwapInt32(&ab.value, oldint32, newint32)
 }
 
+// CASRetry attempts to retry CompareAndSwap for up to 1 second before returning the result.
+func (ab *AtomicBool) CASRetry(old bool, new bool) bool {
+	for i := 0; i < 10; i++ {
+		if ab.CompareAndSwap(old, new) {
+			return true
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+	return false
+}
+
 func Sha1HashString(str string, salt string) string {
 	h := sha1.New()
 	h.Write([]byte(salt + str))

--- a/base/util.go
+++ b/base/util.go
@@ -1141,11 +1141,11 @@ func (ab *AtomicBool) CompareAndSwap(old bool, new bool) bool {
 
 // CASRetry attempts to retry CompareAndSwap for up to 1 second before returning the result.
 func (ab *AtomicBool) CASRetry(old bool, new bool) bool {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		if ab.CompareAndSwap(old, new) {
 			return true
 		}
-		time.Sleep(time.Millisecond * 100)
+		time.Sleep(time.Millisecond * 10)
 	}
 	return false
 }

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -150,7 +150,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 	}
 
 	// Ensure that only _one_ subChanges subscription can be open on this blip connection at any given time.  SG #3222.
-	if !bh.activeSubChanges.CompareAndSwap(false, true) {
+	if !bh.activeSubChanges.CASRetry(false, true) {
 		return fmt.Errorf("blipHandler already has an outstanding continous subChanges.  Cannot open another one.")
 	}
 


### PR DESCRIPTION
## Background
The `activeSubChanges` flag prevents clients from issuing concurrent subChanges requests (see #3222)

## Bug

If a client is rapidly requesting subChanges (like the blackholePuller tool does in the case where there's not many revs to pull), this atomic CompareAndSwap fails, because the defer from the previous subChanges goroutine has not fired yet.

This change makes the CompareAndSwap operation retry for up to 1 second if this scenario is hit to prevent the replication from being killed.

## Repro demonstrating race w/ additional debug logging:

```
$ # create a single small doc
$ curl -X PUT http://localhost:4985/db1/doc1 -H 'Content-Type: application/json' -d '{"foo":"bar"}'
$ # make a single blackholePuller client pull this doc over and over
$ ./blackholePuller -url=http://localhost:4985/db1 -timeout=30s -clients=1
```

Observe that blackholePuller sends the next subChanges when it has recieved the "caught up" signal, but before Sync Gateway has had the chance to run the deferred Set or log the end of the request.

```
...
2020-09-10T13:43:24.149+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG handleSubChanges
2020-09-10T13:43:24.149+01:00 [INF] SyncMsg: c:[6544cd20] #2699: Type:subChanges Since:0
2020-09-10T13:43:24.149+01:00 [INF] Sync: c:[6544cd20] Sending changes since 0
2020-09-10T13:43:24.149+01:00 [INF] Changes: c:[6544cd20] MultiChangesFeed(channels: {*}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 0, ActiveOnly: false}) ...
2020-09-10T13:43:24.149+01:00 [INF] Cache: c:[6544cd20] GetCachedChanges("*", 0) --> 1 changes valid from #1
2020-09-10T13:43:24.149+01:00 [INF] Changes: c:[6544cd20] MultiChangesFeed done
2020-09-10T13:43:24.149+01:00 [INF] Sync: c:[6544cd20] Sent 1 changes to client, from seq 2
2020-09-10T13:43:24.149+01:00 [INF] Sync: c:[6544cd20] Sent all changes to client
2020-09-10T13:43:24.149+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG activeSubChanges goroutine finished
2020-09-10T13:43:24.149+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG activeSubChanges.Set(false)
2020-09-10T13:43:24.150+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG handleSubChanges
2020-09-10T13:43:24.150+01:00 [INF] SyncMsg: c:[6544cd20] #2700: Type:subChanges Since:0
2020-09-10T13:43:24.150+01:00 [INF] Sync: c:[6544cd20] Sending changes since 0
2020-09-10T13:43:24.150+01:00 [INF] Changes: c:[6544cd20] MultiChangesFeed(channels: {*}, options: {Since: 0, Limit: 0, Conflicts: false, IncludeDocs: false, Wait: false, Continuous: false, HeartbeatMs: 0, TimeoutMs: 0, ActiveOnly: false}) ...
2020-09-10T13:43:24.150+01:00 [INF] Cache: c:[6544cd20] GetCachedChanges("*", 0) --> 1 changes valid from #1
2020-09-10T13:43:24.150+01:00 [INF] Changes: c:[6544cd20] MultiChangesFeed done
2020-09-10T13:43:24.150+01:00 [INF] Sync: c:[6544cd20] Sent 1 changes to client, from seq 2
2020-09-10T13:43:24.150+01:00 [INF] Sync: c:[6544cd20] Sent all changes to client
2020-09-10T13:43:24.150+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG handleSubChanges
2020-09-10T13:43:24.155+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG activeSubChanges goroutine finished
2020-09-10T13:43:24.155+01:00 [INF] SyncMsg: c:[6544cd20] DEBUG activeSubChanges.Set(false)
2020-09-10T13:43:24.155+01:00 [INF] SyncMsg: c:[6544cd20] #2701: Type:subChanges   --> 500 Internal error: blipHandler already has an outstanding continous subChanges.  Cannot open another one. Time:4.813318ms
... replication now hangs here becase of error
2020-09-10T13:43:52.963+01:00 [INF] HTTP: c:[6544cd20] #002:    --> BLIP+WebSocket connection closed
```