### PR TITLE
CBG-837: Enhance resync to offer sequence regen

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -252,6 +252,18 @@ func (auth *Authenticator) Save(p Principal) error {
 	return nil
 }
 
+// Used for resync
+func (auth *Authenticator) UpdateSequenceNumber(p Principal, seq uint64) error {
+	p.SetSequence(seq)
+	casOut, writeErr := auth.bucket.WriteCas(p.DocID(), 0, 0, p.Cas(), p, 0)
+	if writeErr != nil {
+		return writeErr
+	}
+	p.SetCas(casOut)
+
+	return nil
+}
+
 // Invalidates the channel list of a user/role by saving its Channels() property as nil.
 func (auth *Authenticator) InvalidateChannels(p Principal) error {
 	invalidateChannelsCallback := func(p Principal) (updatedPrincipal Principal, err error) {

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -141,7 +141,7 @@ func DefaultCacheOptions() CacheOptions {
 			MaxNumChannels:              DefaultChannelCacheMaxNumber,
 			CompactHighWatermarkPercent: DefaultCompactHighWatermarkPercent,
 			CompactLowWatermarkPercent:  DefaultCompactLowWatermarkPercent,
-			ChannelQueryLimit:           DefaultChannelQueryLimit,
+			ChannelQueryLimit:           DefaultQueryPaginationLimit,
 		},
 	}
 }

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -21,7 +21,6 @@ var (
 	DefaultChannelCacheMaxNumber       = 50000            // Default of 50k channel caches
 	DefaultCompactHighWatermarkPercent = 80               // Default compaction high watermark (percent of MaxNumber)
 	DefaultCompactLowWatermarkPercent  = 60               // Default compaction low watermark (percent of MaxNumber)
-	DefaultChannelQueryLimit           = 5000             // Default channel query limit
 )
 
 type ChannelCache interface {

--- a/db/database.go
+++ b/db/database.go
@@ -885,13 +885,10 @@ outerLoop:
 				resultCount++
 			}
 
-			// Skip first result if using startKey as startKey results in an overlapping result
+			// Second part of or skips first result if using startKey as this results in an overlapping result
 			// This was cheaper than a contains check
-			if resultCount == 1 && startKey != "" {
-				continue
-			}
 
