### PR TITLE
CBG-1317: Pass xattrs into Sync Function

### DIFF
--- a/channels/channelmapper.go
+++ b/channels/channelmapper.go
@@ -13,7 +13,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/couchbase/sg-bucket"
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	_ "github.com/robertkrimen/otto/underscore"
 )
@@ -51,9 +51,11 @@ func NewDefaultChannelMapper() *ChannelMapper {
 	return NewChannelMapper(`function(doc){channel(doc.channels);}`)
 }
 
-func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, userCtx map[string]interface{}) (*ChannelMapperOutput, error) {
+func (mapper *ChannelMapper) MapToChannelsAndAccess(body map[string]interface{}, oldBodyJSON string, metaMap map[string]interface{}, userCtx map[string]interface{}) (*ChannelMapperOutput, error) {
 	numberFixBody := ConvertJSONNumbers(body)
-	result1, err := mapper.Call(numberFixBody, sgbucket.JSONString(oldBodyJSON), userCtx)
+	numberFixMetaMap := ConvertJSONNumbers(metaMap)
+
+	result1, err := mapper.Call(numberFixBody, sgbucket.JSONString(oldBodyJSON), numberFixMetaMap, userCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/robertkrimen/otto"
 	"github.com/robertkrimen/otto/underscore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -46,7 +47,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 // verify that our version of Otto treats JSON parsed arrays like real arrays
 func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "abc", "xyz"))
 }
@@ -54,7 +55,7 @@ func TestJavaScriptWorks(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo", "bar", "baz"))
 }
@@ -62,7 +63,7 @@ func TestSyncFunction(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"foo": SetOf(t, "bar", "baz")})
 }
@@ -70,7 +71,7 @@ func TestAccessFunction(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo", "bar ok", "baz"))
 }
@@ -78,21 +79,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, nil, noUser)
 	goassert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	goassert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"bar": SetOf(t, "ginger"), "baz": SetOf(t, "ginger"), "foo": SetOf(t, "ginger")})
 }
@@ -100,14 +101,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf(t, "ginger", "earl_grey", "green")})
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access["lee"], SetOf(t, "ginger", "earl_grey", "green"))
 	goassert.DeepEquals(t, res.Access["nancy"], SetOf(t, "ginger", "earl_grey", "green"))
@@ -115,42 +116,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf(t, "ginger")})
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
@@ -159,7 +160,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 // implementation with access(), so most of the above tests also apply to it.)
 func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Roles, AccessMap{"bar": SetOf(t, "froods"), "baz": SetOf(t, "froods"), "foo": SetOf(t, "froods")})
 }
@@ -167,7 +168,7 @@ func TestRoleFunction(t *testing.T) {
 // Now just make sure the input comes through intact
 func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo"))
 }
@@ -175,11 +176,11 @@ func TestInputParse(t *testing.T) {
 // A more realistic example
 func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo", "bar", "baz"))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, noUser)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
@@ -187,7 +188,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 // Empty/no-op channel mapper fn
 func TestEmptyChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
@@ -197,7 +198,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	underscore.Enable() // It really slows down unit tests (by making otto.New take a lot longer)
 	defer underscore.Disable()
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo"))
 }
