### PR TITLE
CBG-1174: Changed URL redaction method

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -71,18 +71,18 @@ func RedactBasicAuthURLPassword(urlIn string) string {
 func RedactBasicAuthURL(urlIn string, passwordOnly bool) (string, error) {
 	urlParsed, err := url.Parse(urlIn)
 	if err != nil {
+		// err can't be wrapped or logged as it contains unredacted data from the provided url
 		return "", fmt.Errorf("unable to redact URL, returning empty string")
 	}
-	urlEdit := *urlParsed
-	if urlEdit.User != nil {
-		user := urlEdit.User.Username()
+	if urlParsed.User != nil {
+		user := urlParsed.User.Username()
 		if !passwordOnly {
 			user = "xxxxx"
 		}
-		urlEdit.User = url.UserPassword(user, "xxxxx")
+		urlParsed.User = url.UserPassword(user, "xxxxx")
 	}
 
-	return urlEdit.String(), nil
+	return urlParsed.String(), nil
 }
 
 // GenerateRandomSecret returns a cryptographically-secure 160-bit random number encoded as a hex string.

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -596,10 +596,36 @@ func TestRedactBasicAuthURL(t *testing.T) {
 			input:    "http://foo:p@ssw0rd@example.org",
 			expected: "http://xxxxx:xxxxx@example.org",
 		},
+		{
+			input:    "http://foo:@example.org",
+			expected: "http://xxxxx:xxxxx@example.org",
+		},
+		{
+			input:    "http://foo@example.org",
+			expected: "http://xxxxx:xxxxx@example.org",
+		},
+		{
+			input:    "ftp://foo:p@ssw0rd@example.org",
+			expected: "ftp://xxxxx:xxxxx@example.org",
+		},
+		{
+			input:    "",
+			expected: "",
+		},
+		{
+			input:    "http://foo:%f@example.org",
+			expected: "",
+		},
+		{
+			input:    ":invalid:url",
+			expected: "",
+		},
 	}
 
 	for _, test := range tests {
-		goassert.Equals(t, RedactBasicAuthURLUserAndPassword(test.input), test.expected)
+		t.Run(test.input, func(t *testing.T) {
+			assert.Equal(t, test.expected, RedactBasicAuthURLUserAndPassword(test.input))
+		})
 	}
 }
 

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -553,32 +554,52 @@ func TestRedactBasicAuthURL(t *testing.T) {
 		},
 		{
 			input:    "http://username:password@hostname",
-			expected: "http://****:****@hostname",
+			expected: "http://xxxxx:xxxxx@hostname",
 		},
 		{
 			input:    "https://username:password@example.org:8123",
-			expected: "https://****:****@example.org:8123",
+			expected: "https://xxxxx:xxxxx@example.org:8123",
 		},
 		{
 			input:    "https://username:password@example.org/path",
-			expected: "https://****:****@example.org/path",
+			expected: "https://xxxxx:xxxxx@example.org/path",
 		},
 		{
 			input:    "https://username:password@example.org:8123/path?key=val&email=me@example.org",
-			expected: "https://****:****@example.org:8123/path?key=val&email=me@example.org",
+			expected: "https://xxxxx:xxxxx@example.org:8123/path?key=val&email=me@example.org",
 		},
 		{
 			input:    "https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar",
-			expected: "https://****:****@example.com:8888/bar",
+			expected: "https://xxxxx:xxxxx@example.com:8888/bar",
 		},
 		{
 			input:    "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
 			expected: "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",
 		},
+		{
+			input:    "http://example.org",
+			expected: "http://example.org",
+		},
+		{
+			input:    "http://example.org:1234",
+			expected: "http://example.org:1234",
+		},
+		{
+			input:    "http://foo:bar@example.org",
+			expected: "http://xxxxx:xxxxx@example.org",
+		},
+		{
+			input:    "http://foo:bar@example.org:1234",
+			expected: "http://xxxxx:xxxxx@example.org:1234",
+		},
+		{
+			input:    "http://foo:p@ssw0rd@example.org",
+			expected: "http://xxxxx:xxxxx@example.org",
+		},
 	}
 
 	for _, test := range tests {
-		goassert.Equals(t, RedactBasicAuthURL(test.input), test.expected)
+		goassert.Equals(t, RedactBasicAuthURLUserAndPassword(test.input), test.expected)
 	}
 }
 
