### PR TITLE
CBG-1272 Wait for channel cache background tasks to terminate when shutting down the server

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -170,7 +170,7 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 		c.options = DefaultCacheOptions()
 	}
 
-	channelCache, err := NewChannelCacheForContext(&c.backgroundTasks, c.terminator, c.options.ChannelCacheOptions, c.context)
+	channelCache, err := NewChannelCacheForContext(c.options.ChannelCacheOptions, c.context)
 	if err != nil {
 		return err
 	}
@@ -224,7 +224,10 @@ func (c *changeCache) Stop() {
 	close(c.terminator)
 
 	// Wait for changeCache background tasks to finish.
-	c.context.waitForBGTCompletion(BGTCompletionMaxWait, c.backgroundTasks)
+	waitForBGTCompletion(BGTCompletionMaxWait, c.backgroundTasks, c.context.Name)
+
+	// Stop the channel cache and it's background tasks.
+	c.channelCache.Stop()
 
 	c.lock.Lock()
 	c.logsDisabled = true

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -170,7 +170,7 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 		c.options = DefaultCacheOptions()
 	}
 
-	channelCache, err := NewChannelCacheForContext(c.backgroundTasks, c.terminator, c.options.ChannelCacheOptions, c.context)
+	channelCache, err := NewChannelCacheForContext(&c.backgroundTasks, c.terminator, c.options.ChannelCacheOptions, c.context)
 	if err != nil {
 		return err
 	}

