### PR TITLE
[2.8.1 Backport] - CBG-1267 Exit cache processing for _sync:cfg docs after cfgEventCallback

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -401,6 +401,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}
+		return
 	}
 
 	// If this is a delete and there are no xattrs (no existing SG revision), we can ignore


### PR DESCRIPTION
Backports CBG-1151 to 2.8.1.