### PR TITLE
CBG-1218 Use underlying bucket to determine flush eligibility

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -49,6 +49,21 @@ const (
 	IndexBucket
 )
 
+// WrappingBucket interface used to identify buckets that wrap an underlying
+// bucket (leaky bucket, logging bucket)
+type WrappingBucket interface {
+	GetUnderlyingBucket() Bucket
+}
+
+// GetBaseBucket returns the lowest level non-wrapping bucket wrapped by one or more WrappingBuckets
+func GetBaseBucket(b Bucket) Bucket {
+	wb, ok := b.(WrappingBucket)
+	if ok {
+		return GetBaseBucket(wb.GetUnderlyingBucket())
+	}
+	return b
+}
+
 func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
 
 	// Otherwise use the default driver for the bucket type

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -430,3 +430,40 @@ func TestTLSConfig(t *testing.T) {
 	conf = spec.TLSConfig()
 	assert.Empty(t, conf)
 }
+
+func TestBaseBucket(t *testing.T) {
+
+	tests := []struct {
+		name   string
+		bucket Bucket
+	}{
+		{
+			name:   "gocb",
+			bucket: &CouchbaseBucketGoCB{},
+		},
+		{
+			name:   "leaky",
+			bucket: &LeakyBucket{bucket: &CouchbaseBucketGoCB{}},
+		},
+		{
+			name:   "logging",
+			bucket: &LoggingBucket{bucket: &CouchbaseBucketGoCB{}},
+		},
+		{
+			name:   "leakyLogging",
+			bucket: &LeakyBucket{bucket: &LoggingBucket{bucket: &CouchbaseBucketGoCB{}}},
+		},
+		{
+			name:   "loggingLeaky",
+			bucket: &LoggingBucket{bucket: &LeakyBucket{bucket: &CouchbaseBucketGoCB{}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			baseBucket := GetBaseBucket(test.bucket)
+			_, ok := baseBucket.(*CouchbaseBucketGoCB)
+			assert.True(t, ok, "Base bucket wasn't gocb")
+		})
+	}
+}

--- a/rest/api.go
+++ b/rest/api.go
@@ -82,8 +82,10 @@ func (h *handler) handleVacuum() error {
 
 func (h *handler) handleFlush() error {
 
+	baseBucket := base.GetBaseBucket(h.db.Bucket)
+
 	// If it can be flushed, then flush it
-	if _, ok := h.db.Bucket.(sgbucket.FlushableStore); ok {
+	if _, ok := baseBucket.(sgbucket.FlushableStore); ok {
 
 		// If it's not a walrus bucket, don't allow flush unless the unsupported config is set
 		if !h.db.BucketSpec.IsWalrusBucket() {
@@ -129,7 +131,7 @@ func (h *handler) handleFlush() error {
 			return err2
 		}
 
-	} else if bucket, ok := h.db.Bucket.(sgbucket.DeleteableStore); ok {
+	} else if bucket, ok := baseBucket.(sgbucket.DeleteableStore); ok {
 
 		// If it's not flushable, but it's deletable, then delete it
 


### PR DESCRIPTION
Previously wrapped buckets (logging, leaky) were being flagged as ineligible for flush.