### PR TITLE
CBG-1244 - Add winning_rev_only option to DocumentChanged event handler config

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -670,11 +670,8 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 		//set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
 
-		if dc.EventMgr.HasHandlerForEvent(DBStateChange) {
-			err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
-			if err != nil {
-				base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
-			}
+		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface); err != nil {
+			base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
 		}
 
 		return nil

--- a/db/database.go
+++ b/db/database.go
@@ -670,7 +670,7 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 		//set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
 
-		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface); err != nil {
+		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
 			base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
 		}
 

--- a/db/event.go
+++ b/db/event.go
@@ -20,9 +20,9 @@ const (
 	eventTypeCount
 )
 
-var eventTypeNames = []string{"DocumentChange", "DBStateChange", "WinningRevChange"}
+var eventTypeNames = []string{"DocumentChange", "DBStateChange"}
 
-// String returns the string representation of an event type (e.g. "WinningRevChange")
+// String returns the string representation of an event type (e.g. "DBStateChange")
 func (et EventType) String() string {
 	if et >= eventTypeCount {
 		return fmt.Sprintf("EventType(%d)", et)

--- a/db/event.go
+++ b/db/event.go
@@ -10,13 +10,26 @@ import (
 	"github.com/robertkrimen/otto"
 )
 
-// Event type
+// EventType is an enum for each unique event type.
 type EventType uint8
 
 const (
-	DocumentChange EventType = iota
-	DBStateChange
+	DocumentChange EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
+	DBStateChange                   // fires when the database is created or is taken offline/online
+
+	eventTypeCount
 )
+
+var eventTypeNames = []string{"DocumentChange", "DBStateChange"}
+
+// String returns the string representation of an event type (e.g. "WinningRevChange")
+func (et EventType) String() string {
+	if et >= eventTypeCount {
+		return fmt.Sprintf("EventType(%d)", et)
+
+	}
+	return eventTypeNames[et]
+}
 
 // An event that can be raised during SG processing.
 type Event interface {

--- a/db/event.go
+++ b/db/event.go
@@ -14,13 +14,14 @@ import (
 type EventType uint8
 
 const (
-	DocumentChange EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
-	DBStateChange                   // fires when the database is created or is taken offline/online
+	DocumentChange   EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
+	DBStateChange                     // fires when the database is created or is taken offline/online
+	WinningRevChange                  // like DocumentChange, but fires only when the change caused the winning revision to change
 
 	eventTypeCount
 )
 
-var eventTypeNames = []string{"DocumentChange", "DBStateChange"}
+var eventTypeNames = []string{"DocumentChange", "DBStateChange", "WinningRevChange"}
 
 // String returns the string representation of an event type (e.g. "WinningRevChange")
 func (et EventType) String() string {
@@ -46,6 +47,19 @@ type AsyncEvent struct {
 
 func (ae AsyncEvent) Synchronous() bool {
 	return false
+}
+
+// WinningRevChangeEvent is a DocumentChangeEvent that is only raised when the winning revision of a document has changed.
+type WinningRevChangeEvent struct {
+	DocumentChangeEvent
+}
+
+func (wrce *WinningRevChangeEvent) String() string {
+	return fmt.Sprintf("Winning rev change event for doc id: %s", wrce.DocID)
+}
+
+func (wrce *WinningRevChangeEvent) EventType() EventType {
+	return WinningRevChange
 }
 
 // DocumentChangeEvent is raised when a document has been successfully written to the backing
@@ -162,6 +176,11 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 		result, err = ef.Call(sgbucket.JSONString(event.DocBytes), sgbucket.JSONString(event.OldDoc))
 	case *DBStateChangeEvent:
 		result, err = ef.Call(event.Doc)
+	case *WinningRevChangeEvent:
+		result, err = ef.Call(sgbucket.JSONString(event.DocBytes), sgbucket.JSONString(event.OldDoc))
+	default:
+		base.Warnf("unknown event %v tried to call function", event.EventType())
+		return "", fmt.Errorf("unknown event %v tried to call function", event.EventType())
 	}
 
 	if err != nil {
@@ -190,7 +209,7 @@ func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
 		}
 		return boolResult, nil
 	default:
-		base.Warnf("Event validate function returned non-boolean result %v", result)
+		base.Warnf("Event validate function returned non-boolean result %T %v", result, result)
 		return false, errors.New("Validate function returned non-boolean value.")
 	}
 

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -81,8 +81,10 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 	switch event := event.(type) {
 	case *DocumentChangeEvent:
 		// skip event if this is for a non-winning rev and the winning rev only option is enabled
-		if val, ok := wh.options[EventOptionDocumentChangedWinningRevOnly]; ok && val.(bool) && !event.WinningRevChange {
-			return false
+		if !event.WinningRevChange && wh.options != nil {
+			if val, ok := wh.options[EventOptionDocumentChangedWinningRevOnly]; ok && val.(bool) {
+				return false
+			}
 		}
 		payload = event.DocBytes
 	case *DBStateChangeEvent:

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -68,8 +68,6 @@ func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, e
 // on the event type.
 func (wh *Webhook) HandleEvent(event Event) bool {
 
-	var payload []byte
-	var contentType string
 	if wh.filter != nil {
 		// If filter function is defined, use it to determine whether to post
 		success, err := wh.filter.CallValidateFunction(event)
@@ -83,8 +81,14 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 		}
 	}
 
+	var payload []byte
+	var contentType string
+
 	// Different events post different content by default
 	switch event := event.(type) {
+	case *WinningRevChangeEvent:
+		contentType = "application/json"
+		payload = event.DocBytes
 	case *DocumentChangeEvent:
 		contentType = "application/json"
 		payload = event.DocBytes

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -182,3 +182,22 @@ func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, rea
 
 	return em.raiseEvent(event)
 }
+
+// Raises a winning rev change event based on the the document body and channel set.  If the
+// event manager doesn't have a listener for this event, ignores.
+func (em *EventManager) RaiseWinningRevChangeEvent(docBytes []byte, docID string, oldBodyJSON string, channels base.Set) error {
+
+	if !em.activeEventTypes[WinningRevChange] {
+		return nil
+	}
+	event := &WinningRevChangeEvent{
+		DocumentChangeEvent: DocumentChangeEvent{
+			DocID:    docID,
+			DocBytes: docBytes,
+			OldDoc:   oldBodyJSON,
+			Channels: channels,
+		},
+	}
+
+	return em.raiseEvent(event)
+}

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -44,13 +44,10 @@ const kEventWaitTime = 100   // time (ms) to wait before dropping event, when ev
 // Creates a new event manager.  Sets up the event channel for async events, and the goroutine to
 // monitor and process that channel.
 func NewEventManager() *EventManager {
-
-	em := &EventManager{
-		eventHandlers: make(map[EventType][]EventHandler, 0),
+	return &EventManager{
+		eventHandlers:    make(map[EventType][]EventHandler, 0),
+		activeEventTypes: make(map[EventType]bool),
 	}
-	// Create channel for queued asynchronous events.
-	em.activeEventTypes = make(map[EventType]bool)
-	return em
 }
 
 // Starts the listener queue for the event manager
@@ -164,15 +161,20 @@ func (em *EventManager) RaiseDocumentChangeEvent(docBytes []byte, docID string, 
 
 // Raises a DB state change event based on the db name, admininterface, new state, reason and local system time.
 // If the event manager doesn't have a listener for this event, ignores.
-func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, reason string, adminInterface string) error {
+func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, reason string, adminInterface *string) error {
 
 	if !em.activeEventTypes[DBStateChange] {
 		return nil
 	}
 
+	adminInterfaceStr := ""
+	if adminInterface != nil {
+		adminInterfaceStr = *adminInterface
+	}
+
 	body := make(Body, 5)
 	body["dbname"] = dbName
-	body["admininterface"] = adminInterface
+	body["admininterface"] = adminInterfaceStr
 	body["state"] = state
 	body["reason"] = reason
 	body["localtime"] = time.Now().Format(base.ISO8601Format)

--- a/db/event_manager.go
+++ b/db/event_manager.go
@@ -145,16 +145,17 @@ func (em *EventManager) raiseEvent(event Event) error {
 
 // Raises a document change event based on the the document body and channel set.  If the
 // event manager doesn't have a listener for this event, ignores.
-func (em *EventManager) RaiseDocumentChangeEvent(docBytes []byte, docID string, oldBodyJSON string, channels base.Set) error {
+func (em *EventManager) RaiseDocumentChangeEvent(docBytes []byte, docID string, oldBodyJSON string, channels base.Set, winningRevChange bool) error {
 
 	if !em.activeEventTypes[DocumentChange] {
 		return nil
 	}
 	event := &DocumentChangeEvent{
-		DocID:    docID,
-		DocBytes: docBytes,
-		OldDoc:   oldBodyJSON,
-		Channels: channels,
+		DocID:            docID,
+		DocBytes:         docBytes,
+		OldDoc:           oldBodyJSON,
+		Channels:         channels,
+		WinningRevChange: winningRevChange,
 	}
 
 	return em.raiseEvent(event)
@@ -178,25 +179,6 @@ func (em *EventManager) RaiseDBStateChangeEvent(dbName string, state string, rea
 
 	event := &DBStateChangeEvent{
 		Doc: body,
-	}
-
-	return em.raiseEvent(event)
-}
-
-// Raises a winning rev change event based on the the document body and channel set.  If the
-// event manager doesn't have a listener for this event, ignores.
-func (em *EventManager) RaiseWinningRevChangeEvent(docBytes []byte, docID string, oldBodyJSON string, channels base.Set) error {
-
-	if !em.activeEventTypes[WinningRevChange] {
-		return nil
-	}
-	event := &WinningRevChangeEvent{
-		DocumentChangeEvent: DocumentChangeEvent{
-			DocID:    docID,
-			DocBytes: docBytes,
-			OldDoc:   oldBodyJSON,
-			Channels: channels,
-		},
 	}
 
 	return em.raiseEvent(event)

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -103,7 +103,7 @@ func TestDocumentChangeEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -129,12 +129,12 @@ func TestDBStateChangeEvent(t *testing.T) {
 	em.RegisterEventHandler(testHandler, DBStateChange)
 	//Raise online events
 	for i := 0; i < 10; i++ {
-		err := em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", "0.0.0.0:0000")
+		err := em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", base.StringPtr("0.0.0.0:0000"))
 		assert.NoError(t, err)
 	}
 	//Raise offline events
 	for i := 10; i < 20; i++ {
-		err := em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", "0.0.0.0:0000")
+		err := em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", base.StringPtr("0.0.0.0:0000"))
 		assert.NoError(t, err)
 	}
 
@@ -184,7 +184,7 @@ func TestSlowExecutionProcessing(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		body, docid, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -225,7 +225,7 @@ func TestCustomHandler(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -268,7 +268,7 @@ func TestUnhandledEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -445,12 +445,12 @@ func TestWebhookBasic(t *testing.T) {
 	log.Println("Test basic webhook")
 	em := NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil)
+	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err := em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -469,12 +469,12 @@ func TestWebhookBasic(t *testing.T) {
 								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -487,11 +487,11 @@ func TestWebhookBasic(t *testing.T) {
 	wr.Clear()
 	em = NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	body, docId, channels := eventForTest(0)
 	bodyBytes, _ := base.JSONMarshalCanonical(body)
-	err = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+	err = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 	assert.NoError(t, err)
 	err = em.waitForProcessedTotal(context.TODO(), 1, DefaultWaitForWebhook)
 	assert.NoError(t, err)
@@ -505,12 +505,12 @@ func TestWebhookBasic(t *testing.T) {
 	em = NewEventManager()
 	em.Start(5, -1)
 	timeout := uint64(60)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 100, DefaultWaitForWebhook)
@@ -523,12 +523,12 @@ func TestWebhookBasic(t *testing.T) {
 	errCount := 0
 	em = NewEventManager()
 	em.Start(5, 1)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		if err != nil {
 			errCount++
 		}
@@ -545,12 +545,12 @@ func TestWebhookBasic(t *testing.T) {
 	wr.Clear()
 	em = NewEventManager()
 	em.Start(5, 1100)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 100, 10*time.Second)
@@ -592,7 +592,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	log.Println("Test basic webhook where an old doc is passed but not filtered")
 	em := NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil)
+	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -600,7 +600,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 
 	}
@@ -621,7 +621,7 @@ func TestWebhookOldDoc(t *testing.T) {
 								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -629,7 +629,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -649,7 +649,7 @@ func TestWebhookOldDoc(t *testing.T) {
 								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -657,7 +657,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -677,12 +677,12 @@ func TestWebhookOldDoc(t *testing.T) {
 								return false;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	for i := 10; i < 20; i++ {
@@ -691,7 +691,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 20, DefaultWaitForWebhook)
@@ -735,12 +735,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em := NewEventManager()
 	em.Start(0, -1)
 	timeout := uint64(2)
-	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout)
+	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err := em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -757,12 +757,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em = NewEventManager()
 	em.Start(1, 1500)
 	timeout = uint64(1)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_2s", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_2s", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
 			errCount++
@@ -782,12 +782,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em = NewEventManager()
 	em.Start(1, 100)
 	timeout = uint64(9)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_5s", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_5s", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
 			errCount++
@@ -805,12 +805,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em = NewEventManager()
 	em.Start(1, 1100)
 	timeout = uint64(0)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
 			errCount++
@@ -850,12 +850,12 @@ func TestUnavailableWebhook(t *testing.T) {
 
 	em := NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "", nil)
+	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(-i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -13,7 +13,6 @@ func TestEventTypeNames(t *testing.T) {
 
 	assert.Equal(t, "DocumentChange", DocumentChange.String())
 	assert.Equal(t, "DBStateChange", DBStateChange.String())
-	assert.Equal(t, "WinningRevChange", WinningRevChange.String())
 
 	// Test out of bounds event type
 	assert.Equal(t, "EventType(255)", EventType(math.MaxUint8).String())

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventTypeNames(t *testing.T) {
+	// Ensure number of level constants, and names match.
+	assert.Equal(t, int(eventTypeCount), len(eventTypeNames))
+
+	assert.Equal(t, "DocumentChange", DocumentChange.String())
+	assert.Equal(t, "DBStateChange", DBStateChange.String())
+
+	// Test out of bounds event type
+	assert.Equal(t, "EventType(255)", EventType(math.MaxUint8).String())
+}

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -13,6 +13,7 @@ func TestEventTypeNames(t *testing.T) {
 
 	assert.Equal(t, "DocumentChange", DocumentChange.String())
 	assert.Equal(t, "DBStateChange", DBStateChange.String())
+	assert.Equal(t, "WinningRevChange", WinningRevChange.String())
 
 	// Test out of bounds event type
 	assert.Equal(t, "EventType(255)", EventType(math.MaxUint8).String())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4805,6 +4806,74 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	assert.NotEqual(t, revIdAfterAttachment, doc1revId)
 	wg.Add(1)
 	wg.Wait()
+}
+
+// TestWebhookWinningRevChangedEvent ensures the winning_rev_changed event is only fired for a winning revision change, and checks that document_changed is always fired.
+func TestWebhookWinningRevChangedEvent(t *testing.T) {
+
+	wg := sync.WaitGroup{}
+
+	var WinningRevChangedCount uint32
+	var DocumentChangedCount uint32
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		var body db.Body
+		d := base.JSONDecoder(r.Body)
+		require.NoError(t, d.Decode(&body))
+		require.Contains(t, body, db.BodyId)
+		require.Contains(t, body, db.BodyRev)
+
+		event := r.URL.Query().Get("event")
+		switch event {
+		case "WinningRevChanged":
+			atomic.AddUint32(&WinningRevChangedCount, 1)
+		case "DocumentChanged":
+			atomic.AddUint32(&DocumentChangedCount, 1)
+		default:
+			t.Fatalf("unknown event type: %s", event)
+		}
+
+		wg.Done()
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(handler))
+	defer s.Close()
+
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			EventHandlers: &EventHandlerConfig{
+				DocumentChanged: []*EventConfig{
+					{Url: s.URL + "?event=DocumentChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
+				},
+				WinningRevChanged: []*EventConfig{
+					{Url: s.URL + "?event=WinningRevChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
+				},
+			},
+		},
+	}
+	rt := NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	res := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+	rev1 := respRevID(t, res)
+	_, rev1Hash := db.ParseRevID(rev1)
+
+	// push winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+
+	// push non-winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzzzzz","_revisions":{"start":2,"ids":["buzzzzz","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(1)
+
+	wg.Wait()
+
+	assert.Equal(t, 2, int(atomic.LoadUint32(&WinningRevChangedCount)))
+	assert.Equal(t, 3, int(atomic.LoadUint32(&DocumentChangedCount)))
 }
 
 func Benchmark_RestApiGetDocPerformance(b *testing.B) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4844,9 +4844,9 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 			EventHandlers: &EventHandlerConfig{
 				DocumentChanged: []*EventConfig{
 					{Url: s.URL + "?event=DocumentChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
-				},
-				WinningRevChanged: []*EventConfig{
-					{Url: s.URL + "?event=WinningRevChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
+					{Url: s.URL + "?event=WinningRevChanged", Filter: "function(doc){return true;}", HandlerType: "webhook",
+						Options: map[string]interface{}{db.EventOptionDocumentChangedWinningRevOnly: true},
+					},
 				},
 			},
 		},

--- a/rest/config.go
+++ b/rest/config.go
@@ -228,10 +228,11 @@ type CORSConfig struct {
 }
 
 type EventHandlerConfig struct {
-	MaxEventProc    uint           `json:"max_processes,omitempty"`    // Max concurrent event handling goroutines
-	WaitForProcess  string         `json:"wait_for_process,omitempty"` // Max wait time when event queue is full (ms)
-	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
-	DBStateChanged  []*EventConfig `json:"db_state_changed,omitempty"` // DB state change
+	MaxEventProc      uint           `json:"max_processes,omitempty"`       // Max concurrent event handling goroutines
+	WaitForProcess    string         `json:"wait_for_process,omitempty"`    // Max wait time when event queue is full (ms)
+	DocumentChanged   []*EventConfig `json:"document_changed,omitempty"`    // Document changed
+	WinningRevChanged []*EventConfig `json:"winning_rev_changed,omitempty"` // Winning revision changed
+	DBStateChanged    []*EventConfig `json:"db_state_changed,omitempty"`    // DB state change
 }
 
 type EventConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -228,18 +228,18 @@ type CORSConfig struct {
 }
 
 type EventHandlerConfig struct {
-	MaxEventProc      uint           `json:"max_processes,omitempty"`       // Max concurrent event handling goroutines
-	WaitForProcess    string         `json:"wait_for_process,omitempty"`    // Max wait time when event queue is full (ms)
-	DocumentChanged   []*EventConfig `json:"document_changed,omitempty"`    // Document changed
-	WinningRevChanged []*EventConfig `json:"winning_rev_changed,omitempty"` // Winning revision changed
-	DBStateChanged    []*EventConfig `json:"db_state_changed,omitempty"`    // DB state change
+	MaxEventProc    uint           `json:"max_processes,omitempty"`    // Max concurrent event handling goroutines
+	WaitForProcess  string         `json:"wait_for_process,omitempty"` // Max wait time when event queue is full (ms)
+	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document changed
+	DBStateChanged  []*EventConfig `json:"db_state_changed,omitempty"` // DB state change
 }
 
 type EventConfig struct {
-	HandlerType string  `json:"handler"`           // Handler type
-	Url         string  `json:"url,omitempty"`     // Url (webhook)
-	Filter      string  `json:"filter,omitempty"`  // Filter function (webhook)
-	Timeout     *uint64 `json:"timeout,omitempty"` // Timeout (webhook)
+	HandlerType string                 `json:"handler"`           // Handler type
+	Url         string                 `json:"url,omitempty"`     // Url (webhook)
+	Filter      string                 `json:"filter,omitempty"`  // Filter function (webhook)
+	Timeout     *uint64                `json:"timeout,omitempty"` // Timeout (webhook)
+	Options     map[string]interface{} `json:"options,omitempty"` // Options can be specified per-handler, and are specific to each type.
 }
 
 type CacheConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -160,9 +160,7 @@ func (sc *ServerContext) Close() {
 
 	for _, ctx := range sc.databases_ {
 		ctx.Close()
-		if ctx.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
-		}
+		_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
 	}
 
 	sc.databases_ = nil
@@ -569,14 +567,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	if config.StartOffline {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
-		}
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-		if dbcontext.EventMgr.HasHandlerForEvent(db.DBStateChange) {
-			_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
-		}
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
 	}
 
 	return dbcontext, nil
@@ -777,8 +771,9 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 
 	// Load Webhook Filter Function.
 	eventHandlersByType := map[db.EventType][]*EventConfig{
-		db.DocumentChange: config.EventHandlers.DocumentChanged,
-		db.DBStateChange:  config.EventHandlers.DBStateChanged,
+		db.DocumentChange:   config.EventHandlers.DocumentChanged,
+		db.DBStateChange:    config.EventHandlers.DBStateChanged,
+		db.WinningRevChange: config.EventHandlers.WinningRevChanged,
 	}
 
 	for eventType, handlers := range eventHandlersByType {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -161,7 +161,7 @@ func (sc *ServerContext) Close() {
 
 	for _, ctx := range sc.databases_ {
 		ctx.Close()
-		_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", *sc.config.AdminInterface)
+		_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", sc.config.AdminInterface)
 	}
 
 	sc.databases_ = nil
@@ -568,10 +568,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 
 	if config.StartOffline {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", *sc.config.AdminInterface)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", sc.config.AdminInterface)
 	} else {
 		atomic.StoreUint32(&dbcontext.State, db.DBOnline)
-		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", *sc.config.AdminInterface)
+		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "online", "DB loaded from config", sc.config.AdminInterface)
 	}
 
 	return dbcontext, nil


### PR DESCRIPTION
- Adds generic options map to events/webhooks.
- Current validation ensures that `document_changed.winning_rev_only=true/false` is the only allowed option.
- Webhooks are only sent for changes to a winning revision when this option is enabled. 
  - Note this still allows for duplicate revs to be sent, if a previously winning revision is made the winner again (after tombstoning the current winning revision/branch).