### PR TITLE
CBG-1097 Preserve document metadata under localWins conflict resolution

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -746,8 +746,12 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	// Look at attachments with revpos > the last common ancestor's
 	minRevpos := 1
 	if len(history) > 0 {
-		minRevpos, _ := ParseRevID(history[len(history)-1])
-		minRevpos++
+		minRevpos, _ = ParseRevID(history[len(history)-1])
+		// TODO: we can't identify at this point whether the last entry in history represents a
+		// common ancestor, or is the oldest history for a newly inserted doc.  In the former case,
+		// we'd prefer to run with minRevpos++, but since we can't determine without an additional
+		// rev lookup, pay the cost for redundant attachment verification when
+		// the attachment revpos equals the common ancestor
 	}
 
 	// Pull out attachments

--- a/rest/api_test_helpers_test.go
+++ b/rest/api_test_helpers_test.go
@@ -31,9 +31,51 @@ func (rt *RestTester) putDoc(docID string, body string) (response putDocResponse
 	return response
 }
 
+func (rt *RestTester) tombstoneDoc(docID string, revID string) {
+	rawResponse := rt.SendAdminRequest("DELETE", "/db/"+docID+"?rev="+revID, "")
+	assertStatus(rt.tb, rawResponse, 200)
+}
+
+func (rt *RestTester) upsertDoc(docID string, body string) (response putDocResponse) {
+
+	getResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
+	if getResponse.Code == 404 {
+		return rt.putDoc(docID, body)
+	}
+	var getBody db.Body
+	require.NoError(rt.tb, base.JSONUnmarshal(getResponse.Body.Bytes(), &getBody))
+	revID, ok := getBody["revID"].(string)
+	require.True(rt.tb, ok)
+
+	rawResponse := rt.SendAdminRequest("PUT", "/db/"+docID+"?rev="+revID, body)
+	assertStatus(rt.tb, rawResponse, 200)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
+	require.True(rt.tb, response.Ok)
+	require.NotEmpty(rt.tb, response.Rev)
+	return response
+}
+
 func (rt *RestTester) deleteDoc(docID, revID string) {
 	assertStatus(rt.tb, rt.SendAdminRequest(http.MethodDelete,
 		fmt.Sprintf("/db/%s?rev=%s", docID, revID), ""), http.StatusOK)
+}
+
+// PutDocumentWithRevID builds a new_edits=false style put to create a revision with the specified revID.
+// If parentRevID is not specified, treated as insert
+func (rt *RestTester) putNewEditsFalse(docID string, newRevID string, parentRevID string, bodyString string) (response putDocResponse) {
+
+	var body db.Body
+	marshalErr := base.JSONUnmarshal([]byte(bodyString), &body)
+	require.NoError(rt.tb, marshalErr)
+
+	rawResponse, err := rt.PutDocumentWithRevID(docID, newRevID, parentRevID, body)
+	require.NoError(rt.tb, err)
+	assertStatus(rt.tb, rawResponse, 201)
+	require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &response))
+	require.True(rt.tb, response.Ok)
+	require.NotEmpty(rt.tb, response.Rev)
+
+	return response
 }
 
 func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) changesResults {
@@ -41,4 +83,16 @@ func (rt *RestTester) RequireWaitChanges(numChangesExpected int, since string) c
 	require.NoError(rt.tb, err)
 	require.Len(rt.tb, changesResults.Results, numChangesExpected)
 	return changesResults
+}
+
+func (rt *RestTester) waitForRev(docID string, revID string) error {
+	return rt.WaitForCondition(func() bool {
+		rawResponse := rt.SendAdminRequest("GET", "/db/"+docID, "")
+		if rawResponse.Code != 200 && rawResponse.Code != 201 {
+			return false
+		}
+		var body db.Body
+		require.NoError(rt.tb, base.JSONUnmarshal(rawResponse.Body.Bytes(), &body))
+		return body.ExtractRev() == revID
+	})
 }


### PR DESCRIPTION
Fixes issue where document metadata (deleted, attachments) weren't being preserved under localWins conflict resolution.