### PR TITLE
Fix resync status race condition

### DIFF
--- a/rest/api.go
+++ b/rest/api.go
@@ -175,6 +175,8 @@ func (h *handler) handlePostResync() error {
 
 	if action == db.ResyncActionStart {
 		if atomic.CompareAndSwapUint32(&h.db.State, db.DBOffline, db.DBResyncing) {
+			h.db.ResyncManager.SetRunStatus(db.ResyncStateRunning)
+			h.writeJSON(h.db.ResyncManager.GetStatus())
 			go func() {
 				defer atomic.CompareAndSwapUint32(&h.db.State, db.DBResyncing, db.DBOffline)
 				defer h.db.ResyncManager.SetRunStatus(db.ResyncStateStopped)
@@ -184,9 +186,6 @@ func (h *handler) handlePostResync() error {
 					h.db.ResyncManager.SetError(err)
 				}
 			}()
-
-			h.db.ResyncManager.SetRunStatus(db.ResyncStateRunning)
-			h.writeJSON(h.db.ResyncManager.GetStatus())
 		} else {
 			dbState := atomic.LoadUint32(&h.db.State)
 			if dbState == db.DBResyncing {


### PR DESCRIPTION
When running a resync with a low number of docs, it's possible that execution of the resync goroutine finishes before the status is set to `running`, leaving the status incorrectly set to `running`, even though it's finished and should be `stopped`.

Seen as:

```
2021-01-12T07:47:52.345-08:00 [WRN] RetryLoop for Wait for condition giving up after 201 attempts -- base.RetryLoopCtx() at util.go:432
    TestResync/Docs_0,_Limit_Default: admin_api_test.go:1287: 
        	Error Trace:	admin_api_test.go:1287
        	Error:      	Received unexpected error:
        	            	RetryLoop for Wait for condition giving up after 201 attempts
        	Test:       	TestResync/Docs_0,_Limit_Default
```