### PR TITLE
CBG-1230 Include uptime stat in both metrics and expvar endpoints

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -107,7 +107,7 @@ func (g *GlobalStat) initResourceUtilizationStats() {
 		SystemMemoryTotal:                   NewIntStat(ResourceUtilizationSubsystem, "system_memory_total", nil, nil, prometheus.GaugeValue, 0),
 		WarnCount:                           NewIntStat(ResourceUtilizationSubsystem, "warn_count", nil, nil, prometheus.CounterValue, 0),
 		CpuPercentUtil:                      NewFloatStat(ResourceUtilizationSubsystem, "process_cpu_percent_utilization", nil, nil, prometheus.GaugeValue, 0),
-		Uptime:                              NewDurStat(ResourceUtilizationSubsystem, "uptime", nil, nil, prometheus.GaugeValue, time.Now()),
+		Uptime:                              NewDurStat(ResourceUtilizationSubsystem, "uptime", nil, nil, prometheus.CounterValue, time.Now()),
 	}
 }
 
@@ -511,45 +511,40 @@ func (s *SgwFloatStat) Value() float64 {
 
 // SgwDurStat is a wrapper around SgwStat for reporting time duration stats.
 type SgwDurStat struct {
-	SgwStat           // SGW stats for sending metrics to Prometheus.
-	Val     time.Time // Start time to calculate the time duration.
+	SgwStat             // SGW stats for sending metrics to Prometheus.
+	StartTime time.Time // Start time to calculate the time duration.
 }
 
 // NewDurStat creates a new collector for time duration metric, registers it with the
 // Prometheus's DefaultRegisterer and returns the collector. It panics if any error
-// occurs while registering the collector Prometheus registry.
+// occurs while registering the collector on Prometheus registry.
 func NewDurStat(subsystem string, key string, labelKeys []string, labelVals []string,
 	statValueType prometheus.ValueType, initialValue time.Time) *SgwDurStat {
 	stat := &SgwDurStat{
-		SgwStat: *newSGWStat(subsystem, key, labelKeys, labelVals, statValueType),
-		Val:     initialValue,
+		SgwStat:   *newSGWStat(subsystem, key, labelKeys, labelVals, statValueType),
+		StartTime: initialValue,
 	}
 	prometheus.MustRegister(stat)
 	return stat
 }
 
-// Describe sends the super-set of all possible descriptors of metrics
-// collected by duration stats Collector to the provided channel and
-// returns once the last descriptor has been sent. Not implemented yet.
 func (s *SgwDurStat) Describe(ch chan<- *prometheus.Desc) {
 	return
 }
 
-// Collect sends the collected time duration metric via the provided
-// channel and returns once the last metric has been sent.
 func (s *SgwDurStat) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(s.statDesc, s.statValueType,
-		float64(time.Since(s.Val)), s.labelValues...)
+		float64(time.Since(s.StartTime)), s.labelValues...)
 }
 
 // MarshalJSON returns the JSON encoding of duration - the time elapsed since s.Val.
 func (s *SgwDurStat) MarshalJSON() ([]byte, error) {
-	return JSONMarshal(time.Since(s.Val).String())
+	return []byte(strconv.FormatInt(int64(time.Since(s.StartTime)), 10)), nil
 }
 
 // String returns the String representation of duration - the time elapsed since s.Val.
 func (s *SgwDurStat) String() string {
-	return time.Since(s.Val).String()
+	return strconv.FormatInt(int64(time.Since(s.StartTime)), 10)
 }
 
 type QueryStat struct {

--- a/base/stats.go
+++ b/base/stats.go
@@ -539,12 +539,12 @@ func (s *SgwDurStat) Collect(ch chan<- prometheus.Metric) {
 
 // MarshalJSON returns the JSON encoding of duration - the time elapsed since s.Val.
 func (s *SgwDurStat) MarshalJSON() ([]byte, error) {
-	return []byte(strconv.FormatInt(int64(time.Since(s.StartTime)), 10)), nil
+	return []byte(strconv.Itoa(int(time.Since(s.StartTime).Nanoseconds()))), nil
 }
 
 // String returns the String representation of duration - the time elapsed since s.Val.
 func (s *SgwDurStat) String() string {
-	return strconv.FormatInt(int64(time.Since(s.StartTime)), 10)
+	return strconv.Itoa(int(time.Since(s.StartTime).Nanoseconds()))
 }
 
 type QueryStat struct {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5527,3 +5527,24 @@ func TestPutTombstoneWithoutCreateAsDeletedFlagCasFailure(t *testing.T) {
 		assert.Equal(t, 0, int(rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value()))
 	}
 }
+
+func TestUptimeStat(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	uptime1 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.String()
+	duration1, err := time.ParseDuration(uptime1)
+	require.NoError(t, err)
+
+	uptime2 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.String()
+	duration2, err := time.ParseDuration(uptime2)
+	require.NoError(t, err)
+
+	uptime3 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.String()
+	duration3, err := time.ParseDuration(uptime3)
+	require.NoError(t, err)
+
+	log.Printf("uptime1: %s, uptime2: %s, uptime3: %s", uptime1, uptime2, uptime3)
+	assert.True(t, (duration1 < duration2) && (duration1 < duration3))
+	assert.True(t, duration2 < duration3)
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5533,18 +5533,9 @@ func TestUptimeStat(t *testing.T) {
 	defer rt.Close()
 
 	uptime1 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.String()
-	duration1, err := time.ParseDuration(uptime1)
-	require.NoError(t, err)
-
 	uptime2 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.String()
-	duration2, err := time.ParseDuration(uptime2)
-	require.NoError(t, err)
-
 	uptime3 := base.SyncGatewayStats.GlobalStats.ResourceUtilizationStats().Uptime.String()
-	duration3, err := time.ParseDuration(uptime3)
-	require.NoError(t, err)
 
 	log.Printf("uptime1: %s, uptime2: %s, uptime3: %s", uptime1, uptime2, uptime3)
-	assert.True(t, (duration1 < duration2) && (duration1 < duration3))
-	assert.True(t, duration2 < duration3)
+	assert.True(t, (uptime1 < uptime2) && (uptime1 < uptime3) && (uptime2 < uptime3))
 }


### PR DESCRIPTION
Changes to include `uptime` stat in both `metrics` and `expvar` endpoints.