### PR TITLE
CBG-1216: Fix stats race condition

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -511,7 +511,7 @@ type QueryStat struct {
 	QueryTime       *SgwIntStat
 }
 
-func (s *SgwStats) NewDBStats(name string) *DbStats {
+func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled bool, viewsEnabled bool, queryNames ...string) *DbStats {
 	s.dbStatsMapMutex.Lock()
 	defer s.dbStatsMapMutex.Unlock()
 	s.DbStats[name] = &DbStats{
@@ -524,6 +524,26 @@ func (s *SgwStats) NewDBStats(name string) *DbStats {
 	s.DbStats[name].initCBLReplicationPushStats()
 	s.DbStats[name].initDatabaseStats()
 	s.DbStats[name].initSecurityStats()
+
+	if deltaSyncEnabled {
+		s.DbStats[name].InitDeltaSyncStats()
+	}
+
+	if importEnabled {
+		s.DbStats[name].InitSharedBucketImportStats()
+	}
+
+	if viewsEnabled {
+		s.DbStats[name].InitQueryStats(
+			true,
+			queryNames...,
+		)
+	} else {
+		s.DbStats[name].InitQueryStats(
+			false,
+			queryNames...,
+		)
+	}
 
 	return s.DbStats[name]
 }

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -120,7 +120,7 @@ func TestLateSequenceHandling(t *testing.T) {
 	defer context.Close()
 
 	stats := base.NewSyncGatewayStats()
-	cacheStats := stats.NewDBStats("").CacheStats
+	cacheStats := stats.NewDBStats("", false, false, false).CacheStats
 
 	cache := newSingleChannelCache(context, "Test1", 0, cacheStats)
 	goassert.True(t, cache != nil)
@@ -190,7 +190,7 @@ func TestLateSequenceHandlingWithMultipleListeners(t *testing.T) {
 	defer context.Close()
 
 	stats := base.NewSyncGatewayStats()
-	cacheStats := stats.NewDBStats("").CacheStats
+	cacheStats := stats.NewDBStats("", false, false, false).CacheStats
 
 	cache := newSingleChannelCache(context, "Test1", 0, cacheStats)
 	goassert.True(t, cache != nil)

--- a/db/channel_cache_single_test.go
+++ b/db/channel_cache_single_test.go
@@ -21,7 +21,7 @@ func TestDuplicateDocID(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close()
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -68,7 +68,7 @@ func TestLateArrivingSequence(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close()
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -101,7 +101,7 @@ func TestLateSequenceAsFirst(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close()
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(5, "doc1", "1-a"), false)
@@ -134,7 +134,7 @@ func TestDuplicateLateArrivingSequence(t *testing.T) {
 	require.NoError(t, err)
 	defer context.Close()
 
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(10, "doc1", "1-a"), false)
@@ -209,7 +209,7 @@ func TestPrependChanges(t *testing.T) {
 	defer context.Close()
 
 	// 1. Test prepend to empty cache
-	cache := newSingleChannelCache(context, "PrependEmptyCache", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "PrependEmptyCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	changesToPrepend := LogEntries{
 		testLogEntry(10, "doc3", "2-a"),
 		testLogEntry(12, "doc2", "2-a"),
@@ -225,7 +225,7 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 3)
 
 	// 2. Test prepend to populated cache, with overlap and duplicates
-	cache = newSingleChannelCache(context, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache = newSingleChannelCache(context, "PrependPopulatedCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -279,7 +279,7 @@ func TestPrependChanges(t *testing.T) {
 	require.Len(t, cachedChanges, 4)
 
 	// 3. Test prepend that exceeds cache capacity
-	cache = newSingleChannelCache(context, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache = newSingleChannelCache(context, "PrependToFillCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -316,7 +316,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 4. Test prepend where all docids are already present in cache.  Cache entries shouldn't change, but validFrom is updated
-	cache = newSingleChannelCache(context, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache = newSingleChannelCache(context, "PrependDuplicatesOnly", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
 	cache.addToCache(testLogEntry(20, "doc2", "3-a"), false)
@@ -346,7 +346,7 @@ func TestPrependChanges(t *testing.T) {
 	}
 
 	// 5. Test prepend for an already full cache
-	cache = newSingleChannelCache(context, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache = newSingleChannelCache(context, "PrependFullCache", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	cache.options.ChannelCacheMaxLength = 5
 	cache.validFrom = 13
 	cache.addToCache(testLogEntry(14, "doc1", "2-a"), false)
@@ -391,7 +391,7 @@ func TestChannelCacheRemove(t *testing.T) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Test1", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 
 	// Add some entries to cache
 	cache.addToCache(testLogEntry(1, "doc1", "1-a"), false)
@@ -430,7 +430,7 @@ func TestChannelCacheStats(t *testing.T) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 
 	// Add some entries to cache
@@ -500,7 +500,7 @@ func TestChannelCacheStatsOnPrune(t *testing.T) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 0, testStats)
 	cache.options.ChannelCacheMaxLength = 5
 
@@ -530,7 +530,7 @@ func TestChannelCacheStatsOnPrepend(t *testing.T) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(t), false, DatabaseContextOptions{})
 	require.NoError(t, err)
 	defer context.Close()
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	cache := newSingleChannelCache(context, "Test1", 99, testStats)
 	cache.options.ChannelCacheMaxLength = 15
 
@@ -619,7 +619,7 @@ func BenchmarkChannelCacheUniqueDocs_Ordered(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 	docIDs := make([]string, b.N)
 	for i := 0; i < b.N; i++ {
@@ -638,7 +638,7 @@ func BenchmarkChannelCacheRepeatedDocs5(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(5.0, b.N)
@@ -655,7 +655,7 @@ func BenchmarkChannelCacheRepeatedDocs20(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(20.0, b.N)
@@ -672,7 +672,7 @@ func BenchmarkChannelCacheRepeatedDocs50(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(50.0, b.N)
@@ -689,7 +689,7 @@ func BenchmarkChannelCacheRepeatedDocs80(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(80.0, b.N)
@@ -706,7 +706,7 @@ func BenchmarkChannelCacheRepeatedDocs95(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate doc IDs
 
 	docIDs, revStrings := generateDocs(95.0, b.N)
@@ -723,7 +723,7 @@ func BenchmarkChannelCacheUniqueDocs_Unordered(b *testing.B) {
 	context, err := NewDatabaseContext("db", base.GetTestBucket(b), false, DatabaseContextOptions{})
 	require.NoError(b, err)
 	defer context.Close()
-	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("").Cache())
+	cache := newSingleChannelCache(context, "Benchmark", 0, (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache())
 	// generate docs
 	docs := make([]*LogEntry, b.N)
 	r := rand.New(rand.NewSource(99))

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -84,7 +84,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -123,7 +123,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 50
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -181,7 +181,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -277,7 +277,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -350,7 +350,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	options.CompactHighWatermarkPercent = 90
 	options.CompactLowWatermarkPercent = 70
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -418,7 +418,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	options.CompactHighWatermarkPercent = 100
 	options.CompactLowWatermarkPercent = 50
 
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
@@ -514,7 +514,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	options := DefaultCacheOptions().ChannelCacheOptions
 	// Specify illegal time interval for background task. Time interval should be > 0
 	options.ChannelCacheAge = 0
-	testStats := (base.NewSyncGatewayStats()).NewDBStats("").Cache()
+	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)

--- a/db/sequence_allocator_test.go
+++ b/db/sequence_allocator_test.go
@@ -15,7 +15,7 @@ func TestSequenceAllocator(t *testing.T) {
 	defer bucket.Close()
 
 	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("").Database()
+	testStats := sgw.NewDBStats("", false, false, false).Database()
 
 	// Create a sequence allocator without using constructor, to test without a releaseSequenceMonitor
 	//   - allows manually triggered release
@@ -80,7 +80,7 @@ func TestReleaseSequencesOnStop(t *testing.T) {
 	defer bucket.Close()
 
 	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("").Database()
+	testStats := sgw.NewDBStats("", false, false, false).Database()
 
 	oldFrequency := MaxSequenceIncrFrequency
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
@@ -154,7 +154,7 @@ func TestSequenceAllocatorDeadlock(t *testing.T) {
 	defer bucket.Close()
 
 	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("").Database()
+	testStats := sgw.NewDBStats("", false, false, false).Database()
 
 	oldFrequency := MaxSequenceIncrFrequency
 	defer func() { MaxSequenceIncrFrequency = oldFrequency }()
@@ -183,7 +183,7 @@ func TestReleaseSequenceWait(t *testing.T) {
 	defer bucket.Close()
 
 	sgw := base.NewSyncGatewayStats()
-	testStats := sgw.NewDBStats("").Database()
+	testStats := sgw.NewDBStats("", false, false, false).Database()
 
 	a, err := newSequenceAllocator(bucket, testStats)
 	assert.NoError(t, err)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -49,7 +49,7 @@ func TestActiveReplicatorBlipsync(t *testing.T) {
 		ActiveDB:            &db.Database{DatabaseContext: rt.GetDatabase()},
 		RemoteDBURL:         passiveDBURL,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats("test").DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats("test", false, false, false).DBReplicatorStats(t.Name()),
 	})
 
 	startNumReplicationsTotal := rt.GetDatabase().DbStats.Database().NumReplicationsTotal.Value()
@@ -110,7 +110,7 @@ func TestActiveReplicatorHeartbeats(t *testing.T) {
 		RemoteDBURL:           passiveDBURL,
 		WebsocketPingInterval: time.Millisecond * 10,
 		Continuous:            true,
-		ReplicationStatsMap:   base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:   base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 
 	pingCountStart := base.ExpvarVar2Int(expvar.Get("goblip").(*expvar.Map).Get("sender_ping_count"))
@@ -200,7 +200,7 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -288,7 +288,7 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -609,7 +609,7 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -778,7 +778,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -931,7 +931,7 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1023,7 +1023,7 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1109,7 +1109,7 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1227,7 +1227,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name() + "1").DBReplicatorStats(t.Name())
+	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false).DBReplicatorStats(t.Name())
 	ar := db.NewActiveReplicator(&arConfig)
 
 	startNumChangesRequestedFromZeroTotal := rt1.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -1276,7 +1276,7 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 	}
 
 	// Create a new replicator using the same config, which should use the checkpoint set from the first.
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name() + "2").DBReplicatorStats(t.Name())
+	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false).DBReplicatorStats(t.Name())
 	ar = db.NewActiveReplicator(&arConfig)
 	defer func() { assert.NoError(t, ar.Stop()) }()
 	assert.NoError(t, ar.Start())
@@ -1392,7 +1392,7 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -1526,7 +1526,7 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1618,7 +1618,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		Continuous:          true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1718,7 +1718,7 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 		ChangesBatchSize:    200,
 		Continuous:          true,
 		PurgeOnRemoval:      true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -1895,7 +1895,7 @@ func TestActiveReplicatorPullConflict(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver)
 			require.NoError(t, err)
-			replicationStats := base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name())
+			replicationStats := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name())
 			ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 				ID:          t.Name(),
 				Direction:   db.ActiveReplicatorTypePull,
@@ -2142,7 +2142,7 @@ func TestActiveReplicatorPushAndPullConflict(t *testing.T) {
 				ChangesBatchSize:     200,
 				ConflictResolverFunc: customConflictResolver,
 				Continuous:           true,
-				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 			})
 			defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -2293,7 +2293,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		InsecureSkipVerify:  true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Stop()) }()
@@ -2368,7 +2368,7 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled(t *testing.T) {
 		},
 		ChangesBatchSize:    200,
 		InsecureSkipVerify:  false,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, ar.Stop()) }()
@@ -2437,7 +2437,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -2595,7 +2595,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	}
 
 	// Create the first active replicator to pull from seq:0
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name() + "1").DBReplicatorStats(t.Name())
+	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"1", false, false, false).DBReplicatorStats(t.Name())
 	ar := db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
 
@@ -2660,7 +2660,7 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 	require.NoError(t, err)
 	passiveDBURL.User = url.UserPassword("alice", "pass")
 	arConfig.RemoteDBURL = passiveDBURL
-	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name() + "2").DBReplicatorStats(t.Name())
+	arConfig.ReplicationStatsMap = base.SyncGatewayStats.NewDBStats(t.Name()+"2", false, false, false).DBReplicatorStats(t.Name())
 
 	ar = db.NewActiveReplicator(&arConfig)
 	require.NoError(t, err)
@@ -2763,7 +2763,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -2907,7 +2907,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -3018,7 +3018,7 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		ChangesBatchSize:    200,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 	defer func() { assert.NoError(t, ar.Stop()) }()
 
@@ -3114,7 +3114,7 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 		// test isn't long running enough to worry about time-based checkpoints,
 		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
 		CheckpointInterval:  time.Minute * 5,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull chan1 from seq:0
@@ -3319,7 +3319,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 						InitialReconnectInterval: time.Millisecond,
 						MaxReconnectInterval:     time.Millisecond * 50,
 						TotalReconnectTimeout:    timeoutVal,
-						ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+						ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 					}
 
 					// Create the first active replicator to pull from seq:0
@@ -3408,7 +3408,7 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 		// aggressive reconnect intervals for testing purposes
 		InitialReconnectInterval: time.Millisecond,
 		MaxReconnectInterval:     time.Millisecond * 50,
-		ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -3494,7 +3494,7 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 		InitialReconnectInterval: time.Millisecond,
 		MaxReconnectInterval:     time.Millisecond * 50,
 		TotalReconnectTimeout:    time.Second * 5,
-		ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap:      base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -3839,7 +3839,7 @@ func TestActiveReplicatorPullConflictReadWriteIntlProps(t *testing.T) {
 
 			customConflictResolver, err := db.NewCustomConflictResolver(test.conflictResolver)
 			require.NoError(t, err)
-			replicationStats := base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name())
+			replicationStats := base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name())
 			ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 				ID:          t.Name(),
 				Direction:   db.ActiveReplicatorTypePull,
@@ -4275,7 +4275,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 				},
 				Continuous:           true,
 				ConflictResolverFunc: defaultConflictResolver,
-				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 			}
 
 			// Create the first revision of the document on rt1.
@@ -4429,7 +4429,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 				},
 				Continuous:           true,
 				ConflictResolverFunc: defaultConflictResolver,
-				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+				ReplicationStatsMap:  base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 			}
 
 			// Create the first revision of the document on rt2.
@@ -4759,7 +4759,7 @@ func TestSendChangesToNoConflictPreHydrogenTarget(t *testing.T) {
 		},
 		Continuous:          true,
 		InsecureSkipVerify:  true,
-		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})
 
 	defer func() {


### PR DESCRIPTION
Rather than enabling stats such as delta sync and import stats in the NewDatabaseContext we will now do it as part of NewDBStats. This ensures that the database struct is locked when we do this to avoid a possible race.