@@ -205,7 +206,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 // Validation by calling reject()
 func TestChannelMapperReject(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
@@ -213,7 +214,7 @@ func TestChannelMapperReject(t *testing.T) {
 // Rejection by calling throw()
 func TestChannelMapperThrow(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
@@ -221,14 +222,14 @@ func TestChannelMapperThrow(t *testing.T) {
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	goassert.True(t, err != nil)
 }
 
 // Test the public API
 func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, output.Channels, SetOf(t, "foo", "bar", "baz"))
 }
@@ -239,16 +240,16 @@ func TestCheckUser(t *testing.T) {
 			requireUser(doc.owner);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil, sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil, linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorWrongUser))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil, nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -259,16 +260,16 @@ func TestCheckUserArray(t *testing.T) {
 			requireUser(doc.owners);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, nil, sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, nil, linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorWrongUser))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, nil, nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -279,16 +280,16 @@ func TestCheckRole(t *testing.T) {
 			requireRole(doc.role);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil, sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil, linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingRole))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil, nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -299,16 +300,16 @@ func TestCheckRoleArray(t *testing.T) {
 			requireRole(doc.roles);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, nil, sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": map[string]int{"boy": 1, "musician": 1}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil, linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingRole))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil, nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -319,16 +320,16 @@ func TestCheckAccess(t *testing.T) {
 		requireAccess(doc.channel)
 	}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, nil, sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, nil, linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, nil, nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -339,16 +340,16 @@ func TestCheckAccessArray(t *testing.T) {
 		requireAccess(doc.channels)
 	}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, nil, sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, nil, linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, nil, nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -356,12 +357,12 @@ func TestCheckAccessArray(t *testing.T) {
 // Test changing the function
 func TestSetFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
 	assert.True(t, changed, "SetFunction failed")
 	assert.NoError(t, err, "SetFunction failed")
-	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, noUser)
+	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, output.Channels, SetOf(t, "all"))
 }
@@ -369,98 +370,98 @@ func TestSetFunction(t *testing.T) {
 // Test that expiry function sets the expiry property
 func TestExpiryFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
 	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	goassert.True(t, res7.Expiry == nil)
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(100);}`)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("500");}`)
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`)
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`)
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`)
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`)
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`)
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`)
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	mapper = NewChannelMapper(`function(doc) {expiry();}`)
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	goassert.True(t, res7.Expiry == nil)
 }
