### PR TITLE
[2.8.0.1 Backport] - CBG-1179 - Strip basic auth component before sending blipsync websocket request 

### DIFF
--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -243,6 +243,14 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 		target.Scheme = "wss"
 	}
 
+	// Strip userinfo from the URL, don't need it because of the Basic auth header.
+	var basicAuthCreds *url.Userinfo
+	if target.User != nil {
+		// take a copy
+		basicAuthCreds = &*target.User
+		target.User = nil
+	}
+
 	config, err := websocket.NewConfig(target.String()+"/_blipsync?"+BLIPSyncClientTypeQueryParam+"="+string(BLIPClientTypeSGR2), "http://localhost")
 	if err != nil {
 		return nil, err
@@ -255,8 +263,8 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 		config.TlsConfig.InsecureSkipVerify = true
 	}
 
-	if target.User != nil {
-		config.Header.Add("Authorization", "Basic "+base64UserInfo(target.User))
+	if basicAuthCreds != nil {
+		config.Header.Add("Authorization", "Basic "+base64UserInfo(basicAuthCreds))
 	}
 
 	return blipContext.DialConfig(config)

--- a/db/active_replicator_test.go
+++ b/db/active_replicator_test.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlipSyncErrorUserinfo ensures the websocket errors returned by blipSync contain no basic auth component.
+func TestBlipSyncErrorUserinfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		password string
+	}{
+		{
+			name:     "no creds",
+			username: "",
+			password: "",
+		},
+		{
+			name:     "username",
+			username: "foo",
+		},
+		{
+			name:     "user and password",
+			username: "foo",
+			password: "bar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a HTTP server to get past the initial HTTP request inside blipSync.
+			// HTTP errors have basic auth components redacted by the Go stdlib anyway.
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			srvURL, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			if test.username != "" && test.password != "" {
+				srvURL.User = url.UserPassword(test.username, test.password)
+			} else if test.username != "" {
+				srvURL.User = url.User(test.username)
+			}
+
+			srvURL.Path = "/db1"
+			t.Logf("srvURL: %v", srvURL.String())
+
+			_, err = blipSync(*srvURL, NewSGBlipContext(context.Background(), t.Name()), false)
+			require.Error(t, err)
+			t.Logf("error: %v", err)
+			if targetPassword, hasPassword := srvURL.User.Password(); hasPassword {
+				assert.NotContains(t, err.Error(), targetPassword)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backports #4840 to 2.8.0.1