### PR TITLE
CBG-761: Rename and clarify DocumentRevision.MutableBody

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -877,7 +877,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 
 		// _attachments shouldn't be present in the body at this point.
 		// It will be stamped in for 1.x clients that require it further up the stack.
-		body1, err := rev.MutableBody()
+		body1, err := rev.Body()
 		require.NoError(t, err)
 		bodyAtts, foundBodyAtts := body1[BodyAttachments]
 		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
@@ -906,7 +906,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 
 		// _attachments shouldn't be present in the body at this point.
 		// It will be stamped in for 1.x clients that require it further up the stack.
-		body1, err := rev.MutableBody()
+		body1, err := rev.Body()
 		require.NoError(t, err)
 		bodyAtts, foundBodyAtts := body1[BodyAttachments]
 		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
@@ -949,7 +949,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 
 		// _attachments shouldn't be present in the body at this point.
 		// It will be stamped in for 1.x clients that require it further up the stack.
-		body1, err := rev.MutableBody()
+		body1, err := rev.Body()
 		require.NoError(t, err)
 		bodyAtts, foundBodyAtts := body1[BodyAttachments]
 		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
@@ -987,7 +987,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		}
 
 		// update the doc with a copy of the previous doc body
-		newBody, err := rev.DeepMutableBody()
+		newBody, err := rev.MutableBody()
 		require.NoError(t, err)
 		newBody[BodyRev] = "3-a"
 		newBody[BodyAttachments] = newAtts
@@ -1008,7 +1008,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 
 		// _attachments shouldn't be present in the body at this point.
 		// It will be stamped in for 1.x clients that require it further up the stack.
-		body1, err := rev.MutableBody()
+		body1, err := rev.Body()
 		require.NoError(t, err)
 		bodyAtts, foundBodyAtts := body1[BodyAttachments]
 		assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
@@ -1169,7 +1169,7 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 
 	// _attachments shouldn't be present in the body at this point.
 	// It will be stamped in for 1.x clients that require it further up the stack.
-	body1, err := rev.MutableBody()
+	body1, err := rev.Body()
 	require.NoError(t, err)
 	bodyAtts, foundBodyAtts := body1[BodyAttachments]
 	assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)
@@ -1355,7 +1355,7 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 
 	// _attachments shouldn't be present in the body at this point.
 	// It will be stamped in for 1.x clients that require it further up the stack.
-	body1, err := rev.MutableBody()
+	body1, err := rev.Body()
 	require.NoError(t, err)
 	bodyAtts, foundBodyAtts := body1[BodyAttachments]
 	assert.False(t, foundBodyAtts, "not expecting '_attachments' in body but found them: %v", bodyAtts)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -690,7 +690,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 			return base.HTTPErrorf(http.StatusNotFound, "Can't use delta. Found tombstone for deltaSrc=%s", deltaSrcRevID)
 		}
 
-		deltaSrcBody, err := deltaSrcRev.DeepMutableBody()
+		deltaSrcBody, err := deltaSrcRev.MutableBody()
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "Unable to unmarshal mutable body for deltaSrc=%s %v", deltaSrcRevID, err)
 		}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -537,7 +537,7 @@ func (bsc *BlipSyncContext) sendRevision(sender *blip.Sender, docID, revID strin
 			bodyBytes = rev.BodyBytes
 		}
 	} else {
-		body, err := rev.MutableBody()
+		body, err := rev.Body()
 		if err != nil {
 			return bsc.sendNoRev(sender, docID, revID, seq, err)
 		}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -85,7 +85,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "1-a", docRevAgain.RevID)
 
-	body, err = docRevAgain.MutableBody()
+	body, err = docRevAgain.Body()
 	assert.NoError(t, err)
 	_, ok := body["modified"]
 	assert.False(t, ok)
