### PR TITLE
CBG-1071 Restore CBL pull attachment count/attachment bytes

### DIFF
--- a/db/blip_sync_stats.go
+++ b/db/blip_sync_stats.go
@@ -109,8 +109,8 @@ func BlipSyncStatsForCBL(dbStats *base.DbStats) *BlipSyncStats {
 
 	blipStats.HandleRevCount = dbStats.CBLReplicationPush().DocPushCount
 
-	blipStats.GetAttachment = dbStats.CBLReplicationPull().AttachmentPullCount
-	blipStats.GetAttachmentBytes = dbStats.CBLReplicationPull().AttachmentPullBytes
+	blipStats.HandleGetAttachment = dbStats.CBLReplicationPull().AttachmentPullCount
+	blipStats.HandleGetAttachmentBytes = dbStats.CBLReplicationPull().AttachmentPullBytes
 
 	blipStats.HandleChangesResponseCount = dbStats.CBLReplicationPull().RequestChangesCount
 	blipStats.HandleChangesResponseTime = dbStats.CBLReplicationPull().RequestChangesTime


### PR DESCRIPTION
These were incorrectly swapped to the push stats as part of the stat format update.