-			if principalName != "" {
+			if principalName != "" && (resultCount != 1 && startKey != "") {
 				if isUser {
 					users = append(users, principalName)
 				} else {

--- a/db/database.go
+++ b/db/database.go
@@ -1044,8 +1044,7 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 // Re-runs the sync function on every current document in the database (if doCurrentDocs==true)
 // and/or imports docs in the bucket not known to the gateway (if doImportDocs==true).
 // To be used when the JavaScript sync function changes.
-func (db *Database) UpdateAllDocChannels() (int, error) {
-
+func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) {
 	base.Infof(base.KeyAll, "Recomputing document channels...")
 	base.Infof(base.KeyAll, "Re-running sync function on all documents...")
 
@@ -1067,6 +1066,8 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 	defer func() {
 		db.ResyncManager.UpdateProcessedChanged(docsProcessed, docsChanged)
 	}()
+
+	var unusedSequences []uint64
 
 	for {
 		results, err := db.QueryResync(queryLimit, startSeq, endSeq)
@@ -1094,7 +1095,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 			docsProcessed++
 			documentUpdateFunc := func(doc *Document) (updatedDoc *Document, shouldUpdate bool, updatedExpiry *uint32, err error) {
 				highSeq = doc.Sequence
-				imported := false
+				forceUpdate := false
 				if !doc.HasValidSyncData() {
 					// This is a document not known to the sync gateway. Ignore it:
 					return nil, false, nil, base.ErrUpdateCancel
@@ -1124,6 +1125,15 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 					rev.Channels = channels
 
 					if rev.ID == doc.CurrentRev {
+
+						if regenerateSequences {
+							unusedSequences, err = db.assignSequence(0, doc, unusedSequences)
+							if err != nil {
+								base.Warnf("Unable to assign a sequence number: %v", err)
+							}
+							forceUpdate = true
+						}
+
 						changedChannels, err := doc.updateChannels(channels)
 						changed = len(doc.Access.updateAccess(doc, access)) +
 							len(doc.RoleAccess.updateAccess(doc, roles)) +
@@ -1138,7 +1148,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 						}
 					}
 				})
-				shouldUpdate = changed > 0 || imported
+				shouldUpdate = changed > 0 || forceUpdate
 				return doc, shouldUpdate, updatedExpiry, nil
 			}
 			var err error
@@ -1190,6 +1200,7 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 						if updatedExpiry != nil {
 							updatedDoc.UpdateExpiry(*updatedExpiry)
 						}
+
 						updatedBytes, marshalErr := base.JSONMarshal(updatedDoc)
 						return updatedBytes, updatedExpiry, false, marshalErr
 					} else {
@@ -1217,6 +1228,77 @@ func (db *Database) UpdateAllDocChannels() (int, error) {
 		}
 		startSeq = highSeq + 1
 	}
+
+	for _, sequence := range unusedSequences {
+		err := db.sequences.releaseSequence(sequence)
+		if err != nil {
+			base.Warnf("Error attempting to release sequence %d. Error %v", sequence, err)
+		}
+	}
+
+	if regenerateSequences {
+		users, roles, err := db.AllPrincipalIDs()
+		if err != nil {
+			return docsChanged, err
+		}
+
+		authr := db.Authenticator()
+		regeneratePrincipalSequences := func(princ auth.Principal, isUser bool) error {
+			nextSeq, err := db.DatabaseContext.sequences.nextSequence()
+			if err != nil {
+				return err
+			}
+			princ.SetSequence(nextSeq)
+
+			princChannels := princ.Channels()
+			for name := range princChannels {
+				princChannels[name] = channels.NewVbSimpleSequence(nextSeq)
+			}
+			princ.SetExplicitChannels(princChannels)
+
+			if isUser {
+				user := princ.(auth.User)
+				princRoles := user.ExplicitRoles()
+				for name := range princRoles {
+					princRoles[name] = channels.NewVbSimpleSequence(nextSeq)
+				}
+				user.SetExplicitRoles(princRoles)
+			}
+
+			err = authr.Save(princ)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+
+		for _, role := range roles {
+			authr := db.Authenticator()
+			role, err := authr.GetRole(role)
+			if err != nil {
+				return docsChanged, err
+			}
+			err = regeneratePrincipalSequences(role, false)
+			if err != nil {
+				return docsChanged, err
+			}
+		}
+
+		for _, user := range users {
+			authr := db.Authenticator()
+			user, err := authr.GetUser(user)
+			if err != nil {
+				return docsChanged, err
+			}
+			err = regeneratePrincipalSequences(user, true)
+			if err != nil {
+				return docsChanged, err
+			}
+		}
+
+	}
+
 	base.Infof(base.KeyAll, "Finished re-running sync function; %d/%d docs changed", docsChanged, docsProcessed)
 
 	if docsChanged > 0 {

--- a/db/database.go
+++ b/db/database.go
@@ -69,8 +69,7 @@ var (
 
 var DefaultCompactInterval = uint32(60 * 60 * 24) // Default compact interval in seconds = 1 Day
 var (
-	DefaultResyncQueryLimit    = 5000
-	DefaultPrincipalQueryLimit = 5000
+	DefaultQueryPaginationLimit = 5000
 )
 
 const (
@@ -142,8 +141,7 @@ type DatabaseContextOptions struct {
 	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
 	SGReplicateOptions        SGReplicateOptions
 	SlowQueryWarningThreshold time.Duration
-	ResyncQueryLimit          int // Limit used for pagination of resync queries. If not set defaults to DefaultResyncQueryLimit
-	PrincipalQueryLimit       int // Limit used for pagination of principal doc queries. If not set defaults to DefaultPrincipalQueryLimit
+	QueryPaginationLimit      int // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
 }
 
 type SGReplicateOptions struct {
@@ -845,7 +843,7 @@ type principalsViewRow struct {
 func (db *DatabaseContext) AllPrincipalIDs() (users, roles []string, err error) {
 
 	startKey := ""
-	limit := db.Options.PrincipalQueryLimit
+	limit := db.Options.QueryPaginationLimit
 
 	users = []string{}
 	roles = []string{}
@@ -1077,7 +1075,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) 
 	base.Infof(base.KeyAll, "Recomputing document channels...")
 	base.Infof(base.KeyAll, "Re-running sync function on all documents...")
 
-	queryLimit := db.Options.ResyncQueryLimit
+	queryLimit := db.Options.QueryPaginationLimit
 	startSeq := uint64(0)
 	endSeq, err := db.sequences.getSequence()
 	if err != nil {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2357,7 +2357,7 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 		channel("x")
 	}`
 
-	db := setupTestDBWithOptions(t, DatabaseContextOptions{ResyncQueryLimit: 5000})
+	db := setupTestDBWithOptions(t, DatabaseContextOptions{QueryPaginationLimit: 5000})
 
 	_, err := db.UpdateSyncFun(syncFn)
 	assert.NoError(t, err)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2379,7 +2379,8 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 		return state == DBOffline
 	})
 
-	_, err = db.UpdateAllDocChannels()
+	_, err = db.UpdateAllDocChannels(false)
+	assert.NoError(t, err)
 
 	syncFnCount := int(db.DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 	assert.Equal(t, 20, syncFnCount)

--- a/db/query.go
+++ b/db/query.go
@@ -220,7 +220,6 @@ const (
 	QueryParamStartKey    = "startkey"
 	QueryParamEndKey      = "endkey"
 	QueryParamLimit       = "limit"
-	QueryParamSkip        = "skip"
 
 	// Variables in the select clause can't be parameterized, require additional handling
 	QuerySelectUserName = "$$selectUserName"

--- a/db/query.go
+++ b/db/query.go
@@ -140,8 +140,9 @@ var QueryPrincipals = SGQuery{
 			"USE INDEX($idx) "+
 			"WHERE META(`%s`).id LIKE '%s' "+
 			"AND (META(`%s`).id LIKE '%s' "+
-			"OR META(`%s`).id LIKE '%s')",
-		base.BucketQueryToken, base.BucketQueryToken, base.BucketQueryToken, SyncDocWildcard, base.BucketQueryToken, `\\_sync:user:%`, base.BucketQueryToken, `\\_sync:role:%`),
+			"OR META(`%s`).id LIKE '%s')"+
+			"ORDER BY META(`%s`).id",
+		base.BucketQueryToken, base.BucketQueryToken, base.BucketQueryToken, SyncDocWildcard, base.BucketQueryToken, `\\_sync:user:%`, base.BucketQueryToken, `\\_sync:role:%`, base.BucketQueryToken),
 	adhoc: false,
 }
 
@@ -412,7 +413,7 @@ func (context *DatabaseContext) QueryResync(limit int, startSeq, endSeq uint64) 
 }
 
 // Query to retrieve the set of user and role doc ids, using the primary index
-func (context *DatabaseContext) QueryPrincipals() (sgbucket.QueryResultIterator, error) {
+func (context *DatabaseContext) QueryPrincipals(limit int) (sgbucket.QueryResultIterator, error) {
 
 	// View Query
 	if context.Options.UseViews {
@@ -421,6 +422,11 @@ func (context *DatabaseContext) QueryPrincipals() (sgbucket.QueryResultIterator,
 	}
 
 	queryStatement := replaceIndexTokensQuery(QueryPrincipals.statement, sgIndexes[IndexSyncDocs], context.UseXattrs())
+
+	if limit > 0 {
+		// ADD LIMIT
+		// queryStatement = fmt.Sprintf("")
+	}
 
 	// N1QL Query
 	return context.N1QLQueryWithStats(QueryTypePrincipals, queryStatement, nil, gocb.RequestPlus, QueryPrincipals.adhoc)

--- a/db/query.go
+++ b/db/query.go
@@ -437,7 +437,7 @@ func (context *DatabaseContext) QueryPrincipals(startKey string, limit int) (sgb
 		queryStatement = fmt.Sprintf("%s LIMIT %d", queryStatement, limit)
 	}
 
-	params := make(map[string]interface{}, 0)
+	params := make(map[string]interface{})
 	if startKey != "" {
 		queryStatement = fmt.Sprintf("%s AND META(`%s`).id >= $startkey",
 			queryStatement, context.Bucket.GetName())

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1631,27 +1631,29 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	request, _ = http.NewRequest("GET", "/db/_all_docs", nil)
-	request.SetBasicAuth("user1", "letmein")
-	response = rt.Send(request)
-	assertStatus(t, response, http.StatusOK)
+	// Data is wiped from walrus when brought back online
+	if !base.UnitTestUrlIsWalrus() {
+		request, _ = http.NewRequest("GET", "/db/_all_docs", nil)
+		request.SetBasicAuth("user1", "letmein")
+		response = rt.Send(request)
+		assertStatus(t, response, http.StatusOK)
 
-	fmt.Println(string(response.BodyBytes()))
+		fmt.Println(string(response.BodyBytes()))
 
-	request, _ = http.NewRequest("GET", "/db/_all_docs", nil)
-	request.SetBasicAuth("user1", "letmein")
-	response = rt.Send(request)
-	assertStatus(t, response, http.StatusOK)
-	fmt.Println(string(response.BodyBytes()))
+		request, _ = http.NewRequest("GET", "/db/_all_docs", nil)
+		request.SetBasicAuth("user1", "letmein")
+		response = rt.Send(request)
+		assertStatus(t, response, http.StatusOK)
 
-	request, _ = http.NewRequest("GET", "/db/_changes?since="+changesResp.LastSeq, nil)
-	request.SetBasicAuth("user1", "letmein")
-	response = rt.Send(request)
-	assertStatus(t, response, http.StatusOK)
-	err = json.Unmarshal(response.BodyBytes(), &changesResp)
-	assert.Len(t, changesResp.Results, 3)
-	assert.True(t, changesRespContains(changesResp, "userdoc"))
-	assert.True(t, changesRespContains(changesResp, "userdoc2"))
+		request, _ = http.NewRequest("GET", "/db/_changes?since="+changesResp.LastSeq, nil)
+		request.SetBasicAuth("user1", "letmein")
+		response = rt.Send(request)
+		assertStatus(t, response, http.StatusOK)
+		err = json.Unmarshal(response.BodyBytes(), &changesResp)
+		assert.Len(t, changesResp.Results, 3)
+		assert.True(t, changesRespContains(changesResp, "userdoc"))
+		assert.True(t, changesRespContains(changesResp, "userdoc2"))
+	}
 
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1540,15 +1540,6 @@ func TestResyncRegenerateSequences(t *testing.T) {
 
 	response = rt.SendAdminRequest("POST", "/db/_online", "")
 	assertStatus(t, response, http.StatusOK)
-
-	srv := httptest.NewServer(rt.TestAdminHandler())
-	defer srv.Close()
-
-	fmt.Println("==============================")
-	fmt.Println(srv.URL)
-
-	time.Sleep(10 * time.Minute)
-	fmt.Println("x")
 }
 
 // Single threaded bring DB online

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1503,7 +1503,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 		channel("x")
 	}`
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	// defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	rt := NewRestTester(t,
 		&RestTesterConfig{

--- a/rest/api.go
+++ b/rest/api.go
@@ -174,7 +174,7 @@ func (h *handler) handleGetResync() error {
 func (h *handler) handlePostResync() error {
 	action := h.getQuery("action")
 	// TODO: To be added in CBG-837
-	// regenerateSequences, _ := h.getOptBoolQuery("regenerate_sequences", false)
+	regenerateSequences, _ := h.getOptBoolQuery("regenerate_sequences", false)
 
 	if action != "" && action != db.ResyncActionStart && action != db.ResyncActionStop {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unknown parameter for 'action'. Must be start or stop")
@@ -191,7 +191,7 @@ func (h *handler) handlePostResync() error {
 			go func() {
 				defer atomic.CompareAndSwapUint32(&h.db.State, db.DBResyncing, db.DBOffline)
 				defer h.db.ResyncManager.SetRunStatus(db.ResyncStateStopped)
-				_, err := h.db.UpdateAllDocChannels()
+				_, err := h.db.UpdateAllDocChannels(regenerateSequences)
 				if err != nil {
 					base.Errorf("Error occurred running resync operation: %v", err)
 					h.db.ResyncManager.SetError(err)

--- a/rest/api.go
+++ b/rest/api.go
@@ -173,7 +173,6 @@ func (h *handler) handleGetResync() error {
 
 func (h *handler) handlePostResync() error {
 	action := h.getQuery("action")
-	// TODO: To be added in CBG-837
 	regenerateSequences, _ := h.getOptBoolQuery("regenerate_sequences", false)
 
 	if action != "" && action != db.ResyncActionStart && action != db.ResyncActionStop {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2234,7 +2234,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	changed, err := database.UpdateSyncFun(`function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.NoError(t, err)
 	assert.True(t, changed)
-	changeCount, err := database.UpdateAllDocChannels()
+	changeCount, err := database.UpdateAllDocChannels(false)
 	assert.NoError(t, err)
 	assert.Equal(t, 9, changeCount)
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -2899,7 +2899,7 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 
 	rtConfig := RestTesterConfig{SyncFn: `function(doc, oldDoc){channel(doc.channels);}`}
 	queryLimit := 5
-	rtConfig.DatabaseConfig = &DbConfig{CacheConfig: &CacheConfig{ChannelCacheConfig: &ChannelCacheConfig{QueryLimit: &queryLimit}}}
+	rtConfig.DatabaseConfig = &DbConfig{CacheConfig: &CacheConfig{ChannelCacheConfig: &ChannelCacheConfig{DeprecatedQueryLimit: &queryLimit}}}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -197,8 +197,7 @@ type DbConfig struct {
 	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
-	ResyncQueryLimit                 *int                             `json:"resync_query_limit,omitempty"`
-	PrincipalQueryLimit              *int                             `json:"principal_query_limit,omitempty"`
+	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`
 }
 
 type DeltaSyncConfig struct {
@@ -279,7 +278,7 @@ type ChannelCacheConfig struct {
 	MaxLength            *int    `json:"max_length,omitempty"`                 // Maximum number of entries maintained in cache per channel
 	MinLength            *int    `json:"min_length,omitempty"`                 // Minimum number of entries maintained in cache per channel
 	ExpirySeconds        *int    `json:"expiry_seconds,omitempty"`             // Time (seconds) to keep entries in cache beyond the minimum retained
-	QueryLimit           *int    `json:"query_limit,omitempty"`                // Limit used for channel queries, if not specified by client
+	DeprecatedQueryLimit *int    `json:"query_limit,omitempty"`                // Limit used for channel queries, if not specified by client DEPRECATED in favour of db.QueryPaginationLimit
 }
 
 type UnsupportedServerConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -198,6 +198,7 @@ type DbConfig struct {
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	ResyncQueryLimit                 *int                             `json:"resync_query_limit,omitempty"`
+	PrincipalQueryLimit              *int                             `json:"principal_query_limit,omitempty"`
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1004,7 +1004,7 @@ func TestConfigToDatabaseOptions(t *testing.T) {
 	database, addDatabaseError := sc.AddDatabaseFromConfig(config.Databases["db"])
 	require.NoError(t, addDatabaseError)
 
-	assert.Equal(t, *config.Databases["db"].CacheConfig.ChannelCacheConfig.QueryLimit, database.Options.CacheOptions.ChannelQueryLimit)
+	assert.Equal(t, *config.Databases["db"].CacheConfig.ChannelCacheConfig.DeprecatedQueryLimit, database.Options.QueryPaginationLimit)
 
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -688,6 +688,17 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 	resyncQueryLimit := db.DefaultResyncQueryLimit
 	if config.ResyncQueryLimit != nil {
 		resyncQueryLimit = *config.ResyncQueryLimit
+		if *config.ResyncQueryLimit < 1 {
+			return db.DatabaseContextOptions{}, fmt.Errorf("resync_query_limit: %d must be greater than 0", *config.ResyncQueryLimit)
+		}
+	}
+
+	principalQueryLimit := db.DefaultPrincipalQueryLimit
+	if config.PrincipalQueryLimit != nil {
+		if *config.PrincipalQueryLimit < 2 {
+			return db.DatabaseContextOptions{}, fmt.Errorf("principal_query_limit: %d must be greater than 1", *config.PrincipalQueryLimit)
+		}
+		principalQueryLimit = *config.PrincipalQueryLimit
 	}
 
 	secureCookieOverride := sc.config.SSLCert != nil
@@ -729,6 +740,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
 		ResyncQueryLimit:          resyncQueryLimit,
+		PrincipalQueryLimit:       principalQueryLimit,
 		SGReplicateOptions: db.SGReplicateOptions{
 			Enabled:               sgReplicateEnabled,
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -682,39 +682,33 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		compactIntervalSecs = uint32(*config.CompactIntervalDays * 60 * 60 * 24)
 	}
 
-	var queryPaginationLimit *int
+	var queryPaginationLimit int
 
 	// If QueryPaginationLimit has been set use that first
 	if config.QueryPaginationLimit != nil {
-		queryPaginationLimit = config.QueryPaginationLimit
+		queryPaginationLimit = *config.QueryPaginationLimit
 	}
 
 	// If DeprecatedQueryLimit is set we need to handle this
 	if config.CacheConfig != nil && config.CacheConfig.ChannelCacheConfig != nil && config.CacheConfig.ChannelCacheConfig.DeprecatedQueryLimit != nil {
 		// If QueryPaginationLimit has not been set use the deprecated option
-		if queryPaginationLimit == nil {
+		if queryPaginationLimit == 0 {
 			base.Warnf("Using deprecated config parameter 'cache.channel_cache.query_limit'. Use 'query_pagination_limit' instead")
-			queryPaginationLimit = config.CacheConfig.ChannelCacheConfig.DeprecatedQueryLimit
-
-			// If DeprecatedQueryLimit is 0 we need to use the default value to maintain backwards compatibility with
-			// previous handling
-			if queryPaginationLimit == nil {
-				queryPaginationLimit = &db.DefaultQueryPaginationLimit
-			}
+			queryPaginationLimit = *config.CacheConfig.ChannelCacheConfig.DeprecatedQueryLimit
 		} else {
-			base.Warnf("Both 'cache.channel_cache.query_limit' and 'query_pagination_limit' have been used. Will use query_pagination_limit")
+			base.Warnf("Both query_pagination_limit and the deprecated cache.channel_cache.query_limit have been specified in config - using query_pagination_limit")
 		}
 	}
 
-	// If no limit has been set we will now choose the default
-	if queryPaginationLimit == nil {
-		queryPaginationLimit = &db.DefaultQueryPaginationLimit
+	// If no limit has been set (or is set to 0) we will now choose the default
+	if queryPaginationLimit == 0 {
+		queryPaginationLimit = db.DefaultQueryPaginationLimit
 	}
 
-	if *queryPaginationLimit < 2 {
+	if queryPaginationLimit < 2 {
 		return db.DatabaseContextOptions{}, fmt.Errorf("query_pagination_limit: %d must be greater than 1", queryPaginationLimit)
 	}
-	cacheOptions.ChannelQueryLimit = *queryPaginationLimit
+	cacheOptions.ChannelQueryLimit = queryPaginationLimit
 
 	secureCookieOverride := sc.config.SSLCert != nil
 	if config.SecureCookieOverride != nil {
@@ -754,7 +748,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
-		QueryPaginationLimit:      *queryPaginationLimit,
+		QueryPaginationLimit:      queryPaginationLimit,
 		SGReplicateOptions: db.SGReplicateOptions{
 			Enabled:               sgReplicateEnabled,
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,


### PR DESCRIPTION
Adds sequence regeneration option to resync query.
This also adds pagination to AllPrincipalIDs Query to avoid timeouts on that side.

Tested with unit test

- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/653/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/654/
