### PR TITLE
CBG-1095 Re-register import node after transient removal

### DIFF
--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -315,16 +315,33 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	assert.NoError(t, node3.Start())
 
 	// Create three heartbeat listeners, associate one with each node
-	testManagerVersion := ""
-	listener1, err := NewImportHeartbeatListener(cfgCB, testManagerVersion)
+	testUUID := cbgt.NewUUID()
+	var eventHandlers cbgt.ManagerEventHandlers
+	options := make(map[string]string)
+	options[cbgt.FeedAllotmentOption] = cbgt.FeedAllotmentOnePerPIndex
+	options["managerLoadDataDir"] = "false"
+	testManager := cbgt.NewManagerEx(
+		cbgt.VERSION,
+		cbgt.NewCfgMem(),
+		testUUID,
+		nil,
+		"",
+		1,
+		"",
+		testUUID,
+		"",
+		"some-datasource",
+		eventHandlers,
+		options)
+	listener1, err := NewImportHeartbeatListener(cfgCB, testManager)
 	assert.NoError(t, err)
 	assert.NoError(t, node1.RegisterListener(listener1))
 
-	listener2, err := NewImportHeartbeatListener(cfgCB, testManagerVersion)
+	listener2, err := NewImportHeartbeatListener(cfgCB, testManager)
 	assert.NoError(t, err)
 	assert.NoError(t, node2.RegisterListener(listener2))
 
-	listener3, err := NewImportHeartbeatListener(cfgCB, testManagerVersion)
+	listener3, err := NewImportHeartbeatListener(cfgCB, testManager)
 	assert.NoError(t, err)
 	assert.NoError(t, node3.RegisterListener(listener3))
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -1396,14 +1396,14 @@ func (l *ReplicationHeartbeatListener) subscribeNodeSetChanges() error {
 			select {
 			case <-cfgEvents:
 				localNodeRegistered, err := l.reloadNodes()
+				if err != nil {
+					base.Warnf("Error while reloading heartbeat node definitions: %v", err)
+				}
 				if !localNodeRegistered {
 					registerErr := l.mgr.RegisterNode(l.mgr.localNodeUUID)
 					if registerErr != nil {
 						base.Warnf("Error attempting to re-register node, node will not participate in sg-replicate until restarted or replication cfg is next updated: %v", registerErr)
 					}
-				}
-				if err != nil {
-					base.Warnf("Error while reloading heartbeat node definitions: %v", err)
 				}
 			case <-l.terminator:
 				return


### PR DESCRIPTION
If an import node is temporarily removed from the set of cbgt node definitions (e.g. due to temporary dropped heartbeats), have nodes re-register themselves.