### PR TITLE
Unit test for Include token_endpoint_auth_methods_supported option in mocked discovery response

### DIFF
--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -208,6 +208,13 @@ func (s *mockAuthServer) discoveryHandler(w http.ResponseWriter, r *http.Request
 		JwksUri:                          issuer + "/keys",
 		AuthorizationEndpoint:            issuer + "/auth",
 		IdTokenSigningAlgValuesSupported: []string{"RS256"},
+		TokenEndpointAuthMethodsSupported: []string{
+			"client_secret_basic",
+			"client_secret_post",
+			"client_secret_jwt",
+			"private_key_jwt",
+			"none",
+		},
 	}
 	renderJSON(w, r, http.StatusOK, metadata)
 }


### PR DESCRIPTION
This PR contains the changes ensure that the latest Go OpenID Connect library doesn’t throw any error when the provider discovery endpoint exposes token_endpoint_auth_methods_supported with a value “none” and Sync Gateway doesn’t hurt while fetching provider metadata from discovery endpoint in such situations.

Verifies that the fix addressed in the old go-oidc lib: https://github.com/coreos/go-oidc/pull/138/files is also working in the updated library.

