### PR TITLE
CBG-1054: Add mechanism to close StatsLogger goroutine loop

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -650,7 +650,7 @@ func TestPublicPortAuthentication(t *testing.T) {
 	require.NoError(t, err, "Error sending revision")
 
 	// Create bliptester that is connected as user2, with access to the * channel
-	btUser2, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	btUser2, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
@@ -771,7 +771,7 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -900,7 +900,7 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
@@ -1042,7 +1042,7 @@ func TestBlipSendAndGetRev(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1094,7 +1094,7 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1155,7 +1155,7 @@ func TestBlipSetCheckpoint(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1219,7 +1219,7 @@ func TestReloadUser(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 		restTester:         rt,
@@ -1277,7 +1277,7 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 		restTester:         rt,
@@ -1617,7 +1617,7 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
 		restTester:         rt,
@@ -1773,7 +1773,7 @@ func TestGetRemovedDoc(t *testing.T) {
 		connectingPassword: "1234",
 		restTester:         rt,
 	}
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1787,7 +1787,7 @@ func TestGetRemovedDoc(t *testing.T) {
 		connectingUserChannelGrants: []string{"user1"}, // so it can see user1's docs
 		restTester:                  rt,
 	}
-	bt2, err := NewBlipTesterFromSpec(t, btSpec2)
+	bt2, err := NewBlipTesterAvoidRTClose(t, &btSpec2)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt2.Close()
 
@@ -1925,7 +1925,7 @@ func TestMissingNoRev(t *testing.T) {
 		restTester: rt,
 	}
 	defer rt.Close()
-	bt, err := NewBlipTesterFromSpec(t, btSpec)
+	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
 	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1982,7 +1982,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		deltaSentCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2056,7 +2056,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 	deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2113,7 +2113,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOpts(t, rt, &BlipTesterClientOpts{
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
@@ -2179,7 +2179,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client, err := NewBlipTesterClientOpts(t, rt, &BlipTesterClientOpts{
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
@@ -2274,7 +2274,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client1, err := NewBlipTesterClientOpts(t, rt, &BlipTesterClientOpts{
+	client1, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
 		Username:     "client1",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
@@ -2282,7 +2282,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	require.NoError(t, err)
 	defer client1.Close()
 
-	client2, err := NewBlipTesterClientOpts(t, rt, &BlipTesterClientOpts{
+	client2, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
 		Username:     "client2",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
@@ -2383,7 +2383,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 	client.ClientDeltas = true
@@ -2427,7 +2427,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2445,7 +2445,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 	// Perform a one-shot pull as client 2 to pull down the first revision
 
-	client2, err := NewBlipTesterClient(t, rt)
+	client2, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client2.Close()
 
@@ -2511,7 +2511,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2615,7 +2615,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2664,7 +2664,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClient(t, rt)
+	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2754,7 +2754,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClient(t, rt)
+	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
 
@@ -2790,7 +2790,7 @@ func TestBlipNorev(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClient(t, rt)
+	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
 
@@ -2828,7 +2828,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: base.BoolPtr(true)}}})
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClient(t, rt)
+	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
 
@@ -2883,7 +2883,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClient(t, rt)
+	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
 	assert.NoError(t, err)
 	defer btc.Close()
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -650,13 +650,12 @@ func TestPublicPortAuthentication(t *testing.T) {
 	require.NoError(t, err, "Error sending revision")
 
 	// Create bliptester that is connected as user2, with access to the * channel
-	btUser2, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
+	btUser2, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		noAdminParty:                true,
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
-		connectingUserChannelGrants: []string{"*"},      // user2 has access to all channels
-		restTester:                  btUser1.restTester, // re-use rest tester, otherwise it will create a new underlying bucket in walrus case
-	})
+		connectingUserChannelGrants: []string{"*"}, // user2 has access to all channels
+	}, btUser1.restTester) // re-use rest tester, otherwise it will create a new underlying bucket in walrus case
 	require.NoError(t, err, "Error creating BlipTester")
 	defer btUser2.Close()
 
@@ -703,12 +702,11 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
-	bt, err := NewBlipTesterFromSpec(t, BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
-	})
+	}, rt)
 	assert.NoError(t, err, "Error creating BlipTester")
 
 	// Attempt to send a doc, should be rejected
@@ -771,12 +769,11 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
-	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
-	})
+	}, rt)
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -900,12 +897,11 @@ function(doc, oldDoc) {
 	defer rt.Close()
 
 	// Create bliptester that is connected as user1, with no access to channel ABC
-	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		noAdminParty:       true,
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
-	})
+	}, rt)
 	assert.NoError(t, err, "Error creating BlipTester")
 	defer bt.Close()
 
