### PR TITLE
Atomically take db offline from online state first, before falling back to silent-return

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -677,15 +677,20 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
 		return nil
 	} else {
-		// If the DB is already transitioning to: offline or is offline silently return
 		dbState := atomic.LoadUint32(&dc.State)
+
+		// If the DB is already transitioning to: offline or is offline silently return
 		if dbState == DBOffline || dbState == DBResyncing || dbState == DBStopping {
 			return nil
 		}
 
-		msg := "Unable to take Database offline, database must be in Online state but was %s"
-		base.Infof(base.KeyCRUD, msg, RunStateString[dbState])
-		return base.HTTPErrorf(http.StatusServiceUnavailable, msg, RunStateString[dbState])
+		msg := "Unable to take Database offline, database must be in Online state but was " + RunStateString[dbState]
+		if dbState == DBOnline {
+			msg = "Unable to take Database offline, another operation was already in progress. Please try again."
+		}
+
+		base.Infof(base.KeyCRUD, msg)
+		return base.HTTPErrorf(http.StatusServiceUnavailable, msg)
 	}
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -656,13 +656,6 @@ func (context *DatabaseContext) NotifyTerminatedChanges(username string) {
 
 func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
-	dbState := atomic.LoadUint32(&dc.State)
-
-	//If the DB is already transitioning to: offline or is offline silently return
-	if dbState == DBOffline || dbState == DBResyncing || dbState == DBStopping {
-		return nil
-	}
-
 	if atomic.CompareAndSwapUint32(&dc.State, DBOnline, DBStopping) {
 
 		//notify all active _changes feeds to close
@@ -684,9 +677,15 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
 		return nil
 	} else {
-		msg := "Unable to take Database offline, database must be in Online state"
-		base.Infof(base.KeyCRUD, msg)
-		return base.HTTPErrorf(http.StatusServiceUnavailable, msg)
+		// If the DB is already transitioning to: offline or is offline silently return
+		dbState := atomic.LoadUint32(&dc.State)
+		if dbState == DBOffline || dbState == DBResyncing || dbState == DBStopping {
+			return nil
+		}
+
+		msg := "Unable to take Database offline, database must be in Online state but was %s"
+		base.Infof(base.KeyCRUD, msg, RunStateString[dbState])
+		return base.HTTPErrorf(http.StatusServiceUnavailable, msg, RunStateString[dbState])
 	}
 }
 


### PR DESCRIPTION
There was a functional race condition seen in `TestDBOfflineConcurrent` where 2 concurrent requests to take the db offline would run, expecting 1 to succeed, and the other one to noop from line 663.

The race between lines 659 and 666 allow both concurrent requests to hit the CompareAndSwap, and one of the requests returns `StatusServiceUnavailable` instead.