### PR TITLE
CBG-1076: Ensure pruning of tombstoned branches

### DIFF
--- a/db/document_test.go
+++ b/db/document_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"log"
-	"sort"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -222,41 +221,4 @@ func TestParseDocumentCas(t *testing.T) {
 	casInt := syncData.GetSyncCas()
 
 	goassert.Equals(t, casInt, uint64(1492749160563736576))
-}
-
-func TestPruneRevisionsWithDisconnected(t *testing.T) {
-	revTree := RevTree{
-		"100-abc": {ID: "100-abc"},
-		"101-def": {ID: "101-def", Parent: "100-abc", Deleted: true},
-		"101-abc": {ID: "101-abc", Parent: "100-abc"},
-		"102-abc": {ID: "102-abc", Parent: "101-abc"},
-		"103-def": {ID: "103-def", Parent: "102-abc", Deleted: true},
-		"103-abc": {ID: "103-abc", Parent: "102-abc"},
-		"104-abc": {ID: "104-abc", Parent: "103-abc"},
-		"105-abc": {ID: "105-abc", Parent: "104-abc"},
-		"106-def": {ID: "106-def", Parent: "105-abc", Deleted: true},
-		"106-abc": {ID: "106-abc", Parent: "105-abc"},
-		"107-abc": {ID: "107-abc", Parent: "106-abc"},
-
-		"1-abc": {ID: "1-abc"},
-		"2-abc": {ID: "2-abc", Parent: "1-abc"},
-		"3-abc": {ID: "3-abc", Parent: "2-abc"},
-		"4-abc": {ID: "4-abc", Parent: "3-abc", Deleted: true},
-
-		"70-abc": {ID: "70-abc"},
-		"71-abc": {ID: "71-abc", Parent: "70-abc"},
-		"72-abc": {ID: "72-abc", Parent: "71-abc"},
-		"73-abc": {ID: "73-abc", Parent: "72-abc", Deleted: true},
-	}
-
-	prunedCount, _ := revTree.pruneRevisions(4, "")
-	assert.Equal(t, 10, prunedCount)
-
-	remainingKeys := make([]string, 0, len(revTree))
-	for key := range revTree {
-		remainingKeys = append(remainingKeys, key)
-	}
-	sort.Strings(remainingKeys)
-
-	assert.Equal(t, []string{"101-abc", "102-abc", "103-abc", "103-def", "104-abc", "105-abc", "106-abc", "106-def", "107-abc"}, remainingKeys)
 }

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"log"
+	"sort"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
@@ -221,4 +222,41 @@ func TestParseDocumentCas(t *testing.T) {
 	casInt := syncData.GetSyncCas()
 
 	goassert.Equals(t, casInt, uint64(1492749160563736576))
+}
+
+func TestPruneRevisionsWithDisconnected(t *testing.T) {
+	revTree := RevTree{
+		"100-abc": {ID: "100-abc"},
+		"101-def": {ID: "101-def", Parent: "100-abc", Deleted: true},
+		"101-abc": {ID: "101-abc", Parent: "100-abc"},
+		"102-abc": {ID: "102-abc", Parent: "101-abc"},
+		"103-def": {ID: "103-def", Parent: "102-abc", Deleted: true},
+		"103-abc": {ID: "103-abc", Parent: "102-abc"},
+		"104-abc": {ID: "104-abc", Parent: "103-abc"},
+		"105-abc": {ID: "105-abc", Parent: "104-abc"},
+		"106-def": {ID: "106-def", Parent: "105-abc", Deleted: true},
+		"106-abc": {ID: "106-abc", Parent: "105-abc"},
+		"107-abc": {ID: "107-abc", Parent: "106-abc"},
+
+		"1-abc": {ID: "1-abc"},
+		"2-abc": {ID: "2-abc", Parent: "1-abc"},
+		"3-abc": {ID: "3-abc", Parent: "2-abc"},
+		"4-abc": {ID: "4-abc", Parent: "3-abc", Deleted: true},
+
+		"70-abc": {ID: "70-abc"},
+		"71-abc": {ID: "71-abc", Parent: "70-abc"},
+		"72-abc": {ID: "72-abc", Parent: "71-abc"},
+		"73-abc": {ID: "73-abc", Parent: "72-abc", Deleted: true},
+	}
+
+	prunedCount, _ := revTree.pruneRevisions(4, "")
+	assert.Equal(t, 10, prunedCount)
+
+	remainingKeys := make([]string, 0, len(revTree))
+	for key := range revTree {
+		remainingKeys = append(remainingKeys, key)
+	}
+	sort.Strings(remainingKeys)
+
+	assert.Equal(t, []string{"101-abc", "102-abc", "103-abc", "103-def", "104-abc", "105-abc", "106-abc", "106-def", "107-abc"}, remainingKeys)
 }

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -442,8 +442,14 @@ func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int,
 	}
 
 	computedMaxDepth, leaves := tree.computeDepthsAndFindLeaves()
-	if computedMaxDepth <= maxDepth {
-		return
+	if computedMaxDepth > maxDepth {
+		// Delete nodes whose depth is greater than maxDepth:
+		for revid, node := range tree {
+			if node.depth > maxDepth {
+				delete(tree, revid)
+				pruned++
+			}
+		}
 	}
 
 	// Calculate tombstoneGenerationThreshold
@@ -452,14 +458,6 @@ func (tree RevTree) pruneRevisions(maxDepth uint32, keepRev string) (pruned int,
 	if foundShortestNonTSBranch {
 		// Only set the tombstoneGenerationThreshold if a genShortestNonTSBranch was found.  (fixes #2695)
 		tombstoneGenerationThreshold = genShortestNonTSBranch - int(maxDepth)
-	}
-
-	// Delete nodes whose depth is greater than maxDepth:
-	for revid, node := range tree {
-		if node.depth > maxDepth {
-			delete(tree, revid)
-			pruned++
-		}
 	}
 
 	// If we have a valid tombstoneGenerationThreshold, delete any tombstoned branches that are too old


### PR DESCRIPTION
Previously behaviour was to exit out if the maximum depth (as calculated in `computeDepthsAndFindLeaves`) was less than the allowed maximum depth as set through revs_limit. However, this would mean that no processing would be done to find tombstoned branches such as disconnected ones referenced in this ticket. 
Altered this to ensure this always runs and have added a test to ensure this is the case.


For reference:

Revtree (prior to fix prune wouldn't alter this):
![image](https://user-images.githubusercontent.com/3264971/94300278-aa759f80-ff60-11ea-96d6-41d8e2935ddc.png)

Revtree after prune:

![image](https://user-images.githubusercontent.com/3264971/94300337-beb99c80-ff60-11ea-8141-ff9073d0b57c.png)
