### PR TITLE
CBG-1376 - Fix incorrect error type checking around go-fleecedelta

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1128,6 +1128,15 @@ func DefaultHTTPTransport() *http.Transport {
 	return http.DefaultTransport.(*http.Transport).Clone()
 }
 
+// IsFleeceDeltaError returns true if the given error originates from go-fleecedelta.
+func IsFleeceDeltaError(err error) bool { return errors.As(err, &FleeceDeltaError{}) }
+
+// FleeceDeltaError is a typed error wrapped around any error returned from go-fleecedelta.
+type FleeceDeltaError struct{ e error }
+
+func (e FleeceDeltaError) Error() string { return e.e.Error() }
+func (e FleeceDeltaError) Unwrap() error { return e.e }
+
 func ContainsString(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {

--- a/base/util_ce.go
+++ b/base/util_ce.go
@@ -11,11 +11,6 @@ import (
 // ErrDeltasNotSupported is returned when these functions are called in CE
 var ErrDeltasNotSupported = fmt.Errorf("Deltas not supported in CE")
 
-// IsDeltaError is only implemented in EE, the CE stub always returns false.
-func IsDeltaError(_ error) bool {
-	return false
-}
-
 // Diff is only implemented in EE, the CE stub always returns an error.
 func Diff(old, new map[string]interface{}) (delta []byte, err error) {
 	return nil, ErrDeltasNotSupported

--- a/base/util_ee.go
+++ b/base/util_ee.go
@@ -19,20 +19,11 @@ func init() {
 	fleecedelta.StringDiffTimeout = time.Millisecond // Aggressive string diff timeout
 }
 
-// DeltaError is a typed error wrapped around any error returned from go-fleecedelta.
-type DeltaError error
-
-// IsDeltaError returns true if the given delta originates from go-fleecedelta.
-func IsDeltaError(err error) bool {
-	_, isDeltaError := err.(DeltaError)
-	return isDeltaError
-}
-
 // Diff will return the fleece delta between old and new.
 func Diff(old, new map[string]interface{}) (delta []byte, err error) {
 	delta, err = fleecedelta.DiffJSON(old, new)
 	if err != nil {
-		return nil, DeltaError(err)
+		return nil, FleeceDeltaError{e: err}
 	}
 	return delta, nil
 }
@@ -41,7 +32,7 @@ func Diff(old, new map[string]interface{}) (delta []byte, err error) {
 func Patch(old *map[string]interface{}, delta map[string]interface{}) (err error) {
 	err = fleecedelta.PatchJSONWithUnmarshalledDelta(old, delta)
 	if err != nil {
-		return DeltaError(err)
+		return FleeceDeltaError{e: err}
 	}
 	return nil
 }


### PR DESCRIPTION
The change in #4457 caused non-fleecedelta errors to be logged as warn instead of debug.
Replaced DeltaError type with a Go 1.13 style wrapped error to correctly determine log level.