### PR TITLE
CBG-1086 Fix Data race in TestReplicationRebalancePull

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -16,31 +16,7 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-var (
-	// defaultCheckpointIntervalLock is a reader/writer mutual
-	// exclusion lock that guards the defaultCheckpointInterval.
-	defaultCheckpointIntervalLock sync.RWMutex
-
-	// defaultCheckpointInterval represents the default
-	// replication checkpoint interval.
-	defaultCheckpointInterval = time.Second * 5
-)
-
-// DefaultCheckpointInterval returns the default
-// replication checkpoint interval.
-func DefaultCheckpointInterval() time.Duration {
-	defaultCheckpointIntervalLock.RLock()
-	defer defaultCheckpointIntervalLock.RUnlock()
-	return defaultCheckpointInterval
-}
-
-// SetDefaultCheckpointInterval overwrites the replication
-// checkpoint interval with the new interval specified.
-func SetDefaultCheckpointInterval(interval time.Duration) {
-	defaultCheckpointIntervalLock.Lock()
-	defer defaultCheckpointIntervalLock.Unlock()
-	defaultCheckpointInterval = interval
-}
+var DefaultCheckpointInterval = time.Second * 5
 
 // Checkpointer implements replicator checkpointing, by keeping two lists of sequences. Those which we expect to be processing revs for (either push or pull), and a map for those which we have done so on.
 // Periodically (based on a time interval), these two lists are used to calculate the highest sequence number which we've not had a gap for yet, and send a SetCheckpoint message for this sequence.
@@ -81,6 +57,9 @@ type Checkpointer struct {
 	remoteDBURL *url.URL
 
 	stats CheckpointerStats
+
+	// closeWg waits for the time-based checkpointer goroutine to finish.
+	closeWg sync.WaitGroup
 }
 
 type statusFunc func(lastSeq string) *ReplicationStatus
@@ -212,8 +191,10 @@ func (c *Checkpointer) AddExpectedSeqIDAndRevs(seqs map[IDAndRev]string) {
 
 func (c *Checkpointer) Start() {
 	// Start a time-based checkpointer goroutine
+	c.closeWg.Add(1)
 	go func() {
-		checkpointInterval := DefaultCheckpointInterval()
+		defer c.closeWg.Done()
+		checkpointInterval := DefaultCheckpointInterval
 		if c.checkpointInterval > 0 {
 			checkpointInterval = c.checkpointInterval
 		}

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -159,6 +159,7 @@ func (a *activeReplicatorCommon) _disconnect() error {
 	if a.checkpointerCtx != nil {
 		a.checkpointerCtxCancel()
 		a.Checkpointer.CheckpointNow()
+		a.Checkpointer.closeWg.Wait()
 	}
 	a.checkpointerCtx = nil
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -2021,29 +2021,10 @@ func TestReplicationConfigChange(t *testing.T) {
 	require.Len(t, changesResults.Results, 8)
 }
 
-// SetDefaultCheckpointInterval overwrites the replication checkpoint interval
-// with the new interval specified and returns a teardown function to reset the
-// default interval original value that can be deferred from the caller.
-func SetDefaultCheckpointInterval(currentInterval time.Duration) func() {
-	previousInterval := db.DefaultCheckpointInterval()
-	db.SetDefaultCheckpointInterval(currentInterval)
-	return func() { db.SetDefaultCheckpointInterval(previousInterval) }
-}
-
-func TestDefaultCheckpointIntervalDataRace(t *testing.T) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer SetDefaultCheckpointInterval(10 * time.Second)()
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		log.Printf("DefaultCheckpointInterval: %v", db.DefaultCheckpointInterval())
-	}()
-
-	wg.Wait()
-	assert.Equal(t, 5*time.Second, db.DefaultCheckpointInterval())
+func SetDefaultCheckpointInterval(d time.Duration) func() {
+	previousInterval := db.DefaultCheckpointInterval
+	db.DefaultCheckpointInterval = d
+	return func() {
+		db.DefaultCheckpointInterval = previousInterval
+	}
 }


### PR DESCRIPTION
This PR contains the changes to fix the data race emerged from TestReplicationRebalancePull due to concurrent access of default checkpoint interval. Related build failure: http://mobile.jenkins.couchbase.com/view/Sync_Gateway/job/sgw-unix-build/14418/consoleFull#-193976283857ab531-e808-4d97-b44b-e8a7cb55e9a7