### PR TITLE
CBG-841: Allow users to opt in to accepting unsigned tokens from providers in SG's provider config

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -160,6 +160,9 @@ type OIDCProvider struct {
 	// Sync Gateway and the underlying OIDC library.
 	UsernameClaim string `json:"username_claim"`
 
+	// AllowUnsignedProviderTokens allows users to opt-in to accepting unsigned tokens from providers.
+	AllowUnsignedProviderTokens bool `json:"allow_unsigned_provider_tokens"`
+
 	// client represents client configurations to authenticate end-users
 	// with an OpenID Connect provider. It must not be accessed directly,
 	// use the accessor method GetClient() instead.
@@ -322,7 +325,7 @@ func (op *OIDCProvider) initOIDCClient() error {
 		return pkgerrors.Wrap(err, ErrMsgUnableToDiscoverConfig)
 	}
 
-	verifier = op.generateVerifier(&metadata, context.Background())
+	verifier = op.generateVerifier(&metadata, GetOIDCClientContext(op.InsecureSkipVerify))
 	if verifier == nil {
 		return pkgerrors.Wrap(err, ErrMsgUnableToGenerateVerifier)
 	}

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -262,7 +262,7 @@ func (h *handler) handleOIDCRefresh() error {
 }
 
 func (h *handler) createSessionForTrustedIdToken(rawIDToken string, provider *auth.OIDCProvider) (username string, sessionID string, err error) {
-	user, tokenExpiryTime, err := h.db.Authenticator().AuthenticateTrustedJWT(rawIDToken, provider)
+	user, tokenExpiryTime, err := h.db.Authenticator().AuthenticateTrustedJWT(rawIDToken, provider, h.getOIDCCallbackURL)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
We've got a lot of cloned code in auth/oidc.go that's just to support the ability to verify a trusted JWT token without doing signature validation, which we're doing from the refresh and callback handlers. This is required (at least for backward compatibility), but as per the OIDC spec it's not valid for providers to return unsigned certificates in those situations. This PR contains the changes to enable default to the normal signed verification path, and force users to opt in to accepting unsigned tokens from providers in SG's provider config.