### PR TITLE
CBG-1114 Add test coverage for ServerMain/RunServer

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1260,8 +1260,9 @@ func setupServerConfig(args []string) (config *ServerConfig, err error) {
 	return config, nil
 }
 
-// Main entry point for a simple server; you can have your main() function just call this.
-// It parses command-line flags, reads the optional configuration file, then starts the server.
+// ServerMain is the main entry point of launching the Sync Gateway server; the main
+// function directly calls this. It registers both signal and fatal panic handlers,
+// does the initial setup and finally starts the server.
 func ServerMain() {
 	RegisterSignalHandler()
 	defer base.FatalPanicHandler()

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1219,3 +1219,169 @@ func TestExpandEnv(t *testing.T) {
 		})
 	}
 }
+
+// createTempFile creates a temporary file with the given content.
+func createTempFile(t *testing.T, content []byte) *os.File {
+	file, err := ioutil.TempFile("", "*-sync_gateway.conf")
+	require.NoError(t, err, "Error creating temp file")
+	_, err = file.Write(content)
+	require.NoError(t, err, "Error writing bytes")
+	return file
+}
+
+// deleteTempFile deletes the given file.
+func deleteTempFile(t *testing.T, file *os.File) {
+	path := file.Name()
+	require.NoError(t, file.Close(), "Error closing file: %s ", path)
+	require.NoError(t, os.Remove(path), "Error removing file: %s ", path)
+	require.False(t, base.FileExists(path), "Deleted file %s shouldn't exist", path)
+}
+
+func TestSetupAndValidate(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
+		configFile := createTempFile(t, []byte(`{
+          "databases": {
+            "db": {
+              "bucket": "data_bucket",
+              "enable_shared_bucket_access": true,
+              "import_docs": true,
+              "server": "couchbase://localhost",
+              "username": "Administrator",
+              "password": "password",
+              "use_views": false,
+              "revs_limit": 200,
+              "num_index_replicas": 1,
+              "users": {
+                "GUEST": { "admin_channels": ["*"] }
+              }
+            }
+          },
+          "logging": {
+            "console": {
+              "enabled": true,
+              "log_level": "debug",
+              "log_keys": [
+                "*"
+              ],
+              "color_enabled": true
+            }
+          }
+        }`))
+		defer deleteTempFile(t, configFile)
+		args := []string{"sync_gateway", configFile.Name()}
+		config, err := setupServerConfig(args)
+		require.NoError(t, err, "Error reading config file")
+		require.NotNil(t, config)
+
+		db := config.Databases["db"]
+		require.NotNil(t, db)
+
+		assert.Equal(t, "db", db.Name)
+		assert.NotNil(t, db.Bucket)
+
+		assert.Equal(t, "data_bucket", *db.Bucket)
+		assert.NotNil(t, db.Server)
+
+		assert.NotNil(t, db.EnableXattrs)
+		assert.True(t, *db.EnableXattrs)
+
+		assert.Equal(t, "couchbase://localhost", *db.Server)
+		assert.Equal(t, "Administrator", db.Username)
+
+		assert.Equal(t, "password", db.Password)
+		assert.False(t, db.UseViews)
+
+		assert.NotNil(t, db.RevsLimit)
+		assert.Equal(t, 200, int(*db.RevsLimit))
+
+		assert.NotNil(t, db.NumIndexReplicas)
+		assert.Equal(t, 1, int(*db.NumIndexReplicas))
+
+		require.NotNil(t, config.Logging)
+		require.NotNil(t, config.Logging.Console)
+
+		require.NotNil(t, config.Logging.Console.ColorEnabled)
+		assert.True(t, *config.Logging.Console.ColorEnabled)
+
+		require.NotNil(t, config.Logging.Console.Enabled)
+		assert.True(t, *config.Logging.Console.Enabled)
+
+		require.NotNil(t, config.Logging.Console.LogLevel)
+		assert.Equal(t, "debug", config.Logging.Console.LogLevel.String())
+		assert.Equal(t, []string{"*", "HTTP"}, config.Logging.Console.LogKeys)
+	})
+
+	t.Run("Run setupAndValidate with unknown field in config file", func(t *testing.T) {
+		configFile := createTempFile(t, []byte(`{"unknownKey":"unknownValue"}`))
+		defer deleteTempFile(t, configFile)
+		args := []string{"sync_gateway", configFile.Name()}
+		config, err := setupServerConfig(args)
+		require.Error(t, err, "Should throw error reading file")
+		assert.Contains(t, err.Error(), "unrecognized JSON field")
+		assert.Nil(t, config)
+	})
+
+	t.Run("Run setupAndValidate with a config file that doesn't exist", func(t *testing.T) {
+		configFile := createTempFile(t, []byte(``))
+		args := []string{"sync_gateway", configFile.Name()}
+		deleteTempFile(t, configFile)
+		config, err := setupServerConfig(args)
+		require.Error(t, err, "Should throw error reading file")
+		assert.Contains(t, err.Error(), "Error reading config file")
+		assert.Nil(t, config)
+	})
+
+	t.Run("Run setupAndValidate with illegal value for stats_log_freq_secs", func(t *testing.T) {
+		configFile := createTempFile(t, []byte(`
+		{
+		  "databases": {
+		    "db": {
+		      "bucket": "leaky_bucket",
+		      "server": "couchbase://localhost",
+		      "username": "Administrator",
+		      "password": "password"
+		    }
+		  },
+		  "unsupported": {
+		    "stats_log_freq_secs": 1
+		  }
+		}`))
+		defer deleteTempFile(t, configFile)
+		args := []string{"sync_gateway", configFile.Name()}
+		config, err := setupServerConfig(args)
+		require.Error(t, err, "Should throw error reading file")
+		assert.Contains(t, err.Error(), "minimum value for unsupported.stats_log_freq_secs is: 10")
+		assert.Nil(t, config)
+	})
+
+}
+
+func TestSetupServerContext(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	config := &ServerConfig{
+		Logging: &base.LoggingConfig{
+			RedactionLevel: base.RedactFull,
+		},
+	}
+	sc, err := setupServerContext(config)
+	require.NoError(t, err)
+	sc.Close()
+}
+
+func TestStartServer(t *testing.T) {
+	t.Skip("Skipping this test temporarily")
+	config := &ServerConfig{
+		Logging: &base.LoggingConfig{
+			RedactionLevel: base.RedactFull,
+		},
+		ProfileInterface: base.StringPtr("localhost:4987"),
+		MetricsInterface: base.StringPtr("localhost:4986"),
+		AdminInterface:   base.StringPtr("localhost:4985"),
+		Interface:        base.StringPtr("localhost:-1"), // Force HTTP server startup to fail.
+	}
+	sc, err := setupServerContext(config)
+	require.NoError(t, err)
+	defer sc.Close()
+	startServer(config, sc)
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1401,20 +1401,3 @@ func TestSetupServerContext(t *testing.T) {
 		assert.Nil(t, sc)
 	})
 }
-
-func TestStartServer(t *testing.T) {
-	t.Skip("Skipping this test temporarily")
-	config := &ServerConfig{
-		Logging: &base.LoggingConfig{
-			RedactionLevel: base.RedactFull,
-		},
-		ProfileInterface: base.StringPtr("localhost:4987"),
-		MetricsInterface: base.StringPtr("localhost:4986"),
-		AdminInterface:   base.StringPtr("localhost:4985"),
-		Interface:        base.StringPtr("localhost:-1"), // Force HTTP server startup to fail.
-	}
-	sc, err := setupServerContext(config)
-	require.NoError(t, err)
-	defer sc.Close()
-	startServer(config, sc)
-}


### PR DESCRIPTION
This PR was originally intended to address the coverage requirements specified in [CBG-1114](https://issues.couchbase.com/browse/CBG-1114) for ServerMain and RunServer. But when looking closer, most of the individual functions/methods used inside these two functions are separately covered. Moreover, refactoring  the existing ServerMain and RunServer code just to cover the functions themselves doesn’t seem to be adding reasonable benefits when thinking in a broader perspective. One thing that we can do here in terms of coverage is to move out the block of code that is being used to set both BcryptCost and UseStdlibJSON out of RunServer and include additional coverage for those individual functions.