### PR TITLE
CBG-1177: Log buffers

### DIFF
--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -194,20 +194,14 @@ func ToLogKey(keysStr []string) (logKeys LogKeyMask) {
 		// Strip a single "+" suffix in log keys and warn (for backwards compatibility)
 		if strings.HasSuffix(key, "+") {
 			newLogKey := strings.TrimSuffix(key, "+")
-
-			// warnings = append(warnings, func() {
 			Warnf("Deprecated log key: %q found. Changing to: %q.", originalKey, newLogKey)
-			// })
-
 			key = newLogKey
 		}
 
 		if logKey, ok := logKeyNamesInverse[key]; ok {
 			logKeys.Enable(logKey)
 		} else {
-			// warnings = append(warnings, func() {
 			Warnf("Invalid log key: %v", originalKey)
-			// })
 		}
 	}
 

--- a/base/log_keys.go
+++ b/base/log_keys.go
@@ -176,7 +176,7 @@ func (keyMask *LogKeyMask) EnabledLogKeys() []string {
 
 // ToLogKey takes a slice of case-sensitive log key names and will return a LogKeyMask bitfield
 // and a slice of deferred log functions for any warnings that may occurr.
-func ToLogKey(keysStr []string) (logKeys LogKeyMask, warnings []DeferredLogFn) {
+func ToLogKey(keysStr []string) (logKeys LogKeyMask) {
 
 	for _, key := range keysStr {
 		// Take a copy of key, so we can use it in a closure outside the scope
@@ -195,9 +195,9 @@ func ToLogKey(keysStr []string) (logKeys LogKeyMask, warnings []DeferredLogFn) {
 		if strings.HasSuffix(key, "+") {
 			newLogKey := strings.TrimSuffix(key, "+")
 
-			warnings = append(warnings, func() {
-				Warnf("Deprecated log key: %q found. Changing to: %q.", originalKey, newLogKey)
-			})
+			// warnings = append(warnings, func() {
+			Warnf("Deprecated log key: %q found. Changing to: %q.", originalKey, newLogKey)
+			// })
 
 			key = newLogKey
 		}
@@ -205,13 +205,13 @@ func ToLogKey(keysStr []string) (logKeys LogKeyMask, warnings []DeferredLogFn) {
 		if logKey, ok := logKeyNamesInverse[key]; ok {
 			logKeys.Enable(logKey)
 		} else {
-			warnings = append(warnings, func() {
-				Warnf("Invalid log key: %v", originalKey)
-			})
+			// warnings = append(warnings, func() {
+			Warnf("Invalid log key: %v", originalKey)
+			// })
 		}
 	}
 
-	return logKeys, warnings
+	return logKeys
 }
 
 func inverselogKeyNames(in [LogKeyCount]string) map[string]LogKey {

--- a/base/log_keys_test.go
+++ b/base/log_keys_test.go
@@ -48,40 +48,34 @@ func TestLogKeyNames(t *testing.T) {
 	goassert.StringContains(t, name, "Replicate")
 
 	keys := []string{}
-	logKeys, warnings := ToLogKey(keys)
-	goassert.Equals(t, len(warnings), 0)
+	logKeys := ToLogKey(keys)
 	goassert.Equals(t, logKeys, LogKeyMask(0))
 	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{})
 
 	keys = append(keys, "DCP")
-	logKeys, warnings = ToLogKey(keys)
-	goassert.Equals(t, len(warnings), 0)
+	logKeys = ToLogKey(keys)
 	goassert.Equals(t, logKeys, *logKeyMask(KeyDCP))
 	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String()})
 
 	keys = append(keys, "Access")
-	logKeys, warnings = ToLogKey(keys)
-	goassert.Equals(t, len(warnings), 0)
+	logKeys = ToLogKey(keys)
 	goassert.Equals(t, logKeys, *logKeyMask(KeyAccess, KeyDCP))
 	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAccess.String(), KeyDCP.String()})
 
 	keys = []string{"*", "DCP"}
-	logKeys, warnings = ToLogKey(keys)
-	goassert.Equals(t, len(warnings), 0)
+	logKeys = ToLogKey(keys)
 	goassert.Equals(t, logKeys, *logKeyMask(KeyAll, KeyDCP))
 	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyAll.String(), KeyDCP.String()})
 
 	// Special handling of log keys
 	keys = []string{"HTTP+"}
-	logKeys, warnings = ToLogKey(keys)
-	goassert.Equals(t, len(warnings), 0)
+	logKeys = ToLogKey(keys)
 	goassert.Equals(t, logKeys, *logKeyMask(KeyHTTP, KeyHTTPResp))
 	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyHTTP.String(), KeyHTTPResp.String()})
 
 	// Test that invalid log keys are ignored, and "+" suffixes are stripped.
 	keys = []string{"DCP", "WS+", "InvalidLogKey"}
