### PR TITLE
CBG-1312: Expose metrics API by default

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -40,6 +40,7 @@ import (
 var (
 	DefaultInterface              = ":4984"
 	DefaultAdminInterface         = "127.0.0.1:4985" // Only accessible on localhost!
+	DefaultMetricsInterface       = "127.0.0.1:4986" // Only accessible on localhost!
 	DefaultServer                 = "walrus:"
 	DefaultMinimumTLSVersionConst = tls.VersionTLS10
 
@@ -1126,6 +1127,10 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 		}
 	}
 
+	if config.MetricsInterface == nil {
+		config.MetricsInterface = &DefaultMetricsInterface
+	}
+
 	return config, err
 }
 
@@ -1226,10 +1231,8 @@ func startServer(config *ServerConfig, sc *ServerContext) {
 
 	go sc.PostStartup()
 
-	if config.MetricsInterface != nil {
-		base.Consolef(base.LevelInfo, base.KeyAll, "Starting metrics server on %s", *config.MetricsInterface)
-		go config.Serve(*config.MetricsInterface, CreateMetricHandler(sc))
-	}
+	base.Consolef(base.LevelInfo, base.KeyAll, "Starting metrics server on %s", *config.MetricsInterface)
+	go config.Serve(*config.MetricsInterface, CreateMetricHandler(sc))
 
 	base.Consolef(base.LevelInfo, base.KeyAll, "Starting admin server on %s", *config.AdminInterface)
 	go config.Serve(*config.AdminInterface, CreateAdminHandler(sc))


### PR DESCRIPTION
By default expose the metrics API on 127.0.0.1:4986
