### PR TITLE
CBG-1322: Avoid revID update when only user xattr is changed

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -457,7 +457,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		if syncData == nil {
 			return
 		}
-		isSGWrite, _ := syncData.IsSGWrite(event.Cas, rawBody, rawUserXattr)
+		isSGWrite, _, _ := syncData.IsSGWrite(event.Cas, rawBody, rawUserXattr)
 		if !isSGWrite {
 			return
 		}

--- a/db/crud.go
+++ b/db/crud.go
@@ -817,7 +817,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 	delete(body, BodyRevisions)
 
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 
 		var isSgWrite bool
 		var crc32Match bool
@@ -919,7 +919,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 	}
 
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1594,7 +1594,7 @@ func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted
 	return true
 }
 
-func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, revIDGenerationSkipped bool, err error) {
+func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, createNewRevIDSkipped bool, err error) {
 
 	err = db.validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -1602,7 +1602,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	// Invoke the callback to update the document and return a new revision body:
-	newDoc, newAttachments, revIDGenerationSkipped, updatedExpiry, err := callback(doc)
+	newDoc, newAttachments, createNewRevIDSkipped, updatedExpiry, err := callback(doc)
 	if err != nil {
 		return
 	}
@@ -1653,7 +1653,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		return
 	}
 
-	if doc.CurrentRev != prevCurrentRev || revIDGenerationSkipped {
+	if doc.CurrentRev != prevCurrentRev || createNewRevIDSkipped {
 		// Most of the time this update will change the doc's current rev. (The exception is
 		// if the new rev is a conflict that doesn't win the revid comparison.) If so, we
 		// need to update the doc's top-level Channels and Access properties to correspond
@@ -1685,11 +1685,11 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	doc.TimeSaved = time.Now()
-	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, revIDGenerationSkipped, err
+	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err
 }
 
 // Function type for the callback passed into updateAndReturnDoc
-type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error)
+type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error)
 
 // Calling updateAndReturnDoc directly allows callers to:
 //   1. Receive the updated document body in the response
@@ -1708,7 +1708,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	var docSequence uint64                                       // Must be scoped outside callback, used over multiple iterations
 	var unusedSequences []uint64                                 // Must be scoped outside callback, used over multiple iterations
 	var oldBodyJSON string                                       // Stores previous revision body for use by DocumentChangeEvent
-	var revIDGenerationSkipped bool
+	var createNewRevIDSkipped bool
 
 	// Update the document
 	inConflict := false
@@ -1724,7 +1724,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 			prevCurrentRev = doc.CurrentRev
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, revIDGenerationSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1764,7 +1764,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, revIDGenerationSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, createNewRevIDSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1791,6 +1791,11 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 					db.DbStats.Database().WarnXattrSizeCount.Add(1)
 					base.WarnfCtx(db.Ctx, "Doc id: %v sync metadata size: %d bytes exceeds %d bytes for sync metadata warning threshold", base.UD(doc.ID), xattrBytes, *xattrBytesThreshold)
 				}
+			}
+
+			// Prior to saving doc invalidate the revision in cache
+			if createNewRevIDSkipped {
+				db.revisionCache.Invalidate(doc.ID, doc.CurrentRev)
 			}
 
 			base.DebugfCtx(db.Ctx, base.KeyCRUD, "Saving doc (seq: #%d, id: %v rev: %v)", doc.Sequence, base.UD(doc.ID), doc.CurrentRev)
@@ -1865,7 +1870,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			_shallowCopyBody: storedDoc.Body(),
 		}
 
-		if revIDGenerationSkipped {
+		if createNewRevIDSkipped {
 			db.revisionCache.Upsert(documentRevision)
 		} else {
 			db.revisionCache.Put(documentRevision)

--- a/db/crud.go
+++ b/db/crud.go
@@ -58,7 +58,7 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 			return nil, err
 		}
 
-		isSgWrite, crc32Match := doc.IsSGWrite(rawBucketDoc.Body)
+		isSgWrite, crc32Match, _ := doc.IsSGWrite(rawBucketDoc.Body)
 		if crc32Match {
 			db.DbStats.Database().Crc32MatchCount.Add(1)
 		}
@@ -139,7 +139,7 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 			return emptySyncData, unmarshalErr
 		}
 
