### PR TITLE
CBG-1195 Ensure all goroutines gets terminated when the server context is closed

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -59,7 +59,7 @@ type changeCache struct {
 	lock               sync.RWMutex            // Coordinates access to struct fields
 	options            CacheOptions            // Cache config
 	terminator         chan bool               // Signal termination of background goroutines
-	terminated         []TaskStat              // Notifies on each background task termination.
+	backgroundTasks    []BackgroundTask        // List of background tasks.
 	initTime           time.Time               // Cache init time - used for latency calculations
 	channelCache       ChannelCache            // Underlying channel cache
 	lastAddPendingTime int64                   // The most recent time _addPendingLogs was run, as epoch time
@@ -170,7 +170,7 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 		c.options = DefaultCacheOptions()
 	}
 
-	channelCache, err := NewChannelCacheForContext(c.terminator, c.options.ChannelCacheOptions, c.context)
+	channelCache, err := NewChannelCacheForContext(c.backgroundTasks, c.terminator, c.options.ChannelCacheOptions, c.context)
 	if err != nil {
 		return err
 	}
@@ -181,17 +181,17 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 	heap.Init(&c.pendingLogs)
 
 	// background tasks that perform housekeeping duties on the cache
-	done, err := NewBackgroundTask("InsertPendingEntries", c.context.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
+	bgt, err := NewBackgroundTask("InsertPendingEntries", c.context.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
-	c.terminated = append(c.terminated, TaskStat{"InsertPendingEntries", c.context.Name, done})
+	c.backgroundTasks = append(c.backgroundTasks, bgt)
 
-	done, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.context.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
+	bgt, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.context.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
-	c.terminated = append(c.terminated, TaskStat{"CleanSkippedSequenceQueue", c.context.Name, done})
+	c.backgroundTasks = append(c.backgroundTasks, bgt)
 
 	// Lock the cache -- not usable until .Start() called.  This fixes the DCP startup race condition documented in SG #3558.
 	c.lock.Lock()
@@ -212,26 +212,6 @@ func (c *changeCache) Start(initialSequence uint64) error {
 	return nil
 }
 
-// waitForBGTCompletion waits for all the background tasks to finish.
-func waitForBGTCompletion(waitTime time.Duration, terminated []TaskStat) {
-	for i, t := range terminated {
-	waitForCompletion:
-		for {
-			select {
-			case <-t.done:
-				break waitForCompletion
-			case <-time.After(waitTime):
-				for _, v := range terminated[i:] {
-					base.Infof(base.KeyAll,
-						"Timeout after %v of waiting for background task %q on database %q to terminate",
-						waitTime, v.name, v.dbName)
-				}
-				return
-			}
-		}
-	}
-}
-
 // Stops the cache. Clears its state and tells the housekeeping task to stop.
 func (c *changeCache) Stop() {
 
@@ -240,7 +220,7 @@ func (c *changeCache) Stop() {
 	close(c.terminator)
 
 	// Wait for changeCache background tasks to finish.
-	waitForBGTCompletion(BGTCompletionMaxWait, c.terminated)
+	c.context.waitForBGTCompletion(BGTCompletionMaxWait, c.backgroundTasks)
 
 	c.lock.Lock()
 	c.stopped = true

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -59,7 +59,7 @@ type changeCache struct {
 	lock               sync.RWMutex            // Coordinates access to struct fields
 	options            CacheOptions            // Cache config
 	terminator         chan bool               // Signal termination of background goroutines
-	terminated         []chan struct{}         // Notifies on each background task termination.
+	terminated         []TaskStat              // Notifies on each background task termination.
 	initTime           time.Time               // Cache init time - used for latency calculations
 	channelCache       ChannelCache            // Underlying channel cache
 	lastAddPendingTime int64                   // The most recent time _addPendingLogs was run, as epoch time
@@ -181,18 +181,17 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 	heap.Init(&c.pendingLogs)
 
 	// background tasks that perform housekeeping duties on the cache
-	done, err := NewBackgroundTask("InsertPendingEntries", c.context.Name, c.InsertPendingEntries,
-		c.options.CachePendingSeqMaxWait/2, c.terminator)
+	done, err := NewBackgroundTask("InsertPendingEntries", c.context.Name, c.InsertPendingEntries, c.options.CachePendingSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
-	c.terminated = append(c.terminated, done)
+	c.terminated = append(c.terminated, TaskStat{"InsertPendingEntries", c.context.Name, done})
 
 	done, err = NewBackgroundTask("CleanSkippedSequenceQueue", c.context.Name, c.CleanSkippedSequenceQueue, c.options.CacheSkippedSeqMaxWait/2, c.terminator)
 	if err != nil {
 		return err
 	}
-	c.terminated = append(c.terminated, done)
+	c.terminated = append(c.terminated, TaskStat{"CleanSkippedSequenceQueue", c.context.Name, done})
 
 	// Lock the cache -- not usable until .Start() called.  This fixes the DCP startup race condition documented in SG #3558.
 	c.lock.Lock()
@@ -214,14 +213,19 @@ func (c *changeCache) Start(initialSequence uint64) error {
 }
 
 // waitForBGTCompletion waits for all the background tasks to finish.
-func waitForBGTCompletion(waitTime time.Duration, terminated ...chan struct{}) {
-	for _, t := range terminated {
+func waitForBGTCompletion(waitTime time.Duration, terminated []TaskStat) {
+	for i, t := range terminated {
 	waitForCompletion:
 		for {
 			select {
-			case <-t:
+			case <-t.done:
 				break waitForCompletion
 			case <-time.After(waitTime):
+				for _, v := range terminated[i:] {
+					base.Infof(base.KeyAll,
+						"Timeout after %v of waiting for background task %q on database %q to terminate",
+						waitTime, v.name, v.dbName)
+				}
 				return
 			}
 		}
@@ -236,7 +240,7 @@ func (c *changeCache) Stop() {
 	close(c.terminator)
 
 	// Wait for changeCache background tasks to finish.
-	waitForBGTCompletion(BGTCompletionMaxWait, c.terminated...)
+	waitForBGTCompletion(BGTCompletionMaxWait, c.terminated)
 
 	c.lock.Lock()
 	c.stopped = true

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -86,7 +86,7 @@ func NewChannelCacheForContext(terminator chan bool, options ChannelCacheOptions
 	return newChannelCache(context.Name, terminator, context.terminated, options, context, context.activeChannels, context.DbStats.Cache())
 }
 
-func newChannelCache(dbName string, terminator chan bool, terminated []chan struct{},
+func newChannelCache(dbName string, terminator chan bool, terminated []TaskStat,
 	options ChannelCacheOptions, queryHandler ChannelQueryHandler, activeChannels *channels.ActiveChannels,
 	cacheStats *base.CacheStats) (*channelCacheImpl, error) {
 
@@ -106,7 +106,7 @@ func newChannelCache(dbName string, terminator chan bool, terminated []chan stru
 	if err != nil {
 		return nil, err
 	}
-	terminated = append(terminated, done)
+	terminated = append(terminated, TaskStat{"CleanAgedItems", dbName, done})
 	base.Debugf(base.KeyCache, "Initialized channel cache with maxChannels:%d, HWM: %d, LWM: %d",
 		channelCache.maxChannels, channelCache.compactHighWatermark, channelCache.compactLowWatermark)
 	return channelCache, nil

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -68,6 +68,7 @@ type StableSequenceCallbackFunc func() uint64
 type channelCacheImpl struct {
 	queryHandler         ChannelQueryHandler       // Passed to singleChannelCacheImpl for view queries.
 	channelCaches        *base.RangeSafeCollection // A collection of singleChannelCaches
+	backgroundTasks      []BackgroundTask          // List of background tasks.
 	terminator           chan bool                 // Signal terminator of background goroutines
 	options              ChannelCacheOptions       // Channel cache options
 	lateSeqLock          sync.RWMutex              // Coordinates access to late sequence caches
@@ -82,17 +83,18 @@ type channelCacheImpl struct {
 	validFromLock        sync.RWMutex              // Mutex used to avoid race between AddToCache and addChannelCache.  See CBG-520 for more details
 }
 
-func NewChannelCacheForContext(terminator chan bool, options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
-	return newChannelCache(context.Name, terminator, context.terminated, options, context, context.activeChannels, context.DbStats.Cache())
+func NewChannelCacheForContext(backgroundTasks []BackgroundTask, terminator chan bool, options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
+	return newChannelCache(context.Name, backgroundTasks, terminator, options, context, context.activeChannels, context.DbStats.Cache())
 }
 
-func newChannelCache(dbName string, terminator chan bool, terminated []TaskStat,
+func newChannelCache(dbName string, backgroundTasks []BackgroundTask, terminator chan bool,
 	options ChannelCacheOptions, queryHandler ChannelQueryHandler, activeChannels *channels.ActiveChannels,
 	cacheStats *base.CacheStats) (*channelCacheImpl, error) {
 
 	channelCache := &channelCacheImpl{
 		queryHandler:         queryHandler,
 		channelCaches:        base.NewRangeSafeCollection(),
+		backgroundTasks:      backgroundTasks,
 		terminator:           terminator,
 		options:              options,
 		maxChannels:          options.MaxNumChannels,
@@ -101,12 +103,11 @@ func newChannelCache(dbName string, terminator chan bool, terminated []TaskStat,
 		activeChannels:       activeChannels,
 		cacheStats:           cacheStats,
 	}
-	done, err := NewBackgroundTask("CleanAgedItems", dbName, channelCache.cleanAgedItems, options.ChannelCacheAge,
-		terminator)
+	bgt, err := NewBackgroundTask("CleanAgedItems", dbName, channelCache.cleanAgedItems, options.ChannelCacheAge, terminator)
 	if err != nil {
 		return nil, err
 	}
-	terminated = append(terminated, TaskStat{"CleanAgedItems", dbName, done})
+	backgroundTasks = append(backgroundTasks, bgt)
 	base.Debugf(base.KeyCache, "Initialized channel cache with maxChannels:%d, HWM: %d, LWM: %d",
 		channelCache.maxChannels, channelCache.compactHighWatermark, channelCache.compactLowWatermark)
 	return channelCache, nil

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -76,8 +76,8 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, hwm will be 16, low water mark will be 12
@@ -88,7 +88,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	// Add 16 channels to the cache.  Shouldn't trigger compaction (hwm is not exceeded)
@@ -113,8 +113,8 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/90
@@ -127,7 +127,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	// Add 16 channels to the cache.  Mark odd channels as active, even channels as inactive.
@@ -171,8 +171,8 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/90
@@ -185,7 +185,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	// Add 18 channels to the cache.  Mark channels 1-10 as active
@@ -267,8 +267,8 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/90
@@ -281,7 +281,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	channelCount := 90
@@ -340,8 +340,8 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 100, watermarks 90/70
@@ -354,7 +354,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	channelCount := 200
@@ -408,8 +408,8 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 func TestChannelCacheBypass(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/100
@@ -422,7 +422,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	channelCount := 100
@@ -507,8 +507,8 @@ func (qh *testQueryHandler) seedEntries(seededEntries LogEntries) {
 
 func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
+	var backgroundTasks []BackgroundTask
 	terminator := make(chan bool)
-	var terminated []TaskStat
 	defer close(terminator)
 
 	options := DefaultCacheOptions().ChannelCacheOptions
@@ -518,7 +518,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", terminator, terminated, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	assert.Error(t, err, "Background task error whilst creating channel cache")
 	assert.Nil(t, cache)
 	backgroundTaskError, ok := err.(*BackgroundTaskError)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -77,7 +77,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, hwm will be 16, low water mark will be 12
@@ -114,7 +114,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/90
@@ -172,7 +172,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/90
@@ -268,7 +268,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/90
@@ -341,7 +341,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 100, watermarks 90/70
@@ -409,7 +409,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	// Define cache with max channels 20, watermarks 50/100
@@ -508,7 +508,7 @@ func (qh *testQueryHandler) seedEntries(seededEntries LogEntries) {
 func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 	terminator := make(chan bool)
-	var terminated []chan struct{}
+	var terminated []TaskStat
 	defer close(terminator)
 
 	options := DefaultCacheOptions().ChannelCacheOptions

--- a/db/database.go
+++ b/db/database.go
@@ -74,6 +74,10 @@ const (
 	CompactIntervalMaxDays = float32(60)   // 60 Days in days
 )
 
+// BGTCompletionMaxWait is the maximum amount of time to wait for
+// completion of all background tasks before the server is stopped.
+const BGTCompletionMaxWait = 30 * time.Second
+
 // Basic description of a database. Shared between all Database objects on the same database.
 // This object is thread-safe so it can be shared between HTTP handlers.
 type DatabaseContext struct {
@@ -587,7 +591,7 @@ func (context *DatabaseContext) Close() {
 	context.OIDCProviders.Stop()
 	close(context.terminator)
 	// Wait for database background tasks to finish.
-	waitForBGTCompletion(context.terminated...)
+	waitForBGTCompletion(BGTCompletionMaxWait, context.terminated...)
 	context.sequences.Stop()
 	context.mutationListener.Stop()
 	context.changeCache.Stop()

--- a/db/utils.go
+++ b/db/utils.go
@@ -13,14 +13,18 @@ type BackgroundTaskFunc func(ctx context.Context) error
 // backgroundTask runs task at the specified time interval in its own goroutine until stopped or an error is thrown by
 // the BackgroundTaskFunc
 func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, interval time.Duration,
-	c chan bool) (done chan struct{}, err error) {
+	c chan bool) (bgt BackgroundTask, err error) {
 	if interval <= 0 {
-		return done, &BackgroundTaskError{TaskName: taskName, Interval: interval}
+		return BackgroundTask{}, &BackgroundTaskError{TaskName: taskName, Interval: interval}
 	}
-	done = make(chan struct{})
+	bgt = BackgroundTask{
+		taskName: taskName,
+		doneChan: make(chan struct{}),
+	}
+
 	base.Infof(base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
-		defer close(done)
+		defer close(bgt.doneChan)
 		defer base.FatalPanicHandler()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -38,7 +42,7 @@ func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, 
 			}
 		}
 	}()
-	return done, nil
+	return bgt, nil
 }
 
 type BackgroundTaskError struct {
@@ -50,11 +54,9 @@ func (err *BackgroundTaskError) Error() string {
 	return fmt.Sprintf("Can't create background task: %q with interval %v", err.TaskName, err.Interval)
 }
 
-// TaskStat is a container that holds the background task, associated
-// database name and a channel to receive a signal about the background
-// task termination.
-type TaskStat struct {
-	name   string        // Background Task name
-	dbName string        // Associated database name
-	done   chan struct{} // Channel to to receive termination signal
+// BackgroundTask contains the name of the background task that is
+// initiated and a channel that notifies background task termination.
+type BackgroundTask struct {
+	taskName string        // Name of the background task.
+	doneChan chan struct{} // doneChan is closed when background task is terminated.
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -13,12 +13,14 @@ type BackgroundTaskFunc func(ctx context.Context) error
 // backgroundTask runs task at the specified time interval in its own goroutine until stopped or an error is thrown by
 // the BackgroundTaskFunc
 func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, interval time.Duration,
-	c chan bool) error {
+	c chan bool) (done chan struct{}, err error) {
 	if interval <= 0 {
-		return &BackgroundTaskError{TaskName: taskName, Interval: interval}
+		return done, &BackgroundTaskError{TaskName: taskName, Interval: interval}
 	}
+	done = make(chan struct{})
 	base.Infof(base.KeyAll, "Created background task: %q with interval %v", taskName, interval)
 	go func() {
+		defer close(done)
 		defer base.FatalPanicHandler()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -36,7 +38,7 @@ func NewBackgroundTask(taskName string, dbName string, task BackgroundTaskFunc, 
 			}
 		}
 	}()
-	return nil
+	return done, nil
 }
 
 type BackgroundTaskError struct {

--- a/db/utils.go
+++ b/db/utils.go
@@ -49,3 +49,12 @@ type BackgroundTaskError struct {
 func (err *BackgroundTaskError) Error() string {
 	return fmt.Sprintf("Can't create background task: %q with interval %v", err.TaskName, err.Interval)
 }
+
+// TaskStat is a container that holds the background task, associated
+// database name and a channel to receive a signal about the background
+// task termination.
+type TaskStat struct {
+	name   string        // Background Task name
+	dbName string        // Associated database name
+	done   chan struct{} // Channel to to receive termination signal
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -961,7 +961,6 @@ func TestParseCommandLineWithIllegalOptionBucket(t *testing.T) {
 }
 
 func TestPutInvalidConfig(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -961,6 +961,7 @@ func TestParseCommandLineWithIllegalOptionBucket(t *testing.T) {
 }
 
 func TestPutInvalidConfig(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
@@ -970,7 +971,7 @@ func TestPutInvalidConfig(t *testing.T) {
 
 // Validate basic mapping from config to database options
 func TestConfigToDatabaseOptions(t *testing.T) {
-
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 
@@ -1248,8 +1249,7 @@ func deleteTempFile(t *testing.T, file *os.File) {
 }
 
 func TestSetupAndValidate(t *testing.T) {
-	t.Skip("Skipping this test temporarily; until CBG-1195 is fixed")
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{
           "databases": {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -984,7 +984,9 @@ func (sc *ServerContext) startStatsLogger() {
 
 	sc.statsContext.statsLoggingTicker = time.NewTicker(interval)
 	sc.statsContext.terminator = make(chan struct{})
+	sc.statsContext.statsLoggerWg.Add(1)
 	go func() {
+		defer sc.statsContext.statsLoggerWg.Done()
 		for {
 			select {
 			case <-sc.statsContext.statsLoggingTicker.C:
@@ -1006,6 +1008,7 @@ func (sc *ServerContext) startStatsLogger() {
 func (sc *ServerContext) stopStatsLogger() {
 	if sc.statsContext.terminator != nil {
 		close(sc.statsContext.terminator)
+		sc.statsContext.statsLoggerWg.Wait()
 	}
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -984,9 +984,9 @@ func (sc *ServerContext) startStatsLogger() {
 
 	sc.statsContext.statsLoggingTicker = time.NewTicker(interval)
 	sc.statsContext.terminator = make(chan struct{})
-	sc.statsContext.statsLoggerWg.Add(1)
+	sc.statsContext.doneChan = make(chan struct{})
 	go func() {
-		defer sc.statsContext.statsLoggerWg.Done()
+		defer close(sc.statsContext.doneChan)
 		for {
 			select {
 			case <-sc.statsContext.statsLoggingTicker.C:
@@ -1005,10 +1005,22 @@ func (sc *ServerContext) startStatsLogger() {
 
 }
 
+// StatsLoggerStopMaxWait is the maximum amount of time to wait for
+// stats logger goroutine to terminate before the server is stopped.
+const StatsLoggerStopMaxWait = 30 * time.Second
+
+// stopStatsLogger stops the stats logger.
 func (sc *ServerContext) stopStatsLogger() {
 	if sc.statsContext.terminator != nil {
 		close(sc.statsContext.terminator)
-		sc.statsContext.statsLoggerWg.Wait()
+
+		waitTime := StatsLoggerStopMaxWait
+		select {
+		case <-sc.statsContext.doneChan:
+			// Stats logger goroutine is terminated and doneChan is already closed.
+		case <-time.After(waitTime):
+			base.Infof(base.KeyAll, "Timeout after %v of waiting for stats logger to terminate", waitTime)
+		}
 	}
 }
 

--- a/rest/stats_context.go
+++ b/rest/stats_context.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +19,7 @@ type statsContext struct {
 	statsLoggingTicker *time.Ticker
 	terminator         chan struct{} // Used to stop the goroutine handling the stats logging
 	cpuStatsSnapshot   *cpuStatsSnapshot
+	statsLoggerWg      sync.WaitGroup // Waits for the stats logger goroutine to finish.
 }
 
 // The peak number of goroutines observed during lifetime of program

--- a/rest/stats_context.go
+++ b/rest/stats_context.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,7 +18,7 @@ type statsContext struct {
 	statsLoggingTicker *time.Ticker
 	terminator         chan struct{} // Used to stop the goroutine handling the stats logging
 	cpuStatsSnapshot   *cpuStatsSnapshot
-	statsLoggerWg      sync.WaitGroup // Waits for the stats logger goroutine to finish.
+	doneChan           chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }
 
 // The peak number of goroutines observed during lifetime of program


### PR DESCRIPTION
Integration test was broken while enabling TestSetupAndValidate due to underlying data race that is specifically related to logging context being used after server context is closed (by goroutines that are still in the middle of teardown).  Waiting for goroutine termination is one option. This PR ensures all background goroutines are getting terminated when the server context is closed