### PR TITLE
CBG-1304: Fix ISGR proposeChanges error when pulling into an allow_conflicts=false node

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -214,13 +214,14 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()
 		_ = bh.sendChanges(rq.Sender, &sendChangesOptions{
-			docIDs:     subChangesParams.docIDs(),
-			since:      subChangesParams.Since(),
-			continuous: continuous,
-			activeOnly: subChangesParams.activeOnly(),
-			batchSize:  subChangesParams.batchSize(),
-			channels:   channels,
-			clientType: clientType,
+			docIDs:            subChangesParams.docIDs(),
+			since:             subChangesParams.Since(),
+			continuous:        continuous,
+			activeOnly:        subChangesParams.activeOnly(),
+			batchSize:         subChangesParams.batchSize(),
+			channels:          channels,
+			clientType:        clientType,
+			ignoreNoConflicts: clientType == clientTypeSGR2, // force this side to accept a "changes" message, even in no conflicts mode for SGR2.
 		})
 		base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s   --> Time:%v", bh.serialNumber, rq.Profile(), time.Since(startTime))
 	}()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -3035,16 +3035,6 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
 	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
-
-	arStatus := ar.GetStatus()
-
-	rt1RemoteDoc, err := rt2.GetDatabase().GetDocument(rt1docID, db.DocUnmarshalAll)
-	assert.NoError(t, err)
-	assert.Equal(t, strconv.FormatUint(rt1RemoteDoc.Sequence, 10), arStatus.LastSeqPush)
-
-	rt2RemoteDoc, err := rt2.GetDatabase().GetDocument(rt2docID, db.DocUnmarshalAll)
-	assert.NoError(t, err)
-	assert.Equal(t, strconv.FormatUint(rt2RemoteDoc.Sequence, 10), arStatus.LastSeqPull)
 }
 
 // TestActiveReplicatorPullFromCheckpointModifiedHash:


### PR DESCRIPTION
- Expand `TestActiveReplicatorIgnoreNoConflicts` to cover push and pull with `allow_conflicts=false`
- Make active pull ISGR replications use ignoreNoConflicts flag to fix issue