-		isSgWrite, crc32Match := doc.IsSGWrite(rawDoc)
+		isSgWrite, crc32Match, _ := doc.IsSGWrite(rawDoc)
 		if crc32Match {
 			db.DbStats.Database().Crc32MatchCount.Add(1)
 		}
@@ -817,14 +817,14 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 	delete(body, BodyRevisions)
 
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, newRevIDGenerated bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error) {
 
 		var isSgWrite bool
 		var crc32Match bool
 
 		// Is this doc an sgWrite?
 		if doc != nil {
-			isSgWrite, crc32Match = doc.IsSGWrite(nil)
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(nil)
 			if crc32Match {
 				db.DbStats.Database().Crc32MatchCount.Add(1)
 			}
@@ -919,7 +919,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 	}
 
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, newRevIDGenerated bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -927,7 +927,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 
 		// Is this doc an sgWrite?
 		if doc != nil {
-			isSgWrite, crc32Match = doc.IsSGWrite(nil)
+			isSgWrite, crc32Match, _ = doc.IsSGWrite(nil)
 			if crc32Match {
 				db.DbStats.Database().Crc32MatchCount.Add(1)
 			}
@@ -1594,7 +1594,7 @@ func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted
 	return true
 }
 
-func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, newRevIDGenerated bool, err error) {
+func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, revIDGenerationSkipped bool, err error) {
 
 	err = db.validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -1602,7 +1602,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	// Invoke the callback to update the document and return a new revision body:
-	newDoc, newAttachments, avoidRevIDGeneration, updatedExpiry, err := callback(doc)
+	newDoc, newAttachments, revIDGenerationSkipped, updatedExpiry, err := callback(doc)
 	if err != nil {
 		return
 	}
@@ -1653,7 +1653,7 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		return
 	}
 
-	if doc.CurrentRev != prevCurrentRev || avoidRevIDGeneration {
+	if doc.CurrentRev != prevCurrentRev || revIDGenerationSkipped {
 		// Most of the time this update will change the doc's current rev. (The exception is
 		// if the new rev is a conflict that doesn't win the revid comparison.) If so, we
 		// need to update the doc's top-level Channels and Access properties to correspond
@@ -1685,11 +1685,11 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	doc.TimeSaved = time.Now()
-	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, avoidRevIDGeneration, err
+	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, revIDGenerationSkipped, err
 }
 
 // Function type for the callback passed into updateAndReturnDoc
-type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, newRevIDGenerated bool, updatedExpiry *uint32, resultErr error)
+type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error)
 
 // Calling updateAndReturnDoc directly allows callers to:
 //   1. Receive the updated document body in the response
@@ -1708,7 +1708,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	var docSequence uint64                                       // Must be scoped outside callback, used over multiple iterations
 	var unusedSequences []uint64                                 // Must be scoped outside callback, used over multiple iterations
 	var oldBodyJSON string                                       // Stores previous revision body for use by DocumentChangeEvent
-	var newRevIDGenerated bool
+	var revIDGenerationSkipped bool
 
 	// Update the document
 	inConflict := false
@@ -1724,7 +1724,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 			prevCurrentRev = doc.CurrentRev
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, newRevIDGenerated, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, revIDGenerationSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1764,7 +1764,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, newRevIDGenerated, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, revIDGenerationSkipped, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1865,7 +1865,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			_shallowCopyBody: storedDoc.Body(),
 		}
 
