### PR TITLE
CBG-1311 Backport CBG-1304 to 2.8.1

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -212,13 +212,14 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 		// sendChanges runs until blip context closes, or fails due to error
 		startTime := time.Now()
 		_ = bh.sendChanges(rq.Sender, &sendChangesOptions{
-			docIDs:     subChangesParams.docIDs(),
-			since:      subChangesParams.Since(),
-			continuous: continuous,
-			activeOnly: subChangesParams.activeOnly(),
-			batchSize:  subChangesParams.batchSize(),
-			channels:   channels,
-			clientType: clientType,
+			docIDs:            subChangesParams.docIDs(),
+			since:             subChangesParams.Since(),
+			continuous:        continuous,
+			activeOnly:        subChangesParams.activeOnly(),
+			batchSize:         subChangesParams.batchSize(),
+			channels:          channels,
+			clientType:        clientType,
+			ignoreNoConflicts: clientType == clientTypeSGR2, // force this side to accept a "changes" message, even in no conflicts mode for SGR2.
 		})
 		base.DebugfCtx(bh.loggingCtx, base.KeySyncMsg, "#%d: Type:%s   --> Time:%v", bh.serialNumber, rq.Profile(), time.Since(startTime))
 	}()

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2999,16 +2999,16 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	// Active
 	rt1 := NewRestTester(t, &RestTesterConfig{
 		TestBucket: base.GetTestBucket(t),
+		DatabaseConfig: &DbConfig{
+			AllowConflicts: base.BoolPtr(false),
+		},
 	})
 	defer rt1.Close()
 
-	docID := t.Name() + "rt1doc1"
-	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+docID, `{"source":"rt1","channels":["alice"]}`)
+	rt1docID := t.Name() + "rt1doc1"
+	resp := rt1.SendAdminRequest(http.MethodPut, "/db/"+rt1docID, `{"source":"rt1","channels":["alice"]}`)
 	assertStatus(t, resp, http.StatusCreated)
-	revID := respRevID(t, resp)
-
-	localDoc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
-	assert.NoError(t, err)
+	rt1revID := respRevID(t, resp)
 
 	// Make rt2 listen on an actual HTTP port, so it can receive the blipsync request from rt1.
 	srv := httptest.NewServer(rt2.TestPublicHandler())
@@ -3022,11 +3022,12 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 
 	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
 		ID:          t.Name(),
-		Direction:   db.ActiveReplicatorTypePush,
+		Direction:   db.ActiveReplicatorTypePushAndPull,
 		RemoteDBURL: passiveDBURL,
 		ActiveDB: &db.Database{
 			DatabaseContext: rt1.GetDatabase(),
 		},
+		Continuous:          true,
 		ChangesBatchSize:    200,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name()).DBReplicatorStats(t.Name()),
 	})
@@ -3041,15 +3042,32 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	changesResults, err := rt2.WaitForChanges(1, "/db/_changes?since=0", "", true)
 	require.NoError(t, err)
 	require.Len(t, changesResults.Results, 1)
-	assert.Equal(t, docID, changesResults.Results[0].ID)
+	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
 
-	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
+	doc, err := rt2.GetDatabase().GetDocument(rt1docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
 
-	assert.Equal(t, revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, rt1revID, doc.SyncData.CurrentRev)
 	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
 
-	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
+	// write a doc on rt2 ...
+	rt2docID := t.Name() + "rt2doc1"
+	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+rt2docID, `{"source":"rt2","channels":["alice"]}`)
+	assertStatus(t, resp, http.StatusCreated)
+	rt2revID := respRevID(t, resp)
+
+	// ... and wait to arrive at rt1
+	changesResults, err = rt1.WaitForChanges(2, "/db/_changes?since=0", "", true)
+	require.NoError(t, err)
+	require.Len(t, changesResults.Results, 2)
+	assert.Equal(t, rt1docID, changesResults.Results[0].ID)
+	assert.Equal(t, rt2docID, changesResults.Results[1].ID)
+
+	doc, err = rt1.GetDatabase().GetDocument(rt2docID, db.DocUnmarshalAll)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
+	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
 }
 
 // TestActiveReplicatorPullFromCheckpointModifiedHash:


### PR DESCRIPTION
Fixes ISGR: Pull replications incompatible with active-side allow_conflicts=false