### PR TITLE
CBG-879 Disable guest user access by default and allow tests to opt-in Guest usage

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -594,6 +594,7 @@ func TestProposedChangesNoConflictsMode(t *testing.T) {
 
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
 		noConflictsMode: true,
+		guestEnabled:    true,
 	})
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
@@ -633,7 +634,6 @@ func TestPublicPortAuthentication(t *testing.T) {
 
 	// Create bliptester that is connected as user1, with access to the user1 channel
 	btUser1, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
@@ -651,7 +651,6 @@ func TestPublicPortAuthentication(t *testing.T) {
 
 	// Create bliptester that is connected as user2, with access to the * channel
 	btUser2, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
-		noAdminParty:                true,
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // user2 has access to all channels
@@ -703,7 +702,6 @@ function(doc, oldDoc) {
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	}, rt)
@@ -770,7 +768,6 @@ function(doc, oldDoc) {
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	}, rt)
@@ -898,7 +895,6 @@ function(doc, oldDoc) {
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	}, rt)
@@ -1027,11 +1023,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
-	// Setup
-	rtConfig := RestTesterConfig{
-		noAdminParty: true,
-	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
@@ -1078,11 +1070,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
-	// Setup
-	rtConfig := RestTesterConfig{
-		noAdminParty: true,
-	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
@@ -1138,11 +1126,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
-	// Setup
-	rtConfig := RestTesterConfig{
-		noAdminParty: true,
-	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
@@ -1206,10 +1190,7 @@ func TestReloadUser(t *testing.T) {
     `
 
 	// Setup
-	rtConfig := RestTesterConfig{
-		SyncFn:       syncFn,
-		noAdminParty: true,
-	}
+	rtConfig := RestTesterConfig{SyncFn: syncFn}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
@@ -1264,8 +1245,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 
 	// Setup
 	rtConfig := RestTesterConfig{
-		SyncFn:       `function(doc) {channel(doc.channels); access(doc.accessUser, doc.accessChannel);}`,
-		noAdminParty: true,
+		SyncFn: `function(doc) {channel(doc.channels); access(doc.accessUser, doc.accessChannel);}`,
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
@@ -1311,7 +1291,6 @@ func TestAccessGrantViaAdminApi(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
@@ -1350,7 +1329,6 @@ func TestCheckpoint(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
@@ -1420,7 +1398,6 @@ func TestPutAttachmentViaBlipGetViaRest(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 	})
@@ -1466,7 +1443,6 @@ func TestPutAttachmentViaBlipGetViaBlip(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:                true,
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // All channels
@@ -1551,7 +1527,6 @@ func TestPutInvalidAttachment(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:                true,
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // All channels
@@ -1602,10 +1577,7 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
     `
 
 	// Setup
-	rtConfig := RestTesterConfig{
-		SyncFn:       syncFn,
-		noAdminParty: true,
-	}
+	rtConfig := RestTesterConfig{SyncFn: syncFn}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
@@ -1646,7 +1618,6 @@ func TestPutInvalidRevMalformedBody(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noAdminParty:                true,
 		connectingUsername:          "user1",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"*"}, // All channels
@@ -1685,7 +1656,9 @@ func TestPutRevNoConflictsMode(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode: true,
+		noConflictsMode:    true,
+		connectingUsername: "user1",
+		connectingPassword: "1234",
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
@@ -1713,7 +1686,9 @@ func TestPutRevConflictsMode(t *testing.T) {
 
 	// Create blip tester
 	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
-		noConflictsMode: false,
+		noConflictsMode:    false,
+		connectingUsername: "user1",
+		connectingPassword: "1234",
 	})
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
@@ -1752,11 +1727,7 @@ func TestGetRemovedDoc(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
 
-	// Setup
-	rtConfig := RestTesterConfig{
-		noAdminParty: true,
-	}
-	rt := NewRestTester(t, &rtConfig)
+	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
@@ -1908,7 +1879,7 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 //   - Expected: receive all 5 docs (4 revs and 1 norev)
 //   - Actual: only receive 4 docs (4 revs)
 func TestMissingNoRev(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 	bt, err := NewBlipTesterFromSpecWithRT(t, nil, rt)
 	require.NoError(t, err, "Unexpected error creating BlipTester")
@@ -1957,7 +1928,14 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2030,7 +2008,14 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: base.BoolPtr(true)}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.BoolPtr(true),
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2094,7 +2079,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{noAdminParty: true, DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2148,7 +2133,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{noAdminParty: true, DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2243,7 +2228,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{noAdminParty: true, DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2364,7 +2349,14 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2408,7 +2400,14 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2492,7 +2491,14 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2596,7 +2602,14 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2645,7 +2658,14 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: &sgUseDeltas,
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -2736,7 +2756,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -2772,7 +2792,7 @@ func TestBlipNorev(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -2810,7 +2830,14 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 
 	const docID = "pushAttachmentDoc"
 
-	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: base.BoolPtr(true)}}})
+	rt := NewRestTester(t, &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.BoolPtr(true),
+			},
+		},
+		guestEnabled: true,
+	})
 	defer rt.Close()
 
 	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
@@ -2864,7 +2891,14 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
 	}
-	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: base.BoolPtr(true)}}}
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.BoolPtr(true),
+			},
+		},
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/multipart_test.go
+++ b/rest/multipart_test.go
@@ -32,10 +32,10 @@ Content-Type: application/json
 {"key":"foo","value":"bar"}
 --0123456789--`
 
-	response := rt.SendRequestWithHeaders(http.MethodPut, "/db/doc1", bodyText, reqHeaders)
+	response := rt.SendAdminRequestWithHeaders(http.MethodPut, "/db/doc1", bodyText, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 
-	response = rt.SendRequestWithHeaders(http.MethodGet, "/db/doc1", "", reqHeaders)
+	response = rt.SendAdminRequestWithHeaders(http.MethodGet, "/db/doc1", "", reqHeaders)
 	log.Printf("response: %v", string(response.BodyBytes()))
 	assertStatus(t, response, http.StatusOK)
 }
@@ -127,10 +127,10 @@ Content-Disposition: attachment; filename=att.txt
 {"root":"Jacques' JSON attachment"}
 --123--`
 