-		if newRevIDGenerated {
+		if revIDGenerationSkipped {
 			db.revisionCache.Upsert(documentRevision)
 		} else {
 			db.revisionCache.Put(documentRevision)

--- a/db/crud.go
+++ b/db/crud.go
@@ -817,7 +817,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 	delete(body, BodyRevisions)
 
 	allowImport := db.UseXattrs()
-	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, importFromUserXattrs bool, updatedExpiry *uint32, resultErr error) {
+	doc, newRevID, err = db.updateAndReturnDoc(newDoc.ID, allowImport, expiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, avoidRevIDGeneration bool, updatedExpiry *uint32, resultErr error) {
 
 		var isSgWrite bool
 		var crc32Match bool
@@ -919,7 +919,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 	}
 
 	allowImport := db.UseXattrs()
-	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, importFromUserXattrs bool, updatedExpiry *uint32, resultErr error) {
+	doc, _, err = db.updateAndReturnDoc(newDoc.ID, allowImport, newDoc.DocExpiry, nil, func(doc *Document) (resultDoc *Document, resultAttachmentData AttachmentData, avoidRevIDGeneration bool, updatedExpiry *uint32, resultErr error) {
 		// (Be careful: this block can be invoked multiple times if there are races!)
 
 		var isSgWrite bool
@@ -1594,7 +1594,7 @@ func (db *Database) IsIllegalConflict(doc *Document, parentRevID string, deleted
 	return true
 }
 
-func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, err error) {
+func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImport bool, previousDocSequenceIn uint64, unusedSequences []uint64, callback updateAndReturnDocCallback, expiry uint32) (retSyncFuncExpiry *uint32, retNewRevID string, retStoredDoc *Document, retOldBodyJSON string, retUnusedSequences []uint64, changedAccessPrincipals []string, changedRoleAccessUsers []string, importFromUserXattrs bool, err error) {
 
 	err = db.validateExistingDoc(doc, allowImport, docExists)
 	if err != nil {
@@ -1685,11 +1685,11 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	}
 
 	doc.TimeSaved = time.Now()
-	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, err
+	return updatedExpiry, newRevID, newDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, importFromUserXattrs, err
 }
 
 // Function type for the callback passed into updateAndReturnDoc
-type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, importFromUserXattrs bool, updatedExpiry *uint32, resultErr error)
+type updateAndReturnDocCallback func(*Document) (resultDoc *Document, resultAttachmentData AttachmentData, avoidRevIDGeneration bool, updatedExpiry *uint32, resultErr error)
 
 // Calling updateAndReturnDoc directly allows callers to:
 //   1. Receive the updated document body in the response
@@ -1708,6 +1708,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	var docSequence uint64                                       // Must be scoped outside callback, used over multiple iterations
 	var unusedSequences []uint64                                 // Must be scoped outside callback, used over multiple iterations
 	var oldBodyJSON string                                       // Stores previous revision body for use by DocumentChangeEvent
+	var avoidRevIDGeneration bool
 
 	// Update the document
 	inConflict := false
@@ -1723,7 +1724,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 			prevCurrentRev = doc.CurrentRev
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, avoidRevIDGeneration, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1763,7 +1764,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			}
 
 			docExists := currentValue != nil
-			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
+			syncFuncExpiry, newRevID, storedDoc, oldBodyJSON, unusedSequences, changedAccessPrincipals, changedRoleAccessUsers, avoidRevIDGeneration, err = db.documentUpdateFunc(docExists, doc, allowImport, docSequence, unusedSequences, callback, expiry)
 			if err != nil {
 				return
 			}
@@ -1863,7 +1864,12 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 			Deleted:          doc.History[newRevID].Deleted,
 			_shallowCopyBody: storedDoc.Body(),
 		}
