### PR TITLE
CBG-1151: Exit cache processing for _sync:cfg docs after cfgEventCallback

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -401,6 +401,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}
+		return
 	}
 
 	// If this is a delete and there are no xattrs (no existing SG revision), we can ignore


### PR DESCRIPTION
Avoids log noise associated with cfg files.