### PR TITLE
Skip in-flight rev backup for non-existent rev

### DIFF
--- a/db/revision.go
+++ b/db/revision.go
@@ -254,7 +254,9 @@ func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody
 
 	// Without delta sync, store the old rev for in-flight replication purposes
 	if !db.DeltaSyncEnabled() || db.Options.DeltaSyncOptions.RevMaxAgeSeconds == 0 {
-		_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.OldRevExpirySeconds)
+		if oldRevId != "" {
+			_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.OldRevExpirySeconds)
+		}
 		return
 	}
 

--- a/db/revision.go
+++ b/db/revision.go
@@ -254,7 +254,7 @@ func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody
 
 	// Without delta sync, store the old rev for in-flight replication purposes
 	if !db.DeltaSyncEnabled() || db.Options.DeltaSyncOptions.RevMaxAgeSeconds == 0 {
-		if oldRevId != "" {
+		if len(oldBody) > 0 {
 			_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.OldRevExpirySeconds)
 		}
 		return


### PR DESCRIPTION
When updating a document, this logic stores a temporary revision body for 5 minutes for any in-flight changes requests.

This happens regardless of whether the document being updated is at rev 1 (for delta sync purposes), but in the case where deltas are disabled, we want to avoid storing an empty "old" revision.

Fixes this happening:

```
2021-01-12T14:37:12.935Z [DBG] CRUD+: Backed up revision body "doc1"/"" (0 bytes, ttl:300)
```