### PR TITLE
Tweak ConsoleLogger's location self-logging to fix broken benchmark output

### DIFF
--- a/base/logger_console_test.go
+++ b/base/logger_console_test.go
@@ -88,7 +88,7 @@ func TestConsoleShouldLog(t *testing.T) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := newConsoleLoggerOrPanic(false, &ConsoleLoggerConfig{
+		l := newConsoleLoggerOrPanic(&ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{
@@ -109,7 +109,7 @@ func BenchmarkConsoleShouldLog(b *testing.B) {
 			test.loggerLevel.StringShort(), test.loggerKeys,
 			test.logToLevel.StringShort(), test.logToKey)
 
-		l := newConsoleLoggerOrPanic(false, &ConsoleLoggerConfig{
+		l := newConsoleLoggerOrPanic(&ConsoleLoggerConfig{
 			LogLevel: &test.loggerLevel,
 			LogKeys:  test.loggerKeys,
 			FileLoggerConfig: FileLoggerConfig{

--- a/base/logging.go
+++ b/base/logging.go
@@ -351,7 +351,7 @@ func init() {
 	// initializing a logging config, and when running under a test scenario.
 	initialCollationBufferSize := 0
 
-	consoleLogger = newConsoleLoggerOrPanic(true, &ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
+	consoleLogger = newConsoleLoggerOrPanic(&ConsoleLoggerConfig{FileLoggerConfig: FileLoggerConfig{Enabled: BoolPtr(true), CollationBufferSize: &initialCollationBufferSize}})
 	initExternalLoggers()
 }
 

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -52,7 +52,7 @@ func (c *LoggingConfig) Init(defaultLogFilePath string) (err error) {
 		return errors.New("nil LoggingConfig")
 	}
 
-	consoleLogger, err = NewConsoleLogger(false, &c.Console)
+	consoleLogger, err = NewConsoleLogger(true, &c.Console)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I've reversed the logic of the flag to be _opt-in_ to logging console location, as the only case for it being `true` is from `LoggingConfig.Init()`. All other cases should default to off/false.

Fixes logging breaking benchmark output in `BenchmarkConsoleShouldLog`:

```
2020-12-15T06:47:41.665-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{INF,[HTTP]}.shouldLog(INF,HTTP)-4         	152641118	         7.53 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:43.616-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{INF,[HTTP]}.shouldLog(WRN,HTTP)-4         	147346510	         7.35 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:45.526-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{WRN,[HTTP]}.shouldLog(INF,HTTP)-4         	297721826	         3.64 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:47.019-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{NON,[HTTP]}.shouldLog(ERR,HTTP)-4         	355381657	         3.47 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:48.599-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{INF,[]}.shouldLog(INF,DCP)-4              	152725216	         7.13 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:50.485-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{INF,[HTTP]}.shouldLog(INF,DCP)-4          	147592063	         7.22 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:52.374-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{INF,[*]}.shouldLog(INF,DCP)-4             	209776600	         5.63 ns/op	       0 B/op	       0 allocs/op
2020-12-15T06:47:54.134-08:00 [INF] Logging: Console to stderr
BenchmarkConsoleShouldLog/logger{WRN,[*]}.shouldLog(INF,DCP)-4             	359623335	         3.49 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileShouldLog/logger{INF,[]}.shouldLog(INF,)-4                    	1000000000	         0.771 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileShouldLog/logger{INF,[]}.shouldLog(WRN,)-4                    	1000000000	         0.707 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileShouldLog/logger{WRN,[]}.shouldLog(INF,)-4                    	1000000000	         0.718 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileShouldLog/logger{NON,[]}.shouldLog(ERR,)-4                    	1000000000	         0.717 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileShouldLog/logger{NON,[]}.shouldLog(INF,)-4                    	1000000000	         0.761 ns/op	       0 B/op	       0 allocs/op
```