### PR TITLE
CBG-1337 Add an option to skip TLS certificates verification while loading JavaScript from HTTPS endpoints

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -171,13 +171,14 @@ type APIEndpoints struct {
 }
 
 type UnsupportedOptions struct {
-	UserViews                UserViewsOptions        `json:"user_views,omitempty"`                  // Config settings for user views
-	OidcTestProvider         OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`          // Config settings for OIDC Provider
-	APIEndpoints             APIEndpoints            `json:"api_endpoints,omitempty"`               // Config settings for API endpoints
-	WarningThresholds        WarningThresholds       `json:"warning_thresholds,omitempty"`          // Warning thresholds related to _sync size
-	DisableCleanSkippedQuery bool                    `json:"disable_clean_skipped_query,omitempty"` // Clean skipped sequence processing bypasses final check
-	OidcTlsSkipVerify        bool                    `json:"oidc_tls_skip_verify"`                  // Config option to enable self-signed certs for OIDC testing.
-	SgrTlsSkipVerify         bool                    `json:"sgr_tls_skip_verify"`                   // Config option to enable self-signed certs for SG-Replicate testing.
+	UserViews                 UserViewsOptions        `json:"user_views,omitempty"`                  // Config settings for user views
+	OidcTestProvider          OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`          // Config settings for OIDC Provider
+	APIEndpoints              APIEndpoints            `json:"api_endpoints,omitempty"`               // Config settings for API endpoints
+	WarningThresholds         WarningThresholds       `json:"warning_thresholds,omitempty"`          // Warning thresholds related to _sync size
+	DisableCleanSkippedQuery  bool                    `json:"disable_clean_skipped_query,omitempty"` // Clean skipped sequence processing bypasses final check
+	OidcTlsSkipVerify         bool                    `json:"oidc_tls_skip_verify"`                  // Config option to enable self-signed certs for OIDC testing.
+	SgrTlsSkipVerify          bool                    `json:"sgr_tls_skip_verify"`                   // Config option to enable self-signed certs for SG-Replicate testing.
+	RemoteConfigTlsSkipVerify bool                    `json:"remote_config_tls_skip_verify"`         // Config option to enable self signed certificates for external JavaScript load.
 }
 
 type WarningThresholds struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -340,7 +340,7 @@ func (dbConfig *DbConfig) setup(name string) error {
 
 	// Load Sync Function.
 	if dbConfig.Sync != nil {
-		sync, err := loadJavaScript(*dbConfig.Sync)
+		sync, err := loadJavaScript(*dbConfig.Sync, dbConfig.Unsupported.RemoteConfigTlsSkipVerify)
 		if err != nil {
 			return &JavaScriptLoadError{
 				JSLoadType: SyncFunction,
@@ -353,7 +353,7 @@ func (dbConfig *DbConfig) setup(name string) error {
 
 	// Load Import Filter Function.
 	if dbConfig.ImportFilter != nil {
-		importFilter, err := loadJavaScript(*dbConfig.ImportFilter)
+		importFilter, err := loadJavaScript(*dbConfig.ImportFilter, dbConfig.Unsupported.RemoteConfigTlsSkipVerify)
 		if err != nil {
 			return &JavaScriptLoadError{
 				JSLoadType: ImportFilter,
@@ -367,7 +367,7 @@ func (dbConfig *DbConfig) setup(name string) error {
 	// Load Conflict Resolution Function.
 	for _, rc := range dbConfig.Replications {
 		if rc.ConflictResolutionFn != "" {
-			conflictResolutionFn, err := loadJavaScript(rc.ConflictResolutionFn)
+			conflictResolutionFn, err := loadJavaScript(rc.ConflictResolutionFn, dbConfig.Unsupported.RemoteConfigTlsSkipVerify)
 			if err != nil {
 				return &JavaScriptLoadError{
 					JSLoadType: ConflictResolver,
@@ -386,8 +386,8 @@ func (dbConfig *DbConfig) setup(name string) error {
 // If the specified path does not qualify for a valid file or an URI, it returns the input path
 // as-is with the assumption that it is an inline JavaScript source. Returns error if there is
 // any failure in reading the JavaScript file or URI.
-func loadJavaScript(path string) (js string, err error) {
-	rc, err := readFromPath(path)
+func loadJavaScript(path string, insecureSkipVerify bool) (js string, err error) {
+	rc, err := readFromPath(path, insecureSkipVerify)
 	if errors.Is(err, ErrPathNotFound) {
 		// If rc is nil and readFromPath returns no error, treat the
 		// the given path as an inline JavaScript and return it as-is.
@@ -446,11 +446,12 @@ var ErrPathNotFound = errors.New("path not found")
 
 // readFromPath creates a ReadCloser from the given path. The path must be either a valid file
 // or an HTTP/HTTPS endpoint. Returns an error if there is any failure in building ReadCloser.
-func readFromPath(path string) (rc io.ReadCloser, err error) {
+func readFromPath(path string, insecureSkipVerify bool) (rc io.ReadCloser, err error) {
 	messageFormat := "Loading content from [%s] ..."
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
 		base.Infof(base.KeyAll, messageFormat, path)
-		resp, err := http.Get(path)
+		client := base.GetHttpClient(insecureSkipVerify)
+		resp, err := client.Get(path)
 		if err != nil {
 			return nil, err
 		} else if resp.StatusCode >= 300 {
@@ -752,7 +753,7 @@ func (clusterConfig *ClusterConfig) GetCredentials() (string, string, string) {
 
 // LoadServerConfig loads a ServerConfig from either a JSON file or from a URL
 func LoadServerConfig(path string) (config *ServerConfig, err error) {
-	rc, err := readFromPath(path)
+	rc, err := readFromPath(path, false)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -398,9 +398,8 @@ func loadJavaScript(path string, insecureSkipVerify bool) (js string, err error)
 		if !insecureSkipVerify {
 			var unkAuthErr x509.UnknownAuthorityError
 			if errors.As(err, &unkAuthErr) {
-				return "", fmt.Errorf("%w. SSL certificate verification is turned "+
-					"on by default when loading config over HTTPS. Can be overriden by "+
-					"the unsupported \"remote_config_tls_skip_verify\" option", err)
+				return "", fmt.Errorf("%w. TLS certificate failed verification.  TLS verification "+
+					"can be disabled using the unsupported \"remote_config_tls_skip_verify\" option", err)
 			}
 			return "", err
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -398,7 +398,7 @@ func loadJavaScript(path string, insecureSkipVerify bool) (js string, err error)
 		if !insecureSkipVerify {
 			var unkAuthErr x509.UnknownAuthorityError
 			if errors.As(err, &unkAuthErr) {
-				return "", fmt.Errorf("%w. TLS certificate failed verification.  TLS verification "+
+				return "", fmt.Errorf("%w. TLS certificate failed verification. TLS verification "+
 					"can be disabled using the unsupported \"remote_config_tls_skip_verify\" option", err)
 			}
 			return "", err

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1420,7 +1419,7 @@ func TestLoadJavaScript(t *testing.T) {
 			jsInput:            javaScriptHttpsEndpoint(t, js),
 			insecureSkipVerify: false,
 			jsExpected:         "",
-			errExpected:        &url.Error{},
+			errExpected:        httpSSLVerifyError{},
 		},
 		{
 			name:               "Load JavaScript from an external https endpoint with ssl verification disabled",
@@ -1501,7 +1500,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 			jsSyncInput:        javaScriptHttpsEndpoint(t, jsSync),
 			insecureSkipVerify: false,
 			jsSyncFnExpected:   "",
-			errExpected:        &url.Error{},
+			errExpected:        httpSSLVerifyError{},
 		},
 		{
 			name:               "Load sync function from an external https endpoint with ssl verification disabled",
@@ -1600,7 +1599,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 			jsImportFilterInput:    javaScriptHttpsEndpoint(t, jsImportFilter),
 			insecureSkipVerify:     false,
 			jsImportFilterExpected: "",
-			errExpected:            &url.Error{},
+			errExpected:            httpSSLVerifyError{},
 		},
 		{
 			name:                   "Load import filter from an external https endpoint with ssl verification disabled",
@@ -1705,7 +1704,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 			jsConflictResInput:    javaScriptHttpsEndpoint(t, jsConflictResolution),
 			insecureSkipVerify:    false,
 			jsConflictResExpected: "",
-			errExpected:           &url.Error{},
+			errExpected:           httpSSLVerifyError{},
 		},
 		{
 			name:                  "Load conflict resolution function from an external http endpoint with ssl verification disabled",
@@ -1808,7 +1807,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 			name:                 "Load webhook filter function from an external https endpoint with ssl verification enabled",
 			jsWebhookFilterInput: javaScriptHttpsEndpoint(t, jsWebhookFilter),
 			insecureSkipVerify:   false,
-			errExpected:          &url.Error{},
+			errExpected:          httpSSLVerifyError{},
 		},
 		{
 			name:                 "Load webhook filter function from an external https endpoint with ssl verification disabled",

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -839,7 +839,7 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 			}
 
 			// Load external webhook filter function
-			filter, err := loadJavaScript(conf.Filter)
+			filter, err := loadJavaScript(conf.Filter, config.Unsupported.RemoteConfigTlsSkipVerify)
 			if err != nil {
 				return &JavaScriptLoadError{
 					JSLoadType: WebhookFilter,


### PR DESCRIPTION
Changes to provide an unsupported config option that allows the users to skip TLS verification (or allowing users to use self signed certificate) while loading external JavaScript for import filer, sync function, conflict resolver function and Webhook filter function.