### PR TITLE
[2.8.1 Backport] - CBG-1244 - DocumentChange event winning_rev_only option

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -752,22 +752,32 @@ func GetGoCBBucketFromBaseBucket(baseBucket Bucket) (bucket CouchbaseBucketGoCB,
 	}
 }
 
+// StringPtr returns a pointer to the given string literal.
 func StringPtr(value string) *string {
 	return &value
 }
 
+// Uint32Ptr returns a pointer to the given uint32 literal.
 func Uint32Ptr(u uint32) *uint32 {
 	return &u
 }
 
+// Uint64Ptr returns a pointer to the given uint64 literal.
+func Uint64Ptr(u uint64) *uint64 {
+	return &u
+}
+
+// UintPtr returns a pointer to the given uint literal.
 func UintPtr(u uint) *uint {
 	return &u
 }
 
+// IntPtr returns a pointer to the given int literal.
 func IntPtr(i int) *int {
 	return &i
 }
 
+// BoolPtr returns a pointer to the given bool literal.
 func BoolPtr(b bool) *bool {
 	return &b
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1677,6 +1677,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 		return nil, "", base.HTTPErrorf(400, "Invalid doc ID")
 	}
 
+	var prevCurrentRev string
 	var storedDoc *Document
 	var changedAccessPrincipals, changedRoleAccessUsers []string // Returned by documentUpdateFunc
 	var docSequence uint64                                       // Must be scoped outside callback, used over multiple iterations
@@ -1695,6 +1696,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			if doc, err = unmarshalDocument(docid, currentValue); err != nil {
 				return
 			}
+			prevCurrentRev = doc.CurrentRev
 			docExists := currentValue != nil
 			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
@@ -1728,6 +1730,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			if doc, err = unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll); err != nil {
 				return
 			}
+			prevCurrentRev = doc.CurrentRev
 
 			// Check whether Sync Data originated in body
 			if currentXattr == nil && doc.Sequence > 0 {
@@ -1835,12 +1838,14 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			_shallowCopyBody: storedDoc.Body(),
 		}
 		db.revisionCache.Put(documentRevision)
