### PR TITLE
Re-enable TestMalformedN1qlQuery for GSI tests

### DIFF
--- a/base/bucket_n1ql_test.go
+++ b/base/bucket_n1ql_test.go
@@ -249,9 +249,6 @@ func TestIndexMeta(t *testing.T) {
 // Ensure that n1ql query errors are handled and returned (and don't result in panic etc)
 func TestMalformedN1qlQuery(t *testing.T) {
 
-	// FIXME: Test fails regularly on a full test suite run, not exactly sure why.
-	t.Skip("WARNING: Disabled test")
-
 	if TestsDisableGSI() {
 		t.Skip("This test only works with Couchbase Server and UseViews=false")
 	}


### PR DESCRIPTION
The test was skipped during GSI fixes (#4865), but was never re-enabled.
I think this test should be stable now based on local integration tests.