### PR TITLE
Add SG_TEST_LOG_LEVEL flag for global test logging override

### DIFF
--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer base.SetUpGlobalTestLogging(m)()
+
 	base.GTestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
 
 	status := m.Run()

--- a/base/constants.go
+++ b/base/constants.go
@@ -54,6 +54,9 @@ const (
 	// Don't use an auth handler by default, but provide a way to override
 	TestEnvSyncGatewayUseAuthHandler = "SG_TEST_USE_AUTH_HANDLER"
 
+	// Can be used to set a global log level for all tests at runtime.
+	TestEnvGlobalLogLevel = "SG_TEST_LOG_LEVEL"
+
 	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
 	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config
 

--- a/base/logging_test.go
+++ b/base/logging_test.go
@@ -321,6 +321,10 @@ func TestLastComponent(t *testing.T) {
 }
 
 func TestLogSyncGatewayVersion(t *testing.T) {
+	if GlobalTestLoggingSet.IsTrue() {
+		t.Skip("Test does not work when a global test log level is set")
+	}
+
 	for i := LevelNone; i < levelCount; i++ {
 		t.Run(i.String(), func(t *testing.T) {
 			consoleLogger.LogLevel.Set(i)

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer SetUpGlobalTestLogging(m)()
+
 	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
 
 	status := m.Run()

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -630,6 +630,10 @@ func TestRedactBasicAuthURL(t *testing.T) {
 }
 
 func TestSetUpTestLogging(t *testing.T) {
+	if GlobalTestLoggingSet.IsTrue() {
+		t.Skip("Test does not work when a global test log level is set")
+	}
+
 	// Check default state of logging is as expected.
 	require.Equal(t, LevelInfo, *consoleLogger.LogLevel)
 	require.Equal(t, *logKeyMask(KeyHTTP), *consoleLogger.LogKeyMask)

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -1,4 +1,4 @@
-package db
+package channels
 
 import (
 	"os"
@@ -10,11 +10,7 @@ import (
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
 
-	base.GTestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
-
 	status := m.Run()
-
-	base.GTestBucketPool.Close()
 
 	os.Exit(status)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -436,11 +436,15 @@ function(doc, oldDoc) {
 }
 
 func TestLoggingKeys(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
+	if base.GlobalTestLoggingSet.IsTrue() {
+		t.Skip("Test does not work when a global test log level is set")
+	}
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
 
 	//Assert default log channels are enabled
 	response := rt.SendAdminRequest("GET", "/_logging", "")
@@ -512,11 +516,15 @@ func TestLoggingKeys(t *testing.T) {
 }
 
 func TestLoggingLevels(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
+	if base.GlobalTestLoggingSet.IsTrue() {
+		t.Skip("Test does not work when a global test log level is set")
+	}
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
 
 	// Log keys should be blank
 	response := rt.SendAdminRequest("GET", "/_logging", "")
@@ -546,11 +554,15 @@ func TestLoggingLevels(t *testing.T) {
 }
 
 func TestLoggingCombined(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
+	if base.GlobalTestLoggingSet.IsTrue() {
+		t.Skip("Test does not work when a global test log level is set")
+	}
 
 	// Reset logging to initial state, in case any other tests forgot to clean up after themselves
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
 
 	// Log keys should be blank
 	response := rt.SendAdminRequest("GET", "/_logging", "")

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer base.SetUpGlobalTestLogging(m)()
+
 	base.GTestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
 
 	status := m.Run()


### PR DESCRIPTION
Allows runtime changes of global test log levels.

I can see this being useful for gathering more information about a failing Jenkins test without committing a log level change.