### PR TITLE
CBG-1018: Remove pool option

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -130,10 +130,6 @@ func (spec BucketSpec) UseClientCert() bool {
 	return true
 }
 
-func (spec BucketSpec) GetPoolName() string {
-	return DefaultPool
-}
-
 // Builds a gocb connection string based on BucketSpec.Server.
 // Adds idle connection configuration, and X.509 auth settings when
 // certpath/keypath/cacertpath specified.
@@ -303,7 +299,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 	if isWalrus, _ := regexp.MatchString(`^(walrus:|file:|/|\.)`, spec.Server); isWalrus {
 		Infof(KeyAll, "Opening Walrus database %s on <%s>", MD(spec.BucketName), SD(spec.Server))
 		sgbucket.SetLogging(ConsoleLogKey().Enabled(KeyBucket))
-		bucket, err = walrus.GetBucket(spec.Server, spec.GetPoolName(), spec.BucketName)
+		bucket, err = walrus.GetBucket(spec.Server, DefaultPool, spec.BucketName)
 		// If feed type is not specified (defaults to DCP) or isn't TAP, wrap with pseudo-vbucket handling for walrus
 		if spec.FeedType == "" || spec.FeedType != TapFeedType {
 			bucket = &LeakyBucket{bucket: bucket, config: LeakyBucketConfig{TapFeedVbuckets: true}}

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -287,11 +287,6 @@ func TestUseClientCert(t *testing.T) {
 	assert.True(t, fakeBucketSpec.UseClientCert())
 }
 
-func TestGetPoolName(t *testing.T) {
-	fakeBucketSpec := &BucketSpec{}
-	assert.Equal(t, "default", fakeBucketSpec.GetPoolName())
-}
-
 func TestGetViewQueryTimeout(t *testing.T) {
 	fakeBucketSpec := &BucketSpec{}
 	expectedViewQueryTimeout := 75 * time.Second

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -290,8 +290,6 @@ func TestUseClientCert(t *testing.T) {
 func TestGetPoolName(t *testing.T) {
 	fakeBucketSpec := &BucketSpec{}
 	assert.Equal(t, "default", fakeBucketSpec.GetPoolName())
-	fakeBucketSpec.PoolName = "Liverpool"
-	assert.Equal(t, "Liverpool", fakeBucketSpec.GetPoolName())
 }
 
 func TestGetViewQueryTimeout(t *testing.T) {

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -468,7 +468,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 		feedName,
 		indexName,
 		serverURLsString,
-		spec.GetPoolName(),
+		DefaultPool,
 		spec.BucketName,
 		bucketUUID,
 		paramsStr,

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -222,10 +222,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		return errConvertServerSpec
 	}
 
-	poolName := spec.PoolName
-	if poolName == "" {
-		poolName = "default"
-	}
+	poolName := spec.GetPoolName()
 	bucketName := spec.BucketName
 
 	vbucketIdsArr := []uint16(nil) // nil means get all the vbuckets.

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -222,7 +222,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		return errConvertServerSpec
 	}
 
-	poolName := spec.GetPoolName()
+	poolName := DefaultPool
 	bucketName := spec.BucketName
 
 	vbucketIdsArr := []uint16(nil) // nil means get all the vbuckets.

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1780,12 +1780,11 @@ func TestHandleCreateDB(t *testing.T) {
 	defer rt.Close()
 
 	server := "walrus:"
-	pool := "liverpool"
 	bucket := "albums"
 	kvTLSPort := 11207
 	resource := fmt.Sprintf("/%s/", bucket)
 
-	bucketConfig := BucketConfig{Server: &server, Pool: &pool, Bucket: &bucket, KvTLSPort: kvTLSPort}
+	bucketConfig := BucketConfig{Server: &server, Bucket: &bucket, KvTLSPort: kvTLSPort}
 	dbConfig := &DbConfig{BucketConfig: bucketConfig, SGReplicateEnabled: base.BoolPtr(false)}
 	var respBody db.Body
 
@@ -1804,7 +1803,7 @@ func TestHandleCreateDB(t *testing.T) {
 
 	// Try to create database with bad JSON request body and simulate JSON
 	// parsing error from the handler; handleCreateDB.
-	reqBodyJson := `"server":"walrus:","pool":"liverpool","bucket":"albums","kv_tls_port":11207`
+	reqBodyJson := `"server":"walrus:","pool":"default","bucket":"albums","kv_tls_port":11207`
 	resp = rt.SendAdminRequest(http.MethodPut, "/photos/", reqBodyJson)
 	assertStatus(t, resp, http.StatusBadRequest)
 }
@@ -1814,7 +1813,6 @@ func TestHandleDBConfig(t *testing.T) {
 	defer rt.Close()
 
 	server := "walrus:"
-	pool := "liverpool"
 	bucket := "albums"
 	kvTLSPort := 443
 	certPath := "/etc/ssl/certs/client.cert"
@@ -1843,7 +1841,6 @@ func TestHandleDBConfig(t *testing.T) {
 
 	bucketConfig := BucketConfig{
 		Server:     &server,
-		Pool:       &pool,
 		Bucket:     &bucket,
 		Username:   username,
 		Password:   password,
@@ -1867,7 +1864,6 @@ func TestHandleDBConfig(t *testing.T) {
 
 	assert.Equal(t, bucket, respBody["bucket"].(string))
 	assert.Equal(t, bucket, respBody["name"].(string))
-	assert.Equal(t, pool, respBody["pool"].(string))
 	assert.Equal(t, server, respBody["server"].(string))
 	assert.Equal(t, username, respBody["username"].(string))
 	assert.Equal(t, password, respBody["password"].(string))

--- a/rest/config.go
+++ b/rest/config.go
@@ -477,7 +477,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) []error {
 	}
 
 	if dbConfig.DeprecatedPool != nil {
-		base.Warnf(`"pool" config option is deprecated and is not supported. This will be set the the default of "default" and the option should be removed from config gile.`)
+		base.Warnf(`"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
 	}
 
 	return errorMessages

--- a/rest/config.go
+++ b/rest/config.go
@@ -39,7 +39,6 @@ var (
 	DefaultInterface              = ":4984"
 	DefaultAdminInterface         = "127.0.0.1:4985" // Only accessible on localhost!
 	DefaultServer                 = "walrus:"
-	DefaultPool                   = "default"
 	DefaultMinimumTLSVersionConst = tls.VersionTLS10
 
 	// The value of defaultLogFilePath is populated by --defaultLogFilePath in ParseCommandLine()
@@ -132,7 +131,6 @@ func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 
 	return base.BucketSpec{
 		Server:     server,
-		PoolName:   DefaultPool,
 		BucketName: bucketName,
 		Keypath:    bc.KeyPath,
 		Certpath:   bc.CertPath,

--- a/rest/config.go
+++ b/rest/config.go
@@ -102,14 +102,15 @@ type ServerConfig struct {
 
 // Bucket configuration elements - used by db, index
 type BucketConfig struct {
-	Server     *string `json:"server,omitempty"`      // Couchbase server URL
-	Bucket     *string `json:"bucket,omitempty"`      // Bucket name
-	Username   string  `json:"username,omitempty"`    // Username for authenticating to server
-	Password   string  `json:"password,omitempty"`    // Password for authenticating to server
-	CertPath   string  `json:"certpath,omitempty"`    // Cert path (public key) for X.509 bucket auth
-	KeyPath    string  `json:"keypath,omitempty"`     // Key path (private key) for X.509 bucket auth
-	CACertPath string  `json:"cacertpath,omitempty"`  // Root CA cert path for X.509 bucket auth
-	KvTLSPort  int     `json:"kv_tls_port,omitempty"` // Memcached TLS port, if not default (11207)
+	Server         *string `json:"server,omitempty"`      // Couchbase server URL
+	DeprecatedPool *string `json:"pool,omitempty"`        // Couchbase pool name - This is now deprecated and forced to be "default"
+	Bucket         *string `json:"bucket,omitempty"`      // Bucket name
+	Username       string  `json:"username,omitempty"`    // Username for authenticating to server
+	Password       string  `json:"password,omitempty"`    // Password for authenticating to server
+	CertPath       string  `json:"certpath,omitempty"`    // Cert path (public key) for X.509 bucket auth
+	KeyPath        string  `json:"keypath,omitempty"`     // Key path (private key) for X.509 bucket auth
+	CACertPath     string  `json:"cacertpath,omitempty"`  // Root CA cert path for X.509 bucket auth
+	KvTLSPort      int     `json:"kv_tls_port,omitempty"` // Memcached TLS port, if not default (11207)
 }
 
 func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
@@ -473,6 +474,10 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) []error {
 		} else if *dbConfig.ImportPartitions < 1 || *dbConfig.ImportPartitions > 1024 {
 			errorMessages = append(errorMessages, fmt.Errorf(rangeValueErrorMsg, "import_partitions", "1-1024"))
 		}
+	}
+
+	if dbConfig.DeprecatedPool != nil {
+		base.Warnf(`"pool" config option is deprecated and is not supported. This will be set the the default of "default" and the option should be removed from config gile.`)
 	}
 
 	return errorMessages

--- a/rest/config.go
+++ b/rest/config.go
@@ -104,7 +104,6 @@ type ServerConfig struct {
 // Bucket configuration elements - used by db, index
 type BucketConfig struct {
 	Server     *string `json:"server,omitempty"`      // Couchbase server URL
-	Pool       *string `json:"pool,omitempty"`        // Couchbase pool name, default "default"
 	Bucket     *string `json:"bucket,omitempty"`      // Bucket name
 	Username   string  `json:"username,omitempty"`    // Username for authenticating to server
 	Password   string  `json:"password,omitempty"`    // Password for authenticating to server
@@ -117,15 +116,11 @@ type BucketConfig struct {
 func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 
 	server := "http://localhost:8091"
-	pool := "default"
 	bucketName := ""
 	tlsPort := 11207
 
 	if bc.Server != nil {
 		server = *bc.Server
-	}
-	if bc.Pool != nil {
-		pool = *bc.Pool
 	}
 	if bc.Bucket != nil {
 		bucketName = *bc.Bucket
@@ -137,7 +132,7 @@ func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 
 	return base.BucketSpec{
 		Server:     server,
-		PoolName:   pool,
+		PoolName:   DefaultPool,
 		BucketName: bucketName,
 		Keypath:    bc.KeyPath,
 		Certpath:   bc.CertPath,
@@ -318,9 +313,6 @@ func (dbConfig *DbConfig) setup(name string) error {
 	}
 	if dbConfig.Server == nil {
 		dbConfig.Server = &DefaultServer
-	}
-	if dbConfig.Pool == nil {
-		dbConfig.Pool = &DefaultPool
 	}
 
 	url, err := url.Parse(*dbConfig.Server)
@@ -860,7 +852,6 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 	configServer := flagSet.String("configServer", "", "URL of server that can return database configs")
 	deploymentID := flagSet.String("deploymentID", "", "Customer/project identifier for stats reporting")
 	couchbaseURL := flagSet.String("url", DefaultServer, "Address of Couchbase server")
-	poolName := flagSet.String("pool", DefaultPool, "Name of pool")
 	dbName := flagSet.String("dbname", "", "Name of Couchbase Server database (defaults to name of bucket)")
 	pretty := flagSet.Bool("pretty", false, "Pretty-print JSON responses")
 	verbose := flagSet.Bool("verbose", false, "Log more info about requests")
@@ -979,7 +970,6 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 					BucketConfig: BucketConfig{
 						Server:     couchbaseURL,
 						Bucket:     &defaultBucketName,
-						Pool:       poolName,
 						CertPath:   *certpath,
 						CACertPath: *cacertpath,
 						KeyPath:    *keypath,

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -673,7 +673,6 @@ func TestParseCommandLine(t *testing.T) {
 		keypath            = "/etc/ssl/certs/key.pem"
 		logKeys            = "Admin,Access,Auth,Bucket"
 		logFilePath        = "/var/log/sync_gateway"
-		pool               = "liverpool"
 	)
 	args := []string{
 		"sync_gateway",
@@ -688,7 +687,6 @@ func TestParseCommandLine(t *testing.T) {
 		"--keypath", keypath,
 		"--log", logKeys,
 		"--logFilePath", logFilePath,
-		"--pool", pool,
 		"--pretty"}
 
 	config, err := ParseCommandLine(args, flag.ContinueOnError)
@@ -704,7 +702,6 @@ func TestParseCommandLine(t *testing.T) {
 	assert.Len(t, databases, 1)
 	assert.Equal(t, dbname, databases[dbname].Name)
 	assert.Equal(t, bucket, *databases[dbname].Bucket)
-	assert.Equal(t, pool, *databases[dbname].Pool)
 	assert.Equal(t, cacertpath, databases[dbname].CACertPath)
 	assert.Equal(t, certpath, databases[dbname].CertPath)
 	assert.Equal(t, keypath, databases[dbname].KeyPath)
@@ -781,7 +778,7 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 	content := `{"logging":{"log_file_path":"/var/tmp/sglogs","console":{"log_level":"debug","log_keys":["*"]},
 		"error":{"enabled":true,"rotation":{"max_size":20,"max_age":180}},"warn":{"enabled":true,"rotation":{
         "max_size":20,"max_age":90}},"info":{"enabled":false},"debug":{"enabled":false}},"databases":{"db1":{
-        "server":"couchbase://localhost","username":"username","password":"password","bucket":"default","pool":"pool1",
+        "server":"couchbase://localhost","username":"username","password":"password","bucket":"default",
         "certpath":"/etc/ssl/certs/cert.pem","cacertpath":"/etc/ssl/certs/ca.cert","keypath":"/etc/ssl/certs/key.pem",
         "users":{"GUEST":{"disabled":false,"admin_channels":["*"]}},"allow_conflicts":false,"revs_limit":20}}}`
 
@@ -809,7 +806,6 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 		keypath            = "/etc/ssl/certs/key.pem"
 		logKeys            = "Admin,Access,Auth,Bucket"
 		logFilePath        = "/var/log/sync_gateway"
-		pool               = "liverpool"
 	)
 	args := []string{
 		"sync_gateway",
@@ -823,7 +819,6 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 		"--keypath", keypath,
 		"--log", logKeys,
 		"--logFilePath", logFilePath,
-		"--pool", pool,
 		"--pretty",
 		"--verbose",
 		"--profileInterface", profileInterface,
@@ -847,7 +842,6 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 	assert.Equal(t, "password", db1.BucketConfig.Password)
 	assert.Equal(t, "default", *db1.BucketConfig.Bucket)
 	assert.Equal(t, "couchbase://localhost", *db1.BucketConfig.Server)
-	assert.Equal(t, "pool1", *db1.BucketConfig.Pool)
 	assert.Equal(t, "/etc/ssl/certs/cert.pem", db1.BucketConfig.CertPath)
 	assert.Equal(t, "/etc/ssl/certs/ca.cert", db1.BucketConfig.CACertPath)
 	assert.Equal(t, "/etc/ssl/certs/key.pem", db1.BucketConfig.KeyPath)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -346,7 +346,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	// Connect to bucket
 	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
-		base.MD(dbName), base.MD(spec.BucketName), base.SD(spec.PoolName), base.SD(spec.Server))
+		base.MD(dbName), base.MD(spec.BucketName), base.SD(spec.GetPoolName()), base.SD(spec.Server))
 	bucket, err := db.ConnectToBucket(spec)
 	if err != nil {
 		return nil, err

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -346,7 +346,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	// Connect to bucket
 	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
-		base.MD(dbName), base.MD(spec.BucketName), base.SD(spec.GetPoolName()), base.SD(spec.Server))
+		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))
 	bucket, err := db.ConnectToBucket(spec)
 	if err != nil {
 		return nil, err

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -168,7 +168,6 @@ func bucketConfigFromTestBucket(tb *base.TestBucket) BucketConfig {
 	tbUser, tbPassword, _ := tb.BucketSpec.Auth.GetCredentials()
 	return BucketConfig{
 		Server:     &tb.BucketSpec.Server,
-		Pool:       &tb.BucketSpec.PoolName,
 		Bucket:     &tb.BucketSpec.BucketName,
 		Username:   tbUser,
 		Password:   tbPassword,


### PR DESCRIPTION
Pool command line option removed but kept config option (marked deprecated) to ensure existing configs don't break on update. A warn message is given when it's used.
All uses of the pool parameter have been switched to using `GetPoolName` which will always return the default const "default".

Did a manual test to ensure warning message is output.