@@ -468,38 +469,71 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 // Test that expiry function when invoked more than once by sync function
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res6.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, nil, noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res7.Expiry == nil)
+}
+
+func TestMetaMap(t *testing.T) {
+	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.channels);}`)
+
+	channels := []string{"chan1", "chan2"}
+
+	metaMap := map[string]interface{}{
+		"xattrs": map[string]interface{}{
+			"myxattr": map[string]interface{}{
+				"channels": channels,
+			},
+		},
+	}
+
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, res.Channels.ToArray(), channels)
+}
+
+func TestNilMetaMap(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	mapper := NewChannelMapper(`function(doc, oldDoc, meta) {channel(meta.xattrs.myxattr.val);}`)
+
+	metaMap := map[string]interface{}{
+		"xattrs": map[string]interface{}{
+			"": nil,
+		},
+	}
+
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, metaMap, noUser)
+	require.Error(t, err)
+	assert.True(t, err.Error() == "TypeError: Cannot access member 'val' of undefined")
 }
 
 func TestChangedUsers(t *testing.T) {

--- a/channels/channelmapper_test.go
+++ b/channels/channelmapper_test.go
@@ -30,6 +30,12 @@ func parse(jsonStr string) map[string]interface{} {
 	return parsed
 }
 
+func emptyMetaMap() map[string]interface{} {
+	return map[string]interface{}{
+		"xattrs": nil,
+	}
+}
+
 var noUser = map[string]interface{}{"name": nil, "channels": []string{}}
 
 func TestOttoValueToStringArray(t *testing.T) {
@@ -47,7 +53,7 @@ func TestOttoValueToStringArray(t *testing.T) {
 // verify that our version of Otto treats JSON parsed arrays like real arrays
 func TestJavaScriptWorks(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.x.concat(doc.y));}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"x":["abc"],"y":["xyz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "abc", "xyz"))
 }
@@ -55,7 +61,7 @@ func TestJavaScriptWorks(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel("foo", "bar"); channel("baz")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo", "bar", "baz"))
 }
@@ -63,7 +69,7 @@ func TestSyncFunction(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bar"); access("foo", "baz")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"foo": SetOf(t, "bar", "baz")})
 }
@@ -71,7 +77,7 @@ func TestAccessFunction(t *testing.T) {
 // Just verify that the calls to the channel() fn show up in the output channel list.
 func TestSyncFunctionTakesArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bar ok","baz"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo", "bar ok", "baz"))
 }
@@ -79,21 +85,21 @@ func TestSyncFunctionTakesArray(t *testing.T) {
 // Calling channel() with an invalid channel name should return an error.
 func TestSyncFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(["foo", "bad,name","baz"])}`)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, nil, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": []}`), `{}`, emptyMetaMap(), noUser)
 	goassert.True(t, err != nil)
 }
 
 // Calling access() with an invalid channel name should return an error.
 func TestAccessFunctionRejectsInvalidChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("foo", "bad,name");}`)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	goassert.True(t, err != nil)
 }
 
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["foo","bar","baz"], "ginger")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"bar": SetOf(t, "ginger"), "baz": SetOf(t, "ginger"), "foo": SetOf(t, "ginger")})
 }
@@ -101,14 +107,14 @@ func TestAccessFunctionTakesArrayOfUsers(t *testing.T) {
 // Just verify that the calls to the access() fn show up in the output channel list.
 func TestAccessFunctionTakesArrayOfChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", "earl_grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf(t, "ginger", "earl_grey", "green")})
 }
 
 func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(["lee", "nancy"], ["ginger", "earl_grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access["lee"], SetOf(t, "ginger", "earl_grey", "green"))
 	goassert.DeepEquals(t, res.Access["nancy"], SetOf(t, "ginger", "earl_grey", "green"))
@@ -116,42 +122,42 @@ func TestAccessFunctionTakesArrayOfChannelsAndUsers(t *testing.T) {
 
 func TestAccessFunctionTakesEmptyArrayUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access([], ["ginger", "earl grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesEmptyArrayChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", [])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access(null, ["ginger", "earl grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNullChannels(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", null)}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
 
 func TestAccessFunctionTakesNonChannelsInArray(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {access("lee", ["ginger", null, 5])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{"lee": SetOf(t, "ginger")})
 }
 
 func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {var x = {}; access(x.nothing, ["ginger", "earl grey", "green"])}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Access, AccessMap{})
 }
@@ -160,7 +166,7 @@ func TestAccessFunctionTakesUndefinedUser(t *testing.T) {
 // implementation with access(), so most of the above tests also apply to it.)
 func TestRoleFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {role(["foo","bar","baz"], "role:froods")}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Roles, AccessMap{"bar": SetOf(t, "froods"), "baz": SetOf(t, "froods"), "foo": SetOf(t, "froods")})
 }
@@ -168,7 +174,7 @@ func TestRoleFunction(t *testing.T) {
 // Now just make sure the input comes through intact
 func TestInputParse(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channel);}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "foo"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo"))
 }
@@ -176,11 +182,11 @@ func TestInputParse(t *testing.T) {
 // A more realistic example
 func TestDefaultChannelMapper(t *testing.T) {
 	mapper := NewDefaultChannelMapper()
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo", "bar", "baz"))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, nil, noUser)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"x": "y"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
@@ -188,7 +194,7 @@ func TestDefaultChannelMapper(t *testing.T) {
 // Empty/no-op channel mapper fn
 func TestEmptyChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, base.Set{})
 }
@@ -198,7 +204,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 	underscore.Enable() // It really slows down unit tests (by making otto.New take a lot longer)
 	defer underscore.Disable()
 	mapper := NewChannelMapper(`function(doc) {channel(_.first(doc.channels));}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Channels, SetOf(t, "foo"))
 }
