### PR TITLE
CBG-789: Update attachment change with same name

### DIFF
--- a/db/attachment.go
+++ b/db/attachment.go
@@ -98,11 +98,8 @@ func (db *Database) storeAttachments(doc *Document, newAttachmentsMeta Attachmen
 			if parentAttachments != nil {
 				if parentAttachment := parentAttachments[name]; parentAttachment != nil {
 					parentrevpos, ok := base.ToInt64(parentAttachment.(map[string]interface{})["revpos"])
-					if !ok {
-						return nil, nil
-					}
 
-					if revpos <= parentrevpos {
+					if ok && revpos <= parentrevpos {
 						atts[name] = parentAttachment
 					}
 				}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -2966,4 +2967,69 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	assert.Equal(t, float64(11), world["length"])
 	assert.Equal(t, float64(2), world["revpos"])
 	assert.Equal(t, true, world["stub"])
+}
+
+func TestUpdateExistingAttachment(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{
+		guestEnabled: true,
+	})
+	defer rt.Close()
+
+	btc, err := NewBlipTesterClient(t, rt)
+	assert.NoError(t, err)
+	defer btc.Close()
+
+	var doc1Body db.Body
+	var doc2Body db.Body
+
+	// Add doc1 and doc2
+	req := rt.SendAdminRequest("PUT", "/db/doc1", `{}`)
+	assertStatus(t, req, http.StatusCreated)
+	doc1Bytes := req.BodyBytes()
+	req = rt.SendAdminRequest("PUT", "/db/doc2", `{}`)
+	assertStatus(t, req, http.StatusCreated)
+	doc2Bytes := req.BodyBytes()
+
+	err = json.Unmarshal(doc1Bytes, &doc1Body)
+	assert.NoError(t, err)
+	err = json.Unmarshal(doc2Bytes, &doc2Body)
+	assert.NoError(t, err)
+
+	err = btc.StartOneshotPull()
+	assert.NoError(t, err)
+
+	_, ok := btc.WaitForRev("doc1", "1-ca9ad22802b66f662ff171f226211d5c")
+	require.True(t, ok)
+	_, ok = btc.WaitForRev("doc2", "1-ca9ad22802b66f662ff171f226211d5c")
+	require.True(t, ok)
+
+	attachmentAData := base64.StdEncoding.EncodeToString([]byte("attachmentA"))
+	attachmentBData := base64.StdEncoding.EncodeToString([]byte("attachmentB"))
+
+	revIDDoc1, err := btc.PushRev("doc1", doc1Body["rev"].(string), []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentAData+`"}}}`))
+	require.NoError(t, err)
+	revIDDoc2, err := btc.PushRev("doc2", doc2Body["rev"].(string), []byte(`{"key": "val", "_attachments": {"attachment": {"data": "`+attachmentBData+`"}}}`))
+	require.NoError(t, err)
+
+	err = rt.waitForRev("doc1", revIDDoc1)
+	assert.NoError(t, err)
+	err = rt.waitForRev("doc2", revIDDoc2)
+	assert.NoError(t, err)
+
+	doc1, err := rt.GetDatabase().GetDocument("doc1", db.DocUnmarshalAll)
+	_, err = rt.GetDatabase().GetDocument("doc2", db.DocUnmarshalAll)
+
+	revIDDoc1, err = btc.PushRev("doc1", revIDDoc1, []byte(`{"key": "val", "_attachments":{"attachment":{"digest":"sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=","length":11,"content_type":"","stub":true,"revpos":3}}}`))
+	require.NoError(t, err)
+
+	err = rt.waitForRev("doc1", revIDDoc1)
+	assert.NoError(t, err)
+
+	doc1, err = rt.GetDatabase().GetDocument("doc1", db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "sha1-SKk0IV40XSHW37d3H0xpv2+z9Ck=", doc1.Attachments["attachment"].(map[string]interface{})["digest"])
+
+	req = rt.SendAdminRequest("GET", "/db/doc1/attachment", "")
+	assert.Equal(t, "attachmentB", string(req.BodyBytes()))
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4587,7 +4587,7 @@ func TestLocalWinsConflictResolution(t *testing.T) {
 			initialState:   newRevisionState(3, "a", false, 0),
 			localMutation:  newRevisionState(6, "b", false, 4),
 			remoteMutation: newRevisionState(6, "c", false, 5),
-			expectedResult: newRevisionState(7, "b", false, 5),
+			expectedResult: newRevisionState(7, "b", false, 7),
 		},
 	}
 
@@ -4782,6 +4782,112 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 
 	assert.Equal(t, db.ReplicationStateStopped, ar.GetStatus().Status)
 	assert.Equal(t, db.PreHydrogenTargetAllowConflictsError.Error(), ar.GetStatus().ErrorMessage)
