### PR TITLE
CBG-1217 Ensure change listener goroutines terminates before the server is stopped

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -345,6 +345,7 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 	// Close the feed if feed terminator is closed
 	if args.Terminator != nil {
 		go func() {
+			defer close(args.DoneChan)
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {
@@ -491,6 +492,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	// Close the feed if feed terminator is closed
 	if args.Terminator != nil {
 		go func() {
+			defer close(args.DoneChan)
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -345,11 +345,13 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 	// Close the feed if feed terminator is closed
 	if args.Terminator != nil {
 		go func() {
-			defer close(args.DoneChan)
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {
 				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(spec.BucketName), feedName, err)
+			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
 			}
 		}()
 	}
@@ -492,11 +494,13 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	// Close the feed if feed terminator is closed
 	if args.Terminator != nil {
 		go func() {
-			defer close(args.DoneChan)
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {
 				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(spec.BucketName), feedName, err)
+			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
 			}
 		}()
 	}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -322,6 +322,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	// Close the data source if feed terminator is closed
 	if args.Terminator != nil {
 		go func() {
+			defer close(args.DoneChan)
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
 			if err := bds.Close(); err != nil {

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -322,11 +322,13 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	// Close the data source if feed terminator is closed
 	if args.Terminator != nil {
 		go func() {
-			defer close(args.DoneChan)
 			<-args.Terminator
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(bucketName), feedID)
 			if err := bds.Close(); err != nil {
 				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(bucketName), feedID, err)
+			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
 			}
 		}()
 	}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -262,6 +262,9 @@ func (b *LeakyBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.
 				event.VbNo = uint16(VBHash(key, 1024))
 				vbTapFeed.channel <- event
 			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
+			}
 		}()
 		return vbTapFeed, nil
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -73,9 +73,9 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 				if listener.FeedArgs.DoneChan != nil {
 					close(listener.FeedArgs.DoneChan)
 				}
-				base.FatalPanicHandler()
-				listener.notifyStopping()
 			}()
+			defer base.FatalPanicHandler()
+			defer listener.notifyStopping()
 			for event := range listener.tapFeed.Events() {
 				event.TimeReceived = time.Now()
 				listener.ProcessFeedEvent(event)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -37,6 +37,7 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 		ID:         base.DCPImportFeedID,
 		Backfill:   sgbucket.FeedResume,
 		Terminator: il.terminator,
+		DoneChan:   make(chan struct{}),
 	}
 
 	importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="7ab835134e1cf82c1befec717d507d5402ed01fa"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="73fbf07971554a77e32b0d61ddad578065e95856"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="ec96142448b9f60998f276fc4394559e9da4c1aa"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="7ab835134e1cf82c1befec717d507d5402ed01fa"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="73fbf07971554a77e32b0d61ddad578065e95856"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="bc5fd87f01d1819c14c92e4e51b63f0d7e77a69c"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f0c94dfbbe35fc31012b1fc0b3fb6d8d490c6199"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="aba85317d4695c881ad71a9a0b570e7e99347c67"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="e8d089489387294d441b25e17eb1d006178bbd3b"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="ec96142448b9f60998f276fc4394559e9da4c1aa"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="4f1478f0a956cdabd36db119ea64dc4d9b071bdc"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="f0c94dfbbe35fc31012b1fc0b3fb6d8d490c6199"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1245,7 +1245,9 @@ func deleteTempFile(t *testing.T, file *os.File) {
 }
 
 func TestSetupAndValidate(t *testing.T) {
-	t.Skip("Skipping this test temporarily; until CBG-1217 is fixed")
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Skipping this test; it only works on Walrus bucket")
+	}
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{


### PR DESCRIPTION
When running on slow hardware the change listener goroutines takes a little while to terminate and eventually ends up in "TestSetupAndValidate" failure. We need to address this issue adding a mechanism to gracefully exit both Tap and DCP feed event workers before the server is stopped.

**Dependencies:**
- [x] https://github.com/couchbase/sg-bucket/pull/58
- [x] https://github.com/couchbaselabs/walrus/pull/55

## Integration Tests
- [ ] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/623/