@@ -206,7 +212,7 @@ func TestChannelMapperUnderscoreLib(t *testing.T) {
 // Validation by calling reject()
 func TestChannelMapperReject(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {reject(403, "bad");}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
@@ -214,7 +220,7 @@ func TestChannelMapperReject(t *testing.T) {
 // Rejection by calling throw()
 func TestChannelMapperThrow(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {throw({forbidden:"bad"});}`)
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, "bad"))
 }
@@ -222,14 +228,14 @@ func TestChannelMapperThrow(t *testing.T) {
 // Test other runtime exception
 func TestChannelMapperException(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {(nil)[5];}`)
-	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	_, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	goassert.True(t, err != nil)
 }
 
 // Test the public API
 func TestPublicChannelMapper(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, output.Channels, SetOf(t, "foo", "bar", "baz"))
 }
@@ -240,16 +246,16 @@ func TestCheckUser(t *testing.T) {
 			requireUser(doc.owner);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorWrongUser))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, nil, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owner": "sally"}`), `{}`, emptyMetaMap(), nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -260,16 +266,16 @@ func TestCheckUserArray(t *testing.T) {
 			requireUser(doc.owners);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "channels": []string{}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, nil, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "channels": []string{}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, nil, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally", "joe"]}`), `{}`, emptyMetaMap(), linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorWrongUser))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, nil, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"owners": ["sally"]}`), `{}`, emptyMetaMap(), nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -280,16 +286,16 @@ func TestCheckRole(t *testing.T) {
 			requireRole(doc.role);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingRole))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, nil, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"role": "girl"}`), `{}`, emptyMetaMap(), nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -300,16 +306,16 @@ func TestCheckRoleArray(t *testing.T) {
 			requireRole(doc.roles);
 		}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": map[string]int{"girl": 1, "5yo": 1}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, nil, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"roles": ["kid","girl"]}`), `{}`, emptyMetaMap(), sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": map[string]int{"boy": 1, "musician": 1}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingRole))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, nil, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"roles": ["girl"]}`), `{}`, emptyMetaMap(), nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -320,16 +326,16 @@ func TestCheckAccess(t *testing.T) {
 		requireAccess(doc.channel)
 	}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, nil, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channel": "party"}`), `{}`, emptyMetaMap(), sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, nil, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "work"}`), `{}`, emptyMetaMap(), linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, nil, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channel": "magic"}`), `{}`, emptyMetaMap(), nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -340,16 +346,16 @@ func TestCheckAccessArray(t *testing.T) {
 		requireAccess(doc.channels)
 	}`)
 	var sally = map[string]interface{}{"name": "sally", "roles": []string{"girl", "5yo"}, "channels": []string{"party", "school"}}
-	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, nil, sally)
+	res, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["swim","party"]}`), `{}`, emptyMetaMap(), sally)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 
 	var linus = map[string]interface{}{"name": "linus", "roles": []string{"boy", "musician"}, "channels": []string{"party", "school"}}
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, nil, linus)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["work"]}`), `{}`, emptyMetaMap(), linus)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, base.HTTPErrorf(403, base.SyncFnErrorMissingChannelAccess))
 
-	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, nil, nil)
+	res, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["magic"]}`), `{}`, emptyMetaMap(), nil)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, res.Rejection, nil)
 }
@@ -357,12 +363,12 @@ func TestCheckAccessArray(t *testing.T) {
 // Test changing the function
 func TestSetFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {channel(doc.channels);}`)
-	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	output, err := mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	changed, err := mapper.SetFunction(`function(doc) {channel("all");}`)
 	assert.True(t, changed, "SetFunction failed")
 	assert.NoError(t, err, "SetFunction failed")