+}
+
+func TestReplicatorConflictAttachment(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("requires enterprise edition")
+	}
+
+	testCases := []struct {
+		name                      string
+		conflictResolution        db.ConflictResolverType
+		expectedFinalRev          string
+		expectedRevPos            int
+		expectedAttachmentContent string
+	}{
+		{
+			name:                      "local",
+			conflictResolution:        db.ConflictResolverLocalWins,
+			expectedFinalRev:          "6-3545745ab68aec5b00e745f9e0e3277c",
+			expectedRevPos:            6,
+			expectedAttachmentContent: "hello world",
+		},
+		{
+			name:                      "remote",
+			conflictResolution:        db.ConflictResolverRemoteWins,
+			expectedFinalRev:          "5-remote",
+			expectedRevPos:            4,
+			expectedAttachmentContent: "goodbye cruel world",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
+			defer teardown()
+
+			docID := test.name
+
+			var parentRevID, newRevID string
+			for gen := 1; gen <= 3; gen++ {
+				newRevID = fmt.Sprintf("%d-initial", gen)
+				resp := activeRT.putNewEditsFalse(docID, newRevID, parentRevID, "{}")
+				parentRevID = newRevID
+				assert.True(t, resp.Ok)
+			}
+
+			replicationID := "replication"
+			activeRT.createReplication(replicationID, remoteURLString, db.ActiveReplicatorTypePushAndPull, nil, true, test.conflictResolution)
+			activeRT.assertReplicationState(replicationID, db.ReplicationStateRunning)
+
+			assert.NoError(t, remoteRT.waitForRev(docID, newRevID))
+
+			response := activeRT.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=stop", "")
+			assertStatus(t, response, http.StatusOK)
+			activeRT.waitForReplicationStatus(replicationID, db.ReplicationStateStopped)
+
+			nextGen := 4
+
+			localGen := nextGen
+			localParentRevID := newRevID
+			newLocalRevID := fmt.Sprintf("%d-local", localGen)
+			resp := activeRT.putNewEditsFalse(docID, newLocalRevID, localParentRevID, `{"_attachments": {"attach": {"data":"aGVsbG8gd29ybGQ="}}}`)
+			assert.True(t, resp.Ok)
+			localParentRevID = newLocalRevID
+
+			localGen++
+			newLocalRevID = fmt.Sprintf("%d-local", localGen)
+			resp = activeRT.putNewEditsFalse(docID, newLocalRevID, localParentRevID, fmt.Sprintf(`{"_attachments": {"attach": {"stub": true, "revpos": %d, "digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`, localGen-1))
+			assert.True(t, resp.Ok)
+
+			remoteGen := nextGen
+			remoteParentRevID := newRevID
+			newRemoteRevID := fmt.Sprintf("%d-remote", remoteGen)
+			resp = remoteRT.putNewEditsFalse(docID, newRemoteRevID, remoteParentRevID, `{"_attachments": {"attach": {"data":"Z29vZGJ5ZSBjcnVlbCB3b3JsZA=="}}}`)
+			assert.True(t, resp.Ok)
+			remoteParentRevID = newRemoteRevID
+
+			remoteGen++
+			newRemoteRevID = fmt.Sprintf("%d-remote", remoteGen)
+			resp = remoteRT.putNewEditsFalse(docID, newRemoteRevID, remoteParentRevID, fmt.Sprintf(`{"_attachments": {"attach": {"stub": true, "revpos": %d, "digest":"sha1-gwwPApfQR9bzBKpqoEYwFmKp98A="}}}`, remoteGen-1))
+
+			response = activeRT.SendAdminRequest("PUT", "/db/_replicationStatus/"+replicationID+"?action=start", "")
+			assertStatus(t, response, http.StatusOK)
+
+			waitErr := activeRT.waitForRev(docID, test.expectedFinalRev)
+			assert.NoError(t, waitErr)
+			waitErr = remoteRT.waitForRev(docID, test.expectedFinalRev)
+			assert.NoError(t, waitErr)
+
+			localDoc := activeRT.getDoc(docID)
+			localRevID := localDoc.ExtractRev()
+
+			remoteDoc := remoteRT.getDoc(docID)
+			remoteRevID := remoteDoc.ExtractRev()
+
+			assert.Equal(t, localRevID, remoteRevID)
+			remoteRevpos := getTestRevpos(t, remoteDoc, "attach")
+			assert.Equal(t, test.expectedRevPos, remoteRevpos)
+
+			response = activeRT.SendAdminRequest("GET", "/db/"+docID+"/attach", "")
+			assert.Equal(t, test.expectedAttachmentContent, string(response.BodyBytes()))
+		})
+	}
 }
 
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {


### PR DESCRIPTION
When stub attachment is updated with the same name at present this docs sync data doesn't actually get its attachment digest updated. This is because we were doing a name check on ancestor attachments. Added revpos check to ensure the correct attachment is saved in the sync data.
Added multiple tests to test the fix.