### PR TITLE
CBG-1113 - Notify termination for waiting ChangeWaiter triggered by Admins/Guest

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -194,6 +194,7 @@ type CBLReplicationPullStats struct {
 	NumPullReplActiveContinuous *SgwIntStat `json:"num_pull_repl_active_continuous"`
 	NumPullReplActiveOneShot    *SgwIntStat `json:"num_pull_repl_active_one_shot"`
 	NumPullReplCaughtUp         *SgwIntStat `json:"num_pull_repl_caught_up"`
+	NumPullReplTotalCaughtUp    *SgwIntStat `json:"num_pull_repl_total_caught_up"`
 	NumPullReplSinceZero        *SgwIntStat `json:"num_pull_repl_since_zero"`
 	NumPullReplTotalContinuous  *SgwIntStat `json:"num_pull_repl_total_continuous"`
 	NumPullReplTotalOneShot     *SgwIntStat `json:"num_pull_repl_total_one_shot"`
@@ -579,6 +580,7 @@ func (d *DbStats) initCBLReplicationPullStats() {
 		NumPullReplActiveContinuous: NewIntStat(SubsystemReplicationPull, "num_pull_repl_active_one_shot", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		NumPullReplActiveOneShot:    NewIntStat(SubsystemReplicationPull, "num_replications_active", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		NumPullReplCaughtUp:         NewIntStat(SubsystemReplicationPull, "num_pull_repl_caught_up", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		NumPullReplTotalCaughtUp:    NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_caught_up", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		NumPullReplSinceZero:        NewIntStat(SubsystemReplicationPull, "num_pull_repl_since_zero", labelKeys, labelVals, prometheus.CounterValue, 0),
 		NumPullReplTotalContinuous:  NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_continuous", labelKeys, labelVals, prometheus.GaugeValue, 0),
 		NumPullReplTotalOneShot:     NewIntStat(SubsystemReplicationPull, "num_pull_repl_total_one_shot", labelKeys, labelVals, prometheus.GaugeValue, 0),

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -317,11 +317,15 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	})
 
 	// On forceClose, send notify to trigger immediate exit from change waiter
-	if forceClose && bh.db.User() != nil {
-		bh.db.DatabaseContext.NotifyTerminatedChanges(bh.db.User().Name())
+	if forceClose {
+		user := ""
+		if bh.db.User() != nil {
+			user = bh.db.User().Name()
+		}
+		bh.db.DatabaseContext.NotifyTerminatedChanges(user)
 	}
-	return !forceClose
 
+	return !forceClose
 }
 
 func (bh *blipHandler) sendBatchOfChanges(sender *blip.Sender, changeArray [][]interface{}, ignoreNoConflicts bool) error {

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -70,11 +70,7 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 		go func() {
 			defer base.FatalPanicHandler()
 			defer listener.notifyStopping()
-			for {
-				event, ok := <-listener.tapFeed.Events()
-				if !ok {
-					return
-				}
+			for event := range listener.tapFeed.Events() {
 				event.TimeReceived = time.Now()
 				listener.ProcessFeedEvent(event)
 			}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -70,7 +70,11 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 		go func() {
 			defer base.FatalPanicHandler()
 			defer listener.notifyStopping()
-			for event := range listener.tapFeed.Events() {
+			for {
+				event, ok := <-listener.tapFeed.Events()
+				if !ok {
+					return
+				}
 				event.TimeReceived = time.Now()
 				listener.ProcessFeedEvent(event)
 			}

--- a/db/changes.go
+++ b/db/changes.go
@@ -735,6 +735,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 					break waitForChanges
 				}
 
+				db.DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp.Add(1)
 				db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Add(1)
 				waitResponse := changeWaiter.Wait()
 				db.DbStats.CBLReplicationPull().NumPullReplCaughtUp.Add(-1)

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -161,7 +161,7 @@ func (sw *StatWaiter) Wait() {
 			}
 		}
 
-		sw.tb.Fatalf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d)", sw.targetCount, actualCount)
+		sw.tb.Errorf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d) %s", sw.targetCount, actualCount, base.GetCallersName(2, true))
 	} else {
 		actualCount := sw.newStat.Value()
 		if actualCount >= sw.targetCount {
@@ -178,7 +178,7 @@ func (sw *StatWaiter) Wait() {
 			}
 		}
 
-		sw.tb.Fatalf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d)", sw.targetCount, actualCount)
+		sw.tb.Errorf("StatWaiter.Wait timed out waiting for stat to reach %d (actual: %d) %s", sw.targetCount, actualCount, base.GetCallersName(2, true))
 	}
 }
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -323,8 +323,12 @@ func (h *handler) handleChanges() error {
 	close(options.Terminator)
 
 	// On forceClose, send notify to trigger immediate exit from change waiter
-	if forceClose && h.user != nil {
-		h.db.DatabaseContext.NotifyTerminatedChanges(h.user.Name())
+	if forceClose {
+		user := ""
+		if h.user != nil {
+			user = h.user.Name()
+		}
+		h.db.DatabaseContext.NotifyTerminatedChanges(user)
 	}
 
 	return err

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -697,6 +698,104 @@ func TestPostChangesAdminChannelGrantRemoval(t *testing.T) {
 		assert.Equal(t, expectedChange.Changes, result.Changes)
 		assert.Equal(t, expectedChange.Deleted, result.Deleted)
 		assert.Equal(t, expectedChange.Removed, result.Removed)
+	}
+}
+
+// Ensures that changes feed goroutines blocked on a ChangeWaiter are closed when the changes feed is terminated.
+// Reproduces CBG-1113 and #1329 (even with the fix in PR #1360)
+// Tests all combinations of HTTP feed types, admin/non-admin, and with and without a manual notify to wake up.
+func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
+
+	const username = "bernard"
+
+	tests := []struct {
+		feedType     string
+		manualNotify bool
+		username     string // "" for admin
+	}{
+		{"normal", false, username},
+		{"normal", true, username},
+		{"normal", false, ""},
+		{"normal", true, ""},
+		{"continuous", false, username},
+		{"continuous", true, username},
+		{"continuous", false, ""},
+		{"continuous", true, ""},
+		{"longpoll", false, username},
+		{"longpoll", true, username},
+		{"longpoll", false, ""},
+		{"longpoll", true, ""},
+		// Can't test websocket feeds in the same way as other REST types
+		// for manual websocket testing:
+		// $ echo "{}" | wsd -url='ws://127.0.0.1:4985/db1/_changes?since=0&feed=websocket&continuous=true'
+	}
+
+	sendRequestFn := func(rt *RestTester, username string, method, resource, body string) *TestResponse {
+		if username == "" {
+			return rt.SendAdminRequest(method, resource, body)
+		}
+		return rt.Send(requestByUser(method, resource, body, username))
+	}
+
+	for _, test := range tests {
+		testName := fmt.Sprintf("%v user:%v manualNotify:%t", test.feedType, test.username, test.manualNotify)
+		t.Run(testName, func(t *testing.T) {
+			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+			defer base.Errorf("test finished")
+
+			const numChangesToSend = 1000
+
+			rt := NewRestTester(t, nil)
+			defer rt.Close()
+
+			if test.username != "" {
+				a := rt.GetDatabase().Authenticator()
+				bernard, err := a.NewUser(username, "letmein", base.Set{})
+				require.NoError(t, err)
+				require.NoError(t, a.Save(bernard))
+			}
+
+			// Create a doc and send an initial changes
+			resp := sendRequestFn(rt, test.username, http.MethodPut, "/db/doc1", `{"foo":"bar"}`)
+			assertStatus(t, resp, http.StatusCreated)
+			c, err := rt.WaitForChanges(1, "/db/_changes?since=0", "", true)
+			require.NoError(t, err)
+
+			lastSeq := c.Last_Seq.(string)
+			t.Logf("lastSeq: %v %v", lastSeq, c)
+
+			startGoroutines := runtime.NumGoroutine()
+			t.Logf("start goroutines: %d", startGoroutines)
+
+			// Send all of these concurrently, just to speed up testing. Not reliant on concurrency to trigger goroutine leak.
+			wg := sync.WaitGroup{}
+			for i := 0; i < numChangesToSend; i++ {
+				wg.Add(1)
+				go func() {
+					resp := sendRequestFn(rt, test.username, http.MethodGet, "/db/_changes?since="+lastSeq+"&feed="+test.feedType+"&timeout=100", "")
+					assertStatus(t, resp, http.StatusOK)
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+
+			// write a doc to force change waiters to be triggered
+			if test.manualNotify {
+				resp = sendRequestFn(rt, test.username, http.MethodPut, "/db/doc2", `{"foo":"bar"}`)
+				assertStatus(t, resp, http.StatusCreated)
+				_, err := rt.WaitForChanges(1, "/db/_changes?since="+lastSeq, "", true)
+				assert.NoError(t, err)
+			}
+
+			// wait for goroutines to drop to starting value
+			endGoroutines := runtime.NumGoroutine()
+			assert.NoError(t, rt.WaitForCondition(func() bool {
+				endGoroutines = runtime.NumGoroutine()
+				return endGoroutines <= startGoroutines
+			}))
+			t.Logf("end goroutines: %d", endGoroutines)
+		})
 	}
 }
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -783,12 +783,8 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			if test.feedType != "normal" {
 				assert.NoError(t, rt.WaitForCondition(func() bool {
 					// can't check for equality with numChangesToSend because they might've timed out by now on slow test runs.
-					// Assume there's at least one still running though.
+					// Assume there's at least one still running. If this fails, it's likely the test took to long and the requests timed out before this stat was checked.
 					return rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value() > 0
-				}))
-			} else {
-				assert.NoError(t, rt.WaitForCondition(func() bool {
-					return rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp.Value() == 0
 				}))
 			}
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -742,7 +742,7 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 			const (
-				numChangesToSend = 1000
+				numChangesToSend = 5
 				requestTimeoutMs = "2500"
 			)
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1584,7 +1584,11 @@ func TestSGR1CheckpointMigrationPull(t *testing.T) {
 			// listen on a random available port for activeRTSGR1. The address is needed before
 			// creating activeRTSGR1 due to the presence of it in the server config.
 			l, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err)
+			if err != nil {
+				remoteRTHTTPServer.Close()
+				t.Fatalf("unexpected error listening on address: %v", err)
+			}
+
 			defer func() {
 				// Close the HTTP Server before we close the socket
 				remoteRTHTTPServer.Close()
@@ -1763,7 +1767,11 @@ func TestSGR1CheckpointMigrationPush(t *testing.T) {
 	// listen on a random available port for activeRTSGR1. The address is needed before
 	// creating activeRTSGR1 due to the presence of it in the server config.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	if err != nil {
+		remoteRTHTTPServer.Close()
+		t.Fatalf("unexpected error listening on address: %v", err)
+	}
+
 	defer func() {
 		// Close the HTTP Server before we close the socket
 		remoteRTHTTPServer.Close()

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1570,7 +1570,6 @@ func TestSGR1CheckpointMigrationPull(t *testing.T) {
 			remoteRT := NewRestTester(t, nil)
 			defer remoteRT.Close()
 			remoteRTHTTPServer := httptest.NewServer(remoteRT.TestAdminHandler())
-			defer remoteRTHTTPServer.Close()
 
 			// Create docs on remote
 			docABC1 := test.name + "ABC1"
@@ -1586,7 +1585,11 @@ func TestSGR1CheckpointMigrationPull(t *testing.T) {
 			// creating activeRTSGR1 due to the presence of it in the server config.
 			l, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
-			defer func() { _ = l.Close() }()
+			defer func() {
+				// Close the HTTP Server before we close the socket
+				remoteRTHTTPServer.Close()
+				_ = l.Close()
+			}()
 
 			const replicationID = "TestSGR1CheckpointMigrationPull"
 
@@ -1762,12 +1765,10 @@ func TestSGR1CheckpointMigrationPush(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer func() {
-		log.Printf("bbrks: before net.Listen Close")
-		err := l.Close()
-		log.Printf("bbrks: after net.Listen Close %v", err)
+		// Close the HTTP Server before we close the socket
+		remoteRTHTTPServer.Close()
+		_ = l.Close()
 	}()
-
-	defer remoteRTHTTPServer.Close()
 
 	const replicationID = "TestSGR1CheckpointMigrationPush"
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1750,8 +1750,8 @@ func TestSGR1CheckpointMigrationPush(t *testing.T) {
 
 	remoteRT := NewRestTester(t, nil)
 	defer remoteRT.Close()
+
 	remoteRTHTTPServer := httptest.NewServer(remoteRT.TestAdminHandler())
-	defer remoteRTHTTPServer.Close()
 
 	// Bucket for activeRTSGR1 and activeRTSGR2
 	activeBucket := base.GetTestBucket(t)
@@ -1761,7 +1761,13 @@ func TestSGR1CheckpointMigrationPush(t *testing.T) {
 	// creating activeRTSGR1 due to the presence of it in the server config.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer func() { _ = l.Close() }()
+	defer func() {
+		log.Printf("bbrks: before net.Listen Close")
+		err := l.Close()
+		log.Printf("bbrks: after net.Listen Close %v", err)
+	}()
+
+	defer remoteRTHTTPServer.Close()
 
 	const replicationID = "TestSGR1CheckpointMigrationPush"
 


### PR DESCRIPTION
Prevents goroutine leaks for longpoll, continuous, and websocket changes requests when sent by the admin/guest user by waking up the ChangeWaiters and allowing them to terminate.