### PR TITLE
CBG-1339: Avoid infinite retry loop when creating as tombstone

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -455,7 +455,7 @@ func RetryLoopCas(description string, worker RetryCasWorker, sleeper RetrySleepe
 		shouldRetry, err, value := worker()
 		if !shouldRetry {
 			if err != nil {
-				return err, 0
+				return err, value
 			}
 			return nil, value
 		}


### PR DESCRIPTION
At present GetWithXattr returns an ErrKeyNotFound in the event that there is no document body and no sync data available. This results in cas also being set to 0. However, in this scenario there could still be a Couchbase tombstone present. 
This (cas=0) causes a problem when trying to create as tombstone in UpdateXattr, as it treats as cas mismatch when using SubdocDocFlagCreateAsDeleted, resulting in cas retry. 

The fix is to preserve the cas in GetWithXattr so that UpdateXattr updates the existing tombstone to add the sync xattr.

- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/731/