-		db.revisionCache.Put(documentRevision)
+
+		if avoidRevIDGeneration {
+			db.revisionCache.Update(documentRevision)
+		} else {
+			db.revisionCache.Put(documentRevision)
+		}
 
 		if db.EventMgr.HasHandlerForEvent(DocumentChange) {
 			webhookJSON, err := doc.BodyWithSpecialProperties()

--- a/db/document.go
+++ b/db/document.go
@@ -146,6 +146,13 @@ func (sd *SyncData) HashRedact(salt string) SyncData {
 	return redactedSyncData
 }
 
+func (s *SyncData) BodyChanged(rawBody []byte) bool {
+	if s.Crc32c == base.Crc32cHashString(rawBody) {
+		return false
+	}
+	return true
+}
+
 // A document as stored in Couchbase. Contains the body of the current revision plus metadata.
 // In its JSON form, the body's properties are at top-level while the SyncData is in a special
 // "_sync" property.

--- a/db/document.go
+++ b/db/document.go
@@ -555,7 +555,7 @@ func (s *SyncData) IsSGWrite(cas uint64, rawBody []byte, rawUserXattr []byte) (i
 		return true, false, false
 	}
 
-	// If crc32c hash of body matches value stored in SG metadata, SG metadata is still valid
+	// If crc32c hash of body doesn't match value stored in SG metadata then import is required
 	if base.Crc32cHashString(rawBody) != s.Crc32c {
 		return false, false, true
 	}

--- a/db/document.go
+++ b/db/document.go
@@ -146,13 +146,6 @@ func (sd *SyncData) HashRedact(salt string) SyncData {
 	return redactedSyncData
 }
 
-func (s *SyncData) BodyChanged(rawBody []byte) bool {
-	if s.Crc32c == base.Crc32cHashString(rawBody) {
-		return false
-	}
-	return true
-}
-
 // A document as stored in Couchbase. Contains the body of the current revision plus metadata.
 // In its JSON form, the body's properties are at top-level while the SyncData is in a special
 // "_sync" property.
@@ -555,55 +548,50 @@ func HasUserXattrChanged(userXattr []byte, prevUserXattrHash string) bool {
 }
 
 // SyncData.IsSGWrite - used during feed-based import
-func (s *SyncData) IsSGWrite(cas uint64, rawBody []byte, rawUserXattr []byte) (isSGWrite bool, crc32Match bool) {
+func (s *SyncData) IsSGWrite(cas uint64, rawBody []byte, rawUserXattr []byte) (isSGWrite bool, crc32Match bool, bodyChanged bool) {
 
 	// If cas matches, it was a SG write
 	if cas == s.GetSyncCas() {
-		return true, false
-	}
-
-	if HasUserXattrChanged(rawUserXattr, s.Crc32cUserXattr) {
-		return false, false
+		return true, false, false
 	}
 
 	// If crc32c hash of body matches value stored in SG metadata, SG metadata is still valid
 	if base.Crc32cHashString(rawBody) != s.Crc32c {
-		return false, false
+		return false, false, true
 	}
 
-	return true, true
+	if HasUserXattrChanged(rawUserXattr, s.Crc32cUserXattr) {
+		return false, false, false
+	}
+
+	return true, true, false
 }
 
 // doc.IsSGWrite - used during on-demand import.  Doesn't invoke SyncData.IsSGWrite so that we
 // can complete the inexpensive cas check before the (potential) doc marshalling.
-func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool) {
+func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool, bodyChanged bool) {
 
 	// If the raw body is available, use SyncData.IsSGWrite
 	if rawBody != nil && len(rawBody) > 0 {
 
-		isSgWriteFeed, crc32MatchFeed := doc.SyncData.IsSGWrite(doc.Cas, rawBody, doc.rawUserXattr)
+		isSgWriteFeed, crc32MatchFeed, bodyChangedFeed := doc.SyncData.IsSGWrite(doc.Cas, rawBody, doc.rawUserXattr)
 		if !isSgWriteFeed {
 			base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
 		}
 
-		return isSgWriteFeed, crc32MatchFeed
+		return isSgWriteFeed, crc32MatchFeed, bodyChangedFeed
 	}
 
 	// If raw body isn't available, first do the inexpensive cas check
 	if doc.Cas == doc.SyncData.GetSyncCas() {
-		return true, false
-	}
-
-	if HasUserXattrChanged(doc.rawUserXattr, doc.Crc32cUserXattr) {
-		base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on user xattr hash", base.UD(doc.ID))
-		return false, false
+		return true, false, false
 	}
 
 	// Since raw body isn't available, marshal from the document to perform body hash comparison
 	bodyBytes, err := doc.BodyBytes()
 	if err != nil {
 		base.Warnf("Unable to marshal doc body during SG write check for doc %s. Error: %v", base.UD(doc.ID), err)
-		return false, false
+		return false, false, false
 	}
 	// The bodyBytes would be replaced with "{}" if the document is a "Delete" and it can’t be used for
 	// CRC-32 checksum comparison to determine whether the document has already been imported. So the value
@@ -616,10 +604,15 @@ func (doc *Document) IsSGWrite(rawBody []byte) (isSGWrite bool, crc32Match bool)
 	// If the current body crc32c matches the one in doc.SyncData, this was an SG write (i.e. has already been imported)
 	if currentBodyCrc32c != doc.SyncData.Crc32c {
 		base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on cas and body hash. cas:%x syncCas:%q", base.UD(doc.ID), doc.Cas, doc.SyncData.Cas)
-		return false, false
+		return false, false, true
 	}
 
-	return true, true
+	if HasUserXattrChanged(doc.rawUserXattr, doc.Crc32cUserXattr) {
+		base.Debugf(base.KeyCRUD, "Doc %s is not an SG write, based on user xattr hash", base.UD(doc.ID))
+		return false, false, false
+	}
+
+	return true, true, false
 }
 
 func (doc *Document) hasFlag(flag uint8) bool {

--- a/db/import.go
+++ b/db/import.go
@@ -133,7 +133,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 	var newRev string
 	var alreadyImportedDoc *Document
-	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, createNewRevIDSkipped bool, updatedExpiry *uint32, resultErr error) {
 
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.

--- a/db/import.go
+++ b/db/import.go
@@ -133,7 +133,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 	var newRev string
 	var alreadyImportedDoc *Document
-	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, newRevIDGenerated bool, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, revIDGenerationSkipped bool, updatedExpiry *uint32, resultErr error) {
 
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
@@ -209,7 +209,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		}
 
 		// Is this doc an SG Write?
-		isSgWrite, crc32Match := doc.IsSGWrite(existingDoc.Body)
+		isSgWrite, crc32Match, bodyChanged := doc.IsSGWrite(existingDoc.Body)
 		if crc32Match {
 			db.DbStats.Database().Crc32MatchCount.Add(1)
 		}
@@ -263,11 +263,11 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 			}
 		}
 
