### PR TITLE
Force Grafana Gauge threshold color

### DIFF
--- a/examples/grafana/dashboard.jsonnet
+++ b/examples/grafana/dashboard.jsonnet
@@ -94,6 +94,7 @@ dashboard.new(
       'Current CPU Utilization',
       min=0,
     )
+    .addThreshold({ color: 'green', value: 0 })
     .addTarget(
       prometheus.target(
         'sgw_resource_utilization_process_cpu_percent_utilization{instance=~"$instance"}',


### PR DESCRIPTION
Looks like there is a regression in the latest version of Grafana? Previously if you left this threshold field blank it would set a default, however, it now appears to error if no threshold is set.