### PR TITLE
CBG-1269 - Abort import of doc if importListener is stopped during in-flight feed event processing

### DIFF
--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -125,6 +125,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 		// last attempt to exit processing if the importListener has been closed before attempting to write to the bucket
 		select {
 		case <-il.terminator:
+			base.Infof(base.KeyImport, "Aborting import for doc %q - importListener.terminator was closed", base.UD(docID))
 			return
 		default:
 		}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -121,6 +121,14 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 			rawBody = nil
 		}
 		docID := string(event.Key)
+
+		// last attempt to exit processing if the importListener has been closed before attempting to write to the bucket
+		select {
+		case <-il.terminator:
+			return
+		default:
+		}
+
 		_, err := il.database.ImportDocRaw(docID, rawBody, rawXattr, isDelete, event.Cas, &event.Expiry, ImportFromFeed)
 		if err != nil {
 			if err == base.ErrImportCasFailure {


### PR DESCRIPTION
(mostly) closes up a race condition where use of a nil bucket can cause a panic when an importListener is closed with in-flight events still being processed

There might be a more comprehensive fix to ensure all feed events are drained before unblocking `importListener.Stop()`, but it's tricky given the callback is invoked by cbgt.

## Integration tests
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/630/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/631/