### PR TITLE
Fix broken Windows build due to TestHandlePutDbConfigWithBackticks failure

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -353,7 +353,7 @@ func FileExists(filename string) bool {
 	if err != nil {
 		return false
 	}
-	return info != nil && !info.IsDir()
+	return !info.IsDir()
 }
 
 func DirExists(filename string) bool {
@@ -361,7 +361,7 @@ func DirExists(filename string) bool {
 	if err != nil {
 		return false
 	}
-	return info != nil && info.IsDir()
+	return info.IsDir()
 }
 
 // WaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -350,18 +350,18 @@ func testRetryUntilTrueCustom(t *testing.T, retryFunc RetryUntilTrueFunc, waitTi
 
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
-	return !info.IsDir()
+	return info != nil && !info.IsDir()
 }
 
 func DirExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
-	return info.IsDir()
+	return info != nil && info.IsDir()
 }
 
 // WaitForStat will retry for up to 20 seconds until the result of getStatFunc is equal to the expected value.


### PR DESCRIPTION
The utility function “FileExists” to check whether the given path does exist. This function internally makes use of the os.Stat to collect the FileInfo describing the named file (If the given path doesn’t exist or there is an error, os.Stat will return an error and that will be of type *PathError). Next, the use of IsNotExist function from os package to check for any error and if there is an error due to the given file or directory does not exist. The underlying os error code returned in Windows is different from POSIX machine (ENOENT (2)) and IsNotExist returns false and then the subsequent attempt ensures the file is not a directory and ends up in nil pointer reference. It would be safer to just check for error instead of IsNotExist.