@@ -1310,4 +1331,21 @@ func TestGetRestrictedIntQuery(t *testing.T) {
 		false,
 	)
 	assert.Equal(t, minValue, restricted)
+}
+
+func BenchmarkURLParse(b *testing.B) {
+	var basicAuthURLRegexp = regexp.MustCompilePOSIX(`:\/\/[^:/]+:[^@/]+@`)
+	b.ResetTimer()
+	urlString := "https://username:password@example.org:8123/path?key=val&email=me@example.org"
+	b.Run("url.Parse", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = url.Parse(urlString)
+		}
+	})
+
+	b.Run("regex", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = basicAuthURLRegexp.ReplaceAllLiteralString(urlString, "://****:****@")
+		}
+	})
 }

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -145,5 +145,5 @@ func (wh *Webhook) String() string {
 
 func (wh *Webhook) SanitizedUrl() string {
 	// Basic auth credentials may have been included in the URL, in which case obscure them
-	return base.RedactBasicAuthURL(wh.url)
+	return base.RedactBasicAuthURLUserAndPassword(wh.url)
 }

--- a/db/event_handler_test.go
+++ b/db/event_handler_test.go
@@ -13,7 +13,7 @@ func TestWebhookString(t *testing.T) {
 	wh = &Webhook{
 		url: "http://username:password@example.com/foo",
 	}
-	assert.Equal(t, "Webhook handler [http://****:****@example.com/foo]", wh.String())
+	assert.Equal(t, "Webhook handler [http://xxxxx:xxxxx@example.com/foo]", wh.String())
 
 	wh = &Webhook{
 		url: "http://example.com:9000/baz",
@@ -27,7 +27,7 @@ func TestSanitizedUrl(t *testing.T) {
 	wh = &Webhook{
 		url: "https://foo%40bar.baz:my-%24ecret-p%40%25%24w0rd@example.com:8888/bar",
 	}
-	assert.Equal(t, "https://****:****@example.com:8888/bar", wh.SanitizedUrl())
+	assert.Equal(t, "https://xxxxx:xxxxx@example.com:8888/bar", wh.SanitizedUrl())
 
 	wh = &Webhook{
 		url: "https://example.com/does-not-count-as-url-embedded:basic-auth-credentials@qux",

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -326,7 +326,7 @@ func (rc *ReplicationConfig) Equals(compareToCfg *ReplicationConfig) (bool, erro
 func (rc *ReplicationConfig) Redacted() *ReplicationConfig {
 	config := *rc
 	if config.Password != "" {
-		config.Password = "****"
+		config.Password = "xxxxx"
 	}
 	config.Remote = base.RedactBasicAuthURLPassword(config.Remote)
 	return &config

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -194,8 +194,7 @@ func (rc *ReplicationConfig) ValidateReplication(fromConfig bool) (err error) {
 
 	remoteURL, err := url.Parse(rc.Remote)
 	if err != nil {
-		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote URL [%s] is invalid: %v",
-			base.RedactBasicAuthURLPassword(rc.Remote), base.RedactBasicAuthURLPassword(err.Error()))
+		return base.HTTPErrorf(http.StatusBadRequest, "Replication remote URL is invalid")
 	}
 
 	if (remoteURL != nil && remoteURL.User.Username() != "") && rc.Username != "" {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2170,8 +2170,8 @@ func TestConfigRedaction(t *testing.T) {
 	err := json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "****", unmarshaledConfig.Password)
-	assert.Equal(t, "****", *unmarshaledConfig.Users["alice"].Password)
+	assert.Equal(t, "xxxxx", unmarshaledConfig.Password)
+	assert.Equal(t, "xxxxx", *unmarshaledConfig.Users["alice"].Password)
 
 	// Test default db config redaction when redaction disabled
 	response = rt.SendAdminRequest("GET", "/db/_config?redact=false", "")
@@ -2187,8 +2187,8 @@ func TestConfigRedaction(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "****", unmarshaledServerConfig.Databases["db"].Password)
-	assert.Equal(t, "****", *unmarshaledServerConfig.Databases["db"].Users["alice"].Password)
+	assert.Equal(t, "xxxxx", unmarshaledServerConfig.Databases["db"].Password)
+	assert.Equal(t, "xxxxx", *unmarshaledServerConfig.Databases["db"].Users["alice"].Password)
 
 	// Test default server config redaction when redaction disabled
 	response = rt.SendAdminRequest("GET", "/_config?redact=false", "")

--- a/rest/config.go
+++ b/rest/config.go
@@ -596,10 +596,10 @@ func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
 		return nil, err
 	}
 
-	config.Password = "****"
+	config.Password = "xxxxx"
 
 	for i := range config.Users {
-		config.Users[i].Password = base.StringPtr("****")
+		config.Users[i].Password = base.StringPtr("xxxxx")
 	}
 
 	for i, _ := range config.Replications {

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1180,7 +1180,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		assert.Equal(t, expected.Username, actual.Username, "Couldn't redact username")
 		assert.Equal(t, expected.Password, actual.Password, "Couldn't redact password")
 	}
-	replication1Config.Password = "****"
+	replication1Config.Password = "xxxxx"
 	checkReplicationConfig(&replication1Config, &configResponse)
 
 	// Create another replication with auth credentials defined in Remote URL
@@ -1199,7 +1199,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 	configResponse = db.ReplicationConfig{}
 	err = json.Unmarshal(response.BodyBytes(), &configResponse)
 	require.NoError(t, err, "Error un-marshalling replication response")
-	replication2Config.Remote = "http://bob:****@remote:4984/db"
+	replication2Config.Remote = "http://bob:xxxxx@remote:4984/db"
 	//checkReplicationConfig(&replication2Config, &configResponse)
 
 	// Check whether auth are credentials redacted from all replications response
@@ -1427,14 +1427,12 @@ func TestValidateReplicationWithInvalidURL(t *testing.T) {
 	replicationConfig := db.ReplicationConfig{Remote: "http://user:foo{bar=pass@remote:4984/db"}
 	err := replicationConfig.ValidateReplication(false)
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
-	assert.Contains(t, err.Error(), "http://user:****@remote:4984/db")
 	assert.NotContains(t, err.Error(), "user:foo{bar=pass")
 
 	// Replication config with no credentials in an invalid remote URL
 	replicationConfig = db.ReplicationConfig{Remote: "http://{unknown@remote:4984/db"}
 	err = replicationConfig.ValidateReplication(false)
 	assert.Contains(t, err.Error(), strconv.Itoa(http.StatusBadRequest))
-	assert.Contains(t, err.Error(), "http://{unknown@remote:4984/db")
 }
 
 func TestGetStatusWithReplication(t *testing.T) {
@@ -1495,13 +1493,13 @@ func TestGetStatusWithReplication(t *testing.T) {
 	// Check replication1 details in cluster response
 	repl, ok := database.SGRCluster.Replications[config1.ID]
 	assert.True(t, ok, "Error getting replication")
-	config1.Password = "****"
+	config1.Password = "xxxxx"
 	assertReplication(config1, repl)
 
 	// Check replication2 details in cluster response
 	repl, ok = database.SGRCluster.Replications[config2.ID]
 	assert.True(t, ok, "Error getting replication")
-	config2.Remote = "http://bob:****@remote:4984/db"
+	config2.Remote = "http://bob:xxxxx@remote:4984/db"
 	assertReplication(config2, repl)
 
 	// Delete both replications


### PR DESCRIPTION
The regex was unable to properly catch instances where basic auth password included an @. I have changed to use the URL parse method and use that to perform redaction. Also to avoid URL encoding I have changed from *** to xxxxx (as is used by Golang redact method in 1.15).
Tested with unit tests and a number of existing tests had to be changed to fit this newer method.

Its worth noting that its roughly 2x faster as tested with benchmark:

```
BenchmarkURLParse/url.Parse-8         	 2089926	       541 ns/op	     176 B/op	       2 allocs/op
BenchmarkURLParse/regex-8             	 1000000	      1050 ns/op	     218 B/op	       5 allocs/op
```

Running integration tests to double check no integration test only behaviour is affected
- [ ] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/506/