-	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, nil, noUser)
+	output, err = mapper.MapToChannelsAndAccess(parse(`{"channels": ["foo", "bar", "baz"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, output.Channels, SetOf(t, "all"))
 }
@@ -370,98 +376,98 @@ func TestSetFunction(t *testing.T) {
 // Test that expiry function sets the expiry property
 func TestExpiryFunction(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry);}`)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, nil, noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, nil, noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, nil, noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"2105-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, nil, noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, nil, noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, nil, noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, nil, noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry > unit32")
 	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, nil, noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"1805-01-01T00:00:00.000+00:00"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, nil, noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	goassert.True(t, res7.Expiry == nil)
 }
 
 func TestExpiryFunctionConstantValue(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(100);}`)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("500");}`)
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	mapper = NewChannelMapper(`function(doc) {expiry("2105-01-01T00:00:00.000+00:00");}`)
-	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res_stringDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error")
 	goassert.DeepEquals(t, *res_stringDate.Expiry, uint32(4260211200))
 
 	// Validate invalid expiry values log warning and don't set expiry
 	mapper = NewChannelMapper(`function(doc) {expiry("abc");}`)
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
 	mapper = NewChannelMapper(`function(doc) {expiry(["100", "200"]);}`)
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
 	mapper = NewChannelMapper(`function(doc) {expiry(-100);}`)
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as negative value")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
 	mapper = NewChannelMapper(`function(doc) {expiry(123456789012345);}`)
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry as > unit32")
 	goassert.True(t, res6.Expiry == nil)
 
 	// Invalid - non-unix date
 	mapper = NewChannelMapper(`function(doc) {expiry("1805-01-01T00:00:00.000+00:00");}`)
-	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	resInvalidDate, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry:1805-01-01T00:00:00.000+00:00")
 	goassert.True(t, resInvalidDate.Expiry == nil)
 
 	// No expiry specified
 	mapper = NewChannelMapper(`function(doc) {expiry();}`)
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, nil, noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess error for expiry not specified")
 	goassert.True(t, res7.Expiry == nil)
 }
@@ -469,36 +475,36 @@ func TestExpiryFunctionConstantValue(t *testing.T) {
 // Test that expiry function when invoked more than once by sync function
 func TestExpiryFunctionMultipleInvocation(t *testing.T) {
 	mapper := NewChannelMapper(`function(doc) {expiry(doc.expiry); expiry(doc.secondExpiry)}`)
-	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, nil, noUser)
+	res1, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, *res1.Expiry, uint32(100))
 
-	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, nil, noUser)
+	res2, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"500"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess failed")
 	goassert.DeepEquals(t, *res2.Expiry, uint32(500))
 
 	// Validate invalid expiry values log warning and don't set expiry
-	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, nil, noUser)
+	res3, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":"abc"}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry:abc")
 	goassert.True(t, res3.Expiry == nil)
 
 	// Invalid: non-numeric
-	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, nil, noUser)
+	res4, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":["100", "200"]}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res4.Expiry == nil)
 
 	// Invalid: negative value
-	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, nil, noUser)
+	res5, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":-100}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res5.Expiry == nil)
 
 	// Invalid - larger than uint32
-	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, nil, noUser)
+	res6, err := mapper.MapToChannelsAndAccess(parse(`{"expiry":123456789012345}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res6.Expiry == nil)
 
 	// No expiry specified
-	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, nil, noUser)
+	res7, err := mapper.MapToChannelsAndAccess(parse(`{"value":5}`), `{}`, emptyMetaMap(), noUser)
 	assert.NoError(t, err, "MapToChannelsAndAccess filed for expiry as array")
 	goassert.True(t, res7.Expiry == nil)
 }

--- a/channels/sync_runner.go
+++ b/channels/sync_runner.go
@@ -82,7 +82,7 @@ const funcWrapper = `
 					throw({forbidden: "%s"});
 		}
 
-		return function (newDoc, oldDoc, _realUserCtx) {
+		return function (newDoc, oldDoc, meta, _realUserCtx) {
 			realUserCtx = _realUserCtx;
 
 			if (oldDoc) {
@@ -93,7 +93,7 @@ const funcWrapper = `
 			shouldValidate = (realUserCtx != null && realUserCtx.name != null);
 
 			try {
-				syncFn(newDoc, oldDoc);
+				syncFn(newDoc, oldDoc, meta);
 			} catch(x) {
 				if (x.forbidden)
 				reject(403, x.forbidden);

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -14,11 +14,11 @@ func TestRequireUser(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), nil, parse(`{"name": "alpha"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), emptyMetaMap(), parse(`{"name": "alpha"}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["beta", "gamma"]}`), nil, parse(`{"name": "beta"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["beta", "gamma"]}`), emptyMetaMap(), parse(`{"name": "beta"}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["delta"]}`), nil, parse(`{"name": "beta"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["delta"]}`), emptyMetaMap(), parse(`{"name": "beta"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorWrongUser))
 }
 
@@ -27,11 +27,11 @@ func TestRequireRole(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), nil, parse(`{"name": "", "roles": {"alpha":""}}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"alpha":""}}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["beta", "gamma"]}`), nil, parse(`{"name": "", "roles": {"beta": ""}}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["beta", "gamma"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"beta": ""}}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["delta"]}`), nil, parse(`{"name": "", "roles": {"beta":""}}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["delta"]}`), emptyMetaMap(), parse(`{"name": "", "roles": {"beta":""}}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorMissingRole))
 }
 
