### PR TITLE
CBG-1271: Remove usage of empty braces for nil doc

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -672,7 +672,13 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		ID:    docID,
 		RevID: revID,
 	}
-	newDoc.UpdateBodyBytes(bodyBytes)
+	newDoc.Deleted = revMessage.Deleted()
+
+	if !newDoc.Deleted || string(bodyBytes) != "null" {
+		newDoc.UpdateBodyBytes(bodyBytes)
+	} else {
+		fmt.Printf("xxx")
+	}
 
 	injectedAttachmentsForDelta := false
 	if deltaSrcRevID, isDelta := revMessage.DeltaSrc(); isDelta {
@@ -734,8 +740,6 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		newDoc.DocExpiry = expiry
 		newDoc.UpdateBody(body)
 	}
-
-	newDoc.Deleted = revMessage.Deleted()
 
 	// noconflicts flag from LiteCore
 	// https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol#rev

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -674,6 +674,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 	}
 	newDoc.Deleted = revMessage.Deleted()
 
+	// If doc is deleted or receive "null" as body don't set the document body and leave as default nil
 	if !newDoc.Deleted || string(bodyBytes) != "null" {
 		newDoc.UpdateBodyBytes(bodyBytes)
 	}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -676,8 +676,6 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 
 	if !newDoc.Deleted || string(bodyBytes) != "null" {
 		newDoc.UpdateBodyBytes(bodyBytes)
-	} else {
-		fmt.Printf("xxx")
 	}
 
 	injectedAttachmentsForDelta := false

--- a/db/crud.go
+++ b/db/crud.go
@@ -1367,10 +1367,15 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 		}
 
 		// Stamp _attachments and _deleted into rev tree bodies
+		if len(oldBodyJson) == 0 {
+			oldBodyJson = []byte("{}")
+		}
+
 		oldBodyJson, marshalErr = base.InjectJSONProperties(oldBodyJson, kvPairs...)
 		if marshalErr != nil {
 			base.WarnfCtx(db.Ctx, "Unable to marshal document body properties for storage in rev tree: %v", marshalErr)
 		}
+
 		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, db.AllowExternalRevBodyStorage())
 	}
 	// Store the new revision body into the doc:

--- a/db/crud.go
+++ b/db/crud.go
@@ -1366,16 +1366,16 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 			kvPairs = append(kvPairs, base.KVPair{Key: BodyDeleted, Val: true})
 		}
 
-		// Stamp _attachments and _deleted into rev tree bodies
+		// If body is nil initialize empty body to allow values to be stamped in
 		if len(oldBodyJson) == 0 {
 			oldBodyJson = []byte("{}")
 		}
 
+		// Stamp _attachments and _deleted into rev tree bodies
 		oldBodyJson, marshalErr = base.InjectJSONProperties(oldBodyJson, kvPairs...)
 		if marshalErr != nil {
 			base.WarnfCtx(db.Ctx, "Unable to marshal document body properties for storage in rev tree: %v", marshalErr)
 		}
-
 		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, db.AllowExternalRevBodyStorage())
 	}
 	// Store the new revision body into the doc:

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -1137,7 +1137,6 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	assert.Contains(t, err.Error(), "404 missing")
 	assert.Empty(t, bodyBytes, "Provided revision doesn't exists")
 	assert.False(t, removed, "This shouldn't be a removed revision")
-	assert.Error(t, response.Unmarshal(bodyBytes), "Unexpected empty JSON input to body.Unmarshal")
 
 	// Deletes the document, by adding a new revision whose _deleted property is true.
 	body := Body{BodyDeleted: true, BodyRev: rev2}
