### PR TITLE
CBG-1316: Obtain user xattrs

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1349,7 +1349,7 @@ func (bucket *CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, userX
 
 			case gocb.ErrKeyNotFound:
 				// If key not found it has been deleted in between the first op and this op.
-				return false, err, uint64(0)
+				return false, err, userXattrCas
 
 			case gocb.ErrSubDocBadMulti:
 				// Xattr doesn't exist, can skip

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1356,12 +1356,12 @@ func (bucket *CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, userX
 
 			case nil:
 				if cas != userXattrCas {
-					return true, err, uint64(0)
+					return true, errors.New("cas mismatch between user xattr and document body"), uint64(0)
 				}
 			default:
 				// Unknown error occurred
-				shouldRetry = isRecoverableWriteError(err)
-				return shouldRetry, err, uint64(0)
+				// Shouldn't retry as any recoverable error will have been retried already in GetXattr
+				return false, err, uint64(0)
 			}
 		}
 
@@ -1678,7 +1678,6 @@ func (bucket *CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey strin
 				value = nil
 				xattrValue = nil
 			}
-
 		}
 
 		// Invoke callback to get updated value

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1618,8 +1618,8 @@ func (bucket *CouchbaseBucketGoCB) Update(k string, exp uint32, callback sgbucke
 	}
 }
 
