### PR TITLE
CBG-551 Avoid storing _removed:true revision bodies in the revision cache

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -258,7 +258,7 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 		return DocumentRevision{}, err
 	}
 
-	if revision.BodyBytes == nil && !revision.Removed {
+	if revision.BodyBytes == nil {
 		return DocumentRevision{}, base.HTTPErrorf(404, "missing")
 	}
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -258,6 +258,10 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 		return DocumentRevision{}, err
 	}
 
+	if revision.BodyBytes == nil && !revision.Removed {
+		return DocumentRevision{}, base.HTTPErrorf(404, "missing")
+	}
+
 	// RequestedHistory is the _revisions returned in the body.  Avoids mutating revision.History, in case it's needed
 	// during attachment processing below
 	requestedHistory := revision.History

--- a/db/crud.go
+++ b/db/crud.go
@@ -258,10 +258,6 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 		return DocumentRevision{}, err
 	}
 
-	if revision.BodyBytes == nil {
-		return DocumentRevision{}, base.HTTPErrorf(404, "missing")
-	}
-
 	// RequestedHistory is the _revisions returned in the body.  Avoids mutating revision.History, in case it's needed
 	// during attachment processing below
 	requestedHistory := revision.History
@@ -282,7 +278,7 @@ func (db *Database) getRev(docid, revid string, maxHistory int, historyFrom []st
 
 	// If the revision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
-	if revision.IsRemoval() {
+	if revision.Removed {
 		return DocumentRevision{}, base.HTTPErrorf(404, "missing")
 	}
 
@@ -303,16 +299,16 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 
 	fromRevision, err := db.revisionCache.Get(docID, fromRevID, RevCacheOmitBody, RevCacheIncludeDelta)
 
-	// If both body and delta are not available for fromRevId, the delta can't be generated
-	if fromRevision.BodyBytes == nil && fromRevision.Delta == nil {
-		return nil, nil, err
-	}
-
 	// If the fromRevision is a removal cache entry (no body), but the user has access to that removal, then just
 	// return 404 missing to indicate that the body of the revision is no longer available.
 	// Delta can't be generated if we don't have the fromRevision body.
-	if fromRevision.IsRemoval() {
+	if fromRevision.Removed {
 		return nil, nil, base.HTTPErrorf(404, "missing")
+	}
+
+	// If both body and delta are not available for fromRevId, the delta can't be generated
+	if fromRevision.BodyBytes == nil && fromRevision.Delta == nil {
+		return nil, nil, err
 	}
 
 	// If delta is found, check whether it is a delta for the toRevID we want
@@ -350,7 +346,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 			return nil, &redactedBody, nil
 		}
 
-		if toRevision.IsRemoval() {
+		if toRevision.Removed {
 			return nil, nil, base.HTTPErrorf(404, "missing")
 		}
 

--- a/db/document.go
+++ b/db/document.go
@@ -817,14 +817,6 @@ func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history R
 		return nil, nil, nil, false, false, nil
 	}
 
-	// Construct removal body
-	// doc ID and rev ID aren't required to be inserted here, as both of those are available in the request.
-	if isDelete {
-		bodyBytes = []byte(`{"` + BodyDeleted + `":true,"` + BodyRemoved + `":true}`)
-	} else {
-		bodyBytes = []byte(RemovedRedactedDocument)
-	}
-
 	activeChannels := make(base.Set)
 	// Add active channels to the channel set if the the revision is available in the revision tree.
 	if revInfo, ok := doc.History[revID]; ok {

--- a/db/document.go
+++ b/db/document.go
@@ -799,7 +799,7 @@ func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
 // Set of channels returned from IsChannelRemoval are "Active" channels and NOT "Removed".
-func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
+func (doc *Document) IsChannelRemoval(revID string) (history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
 
 	removedChannels := make(base.Set)
 
@@ -814,7 +814,7 @@ func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history R
 	}
 	// If no matches found, return isRemoval=false
 	if len(removedChannels) == 0 {
-		return nil, nil, nil, false, false, nil
+		return nil, nil, false, false, nil
 	}
 
 	activeChannels := make(base.Set)
@@ -828,7 +828,7 @@ func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history R
 	// Build revision history for revID
 	revHistory, err := doc.History.getHistory(revID)
 	if err != nil {
-		return nil, nil, nil, false, false, err
+		return nil, nil, false, false, err
 	}
 
 	// If there's no history (because the revision has been pruned from the rev tree), treat revision history as only the specified rev id.
@@ -837,7 +837,7 @@ func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history R
 	}
 	history = encodeRevisions(revHistory)
 
-	return bodyBytes, history, activeChannels, true, isDelete, nil
+	return history, activeChannels, true, isDelete, nil
 }
 
 // Updates a document's channel/role UserAccessMap with new access settings from an AccessMap.

--- a/db/document.go
+++ b/db/document.go
@@ -799,7 +799,7 @@ func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.
 // Determine whether the specified revision was a channel removal, based on doc.Channels.  If so, construct the standard document body for a
 // removal notification (_removed=true)
 // Set of channels returned from IsChannelRemoval are "Active" channels and NOT "Removed".
-func (doc *Document) IsChannelRemoval(revID string) (history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
+func (doc *Document) IsChannelRemoval(revID string) (bodyBytes []byte, history Revisions, channels base.Set, isRemoval bool, isDelete bool, err error) {
 
 	removedChannels := make(base.Set)
 
@@ -814,8 +814,12 @@ func (doc *Document) IsChannelRemoval(revID string) (history Revisions, channels
 	}
 	// If no matches found, return isRemoval=false
 	if len(removedChannels) == 0 {
-		return nil, nil, false, false, nil
+		return nil, nil, nil, false, false, nil
 	}
+
+	// Construct removal body
+	// doc ID and rev ID aren't required to be inserted here, as both of those are available in the request.
+	bodyBytes = []byte(RemovedRedactedDocument)
 
 	activeChannels := make(base.Set)
 	// Add active channels to the channel set if the the revision is available in the revision tree.
@@ -828,7 +832,7 @@ func (doc *Document) IsChannelRemoval(revID string) (history Revisions, channels
 	// Build revision history for revID
 	revHistory, err := doc.History.getHistory(revID)
 	if err != nil {
-		return nil, nil, false, false, err
+		return nil, nil, nil, false, false, err
 	}
 
 	// If there's no history (because the revision has been pruned from the rev tree), treat revision history as only the specified rev id.
@@ -837,7 +841,7 @@ func (doc *Document) IsChannelRemoval(revID string) (history Revisions, channels
 	}
 	history = encodeRevisions(revHistory)
 
-	return history, activeChannels, true, isDelete, nil
+	return bodyBytes, history, activeChannels, true, isDelete, nil
 }
 
 // Updates a document's channel/role UserAccessMap with new access settings from an AccessMap.

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -33,7 +33,7 @@ func (rc *BypassRevisionCache) Get(docID, revID string, includeBody bool, includ
 	docRev = DocumentRevision{
 		RevID: revID,
 	}
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, revID)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, revID)
 	if err != nil {
 		return DocumentRevision{}, err
 	}
@@ -59,7 +59,7 @@ func (rc *BypassRevisionCache) GetActive(docID string, includeBody bool) (docRev
 		RevID: doc.CurrentRev,
 	}
 
-	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.SyncData.CurrentRev)
+	docRev.BodyBytes, docRev._shallowCopyBody, docRev.History, docRev.Channels, docRev.Removed, docRev.Attachments, docRev.Deleted, docRev.Expiry, err = revCacheLoaderForDocument(rc.backingStore, doc, doc.SyncData.CurrentRev)
 	if err != nil {
 		return DocumentRevision{}, err
 	}

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -242,13 +242,13 @@ func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Docu
 	if bodyBytes, body, attachments, err = backingStore.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
-		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
+		removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
 		if isRemovalErr != nil {
 			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return nil, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
 			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -242,13 +242,13 @@ func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Docu
 	if bodyBytes, body, attachments, err = backingStore.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
-		removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
+		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
 		if isRemovalErr != nil {
 			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
 
 		if isRemoval {
-			return nil, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
+			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
 			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -101,16 +101,9 @@ type DocumentRevision struct {
 	Attachments AttachmentsMeta
 	Delta       *RevisionDelta
 	Deleted     bool
+	Removed     bool // True if the revision is a removal.
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
-}
-
-// IsRemoval determines whether the revision is a removal by
-// inspecting the revision body bytes.
-func (rev *DocumentRevision) IsRemoval() bool {
-	body := string(rev.BodyBytes)
-	return body == RemovedRedactedDocument ||
-		body == `{"`+BodyDeleted+`":true,"`+BodyRemoved+`":true}`
 }
 
 // MutableBody returns a deep copy of the given document revision as a plain body (without any special properties)
@@ -231,34 +224,34 @@ func newRevCacheDelta(deltaBytes []byte, fromRevID string, toRevision DocumentRe
 
 // This is the RevisionCacheLoaderFunc callback for the context's RevisionCache.
 // Its job is to load a revision from the bucket when there's a cache miss.
-func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoader(backingStore RevisionCacheBackingStore, id IDAndRev, unmarshalBody bool) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
 	var doc *Document
 	unmarshalLevel := DocUnmarshalSync
 	if unmarshalBody {
 		unmarshalLevel = DocUnmarshalAll
 	}
 	if doc, err = backingStore.GetDocument(id.DocID, unmarshalLevel); doc == nil {
-		return bodyBytes, body, history, channels, attachments, deleted, expiry, err
+		return bodyBytes, body, history, channels, removed, attachments, deleted, expiry, err
 	}
 
 	return revCacheLoaderForDocument(backingStore, doc, id.RevID)
 }
 
 // Common revCacheLoader functionality used either during a cache miss (from revCacheLoader), or directly when retrieving current rev from cache
-func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
+func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Document, revid string) (bodyBytes []byte, body Body, history Revisions, channels base.Set, removed bool, attachments AttachmentsMeta, deleted bool, expiry *time.Time, err error) {
 	if bodyBytes, body, attachments, err = backingStore.getRevision(doc, revid); err != nil {
 		// If we can't find the revision (either as active or conflicted body from the document, or as old revision body backup), check whether
 		// the revision was a channel removal. If so, we want to store as removal in the revision cache
 		removalBodyBytes, removalHistory, activeChannels, isRemoval, isDelete, isRemovalErr := doc.IsChannelRemoval(revid)
 		if isRemovalErr != nil {
-			return bodyBytes, body, history, channels, nil, isDelete, nil, isRemovalErr
+			return bodyBytes, body, history, channels, isRemoval, nil, isDelete, nil, isRemovalErr
 		}
 
 		if isRemoval {
-			return removalBodyBytes, body, removalHistory, activeChannels, nil, isDelete, nil, nil
+			return removalBodyBytes, body, removalHistory, activeChannels, isRemoval, nil, isDelete, nil, nil
 		} else {
 			// If this wasn't a removal, return the original error from getRevision
-			return bodyBytes, body, history, channels, nil, isDelete, nil, err
+			return bodyBytes, body, history, channels, removed, nil, isDelete, nil, err
 		}
 	}
 
@@ -266,10 +259,10 @@ func revCacheLoaderForDocument(backingStore RevisionCacheBackingStore, doc *Docu
 
 	validatedHistory, getHistoryErr := doc.History.getHistory(revid)
 	if getHistoryErr != nil {
-		return bodyBytes, body, history, channels, nil, deleted, nil, getHistoryErr
+		return bodyBytes, body, history, channels, removed, nil, deleted, nil, getHistoryErr
 	}
 	history = encodeRevisions(validatedHistory)
 	channels = doc.History[revid].Channels
 
-	return bodyBytes, body, history, channels, attachments, deleted, doc.Expiry, err
+	return bodyBytes, body, history, channels, removed, attachments, deleted, doc.Expiry, err
 }


### PR DESCRIPTION
Changes to store a nil/empty body in the revision cache instead of "_removed:true" and use a new metadata property in the revision cache entry ('Removed') to identify removals. 

## Integration tests
- [x] xattrs=true http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/549/
- [x] xattrs=false http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/550/