--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -68,7 +68,6 @@ type StableSequenceCallbackFunc func() uint64
 type channelCacheImpl struct {
 	queryHandler         ChannelQueryHandler       // Passed to singleChannelCacheImpl for view queries.
 	channelCaches        *base.RangeSafeCollection // A collection of singleChannelCaches
-	backgroundTasks      []BackgroundTask          // List of background tasks.
 	terminator           chan bool                 // Signal terminator of background goroutines
 	options              ChannelCacheOptions       // Channel cache options
 	lateSeqLock          sync.RWMutex              // Coordinates access to late sequence caches
@@ -83,18 +82,18 @@ type channelCacheImpl struct {
 	validFromLock        sync.RWMutex              // Mutex used to avoid race between AddToCache and addChannelCache.  See CBG-520 for more details
 }
 
-func NewChannelCacheForContext(backgroundTasks []BackgroundTask, terminator chan bool, options ChannelCacheOptions, context *DatabaseContext) (*channelCacheImpl, error) {
+func NewChannelCacheForContext(backgroundTasks *[]BackgroundTask, terminator chan bool, options ChannelCacheOptions,
+	context *DatabaseContext) (*channelCacheImpl, error) {
 	return newChannelCache(context.Name, backgroundTasks, terminator, options, context, context.activeChannels, context.DbStats.Cache())
 }
 
-func newChannelCache(dbName string, backgroundTasks []BackgroundTask, terminator chan bool,
+func newChannelCache(dbName string, backgroundTasks *[]BackgroundTask, terminator chan bool,
 	options ChannelCacheOptions, queryHandler ChannelQueryHandler, activeChannels *channels.ActiveChannels,
 	cacheStats *base.CacheStats) (*channelCacheImpl, error) {
 
 	channelCache := &channelCacheImpl{
 		queryHandler:         queryHandler,
 		channelCaches:        base.NewRangeSafeCollection(),
-		backgroundTasks:      backgroundTasks,
 		terminator:           terminator,
 		options:              options,
 		maxChannels:          options.MaxNumChannels,
@@ -107,7 +106,7 @@ func newChannelCache(dbName string, backgroundTasks []BackgroundTask, terminator
 	if err != nil {
 		return nil, err
 	}
-	backgroundTasks = append(backgroundTasks, bgt)
+	*backgroundTasks = append(*backgroundTasks, bgt)
 	base.Debugf(base.KeyCache, "Initialized channel cache with maxChannels:%d, HWM: %d, LWM: %d",
 		channelCache.maxChannels, channelCache.compactHighWatermark, channelCache.compactLowWatermark)
 	return channelCache, nil

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -76,10 +76,6 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	// Define cache with max channels 20, hwm will be 16, low water mark will be 12
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
@@ -88,8 +84,9 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
+	defer cache.Stop()
 
 	// Add 16 channels to the cache.  Shouldn't trigger compaction (hwm is not exceeded)
 	for i := 1; i <= 16; i++ {
@@ -113,10 +110,6 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
@@ -127,8 +120,9 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
+	defer cache.Stop()
 
 	// Add 16 channels to the cache.  Mark odd channels as active, even channels as inactive.
 	// Shouldn't trigger compaction (hwm is not exceeded)
@@ -171,10 +165,6 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyCache)()
 
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
@@ -185,8 +175,9 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
+	defer cache.Stop()
 
 	// Add 18 channels to the cache.  Mark channels 1-10 as active
 	// Shouldn't trigger compaction (hwm is not exceeded)
@@ -267,10 +258,6 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	// Define cache with max channels 20, watermarks 50/90
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 100
@@ -281,8 +268,9 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
+	defer cache.Stop()
 
 	channelCount := 90
 	// define channel set
@@ -340,10 +328,6 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	// Define cache with max channels 100, watermarks 90/70
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 100
@@ -354,8 +338,9 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
+	defer cache.Stop()
 
 	channelCount := 200
 	// define channel set
@@ -408,10 +393,6 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 func TestChannelCacheBypass(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
 
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	// Define cache with max channels 20, watermarks 50/100
 	options := DefaultCacheOptions().ChannelCacheOptions
 	options.MaxNumChannels = 20
@@ -422,8 +403,9 @@ func TestChannelCacheBypass(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
+	defer cache.Stop()
 
 	channelCount := 100
 	// define channel set
@@ -507,20 +489,20 @@ func (qh *testQueryHandler) seedEntries(seededEntries LogEntries) {
 
 func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelWarn, base.KeyCache)()
-	var backgroundTasks []BackgroundTask
-	terminator := make(chan bool)
-	defer close(terminator)
-
 	options := DefaultCacheOptions().ChannelCacheOptions
+
 	// Specify illegal time interval for background task. Time interval should be > 0
 	options.ChannelCacheAge = 0
 	testStats := (base.NewSyncGatewayStats()).NewDBStats("", false, false, false).Cache()
+
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+
+	cache, err := newChannelCache("testDb", options, queryHandler, activeChannels, testStats)
 	assert.Error(t, err, "Background task error whilst creating channel cache")
 	assert.Nil(t, cache)
+
 	backgroundTaskError, ok := err.(*BackgroundTaskError)
 	require.True(t, ok)
 	assert.Equal(t, "CleanAgedItems", backgroundTaskError.TaskName)

--- a/db/channel_cache_test.go
+++ b/db/channel_cache_test.go
@@ -88,7 +88,7 @@ func TestChannelCacheSimpleCompact(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	// Add 16 channels to the cache.  Shouldn't trigger compaction (hwm is not exceeded)
@@ -127,7 +127,7 @@ func TestChannelCacheCompactInactiveChannels(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	// Add 16 channels to the cache.  Mark odd channels as active, even channels as inactive.
@@ -185,7 +185,7 @@ func TestChannelCacheCompactNRU(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	// Add 18 channels to the cache.  Mark channels 1-10 as active
@@ -281,7 +281,7 @@ func TestChannelCacheHighLoadCacheHit(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	channelCount := 90
@@ -354,7 +354,7 @@ func TestChannelCacheHighLoadCacheMiss(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	channelCount := 200
@@ -422,7 +422,7 @@ func TestChannelCacheBypass(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	require.NoError(t, err, "Background task error whilst creating channel cache")
 
 	channelCount := 100
@@ -518,7 +518,7 @@ func TestChannelCacheBackgroundTaskWithIllegalTimeInterval(t *testing.T) {
 	queryHandler := &testQueryHandler{}
 	activeChannelStat := &base.SgwIntStat{}
 	activeChannels := channels.NewActiveChannels(activeChannelStat)
-	cache, err := newChannelCache("testDb", backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
+	cache, err := newChannelCache("testDb", &backgroundTasks, terminator, options, queryHandler, activeChannels, testStats)
 	assert.Error(t, err, "Background task error whilst creating channel cache")
 	assert.Nil(t, cache)
 	backgroundTaskError, ok := err.(*BackgroundTaskError)

--- a/db/database.go
+++ b/db/database.go
@@ -567,7 +567,7 @@ func (context *DatabaseContext) Close() {
 	context.OIDCProviders.Stop()
 	close(context.terminator)
 	// Wait for database background tasks to finish.
-	context.waitForBGTCompletion(BGTCompletionMaxWait, context.backgroundTasks)
+	waitForBGTCompletion(BGTCompletionMaxWait, context.backgroundTasks, context.Name)
 	context.sequences.Stop()
 	context.mutationListener.Stop()
 	context.changeCache.Stop()
@@ -586,7 +586,7 @@ func (context *DatabaseContext) Close() {
 }
 
 // waitForBGTCompletion waits for all the background tasks to finish.
-func (context *DatabaseContext) waitForBGTCompletion(waitTimeMax time.Duration, tasks []BackgroundTask) {
+func waitForBGTCompletion(waitTimeMax time.Duration, tasks []BackgroundTask, dbName string) {
 	waitTime := waitTimeMax
 	for _, t := range tasks {
 		start := time.Now()
@@ -598,7 +598,7 @@ func (context *DatabaseContext) waitForBGTCompletion(waitTimeMax time.Duration, 
 			// Timeout after waiting for background task to terminate.
 		}
 		base.Infof(base.KeyAll, "Timeout after %v of waiting for background task %q to "+
-			"terminate, database: %s", waitTimeMax, t.taskName, context.Name)
+			"terminate, database: %s", waitTimeMax, t.taskName, dbName)
 	}
 }
 


### PR DESCRIPTION
The channel cache spawns a background task to prune the cached entries (based on the age of items) upon initialization of the cache. This task will always be running in the background as long as the server is alive. When the server stops under normal circumstances, this task will be terminated eventually along with the rest of the tasks running in the background. To ensure the graceful termination of each background task, Sync Gateway maintains a list of tasks that are running in the background. Each background task will be added to this list at the time of creation and wait for a maximum of 30 seconds (in total ) to terminate all those tasks before timeout during server shutdown. This is a synchronous wait - it blocks subsequent execution of the remaining cleanup tasks to shut down the server completely and it is an intended behavior. 

If a background task is not added to the internal list of running background tasks, the server will not wait for that task to terminate during shutdown. The CleanAgedItems task initiated by channel cache was not added to the list of background tasks (which is unintentional) and the server was ignoring it silently during shutdown as a result. We need to have a mechanism to avoid this situation by implementing a stop method on channel which internally signals the CleanAgedItems task to terminate and wait for this task to finish. This new stop method can be called while stopping the change cache during server shutdown.

A potential advantage of this proposal is, we can avoid the data [races](http://mobile.jenkins.couchbase.com/job/sgw-unix-build/15171/consoleFull) which may arise while resetting the loggers inside TestSetupAndValidate that is still being used by the background task spawned from TestPutInvalidConfig earlier in the test.