### PR TITLE
CBG-1194 2.8 sgcollect_info is not collecting system information in sync_gateway.log

### DIFF
--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -202,7 +202,7 @@ class Task(object):
 
     def will_run(self):
         """Determine if this task will run on this platform."""
-        return sys.platform in self.platforms
+        return sys.platform.startswith(tuple(self.platforms))
 
 
 class PythonTask(object):
@@ -386,7 +386,7 @@ class SolarisTask(Task):
 
 
 class LinuxTask(Task):
-    platforms = ['linux2']
+    platforms = ['linux']
 
 
 class WindowsTask(Task):


### PR DESCRIPTION
During normal runs, sgcollect gathers the system information by running os specific tasks. Just before issuing the os specific tasks, sgcollect also ensures that the task that is going to fire is eligible to run on the underlying os platform; it relies on the Python “sys” module, “sys.platform” in particular to make this decision. 

The “sys.platform” is a string containing a platform identifier that can be used to append platform-specific components to sys.path, for instance. For Unix systems, except on Linux and AIX, this is the lowercased OS name as returned by uname -s with the first part of the version as returned by uname -r appended, e.g. 'sunos5' or 'freebsd8', at the time when Python was built.

Today, on Linux systems, sgcollect specifically checks for ‘linux2’ (like the way it was there before Python 3 migration), but starting from Python 3.3.x, the “sys.platform” doesn’t contain the major version anymore. It is always 'linux', instead of 'linux2' or 'linux3'. Due to this, the os specific tasks are not running under the hood and system information is not gathered during collection. In addition to this, the sgcollect_info_options.log file is also not generated and included in the final collection bundle. 

This PR addresses the fix for above issue. We can make use of the starts with the idiom “sys.platform.startswith('linux')” to determine whether the collection task will run on the underlying platform. This would support both older Python versions (but not older than Python 3.0) that include the version number and newer versions (Python 3 or later) that does not doesn’t contain the major version anymore.