### PR TITLE
CBG-1060 Fix race between bucket close and replicator.Complete 

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -85,12 +85,12 @@ func (ar *ActiveReplicator) Stop() error {
 
 	var pushErr error
 	if ar.Push != nil {
-		pushErr = ar.Push.stop()
+		pushErr = ar.Push.Stop()
 	}
 
 	var pullErr error
 	if ar.Pull != nil {
-		pullErr = ar.Pull.stop()
+		pullErr = ar.Pull.Stop()
 	}
 
 	if pushErr != nil {

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -85,12 +85,12 @@ func (ar *ActiveReplicator) Stop() error {
 
 	var pushErr error
 	if ar.Push != nil {
-		pushErr = ar.Push.Stop()
+		pushErr = ar.Push.stop()
 	}
 
 	var pullErr error
 	if ar.Pull != nil {
-		pullErr = ar.Pull.Stop()
+		pullErr = ar.Pull.stop()
 	}
 
 	if pushErr != nil {

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -133,8 +133,8 @@ func (a *activeReplicatorCommon) reconnectLoop() {
 	}
 }
 
-// Stop runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
-func (a *activeReplicatorCommon) Stop() error {
+// stopAndDisconnect runs _disconnect and _stop on the replicator, and sets the Stopped replication state.
+func (a *activeReplicatorCommon) stopAndDisconnect() error {
 	a.lock.Lock()
 	a._stop()
 	err := a._disconnect()

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -142,13 +142,11 @@ func (a *activeReplicatorCommon) Stop() error {
 	a._publishStatus()
 	a.lock.Unlock()
 
-	// Wait for up to 10s for reconnect, subChanges, and sendChanges goroutines to exit.
+	// Wait for up to 10s for reconnect goroutine to exit
 	teardownStart := time.Now()
-	for (a.reconnectActive.IsTrue() || (a.blipSyncContext != nil && a.blipSyncContext.activeSubChanges.IsTrue()) ||
-		a.activeSendChanges.IsTrue()) && (time.Since(teardownStart) < time.Second*10) {
+	for a.reconnectActive.IsTrue() && (time.Since(teardownStart) < time.Second*10) {
 		time.Sleep(10 * time.Millisecond)
 	}
-
 	return err
 }
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -214,9 +214,9 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 	}
 }
 
-// stop stops the pull replication and waits for the sub changes goroutine to finish.
-func (apr *ActivePullReplicator) stop() error {
-	if err := apr.Stop(); err != nil {
+// Stop stops the pull replication and waits for the sub changes goroutine to finish.
+func (apr *ActivePullReplicator) Stop() error {
+	if err := apr.stopAndDisconnect(); err != nil {
 		return err
 	}
 	teardownStart := time.Now()

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 )
@@ -211,4 +212,17 @@ func (apr *ActivePullReplicator) registerCheckpointerCallbacks() {
 			go apr.Complete()
 		}
 	}
+}
+
+// stop stops the pull replication and waits for the sub changes goroutine to finish.
+func (apr *ActivePullReplicator) stop() error {
+	if err := apr.Stop(); err != nil {
+		return err
+	}
+	teardownStart := time.Now()
+	for (apr.blipSyncContext != nil && apr.blipSyncContext.activeSubChanges.IsTrue()) &&
+		(time.Since(teardownStart) < time.Second*10) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil
 }

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -247,9 +247,9 @@ func (apr *ActivePushReplicator) _waitForPendingChangesResponse() error {
 	return errors.New("checkpointer _waitForPendingChangesResponse failed to complete after waiting 10s")
 }
 
-// stop stops the push replication and waits for the send changes goroutine to finish.
-func (apr *ActivePushReplicator) stop() error {
-	if err := apr.Stop(); err != nil {
+// Stop stops the push replication and waits for the send changes goroutine to finish.
+func (apr *ActivePushReplicator) Stop() error {
+	if err := apr.stopAndDisconnect(); err != nil {
 		return err
 	}
 	teardownStart := time.Now()

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -89,6 +89,8 @@ func (apr *ActivePushReplicator) _connect() error {
 	}
 
 	go func(s *blip.Sender) {
+		apr.activeSendChanges.Set(true)
+		defer apr.activeSendChanges.Set(false)
 		isComplete := bh.sendChanges(s, &sendChangesOptions{
 			docIDs:            apr.config.DocIDs,
 			since:             seq,


### PR DESCRIPTION
In some cases, the replicator Complete callback is being invoked after the bucket has been closed, which subsequently tries to write a document to the closed bucket, resulting in panics. The race looks like it's due to the “sendChanges” goroutine still being active while closing the bucket from the test during teardown. This PR contains the changes to wait for the “send changes” goroutine to gracefully shutdown when stopping the replication, i.e., wait for 10 seconds like the way we wait for the “reconnect” goroutine to exit.