### PR TITLE
Fix broken build due to TestBackupOldRevision failure

### DIFF
--- a/db/revision.go
+++ b/db/revision.go
@@ -285,7 +285,9 @@ func (db *Database) backupRevisionJSON(docId, newRevId, oldRevId string, newBody
 	}
 
 	// Non-xattr only need to store the previous revision, as all writes come through SG
-	_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+	if len(oldBody) > 0 {
+		_ = db.setOldRevisionJSON(docId, oldRevId, oldBody, db.Options.DeltaSyncOptions.RevMaxAgeSeconds)
+	}
 }
 
 func (db *Database) setOldRevisionJSON(docid string, revid string, body []byte, expiry uint32) error {

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -105,12 +105,8 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// make sure we didn't accidentally store an empty old revision
 	_, err = db.getOldRevisionJSON(docID, "")
-	if xattrsEnabled || !deltasEnabled {
-		require.Error(t, err)
-		assert.Equal(t, "404 missing", err.Error())
-	} else {
-		require.NoError(t, err)
-	}
+	assert.Error(t, err)
+	assert.Equal(t, "404 missing", err.Error())
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
 	_, err = db.getOldRevisionJSON(docID, rev1ID)

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -105,8 +105,12 @@ func TestBackupOldRevision(t *testing.T) {
 
 	// make sure we didn't accidentally store an empty old revision
 	_, err = db.getOldRevisionJSON(docID, "")
-	assert.Error(t, err)
-	assert.Equal(t, "404 missing", err.Error())
+	if xattrsEnabled || !deltasEnabled {
+		require.Error(t, err)
+		assert.Equal(t, "404 missing", err.Error())
+	} else {
+		require.NoError(t, err)
+	}
 
 	// check for current rev backup in xattr+delta case (to support deltas by sdk imports)
 	_, err = db.getOldRevisionJSON(docID, rev1ID)


### PR DESCRIPTION
Build was broken due to the assertion failure in TestBackupOldRevision.
http://mobile.jenkins.couchbase.com/job/sgw-unix-build/15138/consoleFull
The underlying issue was that body length check was not included while storing the previous revision.
This PR contains the fix for the failure.