### PR TITLE
Fix resync integration tests when using GSI

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -44,6 +44,15 @@ func (tb TestBucket) Close() {
 	tb.closeFn()
 }
 
+// LeakyBucketClone wraps the underlying bucket on the TestBucket with a LeakyBucket and returns a new TestBucket handle.
+func (tb *TestBucket) LeakyBucketClone(c LeakyBucketConfig) *TestBucket {
+	return &TestBucket{
+		Bucket:     NewLeakyBucket(tb.Bucket, c),
+		BucketSpec: tb.BucketSpec,
+		closeFn:    tb.Close,
+	}
+}
+
 // NoCloseClone returns a leaky bucket with a no-op close function for the given bucket.
 func NoCloseClone(b Bucket) *LeakyBucket {
 	return NewLeakyBucket(b, LeakyBucketConfig{IgnoreClose: true})

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -215,6 +215,10 @@ func (c *changeCache) Start(initialSequence uint64) error {
 // Stops the cache. Clears its state and tells the housekeeping task to stop.
 func (c *changeCache) Stop() {
 
+	if c.IsStopped() {
+		return
+	}
+
 	// Signal to background goroutines that the changeCache has been stopped, so they can exit
 	// their loop
 	close(c.terminator)

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -215,7 +215,7 @@ func (c *changeCache) Start(initialSequence uint64) error {
 // Stops the cache. Clears its state and tells the housekeeping task to stop.
 func (c *changeCache) Stop() {
 
-	if c.IsStopped() {
+	if !c.setStopped() {
 		return
 	}
 
@@ -227,9 +227,18 @@ func (c *changeCache) Stop() {
 	c.context.waitForBGTCompletion(BGTCompletionMaxWait, c.backgroundTasks)
 
 	c.lock.Lock()
-	c.stopped = true
 	c.logsDisabled = true
 	c.lock.Unlock()
+}
+
+func (c *changeCache) setStopped() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.stopped {
+		return false
+	}
+	c.stopped = true
+	return true
 }
 
 func (c *changeCache) IsStopped() bool {

--- a/db/database.go
+++ b/db/database.go
@@ -1073,16 +1073,30 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 func (db *Database) UpdateAllDocChannels() (int, error) {
 
 	base.Infof(base.KeyAll, "Recomputing document channels...")
+	//
+	// // We are about to alter documents without updating their sequence numbers, which would
+	// // really confuse the changeCache, so turn it off until we're done:
+	// db.changeCache.EnableChannelIndexing(false)
+	// defer db.changeCache.EnableChannelIndexing(true)
 
-	// We are about to alter documents without updating their sequence numbers, which would
-	// really confuse the changeCache, so turn it off until we're done:
-	db.changeCache.EnableChannelIndexing(false)
-	defer db.changeCache.EnableChannelIndexing(true)
-
-	err := db.changeCache.Clear()
+	lastSeq, err := db.sequences.lastSequence()
 	if err != nil {
 		return 0, err
 	}
+
+	db.changeCache.Stop()
+
+	err = db.changeCache.Clear()
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		err = db.changeCache.Start(lastSeq)
+		if err != nil {
+			base.Warnf("Failed to restart change cache: %v", err)
+		}
+	}()
 
 	base.Infof(base.KeyAll, "Re-running sync function on all documents...")
 

--- a/db/database.go
+++ b/db/database.go
@@ -683,14 +683,14 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
 	if atomic.CompareAndSwapUint32(&dc.State, DBOnline, DBStopping) {
 
+		dc.changeCache.Stop()
+
 		//notify all active _changes feeds to close
 		close(dc.ExitChanges)
 
 		//Block until all current calls have returned, including _changes feeds
 		dc.AccessLock.Lock()
 		defer dc.AccessLock.Unlock()
-
-		dc.changeCache.Stop()
 
 		//set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)

--- a/db/database.go
+++ b/db/database.go
@@ -682,15 +682,14 @@ func (context *DatabaseContext) NotifyTerminatedChanges(username string) {
 func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 
 	if atomic.CompareAndSwapUint32(&dc.State, DBOnline, DBStopping) {
-
-		dc.changeCache.Stop()
-
 		//notify all active _changes feeds to close
 		close(dc.ExitChanges)
 
 		//Block until all current calls have returned, including _changes feeds
 		dc.AccessLock.Lock()
 		defer dc.AccessLock.Unlock()
+
+		dc.changeCache.Stop()
 
 		//set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2324,12 +2324,6 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 	})
 
 	_, err = db.UpdateAllDocChannels()
-	assert.NoError(t, err)
-
-	waitAndAssertCondition(t, func() bool {
-		resyncState := db.DatabaseContext.ResyncManager.GetStatus()
-		return resyncState.Status == ResyncStateStopped
-	})
 
 	syncFnCount := int(db.DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 	assert.Equal(t, 20, syncFnCount)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -101,6 +101,9 @@ func setupTestDBWithCustomSyncSeq(t testing.TB, customSeq uint64) *Database {
 	assert.NoError(t, err, "Couldn't create context for database 'db'")
 	db, err := CreateDatabase(context)
 	assert.NoError(t, err, "Couldn't create database 'db'")
+
+	atomic.StoreUint32(&context.State, DBOnline)
+
 	return db
 }
 
@@ -2293,13 +2296,13 @@ func TestRepairUnorderedRecentSequences(t *testing.T) {
 }
 
 func TestResyncUpdateAllDocChannels(t *testing.T) {
-
 	syncFn := `
 	function(doc) {
 		channel("x")
 	}`
 
 	db := setupTestDBWithOptions(t, DatabaseContextOptions{ResyncQueryLimit: 5000})
+
 	_, err := db.UpdateSyncFun(syncFn)
 	assert.NoError(t, err)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1268,6 +1269,11 @@ func TestResync(t *testing.T) {
 			response = rt.SendAdminRequest("POST", "/db/_offline", "")
 			assertStatus(t, response, http.StatusOK)
 
+			waitAndAssertCondition(t, func() bool {
+				state := atomic.LoadUint32(&rt.GetDatabase().State)
+				return state == db.DBOffline
+			})
+
 			response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
 			assertStatus(t, response, http.StatusOK)
 
@@ -1361,6 +1367,11 @@ func TestResyncErrorScenarios(t *testing.T) {
 
 	response = rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, http.StatusOK)
+
+	waitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOffline
+	})
 
 	useCallback = true
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")
@@ -1461,6 +1472,11 @@ func TestResyncStop(t *testing.T) {
 
 	response := rt.SendAdminRequest("POST", "/db/_offline", "")
 	assertStatus(t, response, http.StatusOK)
+
+	waitAndAssertCondition(t, func() bool {
+		state := atomic.LoadUint32(&rt.GetDatabase().State)
+		return state == db.DBOffline
+	})
 
 	useCallback = true
 	response = rt.SendAdminRequest("POST", "/db/_resync?action=start", "")

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1297,6 +1297,12 @@ func TestResync(t *testing.T) {
 }
 
 func TestResyncErrorScenarios(t *testing.T) {
+
+	if !base.UnitTestUrlIsWalrus() {
+		// Limitation of setting LeakyBucket on RestTester
+		t.Skip("This test only works with walrus")
+	}
+
 	syncFn := `
 	function(doc) {
 		channel("x")
@@ -1312,7 +1318,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 	)
 	defer rt.Close()
 
-	leakyBucket, ok := leakyTestBucket.Bucket.(*base.LeakyBucket)
+	leakyBucket, ok := rt.Bucket().(*base.LeakyBucket)
 	require.Truef(t, ok, "Wanted *base.LeakyBucket but got %T", leakyTestBucket.Bucket)
 
 	var (
@@ -1388,15 +1394,15 @@ func TestResyncErrorScenarios(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// FIXME: PostQuery callbacks not firing, meaning we aren't testing concurrent/overlapping start actions
-	if false {
-		assert.True(t, callbackFired, "expecting callback to be fired")
-	}
+	assert.True(t, callbackFired, "expecting callback to be fired")
 }
 
 func TestResyncStop(t *testing.T) {
-	// FIXME: PostQuery callbacks not firing, meaning resync finishes successfully without being stopped
-	t.Skip("TEST DISABLED - PostQuery callbacks not firing, meaning resync finishes successfully without being stopped")
+
+	if !base.UnitTestUrlIsWalrus() {
+		// Limitation of setting LeakyBucket on RestTester
+		t.Skip("This test only works with walrus")
+	}
 
 	syncFn := `
 	function(doc) {
@@ -1416,7 +1422,7 @@ func TestResyncStop(t *testing.T) {
 	)
 	defer rt.Close()
 
-	leakyBucket, ok := leakyTestBucket.Bucket.(*base.LeakyBucket)
+	leakyBucket, ok := rt.Bucket().(*base.LeakyBucket)
 	require.Truef(t, ok, "Wanted *base.LeakyBucket but got %T", leakyTestBucket.Bucket)
 
 	var (

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1389,7 +1389,9 @@ func TestResyncErrorScenarios(t *testing.T) {
 	assert.NoError(t, err)
 
 	// FIXME: PostQuery callbacks not firing, meaning we aren't testing concurrent/overlapping start actions
-	// assert.True(t, callbackFired, "expecting callback to be fired")
+	if false {
+		assert.True(t, callbackFired, "expecting callback to be fired")
+	}
 }
 
 func TestResyncStop(t *testing.T) {


### PR DESCRIPTION
- Fix incorrect N1QL query name for stat assertion (`QueryAllDocs` -> `QueryChannel`)
- Create LeakyBucket on RestTester for setting PostQuery callbacks, avoiding failed type assertion for non-leaky buckets
- Skip test depending on broken query callbacks (they're never invoked, added additional assertions to catch this once re-enabled)
  - [CBG-1247](https://issues.couchbase.com/browse/CBG-1247)

## Resync Integration Tests
- [X] **GSI**✅ **xattrs**✅ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/593/
- [X] **GSI**✅ **xattrs**❌ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/594/
- [X] **GSI**❌ **xattrs**✅ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/595/
- [X] **GSI**❌ **xattrs**❌ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/596/

## Resync Integration Tests 2.0
- [x] **GSI**✅ **xattrs**✅ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/608/ (View issues)
- [x] **GSI**✅ **xattrs**❌ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/608/ (View issues)
- [x] **GSI**❌ **xattrs**✅ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/606/
- [x] **GSI**❌ **xattrs**❌ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/607/ (View issues)

## 3.0
- [x] **GSI**✅ **xattrs**✅ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/612/
- [x] **GSI**✅ **xattrs**❌ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/615/
- [x] **GSI**❌ **xattrs**✅ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/613/
- [x] **GSI**❌ **xattrs**❌ http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/614/