-	response := rt.SendRequestWithHeaders(http.MethodPut, "/db/doc1", bodyText, reqHeaders)
+	response := rt.SendAdminRequestWithHeaders(http.MethodPut, "/db/doc1", bodyText, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 
-	response = rt.SendRequestWithHeaders(http.MethodGet, "/db/doc1", "", reqHeaders)
+	response = rt.SendAdminRequestWithHeaders(http.MethodGet, "/db/doc1", "", reqHeaders)
 	assertStatus(t, response, http.StatusOK)
 
 	var body db.Body

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1026,7 +1026,6 @@ func setupSGRPeers(t *testing.T) (activeRT *RestTester, passiveRT *RestTester, r
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -30,7 +30,6 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 				"alice": {Password: base.StringPtr("pass")},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt.Close()
 
@@ -91,7 +90,6 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 				"alice": {Password: base.StringPtr("pass")},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt.Close()
 
@@ -160,7 +158,6 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -249,7 +246,6 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -426,7 +422,6 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 						},
 					},
 				},
-				noAdminParty: true,
 			})
 			defer rt2.Close()
 
@@ -571,7 +566,6 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -736,7 +730,6 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -896,7 +889,6 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -989,7 +981,6 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1084,7 +1075,6 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1205,7 +1195,6 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1362,7 +1351,6 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1496,7 +1484,6 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1591,7 +1578,6 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1691,7 +1677,6 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -1864,7 +1849,6 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 						},
 					},
 				},
-				noAdminParty: true,
 			})
 			defer rt2.Close()
 
@@ -2064,7 +2048,6 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 						},
 					},
 				},
-				noAdminParty: true,
 			})
 			defer rt2.Close()
 
