### PR TITLE
Disable the test TestSetupAndValidate temporarily

### DIFF
--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1240,6 +1240,7 @@ func deleteTempFile(t *testing.T, file *os.File) {
 }
 
 func TestSetupAndValidate(t *testing.T) {
+	t.Skip("Skipping this test temporarily; until CBG-1195 is fixed")
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{


### PR DESCRIPTION
This PR just disables the test "TestSetupAndValidate" temporarily due to the potential data race detected during the Jenkins build. A separate ticket has been created to track the fix; CBG-1195.
We can enable this test once CBG-1195 is fixed.