### PR TITLE
CBG-1078 Deprecate the use of gozip in sgcollect_info

### DIFF
--- a/build/windows/sgw_windows_build.bat
+++ b/build/windows/sgw_windows_build.bat
@@ -154,8 +154,6 @@ if "%EDITION%" == "enterprise" (
 
 echo go install %GO_EDITION_OPTION% github.com\couchbase\sync_gateway\...
 go install %GO_EDITION_OPTION% github.com\couchbase\sync_gateway\...
-echo go install github.com\couchbase\ns_server\deps\gocode\src\gozip
-go install github.com\couchbase\ns_server\deps\gocode\src\gozip
 
 if NOT EXIST %BIN_DIR%\%SGW_EXEC% (
     echo "############################# Sync-Gateway FAIL! no such file: %BIN_DIR%\%SGW_EXEC%"
@@ -222,7 +220,6 @@ echo ======== sync-gateway package ==========================
 echo ".................staging sgw files to %SGW_INSTALL_DIR%"
 copy  %DEST_DIR%\%SGW_EXEC%             %SGW_INSTALL_DIR%\sync_gateway.exe
 copy  %COLLECTINFO_DIST%                %SGW_INSTALL_DIR%\tools\
-copy  %BIN_DIR%\gozip.exe               %SGW_INSTALL_DIR%\tools\
 copy  %BLD_DIR%\README.txt              %SGW_INSTALL_DIR%\README.txt
 echo  %VERSION%                       > %SGW_INSTALL_DIR%\VERSION.txt
 copy  %LIC_DIR%\LICENSE_%EDITION%.txt   %SGW_INSTALL_DIR%\LICENSE.txt

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -122,9 +122,6 @@
   <project groups="notdefault,cb_sg_enterprise" name="concurrent" path="godeps/src/github.com/modern-go/concurrent" remote="couchbasedeps" revision="bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"/>
   <project groups="notdefault,cb_sg_enterprise" name="reflect2" path="godeps/src/github.com/modern-go/reflect2" remote="couchbasedeps" revision="94122c33edd36123c84d5368cfb2b69df93a0ec8"/>
 
-  <!-- gozip tools -->
-  <project name="ns_server" path="godeps/src/github.com/couchbase/ns_server" remote="couchbase" revision="6d835931f574f25e3781192c09e45a3ee30deb51"/>
-
   <!-- gosigar -->
   <project name="gosigar" path="godeps/src/github.com/elastic/gosigar" remote="couchbasedeps" revision="f498c67133bcded80f5966ee63acfe68cff4e6bf"/>
   <project name="wmi" path="godeps/src/github.com/StackExchange/wmi" remote="couchbasedeps" revision="b12b22c5341f0c26d88c4d66176330500e84db68"/>


### PR DESCRIPTION
[ns_server's cbcollect_info](https://github.com/couchbase/ns_server/blob/master/cbcollect_info) script is in the process of no longer using the gozip tool and using the python [zipfile](https://docs.python.org/3.6/library/zipfile.html) module instead.  The [gozip](https://github.com/couchbase/ns_server/tree/master/deps/gocode/src/gozip) tool was originally done to handle zip'ing files when the various flavors of python on different platforms didn't provide uniform support. With current releases already relying on recent python versions 3.6, the uniform/stable zipfile support is available. This PR contains the changes to remove the use of [gozip](https://github.com/couchbase/ns_server/tree/master/deps/gocode/src/gozip) from [sgcollect_info](https://github.com/couchbase/sync_gateway/blob/master/tools/sgcollect_info) and solely use the [zipfile](https://docs.python.org/3.6/library/zipfile.html) module. 