@@ -1040,9 +1036,8 @@ func TestBlipSendAndGetRev(t *testing.T) {
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
 	}
-	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
+	bt, err := NewBlipTesterFromSpecWithRT(t, &btSpec, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1092,9 +1087,8 @@ func TestBlipSendAndGetLargeNumberRev(t *testing.T) {
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
 	}
-	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
+	bt, err := NewBlipTesterFromSpecWithRT(t, &btSpec, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1153,9 +1147,8 @@ func TestBlipSetCheckpoint(t *testing.T) {
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
 	}
-	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
+	bt, err := NewBlipTesterFromSpecWithRT(t, &btSpec, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1219,11 +1212,10 @@ func TestReloadUser(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
-	})
+	}, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1277,11 +1269,10 @@ func TestAccessGrantViaSyncFunction(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
-	})
+	}, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1617,11 +1608,10 @@ func TestPutInvalidRevSyncFnReject(t *testing.T) {
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
-	bt, err := NewBlipTesterAvoidRTClose(t, &BlipTesterSpec{
+	bt, err := NewBlipTesterFromSpecWithRT(t, &BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
-	})
+	}, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1771,9 +1761,8 @@ func TestGetRemovedDoc(t *testing.T) {
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
-		restTester:         rt,
 	}
-	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
+	bt, err := NewBlipTesterFromSpecWithRT(t, &btSpec, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1785,9 +1774,8 @@ func TestGetRemovedDoc(t *testing.T) {
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"user1"}, // so it can see user1's docs
-		restTester:                  rt,
 	}
-	bt2, err := NewBlipTesterAvoidRTClose(t, &btSpec2)
+	bt2, err := NewBlipTesterFromSpecWithRT(t, &btSpec2, rt)
 	assert.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt2.Close()
 
@@ -1921,11 +1909,8 @@ func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
 //   - Actual: only receive 4 docs (4 revs)
 func TestMissingNoRev(t *testing.T) {
 	rt := NewRestTester(t, nil)
-	btSpec := BlipTesterSpec{
-		restTester: rt,
-	}
 	defer rt.Close()
-	bt, err := NewBlipTesterAvoidRTClose(t, &btSpec)
+	bt, err := NewBlipTesterFromSpecWithRT(t, nil, rt)
 	require.NoError(t, err, "Unexpected error creating BlipTester")
 	defer bt.Close()
 
@@ -1982,7 +1967,7 @@ func TestBlipDeltaSyncPull(t *testing.T) {
 		deltaSentCount = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2056,7 +2041,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 
 	deltaSentCount := rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2113,7 +2098,7 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
@@ -2179,7 +2164,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
 		Username:     "alice",
 		Channels:     []string{"public"},
 		ClientDeltas: true,
@@ -2274,7 +2259,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 		deltasSentStart = rt.GetDatabase().DbStats.DeltaSync().DeltasSent.Value()
 	}
 
-	client1, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
+	client1, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
 		Username:     "client1",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
@@ -2282,7 +2267,7 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 	require.NoError(t, err)
 	defer client1.Close()
 
-	client2, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, &BlipTesterClientOpts{
+	client2, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
 		Username:     "client2",
 		Channels:     []string{"*"},
 		ClientDeltas: true,
@@ -2383,7 +2368,7 @@ func TestBlipPullRevMessageHistory(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 	client.ClientDeltas = true
@@ -2427,7 +2412,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2445,7 +2430,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 
 	// Perform a one-shot pull as client 2 to pull down the first revision
 
-	client2, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client2, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client2.Close()
 
@@ -2511,7 +2496,7 @@ func TestBlipDeltaSyncPush(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2615,7 +2600,7 @@ func TestBlipNonDeltaSyncPush(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2664,7 +2649,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	client, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	client, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer client.Close()
 
@@ -2754,7 +2739,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
 
@@ -2790,7 +2775,7 @@ func TestBlipNorev(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
 
@@ -2828,7 +2813,7 @@ func TestBlipDeltaSyncPushAttachment(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: base.BoolPtr(true)}}})
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	require.NoError(t, err)
 	defer btc.Close()
 
@@ -2883,7 +2868,7 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	btc, err := NewBlipTesterClientOptsAvoidRTClose(t, rt, nil)
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, nil)
 	assert.NoError(t, err)
 	defer btc.Close()
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -412,12 +412,11 @@ func (btc *BlipTesterClient) getLastReplicatedRev(docID string) (revID string, o
 }
 
 func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient) (*BlipTesterReplicator, error) {
-	bt, err := NewBlipTesterFromSpec(tb, BlipTesterSpec{
-		restTester:                  btc.rt,
+	bt, err := NewBlipTesterFromSpecWithRT(tb, &BlipTesterSpec{
 		connectingPassword:          "test",
 		connectingUsername:          btc.Username,
 		connectingUserChannelGrants: btc.Channels,
-	})
+	}, btc.rt)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +432,7 @@ func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient) (
 	return r, nil
 }
 
-func NewBlipTesterClientOpts(tb testing.TB, rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient, err error) {
+func createBlipTesterClientOpts(tb testing.TB, rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient, err error) {
 	if opts == nil {
 		opts = &BlipTesterClientOpts{}
 	}
@@ -463,11 +462,11 @@ func NewBlipTesterClientOpts(tb testing.TB, rt *RestTester, opts *BlipTesterClie
 
 // NewBlipTesterClient returns a client which emulates the behaviour of a CBL client over BLIP.
 func NewBlipTesterClient(tb testing.TB, rt *RestTester) (client *BlipTesterClient, err error) {
-	return NewBlipTesterClientOpts(tb, rt, nil)
+	return createBlipTesterClientOpts(tb, rt, nil)
 }
 
-func NewBlipTesterClientOptsAvoidRTClose(tb testing.TB, rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient, err error) {
-	client, err = NewBlipTesterClientOpts(tb, rt, opts)
+func NewBlipTesterClientOptsWithRT(tb testing.TB, rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient, err error) {
+	client, err = createBlipTesterClientOpts(tb, rt, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -466,6 +466,17 @@ func NewBlipTesterClient(tb testing.TB, rt *RestTester) (client *BlipTesterClien
 	return NewBlipTesterClientOpts(tb, rt, nil)
 }
 
+func NewBlipTesterClientOptsAvoidRTClose(tb testing.TB, rt *RestTester, opts *BlipTesterClientOpts) (client *BlipTesterClient, err error) {
+	client, err = NewBlipTesterClientOpts(tb, rt, opts)
+	if err != nil {
+		return nil, err
+	}
+	client.pullReplication.bt.avoidRestTesterClose = true
+	client.pushReplication.bt.avoidRestTesterClose = true
+
+	return client, nil
+}
+
 // StartPull will begin a continuous pull replication since 0 between the client and server
 func (btc *BlipTesterClient) StartPull() (err error) {
 	return btc.StartPullSince("true", "0", "false")

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"runtime"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -271,4 +272,31 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.NoError(t, err, "No error while trying to get the existing database name")
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
+}
+
+func TestStatsLoggerGoRoutines(t *testing.T) {
+	// Get goroutines prior to getting server context
+	goRoutineCountBefore := runtime.NumGoroutine()
+
+	// Start up stats logger by creating server context
+	ctx := NewServerContext(&ServerConfig{})
+
+	// Confirm an extra goroutine is running which is the stats logger
+	assert.Equal(t, goRoutineCountBefore+1, runtime.NumGoroutine())
+
+	// Close server context which will send signal to close stats logger
+	ctx.Close()
+
+	// Wait for stats logger to stop (ie wait for go routines to go back to prior count
+	sleeper := base.CreateSleeperFunc(200, 100)
+	waitFunc := func() (shouldRetry bool, err error, value interface{}) {
+		if goRoutineCountBefore == runtime.NumGoroutine() {
+			return false, nil, nil
+		}
+		return true, nil, nil
+	}
+	err, _ := base.RetryLoop("Wait for goroutines to go back to original count", waitFunc, sleeper)
+	assert.NoError(t, err)
+
+	assert.Equal(t, goRoutineCountBefore, runtime.NumGoroutine())
 }

--- a/rest/stats_context.go
+++ b/rest/stats_context.go
@@ -16,6 +16,7 @@ import (
 // Group the stats related context that is associated w/ a ServerContext into a struct
 type statsContext struct {
 	statsLoggingTicker *time.Ticker
+	statsLoggingStop   chan struct{}
 	cpuStatsSnapshot   *cpuStatsSnapshot
 }
 

--- a/rest/stats_context.go
+++ b/rest/stats_context.go
@@ -16,7 +16,7 @@ import (
 // Group the stats related context that is associated w/ a ServerContext into a struct
 type statsContext struct {
 	statsLoggingTicker *time.Ticker
-	statsLoggingStop   chan struct{}
+	terminator         chan struct{} // Used to stop the goroutine handling the stats logging
 	cpuStatsSnapshot   *cpuStatsSnapshot
 }
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -242,6 +242,7 @@ func (rt *RestTester) Close() {
 	}
 	if rt.RestTesterServerContext != nil {
 		rt.RestTesterServerContext.Close()
+		rt.RestTesterServerContext = nil
 	}
 	if rt.testBucket != nil {
 		rt.testBucket.Close()


### PR DESCRIPTION
Added an extra channel to ensure the stats logger can be closed following the closure of a server context. 
Added a unit test to confirm this.