### PR TITLE
CBG-1159 - Add default checkpoint interval override to sgReplicateManager

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -16,7 +16,8 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-var DefaultCheckpointInterval = time.Second * 5
+// DefaultCheckpointerInterval is the value used when a Checkpointer has not had a CheckpointInterval value set.
+const DefaultCheckpointerInterval = time.Second * 5
 
 // Checkpointer implements replicator checkpointing, by keeping two lists of sequences. Those which we expect to be processing revs for (either push or pull), and a map for those which we have done so on.
 // Periodically (based on a time interval), these two lists are used to calculate the highest sequence number which we've not had a gap for yet, and send a SetCheckpoint message for this sequence.
@@ -194,7 +195,7 @@ func (c *Checkpointer) Start() {
 	c.closeWg.Add(1)
 	go func() {
 		defer c.closeWg.Done()
-		checkpointInterval := DefaultCheckpointInterval
+		checkpointInterval := DefaultCheckpointerInterval
 		if c.checkpointInterval > 0 {
 			checkpointInterval = c.checkpointInterval
 		}

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -709,14 +709,14 @@ func TestReplicationRebalancePull(t *testing.T) {
 	}
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
-	// Increase checkpoint persistence frequency for cross-node status verification
-	defer SetDefaultCheckpointInterval(50 * time.Millisecond)()
-
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
 	activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
 
 	// Create docs on remote
 	docABC1 := t.Name() + "ABC1"
@@ -744,6 +744,12 @@ func TestReplicationRebalancePull(t *testing.T) {
 	// Add another node to the active cluster
 	activeRT2 := addActiveRT(t, activeRT.TestBucket)
 	defer activeRT2.Close()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT2.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+
+	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
+	require.NoError(t, err)
 
 	// Wait for replication to be rebalanced to activeRT2
 	activeRT.waitForAssignedReplications(1)
@@ -800,14 +806,15 @@ func TestReplicationRebalancePush(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
-	// Increase checkpoint persistence frequency for cross-node status verification
-	defer SetDefaultCheckpointInterval(50 * time.Millisecond)()
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
 	activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
 
 	// Create docs on active
 	docABC1 := t.Name() + "ABC1"
@@ -834,6 +841,12 @@ func TestReplicationRebalancePush(t *testing.T) {
 	// Add another node to the active cluster
 	activeRT2 := addActiveRT(t, activeRT.TestBucket)
 	defer activeRT2.Close()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT2.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+
+	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
+	require.NoError(t, err)
 
 	// Wait for replication to be rebalanced to activeRT2
 	activeRT.waitForAssignedReplications(1)
@@ -945,14 +958,15 @@ func TestReplicationConcurrentPush(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyCRUD, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
-	// Increase checkpoint persistence frequency for cross-node status verification
-	defer SetDefaultCheckpointInterval(50 * time.Millisecond)()
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
 	activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
 
 	// Create push replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
@@ -1076,8 +1090,6 @@ func addActiveRT(t *testing.T, testBucket *base.TestBucket) (activeRT *RestTeste
 		}
 	}
 
-	err := activeRT.GetDatabase().SGReplicateMgr.StartReplications()
-	require.NoError(t, err)
 	return activeRT
 }
 
@@ -2051,14 +2063,14 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	}
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
-	// Increase checkpoint persistence frequency for cross-node status verification
-	defer SetDefaultCheckpointInterval(50 * time.Millisecond)()
-
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()
 
 	activeRT, remoteRT, remoteURLString, teardown := setupSGRPeers(t)
 	defer teardown()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
 
 	// Create docs on remote
 	docABC1 := t.Name() + "ABC1"
@@ -2084,6 +2096,12 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	// Add another node to the active cluster
 	activeRT2 := addActiveRT(t, activeRT.TestBucket)
 	defer activeRT2.Close()
+
+	// Increase checkpoint persistence frequency for cross-node status verification
+	activeRT2.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+
+	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
+	require.NoError(t, err)
 
 	// Wait for replication to be rebalanced to activeRT2
 	activeRT.waitForAssignedReplications(1)
@@ -2115,7 +2133,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	assert.NoError(t, activeRT2Mgr.RemoveNode(activeRTUUID))
 
 	// Wait for nodes to add themselves back to cluster
-	err := activeRT.WaitForCondition(func() bool {
+	err = activeRT.WaitForCondition(func() bool {
 		clusterDef, err := activeRTMgr.GetSGRCluster()
 		if err != nil {
 			return false
@@ -2142,12 +2160,4 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	activeRT.GetDatabase().SGReplicateMgr = nil
 	activeRT2.GetDatabase().SGReplicateMgr.Stop()
 	activeRT2.GetDatabase().SGReplicateMgr = nil
-}
-
-func SetDefaultCheckpointInterval(d time.Duration) func() {
-	previousInterval := db.DefaultCheckpointInterval
-	db.DefaultCheckpointInterval = d
-	return func() {
-		db.DefaultCheckpointInterval = previousInterval
-	}
 }

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -716,7 +716,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 	defer teardown()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	// Create docs on remote
 	docABC1 := t.Name() + "ABC1"
@@ -746,7 +746,7 @@ func TestReplicationRebalancePull(t *testing.T) {
 	defer activeRT2.Close()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT2.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT2.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
 	require.NoError(t, err)
@@ -814,7 +814,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 	defer teardown()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	// Create docs on active
 	docABC1 := t.Name() + "ABC1"
@@ -843,7 +843,7 @@ func TestReplicationRebalancePush(t *testing.T) {
 	defer activeRT2.Close()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT2.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT2.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
 	require.NoError(t, err)
@@ -966,7 +966,7 @@ func TestReplicationConcurrentPush(t *testing.T) {
 	defer teardown()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	// Create push replications, verify running
 	activeRT.createReplication("rep_ABC", remoteURLString, db.ActiveReplicatorTypePush, []string{"ABC"}, true, db.ConflictResolverDefault)
@@ -2070,7 +2070,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	defer teardown()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	// Create docs on remote
 	docABC1 := t.Name() + "ABC1"
@@ -2098,7 +2098,7 @@ func TestReplicationHeartbeatRemoval(t *testing.T) {
 	defer activeRT2.Close()
 
 	// Increase checkpoint persistence frequency for cross-node status verification
-	activeRT2.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+	activeRT2.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 	err := activeRT2.GetDatabase().SGReplicateMgr.StartReplications()
 	require.NoError(t, err)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -411,9 +411,6 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 
 			defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
-			// Increase checkpoint persistence frequency for cross-node status verification
-			defer SetDefaultCheckpointInterval(50 * time.Millisecond)()
-
 			// Disable sequence batching for multi-RT tests (pending CBG-1000)
 			defer db.SuspendSequenceBatching()()
 
@@ -473,6 +470,9 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 				},
 			})
 			defer rt1.Close()
+
+			// Increase checkpoint persistence frequency for cross-node status verification
+			rt1.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
 
 			err = rt1.GetDatabase().SGReplicateMgr.StartReplications()
 			require.NoError(t, err)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -472,7 +472,7 @@ func TestActiveReplicatorPullMergeConflictingAttachments(t *testing.T) {
 			defer rt1.Close()
 
 			// Increase checkpoint persistence frequency for cross-node status verification
-			rt1.GetDatabase().SGReplicateMgr.SetDefaultCheckpointIntervalOverride(50 * time.Millisecond)
+			rt1.GetDatabase().SGReplicateMgr.CheckpointInterval = 50 * time.Millisecond
 
 			err = rt1.GetDatabase().SGReplicateMgr.StartReplications()
 			require.NoError(t, err)
@@ -604,11 +604,8 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous:       true,
-		ChangesBatchSize: changesBatchSize,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
+		ChangesBatchSize:    changesBatchSize,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -773,11 +770,8 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous:       true,
-		ChangesBatchSize: changesBatchSize,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
+		ChangesBatchSize:    changesBatchSize,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -1221,9 +1215,6 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 		},
 		Continuous:       true,
 		ChangesBatchSize: changesBatchSize,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval: time.Minute * 5,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -1387,11 +1378,8 @@ func TestActiveReplicatorPushFromCheckpointIgnored(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous:       true,
-		ChangesBatchSize: changesBatchSize,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
+		ChangesBatchSize:    changesBatchSize,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -2433,10 +2421,7 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous: true,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -2589,9 +2574,6 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous: true,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval: time.Minute * 5,
 	}
 
 	// Create the first active replicator to pull from seq:0
@@ -2759,10 +2741,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous: true,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -2903,10 +2882,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous: true,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -3107,13 +3083,10 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
-		Continuous:       true,
-		ChangesBatchSize: changesBatchSize,
-		Filter:           base.ByChannelFilter,
-		FilterChannels:   []string{"chan1"},
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval:  time.Minute * 5,
+		Continuous:          true,
+		ChangesBatchSize:    changesBatchSize,
+		Filter:              base.ByChannelFilter,
+		FilterChannels:      []string{"chan1"},
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	}
 
@@ -3312,9 +3285,6 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 							DatabaseContext: rt1.GetDatabase(),
 						},
 						Continuous: true,
-						// test isn't long running enough to worry about time-based checkpoints,
-						// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-						CheckpointInterval: time.Minute * 5,
 						// aggressive reconnect intervals for testing purposes
 						InitialReconnectInterval: time.Millisecond,
 						MaxReconnectInterval:     time.Millisecond * 50,
@@ -3402,9 +3372,6 @@ func TestActiveReplicatorReconnectOnStartEventualSuccess(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous: true,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval: time.Minute * 5,
 		// aggressive reconnect intervals for testing purposes
 		InitialReconnectInterval: time.Millisecond,
 		MaxReconnectInterval:     time.Millisecond * 50,
@@ -3487,9 +3454,6 @@ func TestActiveReplicatorReconnectSendActions(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous: true,
-		// test isn't long running enough to worry about time-based checkpoints,
-		// to keep testing simple, bumped these up for deterministic checkpointing via CheckpointNow()
-		CheckpointInterval: time.Minute * 5,
 		// aggressive reconnect intervals for testing purposes
 		InitialReconnectInterval: time.Millisecond,
 		MaxReconnectInterval:     time.Millisecond * 50,


### PR DESCRIPTION
Fixes data race coming from changing a global variable to tweak the checkpoint interval in some tests.

`sgReplicateManager` can control its own default checkpoint interval. Allows for tests that use a REST-based replication to have a customisable checkpoint interval without it being exposed to users or in the distributed configs.