### PR TITLE
Add GitHub action for automated lint comments in PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,45 @@
+name: Go
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'release/*'
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    # Checkout the commit that caused the action to run.
+    # We'll bootstrap for dependencies, but use this copy of the SG code.
+    - uses: actions/checkout@v2
+
+    # Bootstrap (dependencies)
+    # Note: Copying bootstrap.sh because it won't run from the same directory as main.go
+    - name: Bootstrap
+      run: |
+        mkdir -p .sgdeps
+        cp bootstrap.sh .sgdeps/
+        cd .sgdeps
+        chmod +x bootstrap.sh
+        ./bootstrap.sh -c ${{ github.event.pull_request.head.sha }}
+
+    - name: Set GOPATH
+      run: |
+        echo "GOPATH=${GITHUB_WORKSPACE}/.sgdeps/godeps" >> $GITHUB_ENV
+
+    # Lint
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.34
+        only-new-issues: true
+
+# Only Go need if running tests, golangci-lint doesn't need it...
+#     - name: Set up Go 1.13.4
+#       uses: actions/setup-go@v2
+#       with:
+#         go-version: ^1.13.4


### PR DESCRIPTION
Added a GitHub Action that is run on any PR opened targeting `master` or `release/*`

The `golangci-lint-action` leaves inline annotations on PRs for any newly introduced issues it found, based on the rules in the `.golangci.yml` config file we already have in the repo.

Example:
![Screenshot 2021-01-07 at 16 37 57](https://user-images.githubusercontent.com/1525809/103918433-b7309480-5106-11eb-8d3e-34863349ba1d.png)

