### PR TITLE
 [2.7.4] CBG-984: Backport CBG-983 RevID fix for Get1xRevAndChannels (#4677)

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -406,12 +406,12 @@ func (db *Database) authorizeUserForChannels(docID, revID string, channels base.
 
 // Returns the body of a revision of a document, as well as the document's current channels
 // and the user/roles it grants channel access to.
-func (db *Database) Get1xRevAndChannels(docid string, revid string, listRevisions bool) (bodyBytes []byte, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, flags uint8, sequence uint64, gotRevID string, removed bool, err error) {
-	doc, err := db.GetDocument(docid, DocUnmarshalAll)
+func (db *Database) Get1xRevAndChannels(docID string, revID string, listRevisions bool) (bodyBytes []byte, channels channels.ChannelMap, access UserAccessMap, roleAccess UserAccessMap, flags uint8, sequence uint64, gotRevID string, removed bool, err error) {
+	doc, err := db.GetDocument(docID, DocUnmarshalAll)
 	if doc == nil {
 		return
 	}
-	bodyBytes, removed, err = db.get1xRevFromDoc(doc, revid, listRevisions)
+	bodyBytes, removed, err = db.get1xRevFromDoc(doc, revID, listRevisions)
 	if err != nil {
 		return
 	}
@@ -420,7 +420,11 @@ func (db *Database) Get1xRevAndChannels(docid string, revid string, listRevision
 	roleAccess = doc.RoleAccess
 	sequence = doc.Sequence
 	flags = doc.Flags
-	gotRevID = doc.RevID
+	if revID == "" {
+		gotRevID = doc.CurrentRev
+	} else {
+		gotRevID = revID
+	}
 	return
 }
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1815,7 +1815,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 		Doc   db.Body `json:"doc,omitempty"`
 		Error string  `json:"error"`
 	}
-	var allDocsResult struct {
+	type allDocsResponse struct {
 		TotalRows int          `json:"total_rows"`
 		Offset    int          `json:"offset"`
 		Rows      []allDocsRow `json:"rows"`
@@ -1861,6 +1861,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
 
+	allDocsResult := allDocsResponse{}
 	log.Printf("Response = %s", response.Body.Bytes())
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
@@ -1879,6 +1880,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
@@ -1892,6 +1894,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
@@ -1905,6 +1908,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
@@ -1918,6 +1922,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
@@ -1931,6 +1936,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
@@ -1944,6 +1950,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 3)
@@ -1959,18 +1966,23 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
 	goassert.Equals(t, allDocsResult.Rows[0].Key, "doc4")
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc4")
+	goassert.Equals(t, allDocsResult.Rows[0].Value.Rev, "1-e0351a57554e023a77544d33dd21e56c")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 	goassert.Equals(t, allDocsResult.Rows[1].Key, "doc1")
 	goassert.Equals(t, allDocsResult.Rows[1].Error, "forbidden")
+	goassert.Equals(t, allDocsResult.Rows[1].Value.Rev, "")
 	goassert.Equals(t, allDocsResult.Rows[2].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[2].Value.Channels, []string{"Cinemax"})
+	goassert.Equals(t, allDocsResult.Rows[2].Value.Rev, "1-20912648f85f2bbabefb0993ddd37b41")
 	goassert.Equals(t, allDocsResult.Rows[3].Key, "b0gus")
 	goassert.Equals(t, allDocsResult.Rows[3].Error, "not_found")
+	goassert.Equals(t, allDocsResult.Rows[3].Value.Rev, "")
 
 	// Check GET to _all_docs with keys parameter:
 	request, _ = http.NewRequest("GET", `/db/_all_docs?channels=true&keys=%5B%22doc4%22%2C%22doc1%22%2C%22doc3%22%2C%22b0gus%22%5D`, nil)
@@ -1979,6 +1991,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response from GET _all_docs = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 4)
@@ -2000,6 +2013,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Response from POST _all_docs = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 1)
@@ -2012,6 +2026,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	assertStatus(t, response, 200)
 
 	log.Printf("Admin response = %s", response.Body.Bytes())
+	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
 	goassert.Equals(t, len(allDocsResult.Rows), 5)


### PR DESCRIPTION
Get1xRevAndChannels was attempting to return the transport-only revID property, which isn't set in this usage.