### PR TITLE
Remove WriteUpdate from bucket interface

### DIFF
--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -61,7 +61,6 @@ type dataStore struct {
 }
 
 func testAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataStore)) {
-
 	dataStores := make([]dataStore, 0)
 	dataStores = append(dataStores, dataStore{
 		name:   "gocb.v1",
@@ -85,7 +84,6 @@ func testAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.Data
 }
 
 func TestSetGet(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
 		key := t.Name()
@@ -113,7 +111,6 @@ func TestSetGet(t *testing.T) {
 }
 
 func TestSetGetRaw(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
 		key := t.Name()
@@ -141,7 +138,6 @@ func TestSetGetRaw(t *testing.T) {
 }
 
 func TestAddRaw(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 		key := t.Name()
 		val := []byte("bar")
@@ -174,14 +170,12 @@ func TestAddRaw(t *testing.T) {
 			t.Errorf("Error removing key from bucket: %v", err)
 		}
 	})
-
 }
 
 // TestAddRawTimeout attempts to fill up the gocbpipeline by writing large documents concurrently with a small timeout,
 // to verify that timeout errors are returned, and the operation isn't retried (which would return a cas error).
 //   (see CBG-463)
 func TestAddRawTimeoutRetry(t *testing.T) {
-
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
 
@@ -211,13 +205,10 @@ func TestAddRawTimeoutRetry(t *testing.T) {
 
 	}
 	wg.Wait()
-
 }
 
 func TestWriteCasBasic(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
-
 		key := t.Name()
 		val := []byte("bar2")
 
@@ -227,7 +218,6 @@ func TestWriteCasBasic(t *testing.T) {
 		}
 
 		cas := uint64(0)
-
 		cas, err = bucket.WriteCas(key, 0, 0, cas, []byte("bar"), sgbucket.Raw)
 		if err != nil {
 			t.Errorf("Error doing WriteCas: %v", err)
@@ -237,7 +227,6 @@ func TestWriteCasBasic(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error doing WriteCas: %v", err)
 		}
-
 		if casOut == cas {
 			t.Errorf("Expected different casOut value")
 		}
@@ -252,11 +241,9 @@ func TestWriteCasBasic(t *testing.T) {
 			t.Errorf("Error removing key from bucket")
 		}
 	})
-
 }
 
 func TestWriteCasAdvanced(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 		key := t.Name()
 
@@ -287,13 +274,10 @@ func TestWriteCasAdvanced(t *testing.T) {
 			t.Errorf("Error removing key from bucket")
 		}
 	})
-
 }
 
 func TestUpdate(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
-
 		key := t.Name()
 		valInitial := []byte(`{"state":"initial"}`)
 		valUpdated := []byte(`{"state":"updated"}`)
@@ -345,69 +329,9 @@ func TestUpdate(t *testing.T) {
 			t.Errorf("Error removing key from bucket")
 		}
 	})
-
-}
-
-func TestWriteUpdate(t *testing.T) {
-
-	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
-
-		key := t.Name()
-		valInitial := []byte(`{"state":"initial"}`)
-		valUpdated := []byte(`{"state":"updated"}`)
-
-		var rv map[string]interface{}
-		_, err := bucket.Get(key, &rv)
-		if err == nil {
-			t.Errorf("Key should not exist yet, expected error but got nil")
-		}
-
-		updateFunc := func(current []byte) (updated []byte, opt sgbucket.WriteOptions, expiry *uint32, err error) {
-			if len(current) == 0 {
-				return valInitial, opt, nil, nil
-			} else {
-				return valUpdated, opt, nil, nil
-			}
-		}
-		var cas uint64
-		cas, err = bucket.WriteUpdate(key, 0, updateFunc)
-		if err != nil {
-			t.Errorf("Error calling WriteUpdate: %v", err)
-		}
-		if cas == 0 {
-			t.Errorf("Unexpected cas returned by bucket.Update")
-		}
-
-		_, err = bucket.Get(key, &rv)
-		assert.NoError(t, err, "error retrieving initial value")
-		state, ok := rv["state"]
-		assert.True(t, ok, "expected state property not present")
-		assert.Equal(t, "initial", state)
-
-		cas, err = bucket.WriteUpdate(key, 0, updateFunc)
-		if err != nil {
-			t.Errorf("Error calling WriteUpdate: %v", err)
-		}
-		if cas == 0 {
-			t.Errorf("Unexpected cas returned by bucket.Update")
-		}
-
-		_, err = bucket.Get(key, &rv)
-		assert.NoError(t, err, "error retrieving updated value")
-		state, ok = rv["state"]
-		assert.True(t, ok, "expected state property not present")
-		assert.Equal(t, "updated", state)
-
-		err = bucket.Delete(key)
-		if err != nil {
-			t.Errorf("Error removing key from bucket")
-		}
-	})
-
 }
 
 func TestIncrCounter(t *testing.T) {
-
 	testAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 		key := t.Name()
 
@@ -435,7 +359,6 @@ func TestIncrCounter(t *testing.T) {
 		assert.NoError(t, err, "Error incrementing value for existing counter")
 		assert.Equal(t, uint64(2), retrieval)
 	})
-
 }
 
 func TestGetAndTouchRaw(t *testing.T) {

--- a/base/collection.go
+++ b/base/collection.go
@@ -338,16 +338,6 @@ func (c *Collection) Update(k string, exp uint32, callback sgbucket.UpdateFunc) 
 	}
 }
 
