### PR TITLE
Remove docker pull step from pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,7 +329,7 @@ pipeline {
                             steps {
                                 gitStatusWrapper(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", description: 'Running LiteCore Tests', failureDescription: 'EE with LiteCore Test Failed', gitHubContext: 'sgw-pipeline-litecore-ee', successDescription: 'EE with LiteCore Test Passed') {
                                     sh 'touch litecore.out'
-                                    sh 'docker pull couchbase/sg-test-litecore:latest'
+                                    //sh 'docker pull couchbase/sg-test-litecore:latest'
                                     sh 'docker run --net=host --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest'
                                 }
                             }


### PR DESCRIPTION
Hit the issue mentioned here, for now we'll just rely on the locally cached image:

https://www.docker.com/increase-rate-limits 