### PR TITLE
Test race fix: Lazy eval of BlipTesterClient's GetMessages for assertion logging

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2295,14 +2295,20 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 	msg, ok := client1.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac") // docid, revid to get the message
 	assert.True(t, ok)
-	assert.Equal(t, db.MessageRev, msg.Profile(), "unexpected profile for message %v in %v",
-		msg.SerialNumber(), client1.pullReplication.GetMessages())
+	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
+		t.Logf("unexpected profile for message %v in %v",
+			msg.SerialNumber(), client1.pullReplication.GetMessages())
+	}
 	msgBody, err := msg.Body()
 	assert.NoError(t, err)
-	assert.Equal(t, `{}`, string(msgBody), "unexpected body for message %v in %v",
-		msg.SerialNumber(), client1.pullReplication.GetMessages())
-	assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted], "unexpected deleted property for message %v in %v",
-		msg.SerialNumber(), client1.pullReplication.GetMessages())
+	if !assert.Equal(t, `{}`, string(msgBody)) {
+		t.Logf("unexpected body for message %v in %v",
+			msg.SerialNumber(), client1.pullReplication.GetMessages())
+	}
+	if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
+		t.Logf("unexpected deleted property for message %v in %v",
+			msg.SerialNumber(), client1.pullReplication.GetMessages())
+	}
 
 	// Sync Gateway will have cached the tombstone delta, so client 2 should be able to retrieve it from the cache
 	err = client2.StartOneshotPull()
@@ -2314,14 +2320,20 @@ func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
 	msg, ok = client2.WaitForBlipRevMessage("doc1", "2-ed278cbc310c9abeea414da15d0b2cac")
 	assert.True(t, ok)
-	assert.Equal(t, db.MessageRev, msg.Profile(), "unexpected profile for message %v in %v",
-		msg.SerialNumber(), client2.pullReplication.GetMessages())
+	if !assert.Equal(t, db.MessageRev, msg.Profile()) {
+		t.Logf("unexpected profile for message %v in %v",
+			msg.SerialNumber(), client2.pullReplication.GetMessages())
+	}
 	msgBody, err = msg.Body()
 	assert.NoError(t, err)
-	assert.Equal(t, `{}`, string(msgBody), "unexpected body for message %v in %v",
-		msg.SerialNumber(), client2.pullReplication.GetMessages())
-	assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted], "unexpected deleted property for message %v in %v",
-		msg.SerialNumber(), client2.pullReplication.GetMessages())
+	if !assert.Equal(t, `{}`, string(msgBody)) {
+		t.Logf("unexpected body for message %v in %v",
+			msg.SerialNumber(), client2.pullReplication.GetMessages())
+	}
+	if !assert.Equal(t, "1", msg.Properties[db.RevMessageDeleted]) {
+		t.Logf("unexpected deleted property for message %v in %v",
+			msg.SerialNumber(), client2.pullReplication.GetMessages())
+	}
 
 	var deltaCacheHitsEnd int64
 	var deltaCacheMissesEnd int64


### PR DESCRIPTION
Race detector was triggered because the assertion line was evaluating `client.GetMessages()`, even though it's really just for failure diagnostics.

Moved the logging down into a failure-only case to avoid race in a passing test.


https://github.com/couchbase/sync_gateway/runs/1738799061?check_suite_focus=true

