### PR TITLE
README: Update "getting started" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ See the [Extended Build Instructions](docs/BUILD.md) to build with dependency pi
 [CB_DOWNLOAD]: https://www.couchbase.com/downloads
 [CB_FORUM]: http://forums.couchbase.com
 [SG_REPO]: https://github.com/couchbase/sync_gateway
-[SG_DOCS]: https://docs.couchbase.com/sync-gateway/current/getting-started.html
+[SG_DOCS]: https://docs.couchbase.com/sync-gateway/current/introduction.html
 [SG_ISSUES]: https://github.com/couchbase/sync_gateway/issues?q=is%3Aissue+is%3Aopen
 [MAILING_LIST]: https://groups.google.com/forum/?fromgroups#!forum/mobile-couchbase


### PR DESCRIPTION
The doc URLs have been changed again, updating this link to the newest "getting started" URL.