### PR TITLE
CBG-759 - Add option to hide product version info from non-admin requests

### DIFF
--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -558,7 +558,7 @@ func GenerateDcpStreamName(feedID string) (string, error) {
 	return fmt.Sprintf(
 		"%v-v-%v-commit-%v-uuid-%v",
 		feedID,
-		VersionNumber,
+		ProductVersionNumber,
 		commitTruncated,
 		u.String(),
 	), nil

--- a/base/version.go
+++ b/base/version.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-const VersionNumber = "3.0" // API/feature level
+const (
+	ProductName          = "Couchbase Sync Gateway"
+	ProductVersionNumber = "3.0" // API/feature level
+)
 
 var (
 	// VersionString appears in the "Server:" header of HTTP responses.
@@ -16,8 +19,8 @@ var (
 	// LongVersionString includes build number; appears in the response of "GET /" and the initial log message
 	LongVersionString string
 
-	// ProductName comes from Gerrit (jenkins builds) or Git (dev builds)
-	ProductName string
+	// ProductNameString comes from Gerrit (jenkins builds) or Git (dev builds)
+	ProductNameString string
 )
 
 func init() {
@@ -39,11 +42,16 @@ func init() {
 		}
 		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s) %s", buildPlaceholderServerName, BuildVersionString, BuildNumberString, buildPlaceholderVersionCommitSHA, productEditionShortName)
 		VersionString = fmt.Sprintf("%s/%s %s", buildPlaceholderServerName, BuildVersionString, productEditionShortName)
-		ProductName = buildPlaceholderServerName
+		ProductNameString = buildPlaceholderServerName
 	} else {
-		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s) %s", GitProductName, GitBranch, GitCommit, GitDirty, productEditionShortName)
-		VersionString = fmt.Sprintf("%s/%s branch/%s commit/%.7s%s %s", GitProductName, VersionNumber, GitBranch, GitCommit, GitDirty, productEditionShortName)
-		ProductName = GitProductName
+		// GitProductName is set via the build script, but may not be set when unit testing.
+		productName := GitProductName
+		if productName == "" {
+			productName = ProductName
+		}
+		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s) %s", productName, GitBranch, GitCommit, GitDirty, productEditionShortName)
+		VersionString = fmt.Sprintf("%s/%s branch/%s commit/%.7s%s %s", productName, ProductVersionNumber, GitBranch, GitCommit, GitDirty, productEditionShortName)
+		ProductNameString = productName
 	}
 }
 

--- a/base/version.go
+++ b/base/version.go
@@ -5,37 +5,41 @@ import (
 	"strings"
 )
 
-const ServerName = "@PRODUCT_NAME@"                  // DO NOT CHANGE; clients check this
-const VersionNumber = "3.0"                          // API/feature level
-const VersionBuildNumberString = "@PRODUCT_VERSION@" // Real string substituted by Jenkins build
-const VersionCommitSHA = "@COMMIT_SHA@"              // Real string substituted by Jenkins build
+const VersionNumber = "3.0" // API/feature level
 
