### PR TITLE
CBG-1220 sgcollect rest API fails when output_directory not passed in the body of the request

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -580,7 +580,7 @@ func (h *handler) handleSGCollect() error {
 
 	zipFilename := sgcollectFilename()
 
-	if err := sgcollectInstance.Start(h.serialNumber, zipFilename, params); err != nil {
+	if err := sgcollectInstance.Start(h.server.config, h.serialNumber, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -580,7 +580,11 @@ func (h *handler) handleSGCollect() error {
 
 	zipFilename := sgcollectFilename()
 
-	if err := sgcollectInstance.Start(h.server.config, h.serialNumber, zipFilename, params); err != nil {
+	var logFilePath string
+	if h.server.config != nil && h.server.config.Logging != nil && h.server.config.Logging.LogFilePath != "" {
+		logFilePath = h.server.config.Logging.LogFilePath
+	}
+	if err := sgcollectInstance.Start(logFilePath, h.serialNumber, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -580,9 +580,10 @@ func (h *handler) handleSGCollect() error {
 
 	zipFilename := sgcollectFilename()
 
-	var logFilePath string
-	if h.server.config != nil && h.server.config.Logging != nil && h.server.config.Logging.LogFilePath != "" {
-		logFilePath = h.server.config.Logging.LogFilePath
+	logFilePath := ""
+	sc := h.server.config
+	if sc != nil && sc.Logging != nil && sc.Logging.LogFilePath != "" {
+		logFilePath = sc.Logging.LogFilePath
 	}
 	if err := sgcollectInstance.Start(logFilePath, h.serialNumber, zipFilename, params); err != nil {
 		return base.HTTPErrorf(http.StatusInternalServerError, "Error running sgcollect_info: %v", err)

--- a/rest/config.go
+++ b/rest/config.go
@@ -47,8 +47,6 @@ var (
 	defaultLogFilePath string
 )
 
-var config *ServerConfig
-
 const (
 	eeOnlyWarningMsg   = "EE only configuration option %s=%v - Reverting to default value for CE: %v"
 	minValueErrorMsg   = "minimum value for %s is: %v"
@@ -1290,10 +1288,6 @@ func HandleSighup() {
 			base.Warnf("Error rotating %v: %v", logger, err)
 		}
 	}
-}
-
-func GetConfig() *ServerConfig {
-	return config
 }
 
 func RegisterSignalHandler() {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -596,7 +596,7 @@ func TestDeprecatedConfigLoggingFallback(t *testing.T) {
 	}
 
 	// Call deprecatedConfigLoggingFallback with DeprecatedLogFilePath and without DeprecatedDefaultLog
-	config = &ServerConfig{
+	config := &ServerConfig{
 		Logging:               &base.LoggingConfig{},
 		DeprecatedLogFilePath: base.StringPtr(deprecatedDefaultLogFilePathAsFile.Name()),
 		DeprecatedLog:         deprecatedLog,
@@ -887,7 +887,7 @@ func TestValidateServerContext(t *testing.T) {
 	tb2User, tb2Password, _ := tb2.BucketSpec.Auth.GetCredentials()
 
 	xattrs := base.TestUseXattrs()
-	config = &ServerConfig{
+	config := &ServerConfig{
 		Databases: map[string]*DbConfig{
 			"db1": {
 				BucketConfig: BucketConfig{

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -53,7 +53,8 @@ type sgCollect struct {
 }
 
 // Start will attempt to start sgcollect_info, if another is not already running.
-func (sg *sgCollect) Start(config *ServerConfig, ctxSerialNumber uint64, zipFilename string, params sgCollectOptions) error {
+func (sg *sgCollect) Start(logFilePath string, ctxSerialNumber uint64, zipFilename string,
+	params sgCollectOptions) error {
 	if atomic.LoadUint32(sg.status) == sgRunning {
 		return ErrSGCollectInfoAlreadyRunning
 	}
@@ -65,8 +66,8 @@ func (sg *sgCollect) Start(config *ServerConfig, ctxSerialNumber uint64, zipFile
 
 	if params.OutputDirectory == "" {
 		// If no output directory specified, default to the configured LogFilePath
-		if config != nil && config.Logging != nil && config.Logging.LogFilePath != "" {
-			params.OutputDirectory = config.Logging.LogFilePath
+		if logFilePath != "" {
+			params.OutputDirectory = logFilePath
 			base.Debugf(base.KeyAdmin, "sgcollect_info: no output directory specified, using LogFilePath: %v", params.OutputDirectory)
 		} else {
 			// If LogFilePath is not set, and DefaultLogFilePath is not set via a service script, error out.

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -53,8 +53,7 @@ type sgCollect struct {
 }
 
 // Start will attempt to start sgcollect_info, if another is not already running.
-func (sg *sgCollect) Start(logFilePath string, ctxSerialNumber uint64, zipFilename string,
-	params sgCollectOptions) error {
+func (sg *sgCollect) Start(logFilePath string, ctxSerialNumber uint64, zipFilename string, params sgCollectOptions) error {
 	if atomic.LoadUint32(sg.status) == sgRunning {
 		return ErrSGCollectInfoAlreadyRunning
 	}

--- a/rest/sgcollect.go
+++ b/rest/sgcollect.go
@@ -53,7 +53,7 @@ type sgCollect struct {
 }
 
 // Start will attempt to start sgcollect_info, if another is not already running.
-func (sg *sgCollect) Start(ctxSerialNumber uint64, zipFilename string, params sgCollectOptions) error {
+func (sg *sgCollect) Start(config *ServerConfig, ctxSerialNumber uint64, zipFilename string, params sgCollectOptions) error {
 	if atomic.LoadUint32(sg.status) == sgRunning {
 		return ErrSGCollectInfoAlreadyRunning
 	}


### PR DESCRIPTION
While running SGCollect with no output directory specified, SG does use the default log file path specified in the logging configuration. If the log file path is also not specified, it returns an error “no output directory or LogFilePath specified”. The underlying issue is that the package level config that is being referenced in Start() on sgCollect is not getting initialized. Since the refactoring that is done around ServerMain/RunServer to improve the coverage, we stopped setting the global ServerConfig but SGCollect on the other hand is still making use of that global reference. It is reasonable to remove the use of global ServerConfig and refactor the Start() method on sgCollect to accept an additional ServerConfig as input parameter.