### PR TITLE
[2.8.0.1 backport] CBG-1172 - Fix incorrect URL encoding of credentials when using Authorization header

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -256,10 +256,17 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 	}
 
 	if target.User != nil {
-		config.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(target.User.String())))
+		config.Header.Add("Authorization", "Basic "+base64UserInfo(target.User))
 	}
 
 	return blipContext.DialConfig(config)
+}
+
+// base64UserInfo returns the base64 encoded version of the given UserInfo.
+// Can't use i.String() here because that returns URL encoded versions of credentials.
+func base64UserInfo(i *url.Userinfo) string {
+	password, _ := i.Password()
+	return base64.StdEncoding.EncodeToString([]byte(i.Username() + ":" + password))
 }
 
 // combinedState reports a combined replication state for a pushAndPull

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -150,13 +150,18 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	// Passive
 	tb2 := base.GetTestBucket(t)
 
+	const (
+		username = "AL_1c.e-@"
+		password = "pa$$w*rD!"
+	)
+
 	rt2 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: tb2,
 		DatabaseConfig: &DbConfig{
 			Users: map[string]*db.PrincipalConfig{
-				"alice": {
-					Password:         base.StringPtr("pass"),
-					ExplicitChannels: base.SetOf("alice"),
+				username: {
+					Password:         base.StringPtr(password),
+					ExplicitChannels: base.SetOf(username),
 				},
 			},
 		},
@@ -165,7 +170,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	defer rt2.Close()
 
 	docID := t.Name() + "rt2doc1"
-	resp := rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","channels":["alice"]}`)
+	resp := rt2.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt2","channels":["`+username+`"]}`)
 	assertStatus(t, resp, http.StatusCreated)
 	revID := respRevID(t, resp)
 
@@ -180,7 +185,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add basic auth creds to target db URL
-	passiveDBURL.User = url.UserPassword("alice", "pass")
+	passiveDBURL.User = url.UserPassword(username, password)
 
 	// Active
 	tb1 := base.GetTestBucket(t)


### PR DESCRIPTION
Backports #4836 to 2.8.0.1 (CBG-1173)