-// This appears in the "Server:" header of HTTP responses.
-// This should be changed only very cautiously, because Couchbase Lite parses the header value
-// to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version. This in turn
-// determines what replication API features it will use.
-var VersionString string
+var (
+	// VersionString appears in the "Server:" header of HTTP responses.
+	// CBL 1.x parses the header to determine whether it's talking to Sync Gateway (vs. CouchDB) and what version.
+	// This determines what replication API features it will use (E.g: bulk get and POST _changes that are CB-Mobile only features.)
+	VersionString string
 
-// This includes build number; appears in the response of "GET /" and the initial log message
-var LongVersionString string
+	// LongVersionString includes build number; appears in the response of "GET /" and the initial log message
+	LongVersionString string
 
-// Either comes from Gerrit (jenkins builds) or Git (dev builds)
-var ProductName string
+	// ProductName comes from Gerrit (jenkins builds) or Git (dev builds)
+	ProductName string
+)
 
 func init() {
-	if VersionBuildNumberString[0] != '@' {
-		//Split version number and build number (optional)
-		versionTokens := strings.Split(VersionBuildNumberString, "-")
+	// Placeholders substituted by Jenkins build
+	const (
+		buildPlaceholderServerName               = "@PRODUCT_NAME@"
+		buildPlaceholderVersionBuildNumberString = "@PRODUCT_VERSION@"
+		buildPlaceholderVersionCommitSHA         = "@COMMIT_SHA@"
+	)
+
+	// Use build info if available, otherwise use git info to populate instead.
+	if buildPlaceholderVersionBuildNumberString[0] != '@' {
+		// Split version number and build number (optional)
+		versionTokens := strings.Split(buildPlaceholderVersionBuildNumberString, "-")
 		BuildVersionString := versionTokens[0]
 		var BuildNumberString string
 		if len(versionTokens) > 1 {
 			BuildNumberString = fmt.Sprintf("%s;", versionTokens[1])
 		}
-		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s) %s",
-			ServerName, BuildVersionString, BuildNumberString, VersionCommitSHA, productEditionShortName)
-
-		VersionString = fmt.Sprintf("%s/%s %s", ServerName, BuildVersionString, productEditionShortName)
-		ProductName = ServerName
+		LongVersionString = fmt.Sprintf("%s/%s(%s%.7s) %s", buildPlaceholderServerName, BuildVersionString, BuildNumberString, buildPlaceholderVersionCommitSHA, productEditionShortName)
+		VersionString = fmt.Sprintf("%s/%s %s", buildPlaceholderServerName, BuildVersionString, productEditionShortName)
+		ProductName = buildPlaceholderServerName
 	} else {
 		LongVersionString = fmt.Sprintf("%s/%s(%.7s%s) %s", GitProductName, GitBranch, GitCommit, GitDirty, productEditionShortName)
 		VersionString = fmt.Sprintf("%s/%s branch/%s commit/%.7s%s %s", GitProductName, VersionNumber, GitBranch, GitCommit, GitDirty, productEditionShortName)
@@ -46,7 +50,7 @@ func init() {
 // IsEnterpriseEdition returns true if this Sync Gateway node is enterprise edition.
 // This can be used to restrict config options, etc. at runtime. This should not be
 // used as a conditional around private/EE-only code, as CE builds will fail to compile.
-// Use the build tag for conditional compilation instead.
+// Use the cb_sg_enterprise build tag for conditional compilation instead.
 func IsEnterpriseEdition() bool {
 	return productEditionEnterprise == true
 }

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -448,15 +448,13 @@ func (h *handler) handleGetStatus() error {
 	var status = Status{
 		Databases:   make(map[string]DatabaseStatus),
 		ActiveTasks: h.server.replicator.ActiveTasks(),
+		Vendor:      Vendor{Name: base.ProductNameString},
 	}
 
 	// This handler is supposed to be admin-only anyway, but being defensive if this is opened up in the routes file.
-	if h.shouldShowProductInfo() {
+	if h.shouldShowProductVersion() {
 		status.Version = base.LongVersionString
-		status.Vendor = Vendor{
-			Name:    base.ProductNameString,
-			Version: base.ProductVersionNumber,
-		}
+		status.Vendor.Version = base.ProductVersionNumber
 	}
 
 	for _, database := range h.server.databases_ {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -431,16 +431,11 @@ type DatabaseStatus struct {
 	SGRCluster        *db.SGRCluster          `json:"cluster"`
 }
 
-type Vendor struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
 type Status struct {
 	Databases   map[string]DatabaseStatus `json:"databases"`
 	ActiveTasks []base.Task               `json:"active_tasks"`
 	Version     string                    `json:"version"`
-	Vendor      Vendor                    `json:"vendor"`
+	Vendor      vendor                    `json:"vendor"`
 }
 
 func (h *handler) handleGetStatus() error {
@@ -448,7 +443,7 @@ func (h *handler) handleGetStatus() error {
 	var status = Status{
 		Databases:   make(map[string]DatabaseStatus),
 		ActiveTasks: h.server.replicator.ActiveTasks(),
-		Vendor:      Vendor{Name: base.ProductNameString},
+		Vendor:      vendor{Name: base.ProductNameString},
 	}
 
 	// This handler is supposed to be admin-only anyway, but being defensive if this is opened up in the routes file.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -454,8 +454,8 @@ func (h *handler) handleGetStatus() error {
 	if h.shouldShowProductInfo() {
 		status.Version = base.LongVersionString
 		status.Vendor = Vendor{
-			Name:    base.ProductName,
-			Version: base.VersionNumber,
+			Name:    base.ProductNameString,
+			Version: base.ProductVersionNumber,
 		}
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -448,11 +448,15 @@ func (h *handler) handleGetStatus() error {
 	var status = Status{
 		Databases:   make(map[string]DatabaseStatus),
 		ActiveTasks: h.server.replicator.ActiveTasks(),
-		Version:     base.LongVersionString,
-		Vendor: Vendor{
+	}
+
+	// This handler is supposed to be admin-only anyway, but being defensive if this is opened up in the routes file.
+	if h.shouldShowProductInfo() {
+		status.Version = base.LongVersionString
+		status.Vendor = Vendor{
 			Name:    base.ProductName,
 			Version: base.VersionNumber,
-		},
+		}
 	}
 
 	for _, database := range h.server.databases_ {

--- a/rest/api.go
+++ b/rest/api.go
@@ -35,23 +35,31 @@ const (
 	profileRunning
 )
 
+type rootResponse struct {
+	Admin   bool   `json:"ADMIN,omitempty"`
+	CouchDB string `json:"couchdb,omitempty"` // TODO: Lithium - remove couchdb welcome
+	Vendor  vendor `json:"vendor,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type vendor struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
 // HTTP handler for the root ("/")
 func (h *handler) handleRoot() error {
-	// TODO: Lithium - remove couchdb welcome
-	resp := map[string]interface{}{
-		"couchdb": "Welcome",
-		"vendor": map[string]interface{}{
-			"name": base.ProductNameString,
+	resp := rootResponse{
+		Admin:   h.privs == adminPrivs,
+		CouchDB: "Welcome",
+		Vendor: vendor{
+			Name: base.ProductNameString,
 		},
 	}
 
-	if h.privs == adminPrivs {
-		resp["ADMIN"] = true
-	}
-
 	if h.shouldShowProductVersion() {
-		resp["vendor"].(map[string]interface{})["version"] = base.ProductVersionNumber
-		resp["version"] = base.LongVersionString
+		resp.Version = base.LongVersionString
+		resp.Vendor.Version = base.ProductVersionNumber
 	}
 
 	h.writeJSON(resp)

--- a/rest/api.go
+++ b/rest/api.go
@@ -37,21 +37,22 @@ const (
 
 // HTTP handler for the root ("/")
 func (h *handler) handleRoot() error {
+	resp := make(map[string]interface{})
 
-	admin := ""
 	if h.privs == adminPrivs {
-		admin = `"ADMIN":true,`
+		resp["ADMIN"] = true
 	}
 
-	r := []byte(`{` +
-		admin +
-		`"couchdb":"Welcome",` +
-		`"vendor":{` +
-		`"name":"` + base.ProductName + `",` +
-		`"version":"` + base.VersionNumber +
-		`"},` +
-		`"version":"` + base.LongVersionString + `"}`)
-	h.writeRawJSON(r)
+	if h.shouldShowProductInfo() {
+		resp["couchdb"] = "Welcome"
+		resp["vendor"] = map[string]interface{}{
+			"name":    base.ProductName,
+			"version": base.VersionNumber,
+		}
+		resp["version"] = base.LongVersionString
+	}
+
+	h.writeJSON(resp)
 	return nil
 }
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -37,18 +37,20 @@ const (
 
 // HTTP handler for the root ("/")
 func (h *handler) handleRoot() error {
-	resp := make(map[string]interface{})
+	// TODO: Lithium - remove couchdb welcome
+	resp := map[string]interface{}{
+		"couchdb": "Welcome",
+		"vendor": map[string]interface{}{
+			"name": base.ProductNameString,
+		},
+	}
 
 	if h.privs == adminPrivs {
 		resp["ADMIN"] = true
 	}
 
-	if h.shouldShowProductInfo() {
-		resp["couchdb"] = "Welcome"
-		resp["vendor"] = map[string]interface{}{
-			"name":    base.ProductNameString,
-			"version": base.ProductVersionNumber,
-		}
+	if h.shouldShowProductVersion() {
+		resp["vendor"].(map[string]interface{})["version"] = base.ProductVersionNumber
 		resp["version"] = base.LongVersionString
 	}
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -46,8 +46,8 @@ func (h *handler) handleRoot() error {
 	if h.shouldShowProductInfo() {
 		resp["couchdb"] = "Welcome"
 		resp["vendor"] = map[string]interface{}{
-			"name":    base.ProductName,
-			"version": base.VersionNumber,
+			"name":    base.ProductNameString,
+			"version": base.ProductVersionNumber,
 		}
 		resp["version"] = base.LongVersionString
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5354,7 +5354,6 @@ func TestHideProductInfo(t *testing.T) {
 				assert.Equal(t, base.VersionString, resp.Header().Get("Server"))
 
 				body := string(resp.BodyBytes())
-				assert.Contains(t, body, base.ProductNameString)
 				assert.Contains(t, body, base.ProductVersionNumber)
 				return
 			}
@@ -5367,8 +5366,10 @@ func TestHideProductInfo(t *testing.T) {
 			body := string(resp.BodyBytes())
 
 			if test.hideProductInfo {
-				assert.Equal(t, "", serverHeader)
-				assert.NotContains(t, body, base.ProductNameString)
+				assert.Equal(t, base.ProductNameString, serverHeader)
+				assert.Contains(t, body, base.ProductNameString)
+				// no versions
+				assert.NotEqual(t, base.VersionString, serverHeader)
 				assert.NotContains(t, body, base.ProductVersionNumber)
 			} else {
 				assert.Equal(t, base.VersionString, serverHeader)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5313,3 +5313,68 @@ func TestAttachmentContentType(t *testing.T) {
 		assert.Equal(t, "", contentDisposition)
 	}
 }
+
+// TestHideProductInfo ensures that detailed product info is not shown on non-admin REST API responses if set.
+func TestHideProductInfo(t *testing.T) {
+	tests := []struct {
+		hideProductInfo, admin, expectedProductInfo bool
+	}{
+		{
+			hideProductInfo:     false,
+			admin:               false,
+			expectedProductInfo: true,
+		},
+		{
+			hideProductInfo:     false,
+			admin:               true,
+			expectedProductInfo: true,
+		},
+		{
+			hideProductInfo:     true,
+			admin:               true,
+			expectedProductInfo: true,
+		},
+		{
+			hideProductInfo:     true,
+			admin:               false,
+			expectedProductInfo: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("hide:%v admin:%v", test.hideProductInfo, test.admin), func(t *testing.T) {
+			rt := NewRestTester(t, &RestTesterConfig{hideProductInfo: test.hideProductInfo})
+			defer rt.Close()
+
+			// admins can always see product info, even if setting is enabled
+			if test.admin {
+				resp := rt.SendAdminRequest(http.MethodGet, "/", "")
+				assertStatus(t, resp, http.StatusOK)
+
+				assert.Equal(t, base.VersionString, resp.Header().Get("Server"))
+
+				body := string(resp.BodyBytes())
+				assert.Contains(t, body, base.ProductName)
+				assert.Contains(t, body, base.VersionNumber)
+				return
+			}
+
+			// non-admins can only see product info when the hideProductInfo option is disabled
+			resp := rt.SendRequest(http.MethodGet, "/", "")
+			assertStatus(t, resp, http.StatusOK)
+
+			serverHeader := resp.Header().Get("Server")
+			body := string(resp.BodyBytes())
+
+			if test.hideProductInfo {
+				assert.Equal(t, "", serverHeader)
+				assert.NotContains(t, body, base.ProductName)
+				assert.NotContains(t, body, base.VersionNumber)
+			} else {
+				assert.Equal(t, base.VersionString, serverHeader)
+				assert.Contains(t, body, base.ProductName)
+				assert.Contains(t, body, base.VersionNumber)
+			}
+		})
+	}
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5354,8 +5354,8 @@ func TestHideProductInfo(t *testing.T) {
 				assert.Equal(t, base.VersionString, resp.Header().Get("Server"))
 
 				body := string(resp.BodyBytes())
-				assert.Contains(t, body, base.ProductName)
-				assert.Contains(t, body, base.VersionNumber)
+				assert.Contains(t, body, base.ProductNameString)
+				assert.Contains(t, body, base.ProductVersionNumber)
 				return
 			}
 
@@ -5368,12 +5368,12 @@ func TestHideProductInfo(t *testing.T) {
 
 			if test.hideProductInfo {
 				assert.Equal(t, "", serverHeader)
-				assert.NotContains(t, body, base.ProductName)
-				assert.NotContains(t, body, base.VersionNumber)
+				assert.NotContains(t, body, base.ProductNameString)
+				assert.NotContains(t, body, base.ProductVersionNumber)
 			} else {
 				assert.Equal(t, base.VersionString, serverHeader)
-				assert.Contains(t, body, base.ProductName)
-				assert.Contains(t, body, base.VersionNumber)
+				assert.Contains(t, body, base.ProductNameString)
+				assert.Contains(t, body, base.ProductVersionNumber)
 			}
 		})
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -98,7 +98,7 @@ type ServerConfig struct {
 	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"` // BLIP data compression level (0-9)
 	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`            // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
 	MetricsInterface           *string                  `json:"metricsInterface,omitempty"`       // Interface to bind metrics to. If not set then metrics isn't accessible
-	HideProductInfo            bool                     `json:"hide_product_info,omitempty"`      // Determines whether product information (name and version) are removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
+	HideProductVersion         bool                     `json:"hide_product_version,omitempty"`   // Determines whether product versions removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
 }
 
 // Bucket configuration elements - used by db, index

--- a/rest/config.go
+++ b/rest/config.go
@@ -98,6 +98,7 @@ type ServerConfig struct {
 	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"` // BLIP data compression level (0-9)
 	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`            // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
 	MetricsInterface           *string                  `json:"metricsInterface,omitempty"`       // Interface to bind metrics to. If not set then metrics isn't accessible
+	HideProductInfo            bool                     `json:"hide_product_info,omitempty"`      // Determines whether product information (name and version) are removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
 }
 
 // Bucket configuration elements - used by db, index

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -16,7 +16,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"math"
@@ -32,6 +31,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -156,7 +156,9 @@ func (h *handler) invoke(method handlerMethod) error {
 		h.logRequestBody()
 	}
 
-	h.setHeader("Server", base.VersionString)
+	if h.shouldShowProductInfo() {
+		h.setHeader("Server", base.VersionString)
+	}
 
 	// If there is a "db" path variable, look up the database context:
 	var dbContext *db.DatabaseContext
@@ -908,4 +910,10 @@ func (h *handler) formatSerialNumber() string {
 		h.formattedSerialNumber = fmt.Sprintf("#%03d", h.serialNumber)
 	}
 	return h.formattedSerialNumber
+}
+
+// shouldShowProductInfo returns whether the handler should show detailed product info (name and version).
+// Admin requests can always see this, regardless of the HideProductInfo setting.
+func (h *handler) shouldShowProductInfo() bool {
+	return h.privs == adminPrivs || !h.server.config.HideProductInfo
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -156,8 +156,10 @@ func (h *handler) invoke(method handlerMethod) error {
 		h.logRequestBody()
 	}
 
-	if h.shouldShowProductInfo() {
+	if h.shouldShowProductVersion() {
 		h.setHeader("Server", base.VersionString)
+	} else {
+		h.setHeader("Server", base.ProductNameString)
 	}
 
 	// If there is a "db" path variable, look up the database context:
@@ -349,10 +351,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		}
 	}
 
-	realm := ""
-	if h.shouldShowProductInfo() {
-		realm = ` realm="` + base.ProductNameString + `"`
-	}
+	realm := ` realm="` + base.ProductNameString + `"`
 
 	// Check basic auth first
 	if userName, password := h.getBasicAuth(); userName != "" {
@@ -917,8 +916,8 @@ func (h *handler) formatSerialNumber() string {
 	return h.formattedSerialNumber
 }
 
-// shouldShowProductInfo returns whether the handler should show detailed product info (name and version).
-// Admin requests can always see this, regardless of the HideProductInfo setting.
-func (h *handler) shouldShowProductInfo() bool {
-	return h.privs == adminPrivs || !h.server.config.HideProductInfo
+// shouldShowProductVersion returns whether the handler should show detailed product info (version).
+// Admin requests can always see this, regardless of the HideProductVersion setting.
+func (h *handler) shouldShowProductVersion() bool {
+	return h.privs == adminPrivs || !h.server.config.HideProductVersion
 }

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -349,13 +349,18 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		}
 	}
 
+	realm := ""
+	if h.shouldShowProductInfo() {
+		realm = ` realm="` + base.ProductNameString + `"`
+	}
+
 	// Check basic auth first
 	if userName, password := h.getBasicAuth(); userName != "" {
 		h.user = context.Authenticator().AuthenticateUser(userName, password)
 		if h.user == nil {
 			base.Infof(base.KeyAll, "HTTP auth failed for username=%q", base.UD(userName))
 			if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
-				h.response.Header().Set("WWW-Authenticate", `Basic realm="`+base.ProductNameString+`"`)
+				h.response.Header().Set("WWW-Authenticate", "Basic"+realm)
 			}
 			return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 		}
@@ -376,7 +381,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 	}
 	if h.privs == regularPrivs && h.user.Disabled() {
 		if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
-			h.response.Header().Set("WWW-Authenticate", `Basic realm="`+base.ProductNameString+`"`)
+			h.response.Header().Set("WWW-Authenticate", "Basic"+realm)
 		}
 		return base.HTTPErrorf(http.StatusUnauthorized, "Login required")
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -355,7 +355,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		if h.user == nil {
 			base.Infof(base.KeyAll, "HTTP auth failed for username=%q", base.UD(userName))
 			if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
-				h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
+				h.response.Header().Set("WWW-Authenticate", `Basic realm="`+base.ProductNameString+`"`)
 			}
 			return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 		}
@@ -376,7 +376,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 	}
 	if h.privs == regularPrivs && h.user.Disabled() {
 		if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
-			h.response.Header().Set("WWW-Authenticate", `Basic realm="Couchbase Sync Gateway"`)
+			h.response.Header().Set("WWW-Authenticate", `Basic realm="`+base.ProductNameString+`"`)
 		}
 		return base.HTTPErrorf(http.StatusUnauthorized, "Login required")
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -351,7 +351,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		}
 	}
 
-	realm := ` realm="` + base.ProductNameString + `"`
+	wwwAuthenticateHeader := `Basic realm="` + base.ProductNameString + `"`
 
 	// Check basic auth first
 	if userName, password := h.getBasicAuth(); userName != "" {
@@ -359,7 +359,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		if h.user == nil {
 			base.Infof(base.KeyAll, "HTTP auth failed for username=%q", base.UD(userName))
 			if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
-				h.response.Header().Set("WWW-Authenticate", "Basic"+realm)
+				h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)
 			}
 			return base.HTTPErrorf(http.StatusUnauthorized, "Invalid login")
 		}
@@ -380,7 +380,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 	}
 	if h.privs == regularPrivs && h.user.Disabled() {
 		if context.Options.SendWWWAuthenticateHeader == nil || *context.Options.SendWWWAuthenticateHeader {
-			h.response.Header().Set("WWW-Authenticate", "Basic"+realm)
+			h.response.Header().Set("WWW-Authenticate", wwwAuthenticateHeader)
 		}
 		return base.HTTPErrorf(http.StatusUnauthorized, "Login required")
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -116,11 +116,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 		adminInterface = &rt.RestTesterConfig.adminInterface
 	}
 	rt.RestTesterServerContext = NewServerContext(&ServerConfig{
-		CORS:            corsConfig,
-		Facebook:        &FacebookConfig{},
-		AdminInterface:  adminInterface,
-		Replications:    rt.RestTesterConfig.sgr1Replications,
-		HideProductInfo: rt.RestTesterConfig.hideProductInfo,
+		CORS:               corsConfig,
+		Facebook:           &FacebookConfig{},
+		AdminInterface:     adminInterface,
+		Replications:       rt.RestTesterConfig.sgr1Replications,
+		HideProductVersion: rt.RestTesterConfig.hideProductInfo,
 	})
 
 	useXattrs := base.TestUseXattrs()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -42,6 +42,7 @@ type RestTesterConfig struct {
 	adminInterface        string               // adminInterface overrides the default admin interface.
 	sgReplicateEnabled    bool                 // sgReplicateManager disabled by default for RestTester
 	sgr1Replications      []*ReplicateV1Config // sgr1Replications are a list of replications to enable on the server context.
+	hideProductInfo       bool
 }
 
 type RestTester struct {
@@ -115,10 +116,11 @@ func (rt *RestTester) Bucket() base.Bucket {
 		adminInterface = &rt.RestTesterConfig.adminInterface
 	}
 	rt.RestTesterServerContext = NewServerContext(&ServerConfig{
-		CORS:           corsConfig,
-		Facebook:       &FacebookConfig{},
-		AdminInterface: adminInterface,
-		Replications:   rt.RestTesterConfig.sgr1Replications,
+		CORS:            corsConfig,
+		Facebook:        &FacebookConfig{},
+		AdminInterface:  adminInterface,
+		Replications:    rt.RestTesterConfig.sgr1Replications,
+		HideProductInfo: rt.RestTesterConfig.hideProductInfo,
 	})
 
 	useXattrs := base.TestUseXattrs()


### PR DESCRIPTION
- Added opt-in `hide_product_version` server config option to omit product version information from non-admin API response bodies and headers.
- Rescoped/renamed a few build-only placeholders in `version.go` to avoid accidental usage.