### PR TITLE
CBG-1378 Force SG to initialize the OIDC client in the subsequent request when the provider is not reachable in the first request

### DIFF
--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -170,7 +170,7 @@ type OIDCProvider struct {
 
 	// clientOnce synchronises access to the GetClient() and ensures that
 	// the OpenID Connect client only gets initialized exactly once.
-	clientOnce sync.Once
+	clientOnce base.Once
 
 	// IsDefault indicates whether this OpenID Connect provider (the current
 	// instance of OIDCProvider is explicitly specified as default provider
@@ -261,6 +261,11 @@ func (op *OIDCProvider) GetClient(buildCallbackURLFunc OIDCCallbackURLFunc) *OID
 		}
 	})
 
+	// If the provider is not available in the first place, force to reinitialize the client
+	// exactly once to reach the provider in the subsequent request without restarting SG.
+	if op.client == nil {
+		op.clientOnce.Reset()
+	}
 	return op.client
 }
 

--- a/base/once.go
+++ b/base/once.go
@@ -1,0 +1,38 @@
+package base
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Once is an object that will perform exactly one action
+// until Reset is called.
+// See http://golang.org/pkg/sync/#Once
+type Once struct {
+	done uint32
+	m    sync.Mutex
+}
+
+// Do simulates sync.Once.Do by executing the specified function
+// only once, until Reset is called.
+// See http://golang.org/pkg/sync/#Once
+func (o *Once) Do(f func()) {
+	if atomic.LoadUint32(&o.done) == 1 {
+		return
+	}
+	// Slow-path.
+	o.m.Lock()
+	defer o.m.Unlock()
+	if o.done == 0 {
+		defer atomic.StoreUint32(&o.done, 1)
+		f()
+	}
+}
+
+// Reset indicates that the next call to Do should actually be called
+// once again.
+func (o *Once) Reset() {
+	o.m.Lock()
+	defer o.m.Unlock()
+	atomic.StoreUint32(&o.done, 0)
+}

--- a/base/once_test.go
+++ b/base/once_test.go
@@ -1,0 +1,22 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnceReset(t *testing.T) {
+	var calls int
+	var once Once
+	once.Do(func() { calls++ })
+	once.Do(func() { calls++ })
+	once.Do(func() { calls++ })
+	require.Equal(t, 1, calls)
+
+	once.Reset()
+	once.Do(func() { calls++ })
+	once.Do(func() { calls++ })
+	once.Do(func() { calls++ })
+	require.Equal(t, 2, calls)
+}


### PR DESCRIPTION
During OpenID Connect authentication, Sync Gateway initializes the client with the specified configuration by performing an initial provider metadata discovery from a well-known endpoint and initiates the periodic discovery sync in the background. Initialization of the client is performed lazily (when the first request comes in) and exactly once throughout the life cycle of an SG instance. The caveat is that if the provider is not reachable at the time of initializing the OIDC client, SG won’t refresh the client instance that is cached in memory until the time of the next metadata sync. If the provider becomes available later on and any auth request that is made before the next metadata sync can end up in ”401 Invalid Login” even when there is a valid Bearer token provided in the request header that is obtained from the provider. Today, customers are performing a restart to establish the connection with the provider and that is not desirable. The PR includes the changes to force Sync Gateway to reinitialize the client by establishing the connection with the provider during the subsequent authentication request and avoid explicitly restarting the server instance. 