@@ -40,11 +40,11 @@ func TestRequireAccess(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), nil, parse(`{"name": "", "channels": ["alpha"]}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["alpha"]}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["beta", "gamma"]}`), nil, parse(`{"name": "", "channels": ["beta"]}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["beta", "gamma"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["beta"]}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["delta"]}`), nil, parse(`{"name": "", "channels": ["beta"]}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["delta"]}`), emptyMetaMap(), parse(`{"name": "", "channels": ["beta"]}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorMissingChannelAccess))
 }
 
@@ -53,13 +53,13 @@ func TestRequireAdmin(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{"name": ""}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{"name": ""}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{"name": "GUEST"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{"name": "GUEST"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{"name": "beta"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), emptyMetaMap(), parse(`{"name": "beta"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
 }
 

--- a/channels/sync_runner_test.go
+++ b/channels/sync_runner_test.go
@@ -14,11 +14,11 @@ func TestRequireUser(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), parse(`{"name": "alpha"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": "alpha"}`), nil, parse(`{"name": "alpha"}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["beta", "gamma"]}`), parse(`{"name": "beta"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["beta", "gamma"]}`), nil, parse(`{"name": "beta"}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["delta"]}`), parse(`{"name": "beta"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_names": ["delta"]}`), nil, parse(`{"name": "beta"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorWrongUser))
 }
 
@@ -27,11 +27,11 @@ func TestRequireRole(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), parse(`{"name": "", "roles": {"alpha":""}}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["alpha"]}`), nil, parse(`{"name": "", "roles": {"alpha":""}}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["beta", "gamma"]}`), parse(`{"name": "", "roles": {"beta": ""}}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["beta", "gamma"]}`), nil, parse(`{"name": "", "roles": {"beta": ""}}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["delta"]}`), parse(`{"name": "", "roles": {"beta":""}}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_roles": ["delta"]}`), nil, parse(`{"name": "", "roles": {"beta":""}}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorMissingRole))
 }
 
@@ -40,11 +40,11 @@ func TestRequireAccess(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), parse(`{"name": "", "channels": ["alpha"]}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["alpha"]}`), nil, parse(`{"name": "", "channels": ["alpha"]}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["beta", "gamma"]}`), parse(`{"name": "", "channels": ["beta"]}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["beta", "gamma"]}`), nil, parse(`{"name": "", "channels": ["beta"]}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["delta"]}`), parse(`{"name": "", "channels": ["beta"]}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{"_access": ["delta"]}`), nil, parse(`{"name": "", "channels": ["beta"]}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorMissingChannelAccess))
 }
 
@@ -53,13 +53,13 @@ func TestRequireAdmin(t *testing.T) {
 	runner, err := NewSyncRunner(funcSource)
 	require.NoError(t, err)
 	var result interface{}
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{}`))
 	assertNotRejected(t, result)
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{"name": ""}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{"name": ""}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{"name": "GUEST"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{"name": "GUEST"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
-	result, _ = runner.Call(parse(`{}`), parse(`{}`), parse(`{"name": "beta"}`))
+	result, _ = runner.Call(parse(`{}`), parse(`{}`), nil, parse(`{"name": "beta"}`))
 	assertRejected(t, result, base.HTTPErrorf(http.StatusForbidden, base.SyncFnErrorAdminRequired))
 }
 

--- a/db/crud.go
+++ b/db/crud.go
@@ -1608,7 +1608,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	// Marshal raw user xattrs for use in Sync Fn. If this fails we can bail out so we should do early as possible.
-	metaMap, err := doc.GetMetaMap(db.UserXattrKeyOrEmpty())
+	metaMap, err := doc.GetMetaMap(db.Options.UserXattrKey)
 	if err != nil {
 		return
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -1143,7 +1143,7 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) 
 						base.Warnf("Error unmarshalling body %s/%s for sync function %s", base.UD(docid), rev.ID, err)
 						return
 					}
