### PR TITLE
CBG-1079: Fix intermittent failures in TestNumAccessErrors due to data race emerged from gomemcached lib

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -33,7 +33,7 @@
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b1349276dedea51b9aec41dc86dd6598bcfc5e01"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="fb2c298255fcbffc24f1cb824ef9d06defcda199"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
   <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -44,7 +44,7 @@
 
   <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
+  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
   <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="9b201da3276b0475203dfa121a82cd4ccf37b8f2"/>
 


### PR DESCRIPTION
SG currently uses gomemcached lib revision [db06807](https://github.com/couchbase/gomemcached/commit/db06807997e6f778fe135571140a0c4f1f59723c) which is prone to data race whilst running against slow hardware. This is causing TestNumAccessErrors test to end up in intermittent failures. 

Underlying issue has been fixed in the gomemcached revision [83e1dde](https://github.com/couchbase/gomemcached/commit/83e1dde05ac9e4861d4d8d4985046e8920c1d760).  
This PR contains the changes to use the same revision in SG repo manifest to fix the test failure in TestNumAccessErrors.

This change also requires [go-couchbase](https://github.com/couchbase/go-couchbase) package upgrade because the
existing [go-couchbase version](https://github.com/couchbase/go-couchbase/commit/fb2c298255fcbffc24f1cb824ef9d06defcda199) consumes the GetFromCollection interface method from gomemcached lib that was removed in [19ef45f](https://github.com/couchbase/gomemcached/commit/19ef45f259957adc7096e06a460a124d1b2c7f42#diff-b5cef110b23dd5132591705ed2911d4dL39) and later commits; it is reasonable to upgrade the [go-couchbase](https://github.com/couchbase/go-couchbase) package to the latest stable [version](https://github.com/couchbase/go-couchbase/commit/ddac38b31c48eeb93df6b3446e68cd0d6786b56d).