-	logKeys, warnings = ToLogKey(keys)
-	goassert.Equals(t, len(warnings), 2)
+	logKeys = ToLogKey(keys)
 	goassert.Equals(t, logKeys, *logKeyMask(KeyDCP, KeyWebSocket))
 	goassert.DeepEquals(t, logKeys.EnabledLogKeys(), []string{KeyDCP.String(), KeyWebSocket.String()})
 }
@@ -187,7 +181,7 @@ func BenchmarkLogKeyName(b *testing.B) {
 
 func BenchmarkToLogKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _ = ToLogKey([]string{"CRUD", "DCP", "Replicate"})
+		_ = ToLogKey([]string{"CRUD", "DCP", "Replicate"})
 	}
 }
 

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -175,7 +175,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			logger, _, err := NewConsoleLogger(&test.config, false, nil)
+			logger, err := NewConsoleLogger(&test.config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -175,7 +175,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			logger, _, err := NewConsoleLogger(&test.config)
+			logger, _, err := NewConsoleLogger(&test.config, false, nil)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -88,7 +88,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := newConsoleLoggerOrPanic(&ConsoleLoggerConfig{
+		l := newConsoleLoggerOrPanic(false, &ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -109,7 +109,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := newConsoleLoggerOrPanic(&ConsoleLoggerConfig{
+		l := newConsoleLoggerOrPanic(false, &ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -175,7 +175,7 @@ func TestConsoleLogDefaults(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			logger, err := NewConsoleLogger(&test.config)
+			logger, err := NewConsoleLogger(false, &test.config)
 			assert.NoError(tt, err)
 			assert.Equal(tt, test.expected.Enabled, logger.Enabled)
 			assert.Equal(tt, *test.expected.LogLevel, *logger.LogLevel)

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -94,6 +94,12 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFile
 	return logger, nil
 }
 
+func (l *FileLogger) FlushBufferToLog() {
+	// Need to clear hanging new line to avoid empty line
+	logString := strings.TrimSuffix(l.buffer.String(), "\n")
+	l.logf(logString)
+}
+
 // Rotate will rotate the active log file.
 func (l *FileLogger) Rotate() error {
 	if l == nil {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -89,6 +89,18 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFile
 	return logger, nil
 }
 
+func NewMemoryLogger(level LogLevel, buffer *strings.Builder) *FileLogger {
+	logger := &FileLogger{
+		Enabled: true,
+		level:   level,
+		name:    level.String(),
+		output:  buffer,
+		logger:  log.New(buffer, "", 0),
+	}
+
+	return logger
+}
+
 // Rotate will rotate the active log file.
 func (l *FileLogger) Rotate() error {
 	if l == nil {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -43,6 +43,7 @@ type FileLogger struct {
 	name            string
 	output          io.Writer
 	logger          *log.Logger
+	buffer          strings.Builder
 }
 
 type FileLoggerConfig struct {
@@ -61,7 +62,7 @@ type logRotationConfig struct {
 }
 
 // NewFileLogger returns a new FileLogger from a config.
-func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFilePath string, minAge int) (*FileLogger, error) {
+func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFilePath string, minAge int, buffer *strings.Builder) (*FileLogger, error) {
 
 	// validate and set defaults
 	if err := config.init(level, name, logFilePath, minAge); err != nil {
@@ -76,6 +77,10 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFile
 		logger:  log.New(config.Output, "", 0),
 	}
 
+	if buffer != nil {
+		logger.buffer = *buffer
+	}
+
 	// Only create the collateBuffer channel and worker if required.
 	if *config.CollationBufferSize > 1 {
 		logger.collateBuffer = make(chan string, *config.CollationBufferSize)
@@ -87,18 +92,6 @@ func NewFileLogger(config FileLoggerConfig, level LogLevel, name string, logFile
 	}
 
 	return logger, nil
-}
-
-func NewMemoryLogger(level LogLevel, buffer *strings.Builder) *FileLogger {
-	logger := &FileLogger{
-		Enabled: true,
-		level:   level,
-		name:    level.String(),
-		output:  buffer,
-		logger:  log.New(buffer, "", 0),
-	}
-
-	return logger
 }
 
 // Rotate will rotate the active log file.

--- a/base/logging.go
+++ b/base/logging.go
@@ -34,9 +34,6 @@ const (
 
 type Level int32
 
-// DeferredLogFn is an anonymous function that can be executed at a later date to log something.
-type DeferredLogFn func()
-
 //By setting DebugLevel to -1, if LogLevel is not set in the logging config it
 //will default to the zero value for int32 (0) which will disable debug
 //logging, InfoLevel logging will be the default output.
@@ -319,7 +316,6 @@ func PrependContextID(contextID, format string, params ...interface{}) (newForma
 var (
 	consoleLogger                                                              *ConsoleLogger
 	traceLogger, debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
-	// traceBuffer, debugBuffer, infoBuffer, warnBuffer, errorBuffer, statsBuffer strings.Builder
 
 	// envColorCapable evaluated only once to prevent unnecessary
 	// overhead of checking os.Getenv on each colorEnabled() invocation
@@ -353,9 +349,9 @@ func init() {
 
 	// initialCollationBufferSize is set to zero for disabling log collation before
 	// initializing a logging config, and when running under a test scenario.
-	// initialCollationBufferSize := 0
+	initialCollationBufferSize := 0
 
-	// consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -320,7 +320,7 @@ var (
 	consoleLogger                                                              *ConsoleLogger
 	consoleLogBuffer                                                           strings.Builder
 	traceLogger, debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
-	traceBuffer, debugBuffer, infoBuffer, warnBuffer, errorBuffer, statsBuffer strings.Builder
+	// traceBuffer, debugBuffer, infoBuffer, warnBuffer, errorBuffer, statsBuffer strings.Builder
 
 	// envColorCapable evaluated only once to prevent unnecessary
 	// overhead of checking os.Getenv on each colorEnabled() invocation

--- a/base/logging.go
+++ b/base/logging.go
@@ -351,7 +351,7 @@ func init() {
 	// initializing a logging config, and when running under a test scenario.
 	initialCollationBufferSize := 0
 
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	consoleLogger = newConsoleLoggerOrPanic(true, &ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -318,7 +318,9 @@ func PrependContextID(contextID, format string, params ...interface{}) (newForma
 
 var (
 	consoleLogger                                                              *ConsoleLogger
+	consoleLogBuffer                                                           strings.Builder
 	traceLogger, debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
+	traceBuffer, debugBuffer, infoBuffer, warnBuffer, errorBuffer, statsBuffer strings.Builder
 
 	// envColorCapable evaluated only once to prevent unnecessary
 	// overhead of checking os.Getenv on each colorEnabled() invocation
@@ -352,9 +354,9 @@ func init() {
 
 	// initialCollationBufferSize is set to zero for disabling log collation before
 	// initializing a logging config, and when running under a test scenario.
-	initialCollationBufferSize := 0
+	// initialCollationBufferSize := 0
 
-	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	// consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 

--- a/base/logging.go
+++ b/base/logging.go
@@ -318,7 +318,6 @@ func PrependContextID(contextID, format string, params ...interface{}) (newForma
 
 var (
 	consoleLogger                                                              *ConsoleLogger
-	consoleLogBuffer                                                           strings.Builder
 	traceLogger, debugLogger, infoLogger, warnLogger, errorLogger, statsLogger *FileLogger
 	// traceBuffer, debugBuffer, infoBuffer, warnBuffer, errorBuffer, statsBuffer strings.Builder
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -52,7 +52,7 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (err error) {
 		return errors.New("nil LoggingConfig")
 	}
 
-	consoleLogger, err = NewConsoleLogger(&c.Console)
+	consoleLogger, err = NewConsoleLogger(false, &c.Console)
 	if err != nil {
 		return err
 	}

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -62,6 +62,15 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (err error) {
 		Consolef(LevelInfo, KeyNone, "Logging: Files disabled")
 		// Explicitly log this error to console
 		Consolef(LevelError, KeyNone, ErrUnsetLogFilePath.Error())
+
+		// nil out other loggers
+		errorLogger = nil
+		warnLogger = nil
+		infoLogger = nil
+		debugLogger = nil
+		traceLogger = nil
+		statsLogger = nil
+
 		return nil
 	}
 
@@ -130,12 +139,24 @@ func InitializeLoggers() {
 }
 
 func FlushLoggerBuffers() {
-	errorLogger.FlushBufferToLog()
-	warnLogger.FlushBufferToLog()
-	infoLogger.FlushBufferToLog()
-	debugLogger.FlushBufferToLog()
-	traceLogger.FlushBufferToLog()
-	statsLogger.FlushBufferToLog()
+	if errorLogger != nil {
+		errorLogger.FlushBufferToLog()
+	}
+	if warnLogger != nil {
+		warnLogger.FlushBufferToLog()
+	}
+	if infoLogger != nil {
+		infoLogger.FlushBufferToLog()
+	}
+	if debugLogger != nil {
+		debugLogger.FlushBufferToLog()
+	}
+	if traceLogger != nil {
+		traceLogger.FlushBufferToLog()
+	}
+	if statsLogger != nil {
+		statsLogger.FlushBufferToLog()
+	}
 }
 
 // validateLogFilePath ensures the given path is created and is a directory.

--- a/rest/config.go
+++ b/rest/config.go
@@ -1332,6 +1332,9 @@ func RegisterSignalHandler() {
 // performs the config validation and database setup.
 func setupServerConfig(args []string) (config *ServerConfig, err error) {
 	var unknownFieldsErr error
+
+	base.InitializeLoggers()
+
 	config, err = ParseCommandLine(args, flag.ExitOnError)
 	if pkgerrors.Cause(err) == base.ErrUnknownField {
 		unknownFieldsErr = err
@@ -1353,6 +1356,8 @@ func setupServerConfig(args []string) (config *ServerConfig, err error) {
 	// This is the earliest opportunity to log a startup indicator
 	// that will be persisted in all log files.
 	base.LogSyncGatewayVersion()
+
+	base.FlushLoggers()
 
 	// If we got an unknownFields error when reading the config
 	// log and exit now we've tried setting up the logging.

--- a/rest/config.go
+++ b/rest/config.go
@@ -1357,7 +1357,7 @@ func setupServerConfig(args []string) (config *ServerConfig, err error) {
 	// that will be persisted in all log files.
 	base.LogSyncGatewayVersion()
 
-	base.FlushLoggers()
+	base.FlushLoggerBuffers()
 
 	// If we got an unknownFields error when reading the config
 	// log and exit now we've tried setting up the logging.

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -586,13 +586,12 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			config := serverConfig()
 			config.Logging.DeprecatedDefaultLog.LogFilePath = &test.deprecatedLogFilePath
-			warns := config.deprecatedConfigLoggingFallback()
+			config.deprecatedConfigLoggingFallback()
 			require.NoError(t, err, "Error setting up deprecated logging config")
 			assert.Equal(t, test.expectedLogFilePath, config.Logging.LogFilePath, "Error setting log_file_path")
 			assert.Equal(t, config.Logging.DeprecatedDefaultLog.LogKeys, config.Logging.Console.LogKeys)
 			assert.Equal(t, base.ToLogLevel(config.Logging.DeprecatedDefaultLog.LogLevel), config.Logging.Console.LogLevel)
 			assert.Equal(t, config.DeprecatedLog, config.Logging.Console.LogKeys)
-			assert.Len(t, warns, 3)
 		})
 	}
 
@@ -602,21 +601,19 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 		DeprecatedLogFilePath: base.StringPtr(deprecatedDefaultLogFilePathAsFile.Name()),
 		DeprecatedLog:         deprecatedLog,
 	}
-	warns := config.deprecatedConfigLoggingFallback()
+	config.deprecatedConfigLoggingFallback()
 	assert.Equal(t, *config.DeprecatedLogFilePath, config.Logging.LogFilePath)
 	assert.Equal(t, config.DeprecatedLog, config.Logging.Console.LogKeys)
-	assert.Len(t, warns, 2)
 }
 
 func TestSetupAndValidateLogging(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLogging")
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	sc := &ServerConfig{}
-	warns, err := sc.SetupAndValidateLogging()
+	err := sc.SetupAndValidateLogging()
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.NotEmpty(t, sc.Logging)
 	assert.Empty(t, sc.Logging.DeprecatedDefaultLog)
-	assert.Len(t, warns, 2)
 }
 
 func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
@@ -627,9 +624,8 @@ func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	ddl := &base.LogAppenderConfig{LogFilePath: &logFilePath, LogKeys: logKeys, LogLevel: base.PanicLevel}
 	lc := &base.LoggingConfig{DeprecatedDefaultLog: ddl, RedactionLevel: base.RedactFull}
 	sc := &ServerConfig{Logging: lc}
-	warns, err := sc.SetupAndValidateLogging()
+	err := sc.SetupAndValidateLogging()
 	assert.NoError(t, err, "Setup and validate logging should be successful")
-	assert.Len(t, warns, 5)
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)
 	assert.Equal(t, ddl, sc.Logging.DeprecatedDefaultLog)
 }


### PR DESCRIPTION
Added string Builders as "buffers" to FileLoggers. This means we can log using the standard logging functions before logging config has been setup. Once this has been setup the buffers are flushed to the loggers. Means we can remove the DeferredLogFn's.