@@ -937,7 +937,7 @@ func BenchmarkHandleRevDelta(b *testing.B) {
 	getDelta := func(newDoc *Document) {
 		deltaSrcRev, _ := db.GetRev("doc1", "1-a", false, nil)
 
-		deltaSrcBody, _ := deltaSrcRev.DeepMutableBody()
+		deltaSrcBody, _ := deltaSrcRev.MutableBody()
 
 		// Stamp attachments so we can patch them
 		if len(deltaSrcRev.Attachments) > 0 {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1787,7 +1787,7 @@ func TestSyncFnMutateBody(t *testing.T) {
 	assert.NoError(t, err, "Couldn't create document")
 
 	rev, err := db.GetRev("doc1", rev1id, false, nil)
-	revBody, err := rev.MutableBody()
+	revBody, err := rev.Body()
 	require.NoError(t, err, "Couldn't get mutable body")
 	assert.Equal(t, "value1", revBody["key1"])
 	assert.Equal(t, map[string]interface{}{"subkey1": "subvalue1"}, revBody["key2"])
@@ -2000,14 +2000,14 @@ func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
 
 	rev, err := db.GetRev("doc1", "3-b1", false, nil)
 	assert.NoError(t, err, "Retrieve revision 3-b1")
-	revBody, err := rev.MutableBody()
+	revBody, err := rev.Body()
 	assert.NoError(t, err, "Retrieve body of revision 3-b1")
 	assert.Equal(t, "Joshua", revBody["name"])
 	assert.Equal(t, json.Number("11"), revBody["age"])
 
 	rev, err = db.GetRev("doc1", "3-b2", false, nil)
 	assert.NoError(t, err, "Retrieve revision 3-b2")
-	revBody, err = rev.MutableBody()
+	revBody, err = rev.Body()
 	assert.NoError(t, err, "Retrieve body of revision 3-b2")
 	assert.Equal(t, "Liam", revBody["name"])
 	assert.Equal(t, json.Number("12"), revBody["age"])

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -105,9 +105,9 @@ type DocumentRevision struct {
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }
 
-// DeepMutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
+// MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
 // Callers are free to modify any of this body without affecting the document revision.
-func (rev *DocumentRevision) DeepMutableBody() (b Body, err error) {
+func (rev *DocumentRevision) MutableBody() (b Body, err error) {
 	if err := b.Unmarshal(rev.BodyBytes); err != nil {
 		return nil, err
 	}
@@ -115,9 +115,10 @@ func (rev *DocumentRevision) DeepMutableBody() (b Body, err error) {
 	return b, nil
 }
 
-// MutableBody returns a shallow copy of the given document revision as a plain body (without any special properties)
-// Callers are only free to modify top-level properties of this body without affecting the document revision.
-func (rev *DocumentRevision) MutableBody() (b Body, err error) {
+// Body returns an unmarshalled body that is kept in the document revision to produce shallow copies.
+// If an unmarshalled copy is not available in the document revision, it makes a copy from the raw body
+// bytes and stores it in document revision itself before returning the body.
+func (rev *DocumentRevision) Body() (b Body, err error) {
 	// if we already have an unmarshalled body, take a copy and return it
 	if rev._shallowCopyBody != nil {
 		return rev._shallowCopyBody, nil
@@ -136,7 +137,7 @@ func (rev *DocumentRevision) MutableBody() (b Body, err error) {
 // Mutable1xBody returns a copy of the given document revision as a 1.x style body (with special properties)
 // Callers are free to modify this body without affecting the document revision.
 func (rev *DocumentRevision) Mutable1xBody(db *Database, requestedHistory Revisions, attachmentsSince []string, showExp bool) (b Body, err error) {
-	b, err = rev.MutableBody()
+	b, err = rev.Body()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The rev cache changes in 2.7 have changed the expected usage of DocumentRevision. DocumentRevisions returned by the rev cache have already made a mutable copy of the body, and any modifications to the returned DocumentRevision won't impact what's in the revision cache.

As a result, the MutableBody() API on DocumentRevision is no longer required, as DocumentRevisions aren't intended to be shared between processes, and DeepMutableBody can be used in cases a single process needs to copy a revision body.

However, the name and description for MutableBody suggests that a copy is still happening (it's not), and could lead to errors in the future. This PR contains the changes to name the MutableBody() API to just Body(),  DeepMutableBody() API to  MutableBody(), and update the description to make the contract clear.