### PR TITLE
CBG-1217 Fix build failure due to race in TestPutInvalidConfig and TestSetupAndValidate

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -350,6 +350,9 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 			if err = feed.Close(); err != nil {
 				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(spec.BucketName), feedName, err)
 			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
+			}
 		}()
 	}
 
@@ -495,6 +498,9 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 			Tracef(KeyDCP, "Closing DCP Feed [%s-%s] based on termination notification", MD(spec.BucketName), feedName)
 			if err = feed.Close(); err != nil {
 				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(spec.BucketName), feedName, err)
+			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
 			}
 		}()
 	}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -327,6 +327,9 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 			if err := bds.Close(); err != nil {
 				Debugf(KeyDCP, "Error closing DCP Feed [%s-%s] based on termination notification, Error: %v", MD(bucketName), feedID, err)
 			}
+			if args.DoneChan != nil {
+				close(args.DoneChan)
+			}
 		}()
 	}
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -262,6 +262,7 @@ func (b *LeakyBucket) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.
 				event.VbNo = uint16(VBHash(key, 1024))
 				vbTapFeed.channel <- event
 			}
+			close(vbTapFeed.channel)
 		}()
 		return vbTapFeed, nil
 
@@ -302,6 +303,7 @@ func (b *LeakyBucket) wrapFeed(args sgbucket.FeedArguments, callback EventUpdate
 				wrapperFeed.channel <- event
 			}
 		}
+		close(wrapperFeed.channel)
 	}()
 	return wrapperFeed, nil
 }
@@ -336,7 +338,7 @@ func (b *LeakyBucket) wrapFeedForDeduplication(args sgbucket.FeedArguments, dbSt
 	}
 
 	go func() {
-
+		defer close(dupeTapFeed.channel)
 		// the buffer to hold tap events that are candidates for de-duplication
 		deDupeBuffer := []sgbucket.FeedEvent{}
 

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -48,6 +48,7 @@ func (listener *changeListener) Start(bucket base.Bucket, dbStats *expvar.Map) e
 		ID:         base.DCPCachingFeedID,
 		Backfill:   sgbucket.FeedNoBackfill,
 		Terminator: listener.terminator,
+		DoneChan:   make(chan struct{}),
 	}
 
 	return listener.StartMutationFeed(bucket, dbStats)
@@ -68,6 +69,11 @@ func (listener *changeListener) StartMutationFeed(bucket base.Bucket, dbStats *e
 			return err
 		}
 		go func() {
+			defer func() {
+				if listener.FeedArgs.DoneChan != nil {
+					close(listener.FeedArgs.DoneChan)
+				}
+			}()
 			defer base.FatalPanicHandler()
 			defer listener.notifyStopping()
 			for event := range listener.tapFeed.Events() {
@@ -119,6 +125,10 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 	return requiresCheckpointPersistence
 }
 
+// MutationFeedStopMaxWait is the maximum amount of time to wait for
+// mutation feed worker goroutine to terminate before the server is stopped.
+const MutationFeedStopMaxWait = 30 * time.Second
+
 // Stops a changeListener. Any pending Wait() calls will immediately return false.
 func (listener *changeListener) Stop() {
 
@@ -138,6 +148,15 @@ func (listener *changeListener) Stop() {
 		if err != nil {
 			base.Debugf(base.KeyChanges, "Error closing listener tap feed: %v", err)
 		}
+	}
+
+	// Wait for mutation feed worker to terminate.
+	waitTime := MutationFeedStopMaxWait
+	select {
+	case <-listener.FeedArgs.DoneChan:
+		// Mutation feed worker goroutine is terminated and doneChan is already closed.
+	case <-time.After(waitTime):
+		base.Warnf("Timeout after %v of waiting for mutation feed worker to terminate", waitTime)
 	}
 }
 

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -37,6 +37,7 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 		ID:         base.DCPImportFeedID,
 		Backfill:   sgbucket.FeedResume,
 		Terminator: il.terminator,
+		DoneChan:   make(chan struct{}),
 	}
 
 	importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="e8d089489387294d441b25e17eb1d006178bbd3b"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="bc5fd87f01d1819c14c92e4e51b63f0d7e77a69c"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="4f1478f0a956cdabd36db119ea64dc4d9b071bdc"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="aba85317d4695c881ad71a9a0b570e7e99347c67"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1245,7 +1245,9 @@ func deleteTempFile(t *testing.T, file *os.File) {
 }
 
 func TestSetupAndValidate(t *testing.T) {
-	t.Skip("Skipping this test temporarily; until CBG-1217 is fixed")
+	if !base.UnitTestUrlIsWalrus() {
+		t.Skip("Skipping this test; it only works on Walrus bucket")
+	}
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	t.Run("Run setupAndValidate with valid config", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{


### PR DESCRIPTION
Build was broken due to the race in TestPutInvalidConfig and TestSetupAndValidate. The underlying issue was that the goroutine that works with the event channel and processes each event never gets terminated even after closing the tap feed events when stopping the changeListener. Since the range loop relies on the mutation stream (which is backed by a read only channel) to terminate,  an explicit close on the tap feec channel is required in case of Leaky bucket implementation where the vbucket information is being wrapped, because a buffered channel is being used while wrapping tap feed for including vbucket information and events deduplication. This PR includes the changes to enable the TestSetupAndValidate test and ensures the change listener goroutines terminates gracefully.
