### PR TITLE
CBG-1232 Add support for loading webhook filter JavaScript from external file or URL

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -412,7 +412,7 @@ const (
 )
 
 // jsLoadTypes represents the list of different possible JSLoadType.
-var jsLoadTypes = [...]string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
+var jsLoadTypes = []string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
 
 // String returns the string representation of a specific JSLoadType.
 func (t JSLoadType) String() string {

--- a/rest/config.go
+++ b/rest/config.go
@@ -407,6 +407,7 @@ const (
 	SyncFunction     JSLoadType = iota // Sync Function JavaScript load.
 	ImportFilter                       // Import filter JavaScript load.
 	ConflictResolver                   // Conflict Resolver JavaScript load.
+	WebhookFilter                      // Webhook filter JavaScript load.
 )
 
 // String returns the string representation of a specific JSLoadType.

--- a/rest/config.go
+++ b/rest/config.go
@@ -416,7 +416,6 @@ var jsLoadTypes = [...]string{"SyncFunction", "ImportFilter", "ConflictResolver"
 
 // String returns the string representation of a specific JSLoadType.
 func (t JSLoadType) String() string {
-	// jsLoadTypes := [...]string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
 	if len(jsLoadTypes) < int(t) {
 		return fmt.Sprintf("JSLoadType(%d)", t)
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -408,11 +408,15 @@ const (
 	ImportFilter                       // Import filter JavaScript load.
 	ConflictResolver                   // Conflict Resolver JavaScript load.
 	WebhookFilter                      // Webhook filter JavaScript load.
+	jsLoadTypeCount                    // Number of JSLoadType constants.
 )
+
+// jsLoadTypes represents the list of different possible JSLoadType.
+var jsLoadTypes = [...]string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
 
 // String returns the string representation of a specific JSLoadType.
 func (t JSLoadType) String() string {
-	jsLoadTypes := [...]string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
+	// jsLoadTypes := [...]string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
 	if len(jsLoadTypes) < int(t) {
 		return fmt.Sprintf("JSLoadType(%d)", t)
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -412,7 +412,7 @@ const (
 
 // String returns the string representation of a specific JSLoadType.
 func (t JSLoadType) String() string {
-	jsLoadTypes := [...]string{"SyncFunction", "ImportFilter", "ConflictResolver"}
+	jsLoadTypes := [...]string{"SyncFunction", "ImportFilter", "ConflictResolver", "WebhookFilter"}
 	if len(jsLoadTypes) < int(t) {
 		return fmt.Sprintf("JSLoadType(%d)", t)
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1841,7 +1842,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 				EventHandlers: map[string]interface{}{
 					"max_processes":    500,
 					"wait_for_process": "100",
-					"document_changed": []map[string]interface{}{
+					"db_state_changed": []map[string]interface{}{
 						{
 							"handler": "webhook",
 							"url":     "http://localhost:8080/",
@@ -1864,4 +1865,14 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			require.Equal(t, test.errExpected, err)
 		})
 	}
+}
+
+func TestJSLoadTypeString(t *testing.T) {
+	assert.Equal(t, "SyncFunction", SyncFunction.String())
+	assert.Equal(t, "ImportFilter", ImportFilter.String())
+	assert.Equal(t, "ConflictResolver", ConflictResolver.String())
+	assert.Equal(t, "WebhookFilter", WebhookFilter.String())
+
+	// Test out of bounds JSLoadType
+	assert.Equal(t, "JSLoadType(4294967295)", JSLoadType(math.MaxUint32).String())
 }

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1868,6 +1868,9 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 }
 
 func TestJSLoadTypeString(t *testing.T) {
+	// Ensure number of JSLoadType constants, and names match.
+	assert.Equal(t, int(jsLoadTypeCount), len(jsLoadTypes))
+
 	assert.Equal(t, "SyncFunction", SyncFunction.String())
 	assert.Equal(t, "ImportFilter", ImportFilter.String())
 	assert.Equal(t, "ConflictResolver", ConflictResolver.String())

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -798,17 +798,17 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 		}
 
 		// Load Webhook Filter Function.
-		for _, event := range eventHandlers.DocumentChanged {
-			if event.Filter != "" {
-				filter, err := loadJavaScript(event.Filter)
+		for _, conf := range append(eventHandlers.DBStateChanged, eventHandlers.DocumentChanged...) {
+			if conf.Filter != "" {
+				filter, err := loadJavaScript(conf.Filter)
 				if err != nil {
 					return &JavaScriptLoadError{
 						JSLoadType: WebhookFilter,
-						Path:       event.Filter,
+						Path:       conf.Filter,
 						Err:        err,
 					}
 				}
-				event.Filter = filter
+				conf.Filter = filter
 			}
 		}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -797,6 +797,21 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 			return pkgerrors.Wrapf(err, "Error calling base.JSONUnmarshal() in initEventHandlers")
 		}
 
+		// Load Webhook Filter Function.
+		for _, event := range eventHandlers.DocumentChanged {
+			if event.Filter != "" {
+				filter, err := loadJavaScript(event.Filter)
+				if err != nil {
+					return &JavaScriptLoadError{
+						JSLoadType: WebhookFilter,
+						Path:       event.Filter,
+						Err:        err,
+					}
+				}
+				event.Filter = filter
+			}
+		}
+
 		// Process document commit event handlers
 		if err = sc.processEventHandlersForEvent(eventHandlers.DocumentChanged, db.DocumentChange, dbcontext); err != nil {
 			return err


### PR DESCRIPTION
Since Lithium Sync Gateway supports externalizing JavaScript function definitions in separate JavaScript files and referencing those files in the Sync Gateway configuration file. An enhancement has already been merged to master which mainly includes sync function, import filter and conflict resolver function definitions. In addition to this we also need to include the JavaScript filter that is being used in Webhook event handlers to examine the contents of the mutated documents and decide which ones to post to the specified URL.