### PR TITLE
CBG-1158: Cleanup code leftover from pre-2.8 stats

### DIFF
--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -858,8 +858,8 @@ func TestChangeWaiterExitOnChangesTermination(t *testing.T) {
 			rt := NewRestTester(t, nil)
 			defer rt.Close()
 
-			activeCaughtUpStatWaiter := rt.GetDatabase().NewNewStatWaiter(rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp, t)
-			totalCaughtUpStatWaiter := rt.GetDatabase().NewNewStatWaiter(rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp, t)
+			activeCaughtUpStatWaiter := rt.GetDatabase().NewStatWaiter(rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplCaughtUp, t)
+			totalCaughtUpStatWaiter := rt.GetDatabase().NewStatWaiter(rt.GetDatabase().DbStats.CBLReplicationPull().NumPullReplTotalCaughtUp, t)
 
 			if test.username != "" {
 				a := rt.GetDatabase().Authenticator()


### PR DESCRIPTION
Just some minor cleanup / refactoring left over from pre-2.8 stats. Code that was only useful during development.