### PR TITLE
CBG-878 MultiError type/utils for places where we accumulate errors

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,6 +98,9 @@
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 
+  <project name="go-multierror" path="godeps/src/github.com/hashicorp/go-multierror" remote="couchbasedeps" revision="0d28cf682dbe774898e42a3db11b7ce24b36751a"/>
+  <project name="errwrap" path="godeps/src/github.com/hashicorp/errwrap" remote="couchbasedeps" revision="7b00e5db719c64d14dd0caaacbd13e76254d02c0"/>
+
   <project name="sourcemap" path="godeps/src/gopkg.in/sourcemap.v1" remote="couchbasedeps" revision="6e83acea0053641eff084973fee085f0c193c61a"/>
 
   <project name="uuid" path="godeps/src/github.com/google/uuid" remote="couchbasedeps" revision="e704694aed0ea004bb7eb1fc2e911d048a54606a"/>

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -574,7 +574,7 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to parse request body: %v", err)
 	}
 
-	if errs := params.Validate(); errs != nil {
+	if errs := params.Validate(); errs.ErrorOrNil() != nil {
 		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", errs)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -574,8 +574,8 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to parse request body: %v", err)
 	}
 
-	if errs := params.Validate(); len(errs) > 0 {
-		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %#v", errs)
+	if errs := params.Validate(); errs != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", errs)
 	}
 
 	zipFilename := sgcollectFilename()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -574,8 +574,8 @@ func (h *handler) handleSGCollect() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to parse request body: %v", err)
 	}
 
-	if errs := params.Validate(); errs.ErrorOrNil() != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", errs)
+	if multiError := params.Validate(); multiError != nil {
+		return base.HTTPErrorf(http.StatusBadRequest, "Invalid options used for sgcollect_info: %v", multiError)
 	}
 
 	zipFilename := sgcollectFilename()

