### PR TITLE
[2.7.4] CBG-1093 - Backport fix for infinite loop caused by stale view query

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -21,7 +21,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -805,7 +804,7 @@ func (db *Database) Compact() (int, error) {
 	purgeBody := Body{"_purged": true}
 	for {
 		purgedDocs := make([]string, 0)
-		results, err := db.QueryTombstones(purgeOlderThan, QueryTombstoneBatch, gocb.RequestPlus)
+		results, err := db.QueryTombstones(purgeOlderThan, QueryTombstoneBatch)
 		if err != nil {
 			return 0, err
 		}

--- a/db/query.go
+++ b/db/query.go
@@ -496,13 +496,15 @@ func (context *DatabaseContext) QueryAllDocs(startKey string, endKey string) (sg
 	return context.N1QLQueryWithStats(QueryTypeAllDocs, allDocsQueryStatement, params, gocb.RequestPlus, QueryAllDocs.adhoc)
 }
 
-func (context *DatabaseContext) QueryTombstones(olderThan time.Time, limit int, consistencyMode gocb.ConsistencyMode) (sgbucket.QueryResultIterator, error) {
+func (context *DatabaseContext) QueryTombstones(olderThan time.Time, limit int) (sgbucket.QueryResultIterator, error) {
 
 	// View Query
 	if context.Options.UseViews {
-		opts := Body{"stale": "ok"}
-		opts[QueryParamStartKey] = 1
-		opts[QueryParamEndKey] = olderThan.Unix()
+		opts := Body{
+			"stale":            false,
+			QueryParamStartKey: 1,
+			QueryParamEndKey:   olderThan.Unix(),
+		}
 		if limit != 0 {
 			opts[QueryParamLimit] = limit
 		}
@@ -515,11 +517,12 @@ func (context *DatabaseContext) QueryTombstones(olderThan time.Time, limit int, 
 	if limit != 0 {
 		tombstoneQueryStatement = fmt.Sprintf("%s LIMIT %d", tombstoneQueryStatement, limit)
 	}
-	params := make(map[string]interface{}, 1)
-	params[QueryParamOlderThan] = olderThan.Unix()
-	params[QueryParamLimit] = limit
 
-	return context.N1QLQueryWithStats(QueryTypeTombstones, tombstoneQueryStatement, params, consistencyMode, QueryTombstones.adhoc)
+	params := map[string]interface{}{
+		QueryParamOlderThan: olderThan.Unix(),
+	}
+
+	return context.N1QLQueryWithStats(QueryTypeTombstones, tombstoneQueryStatement, params, gocb.RequestPlus, QueryTombstones.adhoc)
 }
 
 func changesViewOptions(channelName string, startSeq, endSeq uint64, limit int) map[string]interface{} {


### PR DESCRIPTION
Backports fix for infinite loop caused by stale view query when running compact (#4544)