### PR TITLE
Skip TestSGR2TombstoneConflictHandling when running with xattrs=false

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3897,6 +3897,11 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 func TestSGR2TombstoneConflictHandling(t *testing.T) {
 
+	// FIXME: CBG-1171
+	if !base.TestUseXattrs() {
+		t.Skip("Test broken under xattrs=false - CBG-1171")
+	}
+
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}


### PR DESCRIPTION
Test is currently broken when run in this configuration. See CBG-1171

## Integration tests:
- [ ] xattrs=true: http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/507/
- [ ] xattrs=false: http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/508/