### PR TITLE
CBG-1161 Fix DefaultPurgeInterval specified in days and used as though in hours

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -196,7 +197,7 @@ func (bucket *CouchbaseBucketGoCB) GetBucketCredentials() (username, password st
 
 // Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
 // found, retrieves the cluster-wide value.
-func (bucket *CouchbaseBucketGoCB) GetMetadataPurgeInterval() (int, error) {
+func (bucket *CouchbaseBucketGoCB) GetMetadataPurgeInterval() (time.Duration, error) {
 
 	// Bucket-specific settings
 	uri := fmt.Sprintf("/pools/default/buckets/%s", bucket.Name())
@@ -219,7 +220,7 @@ func (bucket *CouchbaseBucketGoCB) GetMetadataPurgeInterval() (int, error) {
 // Helper function to retrieve a Metadata Purge Interval from server and convert to hours.  Works for any uri
 // that returns 'purgeInterval' as a root-level property (which includes the two server endpoints for
 // bucket and server purge intervals).
-func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (int, error) {
+func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (time.Duration, error) {
 
 	// Both of the purge interval endpoints (cluster and bucket) return purgeInterval in the same way
 	var purgeResponse struct {
@@ -228,7 +229,7 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (int, error
 
 	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
 	if err != nil {
-		return 0, err
+		return time.Duration(0), err
 	}
 
 	defer func() { _ = resp.Body.Close() }()
@@ -236,21 +237,21 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (int, error
 	if resp.StatusCode == http.StatusForbidden {
 		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if resp.StatusCode != http.StatusOK {
-		return 0, errors.New(resp.Status)
+		return time.Duration(0), errors.New(resp.Status)
 	}
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return 0, err
+		return time.Duration(0), err
 	}
 
 	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
-		return 0, err
+		return time.Duration(0), err
 	}
 
 	// Server purge interval is a float value, in days.  Round up to hours
 	purgeIntervalHours := int(purgeResponse.PurgeInterval*24 + 0.5)
-	return purgeIntervalHours, nil
+	return time.Duration(purgeIntervalHours) * time.Hour, nil
 }
 
 // Get the Server UUID of the bucket, this is also known as the Cluster UUID

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -229,7 +229,7 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (time.Durat
 
 	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
 	if err != nil {
-		return time.Duration(0), err
+		return 0, err
 	}
 
 	defer func() { _ = resp.Body.Close() }()
@@ -237,16 +237,16 @@ func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (time.Durat
 	if resp.StatusCode == http.StatusForbidden {
 		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
 	} else if resp.StatusCode != http.StatusOK {
-		return time.Duration(0), errors.New(resp.Status)
+		return 0, errors.New(resp.Status)
 	}
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return time.Duration(0), err
+		return 0, err
 	}
 
 	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
-		return time.Duration(0), err
+		return 0, err
 	}
 
 	// Server purge interval is a float value, in days.  Round up to hours

--- a/db/database.go
+++ b/db/database.go
@@ -50,9 +50,13 @@ const (
 )
 
 const (
-	DefaultRevsLimitNoConflicts             = 50
-	DefaultRevsLimitConflicts               = 100
-	DefaultPurgeInterval                    = 30 // Default metadata purge interval, in days.  Used if server's purge interval is unavailable
+	DefaultRevsLimitNoConflicts = 50
+	DefaultRevsLimitConflicts   = 100
+
+	// DefaultPurgeInterval represents a time duration of 30 days (in hours)
+	// to be used as default metadata purge interval when the server’s purge
+	// interval (either bucket specific or cluster wide) is not available.
+	DefaultPurgeInterval                    = 30 * 24 * time.Hour
 	DefaultSGReplicateEnabled               = true
 	DefaultSGReplicateWebsocketPingInterval = time.Minute * 5
 )
@@ -94,7 +98,7 @@ type DatabaseContext struct {
 	State              uint32                   // The runtime state of the DB from a service perspective
 	ExitChanges        chan struct{}            // Active _changes feeds on the DB will close when this channel is closed
 	OIDCProviders      auth.OIDCProviderMap     // OIDC clients
-	PurgeInterval      int                      // Metadata purge interval, in hours
+	PurgeInterval      time.Duration            // Metadata purge interval, in hours
 	serverUUID         string                   // UUID of the server, if available
 	DbStats            *base.DbStats            // stats that correspond to this database context
 	CompactState       uint32                   // Status of database compaction
@@ -917,7 +921,7 @@ func (db *Database) Compact() (int, error) {
 	}
 
 	// Trigger view compaction for all tombstoned documents older than the purge interval
-	purgeIntervalDuration := time.Duration(-db.PurgeInterval) * time.Hour
+	purgeIntervalDuration := -db.PurgeInterval * time.Hour
 	startTime := time.Now()
 	purgeOlderThan := startTime.Add(purgeIntervalDuration)
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3784,7 +3784,7 @@ func TestTombstoneCompaction(t *testing.T) {
 	}
 
 	rt := NewRestTester(t, nil)
-	rt.GetDatabase().PurgeInterval = 0
+	rt.GetDatabase().PurgeInterval = time.Duration(0)
 	defer rt.Close()
 
 	compactionTotal := 0

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3784,7 +3784,7 @@ func TestTombstoneCompaction(t *testing.T) {
 	}
 
 	rt := NewRestTester(t, nil)
-	rt.GetDatabase().PurgeInterval = time.Duration(0)
+	rt.GetDatabase().PurgeInterval = 0
 	defer rt.Close()
 
 	compactionTotal := 0


### PR DESCRIPTION
During startup Sync Gateway try to retrieve the purge interval (either bucket specific or cluster wide) from Couchbase server. If it is not available, SG uses the default purge interval of 30 days defined as DefaultPurgeInterval. Even though, the defined constant is in days (which matches how you define the value in Couchbase Server), it is being used as hours in every other places. This needs to be fixed.