### PR TITLE
Avoid race in TestSGR2TombstoneConflictHandling

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3927,8 +3927,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Wait for document to arrive on the doc is was put on
 			err = localActiveRT.WaitForCondition(func() bool {
-				doc, err := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
-				require.NoError(t, err)
+				doc, _ := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
 				if doc == nil {
 					return false
 				}
@@ -3941,8 +3940,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 			// Wait for document to be replicated
 			err = remotePassiveRT.WaitForCondition(func() bool {
-				doc, err := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
-				require.NoError(t, err)
+				doc, _ := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
 				if doc == nil {
 					return false
 				}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3928,7 +3928,10 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			// Wait for document to arrive on the doc is was put on
 			err = localActiveRT.WaitForCondition(func() bool {
 				doc, err := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
-				assert.NoError(t, err)
+				require.NoError(t, err)
+				if doc == nil {
+					return false
+				}
 				if doc.SyncData.CurrentRev == "3-abc" {
 					return true
 				}
@@ -3939,7 +3942,10 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			// Wait for document to be replicated
 			err = remotePassiveRT.WaitForCondition(func() bool {
 				doc, err := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
-				assert.NoError(t, err)
+				require.NoError(t, err)
+				if doc == nil {
+					return false
+				}
 				if doc.SyncData.CurrentRev == "3-abc" {
 					return true
 				}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3874,7 +3874,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
 	for _, test := range tombstoneTests {
 		t.Run(test.name, func(t *testing.T) {
-			defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket)()
+			defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeySync, base.KeyChanges, base.KeyCRUD, base.KeyBucket, base.KeyReplicate)()
 
 			makeDoc := func(rt *RestTester, docid string, rev string, value string) string {
 				var body db.Body
@@ -3926,11 +3926,25 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			localActiveRT.waitForReplicationStatus("replication", db.ReplicationStateRunning)
 
 			// Wait for document to arrive on the doc is was put on
-			_, err = localActiveRT.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			err = localActiveRT.WaitForCondition(func() bool {
+				doc, err := localActiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+				assert.NoError(t, err)
+				if doc.SyncData.CurrentRev == "3-abc" {
+					return true
+				}
+				return false
+			})
 			assert.NoError(t, err)
 
 			// Wait for document to be replicated
-			_, err = remotePassiveRT.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			err = remotePassiveRT.WaitForCondition(func() bool {
+				doc, err := remotePassiveRT.GetDatabase().GetDocument("docid2", db.DocUnmarshalSync)
+				assert.NoError(t, err)
+				if doc.SyncData.CurrentRev == "3-abc" {
+					return true
+				}
+				return false
+			})
 			assert.NoError(t, err)
 
 			// Stop the replication


### PR DESCRIPTION
Added replicator logging
Adjusted check a little

---

Can't repro this locally even with an artificially low CPU so need to run this a few times on jenkins

---

Most recent version has ran a bunch on jenkins successfully. No way to really know its fixed but seems to be stable now.