### PR TITLE
CBG-1182 - TestGetRemovedDoc fix: Wait for changes before client requests them

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"log"
@@ -1762,6 +1763,8 @@ func TestGetRemovedDoc(t *testing.T) {
 	assert.NoError(t, err)                         // no error
 	assert.Empty(t, resp.Properties["Error-Code"]) // no error
 
+	require.NoError(t, rt.GetDatabase().WaitForPendingChanges(context.Background()))
+
 	// Try to get rev 2 via BLIP API and assert that _removed == false
 	resultDoc, err := bt.GetDocAtRev("foo", "2-bcd")
 	assert.NoError(t, err, "Unexpected Error")
@@ -1780,6 +1783,8 @@ func TestGetRemovedDoc(t *testing.T) {
 	assert.True(t, sent)
 	assert.NoError(t, err)                         // no error
 	assert.Empty(t, resp.Properties["Error-Code"]) // no error
+
+	require.NoError(t, rt.GetDatabase().WaitForPendingChanges(context.Background()))
 
 	// Flush rev cache in case this prevents the bug from showing up (didn't make a difference)
 	rt.GetDatabase().FlushRevisionCacheForTest()

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -1709,6 +1709,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	assertStatus(t, rt.SendAdminRequest("PUT", "/db/docC", `{"channels":["beta"]}`), 201)
 	assertStatus(t, rt.SendAdminRequest("PUT", "/db/docD", `{"channels":["beta"]}`), 201)
 
+	require.NoError(t, rt.WaitForPendingChanges())
+
 	// Create struct to hold changes response
 	var changes struct {
 		Results []db.ChangeEntry
@@ -1716,7 +1718,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//User has access to single channel
 	body := `{"filter":"_doc_ids", "doc_ids":["doc4", "doc1", "docA", "b0gus"]}`
-	request, _ := http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err := http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user1", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1726,7 +1729,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//User has access to different single channel
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "docB", "docD", "doc1"]}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user2", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1736,7 +1740,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//User has access to multiple channels
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"]}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1746,7 +1751,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//User has no channel access
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"]}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user4", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1755,7 +1761,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//User has "*" channel access
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1", "docA"]}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1764,7 +1771,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//User has "*" channel access, override POST with GET params
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1", "docA"]}`
-	request, _ = http.NewRequest("POST", `/db/_changes?doc_ids=["docC","doc1"]`, bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", `/db/_changes?doc_ids=["docC","doc1"]`, bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1772,7 +1780,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	require.Len(t, changes.Results, 2)
 
 	//User has "*" channel access, use GET
-	request, _ = http.NewRequest("GET", `/db/_changes?filter=_doc_ids&doc_ids=["docC","doc1","docD"]`, nil)
+	request, err = http.NewRequest("GET", `/db/_changes?filter=_doc_ids&doc_ids=["docC","doc1","docD"]`, nil)
+	require.NoError(t, err)
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1780,7 +1789,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	require.Len(t, changes.Results, 3)
 
 	//User has "*" channel access, use GET with doc_ids plain comma separated list
-	request, _ = http.NewRequest("GET", `/db/_changes?filter=_doc_ids&doc_ids=docC,doc1,doc2,docD`, nil)
+	request, err = http.NewRequest("GET", `/db/_changes?filter=_doc_ids&doc_ids=docC,doc1,doc2,docD`, nil)
+	require.NoError(t, err)
 	request.SetBasicAuth("user5", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1796,7 +1806,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//Use since value to restrict results
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "since":6}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1806,7 +1817,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//Use since value and limit value to restrict results
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "since":6, "limit":1}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1816,7 +1828,8 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 
 	//test parameter include_docs=true
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "include_docs":true }`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)
@@ -1831,8 +1844,11 @@ func TestOneShotChangesWithExplicitDocIds(t *testing.T) {
 	//Create a conflict revision on docC
 	assertStatus(t, rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"new_edits":false, "docs": [{"_id": "docC","_rev": "2-b4afc58d8e61a6b03390e19a89d26643","foo": "bat", "channels":["beta"]}]}`), 201)
 
+	require.NoError(t, rt.WaitForPendingChanges())
+
 	body = `{"filter":"_doc_ids", "doc_ids":["docC", "b0gus", "doc4", "docD", "doc1"], "style":"all_docs"}`
-	request, _ = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	request, err = http.NewRequest("POST", "/db/_changes", bytes.NewBufferString(body))
+	require.NoError(t, err)
 	request.SetBasicAuth("user3", "letmein")
 	response = rt.Send(request)
 	assertStatus(t, response, 200)


### PR DESCRIPTION
## Integration tests
- [ ] xattrs=true http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/511/