-func (bucket *CouchbaseBucketGoCB) WriteXattr(k string, xattrKey string, v interface{}) (uint64, error) {
-	docFrag, err := bucket.Bucket.MutateIn(k, 0, 0).UpsertEx(xattrKey, v, gocb.SubdocFlagXattr|gocb.SubdocFlagCreatePath).Execute()
+func (bucket *CouchbaseBucketGoCB) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (uint64, error) {
+	docFrag, err := bucket.Bucket.MutateIn(docKey, 0, 0).UpsertEx(xattrKey, xattrVal, gocb.SubdocFlagXattr|gocb.SubdocFlagCreatePath).Execute()
 	if err != nil {
 		return 0, err
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1348,9 +1348,8 @@ func (bucket *CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, userX
 			switch pkgerrors.Cause(err) {
 
 			case gocb.ErrKeyNotFound:
-				// If key not found it has been deleted in between the first op and this op. We should retry to now get
-				// the tombstoned xattr.
-				return true, err, uint64(0)
+				// If key not found it has been deleted in between the first op and this op.
+				return false, err, uint64(0)
 
 			case gocb.ErrSubDocBadMulti:
 				// Xattr doesn't exist, can skip

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -473,7 +473,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -491,7 +491,7 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	// Validate against $document.value_crc32c
 	var retrievedVxattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, "$document", retrievedVal, &retrievedVxattr)
+	_, err = bucket.GetWithXattr(key, "$document", "", retrievedVal, &retrievedVxattr, nil)
 	vxattrCrc32c, ok := retrievedVxattr["value_crc32c"].(string)
 	assert.True(t, ok, "Unable to retrieve virtual xattr crc32c as string")
 
@@ -538,7 +538,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -560,7 +560,7 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 
 	var retrievedVal2 map[string]interface{}
 	var retrievedXattr2 map[string]interface{}
-	getCas, err = bucket.GetWithXattr(key, xattrName, &retrievedVal2, &retrievedXattr2)
+	getCas, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal2, &retrievedXattr2, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -603,7 +603,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, "")
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -627,7 +627,7 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 	// Retrieve again, ensure we get the SDK value, SG xattr
 	retrievedVal = nil
 	retrievedXattr = nil
-	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -680,7 +680,7 @@ func TestXattrWriteCasRaw(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -733,7 +733,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -762,7 +762,7 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 	}
 
 	// Verify retrieval
-	getCas, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -818,7 +818,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -849,7 +849,7 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 	// Verify retrieval
 	var modifiedVal map[string]interface{}
 	var modifiedXattr map[string]interface{}
-	getCas, err = bucket.GetWithXattr(key, xattrName, &modifiedVal, &modifiedXattr)
+	getCas, err = bucket.GetWithXattr(key, xattrName, "", &modifiedVal, &modifiedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -887,7 +887,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	var existsVal map[string]interface{}
 	var existsXattr map[string]interface{}
-	_, err := bucket.GetWithXattr(key, xattrName, &existsVal, &existsXattr)
+	_, err := bucket.GetWithXattr(key, xattrName, "", &existsVal, &existsXattr, nil)
 	if err == nil {
 		log.Printf("Key should not exist yet, but get succeeded.  Doing cleanup, assuming couchbase bucket testing")
 		err := bucket.DeleteWithXattr(key, xattrName)
@@ -953,7 +953,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	log.Printf("Retrieval after WriteUpdate insert: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
@@ -966,7 +966,7 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 	}
-	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -977,43 +977,20 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 }
 
-func TestWriteXattr(t *testing.T) {
-	SkipXattrTestsIfNotEnabled(t)
-
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-
-	key := t.Name()
-
-	err := testBucket.Set(key, 0, nil)
-	assert.NoError(t, err)
-
-	xattrKey := "TestXattr"
-	xattrVal := map[string]interface{}{"val": "val"}
-
-	_, err = testBucket.WriteXattr(key, xattrKey, &xattrVal)
-	assert.NoError(t, err)
-
-	var gotVal interface{}
-	_, err = testBucket.GetXattr(key, xattrKey, &gotVal)
-	assert.Equal(t, xattrVal, gotVal)
-
-}
-
 func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
 	testBucket := GetTestBucket(t)
 	defer testBucket.Close()
 
-	// Doc vals
+	gocbBucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
+	if !ok {
+		t.Skip("Can't cast to bucket")
+		return
+	}
+
 	key := t.Name()
-	// val := map[string]interface{}{"val": "val"}
-
-	// Xattr vals
 	xattrKey := SyncXattrName
-	// xattrVal := map[string]interface{}{"seq": float64(1), "rev": "1-abc"}
-
 	userXattrKey := "UserXattr"
 
 	writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
@@ -1067,7 +1044,7 @@ func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 
 	userXattrVal := map[string]interface{}{"val": "val"}
 
-	_, err = testBucket.WriteXattr(key, userXattrKey, userXattrVal)
+	_, err = WriteXattr(gocbBucket, key, userXattrKey, userXattrVal)
 	assert.NoError(t, err)
 
 	_, err = testBucket.WriteUpdateWithXattr(key, xattrKey, userXattrKey, 0, nil, writeUpdateFunc)
@@ -1126,7 +1103,7 @@ func TestXattrDeleteDocument(t *testing.T) {
 	// Verify delete of body was successful, retrieve XATTR
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -1181,7 +1158,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	// Verify delete of body was successful, retrieve XATTR
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if err != nil {
 		t.Errorf("Error doing GetWithXattr: %+v", err)
 	}
@@ -1200,7 +1177,7 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 	// Retrieve the document, validate cas values
 	var postDeleteVal map[string]interface{}
 	var postDeleteXattr map[string]interface{}
-	getCas2, err := bucket.GetWithXattr(key, xattrName, &postDeleteVal, &postDeleteXattr)
+	getCas2, err := bucket.GetWithXattr(key, xattrName, "", &postDeleteVal, &postDeleteXattr, nil)
 	assert.NoError(t, err, "Error getting document post-delete")
 	goassert.Equals(t, postDeleteXattr["seq"], float64(2))
 	goassert.Equals(t, len(postDeleteVal), 0)
@@ -1255,7 +1232,7 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 	// Verify delete of body and XATTR
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	mutateCas, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	mutateCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	goassert.Equals(t, len(retrievedVal), 0)
 	goassert.Equals(t, retrievedXattr["seq"], float64(123))
 	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
@@ -1562,28 +1539,28 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 	// Attempt to retrieve all 4 docs
 	var key1DocResult map[string]interface{}
 	var key1XattrResult map[string]interface{}
-	_, key1err := bucket.GetWithXattr(key1, xattrName, &key1DocResult, &key1XattrResult)
+	_, key1err := bucket.GetWithXattr(key1, xattrName, "", &key1DocResult, &key1XattrResult, nil)
 	assert.NoError(t, key1err, "Unexpected error retrieving doc w/ xattr")
 	assert.Equal(t, key1, key1DocResult["type"])
 	assert.Equal(t, "1-1234", key1XattrResult["rev"])
 
 	var key2DocResult map[string]interface{}
 	var key2XattrResult map[string]interface{}
-	_, key2err := bucket.GetWithXattr(key2, xattrName, &key2DocResult, &key2XattrResult)
+	_, key2err := bucket.GetWithXattr(key2, xattrName, "", &key2DocResult, &key2XattrResult, nil)
 	assert.NoError(t, key2err, "Unexpected error retrieving doc w/out xattr")
 	assert.Equal(t, key2, key2DocResult["type"])
 	assert.Nil(t, key2XattrResult)
 
 	var key3DocResult map[string]interface{}
 	var key3XattrResult map[string]interface{}
-	_, key3err := bucket.GetWithXattr(key3, xattrName, &key3DocResult, &key3XattrResult)
+	_, key3err := bucket.GetWithXattr(key3, xattrName, "", &key3DocResult, &key3XattrResult, nil)
 	assert.NoError(t, key3err, "Unexpected error retrieving doc w/out xattr")
 	assert.Nil(t, key3DocResult)
 	assert.Equal(t, "1-1234", key3XattrResult["rev"])
 
 	var key4DocResult map[string]interface{}
 	var key4XattrResult map[string]interface{}
-	_, key4err := bucket.GetWithXattr(key4, xattrName, &key4DocResult, &key4XattrResult)
+	_, key4err := bucket.GetWithXattr(key4, xattrName, "", &key4DocResult, &key4XattrResult, nil)
 	assert.Equal(t, gocb.ErrKeyNotFound, pkgerrors.Cause(key4err))
 	assert.Nil(t, key4DocResult)
 	assert.Nil(t, key4XattrResult)
@@ -1670,7 +1647,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 	assert.NoError(t, key1err, fmt.Sprintf("Unexpected error mutating %s", key1))
 	var key1DocResult map[string]interface{}
 	var key1XattrResult map[string]interface{}
-	_, key1err = bucket.GetWithXattr(key1, xattrName, &key1DocResult, &key1XattrResult)
+	_, key1err = bucket.GetWithXattr(key1, xattrName, "", &key1DocResult, &key1XattrResult, nil)
 	goassert.Equals(t, key1DocResult["type"], fmt.Sprintf("updated_%s", key1))
 	goassert.Equals(t, key1XattrResult["rev"], "2-1234")
 
@@ -1679,7 +1656,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 	assert.NoError(t, key2err, fmt.Sprintf("Unexpected error mutating %s", key2))
 	var key2DocResult map[string]interface{}
 	var key2XattrResult map[string]interface{}
-	_, key2err = bucket.GetWithXattr(key2, xattrName, &key2DocResult, &key2XattrResult)
+	_, key2err = bucket.GetWithXattr(key2, xattrName, "", &key2DocResult, &key2XattrResult, nil)
 	goassert.Equals(t, key2DocResult["type"], fmt.Sprintf("updated_%s", key2))
 	goassert.Equals(t, key2XattrResult["rev"], "2-1234")
 
@@ -1688,7 +1665,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 	assert.NoError(t, key3err, fmt.Sprintf("Unexpected error mutating %s", key3))
 	var key3DocResult map[string]interface{}
 	var key3XattrResult map[string]interface{}
-	_, key3err = bucket.GetWithXattr(key3, xattrName, &key3DocResult, &key3XattrResult)
+	_, key3err = bucket.GetWithXattr(key3, xattrName, "", &key3DocResult, &key3XattrResult, nil)
 	goassert.Equals(t, key3DocResult["type"], fmt.Sprintf("updated_%s", key3))
 	goassert.Equals(t, key3XattrResult["rev"], "2-1234")
 
@@ -1697,7 +1674,7 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 	assert.NoError(t, key4err, fmt.Sprintf("Unexpected error mutating %s", key4))
 	var key4DocResult map[string]interface{}
 	var key4XattrResult map[string]interface{}
-	_, key4err = bucket.GetWithXattr(key4, xattrName, &key4DocResult, &key4XattrResult)
+	_, key4err = bucket.GetWithXattr(key4, xattrName, "", &key4DocResult, &key4XattrResult, nil)
 	goassert.Equals(t, key4DocResult["type"], fmt.Sprintf("updated_%s", key4))
 	goassert.Equals(t, key4XattrResult["rev"], "2-1234")
 
@@ -2154,7 +2131,7 @@ func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 	// Verify delete of body and XATTR
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 
 	if len(retrievedVal) != 0 {
 		panic(fmt.Sprintf("len(retrievedVal) should be 0"))
@@ -2169,7 +2146,7 @@ func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 func verifyDocAndXattrDeleted(bucket *CouchbaseBucketGoCB, key, xattrName string) bool {
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 	if pkgerrors.Cause(err) != gocbcore.ErrKeyNotFound {
 		return false
 	}
@@ -2179,7 +2156,7 @@ func verifyDocAndXattrDeleted(bucket *CouchbaseBucketGoCB, key, xattrName string
 func verifyDocDeletedXattrExists(bucket *CouchbaseBucketGoCB, key, xattrName string) bool {
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err := bucket.GetWithXattr(key, xattrName, &retrievedVal, &retrievedXattr)
+	_, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 
 	log.Printf("verification for key: %s   body: %s  xattr: %s", key, retrievedVal, retrievedXattr)
 	if err != nil || len(retrievedVal) > 0 || len(retrievedXattr) == 0 {
@@ -2223,7 +2200,7 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 
 	var docResult map[string]interface{}
 	var xattrResult map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrKey, &docResult, &xattrResult)
+	_, err = bucket.GetWithXattr(key, xattrKey, "", &docResult, &xattrResult, nil)
 	assert.Len(t, docResult, 0)
 	assert.Equal(t, "2-EmDC", xattrResult["rev"])
 	assert.Equal(t, DeleteCrc32c, xattrResult[xattrMacroValueCrc32c])
@@ -2264,7 +2241,7 @@ func TestUpdateXattrWithDeleteBodyAndIsNotDelete(t *testing.T) {
 
 	var docResult map[string]interface{}
 	var xattrResult map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrKey, &docResult, &xattrResult)
+	_, err = bucket.GetWithXattr(key, xattrKey, "", &docResult, &xattrResult, nil)
 	assert.Len(t, docResult, 0)
 	assert.Equal(t, "2-EmDC", xattrResult["rev"])
 	assert.NotEqual(t, DeleteCrc32c, xattrResult[xattrMacroValueCrc32c])

--- a/base/collection.go
+++ b/base/collection.go
@@ -402,7 +402,10 @@ func (c *Collection) GetWithXattr(k string, xattrKey string, rv interface{}, xv 
 func (c *Collection) DeleteWithXattr(k string, xattrKey string) error {
 	return errors.New("DeleteWithXattr not implemented")
 }
-func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (c *Collection) WriteXattr(k string, xattrKey string, v interface{}) (casOut uint64, err error) {
+	return 0, errors.New("WriteUpdateWithXattr not implemented")
+}
+func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	return 0, errors.New("WriteUpdateWithXattr not implemented")
 }
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -402,8 +402,8 @@ func (c *Collection) GetWithXattr(k string, xattrKey string, rv interface{}, xv 
 func (c *Collection) DeleteWithXattr(k string, xattrKey string) error {
 	return errors.New("DeleteWithXattr not implemented")
 }
-func (c *Collection) WriteXattr(k string, xattrKey string, v interface{}) (casOut uint64, err error) {
-	return 0, errors.New("WriteUpdateWithXattr not implemented")
+func (c *Collection) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (casOut uint64, err error) {
+	return 0, errors.New("WriteXattr not implemented")
 }
 func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	return 0, errors.New("WriteUpdateWithXattr not implemented")

--- a/base/collection.go
+++ b/base/collection.go
@@ -396,14 +396,11 @@ func (c *Collection) WriteWithXattr(k string, xattrKey string, exp uint32, cas u
 func (c *Collection) GetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
 	return 0, errors.New("GetXattr not implemented")
 }
-func (c *Collection) GetWithXattr(k string, xattrKey string, rv interface{}, xv interface{}) (cas uint64, err error) {
+func (c *Collection) GetWithXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
 	return 0, errors.New("GetWithXattr not implemented")
 }
 func (c *Collection) DeleteWithXattr(k string, xattrKey string) error {
 	return errors.New("DeleteWithXattr not implemented")
-}
-func (c *Collection) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (casOut uint64, err error) {
-	return 0, errors.New("WriteXattr not implemented")
 }
 func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	return 0, errors.New("WriteUpdateWithXattr not implemented")

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -204,8 +204,8 @@ func (b *LeakyBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas 
 	return b.bucket.WriteWithXattr(k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
 }
 
-func (b *LeakyBucket) WriteXattr(k string, xattrKey string, v interface{}) (casOut uint64, err error) {
-	return b.bucket.WriteXattr(k, xattrKey, v)
+func (b *LeakyBucket) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (casOut uint64, err error) {
+	return b.bucket.WriteXattr(docKey, xattrKey, xattrVal)
 }
 
 func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -204,16 +204,20 @@ func (b *LeakyBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas 
 	return b.bucket.WriteWithXattr(k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
 }
 
-func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *LeakyBucket) WriteXattr(k string, xattrKey string, v interface{}) (casOut uint64, err error) {
+	return b.bucket.WriteXattr(k, xattrKey, v)
+}
+
+func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	if b.config.UpdateCallback != nil {
-		wrapperCallback := func(current []byte, xattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
-			updated, updatedXattr, deletedDoc, expiry, err = callback(current, xattr, cas)
+		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
+			updated, updatedXattr, deletedDoc, expiry, err = callback(current, xattr, userXattr, cas)
 			b.config.UpdateCallback(k)
 			return updated, updatedXattr, deletedDoc, expiry, err
 		}
-		return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, wrapperCallback)
+		return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, wrapperCallback)
 	}
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
+	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
 
 func (b *LeakyBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -204,10 +204,6 @@ func (b *LeakyBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas 
 	return b.bucket.WriteWithXattr(k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
 }
 
-func (b *LeakyBucket) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (casOut uint64, err error) {
-	return b.bucket.WriteXattr(docKey, xattrKey, xattrVal)
-}
-
 func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	if b.config.UpdateCallback != nil {
 		wrapperCallback := func(current []byte, xattr []byte, userXattr []byte, cas uint64) (updated []byte, updatedXattr []byte, deletedDoc bool, expiry *uint32, err error) {
@@ -220,8 +216,8 @@ func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey 
 	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
 
-func (b *LeakyBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
-	return b.bucket.GetWithXattr(k, xattr, rv, xv)
+func (b *LeakyBucket) GetWithXattr(k string, xattr string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
+	return b.bucket.GetWithXattr(k, xattr, userXattrKey, rv, xv, uxv)
 }
 
 func (b *LeakyBucket) DeleteWithXattr(k string, xattr string) error {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -91,9 +91,9 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, ca
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
-func (b *LoggingBucket) WriteXattr(k string, xattrKey string, v interface{}) (casOut uint64, err error) {
-	defer b.log(time.Now(), k, xattrKey)
-	return b.bucket.WriteXattr(k, xattrKey, v)
+func (b *LoggingBucket) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (casOut uint64, err error) {
+	defer b.log(time.Now(), docKey, xattrKey)
+	return b.bucket.WriteXattr(docKey, xattrKey, xattrVal)
 }
 
 func (b *LoggingBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -91,11 +91,6 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, ca
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
-func (b *LoggingBucket) WriteXattr(docKey string, xattrKey string, xattrVal interface{}) (casOut uint64, err error) {
-	defer b.log(time.Now(), docKey, xattrKey)
-	return b.bucket.WriteXattr(docKey, xattrKey, xattrVal)
-}
-
 func (b *LoggingBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) {
 	defer b.log(time.Now(), k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
 	return b.bucket.WriteWithXattr(k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
@@ -105,9 +100,9 @@ func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKe
 	defer b.log(time.Now(), k, xattr, exp)
 	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
-func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
-	defer b.log(time.Now(), k, xattr)
-	return b.bucket.GetWithXattr(k, xattr, rv, xv)
+func (b *LoggingBucket) GetWithXattr(k string, xattr string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
+	defer b.log(time.Now(), k, xattr, userXattrKey)
+	return b.bucket.GetWithXattr(k, xattr, userXattrKey, rv, xv, uxv)
 }
 func (b *LoggingBucket) DeleteWithXattr(k string, xattr string) error {
 	defer b.log(time.Now(), k, xattr)

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -91,14 +91,19 @@ func (b *LoggingBucket) WriteCasWithXattr(k string, xattr string, exp uint32, ca
 	return b.bucket.WriteCasWithXattr(k, xattr, exp, cas, v, xv)
 }
 
+func (b *LoggingBucket) WriteXattr(k string, xattrKey string, v interface{}) (casOut uint64, err error) {
+	defer b.log(time.Now(), k, xattrKey)
+	return b.bucket.WriteXattr(k, xattrKey, v)
+}
+
 func (b *LoggingBucket) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) {
 	defer b.log(time.Now(), k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
 	return b.bucket.WriteWithXattr(k, xattrKey, exp, cas, value, xattrValue, isDelete, deleteBody)
 }
 
-func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
 	defer b.log(time.Now(), k, xattr, exp)
-	return b.bucket.WriteUpdateWithXattr(k, xattr, exp, previous, callback)
+	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
 func (b *LoggingBucket) GetWithXattr(k string, xattr string, rv interface{}, xv interface{}) (cas uint64, err error) {
 	defer b.log(time.Now(), k, xattr)

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -15,6 +15,7 @@ import (
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/couchbase/gocb.v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -451,6 +452,15 @@ func WaitForStat(getStatFunc func() int64, expected int64) (int64, bool) {
 	valInt64, ok := val.(int64)
 
 	return valInt64, err == nil && ok
+}
+
+func WriteXattr(gocbBucket *CouchbaseBucketGoCB, docKey string, xattrKey string, xattrVal interface{}) (uint64, error) {
+	docFrag, err := gocbBucket.Bucket.MutateIn(docKey, 0, 0).UpsertEx(xattrKey, xattrVal, gocb.SubdocFlagXattr|gocb.SubdocFlagCreatePath).Execute()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(docFrag.Cas()), nil
 }
 
 type dataStore struct {

--- a/db/crud.go
+++ b/db/crud.go
@@ -111,6 +111,11 @@ func (db *DatabaseContext) GetDocWithXattr(key string, unmarshalLevel DocumentUn
 	if unmarshalErr != nil {
 		return nil, nil, unmarshalErr
 	}
+
+	if len(rawBucketDoc.UserXattr) > 0 {
+		doc.rawUserXattr = rawBucketDoc.UserXattr
+	}
+
 	return doc, rawBucketDoc, nil
 }
 

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -25,7 +25,7 @@ func getRevTreeList(bucket base.Bucket, key string, useXattrs bool) (revTreeList
 	switch useXattrs {
 	case true:
 		var rawDoc, rawXattr []byte
-		_, getErr := bucket.GetWithXattr(key, base.SyncXattrName, &rawDoc, &rawXattr)
+		_, getErr := bucket.GetWithXattr(key, base.SyncXattrName, "", &rawDoc, &rawXattr, nil)
 		if getErr != nil {
 			return revTreeList{}, getErr
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -707,13 +707,6 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 	return authenticator
 }
 
-func (context *DatabaseContext) UserXattrsEnabled() bool {
-	if context.Options.UserXattrKey != nil {
-		return true
-	}
-	return false
-}
-
 func (context *DatabaseContext) UserXattrKeyOrEmpty() string {
 	if context.Options.UserXattrKey == nil {
 		return ""

--- a/db/database.go
+++ b/db/database.go
@@ -1188,11 +1188,10 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) 
 					if currentValue == nil || len(currentValue) == 0 {
 						return nil, nil, deleteDoc, nil, base.ErrUpdateCancel
 					}
-					doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, cas, DocUnmarshalAll)
+					doc, err := unmarshalDocumentWithXattr(docid, currentValue, currentXattr, currentUserXattr, cas, DocUnmarshalAll)
 					if err != nil {
 						return nil, nil, deleteDoc, nil, err
 					}
-					doc.rawUserXattr = currentUserXattr
 					updatedDoc, shouldUpdate, updatedExpiry, err := documentUpdateFunc(doc)
 					if err != nil {
 						return nil, nil, deleteDoc, nil, err

--- a/db/database.go
+++ b/db/database.go
@@ -141,8 +141,8 @@ type DatabaseContextOptions struct {
 	CompactInterval           uint32           // Interval in seconds between compaction is automatically ran - 0 means don't run
 	SGReplicateOptions        SGReplicateOptions
 	SlowQueryWarningThreshold time.Duration
-	QueryPaginationLimit      int // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
-	UserXattrKey              string
+	QueryPaginationLimit      int    // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
+	UserXattrKey              string // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 }
 
 type SGReplicateOptions struct {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2340,7 +2340,7 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 
 	// Ensure document has been added
 	waitAndAssertCondition(t, func() bool {
-		_, err = db.Bucket.GetWithXattr("doc", "_sync", &doc, &xattr)
+		_, err = db.Bucket.GetWithXattr("doc", "_sync", "", &doc, &xattr, nil)
 		return err == nil
 	})
 

--- a/db/document.go
+++ b/db/document.go
@@ -155,7 +155,7 @@ type Document struct {
 	_rawBody     []byte // Raw document body, as retrieved from the bucket.  Marshaled lazily - should be accessed using BodyBytes()
 	ID           string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
 	Cas          uint64 // Document cas
-	RawUserXattr []byte // Raw user xattr as retrieved from the bucket
+	rawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
 	Deleted        bool
 	DocExpiry      uint32

--- a/db/document.go
+++ b/db/document.go
@@ -335,7 +335,7 @@ func unmarshalDocument(docid string, data []byte) (*Document, error) {
 	return doc, nil
 }
 
-func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
+func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, userXattrData []byte, cas uint64, unmarshalLevel DocumentUnmarshalLevel) (doc *Document, err error) {
 
 	if xattrData == nil || len(xattrData) == 0 {
 		// If no xattr data, unmarshal as standard doc
@@ -347,6 +347,11 @@ func unmarshalDocumentWithXattr(docid string, data []byte, xattrData []byte, cas
 	if err != nil {
 		return nil, err
 	}
+
+	if len(userXattrData) > 0 {
+		doc.rawUserXattr = userXattrData
+	}
+
 	doc.Cas = cas
 	return doc, nil
 }

--- a/db/document.go
+++ b/db/document.go
@@ -150,11 +150,12 @@ func (sd *SyncData) HashRedact(salt string) SyncData {
 // "_sync" property.
 // Document doesn't do any locking - document instances aren't intended to be shared across multiple goroutines.
 type Document struct {
-	SyncData        // Sync metadata
-	_body    Body   // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
-	_rawBody []byte // Raw document body, as retrieved from the bucket.  Marshaled lazily - should be accessed using BodyBytes()
-	ID       string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
-	Cas      uint64 // Document cas
+	SyncData            // Sync metadata
+	_body        Body   // Marshalled document body.  Unmarshalled lazily - should be accessed using Body()
+	_rawBody     []byte // Raw document body, as retrieved from the bucket.  Marshaled lazily - should be accessed using BodyBytes()
+	ID           string `json:"-"` // Doc id.  (We're already using a custom MarshalJSON for *document that's based on body, so the json:"-" probably isn't needed here)
+	Cas          uint64 // Document cas
+	RawUserXattr []byte // Raw user xattr as retrieved from the bucket
 
 	Deleted        bool
 	DocExpiry      uint32

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -124,7 +124,7 @@ func BenchmarkDocUnmarshal(b *testing.B) {
 	for _, bm := range unmarshalBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = unmarshalDocumentWithXattr("doc_1k", doc1k_body, doc1k_meta, 1, bm.unmarshalLevel)
+				_, _ = unmarshalDocumentWithXattr("doc_1k", doc1k_body, doc1k_meta, nil, 1, bm.unmarshalLevel)
 			}
 		})
 	}

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -269,7 +269,7 @@ func TestImportWithCasFailureUpdate(t *testing.T) {
 				"time_saved": "2017-11-29T12:46:13.456631-08:00"
 			}`
 
-			cas, _ := db.Bucket.GetWithXattr(key, base.SyncXattrName, &body, &xattr)
+			cas, _ := db.Bucket.GetWithXattr(key, base.SyncXattrName, "", &body, &xattr, nil)
 			_, err := db.Bucket.WriteCasWithXattr(key, base.SyncXattrName, 0, cas, []byte(valStr), []byte(xattrStr))
 			assert.NoError(t, err)
 		}
@@ -319,7 +319,7 @@ func TestImportWithCasFailureUpdate(t *testing.T) {
 			var bodyOut map[string]interface{}
 			var xattrOut map[string]interface{}
 
-			_, err = db.Bucket.GetWithXattr(testcase.docname, base.SyncXattrName, &bodyOut, &xattrOut)
+			_, err = db.Bucket.GetWithXattr(testcase.docname, base.SyncXattrName, "", &bodyOut, &xattrOut, nil)
 			assert.NoError(t, err)
 
 			assert.Equal(t, "2-abc", xattrOut["rev"])
@@ -400,7 +400,7 @@ func TestImportNullDocRaw(t *testing.T) {
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key string, expectedRevGeneration int) {
 	xattr := map[string]interface{}{}
-	_, err := bucket.GetWithXattr(key, base.SyncXattrName, nil, &xattr)
+	_, err := bucket.GetWithXattr(key, base.SyncXattrName, "", nil, &xattr, nil)
 	assert.NoError(t, err, "Error Getting Xattr")
 	revision, ok := xattr["rev"]
 	goassert.True(t, ok)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b084c9cb628c4c6a8ebfec0c866bc42536254e55"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="c623d76532feedb27668043324c5fb86a3a3a2bb"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="41d2f94c66fa0e8224aeacb7b7c36222e605fadb"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="c7c12d9135982e60683eac35e1b6e18a9b5be425"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="5750eccf2977bef2ec91cb96735cc82080cccb02"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="b084c9cb628c4c6a8ebfec0c866bc42536254e55"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="ab2bede9419dc6b1fe4b89485225774a68066735"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="41d2f94c66fa0e8224aeacb7b7c36222e605fadb"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="c623d76532feedb27668043324c5fb86a3a3a2bb"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="72357501c5480e59b7fcb059902ebac8f03eb876"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="c7c12d9135982e60683eac35e1b6e18a9b5be425"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="70f2d2ed927d3e7b0b1251963168f830a53cc2d9"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="bc5fd87f01d1819c14c92e4e51b63f0d7e77a69c"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="5750eccf2977bef2ec91cb96735cc82080cccb02"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="cb3006c10c0e9cd6a8989b9f68be90e3b5ae3fa4"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="ab2bede9419dc6b1fe4b89485225774a68066735"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3912,7 +3912,7 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	gocbBucket, _ := base.AsGoCBBucket(baseBucket)
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = gocbBucket.GetWithXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, &retrievedVal, &retrievedXattr)
+	_, err = gocbBucket.GetWithXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
 	assert.NoError(t, err, "Unexpected Error")
 	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedXattr["rev"])
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -199,7 +199,7 @@ type DbConfig struct {
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
-	UserXattrKey                     *string                          `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If nil the feature will be disabled.
+	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If nil the feature will be disabled.
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -199,6 +199,7 @@ type DbConfig struct {
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`
+	UserXattrKey                     *string                          `json:"user_xattr_key,omitempty"`
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -199,7 +199,7 @@ type DbConfig struct {
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
-	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If nil the feature will be disabled.
+	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -198,8 +198,8 @@ type DbConfig struct {
 	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
-	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`
-	UserXattrKey                     *string                          `json:"user_xattr_key,omitempty"`
+	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
+	UserXattrKey                     *string                          `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If nil the feature will be disabled.
 }
 
 type DeltaSyncConfig struct {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1673,7 +1673,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 		docID := "TestImportDecimalScale" + strconv.Itoa(i)
 		var docBody []byte
 		var syncData db.SyncData
-		_, err := rt.Bucket().GetWithXattr(docID, base.SyncXattrName, &docBody, &syncData)
+		_, err := rt.Bucket().GetWithXattr(docID, base.SyncXattrName, "", &docBody, &syncData, nil)
 		require.NoError(t, err)
 
 		assert.NotEqualf(t, "", syncData.CurrentRev, "Expecting non-empty rev ID for imported doc %v", docID)
@@ -1738,7 +1738,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 		docID := "TestImportDecimalPlacesScientificNotation" + strconv.Itoa(i)
 		var docBody []byte
 		var syncData db.SyncData
-		_, err := rt.Bucket().GetWithXattr(docID, base.SyncXattrName, &docBody, &syncData)
+		_, err := rt.Bucket().GetWithXattr(docID, base.SyncXattrName, "", &docBody, &syncData, nil)
 		require.NoError(t, err)
 
 		assert.NotEqualf(t, "", syncData.CurrentRev, "Expecting non-empty rev ID for imported doc %v", docID)
@@ -2093,7 +2093,7 @@ func rawDocWithSyncMeta() string {
 
 func assertXattrSyncMetaRevGeneration(t *testing.T, bucket base.Bucket, key string, expectedRevGeneration int) {
 	xattr := map[string]interface{}{}
-	_, err := bucket.GetWithXattr(key, base.SyncXattrName, nil, &xattr)
+	_, err := bucket.GetWithXattr(key, base.SyncXattrName, "", nil, &xattr, nil)
 	assert.NoError(t, err, "Error Getting Xattr")
 	revision, ok := xattr["rev"]
 	goassert.True(t, ok)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -749,6 +749,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		DeltaSyncOptions:          deltaSyncOptions,
 		CompactInterval:           compactIntervalSecs,
 		QueryPaginationLimit:      queryPaginationLimit,
+		UserXattrKey:              config.UserXattrKey,
 		SGReplicateOptions: db.SGReplicateOptions{
 			Enabled:               sgReplicateEnabled,
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,


### PR DESCRIPTION
Work to support UserXattrGrants
 - Add config option to specify key
 - Obtain user xattr as part of WriteUpdateWithXattr
 - Add to document struct (ready for later work to pass to Sync Fn)
 - Add tests to test retrieval of value
 - Added WriteXattr to aide tests (will be used for future testing too)

Note: A test which I wanted but couldn't add was one to test the cas retry if an update occurs between getting document and getting user xattr. Couldn't find a way to test this inside of unit tests, however, did a temporary test which proved it works.

- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/737/
- [x] https://github.com/couchbase/sg-bucket/pull/62
- [x] https://github.com/couchbaselabs/walrus/pull/56