-// TODO: Pending removal of WriteUpdate from sg-bucket
-func (c *Collection) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
-	updateCallback := func(current []byte) (updated []byte, expiry *uint32, err error) {
-		updated, _, expiry, err = callback(current)
-		return updated, expiry, err
-	}
-
-	return c.Update(k, exp, updateCallback)
-}
-
 func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
 	if amt == 0 {
 		return 0, errors.New("amt passed to Incr must be non-zero")

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -80,10 +80,6 @@ func (b *LoggingBucket) Update(k string, exp uint32, callback sgbucket.UpdateFun
 	defer b.log(time.Now(), k, exp)
 	return b.bucket.Update(k, exp, callback)
 }
-func (b *LoggingBucket) WriteUpdate(k string, exp uint32, callback sgbucket.WriteUpdateFunc) (casOut uint64, err error) {
-	defer b.log(time.Now(), k, exp)
-	return b.bucket.WriteUpdate(k, exp, callback)
-}
 
 func (b *LoggingBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
 	defer b.log(time.Now(), k, amt, def, exp)

--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -326,7 +326,7 @@ func TestAttachmentCASRetryAfterNewAttachment(t *testing.T) {
 
 	// Use leaky bucket to inject callback in query invocation
 	queryCallbackConfig := base.LeakyBucketConfig{
-		WriteUpdateCallback: writeUpdateCallback,
+		UpdateCallback: writeUpdateCallback,
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
@@ -385,7 +385,7 @@ func TestAttachmentCASRetryDuringNewAttachment(t *testing.T) {
 
 	// Use leaky bucket to inject callback in query invocation
 	queryCallbackConfig := base.LeakyBucketConfig{
-		WriteUpdateCallback: writeUpdateCallback,
+		UpdateCallback: writeUpdateCallback,
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)

--- a/db/crud.go
+++ b/db/crud.go
@@ -1707,7 +1707,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	xattrBytes := 0 // Track size of xattr written, for write stats
 	if !db.UseXattrs() {
 		// Update the document, storing metadata in _sync property
-		_, err = db.Bucket.WriteUpdate(key, expiry, func(currentValue []byte) (raw []byte, writeOpts sgbucket.WriteOptions, syncFuncExpiry *uint32, err error) {
+		_, err = db.Bucket.Update(key, expiry, func(currentValue []byte) (raw []byte, syncFuncExpiry *uint32, err error) {
 			// Be careful: this block can be invoked multiple times if there are races!
 			if doc, err = unmarshalDocument(docid, currentValue); err != nil {
 				return
@@ -1724,7 +1724,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			raw, err = doc.MarshalBodyAndSync()
 			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
 			docBytes = len(raw)
-			return raw, writeOpts, syncFuncExpiry, err
+			return raw, syncFuncExpiry, err
 		})
 
 		// If we can't find sync metadata in the document body, check for upgrade.  If upgrade, retry write using WriteUpdateWithXattr

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2039,7 +2039,7 @@ func TestConcurrentPushSameNewRevision(t *testing.T) {
 
 	// Use leaky bucket to inject callback in query invocation
 	queryCallbackConfig := base.LeakyBucketConfig{
-		WriteUpdateCallback: writeUpdateCallback,
+		UpdateCallback: writeUpdateCallback,
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
@@ -2076,7 +2076,7 @@ func TestConcurrentPushSameNewNonWinningRevision(t *testing.T) {
 
 	// Use leaky bucket to inject callback in query invocation
 	queryCallbackConfig := base.LeakyBucketConfig{
-		WriteUpdateCallback: writeUpdateCallback,
+		UpdateCallback: writeUpdateCallback,
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
@@ -2131,7 +2131,7 @@ func TestConcurrentPushSameTombstoneWinningRevision(t *testing.T) {
 
 	// Use leaky bucket to inject callback in query invocation
 	queryCallbackConfig := base.LeakyBucketConfig{
-		WriteUpdateCallback: writeUpdateCallback,
+		UpdateCallback: writeUpdateCallback,
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
@@ -2186,7 +2186,7 @@ func TestConcurrentPushDifferentUpdateNonWinningRevision(t *testing.T) {
 
 	// Use leaky bucket to inject callback in query invocation
 	queryCallbackConfig := base.LeakyBucketConfig{
-		WriteUpdateCallback: writeUpdateCallback,
+		UpdateCallback: writeUpdateCallback,
 	}
 
 	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), queryCallbackConfig)
@@ -2252,7 +2252,7 @@ func TestIncreasingRecentSequences(t *testing.T) {
 		}
 	}
 
-	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{WriteUpdateCallback: writeUpdateCallback})
+	db = setupTestLeakyDBWithCacheOptions(t, DefaultCacheOptions(), base.LeakyBucketConfig{UpdateCallback: writeUpdateCallback})
 	defer db.Close()
 
 	err := json.Unmarshal([]byte(`{"prop": "value"}`), &body)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="15c8da5201562111cc42eba3ee0cab9d654ea17c"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="e3b4fa4ffff3691ab20bed4709d9f1fb45bd7ee6"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="b9c7e52110021bf5ee9a487009b6a2f9e689ead0"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="15c8da5201562111cc42eba3ee0cab9d654ea17c"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -938,7 +938,7 @@ func TestPullOneshotReplicationAPI(t *testing.T) {
 //   - Write documents to rt1, each belonging to one of the channels (verifies replications are still running)
 //   - Validate replications do not report errors, all docs are replicated
 // Note: This test intermittently reproduced CBG-998 under -race when a 1s sleep was added post-callback to
-//   WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket WriteUpdateCallback.
+//   WriteUpdateWithXattr.  Have been unable to reproduce the same with a leaky bucket UpdateCallback.
 func TestReplicationConcurrentPush(t *testing.T) {
 
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {


### PR DESCRIPTION
WriteOptions aren't being used, so can use Update.  bucket_gocb Update implementation tweaked to follow handling from WriteUpdate (callback returning empty value does not result in delete).

Depends on https://github.com/couchbase/sg-bucket/pull/56