### PR TITLE
CBG-1115: Swapped out some WaitForMessage to WaitForBlipRevMessage

### DIFF
--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -487,11 +487,12 @@ func (bsc *BlipSyncContext) sendDelta(sender *blip.Sender, docID, deltaSrcRevID 
 
 // sendBLIPMessage is a simple wrapper around all sent BLIP messages
 func (bsc *BlipSyncContext) sendBLIPMessage(sender *blip.Sender, msg *blip.Message) bool {
+	ok := sender.Send(msg)
 	if base.LogTraceEnabled(base.KeySyncMsg) {
 		rqBody, _ := msg.Body()
-		base.TracefCtx(bsc.loggingCtx, base.KeySyncMsg, "Send Req %s: Body: '%s' Properties: %v", msg, base.UD(rqBody), base.UD(msg.Properties))
+		base.TracefCtx(bsc.loggingCtx, base.KeySyncMsg, "Sent Req %s: Body: '%s' Properties: %v", msg, base.UD(rqBody), base.UD(msg.Properties))
 	}
-	return sender.Send(msg)
+	return ok
 }
 
 func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, seq SequenceID, err error) error {


### PR DESCRIPTION
PR intended to fix `TestBlipDeltaSyncPullRevCache` and I believe the cause was down to waiting for a blip message ID rather than a specific rev ID. 
I swapped a number of uses for WaitForMessage to WaitForBlipRevMessage. Took this opportunity to do this on a number of tests in an attempt to improve reliability.

- [ ] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/498/console