@@ -2233,7 +2216,6 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -2310,7 +2292,6 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -2377,7 +2358,6 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -2532,7 +2512,6 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1
@@ -2626,7 +2605,6 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -2701,7 +2679,6 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -2853,7 +2830,6 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -2959,7 +2935,6 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -3051,7 +3026,6 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -3253,7 +3227,6 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 								},
 							},
 						},
-						noAdminParty: true,
 					})
 					defer rt2.Close()
 
@@ -3351,8 +3324,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 	rt2 := NewRestTester(t, &RestTesterConfig{
-		TestBucket:   tb2,
-		noAdminParty: true,
+		TestBucket: tb2,
 	})
 	defer rt2.Close()
 
@@ -3438,7 +3410,6 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 				},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt2.Close()
 
@@ -3546,7 +3517,6 @@ func TestBlipSyncNonUpgradableConnection(t *testing.T) {
 				"alice": {Password: base.StringPtr("pass")},
 			},
 		},
-		noAdminParty: true,
 	})
 	defer rt.Close()
 
@@ -3773,7 +3743,6 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 						},
 					},
 				},
-				noAdminParty: true,
 			})
 			defer rt2.Close()
 
@@ -4127,7 +4096,6 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 						},
 					},
 				},
-				noAdminParty: true,
 			})
 			defer rt2.Close()
 
@@ -4282,7 +4250,6 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 						},
 					},
 				},
-				noAdminParty: true,
 			})
 			defer rt2.Close()
 

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDesignDocs(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendRequest(http.MethodGet, "/db/_design/foo", "")
@@ -54,7 +54,7 @@ func TestDesignDocs(t *testing.T) {
 }
 
 func TestViewQuery(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foo", `{"views":{"bar": {"map": "function(doc) {emit(doc.key, doc.value);}"}}}`)
@@ -93,7 +93,7 @@ func TestViewQuery(t *testing.T) {
 
 //Tests #1109, wh ere design doc contains multiple views
 func TestViewQueryMultipleViews(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	//Define three views
@@ -122,7 +122,7 @@ func TestViewQueryMultipleViews(t *testing.T) {
 }
 
 func TestViewQueryWithParams(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	response := rt.SendAdminRequest(http.MethodPut, "/db/_design/foodoc", `{"views": {"foobarview": {"map": "function(doc, meta) {if (doc.value == \"foo\") {emit(doc.key, null);}}"}}}`)
@@ -146,7 +146,7 @@ func TestViewQueryWithParams(t *testing.T) {
 }
 
 func TestViewQueryUserAccess(t *testing.T) {
-	rt := NewRestTester(t, nil)
+	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
 
 	rt.ServerContext().Database("db").SetUserViewsEnabled(true)
@@ -233,7 +233,10 @@ func TestViewQueryMultipleViewsInterfaceValues(t *testing.T) {
 }
 
 func TestUserViewQuery(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:       `function(doc) {channel(doc.channel)}`,
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -303,7 +306,10 @@ func TestUserViewQuery(t *testing.T) {
 
 // This includes a fix for #857
 func TestAdminReduceViewQuery(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:       `function(doc) {channel(doc.channel)}`,
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -348,7 +354,10 @@ func TestAdminReduceViewQuery(t *testing.T) {
 }
 
 func TestAdminReduceSumQuery(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:       `function(doc) {channel(doc.channel)}`,
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -379,7 +388,10 @@ func TestAdminReduceSumQuery(t *testing.T) {
 }
 
 func TestAdminGroupReduceSumQuery(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:       `function(doc) {channel(doc.channel)}`,
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
@@ -523,7 +535,10 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 }
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
-	rtConfig := RestTesterConfig{SyncFn: `function(doc) {channel(doc.channel)}`}
+	rtConfig := RestTesterConfig{
+		SyncFn:       `function(doc) {channel(doc.channel)}`,
+		guestEnabled: true,
+	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 


### PR DESCRIPTION
By default RestTester has GUEST user enabled. This can mask authentication failures, and in general it would be preferable for tests to opt-in to using GUEST. This PR contains the changes to flip the default to GUEST disabled, and opt-in GUEST usage in certain existing tests that depend on GUEST usage.