--- a/rest/config.go
+++ b/rest/config.go
@@ -484,7 +484,7 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 }
 
 func (dbConfig *DbConfig) validateSgDbConfig() (errorMessages *multierror.Error) {
-	if err := dbConfig.validate(); err != nil {
+	if err := dbConfig.validate(); err.ErrorOrNil() != nil {
 		errorMessages = multierror.Append(errorMessages, err)
 	}
 	return errorMessages
@@ -669,7 +669,7 @@ func (config *ServerConfig) setupAndValidateDatabases() (errs *multierror.Error)
 			return multierror.Append(errs, err)
 		}
 
-		if errs = dbConfig.validateSgDbConfig(); errs != nil {
+		if errs = dbConfig.validateSgDbConfig(); errs.ErrorOrNil() != nil {
 			return errs
 		}
 	}
@@ -1217,7 +1217,7 @@ func ServerMain() {
 	var errorMsgs *multierror.Error
 	errorMsgs = multierror.Append(errorMsgs, config.validate())
 	errorMsgs = multierror.Append(errorMsgs, config.setupAndValidateDatabases())
-	if errorMsgs != nil {
+	if errorMsgs.ErrorOrNil() != nil {
 		for _, err := range errorMsgs.Errors {
 			base.Errorf("Error during config validation: %v", err)
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -666,7 +666,7 @@ func (config *ServerConfig) setupAndValidateDatabases() (errs error) {
 	for name, dbConfig := range config.Databases {
 
 		if err := dbConfig.setup(name); err != nil {
-			return multierror.Append(errs, err)
+			return err
 		}
 
 		if errs = dbConfig.validateSgDbConfig(); errs != nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1089,7 +1089,7 @@ func RunServer(config *ServerConfig) {
 	config.Serve(*config.Interface, CreatePublicHandler(sc))
 }
 
-func validateServerContext(sc *ServerContext) (errors *multierror.Error) {
+func validateServerContext(sc *ServerContext) (errors error) {
 	bucketUUIDToDBContext := make(map[string][]*db.DatabaseContext, len(sc.databases_))
 	for _, dbContext := range sc.databases_ {
 		if uuid, err := dbContext.Bucket.UUID(); err == nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1214,10 +1214,10 @@ func ServerMain() {
 	}
 
 	// Validation
-	var multiError error
+	var multiError *multierror.Error
 	multiError = multierror.Append(multiError, config.validate())
 	multiError = multierror.Append(multiError, config.setupAndValidateDatabases())
-	if multiError != nil {
+	if multiError.ErrorOrNil() != nil {
 		base.Errorf("Error during config validation: %v", multiError)
 		base.Fatalf("Error(s) during config validation")
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -934,10 +934,12 @@ func TestValidateServerContext(t *testing.T) {
 	}
 
 	sharedBucketErrors := validateServerContext(sc)
-	require.NotNil(t, sharedBucketErrors.ErrorOrNil())
+	require.NotNil(t, sharedBucketErrors)
+	multiError, ok := sharedBucketErrors.(*multierror.Error)
+	require.NotNil(t, ok)
+	require.Equal(t, multiError.Len(), 1)
 	var sharedBucketError *SharedBucketError
-	require.Equal(t, sharedBucketErrors.Len(), 1)
-	require.True(t, errors.As(sharedBucketErrors.Errors[0], &sharedBucketError))
+	require.True(t, errors.As(multiError.Errors[0], &sharedBucketError))
 	assert.Equal(t, tb1.BucketSpec.BucketName, sharedBucketError.GetSharedBucket().bucketName)
 	assert.Subset(t, []string{"db1", "db2"}, sharedBucketError.GetSharedBucket().dbNames)
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -668,12 +668,9 @@ func TestSetupAndValidateDatabases(t *testing.T) {
 	databases["db1"] = &DbConfig{Name: "db1", BucketConfig: *bc}
 
 	sc = &ServerConfig{Databases: databases}
-	errs = sc.setupAndValidateDatabases()
-	require.NotNil(t, errs)
-	multiError, ok := errs.(*multierror.Error)
-	require.True(t, ok)
-	require.Equal(t, multiError.Len(), 1)
-	assert.Contains(t, multiError.Errors[0].Error(), "invalid control character in URL")
+	validationError := sc.setupAndValidateDatabases()
+	require.NotNil(t, validationError)
+	assert.Contains(t, validationError.Error(), "invalid control character in URL")
 }
 
 func TestParseCommandLine(t *testing.T) {

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
 
@@ -197,23 +198,23 @@ func validateOutputDirectory(dir string) error {
 }
 
 // Validate ensures the options are OK to use in sgcollect_info.
-func (c *sgCollectOptions) Validate() (errs []error) {
+func (c *sgCollectOptions) Validate() (errs *multierror.Error) {
 	if c.OutputDirectory != "" {
 		if err := validateOutputDirectory(c.OutputDirectory); err != nil {
-			errs = append(errs, err)
+			errs = multierror.Append(errs, err)
 		}
 	}
 
 	if c.Ticket != "" {
 		if !validateTicketPattern.MatchString(c.Ticket) {
-			errs = append(errs, errors.New("'ticket' must be 1 to 7 digits"))
+			errs = multierror.Append(errs, errors.New("'ticket' must be 1 to 7 digits"))
 		}
 	}
 
 	if c.Upload {
 		// Customer number is required if uploading.
 		if c.Customer == "" {
-			errs = append(errs, errors.New("'customer' must be set if upload is true"))
+			errs = multierror.Append(errs, errors.New("'customer' must be set if upload is true"))
 		}
 		// Default uploading to support bucket if upload_host is not specified.
 		if c.UploadHost == "" {
@@ -223,18 +224,18 @@ func (c *sgCollectOptions) Validate() (errs []error) {
 		// These fields suggest the user actually wanted to upload,
 		// so we'll enforce "upload: true" if any of these are set.
 		if c.UploadHost != "" {
-			errs = append(errs, errors.New("'upload' must be set to true if 'upload_host' is specified"))
+			errs = multierror.Append(errs, errors.New("'upload' must be set to true if 'upload_host' is specified"))
 		}
 		if c.Customer != "" {
-			errs = append(errs, errors.New("'upload' must be set to true if 'customer' is specified"))
+			errs = multierror.Append(errs, errors.New("'upload' must be set to true if 'customer' is specified"))
 		}
 		if c.Ticket != "" {
-			errs = append(errs, errors.New("'upload' must be set to true if 'ticket' is specified"))
+			errs = multierror.Append(errs, errors.New("'upload' must be set to true if 'ticket' is specified"))
 		}
 	}
 
 	if c.RedactLevel != "" && c.RedactLevel != "none" && c.RedactLevel != "partial" {
-		errs = append(errs, errors.New("'redact_level' must be either 'none' or 'partial'"))
+		errs = multierror.Append(errs, errors.New("'redact_level' must be either 'none' or 'partial'"))
 	}
 
 	return errs

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -198,7 +198,7 @@ func validateOutputDirectory(dir string) error {
 }
 
 // Validate ensures the options are OK to use in sgcollect_info.
-func (c *sgCollectOptions) Validate() (errs *multierror.Error) {
+func (c *sgCollectOptions) Validate() (errs error) {
 	if c.OutputDirectory != "" {
 		if err := validateOutputDirectory(c.OutputDirectory); err != nil {
 			errs = multierror.Append(errs, err)

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -9,6 +9,7 @@ import (
 
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSgcollectFilename(t *testing.T) {
@@ -52,7 +53,7 @@ func TestSgcollectOptionsValidateValid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Nil(t, test.options.Validate())
+			assert.Nil(t, test.options.Validate().ErrorOrNil())
 		})
 	}
 }
@@ -118,7 +119,7 @@ func TestSgcollectOptionsValidateInvalid(t *testing.T) {
 			errs := test.options.Validate()
 
 			// make sure we get at least one error for the given invalid options.
-			assert.NotNil(t, errs)
+			require.NotNil(t, errs.ErrorOrNil())
 
 			// check each error matches the expected string.
 			for _, err := range errs.Errors {

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -52,8 +52,7 @@ func TestSgcollectOptionsValidateValid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			errs := test.options.Validate()
-			assert.Len(t, errs, 0)
+			assert.Nil(t, test.options.Validate())
 		})
 	}
 }
@@ -119,10 +118,10 @@ func TestSgcollectOptionsValidateInvalid(t *testing.T) {
 			errs := test.options.Validate()
 
 			// make sure we get at least one error for the given invalid options.
-			assert.True(t, len(errs) > 0)
+			assert.NotNil(t, errs)
 
 			// check each error matches the expected string.
-			for _, err := range errs {
+			for _, err := range errs.Errors {
 				assert.Contains(ts, err.Error(), test.errContains)
 			}
 		})

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -123,7 +123,7 @@ func TestSgcollectOptionsValidateInvalid(t *testing.T) {
 			require.True(t, ok)
 
 			// make sure we get at least one error for the given invalid options.
-			require.NotNil(t, multiError.ErrorOrNil())
+			require.True(t, multiError.Len() > 0)
 
 			// check each error matches the expected string.
 			for _, err := range multiError.Errors {

--- a/rest/sgcollect_test.go
+++ b/rest/sgcollect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +54,7 @@ func TestSgcollectOptionsValidateValid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Nil(t, test.options.Validate().ErrorOrNil())
+			assert.Nil(t, test.options.Validate())
 		})
 	}
 }
@@ -117,12 +118,15 @@ func TestSgcollectOptionsValidateInvalid(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(ts *testing.T) {
 			errs := test.options.Validate()
+			require.NotNil(t, errs)
+			multiError, ok := errs.(*multierror.Error)
+			require.True(t, ok)
 
 			// make sure we get at least one error for the given invalid options.
-			require.NotNil(t, errs.ErrorOrNil())
+			require.NotNil(t, multiError.ErrorOrNil())
 
 			// check each error matches the expected string.
-			for _, err := range errs.Errors {
+			for _, err := range multiError.Errors {
 				assert.Contains(ts, err.Error(), test.errContains)
 			}
 		})


### PR DESCRIPTION
Prior to Lithium, the multi-error handling pattern used in Sync Gateway is backed by a slice that requires the caller to explicitly equate the length of the returned error slice to zero to ensure there is no error returned from the calling function and a non-zero value for an error. In addition to this, the caller might want to format the  returned list of error messages to present the final error details. 

Most of the multi-error library implementations does the job of formatting the error messages under the hood and doesn’t require the caller to check the length of the returned error slice. It returns a multi-error type that is built of other errors if there is any error and nil reference nil if there is no error instead. 

It’s reasonable to make use of a multi-error implementation of error that is made of other errors in situations where it makes sense to collect and present as many errors as possible. For instance, validating database configuration during the initial Sync Gateway startup, rather than to stop at the first error and report it. 
