### PR TITLE
CBG-1244 - Proposal to add winning_rev_changed event handler

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -693,11 +693,8 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 		//set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
 
-		if dc.EventMgr.HasHandlerForEvent(DBStateChange) {
-			err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
-			if err != nil {
-				base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
-			}
+		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface); err != nil {
+			base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
 		}
 
 		return nil

--- a/db/event.go
+++ b/db/event.go
@@ -10,13 +10,26 @@ import (
 	"github.com/robertkrimen/otto"
 )
 
-// Event type
+// EventType is an enum for each unique event type.
 type EventType uint8
 
 const (
-	DocumentChange EventType = iota
-	DBStateChange
+	DocumentChange EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
+	DBStateChange                   // fires when the database is created or is taken offline/online
+
+	eventTypeCount
 )
+
+var eventTypeNames = []string{"DocumentChange", "DBStateChange"}
+
+// String returns the string representation of an event type (e.g. "WinningRevChange")
+func (et EventType) String() string {
+	if et >= eventTypeCount {
+		return fmt.Sprintf("EventType(%d)", et)
+
+	}
+	return eventTypeNames[et]
+}
 
 // An event that can be raised during SG processing.
 type Event interface {

--- a/db/event.go
+++ b/db/event.go
@@ -14,13 +14,14 @@ import (
 type EventType uint8
 
 const (
-	DocumentChange EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
-	DBStateChange                   // fires when the database is created or is taken offline/online
+	DocumentChange   EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
+	DBStateChange                     // fires when the database is created or is taken offline/online
+	WinningRevChange                  // like DocumentChange, but fires only when the change caused the winning revision to change
 
 	eventTypeCount
 )
 
-var eventTypeNames = []string{"DocumentChange", "DBStateChange"}
+var eventTypeNames = []string{"DocumentChange", "DBStateChange", "WinningRevChange"}
 
 // String returns the string representation of an event type (e.g. "WinningRevChange")
 func (et EventType) String() string {
@@ -46,6 +47,19 @@ type AsyncEvent struct {
 
 func (ae AsyncEvent) Synchronous() bool {
 	return false
+}
+
+// WinningRevChangeEvent is a DocumentChangeEvent that is only raised when the winning revision of a document has changed.
+type WinningRevChangeEvent struct {
+	DocumentChangeEvent
+}
+
+func (wrce *WinningRevChangeEvent) String() string {
+	return fmt.Sprintf("Winning rev change event for doc id: %s", wrce.DocID)
+}
+
+func (wrce *WinningRevChangeEvent) EventType() EventType {
+	return WinningRevChange
 }
 
 // DocumentChangeEvent is raised when a document has been successfully written to the backing
@@ -162,6 +176,11 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 		result, err = ef.Call(sgbucket.JSONString(event.DocBytes), sgbucket.JSONString(event.OldDoc))
 	case *DBStateChangeEvent:
 		result, err = ef.Call(event.Doc)
+	case *WinningRevChangeEvent:
+		result, err = ef.Call(sgbucket.JSONString(event.DocBytes), sgbucket.JSONString(event.OldDoc))
+	default:
+		base.Warnf("unknown event %v tried to call function", event.EventType())
+		return "", fmt.Errorf("unknown event %v tried to call function", event.EventType())
 	}
 
 	if err != nil {
@@ -190,7 +209,7 @@ func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
 		}
 		return boolResult, nil
 	default:
-		base.Warnf("Event validate function returned non-boolean result %v", result)
+		base.Warnf("Event validate function returned non-boolean result %T %v", result, result)
 		return false, errors.New("Validate function returned non-boolean value.")
 	}
 

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -68,8 +68,6 @@ func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, e
 // on the event type.
 func (wh *Webhook) HandleEvent(event Event) bool {
 
-	var payload []byte
-	var contentType string
 	if wh.filter != nil {
 		// If filter function is defined, use it to determine whether to post
 		success, err := wh.filter.CallValidateFunction(event)
@@ -83,8 +81,14 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		}
 	}
 
+	var payload []byte
+	var contentType string
+
 	// Different events post different content by default
 	switch event := event.(type) {
+	case *WinningRevChangeEvent:
+		contentType = "application/json"
+		payload = event.DocBytes
 	case *DocumentChangeEvent:
 		contentType = "application/json"
 		payload = event.DocBytes

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -182,3 +182,22 @@ func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, rea
 
 	return em.raiseEvent(event)
 }
+
+// Raises a winning rev change event based on the the document body and channel set.  If the
+// event manager doesn't have a listener for this event, ignores.
+func (em *EventManager) RaiseWinningRevChangeEvent(docBytes []byte, docID string, oldBodyJSON string, channels base.Set) error {
+
+	if !em.activeEventTypes[WinningRevChange] {
+		return nil
+	}
+	event := &WinningRevChangeEvent{
+		DocumentChangeEvent: DocumentChangeEvent{
+			DocID:    docID,
+			DocBytes: docBytes,
+			OldDoc:   oldBodyJSON,
+			Channels: channels,
+		},
+	}
+
+	return em.raiseEvent(event)
+}

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventTypeNames(t *testing.T) {
+	// Ensure number of level constants, and names match.
+	assert.Equal(t, int(eventTypeCount), len(eventTypeNames))
+
+	assert.Equal(t, "DocumentChange", DocumentChange.String())
+	assert.Equal(t, "DBStateChange", DBStateChange.String())
+
+	// Test out of bounds event type
+	assert.Equal(t, "EventType(255)", EventType(math.MaxUint8).String())
+}

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -13,6 +13,7 @@ func TestEventTypeNames(t *testing.T) {
 
 	assert.Equal(t, "DocumentChange", DocumentChange.String())
 	assert.Equal(t, "DBStateChange", DBStateChange.String())
+	assert.Equal(t, "WinningRevChange", WinningRevChange.String())
 
 	// Test out of bounds event type
 	assert.Equal(t, "EventType(255)", EventType(math.MaxUint8).String())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4805,6 +4806,74 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	assert.NotEqual(t, revIdAfterAttachment, doc1revId)
 	wg.Add(1)
 	wg.Wait()
+}
+
+// TestWebhookWinningRevChangedEvent ensures the winning_rev_changed event is only fired for a winning revision change, and checks that document_changed is always fired.
+func TestWebhookWinningRevChangedEvent(t *testing.T) {
+
+	wg := sync.WaitGroup{}
+
+	var WinningRevChangedCount uint32
+	var DocumentChangedCount uint32
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		var body db.Body
+		d := base.JSONDecoder(r.Body)
+		require.NoError(t, d.Decode(&body))
+		require.Contains(t, body, db.BodyId)
+		require.Contains(t, body, db.BodyRev)
+
+		event := r.URL.Query().Get("event")
+		switch event {
+		case "WinningRevChanged":
+			atomic.AddUint32(&WinningRevChangedCount, 1)
+		case "DocumentChanged":
+			atomic.AddUint32(&DocumentChangedCount, 1)
+		default:
+			t.Fatalf("unknown event type: %s", event)
+		}
+
+		wg.Done()
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(handler))
+	defer s.Close()
+
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			EventHandlers: &EventHandlerConfig{
+				DocumentChanged: []*EventConfig{
+					{Url: s.URL + "?event=DocumentChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
+				},
+				WinningRevChanged: []*EventConfig{
+					{Url: s.URL + "?event=WinningRevChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
+				},
+			},
+		},
+	}
+	rt := NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	res := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+	rev1 := respRevID(t, res)
+	_, rev1Hash := db.ParseRevID(rev1)
+
+	// push winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+
+	// push non-winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzzzzz","_revisions":{"start":2,"ids":["buzzzzz","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(1)
+
+	wg.Wait()
+
+	assert.Equal(t, 2, int(atomic.LoadUint32(&WinningRevChangedCount)))
+	assert.Equal(t, 3, int(atomic.LoadUint32(&DocumentChangedCount)))
 }
 
 func Benchmark_RestApiGetDocPerformance(b *testing.B) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -228,10 +228,11 @@ type CORSConfig struct {
 }
 
 type EventHandlerConfig struct {
-	MaxEventProc    uint           `json:"max_processes,omitempty"`    // Max concurrent event handling goroutines
-	WaitForProcess  string         `json:"wait_for_process,omitempty"` // Max wait time when event queue is full (ms)
-	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
-	DBStateChanged  []*EventConfig `json:"db_state_changed,omitempty"` // DB state change
+	MaxEventProc      uint           `json:"max_processes,omitempty"`       // Max concurrent event handling goroutines
+	WaitForProcess    string         `json:"wait_for_process,omitempty"`    // Max wait time when event queue is full (ms)
+	DocumentChanged   []*EventConfig `json:"document_changed,omitempty"`    // Document changed
+	WinningRevChanged []*EventConfig `json:"winning_rev_changed,omitempty"` // Winning revision changed
+	DBStateChanged    []*EventConfig `json:"db_state_changed,omitempty"`    // DB state change
 }
 
 type EventConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -160,9 +160,7 @@ func (sc *ServerContext) Close() {
 
 	for _, ctx := range sc.databases_ {
 		ctx.Close()
-		if ctx.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
-		}
+		_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
 	}
 
 	sc.databases_ = nil
@@ -569,14 +567,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	if config.StartOffline {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
-		}
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
-		}
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
 	}
 
 	return dbcontext, nil
@@ -777,8 +771,9 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 
 	// Load Webhook Filter Function.
 	eventHandlersByType := map[db.EventType][]*EventConfig{
-		db.DocumentChange: config.EventHandlers.DocumentChanged,
-		db.DBStateChange:  config.EventHandlers.DBStateChanged,
+		db.DocumentChange:   config.EventHandlers.DocumentChanged,
+		db.DBStateChange:    config.EventHandlers.DBStateChanged,
+		db.WinningRevChange: config.EventHandlers.WinningRevChanged,
 	}
 
 	for eventType, handlers := range eventHandlersByType {


### PR DESCRIPTION
Adds a new event handler `winning_rev_changed`, which is only fired when a write happens that changes the current revision.

- [ ] Rebase onto #4898 