### PR TITLE
CBG-1085 Re-register node when not present on cluster update

### DIFF
--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1424,10 +1424,11 @@ func (l *ReplicationHeartbeatListener) reloadNodes() (localNodePresent bool, err
 	if nodeSet != nil {
 		for _, nodeDef := range nodeSet {
 			nodeUUIDs = append(nodeUUIDs, nodeDef.UUID)
+			if nodeDef.UUID == l.mgr.localNodeUUID {
+				localNodePresent = true
+			}
 		}
 	}
-
-	localNodePresent = base.ContainsString(nodeUUIDs, l.mgr.localNodeUUID)
 
 	l.lock.Lock()
 	l.nodeIDs = nodeUUIDs

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -85,14 +85,14 @@ func TestReplicateManagerNodes(t *testing.T) {
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
 
-	err = manager.RegisterNode("node1", "host1")
+	err = manager.registerNodeForHost("node1", "host1")
 	require.NoError(t, err)
 
 	nodes, err := manager.getNodes()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(nodes))
 
-	err = manager.RegisterNode("node2", "host2")
+	err = manager.registerNodeForHost("node2", "host2")
 	require.NoError(t, err)
 
 	nodes, err = manager.getNodes()
@@ -100,7 +100,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	assert.Equal(t, 2, len(nodes))
 
 	// re-adding an existing node is a no-op
-	err = manager.RegisterNode("node1", "host1")
+	err = manager.registerNodeForHost("node1", "host1")
 	require.NoError(t, err)
 
 	nodes, err = manager.getNodes()
@@ -144,7 +144,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 		nodeWg.Add(1)
 		go func(i int) {
 			defer nodeWg.Done()
-			err := manager.RegisterNode(fmt.Sprintf("node_%d", i), fmt.Sprintf("host_%d", i))
+			err := manager.registerNodeForHost(fmt.Sprintf("node_%d", i), fmt.Sprintf("host_%d", i))
 			assert.NoError(t, err)
 		}(i)
 	}


### PR DESCRIPTION
When a SG node receives a cluster cfg update that doesn't it's own node UUID (e.g. it's been removed by another node due to heartbeat expiry), it should re-register itself to the node set.