### PR TITLE
Add GH Action for static analysis and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   ci:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest] # windows-latest missing due to non-cross platform bootstrap process... Go modules should fix this
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -25,7 +22,7 @@ jobs:
           chmod +x bootstrap.sh
           ./bootstrap.sh -c $GITHUB_SHA
           echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
-      # When we're using Go modules, it should be feasible to use `actions/checkout@v2` for each of these jobs to be run in parallel without bootstrap
+      # When we're using Go modules, it should be feasible to use `actions/checkout@v2` for each of these jobs to be run in parallel without bootstrap as it's a lot quicker
       - name: build
         run: go build -v github.com/couchbase/sync_gateway
       - name: gofmt
@@ -35,4 +32,5 @@ jobs:
       - name: vet
         run: go vet github.com/couchbase/sync_gateway/...
       - name: test
-        run: go test -timeout=20m -race -count=1 -v github.com/couchbase/sync_gateway/...
+        # no -race (to speed up testing)
+        run: go test -timeout=20m -count=1 -v github.com/couchbase/sync_gateway/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'gh_actions_for_testing'
+  pull_request:
+    branches:
+      - 'master'
+      - 'release/*'
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest] # windows-latest missing due to non-cross platform bootstrap process... Go modules should fix this
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13.4
+      - name: Bootstrap
+        run: |
+          wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
+          chmod +x bootstrap.sh
+          ./bootstrap.sh -c $GITHUB_SHA
+          echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
+      # When we're using Go modules, it should be feasible to use `actions/checkout@v2` for each of these jobs to be run in parallel without bootstrap
+      - name: build
+        run: go build -v github.com/couchbase/sync_gateway
+      - name: gofmt
+        run: |
+          gofmt -d -e ${GOPATH}/src/github.com/couchbase/sync_gateway | tee gofmt.out
+          test -z "$(cat gofmt.out)"
+      - name: vet
+        run: go vet github.com/couchbase/sync_gateway/...
+      - name: test
+        run: go test -timeout=20m -race -count=1 -v github.com/couchbase/sync_gateway/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - 'release/*'
 
 jobs:
-  ci:
+  static-analysis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
@@ -22,7 +22,6 @@ jobs:
           chmod +x bootstrap.sh
           ./bootstrap.sh -c $GITHUB_SHA
           echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
-      # When we're using Go modules, it should be feasible to use `actions/checkout@v2` for each of these jobs to be run in parallel without bootstrap as it's a lot quicker
       - name: build
         run: go build -v github.com/couchbase/sync_gateway
       - name: gofmt
@@ -31,6 +30,33 @@ jobs:
           test -z "$(cat gofmt.out)"
       - name: vet
         run: go vet github.com/couchbase/sync_gateway/...
-      - name: test
-        # no -race (to speed up testing)
-        run: go test -timeout=20m -count=1 -v github.com/couchbase/sync_gateway/...
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13.4
+      - name: Bootstrap
+        run: |
+          wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
+          chmod +x bootstrap.sh
+          ./bootstrap.sh -c $GITHUB_SHA
+          echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
+      - name: 'test'
+        run: go test -timeout=30m -count=1 -v github.com/couchbase/sync_gateway/...
+
+  test-race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13.4
+      - name: Bootstrap
+        run: |
+          wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
+          chmod +x bootstrap.sh
+          ./bootstrap.sh -c $GITHUB_SHA
+          echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
+      - name: 'test -race'
+        run: go test -race -timeout=30m -count=1 -v github.com/couchbase/sync_gateway/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - 'gh_actions_for_testing'
   pull_request:
     branches:
       - 'master'
@@ -20,7 +17,7 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
           chmod +x bootstrap.sh
-          ./bootstrap.sh -c $GITHUB_SHA
+          ./bootstrap.sh -c ${{ github.event.pull_request.head.sha }}
           echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
       - name: build
         run: go build -v github.com/couchbase/sync_gateway
@@ -41,7 +38,7 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
           chmod +x bootstrap.sh
-          ./bootstrap.sh -c $GITHUB_SHA
+          ./bootstrap.sh -c ${{ github.event.pull_request.head.sha }}
           echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
       - name: 'test'
         run: go test -timeout=30m -count=1 -v github.com/couchbase/sync_gateway/...
@@ -56,7 +53,7 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
           chmod +x bootstrap.sh
-          ./bootstrap.sh -c $GITHUB_SHA
+          ./bootstrap.sh -c ${{ github.event.pull_request.head.sha }}
           echo "GOPATH=$GITHUB_WORKSPACE/godeps" >> $GITHUB_ENV
       - name: 'test -race'
         run: go test -race -timeout=30m -count=1 -v github.com/couchbase/sync_gateway/...


### PR DESCRIPTION
- Runs:
  - `go build`, `go fmt,` and `go vet`
  - `go test`
  - `go test -race`

(with a bootstrap for each job)

Unlike the last GH Actions attempt, this does not utilize any caching, so won't be affected by the same issues we saw with the `golangci-lint` action.