### PR TITLE
[2.8.1 Backport] CBG-1200: Improve handling for newly created tombstones to prevent empty documents (#4884)

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -992,7 +992,9 @@ func (doc *Document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 func (doc *Document) MarshalWithXattr() (data []byte, xdata []byte, err error) {
 	// Grab the rawBody if it's already marshalled, otherwise unmarshal the body
 	if doc._rawBody != nil {
-		data = doc._rawBody
+		if !doc.IsDeleted() {
+			data = doc._rawBody
+		}
 	} else {
 		body := doc._body
 		// If body is non-empty and non-deleted, unmarshal and return

--- a/db/import.go
+++ b/db/import.go
@@ -89,7 +89,11 @@ func (db *Database) ImportDoc(docid string, existingDoc *Document, isDelete bool
 		existingBucketDoc.Body, err = existingDoc.MarshalJSON()
 		existingBucketDoc.Xattr = nil
 	} else {
-		existingBucketDoc.Body, existingBucketDoc.Xattr, err = existingDoc.MarshalWithXattr()
+		if existingDoc.Deleted {
+			existingBucketDoc.Xattr, err = base.JSONMarshal(existingDoc.SyncData)
+		} else {
+			existingBucketDoc.Body, existingBucketDoc.Xattr, err = existingDoc.MarshalWithXattr()
+		}
 	}
 
 	if err != nil {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -46,7 +46,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="db06807997e6f778fe135571140a0c4f1f59723c"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="9b201da3276b0475203dfa121a82cd4ccf37b8f2"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="d4ee4b62887856071adfae0b36636add1946d0c9"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
Backport of #4884 to 2.8.1. Only change that is differing from #4884 is rename of the bucket feature.
- [x] #4934 will need merging for build to succeed
- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/665/
Kicked off integration run to be sure given I had to make some tweaks.