### PR TITLE
Bucket Interface updates

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -82,8 +82,7 @@ func init() {
 	gomemcached.MaxBodyLen = int(20 * 1024 * 1024)
 }
 
-// TODO: unalias these and just pass around sgbucket.X everywhere
-type Bucket sgbucket.Bucket
+type Bucket sgbucket.DataStore
 type FeedArguments sgbucket.FeedArguments
 type TapFeed sgbucket.MutationFeed
 
@@ -335,7 +334,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		// If XATTRS are enabled via enable_shared_bucket_access config flag, assert that Couchbase Server is 5.0
 		// or later, otherwise refuse to connect to the bucket since pre 5.0 versions don't support XATTRs
 		if spec.UseXattrs {
-			if !bucket.IsSupported(sgbucket.BucketFeatureXattrs) {
+			if !bucket.IsSupported(sgbucket.DataStoreFeatureXattrs) {
 				Warnf("If using XATTRS, Couchbase Server version must be >= 5.0.")
 				return nil, ErrFatalBucketConnection
 			}

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -23,8 +23,7 @@ type N1qlIndexOptions struct {
 	DeferBuild      bool `json:"defer_build,omitempty"`          // Whether to defer initial build of index (requires a subsequent BUILD INDEX invocation)
 }
 
-type N1QLBucket interface {
-	Bucket
+type N1QLStore interface {
 	Query(statement string, params interface{}, consistency gocb.ConsistencyMode, adhoc bool) (results gocb.QueryResults, err error)
 	ExplainQuery(statement string, params interface{}) (plain map[string]interface{}, err error)
 	CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
@@ -35,7 +34,7 @@ type N1QLBucket interface {
 	DropIndex(indexName string) error
 }
 
-var _ N1QLBucket = &CouchbaseBucketGoCB{}
+var _ N1QLStore = &CouchbaseBucketGoCB{}
 
 // Query accepts a parameterized statement,  optional list of params, and an optional flag to force adhoc query execution.
 // Params specified using the $param notation in the statement are intended to be used w/ N1QL prepared statements, and will be

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -68,7 +68,7 @@ func NewLeakyBucket(bucket Bucket, config LeakyBucketConfig) *LeakyBucket {
 	}
 }
 
-var _ N1QLBucket = &LeakyBucket{}
+var _ N1QLStore = &LeakyBucket{}
 
 func (b *LeakyBucket) GetUnderlyingBucket() Bucket {
 	return b.bucket
@@ -88,9 +88,6 @@ func (b *LeakyBucket) Get(k string, rv interface{}) (cas uint64, err error) {
 func (b *LeakyBucket) GetRaw(k string) (v []byte, cas uint64, err error) {
 	return b.bucket.GetRaw(k)
 }
-func (b *LeakyBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
-	return b.bucket.GetBulkRaw(keys)
-}
 func (b *LeakyBucket) GetAndTouchRaw(k string, exp uint32) (v []byte, cas uint64, err error) {
 	return b.bucket.GetAndTouchRaw(k, exp)
 }
@@ -102,9 +99,6 @@ func (b *LeakyBucket) Add(k string, exp uint32, v interface{}) (added bool, err 
 }
 func (b *LeakyBucket) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	return b.bucket.AddRaw(k, exp, v)
-}
-func (b *LeakyBucket) Append(k string, data []byte) error {
-	return b.bucket.Append(k, data)
 }
 func (b *LeakyBucket) Set(k string, exp uint32, v interface{}) error {
 	return b.bucket.Set(k, exp, v)
@@ -123,9 +117,6 @@ func (b *LeakyBucket) Delete(k string) error {
 func (b *LeakyBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
 	return b.bucket.Remove(k, cas)
 }
-func (b *LeakyBucket) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
-	return b.bucket.Write(k, flags, exp, v, opt)
-}
 func (b *LeakyBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
 	return b.bucket.WriteCas(k, flags, exp, cas, v, opt)
 }
@@ -142,9 +133,6 @@ func (b *LeakyBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteU
 		return b.bucket.WriteUpdate(k, exp, wrapperCallback)
 	}
 	return b.bucket.WriteUpdate(k, exp, callback)
-}
-func (b *LeakyBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
-	return b.bucket.SetBulk(entries)
 }
 
 func (b *LeakyBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
@@ -215,10 +203,6 @@ func (b *LeakyBucket) ViewQuery(ddoc, name string, params map[string]interface{}
 
 func (b *LeakyBucket) GetMaxVbno() (uint16, error) {
 	return b.bucket.GetMaxVbno()
-}
-
-func (b *LeakyBucket) Refresh() error {
-	return b.bucket.Refresh()
 }
 
 func (b *LeakyBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
@@ -411,13 +395,6 @@ func (b *LeakyBucket) Close() {
 func (b *LeakyBucket) Dump() {
 	b.bucket.Dump()
 }
-func (b *LeakyBucket) VBHash(docID string) uint32 {
-	if b.config.TapFeedVbuckets {
-		return VBHash(docID, 1024)
-	} else {
-		return b.bucket.VBHash(docID)
-	}
-}
 
 func (b *LeakyBucket) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
 	return b.bucket.CouchbaseServerVersion()
@@ -428,7 +405,7 @@ func (b *LeakyBucket) UUID() (string, error) {
 }
 
 func (b *LeakyBucket) CloseAndDelete() error {
-	if bucket, ok := b.bucket.(sgbucket.DeleteableBucket); ok {
+	if bucket, ok := b.bucket.(sgbucket.DeleteableStore); ok {
 		return bucket.CloseAndDelete()
 	}
 	return nil
@@ -448,7 +425,7 @@ func (b *LeakyBucket) SetPostQueryCallback(callback func(ddoc, viewName string, 
 	b.config.PostQueryCallback = callback
 }
 
-func (b *LeakyBucket) IsSupported(feature sgbucket.BucketFeature) bool {
+func (b *LeakyBucket) IsSupported(feature sgbucket.DataStoreFeature) bool {
 	return b.bucket.IsSupported(feature)
 }
 

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -48,10 +48,6 @@ func (b *LoggingBucket) Touch(k string, exp uint32) (cas uint64, err error) {
 	defer b.log(time.Now(), k, exp)
 	return b.bucket.Touch(k, exp)
 }
-func (b *LoggingBucket) GetBulkRaw(keys []string) (map[string][]byte, error) {
-	defer b.log(time.Now(), keys)
-	return b.bucket.GetBulkRaw(keys)
-}
 func (b *LoggingBucket) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	defer b.log(time.Now(), k, exp)
 	return b.bucket.Add(k, exp, v)
@@ -59,10 +55,6 @@ func (b *LoggingBucket) Add(k string, exp uint32, v interface{}) (added bool, er
 func (b *LoggingBucket) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	defer b.log(time.Now(), k, exp)
 	return b.bucket.AddRaw(k, exp, v)
-}
-func (b *LoggingBucket) Append(k string, data []byte) error {
-	defer b.log(time.Now(), k)
-	return b.bucket.Append(k, data)
 }
 func (b *LoggingBucket) Set(k string, exp uint32, v interface{}) error {
 	defer b.log(time.Now(), k, exp)
@@ -79,10 +71,6 @@ func (b *LoggingBucket) Delete(k string) error {
 func (b *LoggingBucket) Remove(k string, cas uint64) (casOut uint64, err error) {
 	defer b.log(time.Now(), k, cas)
 	return b.bucket.Remove(k, cas)
-}
-func (b *LoggingBucket) Write(k string, flags int, exp uint32, v interface{}, opt sgbucket.WriteOptions) error {
-	defer b.log(time.Now(), k, flags, exp, opt)
-	return b.bucket.Write(k, flags, exp, v, opt)
 }
 func (b *LoggingBucket) WriteCas(k string, flags int, exp uint32, cas uint64, v interface{}, opt sgbucket.WriteOptions) (uint64, error) {
 	defer b.log(time.Now(), k, flags, exp, cas, opt)
@@ -101,6 +89,7 @@ func (b *LoggingBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, err
 	defer b.log(time.Now(), k, amt, def, exp)
 	return b.bucket.Incr(k, amt, def, exp)
 }
+
 func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
 	defer b.log(time.Now(), k, xattr, exp, cas)
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
@@ -127,6 +116,7 @@ func (b *LoggingBucket) GetXattr(k string, xattr string, xv interface{}) (cas ui
 	defer b.log(time.Now(), k, xattr)
 	return b.bucket.GetXattr(k, xattr, xv)
 }
+
 func (b *LoggingBucket) GetDDocs(value interface{}) error {
 	defer b.log(time.Now())
 	return b.bucket.GetDDocs(value)
@@ -158,16 +148,6 @@ func (b *LoggingBucket) ViewQuery(ddoc, name string, params map[string]interface
 	return b.bucket.ViewQuery(ddoc, name, params)
 }
 
-func (b *LoggingBucket) SetBulk(entries []*sgbucket.BulkSetEntry) (err error) {
-	defer b.log(time.Now(), entries)
-	return b.bucket.SetBulk(entries)
-}
-
-func (b *LoggingBucket) Refresh() error {
-	defer b.log(time.Now())
-	return b.bucket.Refresh()
-}
-
 func (b *LoggingBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 	defer b.log(time.Now())
 	return b.bucket.StartTapFeed(args, dbStats)
@@ -186,10 +166,13 @@ func (b *LoggingBucket) Dump() {
 	defer b.log(time.Now())
 	b.bucket.Dump()
 }
+
+/*
 func (b *LoggingBucket) VBHash(docID string) uint32 {
 	defer b.log(time.Now())
 	return b.bucket.VBHash(docID)
 }
+*/
 
 func (b *LoggingBucket) GetMaxVbno() (uint16, error) {
 	defer b.log(time.Now())
@@ -217,7 +200,7 @@ func (b *LoggingBucket) GetUnderlyingBucket() Bucket {
 	return b.bucket
 }
 
-func (b *LoggingBucket) IsSupported(feature sgbucket.BucketFeature) bool {
+func (b *LoggingBucket) IsSupported(feature sgbucket.DataStoreFeature) bool {
 	defer b.log(time.Now())
 	return b.bucket.IsSupported(feature)
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -2166,7 +2166,7 @@ func (context *DatabaseContext) ComputeSequenceRolesForUser(user auth.User) (cha
 // Checks whether a document has a mobile xattr.  Used when running in non-xattr mode to support no downtime upgrade.
 func (context *DatabaseContext) checkForUpgrade(key string, unmarshalLevel DocumentUnmarshalLevel) (*Document, *sgbucket.BucketDocument) {
 	// If we are using xattrs or Couchbase Server doesn't support them, an upgrade isn't going to be in progress
-	if context.UseXattrs() || !context.Bucket.IsSupported(sgbucket.BucketFeatureXattrs) {
+	if context.UseXattrs() || !context.Bucket.IsSupported(sgbucket.DataStoreFeatureXattrs) {
 		return nil, nil
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -636,6 +636,10 @@ func (context *DatabaseContext) RemoveObsoleteIndexes(previewOnly bool) (removed
 		return make([]string, 0), nil
 	}
 
+	if !gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql) {
+		return removedIndexes, nil
+	}
+
 	return removeObsoleteIndexes(gocbBucket, previewOnly, context.UseXattrs(), context.UseViews(), sgIndexes)
 }
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/gocb"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
@@ -83,6 +84,7 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
 	assert.True(t, ok)
+	require.True(t, gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	// We have one xattr-only index - adjust expected indexes accordingly
 	expectedIndexes := int(indexTypeCount)
@@ -130,6 +132,7 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 
 	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
 	assert.True(t, ok)
+	require.True(t, gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	copiedIndexes := copySGIndexes(sgIndexes)
 
@@ -178,6 +181,7 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
 	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
 	assert.True(t, ok)
+	require.True(t, gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	_, err := removeObsoleteDesignDocs(gocbBucket, !db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
@@ -231,6 +235,7 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 
 	leakyBucket := base.NewLeakyBucket(db.Bucket, base.LeakyBucketConfig{DropIndexErrorNames: []string{"sg_access_1", "sg_access_x1"}})
 	copiedIndexes := copySGIndexes(sgIndexes)
+	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	//Use existing versions of IndexAccess and IndexChannels and create an old version that will be removed by obsolete
 	//indexes. Resulting from the removal candidates for removeObsoleteIndexes will be:

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b1349276dedea51b9aec41dc86dd6598bcfc5e01"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="9536b43918520a68dd18db3deebcded07c1b6796"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="9b201da3276b0475203dfa121a82cd4ccf37b8f2"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cfd5659497b068d8571b17a6a86b1e4e2a1f5d9b"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -83,7 +83,7 @@ func (h *handler) handleVacuum() error {
 func (h *handler) handleFlush() error {
 
 	// If it can be flushed, then flush it
-	if _, ok := h.db.Bucket.(sgbucket.FlushableBucket); ok {
+	if _, ok := h.db.Bucket.(sgbucket.FlushableStore); ok {
 
 		// If it's not a walrus bucket, don't allow flush unless the unsupported config is set
 		if !h.db.BucketSpec.IsWalrusBucket() {
@@ -112,8 +112,8 @@ func (h *handler) handleFlush() error {
 		}
 		defer tempBucketForFlush.Close() // Close the temporary connection to the bucket that was just for purposes of flushing it
 
-		// Flush the bucket (assuming it conforms to sgbucket.DeleteableBucket interface
-		if tempBucketForFlush, ok := tempBucketForFlush.(sgbucket.FlushableBucket); ok {
+		// Flush the bucket (assuming it conforms to sgbucket.DeleteableStore interface
+		if tempBucketForFlush, ok := tempBucketForFlush.(sgbucket.FlushableStore); ok {
 
 			// Flush
 			err := tempBucketForFlush.Flush()
@@ -129,7 +129,7 @@ func (h *handler) handleFlush() error {
 			return err2
 		}
 
-	} else if bucket, ok := h.db.Bucket.(sgbucket.DeleteableBucket); ok {
+	} else if bucket, ok := h.db.Bucket.(sgbucket.DeleteableStore); ok {
 
 		// If it's not flushable, but it's deletable, then delete it
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -361,7 +361,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	// Initialize Views or GSI indexes for the bucket
 	if !useViews {
-		gsiSupported := bucket.IsSupported(sgbucket.BucketFeatureN1ql)
+		gsiSupported := bucket.IsSupported(sgbucket.DataStoreFeatureN1ql)
 		if !gsiSupported {
 			return nil, errors.New("Sync Gateway was unable to connect to a query node on the provided Couchbase Server cluster.  Ensure a query node is accessible, or set 'use_views':true in Sync Gateway's database config.")
 		}


### PR DESCRIPTION
Removes obsolete bucket API calls, initial renaming from bucket to Store/DataStore.  Removes Bucket from N1QLBucket interface for better functional isolation, required some minor refactoring around use of IsSupported.

Depends on
https://github.com/couchbase/sg-bucket/pull/54
https://github.com/couchbaselabs/walrus/pull/52