-		newRevIDGenerated = !doc.BodyChanged(existingDoc.Body)
+		shouldGenerateNewRev := bodyChanged
 
 		// If the body has changed then the document has been updated and we should generate a new revision. Otherwise
 		// the import was triggered by a user xattr mutation and therefore should not generate a new revision.
-		if !newRevIDGenerated {
+		if shouldGenerateNewRev {
 			// The active rev is the parent for an import
 			parentRev := doc.CurrentRev
 			generation, _ := ParseRevID(parentRev)
@@ -306,7 +306,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 		// Note - no attachments processing is done during ImportDoc.  We don't (currently) support writing attachments through anything but SG.
 
-		return newDoc, nil, newRevIDGenerated, updatedExpiry, nil
+		return newDoc, nil, !shouldGenerateNewRev, updatedExpiry, nil
 	})
 
 	switch err {

--- a/db/import.go
+++ b/db/import.go
@@ -133,7 +133,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 	var newRev string
 	var alreadyImportedDoc *Document
-	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, avoidRevIDGeneration bool, updatedExpiry *uint32, resultErr error) {
+	docOut, _, err = db.updateAndReturnDoc(newDoc.ID, true, existingDoc.Expiry, existingDoc, func(doc *Document) (resultDocument *Document, resultAttachmentData AttachmentData, newRevIDGenerated bool, updatedExpiry *uint32, resultErr error) {
 
 		// Perform cas mismatch check first, as we want to identify cas mismatch before triggering migrate handling.
 		// If there's a cas mismatch, the doc has been updated since the version that triggered the import.  Handling depends on import mode.
@@ -263,11 +263,11 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 			}
 		}
 
-		avoidRevIDGeneration = !doc.BodyChanged(existingDoc.Body)
+		newRevIDGenerated = !doc.BodyChanged(existingDoc.Body)
 
 		// If the body has changed then the document has been updated and we should generate a new revision. Otherwise
 		// the import was triggered by a user xattr mutation and therefore should not generate a new revision.
-		if !avoidRevIDGeneration {
+		if !newRevIDGenerated {
 			// The active rev is the parent for an import
 			parentRev := doc.CurrentRev
 			generation, _ := ParseRevID(parentRev)
@@ -306,7 +306,7 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 
 		// Note - no attachments processing is done during ImportDoc.  We don't (currently) support writing attachments through anything but SG.
 
-		return newDoc, nil, avoidRevIDGeneration, updatedExpiry, nil
+		return newDoc, nil, newRevIDGenerated, updatedExpiry, nil
 	})
 
 	switch err {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -109,7 +109,7 @@ func (il *importListener) ImportFeedEvent(event sgbucket.FeedEvent) {
 	var isSGWrite bool
 	var crc32Match bool
 	if syncData != nil {
-		isSGWrite, crc32Match = syncData.IsSGWrite(event.Cas, rawBody, rawUserXattr)
+		isSGWrite, crc32Match, _ = syncData.IsSGWrite(event.Cas, rawBody, rawUserXattr)
 		if crc32Match {
 			il.stats.Crc32MatchCount.Add(1)
 		}

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -80,7 +80,7 @@ func (rc *BypassRevisionCache) Put(docRev DocumentRevision) {
 }
 
 // Update is a no-op for a BypassRevisionCache
-func (rc *BypassRevisionCache) Update(docRev DocumentRevision) {
+func (rc *BypassRevisionCache) Upsert(docRev DocumentRevision) {
 	// no-op
 }
 

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -84,6 +84,10 @@ func (rc *BypassRevisionCache) Upsert(docRev DocumentRevision) {
 	// no-op
 }
 
+func (rc *BypassRevisionCache) Invalidate(docID, revID string) {
+	// nop
+}
+
 // UpdateDelta is a no-op for a BypassRevisionCache
 func (rc *BypassRevisionCache) UpdateDelta(docID, revID string, toDelta RevisionDelta) {
 	// no-op

--- a/db/revision_cache_bypass.go
+++ b/db/revision_cache_bypass.go
@@ -79,6 +79,11 @@ func (rc *BypassRevisionCache) Put(docRev DocumentRevision) {
 	// no-op
 }
 
+// Update is a no-op for a BypassRevisionCache
+func (rc *BypassRevisionCache) Update(docRev DocumentRevision) {
+	// no-op
+}
+
 // UpdateDelta is a no-op for a BypassRevisionCache
 func (rc *BypassRevisionCache) UpdateDelta(docID, revID string, toDelta RevisionDelta) {
 	// no-op

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -35,6 +35,9 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(docRev DocumentRevision)
 
+	// Invalidate
+	Invalidate(docID, revID string)
+
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(docID, revID string, toDelta RevisionDelta)
 }
@@ -105,6 +108,7 @@ type DocumentRevision struct {
 	Delta       *RevisionDelta
 	Deleted     bool
 	Removed     bool // True if the revision is a removal.
+	Invalid     bool
 
 	_shallowCopyBody Body // an unmarshalled body that can produce shallow copies
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -32,6 +32,9 @@ type RevisionCache interface {
 	// Put will store the given docRev in the cache
 	Put(docRev DocumentRevision)
 
+	// Update will remove existing value and re-create new one
+	Update(docRev DocumentRevision)
+
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(docID, revID string, toDelta RevisionDelta)
 }

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -33,7 +33,7 @@ type RevisionCache interface {
 	Put(docRev DocumentRevision)
 
 	// Update will remove existing value and re-create new one
-	Update(docRev DocumentRevision)
+	Upsert(docRev DocumentRevision)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached
 	UpdateDelta(docID, revID string, toDelta RevisionDelta)

--- a/db/revision_cache_interface.go
+++ b/db/revision_cache_interface.go
@@ -35,7 +35,9 @@ type RevisionCache interface {
 	// Update will remove existing value and re-create new one
 	Upsert(docRev DocumentRevision)
 
-	// Invalidate
+	// Invalidate marks a revision in the cache as invalid. This is used to call into LoadInvalidRevFromBackingStore in LRU.
+	// Marked revision denotes that this value should not be used and should be replaced. Used in the event of an user
+	// xattr only update where there is no revision change.
 	Invalidate(docID, revID string)
 
 	// UpdateDelta stores the given toDelta value in the given rev if cached

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -149,6 +149,8 @@ func (rc *LRURevisionCache) getFromCache(docID, revID string, loadOnCacheMiss bo
 	return docRev, err
 }
 
+// In the event that a revision in invalid it needs to be replaced later and the revision cache value should not be
+// used. This function grabs the value directly from the bucket.
 func (rc *LRURevisionCache) LoadInvalidRevFromBackingStore(key IDAndRev, includeBody bool, includeDelta bool) (DocumentRevision, error) {
 	var delta *RevisionDelta
 	var docRevBody Body

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -54,8 +54,8 @@ func (sc *ShardedLRURevisionCache) Put(docRev DocumentRevision) {
 	sc.getShard(docRev.DocID).Put(docRev)
 }
 
-func (sc *ShardedLRURevisionCache) Update(docRev DocumentRevision) {
-	sc.getShard(docRev.DocID).Update(docRev)
+func (sc *ShardedLRURevisionCache) Upsert(docRev DocumentRevision) {
+	sc.getShard(docRev.DocID).Upsert(docRev)
 }
 
 // An LRU cache of document revision bodies, together with their channel access.
@@ -185,12 +185,11 @@ func (rc *LRURevisionCache) Put(docRev DocumentRevision) {
 	value.store(docRev)
 }
 
-// Updates a revision in the cache.
-func (rc *LRURevisionCache) Update(docRev DocumentRevision) {
-	rc.lock.Lock()
-
+// Upsert a revision in the cache.
+func (rc *LRURevisionCache) Upsert(docRev DocumentRevision) {
 	key := IDAndRev{DocID: docRev.DocID, RevID: docRev.RevID}
 
+	rc.lock.Lock()
 	// If element exists remove from lrulist
 	if elem := rc.cache[key]; elem != nil {
 		rc.lruList.Remove(elem)
@@ -204,10 +203,9 @@ func (rc *LRURevisionCache) Update(docRev DocumentRevision) {
 	for len(rc.cache) > int(rc.capacity) {
 		rc.purgeOldest_()
 	}
+	rc.lock.Unlock()
 
 	value.store(docRev)
-
-	rc.lock.Unlock()
 }
 
 func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *revCacheValue) {

--- a/db/revision_cache_lru.go
+++ b/db/revision_cache_lru.go
@@ -54,6 +54,10 @@ func (sc *ShardedLRURevisionCache) Put(docRev DocumentRevision) {
 	sc.getShard(docRev.DocID).Put(docRev)
 }
 
+func (sc *ShardedLRURevisionCache) Update(docRev DocumentRevision) {
+	sc.getShard(docRev.DocID).Update(docRev)
+}
+
 // An LRU cache of document revision bodies, together with their channel access.
 type LRURevisionCache struct {
 	cache        map[IDAndRev]*list.Element // Fast lookup of list element by doc/rev ID
@@ -179,6 +183,15 @@ func (rc *LRURevisionCache) Put(docRev DocumentRevision) {
 	}
 	value := rc.getValue(docRev.DocID, docRev.RevID, true)
 	value.store(docRev)
+}
+
+// Update a revision
+func (rc *LRURevisionCache) Update(docRev DocumentRevision) {
+	value := rc.getValue(docRev.DocID, docRev.RevID, false)
+	if value != nil {
+		rc.removeValue(value)
+	}
+	rc.Put(docRev)
 }
 
 func (rc *LRURevisionCache) getValue(docID, revID string, create bool) (value *revCacheValue) {

--- a/db/revision_cache_test.go
+++ b/db/revision_cache_test.go
@@ -426,6 +426,46 @@ func TestConcurrentLoad(t *testing.T) {
 
 }
 
+func TestInvalidate(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	rev1id, _, err := db.Put("doc", Body{"val": 123})
+	assert.NoError(t, err)
+
+	docRev, err := db.revisionCache.Get("doc", rev1id, true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, rev1id, docRev.RevID)
+	assert.False(t, docRev.Invalid)
+	assert.Equal(t, int64(0), db.DbStats.Cache().RevisionCacheMisses.Value())
+
+	db.revisionCache.Invalidate("doc", rev1id)
+
+	docRev, err = db.revisionCache.Get("doc", rev1id, true, true)
+	assert.NoError(t, err)
+	assert.Equal(t, rev1id, docRev.RevID)
+	assert.True(t, docRev.Invalid)
+	assert.Equal(t, int64(1), db.DbStats.Cache().RevisionCacheMisses.Value())
+
+	docRev, err = db.revisionCache.GetActive("doc", true)
+	assert.NoError(t, err)
+	assert.Equal(t, rev1id, docRev.RevID)
+	assert.True(t, docRev.Invalid)
+	assert.Equal(t, int64(2), db.DbStats.Cache().RevisionCacheMisses.Value())
+
+	docRev, err = db.GetRev("doc", docRev.RevID, true, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, rev1id, docRev.RevID)
+	assert.True(t, docRev.Invalid)
+	assert.Equal(t, int64(3), db.DbStats.Cache().RevisionCacheMisses.Value())
+
+	docRev, err = db.GetRev("doc", "", true, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, rev1id, docRev.RevID)
+	assert.True(t, docRev.Invalid)
+	assert.Equal(t, int64(4), db.DbStats.Cache().RevisionCacheMisses.Value())
+}
+
 func BenchmarkRevisionCacheRead(b *testing.B) {
 	defer base.SetUpBenchmarkLogging(base.LevelDebug, base.KeyAll)()
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6027,6 +6027,10 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	docKey := t.Name()


### PR DESCRIPTION
In the case where an import is triggered by a change of user xattrs we need to avoid the generation of a new revid and only increment the sequence.