-					metaMap, err := doc.GetMetaMap(db.UserXattrKeyOrEmpty())
+					metaMap, err := doc.GetMetaMap(db.Options.UserXattrKey)
 					if err != nil {
 						return
 					}

--- a/db/database.go
+++ b/db/database.go
@@ -1143,7 +1143,11 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) 
 						base.Warnf("Error unmarshalling body %s/%s for sync function %s", base.UD(docid), rev.ID, err)
 						return
 					}
-					channels, access, roles, syncExpiry, _, err := db.getChannelsAndAccess(doc, body, rev.ID)
+					metaMap, err := doc.GetMetaMap(db.UserXattrKeyOrEmpty())
+					if err != nil {
+						return
+					}
+					channels, access, roles, syncExpiry, _, err := db.getChannelsAndAccess(doc, body, metaMap, rev.ID)
 					if err != nil {
 						// Probably the validator rejected the doc
 						base.Warnf("Error calling sync() on doc %q: %v", base.UD(docid), err)

--- a/db/document.go
+++ b/db/document.go
@@ -318,10 +318,11 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 
 // Builds the Meta Map for use in the Sync Function. This meta map currently only includes the user xattr, however, this
 // can be expanded upon in the future.
+// NOTE: emptyMetaMap() is used within tests in channelmapper_test.go and therefore this should be expanded if the below is
 func (doc *Document) GetMetaMap(userXattrKey string) (map[string]interface{}, error) {
 	xattrsMap := map[string]interface{}{}
 
-	if len(doc.rawUserXattr) > 0 {
+	if userXattrKey != "" {
 		var userXattr interface{}
 		err := base.JSONUnmarshal(doc.rawUserXattr, &userXattr)
 		if err != nil {

--- a/db/document.go
+++ b/db/document.go
@@ -316,19 +316,22 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 	return doc._rawBody, nil
 }
 
+// Builds the Meta Map for use in the Sync Function. This meta map currently only includes the user xattr, however, this
+// can be expanded upon in the future.
 func (doc *Document) GetMetaMap(userXattrKey string) (map[string]interface{}, error) {
-	var userXattr interface{}
+	xattrsMap := map[string]interface{}{}
+
 	if len(doc.rawUserXattr) > 0 {
+		var userXattr interface{}
 		err := base.JSONUnmarshal(doc.rawUserXattr, &userXattr)
 		if err != nil {
 			return nil, err
 		}
+		xattrsMap[userXattrKey] = userXattr
 	}
 
 	return map[string]interface{}{
-		"xattrs": map[string]interface{}{
-			userXattrKey: userXattr,
-		},
+		"xattrs": xattrsMap,
 	}, nil
 }
 

--- a/db/document.go
+++ b/db/document.go
@@ -318,8 +318,8 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 
 func (doc *Document) GetMetaMap(userXattrKey string) (map[string]interface{}, error) {
 	var userXattr interface{}
-	if len(doc.RawUserXattr) > 0 {
-		err := base.JSONUnmarshal(doc.RawUserXattr, &userXattr)
+	if len(doc.rawUserXattr) > 0 {
+		err := base.JSONUnmarshal(doc.rawUserXattr, &userXattr)
 		if err != nil {
 			return nil, err
 		}

--- a/db/document.go
+++ b/db/document.go
@@ -316,6 +316,22 @@ func (doc *Document) BodyBytes() ([]byte, error) {
 	return doc._rawBody, nil
 }
 
+func (doc *Document) GetMetaMap(userXattrKey string) (map[string]interface{}, error) {
+	var userXattr interface{}
+	if len(doc.RawUserXattr) > 0 {
+		err := base.JSONUnmarshal(doc.RawUserXattr, &userXattr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return map[string]interface{}{
+		"xattrs": map[string]interface{}{
+			userXattrKey: userXattr,
+		},
+	}, nil
+}
+
 // Unmarshals a document from JSON data. The doc ID isn't in the data and must be given.  Uses decode to ensure
 // UseNumber handling is applied to numbers in the body.
 func unmarshalDocument(docid string, data []byte) (*Document, error) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5619,3 +5619,41 @@ func TestUptimeStat(t *testing.T) {
 	log.Printf("uptime1: %d, uptime2: %d", uptime1, uptime2)
 	assert.True(t, uptime1 < uptime2)
 }
+
+func TestUserXattrSyncFn(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Couchbase buckets only")
+	}
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		SyncFn: `function(doc, oldDoc, meta){if(meta.xattrs.myxattr !== undefined){channel(meta.xattrs.myxattr);}}`,
+		DatabaseConfig: &DbConfig{
+			UserXattrKey: base.StringPtr("myxattr"),
+		},
+	})
+	defer rt.Close()
+
+	var doc struct {
+		SyncData db.SyncData `json:"_sync"`
+	}
+	res := rt.SendAdminRequest("PUT", "/db/doc", "{}")
+	assertStatus(t, res, http.StatusCreated)
+
+	res = rt.SendAdminRequest("GET", "/db/_raw/doc", "")
+	assertStatus(t, res, http.StatusOK)
+	err := json.Unmarshal(res.BodyBytes(), &doc)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, doc.SyncData.Channels.KeySet())
+
+	_, err = rt.Bucket().WriteXattr("doc", "myxattr", "channel")
+	assert.NoError(t, err)
+
+	res = rt.SendAdminRequest("PUT", "/db/doc?rev="+doc.SyncData.CurrentRev, "{}")
+	assertStatus(t, res, http.StatusCreated)
+
+	res = rt.SendAdminRequest("GET", "/db/_raw/doc", "")
+	assertStatus(t, res, http.StatusOK)
+	err = json.Unmarshal(res.BodyBytes(), &doc)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"channel"}, doc.SyncData.Channels.KeySet())
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5628,10 +5628,15 @@ func TestUserXattrSyncFn(t *testing.T) {
 	rt := NewRestTester(t, &RestTesterConfig{
 		SyncFn: `function(doc, oldDoc, meta){if(meta.xattrs.myxattr !== undefined){channel(meta.xattrs.myxattr);}}`,
 		DatabaseConfig: &DbConfig{
-			UserXattrKey: base.StringPtr("myxattr"),
+			UserXattrKey: "myxattr",
 		},
 	})
 	defer rt.Close()
+
+	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	if !ok {
+		t.Skip("Test requires Couchbase Bucket")
+	}
 
 	var doc struct {
 		SyncData db.SyncData `json:"_sync"`
@@ -5645,7 +5650,7 @@ func TestUserXattrSyncFn(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{}, doc.SyncData.Channels.KeySet())
 
-	_, err = rt.Bucket().WriteXattr("doc", "myxattr", "channel")
+	_, err = base.WriteXattr(gocbBucket, "doc", "myxattr", "channel")
 	assert.NoError(t, err)
 
 	res = rt.SendAdminRequest("PUT", "/db/doc?rev="+doc.SyncData.CurrentRev, "{}")


### PR DESCRIPTION
- Make function to marshal user xattrs into meta map
- Pass marshalled meta map into Sync Function
- Add tests to ensure data in Sync Function can be used (and doesn't break existing uses)

- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/716
- [x] Based onto https://github.com/couchbase/sync_gateway/pull/4963 so that needs merge and then rebase first