```
2021-01-21T01:06:10.7793609Z ==================
2021-01-21T01:06:10.7793877Z WARNING: DATA RACE
2021-01-21T01:06:10.7794179Z Read at 0x00c000548f10 by goroutine 108:
2021-01-21T01:06:10.7794629Z   github.com/couchbase/sync_gateway/rest.(*BlipTesterReplicator).GetMessages()
2021-01-21T01:06:10.7795417Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/blip_client_test.go:727 +0x204
2021-01-21T01:06:10.7796171Z   github.com/couchbase/sync_gateway/rest.TestBlipDeltaSyncPullTombstonedStarChan()
2021-01-21T01:06:10.7796891Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/blip_api_test.go:2318 +0x1a41
2021-01-21T01:06:10.7797343Z   testing.tRunner()
2021-01-21T01:06:10.7797772Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:909 +0x199
2021-01-21T01:06:10.7798040Z 
2021-01-21T01:06:10.7798333Z Previous write at 0x00c000548f10 by goroutine 124:
2021-01-21T01:06:10.7798971Z   github.com/couchbase/go-blip.(*Message).responseComplete()
2021-01-21T01:06:10.7799776Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/message.go:322 +0x13b
2021-01-21T01:06:10.7800470Z   github.com/couchbase/go-blip.(*Sender).send.func1.1()
2021-01-21T01:06:10.7801240Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/sender.go:95 +0x53
2021-01-21T01:06:10.7801919Z   github.com/couchbase/go-blip.(*Message).asyncRead.func1()
2021-01-21T01:06:10.7802722Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/message.go:371 +0x128
2021-01-21T01:06:10.7803048Z 
2021-01-21T01:06:10.7803314Z Goroutine 108 (running) created at:
2021-01-21T01:06:10.7803630Z   testing.(*T).Run()
2021-01-21T01:06:10.7804028Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:960 +0x651
2021-01-21T01:06:10.7804412Z   testing.runTests.func1()
2021-01-21T01:06:10.7804849Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:1202 +0xa6
2021-01-21T01:06:10.7805203Z   testing.tRunner()
2021-01-21T01:06:10.7805705Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:909 +0x199
2021-01-21T01:06:10.7806069Z   testing.runTests()
2021-01-21T01:06:10.7806669Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:1200 +0x521
2021-01-21T01:06:10.7807024Z   testing.(*M).Run()
2021-01-21T01:06:10.7807434Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:1117 +0x2ff
2021-01-21T01:06:10.7807866Z   github.com/couchbase/sync_gateway/rest.TestMain()
2021-01-21T01:06:10.7808430Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/main_test.go:16 +0xe7
2021-01-21T01:06:10.7808871Z   main.main()
2021-01-21T01:06:10.7809150Z       _testmain.go:910 +0x223
2021-01-21T01:06:10.7809336Z 
2021-01-21T01:06:10.7809614Z Goroutine 124 (finished) created at:
2021-01-21T01:06:10.7810187Z   github.com/couchbase/go-blip.(*Message).asyncRead()
2021-01-21T01:06:10.7810966Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/message.go:357 +0x261
2021-01-21T01:06:10.7811640Z   github.com/couchbase/go-blip.(*Sender).send.func1()
2021-01-21T01:06:10.7812395Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/sender.go:93 +0x3fa
2021-01-21T01:06:10.7813117Z   github.com/couchbase/go-blip.(*messageQueue).pushWithCallback()
2021-01-21T01:06:10.7813936Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/messagequeue.go:105 +0x3aa
2021-01-21T01:06:10.7814606Z   github.com/couchbase/go-blip.(*Sender).send()
2021-01-21T01:06:10.7815350Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/sender.go:102 +0xd7
2021-01-21T01:06:10.7815996Z   github.com/couchbase/go-blip.(*Sender).Send()
2021-01-21T01:06:10.7816740Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/go-blip/sender.go:73 +0x78
2021-01-21T01:06:10.7817295Z   github.com/couchbase/sync_gateway/rest.(*BlipTesterReplicator).sendMsg()
2021-01-21T01:06:10.7817923Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/blip_client_test.go:529 +0x76
2021-01-21T01:06:10.7818510Z   github.com/couchbase/sync_gateway/rest.(*BlipTesterClient).StartPullSince()
2021-01-21T01:06:10.7819153Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/blip_client_test.go:493 +0x3a3
2021-01-21T01:06:10.7819954Z   github.com/couchbase/sync_gateway/rest.TestBlipDeltaSyncPullTombstonedStarChan()
2021-01-21T01:06:10.7820667Z       /home/runner/work/sync_gateway/sync_gateway/godeps/src/github.com/couchbase/sync_gateway/rest/blip_client_test.go:485 +0x1736
2021-01-21T01:06:10.7821142Z   testing.tRunner()
2021-01-21T01:06:10.7821543Z       /opt/hostedtoolcache/go/1.13.4/x64/src/testing/testing.go:909 +0x199
2021-01-21T01:06:10.7821876Z ==================
```