### PR TITLE
CBG-1180: Be resilient to DCP deduplication TestChangesFromCompoundSinceViaDocGrant

### DIFF
--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -738,15 +738,19 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Create docs in various channels
 	_ = rt.putDoc("pbs-1", `{"channel":["PBS"]}`)
 	_ = rt.putDoc("hbo-1", `{"channel":["HBO"]}`)
+	cacheWaiter.AddAndWait(2)
+
 	pbs2 := rt.putDoc("pbs-2", `{"channel":["PBS"]}`)
 	hbo2 := rt.putDoc("hbo-2", `{"channel":["HBO"]}`)
+	cacheWaiter.AddAndWait(2)
 
 	// remove channels/tombstone a couple of docs to ensure they're not backfilled after a dynamic grant
 	_ = rt.putDoc("hbo-2", fmt.Sprintf(`{"_rev":%q}`, hbo2.Rev))
 	rt.deleteDoc(pbs2.ID, pbs2.Rev)
+	cacheWaiter.AddAndWait(2)
 
 	_ = rt.putDoc("abc-1", `{"channel":["ABC"]}`)
-	cacheWaiter.AddAndWait(7)
+	cacheWaiter.AddAndWait(1)
 
 	// Issue changes request and check the results, expect only the one doc in ABC
 	expectedResults := []string{

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -738,11 +738,10 @@ func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 	// Create docs in various channels
 	_ = rt.putDoc("pbs-1", `{"channel":["PBS"]}`)
 	_ = rt.putDoc("hbo-1", `{"channel":["HBO"]}`)
-	cacheWaiter.AddAndWait(2)
 
 	pbs2 := rt.putDoc("pbs-2", `{"channel":["PBS"]}`)
 	hbo2 := rt.putDoc("hbo-2", `{"channel":["HBO"]}`)
-	cacheWaiter.AddAndWait(2)
+	cacheWaiter.AddAndWait(4)
 
 	// remove channels/tombstone a couple of docs to ensure they're not backfilled after a dynamic grant
 	_ = rt.putDoc("hbo-2", fmt.Sprintf(`{"_rev":%q}`, hbo2.Rev))


### PR DESCRIPTION
Fix here was just to split up the cache waits to ensure we don't get caught out by DCP deduplication