+
 		if db.EventMgr.HasHandlerForEvent(DocumentChange) {
 			webhookJSON, err := doc.BodyWithSpecialProperties()
 			if err != nil {
 				base.Warnf("Error marshalling doc with id %s and revid %s for webhook post: %v", base.UD(docid), base.UD(newRevID), err)
 			} else {
-				err = db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels)
+				winningRevChange := prevCurrentRev != doc.CurrentRev
+				err = db.EventMgr.RaiseDocumentChangeEvent(webhookJSON, docid, oldBodyJSON, revChannels, winningRevChange)
 				if err != nil {
 					base.Debugf(base.KeyCRUD, "Error raising document change event: %v", err)
 				}

--- a/db/database.go
+++ b/db/database.go
@@ -667,11 +667,8 @@ func (dc *DatabaseContext) TakeDbOffline(reason string) error {
 		//set DB state to Offline
 		atomic.StoreUint32(&dc.State, DBOffline)
 
-		if dc.EventMgr.HasHandlerForEvent(DBStateChange) {
-			err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, *dc.Options.AdminInterface)
-			if err != nil {
-				base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
-			}
+		if err := dc.EventMgr.RaiseDBStateChangeEvent(dc.Name, "offline", reason, dc.Options.AdminInterface); err != nil {
+			base.Debugf(base.KeyCRUD, "Error raising database state change event: %v", err)
 		}
 
 		return nil

--- a/db/event.go
+++ b/db/event.go
@@ -10,13 +10,26 @@ import (
 	"github.com/robertkrimen/otto"
 )
 
-// Event type
+// EventType is an enum for each unique event type.
 type EventType uint8
 
 const (
-	DocumentChange EventType = iota
-	DBStateChange
+	DocumentChange EventType = iota // fires whenever a document is updated (even if the change did not cause the winning rev to change)
+	DBStateChange                   // fires when the database is created or is taken offline/online
+
+	eventTypeCount
 )
+
+var eventTypeNames = []string{"DocumentChange", "DBStateChange"}
+
+// String returns the string representation of an event type (e.g. "DBStateChange")
+func (et EventType) String() string {
+	if et >= eventTypeCount {
+		return fmt.Sprintf("EventType(%d)", et)
+
+	}
+	return eventTypeNames[et]
+}
 
 // An event that can be raised during SG processing.
 type Event interface {
@@ -39,10 +52,11 @@ func (ae AsyncEvent) Synchronous() bool {
 // data store.  Event has the document body and channel set as properties.
 type DocumentChangeEvent struct {
 	AsyncEvent
-	DocBytes []byte
-	DocID    string
-	OldDoc   string
-	Channels base.Set
+	DocBytes         []byte
+	DocID            string
+	OldDoc           string
+	Channels         base.Set
+	WinningRevChange bool // whether this event is a change to the winning revision
 }
 
 func (dce *DocumentChangeEvent) String() string {
@@ -149,6 +163,9 @@ func (ef *JSEventFunction) CallFunction(event Event) (interface{}, error) {
 		result, err = ef.Call(sgbucket.JSONString(event.DocBytes), sgbucket.JSONString(event.OldDoc))
 	case *DBStateChangeEvent:
 		result, err = ef.Call(event.Doc)
+	default:
+		base.Warnf("unknown event %v tried to call function", event.EventType())
+		return "", fmt.Errorf("unknown event %v tried to call function", event.EventType())
 	}
 
 	if err != nil {
@@ -177,7 +194,7 @@ func (ef *JSEventFunction) CallValidateFunction(event Event) (bool, error) {
 		}
 		return boolResult, nil
 	default:
-		base.Warnf("Event validate function returned non-boolean result %v", result)
+		base.Warnf("Event validate function returned non-boolean result %T %v", result, result)
 		return false, errors.New("Validate function returned non-boolean value.")
 	}
 

--- a/db/event.go
+++ b/db/event.go
@@ -16,7 +16,6 @@ type EventType uint8
 const (
 	DocumentChange EventType = iota
 	DBStateChange
-	UserAdd
 )
 
 // An event that can be raised during SG processing.

--- a/db/event_handler.go
+++ b/db/event_handler.go
@@ -27,13 +27,20 @@ type Webhook struct {
 	filter  *JSEventFunction
 	timeout time.Duration
 	client  *http.Client
+	options struct {
+		DocumentChangedWinningRevOnly bool
+	}
 }
 
-// default HTTP post timeout
-const kDefaultWebhookTimeout = 60
+const (
+	// default HTTP post timeout
+	kDefaultWebhookTimeout = 60
+	// EventOptionDocumentChangedWinningRevOnly controls whether a document_changed event is processed for winning revs only.
+	EventOptionDocumentChangedWinningRevOnly = "winning_rev_only"
+)
 
 // Creates a new webhook handler based on the url and filter function.
-func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, error) {
+func NewWebhook(url string, filterFnString string, timeout *uint64, options map[string]interface{}) (*Webhook, error) {
 
 	var err error
 
@@ -60,6 +67,10 @@ func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, e
 	transport.DisableKeepAlives = false
 	wh.client = &http.Client{Transport: transport, Timeout: wh.timeout}
 
+	if options != nil {
+		wh.options.DocumentChangedWinningRevOnly, _ = options[EventOptionDocumentChangedWinningRevOnly].(bool)
+	}
+
 	return wh, err
 }
 
@@ -68,25 +79,16 @@ func NewWebhook(url string, filterFnString string, timeout *uint64) (*Webhook, e
 // on the event type.
 func (wh *Webhook) HandleEvent(event Event) bool {
 
+	const contentType = "application/json"
 	var payload []byte
-	var contentType string
-	if wh.filter != nil {
-		// If filter function is defined, use it to determine whether to post
-		success, err := wh.filter.CallValidateFunction(event)
-		if err != nil {
-			base.Warnf("Error calling webhook filter function: %v", err)
-		}
-
-		// If filter returns false, cancel webhook post
-		if !success {
-			return false
-		}
-	}
 
 	// Different events post different content by default
 	switch event := event.(type) {
 	case *DocumentChangeEvent:
-		contentType = "application/json"
+		// skip event if this is for a non-winning rev and the winning rev only option is enabled
+		if !event.WinningRevChange && wh.options.DocumentChangedWinningRevOnly {
+			return false
+		}
 		payload = event.DocBytes
 	case *DBStateChangeEvent:
 		// for DBStateChangeEvent, post JSON document with the following format
@@ -102,12 +104,25 @@ func (wh *Webhook) HandleEvent(event Event) bool {
 			base.Warnf("Error marshalling doc for webhook post")
 			return false
 		}
-		contentType = "application/json"
 		payload = jsonOut
 	default:
 		base.Warnf("Webhook invoked for unsupported event type.")
 		return false
 	}
+
+	if wh.filter != nil {
+		// If filter function is defined, use it to determine whether to post
+		success, err := wh.filter.CallValidateFunction(event)
+		if err != nil {
+			base.Warnf("Error calling webhook filter function: %v", err)
+		}
+
+		// If filter returns false, cancel webhook post
+		if !success {
+			return false
+		}
+	}
+
 	success := func() bool {
 		resp, err := wh.client.Post(wh.url, contentType, bytes.NewBuffer(payload))
 		defer func() {

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -259,10 +259,10 @@ func TestUnhandledEvent(t *testing.T) {
 
 	resultChannel := make(chan interface{}, 10)
 
-	// create handler for UserAdd events
-	testHandler := &TestingHandler{HandledEvent: UserAdd}
+	// create handler for an unhandled event
+	testHandler := &TestingHandler{HandledEvent: math.MaxUint8}
 	testHandler.SetChannel(resultChannel)
-	em.RegisterEventHandler(testHandler, UserAdd)
+	em.RegisterEventHandler(testHandler, math.MaxUint8)
 
 	// send DocumentChange events to handler
 	for i := 0; i < 10; i++ {

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -103,7 +103,7 @@ func TestDocumentChangeEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -129,12 +129,12 @@ func TestDBStateChangeEvent(t *testing.T) {
 	em.RegisterEventHandler(testHandler, DBStateChange)
 	//Raise online events
 	for i := 0; i < 10; i++ {
-		err := em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", "0.0.0.0:0000")
+		err := em.RaiseDBStateChangeEvent(ids[i], "online", "DB started from config", base.StringPtr("0.0.0.0:0000"))
 		assert.NoError(t, err)
 	}
 	//Raise offline events
 	for i := 10; i < 20; i++ {
-		err := em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", "0.0.0.0:0000")
+		err := em.RaiseDBStateChangeEvent(ids[i], "offline", "Sync Gateway context closed", base.StringPtr("0.0.0.0:0000"))
 		assert.NoError(t, err)
 	}
 
@@ -184,7 +184,7 @@ func TestSlowExecutionProcessing(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		body, docid, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -225,7 +225,7 @@ func TestCustomHandler(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -268,7 +268,7 @@ func TestUnhandledEvent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -445,12 +445,12 @@ func TestWebhookBasic(t *testing.T) {
 	log.Println("Test basic webhook")
 	em := NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil)
+	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err := em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -469,12 +469,12 @@ func TestWebhookBasic(t *testing.T) {
 								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 
@@ -487,11 +487,11 @@ func TestWebhookBasic(t *testing.T) {
 	wr.Clear()
 	em = NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	body, docId, channels := eventForTest(0)
 	bodyBytes, _ := base.JSONMarshalCanonical(body)
-	err = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+	err = em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 	assert.NoError(t, err)
 	err = em.waitForProcessedTotal(context.TODO(), 1, DefaultWaitForWebhook)
 	assert.NoError(t, err)
@@ -505,12 +505,12 @@ func TestWebhookBasic(t *testing.T) {
 	em = NewEventManager()
 	em.Start(5, -1)
 	timeout := uint64(60)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 100, DefaultWaitForWebhook)
@@ -523,12 +523,12 @@ func TestWebhookBasic(t *testing.T) {
 	errCount := 0
 	em = NewEventManager()
 	em.Start(5, 1)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		if err != nil {
 			errCount++
 		}
@@ -545,12 +545,12 @@ func TestWebhookBasic(t *testing.T) {
 	wr.Clear()
 	em = NewEventManager()
 	em.Start(5, 1100)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
 		body, docId, channels := eventForTest(i % 10)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 100, 10*time.Second)
@@ -592,7 +592,7 @@ func TestWebhookOldDoc(t *testing.T) {
 	log.Println("Test basic webhook where an old doc is passed but not filtered")
 	em := NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil)
+	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -600,7 +600,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 
 	}
@@ -621,7 +621,7 @@ func TestWebhookOldDoc(t *testing.T) {
 								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -629,7 +629,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -649,7 +649,7 @@ func TestWebhookOldDoc(t *testing.T) {
 								return true;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		oldBody, oldDocId, _ := eventForTest(strconv.Itoa(-i), i)
@@ -657,7 +657,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -677,12 +677,12 @@ func TestWebhookOldDoc(t *testing.T) {
 								return false;
 							}
 							}`
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/echo", url), filterFunction, nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	for i := 10; i < 20; i++ {
@@ -691,7 +691,7 @@ func TestWebhookOldDoc(t *testing.T) {
 		oldBodyBytes, _ := base.JSONMarshal(oldBody)
 		body, docId, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, string(oldBodyBytes), channels, false)
 		assert.NoError(t, err)
 	}
 	err = em.waitForProcessedTotal(context.TODO(), 20, DefaultWaitForWebhook)
@@ -735,12 +735,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em := NewEventManager()
 	em.Start(0, -1)
 	timeout := uint64(2)
-	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout)
+	webhookHandler, _ := NewWebhook(fmt.Sprintf("%s/echo", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		assert.NoError(t, err)
 	}
 	err := em.waitForProcessedTotal(context.TODO(), 10, DefaultWaitForWebhook)
@@ -757,12 +757,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em = NewEventManager()
 	em.Start(1, 1500)
 	timeout = uint64(1)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_2s", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_2s", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
 			errCount++
@@ -782,12 +782,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em = NewEventManager()
 	em.Start(1, 100)
 	timeout = uint64(9)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_5s", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow_5s", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
 			errCount++
@@ -805,12 +805,12 @@ func TestWebhookTimeout(t *testing.T) {
 	em = NewEventManager()
 	em.Start(1, 1100)
 	timeout = uint64(0)
-	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", &timeout)
+	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docid, channels := eventForTest(strconv.Itoa(i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docid, "", channels, false)
 		time.Sleep(2 * time.Millisecond)
 		if err != nil {
 			errCount++
@@ -850,12 +850,12 @@ func TestUnavailableWebhook(t *testing.T) {
 
 	em := NewEventManager()
 	em.Start(0, -1)
-	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "", nil)
+	webhookHandler, _ := NewWebhook("http://badhost:1000/echo", "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 10; i++ {
 		body, docId, channels := eventForTest(strconv.Itoa(-i), i)
 		bodyBytes, _ := base.JSONMarshal(body)
-		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels)
+		err := em.RaiseDocumentChangeEvent(bodyBytes, docId, "", channels, false)
 		assert.NoError(t, err)
 	}
 	time.Sleep(50 * time.Millisecond)

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventTypeNames(t *testing.T) {
+	// Ensure number of level constants, and names match.
+	assert.Equal(t, int(eventTypeCount), len(eventTypeNames))
+
+	assert.Equal(t, "DocumentChange", DocumentChange.String())
+	assert.Equal(t, "DBStateChange", DBStateChange.String())
+
+	// Test out of bounds event type
+	assert.Equal(t, "EventType(255)", EventType(math.MaxUint8).String())
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4810,6 +4811,98 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	assert.NotEqual(t, revIdAfterAttachment, doc1revId)
 	wg.Add(1)
 	wg.Wait()
+}
+
+// TestWebhookWinningRevChangedEvent ensures the winning_rev_changed event is only fired for a winning revision change, and checks that document_changed is always fired.
+func TestWebhookWinningRevChangedEvent(t *testing.T) {
+
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeyEvents)()
+
+	wg := sync.WaitGroup{}
+
+	var WinningRevChangedCount uint32
+	var DocumentChangedCount uint32
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		var body db.Body
+		d := base.JSONDecoder(r.Body)
+		require.NoError(t, d.Decode(&body))
+		require.Contains(t, body, db.BodyId)
+		require.Contains(t, body, db.BodyRev)
+
+		event := r.URL.Query().Get("event")
+		switch event {
+		case "WinningRevChanged":
+			atomic.AddUint32(&WinningRevChangedCount, 1)
+		case "DocumentChanged":
+			atomic.AddUint32(&DocumentChangedCount, 1)
+		default:
+			t.Fatalf("unknown event type: %s", event)
+		}
+
+		wg.Done()
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(handler))
+	defer s.Close()
+
+	rtConfig := &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			EventHandlers: &EventHandlerConfig{
+				DocumentChanged: []*EventConfig{
+					{Url: s.URL + "?event=DocumentChanged", Filter: "function(doc){return true;}", HandlerType: "webhook"},
+					{Url: s.URL + "?event=WinningRevChanged", Filter: "function(doc){return true;}", HandlerType: "webhook",
+						Options: map[string]interface{}{db.EventOptionDocumentChangedWinningRevOnly: true},
+					},
+				},
+			},
+		},
+	}
+	rt := NewRestTester(t, rtConfig)
+	defer rt.Close()
+
+	res := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+	rev1 := respRevID(t, res)
+	_, rev1Hash := db.ParseRevID(rev1)
+
+	// push winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+
+	// push non-winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzzzzz","_revisions":{"start":2,"ids":["buzzzzz","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(1)
+
+	wg.Wait()
+	assert.Equal(t, 2, int(atomic.LoadUint32(&WinningRevChangedCount)))
+	assert.Equal(t, 3, int(atomic.LoadUint32(&DocumentChangedCount)))
+
+	// tombstone the winning branch and ensure we get a rev changed message for the promoted branch
+	res = rt.SendAdminRequest("DELETE", "/db/doc1?rev=3-buzz", ``)
+	assertStatus(t, res, http.StatusOK)
+	wg.Add(2)
+
+	wg.Wait()
+	assert.Equal(t, 3, int(atomic.LoadUint32(&WinningRevChangedCount)))
+	assert.Equal(t, 4, int(atomic.LoadUint32(&DocumentChangedCount)))
+
+	// push a separate winning branch
+	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+rev1Hash+`"]}}`)
+	assertStatus(t, res, http.StatusCreated)
+	wg.Add(2)
+
+	// tombstone the winning branch, we should get a second webhook fired for rev 2-buzzzzz now it's been resurrected
+	res = rt.SendAdminRequest("DELETE", "/db/doc1?rev=4-quux", ``)
+	assertStatus(t, res, http.StatusOK)
+	wg.Add(2)
+
+	wg.Wait()
+	assert.Equal(t, 5, int(atomic.LoadUint32(&WinningRevChangedCount)))
+	assert.Equal(t, 6, int(atomic.LoadUint32(&DocumentChangedCount)))
 }
 
 func Benchmark_RestApiGetDocPerformance(b *testing.B) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -235,15 +235,16 @@ type CORSConfig struct {
 type EventHandlerConfig struct {
 	MaxEventProc    uint           `json:"max_processes,omitempty"`    // Max concurrent event handling goroutines
 	WaitForProcess  string         `json:"wait_for_process,omitempty"` // Max wait time when event queue is full (ms)
-	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document Commit
+	DocumentChanged []*EventConfig `json:"document_changed,omitempty"` // Document changed
 	DBStateChanged  []*EventConfig `json:"db_state_changed,omitempty"` // DB state change
 }
 
 type EventConfig struct {
-	HandlerType string  `json:"handler"`           // Handler type
-	Url         string  `json:"url,omitempty"`     // Url (webhook)
-	Filter      string  `json:"filter,omitempty"`  // Filter function (webhook)
-	Timeout     *uint64 `json:"timeout,omitempty"` // Timeout (webhook)
+	HandlerType string                 `json:"handler"`           // Handler type
+	Url         string                 `json:"url,omitempty"`     // Url (webhook)
+	Filter      string                 `json:"filter,omitempty"`  // Filter function (webhook)
+	Timeout     *uint64                `json:"timeout,omitempty"` // Timeout (webhook)
+	Options     map[string]interface{} `json:"options,omitempty"` // Options can be specified per-handler, and are specific to each type.
 }
 
 type CacheConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -175,7 +175,7 @@ type DbConfig struct {
 	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                    // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
 	ImportFilter                     *string                          `json:"import_filter,omitempty"`                        // Filter function (import)
 	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                          // Whether import should attempt to create a temporary backup of the previous revision body, when available.
-	EventHandlers                    interface{}                      `json:"event_handlers,omitempty"`                       // Event handlers (webhook)
+	EventHandlers                    *EventHandlerConfig              `json:"event_handlers,omitempty"`                       // Event handlers (webhook)
 	FeedType                         string                           `json:"feed_type,omitempty"`                            // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
 	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                 // Allow empty passwords?  Defaults to false
 	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                                // Cache settings

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -27,7 +27,6 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	sgreplicate "github.com/couchbaselabs/sg-replicate"
-	pkgerrors "github.com/pkg/errors"
 )
 
 // The URL that stats will be reported to if deployment_id is set in the config
@@ -765,59 +764,35 @@ func (sc *ServerContext) TakeDbOnline(database *db.DatabaseContext) {
 }
 
 // Initialize event handlers, if present
-func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config *DbConfig) error {
-	if config.EventHandlers != nil {
-
-		// Temporary solution to do validation of invalid event types in config.EventHandlers.
-		// config.EventHandlers is originally unmarshalled as interface{} so that we retain any
-		// invalid keys during the original config unmarshalling.  We validate the expected entries
-		// manually and throw an error for any invalid keys.  Then remarshal and
-		// unmarshal as EventHandlerConfig (considered manual reflection, but was too painful).  Comes with
-		// some overhead, but will only happen on startup/new config.
-		// Should be replaced when we implement full schema validation on config.
-
-		eventHandlers := &EventHandlerConfig{}
-		eventHandlersMap, ok := config.EventHandlers.(map[string]interface{})
-		if !ok {
-			return errors.New(fmt.Sprintf("Unable to parse event_handlers definition in config for db %s", dbcontext.Name))
-		}
-
-		// validate event-related keys
-		for k := range eventHandlersMap {
-			if k != "max_processes" && k != "wait_for_process" && k != "document_changed" && k != "db_state_changed" {
-				return errors.New(fmt.Sprintf("Unsupported event property '%s' defined for db %s", k, dbcontext.Name))
-			}
-		}
-
-		eventHandlersJSON, err := base.JSONMarshal(eventHandlersMap)
-		if err != nil {
-			return pkgerrors.Wrapf(err, "Error calling base.JSONMarshal() in initEventHandlers")
-		}
-		if err := base.JSONUnmarshal(eventHandlersJSON, eventHandlers); err != nil {
-			return pkgerrors.Wrapf(err, "Error calling base.JSONUnmarshal() in initEventHandlers")
-		}
-
-		// Process document commit event handlers
-		if err = sc.processEventHandlersForEvent(eventHandlers.DocumentChanged, db.DocumentChange, dbcontext); err != nil {
-			return err
-		}
-
-		// Process db state change event handlers
-		if err = sc.processEventHandlersForEvent(eventHandlers.DBStateChanged, db.DBStateChange, dbcontext); err != nil {
-			return err
-		}
-		// WaitForProcess uses string, to support both omitempty and zero values
-		customWaitTime := int64(-1)
-		if eventHandlers.WaitForProcess != "" {
-			customWaitTime, err = strconv.ParseInt(eventHandlers.WaitForProcess, 10, 0)
-			if err != nil {
-				customWaitTime = -1
-				base.Warnf("Error parsing wait_for_process from config, using default %s", err)
-			}
-		}
-		dbcontext.EventMgr.Start(eventHandlers.MaxEventProc, int(customWaitTime))
-
+func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config *DbConfig) (err error) {
+	if config.EventHandlers == nil {
+		return nil
 	}
+
+	// Load Webhook Filter Function.
+	eventHandlersByType := map[db.EventType][]*EventConfig{
+		db.DocumentChange: config.EventHandlers.DocumentChanged,
+		db.DBStateChange:  config.EventHandlers.DBStateChanged,
+	}
+
+	for eventType, handlers := range eventHandlersByType {
+		// Register event handlers
+		if err = sc.processEventHandlersForEvent(handlers, eventType, dbcontext); err != nil {
+			return err
+		}
+	}
+
+	// WaitForProcess uses string, to support both omitempty and zero values
+	customWaitTime := int64(-1)
+	if config.EventHandlers.WaitForProcess != "" {
+		customWaitTime, err = strconv.ParseInt(config.EventHandlers.WaitForProcess, 10, 0)
+		if err != nil {
+			customWaitTime = -1
+			base.Warnf("Error parsing wait_for_process from config, using default %s", err)
+		}
+	}
+	dbcontext.EventMgr.Start(config.EventHandlers.MaxEventProc, int(customWaitTime))
+
 	return nil
 }
 


### PR DESCRIPTION
Backports #4901 to 2.8.1

Related webhook/event changes pulled in for ease of backporting:
- Fix empty webhook payload logging due to buffer-reuse (#4891)
- Use standard config schema validation for event handler config validation (#4898)