@@ -1166,7 +1165,6 @@ func TestGet1xRevFromDoc(t *testing.T) {
 	assert.Contains(t, err.Error(), "404 deleted")
 	assert.Empty(t, bodyBytes, "Document body bytes should be empty")
 	assert.False(t, removed, "This shouldn't be a removed document")
-	assert.Error(t, response.Unmarshal(bodyBytes), "Unexpected empty JSON input to body.Unmarshal")
 }
 
 func TestMergeAttachments(t *testing.T) {

--- a/db/document.go
+++ b/db/document.go
@@ -262,6 +262,7 @@ func (doc *Document) Body() Body {
 
 // Get a deep mutable copy of the body, using _rawBody.  Initializes _rawBody based on _body if not already present.
 func (doc *Document) GetDeepMutableBody() Body {
+	// If document body is nil return initialized body allowing it to be modified
 	if doc.IsNilBody() {
 		return Body{}
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -158,7 +158,6 @@ type Document struct {
 	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
 	Deleted        bool
-	IsNilDoc       bool
 	DocExpiry      uint32
 	RevID          string
 	DocAttachments AttachmentsMeta
@@ -290,13 +289,6 @@ func (doc *Document) GetDeepMutableBody() Body {
 
 	return mutableBody
 }
-
-// func (doc *Document) GetDeepMutableBodyNil() Body {
-// 	if doc.IsNilBody() {
-// 		return Body{}
-// 	}
-// 	return doc.GetDeepMutableBody()
-// }
 
 func (doc *Document) IsNilBody() bool {
 	// return doc.IsNilDoc
@@ -1036,7 +1028,6 @@ func (doc *Document) UnmarshalWithXattr(data []byte, xdata []byte, unmarshalLeve
 		doc._body = nil
 		doc._rawBody = []byte("")
 		doc.Deleted = true
-		doc.IsNilDoc = true
 	}
 	return nil
 }

--- a/db/revision.go
+++ b/db/revision.go
@@ -59,7 +59,6 @@ func (b *Body) Unmarshal(data []byte) error {
 	if len(data) == 0 {
 		b = nil
 		return nil
-		// return errors.New("Unexpected empty JSON input to body.Unmarshal")
 	}
 
 	// Use decoder for unmarshalling to preserve large numbers

--- a/db/revision.go
+++ b/db/revision.go
@@ -12,7 +12,6 @@ package db
 import (
 	"bytes"
 	"crypto/md5"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -58,7 +57,9 @@ const (
 func (b *Body) Unmarshal(data []byte) error {
 
 	if len(data) == 0 {
-		return errors.New("Unexpected empty JSON input to body.Unmarshal")
+		b = nil
+		return nil
+		// return errors.New("Unexpected empty JSON input to body.Unmarshal")
 	}
 
 	// Use decoder for unmarshalling to preserve large numbers

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -277,10 +277,13 @@ func (value *revCacheValue) load(backingStore RevisionCacheBackingStore, include
 // Populate value.Body by unmarshalling value.bodyBytes
 func (value *revCacheValue) updateBody() (err error) {
 	var body Body
-	if err := body.Unmarshal(value.bodyBytes); err != nil {
-		// On unmarshal error, warn return docRev without body
-		base.Warnf("Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
-		return err
+
+	if len(value.bodyBytes) > 0 {
+		if err := body.Unmarshal(value.bodyBytes); err != nil {
+			// On unmarshal error, warn return docRev without body
+			base.Warnf("Unable to marshal BodyBytes in revcache for %s %s", base.UD(value.key.DocID), value.key.RevID)
+			return err
+		}
 	}
 
 	value.lock.Lock()

--- a/db/revision_test.go
+++ b/db/revision_test.go
@@ -54,20 +54,8 @@ func TestBodyUnmarshal(t *testing.T) {
 		t.Run(test.name, func(ts *testing.T) {
 			var b Body
 			err := b.Unmarshal(test.inputBytes)
-
-			// Unmarshal using json.Unmarshal for comparison below
-			var jsonUnmarshalBody Body
-			unmarshalErr := base.JSONUnmarshal(test.inputBytes, &jsonUnmarshalBody)
-
-			if unmarshalErr != nil {
-				// If json.Unmarshal returns error for input, body.Unmarshal should do the same
-				assert.True(t, err != nil, fmt.Sprintf("Expected error when unmarshalling %s", test.name))
-			} else {
-				assert.NoError(t, err, fmt.Sprintf("Expected no error when unmarshalling %s", test.name))
-				goassert.DeepEquals(t, b, test.expectedBody) // Check against expected body
-				goassert.DeepEquals(t, b, jsonUnmarshalBody) // Check against json.Unmarshal results
-			}
-
+			assert.NoError(t, err, fmt.Sprintf("Expected no error when unmarshalling %s", test.name))
+			goassert.DeepEquals(t, b, test.expectedBody) // Check against expected body
 		})
 	}
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -2127,9 +2127,11 @@ func TestDeletedEmptyDocumentImport(t *testing.T) {
 	assert.Equal(t, http.StatusOK, response.Code)
 	rawResponse := make(map[string]interface{})
 	err = base.JSONUnmarshal(response.Body.Bytes(), &rawResponse)
-	assert.NoError(t, err, "Unable to unmarshal raw response")
+	require.NoError(t, err, "Unable to unmarshal raw response")
 
-	assert.True(t, rawResponse[db.BodyDeleted].(bool))
+	deleted, ok := rawResponse[db.BodyDeleted].(bool)
+	require.True(t, ok)
+	assert.True(t, deleted)
 	syncMeta := rawResponse["_sync"].(map[string]interface{})
 	assert.Equal(t, "2-5d3308aae9930225ed7f6614cf115366", syncMeta["rev"])
 }

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4196,7 +4196,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			//	- e.g. local is 3-a(T), remote is 3-b
 			name:             "revGenTieLocalDigestLower",
 			remoteBodyValues: []string{"baz", "EADGBE"},
-			expectedRevID:    "4-c6fe7cde8f7187705f9e048322a9c350",
+			expectedRevID:    "4-3823441c5f4a7219a884c7d1aab7fdcf",
 		},
 		{
 			// Revision tie with local digest is higher than the remote digest.
@@ -4204,7 +4204,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			//	- e.g. local is 3-c(T), remote is 3-b
 			name:             "revGenTieLocalDigestHigher",
 			remoteBodyValues: []string{"baz", "qux"},
-			expectedRevID:    "4-a210e8a790415d7e842e78e1d051cb3d",
+			expectedRevID:    "4-afc7da5789b7e2b7c550c4d105b9b56c",
 		},
 		{
 			// Local revision generation is lower than remote revision generation.
@@ -4212,7 +4212,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			//  - e.g. local is 3-a(T), remote is 4-b
 			name:             "revGenLocalLower",
 			remoteBodyValues: []string{"baz", "qux", "grunt"},
-			expectedRevID:    "5-fe3ac95144be01e9b455bfa163687f0e",
+			expectedRevID:    "5-3f22b63213d9713603df04c90724db11",
 		},
 		{
 			// Local revision generation is higher than remote revision generation.
@@ -4220,7 +4220,7 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			//	- e.g. local is 3-a(T), remote is 2-b
 			name:             "revGenLocalHigher",
 			remoteBodyValues: []string{"baz"},
-			expectedRevID:    "4-232b1f34f6b9341c54435eaf5447d85d",
+			expectedRevID:    "4-80ac8db3e9b9f064d2f9204e94f30050",
 		},
 	}
 
@@ -4313,17 +4313,17 @@ func TestDefaultConflictResolverWithTombstoneLocal(t *testing.T) {
 			// Wait for default conflict resolution policy to be applied through replication and
 			// the winning revision to be written to both rt1 and rt2 buckets. Check whether the
 			// winning revision is a tombstone; tombstone revision wins over non-tombstone revision.
-			waitForTombstone(t, rt2, docID)
-			waitForTombstone(t, rt1, docID)
+			waitForTombstone(tt, rt2, docID)
+			waitForTombstone(tt, rt1, docID)
 
-			requireRevID(t, rt2, docID, test.expectedRevID)
-			requireRevID(t, rt1, docID, test.expectedRevID)
+			requireRevID(tt, rt2, docID, test.expectedRevID)
+			requireRevID(tt, rt1, docID, test.expectedRevID)
 
 			// Ensure that the document body of the winning tombstone revision written to both
 			// rt1 and rt2 is empty, i.e., An attempt to read the document body of a tombstone
 			// revision via SDK should return a "key not found" error.
-			requireErrorKeyNotFound(t, rt2, docID)
-			requireErrorKeyNotFound(t, rt1, docID)
+			requireErrorKeyNotFound(tt, rt2, docID)
+			requireErrorKeyNotFound(tt, rt1, docID)
 		})
 	}
 }


### PR DESCRIPTION
There is a little more work to do but this was 'time boxed' so wanted to display what has been done so far. Work remaining:
 - Review incoming handleRev flow for deleted documents.
 	- Currently if doc is deleted or "null" we nil out the body. The criteria on which to nil out the body needs review
 	- In some scenarios do we need body? If we nil the body do we need to later inject things into the body like attachments? Just need to watch the flow. Is this tested?
 - Remove / review marshal logging. At the moment we have areas where we output warnings if the doc is nil. These can be removed now


Integration Runs:
- [x] GSI=False Xattr=True http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/717/
- [x] GSI=False Xattr=False http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/718/
- [ ] GSI=True Xattr=True http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/719/ GSI test issues