### PR TITLE
CBG-1171 TestSGR2TombstoneConflictHandling fails against Couchbase Server w/ xattrs=false

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3928,17 +3928,6 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 		},
 	}
 
-	isDeleted := func(val int) bool {
-		if val == channels.Deleted {
-			return true
-		} else if val == channels.Branched|channels.Deleted {
-			return true
-		} else if val == channels.Branched|channels.Hidden|channels.Deleted {
-			return true
-		}
-		return false
-	}
-
 	// requireTombstone validates tombstoned revision.
 	requireTombstone := func(t *testing.T, bucket *base.TestBucket, docID string) {
 		var rawBody db.Body
@@ -3953,7 +3942,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 			require.True(t, ok)
 			val, ok := rawSyncData["flags"].(float64)
 			require.True(t, ok)
-			require.True(t, isDeleted(int(val)))
+			require.NotEqual(t, 0, int(val)&channels.Deleted)
 		}
 	}
 

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -14,14 +14,10 @@ import (
 	"testing"
 	"time"
 
-	pkgerrors "github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"gopkg.in/couchbase/gocb.v1"
-
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestActiveReplicatorBlipsync uses an ActiveReplicator with another RestTester instance to connect and cleanly disconnect.
@@ -3936,8 +3932,7 @@ func TestSGR2TombstoneConflictHandling(t *testing.T) {
 		var rawBody db.Body
 		_, err := bucket.Get(docID, &rawBody)
 		if base.TestUseXattrs() {
-			require.Error(t, err)
-			require.Equal(t, gocb.ErrKeyNotFound, pkgerrors.Cause(err))
+			require.True(t, base.IsDocNotFoundError(err))
 			require.Len(t, rawBody, 0)
 		} else {
 			require.NoError(t, err)


### PR DESCRIPTION
Fix for TestSGR2TombstoneConflictHandling failure.vThe error check that's failing the Couchbase Server builds (expecting ErrNotFound, not getting it) is only passing for walrus builds locally because an unrelated error is being returned (trying to unmarshal JSON into []byte). This is addressed in this PR and the test is enabled.