### PR TITLE
Allow for walrus bucket persistence

### DIFF
--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -194,7 +194,10 @@ func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s Bucke
 			FatalfCtx(ctx, "nil TestBucketPool, but not using a Walrus test URL")
 		}
 
-		walrusBucket := walrus.NewBucket(tbpBucketNamePrefix + "walrus_" + GenerateRandomID())
+		walrusBucket, err := walrus.GetBucket(s.Server, DefaultPool, tbpBucketNamePrefix+"walrus_"+GenerateRandomID())
+		if err != nil {
+			FatalfCtx(ctx, "couldn't get walrus bucket: %v", err)
+		}
 
 		// Wrap Walrus buckets with a leaky bucket to support vbucket IDs on feed.
 		b = &LeakyBucket{bucket: walrusBucket, config: LeakyBucketConfig{TapFeedVbuckets: true}}
@@ -203,7 +206,7 @@ func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s Bucke
 		tbp.Logf(ctx, "Creating new walrus test bucket")
 
 		initFuncStart := time.Now()
-		err := tbp.bucketInitFunc(ctx, b, tbp)
+		err = tbp.bucketInitFunc(ctx, b, tbp)
 		if err != nil {
 			FatalfCtx(ctx, "couldn't run bucket init func: %v", err)
 		}

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -237,7 +237,7 @@ func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s Bucke
 
 	// Return a new Walrus bucket when tbp has not been initialized
 	if !tbp.integrationMode {
-		return tbp.GetWalrusTestBucket(t, "")
+		return tbp.GetWalrusTestBucket(t, "walrus:")
 	}
 
 	if atomic.LoadUint32(&tbp.preservedBucketCount) >= uint32(cap(tbp.readyBucketPool)) {

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -518,8 +518,8 @@ func installViews(bucket base.Bucket) error {
 		               }`
 	roleAccess_vbSeq_map = fmt.Sprintf(roleAccess_vbSeq_map, syncData, base.SyncPrefix)
 
-	designDocMap := map[string]sgbucket.DesignDoc{}
-	designDocMap[DesignDocSyncGateway()] = sgbucket.DesignDoc{
+	designDocMap := map[string]*sgbucket.DesignDoc{}
+	designDocMap[DesignDocSyncGateway()] = &sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			ViewChannels:        sgbucket.ViewDef{Map: channels_map},
 			ViewAccess:          sgbucket.ViewDef{Map: access_map},
@@ -533,7 +533,7 @@ func installViews(bucket base.Bucket) error {
 		},
 	}
 
-	designDocMap[DesignDocSyncHousekeeping()] = sgbucket.DesignDoc{
+	designDocMap[DesignDocSyncHousekeeping()] = &sgbucket.DesignDoc{
 		Views: sgbucket.ViewMap{
 			ViewAllDocs:    sgbucket.ViewDef{Map: alldocs_map, Reduce: "_count"},
 			ViewImport:     sgbucket.ViewDef{Map: import_map, Reduce: "_count"},
@@ -555,7 +555,7 @@ func installViews(bucket base.Bucket) error {
 
 		//start a retry loop to put design document backing off double the delay each time
 		worker := func() (shouldRetry bool, err error, value interface{}) {
-			err = bucket.PutDDoc(designDocName, &designDoc)
+			err = bucket.PutDDoc(designDocName, designDoc)
 			if err != nil {
 				base.Warnf("Error installing Couchbase design doc: %v", err)
 			}


### PR DESCRIPTION
- Switch NewBucket to GetBucket. This will allow a file to be created in the event that s.Server is set to walrus://. If it isn't set walrus detects this and will fall back to the NewBucket behaviour.
- Switch design doc map to map of pointers to design doc. Avoids the pointer we pass to PutDDoc from changing underneath us.