### PR TITLE
CBG-1222 Remove legacy cbgt index definition

### DIFF
--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -2,10 +2,13 @@ package base
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"testing"
 
+	"github.com/couchbase/cbgt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // func TransformBucketCredentials(inputUsername, inputPassword, inputBucketname string) (username, password, bucketname string) {
@@ -53,6 +56,311 @@ func TestDCPKeyFilter(t *testing.T) {
 	assert.False(t, dcpKeyFilter([]byte(SyncDataKey)))
 	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
 	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData")))
+}
+
+func TestCBGTIndexCreation(t *testing.T) {
+	if UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server bucket")
+	}
+
+	shortDbName := "testDB"
+	longDbName := "testDB" +
+		"01234567890123456789012345678901234567890123456789" +
+		"01234567890123456789012345678901234567890123456789" +
+		"01234567890123456789012345678901234567890123456789"
+
+	for _, tc := range []struct {
+		name                 string
+		dbName               string
+		existingLegacyIndex  bool
+		existingCurrentIndex bool
+		expectedIndexName    string
+	}{
+		{
+			name:                 "nonUpgradeFirstRun",
+			dbName:               shortDbName,
+			existingLegacyIndex:  false,
+			existingCurrentIndex: false,
+			expectedIndexName:    GenerateIndexName(shortDbName),
+		},
+		{
+			name:                 "nonUpgradeRestart",
+			dbName:               shortDbName,
+			existingLegacyIndex:  false,
+			existingCurrentIndex: true,
+			expectedIndexName:    GenerateIndexName(shortDbName),
+		},
+		{
+			name:                 "nonUpgradeUnsafeName",
+			dbName:               longDbName,
+			existingLegacyIndex:  false,
+			existingCurrentIndex: false,
+			expectedIndexName:    GenerateIndexName(longDbName),
+		},
+		{
+			name:                 "upgradeFromSafeLegacy",
+			dbName:               shortDbName,
+			existingLegacyIndex:  true,
+			existingCurrentIndex: false,
+			expectedIndexName:    GenerateLegacyIndexName(shortDbName),
+		},
+		{
+			name:                 "upgradeFromUnsafeLegacy",
+			dbName:               longDbName,
+			existingLegacyIndex:  true,
+			existingCurrentIndex: false,
+			expectedIndexName:    GenerateIndexName(longDbName),
+		},
+		{
+			name:                 "upgradeFromSafeDualIndex",
+			dbName:               shortDbName,
+			existingLegacyIndex:  true,
+			existingCurrentIndex: true,
+			expectedIndexName:    GenerateIndexName(shortDbName),
+		},
+		{
+			name:                 "upgradeFromUnsafeDualIndex",
+			dbName:               longDbName,
+			existingLegacyIndex:  true,
+			existingCurrentIndex: true,
+			expectedIndexName:    GenerateIndexName(longDbName),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bucket := GetTestBucket(t)
+			defer bucket.Close()
+
+			spec := bucket.BucketSpec
+
+			// Use an in-memory cfg, set up cbgt manager
+			cfg := cbgt.NewCfgMem()
+			context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation")
+			assert.NoError(t, err)
+
+			// Start Manager
+			registerType := cbgt.NODE_DEFS_WANTED
+			err = context.Manager.Start(registerType)
+			require.NoError(t, err)
+
+			// Define index type
+			indexType := CBGTIndexTypeSyncGatewayImport + tc.dbName
+			cbgt.RegisterPIndexImplType(indexType,
+				&cbgt.PIndexImplType{})
+
+			// Create existing index in legacy format
+			if tc.existingLegacyIndex {
+				// Define a CBGT index with legacy naming
+				bucketUUID, _ := bucket.UUID()
+				sourceParams, err := cbgtFeedParams(spec)
+				require.NoError(t, err)
+				legacyIndexName := GenerateLegacyIndexName(tc.dbName)
+				indexParams := `{"name": "` + tc.dbName + `"}`
+				planParams := cbgt.PlanParams{
+					MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
+					NumReplicas:            0,  // No replicas required for SG sharded feed
+				}
+
+				err = context.Manager.CreateIndex(
+					"couchbase",      // sourceType
+					bucket.GetName(), // sourceName
+					bucketUUID,       // sourceUUID
+					sourceParams,     // sourceParams
+					indexType,        // indexType
+					legacyIndexName,  // indexName
+					indexParams,      // indexParams
+					planParams,       // planParams
+					"",               // prevIndexUUID
+				)
+				require.NoError(t, err, "Unable to create legacy-style index")
+			}
+
+			if tc.existingCurrentIndex {
+				// Define an existing CBGT index with current naming
+				bucketUUID, _ := bucket.UUID()
+				sourceParams, err := cbgtFeedParams(spec)
+				require.NoError(t, err)
+				legacyIndexName := GenerateIndexName(tc.dbName)
+				indexParams := `{"name": "` + tc.dbName + `"}`
+				planParams := cbgt.PlanParams{
+					MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
+					NumReplicas:            0,  // No replicas required for SG sharded feed
+				}
+
+				err = context.Manager.CreateIndex(
+					"couchbase",      // sourceType
+					bucket.GetName(), // sourceName
+					bucketUUID,       // sourceUUID
+					sourceParams,     // sourceParams
+					indexType,        // indexType
+					legacyIndexName,  // indexName
+					indexParams,      // indexParams
+					planParams,       // planParams
+					"",               // prevIndexUUID
+				)
+				require.NoError(t, err, "Unable to create legacy-style index")
+			}
+
+			// Create cbgt index via SG handling
+			err = createCBGTIndex(context, tc.dbName, bucket, spec, 16)
+			require.NoError(t, err)
+
+			// Verify single index exists, and matches expected naming
+			_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(indexDefsMap))
+			_, ok := indexDefsMap[tc.expectedIndexName]
+			assert.True(t, ok, "Expected index name"+tc.expectedIndexName+"not found")
+			log.Printf("Index defs: %+v", indexDefsMap)
+		})
+	}
+}
+
+func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server bucket")
+	}
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	spec := bucket.BucketSpec
+
+	// Use an in-memory cfg, set up cbgt manager
+	cfg := cbgt.NewCfgMem()
+	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation")
+	assert.NoError(t, err)
+
+	// Start Manager
+	registerType := cbgt.NODE_DEFS_WANTED
+	err = context.Manager.Start(registerType)
+	require.NoError(t, err)
+
+	// Define index type
+	testDbName := "testDB"
+	indexType := CBGTIndexTypeSyncGatewayImport + testDbName
+	cbgt.RegisterPIndexImplType(indexType,
+		&cbgt.PIndexImplType{})
+
+	// Define a CBGT index with legacy naming within safe limits
+	bucketUUID, _ := bucket.UUID()
+	sourceParams, err := cbgtFeedParams(spec)
+	require.NoError(t, err)
+	legacyIndexName := GenerateLegacyIndexName(testDbName)
+	indexParams := `{"name": "` + testDbName + `"}`
+	planParams := cbgt.PlanParams{
+		MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
+		NumReplicas:            0,  // No replicas required for SG sharded feed
+	}
+
+	err = context.Manager.CreateIndex(
+		"couchbase",      // sourceType
+		bucket.GetName(), // sourceName
+		bucketUUID,       // sourceUUID
+		sourceParams,     // sourceParams
+		indexType,        // indexType
+		legacyIndexName,  // indexName
+		indexParams,      // indexParams
+		planParams,       // planParams
+		"",               // prevIndexUUID
+	)
+	require.NoError(t, err, "Unable to create legacy-style index")
+
+	// Create cbgt index
+	err = createCBGTIndex(context, testDbName, bucket, spec, 16)
+	require.NoError(t, err)
+
+	// Verify single index created
+	_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(indexDefsMap))
+
+	// Attempt to recreate index
+	err = createCBGTIndex(context, testDbName, bucket, spec, 16)
+	require.NoError(t, err)
+
+	// Verify single index defined (acts as upsert to existing)
+	_, indexDefsMap, err = context.Manager.GetIndexDefs(true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(indexDefsMap))
+	_, ok := indexDefsMap[legacyIndexName]
+	assert.True(t, ok)
+}
+
+func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server bucket")
+	}
+	bucket := GetTestBucket(t)
+	defer bucket.Close()
+
+	spec := bucket.BucketSpec
+
+	// Use an in-memory cfg, set up cbgt manager
+	cfg := cbgt.NewCfgMem()
+	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation")
+	assert.NoError(t, err)
+
+	// Start Manager
+	registerType := cbgt.NODE_DEFS_WANTED
+	err = context.Manager.Start(registerType)
+	require.NoError(t, err)
+
+	unsafeTestDBName := "testDB" +
+		"01234567890123456789012345678901234567890123456789" +
+		"01234567890123456789012345678901234567890123456789" +
+		"01234567890123456789012345678901234567890123456789"
+
+	// Define index type
+	indexType := CBGTIndexTypeSyncGatewayImport + unsafeTestDBName
+	cbgt.RegisterPIndexImplType(indexType,
+		&cbgt.PIndexImplType{})
+
+	// Define a CBGT index with legacy naming not within safe limits
+	bucketUUID, _ := bucket.UUID()
+	sourceParams, err := cbgtFeedParams(spec)
+	require.NoError(t, err)
+	legacyIndexName := GenerateLegacyIndexName(unsafeTestDBName)
+	indexParams := `{"name": "` + unsafeTestDBName + `"}`
+	planParams := cbgt.PlanParams{
+		MaxPartitionsPerPIndex: 16, // num vbuckets per Pindex.  Multiple Pindexes could be assigned per node.
+		NumReplicas:            0,  // No replicas required for SG sharded feed
+	}
+
+	err = context.Manager.CreateIndex(
+		"couchbase",      // sourceType
+		bucket.GetName(), // sourceName
+		bucketUUID,       // sourceUUID
+		sourceParams,     // sourceParams
+		indexType,        // indexType
+		legacyIndexName,  // indexName
+		indexParams,      // indexParams
+		planParams,       // planParams
+		"",               // prevIndexUUID
+	)
+	require.NoError(t, err, "Unable to create legacy-style index")
+
+	// Create cbgt index
+	err = createCBGTIndex(context, unsafeTestDBName, bucket, spec, 16)
+	require.NoError(t, err)
+
+	// Verify single index created
+	_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(indexDefsMap))
+
+	// Attempt to recreate index
+	err = createCBGTIndex(context, unsafeTestDBName, bucket, spec, 16)
+	require.NoError(t, err)
+
+	// Verify single index defined (acts as upsert to existing)
+	_, indexDefsMap, err = context.Manager.GetIndexDefs(true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(indexDefsMap))
+	_, ok := indexDefsMap[legacyIndexName]
+	assert.False(t, ok)
+	_, ok = indexDefsMap[GenerateIndexName(unsafeTestDBName)]
+	assert.True(t, ok)
 }
 
 // Compare Atoi vs map lookup for partition conversion


### PR DESCRIPTION
Includes special handling for the case where the legacy index name is DCP-safe (less than 200 characters), and a new index hasn't already been created.  In this scenario, legacy naming continues to be used.