### PR TITLE
Use gopkg.in/couchbase/gocb.v1 for gocb v1 imports

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	"github.com/couchbase/go-couchbase"
-	"github.com/couchbase/gocb"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
 	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -26,9 +26,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
 	"gopkg.in/couchbase/gocbcore.v7"
 )
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	goassert "github.com/couchbaselabs/go.assert"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/couchbase/gocb.v1"
 	"gopkg.in/couchbase/gocbcore.v7"
 )
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/couchbase/gocb"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 const BucketQueryToken = "$_bucket"   // Token used for bucket name replacement in query statements

--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/couchbase/gocb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 var testN1qlOptions = &N1qlIndexOptions{

--- a/base/error.go
+++ b/base/error.go
@@ -14,11 +14,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/couchbase/gocb"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 type sgError struct {

--- a/base/error_test.go
+++ b/base/error_test.go
@@ -7,11 +7,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/couchbase/gocb"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 func TestError(t *testing.T) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -7,8 +7,8 @@ import (
 	"math"
 	"time"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 // A wrapper around a Bucket to support forced errors.  For testing use only.

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -5,8 +5,8 @@ import (
 	"os"
 
 	"github.com/couchbase/clog"
-	"github.com/couchbase/gocb"
 	"github.com/couchbase/goutils/logging"
+	"gopkg.in/couchbase/gocb.v1"
 	"gopkg.in/couchbase/gocbcore.v7"
 )
 

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocb"
 	"github.com/couchbaselabs/walrus"
 	"github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 // GTestBucketPool is a global instance of a TestBucketPool used to manage a pool of buckets for integration testing.

--- a/base/sg_transcoding.go
+++ b/base/sg_transcoding.go
@@ -1,7 +1,7 @@
 package base
 
 import (
-	"github.com/couchbase/gocb"
+	"gopkg.in/couchbase/gocb.v1"
 
 	"gopkg.in/couchbase/gocbcore.v7"
 )

--- a/db/indexes.go
+++ b/db/indexes.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 const (

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"testing"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 func TestInitializeIndexes(t *testing.T) {

--- a/db/query.go
+++ b/db/query.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 // Used for queries that only return doc id

--- a/db/util_testing.go
+++ b/db/util_testing.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocb"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 // Workaround SG #3570 by doing a polling loop until the star channel query returns 0 results.

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -35,9 +35,12 @@
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
-  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
+  <!-- gocb v2 -->
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="171294ec44d0d95af8a261d4231205c567aa63a2" />
+  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="81e2e2022863fa5c42b7351cae8993b6b04c3b64"/>
 
+  <!-- gocb v1 -->
+  <project name="gocb" path="godeps/src/gopkg.in/couchbase/gocb.v1" remote="couchbase" revision="a6e1124eba0e2910e0e4a20cce8dc84e272efea8" />
   <project name="gocbcore" path="godeps/src/gopkg.in/couchbase/gocbcore.v7" remote="couchbase" revision="f3290c5cd250f766251019f542c5041f286ff701"/>
 
   <project name="jsonx" path="godeps/src/gopkg.in/couchbaselabs/jsonx.v1" remote="couchbaselabs" revision="5b7baa20429a46a5543ee259664cc86502738cad"/>

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -49,7 +49,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="d6fef63570d4e921df8b568c2c314e87733596ba"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="b9c7e52110021bf5ee9a487009b6a2f9e689ead0"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -49,7 +49,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cfd5659497b068d8571b17a6a86b1e4e2a1f5d9b"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="d6fef63570d4e921df8b568c2c314e87733596ba"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocb"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/couchbase/gocb.v1"
 )
 
 func SkipImportTestsIfNotEnabled(t *testing.T) {


### PR DESCRIPTION
Switch sync gateway's gocb imports to use gopkg.in, matching existing handling for gocbcore.v7, to support parallel usage of gocb v1 and v2.

Updates manifest entry for gocb and gocbcore to target v2 (2.1.7 and 9.0.7). Not using gopkg.in for these to support shorter turnaround for gocb/gocbcore fixes, and because gopkg.in/couchbase/gocb.v2 still includes github.com/couchbase/gocbcore imports.

Related sg-bucket change: https://github.com/couchbase/sg-bucket/pull/55