### PR TITLE
Fix incorrect db config in TestBackupOldRevision

### DIFF
--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -94,7 +94,8 @@ func TestBackupOldRevision(t *testing.T) {
 	xattrsEnabled := base.TestUseXattrs()
 
 	db := setupTestDBWithOptions(t, DatabaseContextOptions{DeltaSyncOptions: DeltaSyncOptions{
-		Enabled: deltasEnabled,
+		Enabled:          deltasEnabled,
+		RevMaxAgeSeconds: DefaultDeltaSyncRevMaxAge,
 	}})
 
 	docID := t.Name()


### PR DESCRIPTION
Value was being set to `0` instead of the default normally set by ServerContext, which was disabling intended backup behaviour when run as EE+xattrs.