### PR TITLE
CBG-1361: Prepare history on principal docs

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -209,7 +209,7 @@ func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.Time
 
 		// Add grant to history
 		currentHistoryForGrant.UpdatedAt = time.Now().UnixNano()
-		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, GrantHistoryEntry{
+		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, GrantHistorySequencePair{
 			Seq:    previousInfo.Sequence,
 			EndSeq: invalSeq,
 		})

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -157,30 +157,55 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 func (auth *Authenticator) rebuildChannels(princ Principal) error {
 	channels := princ.ExplicitChannels().Copy()
 
-	// Changes for vbucket sequence management.  We can't determine relative ordering of sequences
-	// across vbuckets. To avoid redundant channel backfills during changes processing, we maintain
-	// the previous vb/seq for a channel in PreviousChannels.  If that channel is still present during
-	// this rebuild, we reuse the vb/seq from PreviousChannels (using UpdateIfPresent).  If PreviousChannels
-	// is nil, reverts to normal sequence handling.
-
-	previousChannels := princ.PreviousChannels().Copy()
-	if previousChannels != nil {
-		channels.UpdateIfPresent(previousChannels)
-	}
-
 	if auth.channelComputer != nil {
 		viewChannels, err := auth.channelComputer.ComputeChannelsForPrincipal(princ)
 		if err != nil {
 			base.Warnf("channelComputer.ComputeChannelsForPrincipal returned error for %v: %v", base.UD(princ), err)
 			return err
 		}
-		if previousChannels != nil {
-			viewChannels.UpdateIfPresent(previousChannels)
-		}
 		channels.Add(viewChannels)
 	}
 	// always grant access to the public document channel
 	channels.AddChannel(ch.DocumentStarChannel, 1)
+
+	var previousChannelEntries ch.TimedSet
+	var previousInvalSeq uint64
+
+	if princ.PreviousChannels() != nil {
+		previousChannelEntries = princ.PreviousChannels().Entries
+		previousInvalSeq = princ.PreviousChannels().InvalSeq
+	}
+
+	removedChannels := ch.TimedSet{}
+	for previousChannelName, previousChannelInfo := range previousChannelEntries {
+		if _, ok := channels[previousChannelName]; !ok {
+			removedChannels[previousChannelName] = previousChannelInfo
+		}
+	}
+
+	channelHistory := princ.ChannelHistory()
+	if channelHistory == nil {
+		channelHistory = map[string]ChannelOrRoleHistoryEntries{}
+	}
+
+	for name, channelInfo := range removedChannels {
+		currentChannelHistory, ok := channelHistory[name]
+		if !ok {
+			currentChannelHistory = ChannelOrRoleHistoryEntries{}
+		}
+
+		currentChannelHistory.UpdatedAt = time.Now().UnixNano()
+		currentChannelHistory.Entries = append(currentChannelHistory.Entries, ChannelOrRoleHistoryEntry{
+			Seq:    channelInfo.Sequence,
+			EndSeq: previousInvalSeq,
+		})
+
+		channelHistory[name] = currentChannelHistory
+	}
+
+	if len(channelHistory) != 0 {
+		princ.SetChannelHistory(channelHistory)
+	}
 
 	base.Infof(base.KeyAccess, "Recomputed channels for %q: %s", base.UD(princ.Name()), base.UD(channels))
 	princ.SetPreviousChannels(nil)
@@ -208,8 +233,48 @@ func (auth *Authenticator) rebuildRoles(user User) error {
 		roles.Add(explicit)
 	}
 
+	var previousRoleEntries ch.TimedSet
+	var previousInvalSeq uint64
+
+	if user.PreviousRoles() != nil {
+		previousRoleEntries = user.PreviousRoles().Entries
+		previousInvalSeq = user.PreviousRoles().InvalSeq
+	}
+
+	removedRoles := ch.TimedSet{}
+	for previousRoleName, previousRoleInfo := range previousRoleEntries {
+		if _, ok := roles[previousRoleName]; !ok {
+			removedRoles[previousRoleName] = previousRoleInfo
+		}
+	}
+
+	roleHistory := user.RoleHistory()
+	if roleHistory == nil {
+		roleHistory = map[string]ChannelOrRoleHistoryEntries{}
+	}
+
+	for name, roleInfo := range removedRoles {
+		currentRoleHistory, ok := roleHistory[name]
+		if !ok {
+			currentRoleHistory = ChannelOrRoleHistoryEntries{}
+		}
+
+		currentRoleHistory.UpdatedAt = time.Now().UnixNano()
+		currentRoleHistory.Entries = append(currentRoleHistory.Entries, ChannelOrRoleHistoryEntry{
+			Seq:    roleInfo.Sequence,
+			EndSeq: previousInvalSeq,
+		})
+
+		roleHistory[name] = currentRoleHistory
+	}
+
+	if len(roleHistory) != 0 {
+		user.SetRoleHistory(roleHistory)
+	}
+
 	base.Infof(base.KeyAccess, "Computed roles for %q: %s", base.UD(user.Name()), base.UD(roles))
 	user.setRolesSince(roles)
+	user.SetPreviousRoles(nil)
 	return nil
 }
 
@@ -265,7 +330,7 @@ func (auth *Authenticator) UpdateSequenceNumber(p Principal, seq uint64) error {
 }
 
 // Invalidates the channel list of a user/role by saving its Channels() property as nil.
-func (auth *Authenticator) InvalidateChannels(p Principal) error {
+func (auth *Authenticator) InvalidateChannels(p Principal, invalSeq uint64) error {
 	invalidateChannelsCallback := func(p Principal) (updatedPrincipal Principal, err error) {
 
 		if p == nil || p.Channels() == nil {
@@ -273,6 +338,14 @@ func (auth *Authenticator) InvalidateChannels(p Principal) error {
 		}
 
 		base.Infof(base.KeyAccess, "Invalidate access of %q", base.UD(p.Name()))
+
+		if p.PreviousChannels() == nil {
+			p.SetPreviousChannels(&PreviousChannelsOrRole{
+				Entries:  p.Channels(),
+				InvalSeq: invalSeq,
+			})
+		}
+
 		p.setChannels(nil)
 		return p, nil
 	}
@@ -280,7 +353,7 @@ func (auth *Authenticator) InvalidateChannels(p Principal) error {
 }
 
 // Invalidates the role list of a user by saving its Roles() property as nil.
-func (auth *Authenticator) InvalidateRoles(user User) error {
+func (auth *Authenticator) InvalidateRoles(user User, invalSeq uint64) error {
 
 	invalidateRolesCallback := func(p Principal) (updatedPrincipal Principal, err error) {
 		user, ok := p.(User)
@@ -291,6 +364,15 @@ func (auth *Authenticator) InvalidateRoles(user User) error {
 			return p, base.ErrUpdateCancel
 		}
 		base.Infof(base.KeyAccess, "Invalidate roles of %q", base.UD(user.Name()))
+
+		if user.PreviousRoles() == nil {
+			roleNames := user.RoleNames()
+			user.SetPreviousRoles(&PreviousChannelsOrRole{
+				Entries:  roleNames,
+				InvalSeq: invalSeq,
+			})
+		}
+
 		user.setRolesSince(nil)
 		return user, nil
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -210,8 +210,8 @@ func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.Time
 		// Add grant to history
 		currentHistoryForGrant.UpdatedAt = time.Now().UnixNano()
 		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, GrantHistorySequencePair{
-			Seq:    previousInfo.Sequence,
-			EndSeq: invalSeq,
+			StartSeq: previousInfo.Sequence,
+			EndSeq:   invalSeq,
 		})
 		currentHistory[previousName] = currentHistoryForGrant
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -182,10 +182,10 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 }
 
 // Calculates history for either roles or channels
-func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.TimedSet, newGrants ch.TimedSet, currentHistory TimeSetHistory) TimeSetHistory {
+func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.TimedSet, newGrants ch.TimedSet, currentHistory TimedSetHistory) TimedSetHistory {
 	// Initialize history if currently empty
 	if currentHistory == nil {
-		currentHistory = map[string]TimeSetHistoryEntries{}
+		currentHistory = map[string]TimedSetHistoryEntries{}
 	}
 
 	// Iterate over invalidated grants
@@ -202,14 +202,14 @@ func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.Time
 		// Start building history for the principal. If it currently doesn't exist initialize it.
 		currentHistoryForGrant, ok := currentHistory[previousName]
 		if !ok {
-			currentHistoryForGrant = TimeSetHistoryEntries{}
+			currentHistoryForGrant = TimedSetHistoryEntries{}
 		}
 
 		// TODO: Will perform pruning here once full
 
 		// Add grant to history
 		currentHistoryForGrant.UpdatedAt = time.Now().UnixNano()
-		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, TimeSetHistoryEntry{
+		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, TimedSetHistoryEntry{
 			Seq:    previousInfo.Sequence,
 			EndSeq: invalSeq,
 		})

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -185,7 +185,7 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.TimedSet, newGrants ch.TimedSet, currentHistory TimedSetHistory) TimedSetHistory {
 	// Initialize history if currently empty
 	if currentHistory == nil {
-		currentHistory = map[string]TimedSetHistoryEntries{}
+		currentHistory = map[string]GrantHistory{}
 	}
 
 	// Iterate over invalidated grants
@@ -202,14 +202,14 @@ func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.Time
 		// Start building history for the principal. If it currently doesn't exist initialize it.
 		currentHistoryForGrant, ok := currentHistory[previousName]
 		if !ok {
-			currentHistoryForGrant = TimedSetHistoryEntries{}
+			currentHistoryForGrant = GrantHistory{}
 		}
 
 		// TODO: Will perform pruning here once full
 
 		// Add grant to history
 		currentHistoryForGrant.UpdatedAt = time.Now().UnixNano()
-		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, TimedSetHistoryEntry{
+		currentHistoryForGrant.Entries = append(currentHistoryForGrant.Entries, GrantHistoryEntry{
 			Seq:    previousInfo.Sequence,
 			EndSeq: invalSeq,
 		})

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1333,6 +1333,10 @@ func initializeScenario(t *testing.T, auth *Authenticator) (*userImpl, Principal
 // https://docs.google.com/spreadsheets/d/1pTLyJqrSdde-dAxDfMkKGXi0ttWF4GVCOBFJg7hRY0U/edit?usp=sharing
 // =======================================================================================================
 
+// Scenario 1
+// Get Doc
+// Revoke / Re-grant - no-op
+// Re-revoke
 func TestRevocationScenario1(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1399,12 +1403,17 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 }
 
+// Scenario 2
+// Get Doc
+// Revoke doc role
+// Re-grant
+// Re-revoke via both role and channel
 func TestRevocationScenario2(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1442,7 +1451,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 
@@ -1456,7 +1465,7 @@ func TestRevocationScenario2(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
-	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 
@@ -1471,16 +1480,21 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 3
+// Get Doc
+// Revoke via both role and channel
+// Re-grant
+// Re-revoke via both role and channel
 func TestRevocationScenario3(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1519,11 +1533,11 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1552,18 +1566,24 @@ func TestRevocationScenario3(t *testing.T) {
 
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 4
+// Get Doc
+// Revoke via both role and channel
+// Re-grant only role revoke
+// Re-grant channel - has access
+// Re-revoke via both role and channel
 func TestRevocationScenario4(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1604,7 +1624,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1631,14 +1651,18 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 5
+// Get Doc
+// Revoke / Re-grant - no-op
+// Re-revoke
 func TestRevocationScenario5(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1693,13 +1717,17 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 6
+// Get Doc
+// Revoke
+// Still revoked - noop
 func TestRevocationScenario6(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1743,7 +1771,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1757,14 +1785,18 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 7
+// Get Doc
+// Revoke
+// Still revoked - noop
 func TestRevocationScenario7(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1809,11 +1841,11 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1829,6 +1861,9 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 8
+// Revoke doc - noop
+// Grant/revoke - noop
 func TestRevocationScenario8(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1873,11 +1908,14 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 9
+// Revoke doc - noop
+// Grant/revoke - noop
 func TestRevocationScenario9(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1924,6 +1962,9 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }
 
+// Scenario 10
+// Revoke doc - noop
+// Grant/revoke - noop
 func TestRevocationScenario10(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -1968,11 +2009,15 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }
 
+// Scenario 11
+// Revoke doc - noop
+// Grant - get doc
+// Revoke
 func TestRevocationScenario11(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2017,15 +2062,18 @@ func TestRevocationScenario11(t *testing.T) {
 
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
+// Scenario 12
+// Revoke role - noop
+// Revoke channel - noop
 func TestRevocationScenario12(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
@@ -2070,11 +2118,13 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }
 
+// Scenario 13
+// Never had access
 func TestRevocationScenario13(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -321,7 +321,7 @@ func TestRebuildUserChannels(t *testing.T) {
 	computer := mockComputer{channels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "explicit1"))
-	user.SetChannelInvaliSeq(2)
+	user.SetChannelInvalSeq(2)
 	err := auth.Save(user)
 	assert.Equal(t, nil, err)
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1399,10 +1399,10 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 }
 
 func TestRevocationScenario2(t *testing.T) {
@@ -1442,7 +1442,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 
@@ -1456,7 +1456,7 @@ func TestRevocationScenario2(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 
@@ -1471,12 +1471,12 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -1519,11 +1519,11 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1552,14 +1552,14 @@ func TestRevocationScenario3(t *testing.T) {
 
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -1604,7 +1604,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1631,11 +1631,11 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
@@ -1693,10 +1693,10 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
@@ -1743,7 +1743,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1757,11 +1757,11 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
@@ -1809,11 +1809,11 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1873,7 +1873,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -1968,7 +1968,7 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }
@@ -2017,11 +2017,11 @@ func TestRevocationScenario11(t *testing.T) {
 
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -2070,7 +2070,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, TimedSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -339,7 +339,7 @@ func TestRebuildRoleChannels(t *testing.T) {
 	auth := NewAuthenticator(bucket, &computer)
 	role, err := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
 	assert.NoError(t, err)
-	err = auth.InvalidateChannels(role)
+	err = auth.InvalidateChannels(role, 1)
 	assert.Equal(t, nil, err)
 
 	role2, err := auth.GetRole("testRole")
@@ -355,7 +355,7 @@ func TestRebuildChannelsError(t *testing.T) {
 	auth := NewAuthenticator(bucket, &computer)
 	role, err := auth.NewRole("testRole2", ch.SetOf(t, "explicit1"))
 	assert.NoError(t, err)
-	assert.Equal(t, nil, auth.InvalidateChannels(role))
+	assert.Equal(t, nil, auth.InvalidateChannels(role, 1))
 
 	computer.err = errors.New("I'm sorry, Dave.")
 
@@ -383,7 +383,7 @@ func TestRebuildUserRoles(t *testing.T) {
 	goassert.DeepEquals(t, user1.RoleNames(), expected)
 
 	// Invalidate the roles, triggers rebuild
-	err = auth.InvalidateRoles(user1)
+	err = auth.InvalidateRoles(user1, 1)
 	assert.Equal(t, nil, err)
 
 	user2, err := auth.GetUser("testUser")
@@ -522,7 +522,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 			t.Errorf("User is nil prior to invalidate channels, error: %v", getErr)
 		}
 
-		invalidateErr := auth.InvalidateChannels(user)
+		invalidateErr := auth.InvalidateChannels(user, 1)
 		if invalidateErr != nil {
 			t.Errorf("Error invalidating user's channels: %v", invalidateErr)
 		}
@@ -554,7 +554,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 			t.Errorf("User is nil prior to invalidate roles, error: %v", getErr)
 		}
 
-		updateErr := auth.InvalidateRoles(user)
+		updateErr := auth.InvalidateRoles(user, 1)
 		if updateErr != nil {
 			t.Errorf("Error invalidating roles: %v", updateErr)
 		}
@@ -1239,4 +1239,1207 @@ func TestAuthenticateUntrustedJWT(t *testing.T) {
 		assert.Error(t, err, "Error authenticating with trusted JWT")
 		assert.Nil(t, user, "User shouldn't be returned without signature verification")
 	})
+}
+
+type mockComputerV2 struct {
+	channels     map[string]ch.TimedSet
+	roles        map[string]ch.TimedSet
+	roleChannels map[string]ch.TimedSet
+	err          error
+}
+
+func (m mockComputerV2) ComputeChannelsForPrincipal(principal Principal) (ch.TimedSet, error) {
+	if user, ok := principal.(User); ok {
+		return m.channels[user.Name()].Copy(), nil
+	} else {
+		return m.roleChannels[principal.Name()].Copy(), nil
+	}
+}
+
+func (m mockComputerV2) ComputeRolesForUser(user User) (ch.TimedSet, error) {
+	return m.roles[user.Name()].Copy(), nil
+}
+
+func (m mockComputerV2) addRoleChannels(t *testing.T, auth *Authenticator, princ Principal, roleName, channelName string, invalSeq uint64) {
+	if _, ok := m.roleChannels[roleName]; !ok {
+		m.roleChannels[roleName] = ch.TimedSet{}
+	}
+
+	m.roleChannels[roleName].Add(ch.AtSequence(ch.SetOf(t, channelName), invalSeq))
+	err := auth.InvalidateChannels(princ, invalSeq)
+	assert.NoError(t, err)
+	err = auth.Save(princ)
+	assert.NoError(t, err)
+}
+
+func (m mockComputerV2) removeRoleChannel(t *testing.T, auth *Authenticator, princ Principal, roleName, channelName string, invalSeq uint64) {
+	delete(m.roleChannels[roleName], channelName)
+	err := auth.InvalidateChannels(princ, invalSeq)
+	assert.NoError(t, err)
+	err = auth.Save(princ)
+	assert.NoError(t, err)
+}
+
+func (m mockComputerV2) addRole(t *testing.T, auth *Authenticator, user User, userName, roleName string, invalSeq uint64) {
+	if _, ok := m.roles[userName]; !ok {
+		m.roles[userName] = ch.TimedSet{}
+	}
+
+	m.roles[userName].Add(ch.AtSequence(ch.SetOf(t, roleName), invalSeq))
+	err := auth.InvalidateRoles(user, invalSeq)
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+}
+
+func (m mockComputerV2) removeRole(t *testing.T, auth *Authenticator, user User, userName, roleName string, invalSeq uint64) {
+	delete(m.roles[userName], roleName)
+	err := auth.InvalidateRoles(user, invalSeq)
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+}
+
+// =======================================================================================================
+// The below 'TestRevocationScenario' tests refer to scenarios in the following Google Sheet
+// https://docs.google.com/spreadsheets/d/1pTLyJqrSdde-dAxDfMkKGXi0ttWF4GVCOBFJg7hRY0U/edit?usp=sharing
+// =======================================================================================================
+
+func TestRevocationScenario1(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	// Get Principals / Rebuild Seq 40
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	// Get Principals / Rebuild Seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Get Principals / Rebuild Seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+}
+
+func TestRevocationScenario2(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+
+	// Get Principals / Rebuild Seq 50
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	// Get Principals / Rebuild Seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Get Principals / Rebuild Seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario3(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	// Rebuild seq 60
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+
+	assert.Equal(t, 0, len(user.ChannelHistory()))
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	// Rebuild seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(user.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+
+	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+
+	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+
+	assert.Equal(t, 0, len(user.ChannelHistory()))
+}
+
+func TestRevocationScenario4(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+
+	// Get Principals / Rebuild Seq 70
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	// Get Principals / Rebuild Seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Get Principals / Rebuild Seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario5(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	// Get Principals / Rebuild Seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Get Principals / Rebuild Seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario6(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+
+	// Rebuild seq 90
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 100
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+
+	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario7(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	// Get Principals / Rebuild Seq 25
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Get Principals / Rebuild Seq 100
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+
+	// Get Principals / Rebuild Seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+
+	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario8(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+
+	// Get Principals / Rebuild Seq 50
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario9(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	// Get Principals / Rebuild Seq 60
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario10(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+
+	// Get Principals / Rebuild Seq 70
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario11(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	// Get Principals / Rebuild Seq 80
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user can see ch1 (via role)
+	// Verify history
+	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+
+	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario12(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+
+	// Get Principals / Rebuild Seq 90
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
+	require.True(t, ok)
+	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+}
+
+func TestRevocationScenario13(t *testing.T) {
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	testMockComputer := mockComputerV2{
+		roles:        map[string]ch.TimedSet{},
+		channels:     map[string]ch.TimedSet{},
+		roleChannels: map[string]ch.TimedSet{},
+	}
+
+	getPrincipals := func(auth *Authenticator) (*userImpl, Principal) {
+		principal, err := auth.GetPrincipal("alice", true)
+		assert.NoError(t, err)
+		userPrincipal, ok := principal.(*userImpl)
+		assert.True(t, ok)
+		rolePrincipal, err := auth.GetPrincipal("foo", false)
+		assert.NoError(t, err)
+		return userPrincipal, rolePrincipal
+	}
+
+	auth := NewAuthenticator(testBucket, &testMockComputer)
+
+	user, err := auth.NewUser("alice", "password", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(user)
+	assert.NoError(t, err)
+
+	role, err := auth.NewRole("foo", ch.SetOf(t))
+	assert.NoError(t, err)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	// Get principals to do initial ops on
+	alicePrincipal, err := auth.GetPrincipal("alice", true)
+	assert.NoError(t, err)
+	aliceUserPrincipal, ok := alicePrincipal.(*userImpl)
+	assert.True(t, ok)
+	fooPrincipal, err := auth.GetPrincipal("foo", false)
+	assert.NoError(t, err)
+
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+
+	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+
+	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+
+	// Get Principals / Rebuild Seq 100
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
+
+	// Rebuild seq 110
+	aliceUserPrincipal, fooPrincipal = getPrincipals(auth)
+
+	// Ensure user cannot see ch1 (via role)
+	// Verify history
+	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
+	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
+	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
+	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -316,13 +316,12 @@ func (self *mockComputer) UseGlobalSequence() bool {
 }
 
 func TestRebuildUserChannels(t *testing.T) {
-
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	computer := mockComputer{channels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "explicit1"))
-	user.setChannels(nil)
+	user.SetChannelInvaliSeq(2)
 	err := auth.Save(user)
 	assert.Equal(t, nil, err)
 
@@ -1398,10 +1397,10 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 }
 
 func TestRevocationScenario2(t *testing.T) {
@@ -1468,7 +1467,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 
@@ -1482,7 +1481,7 @@ func TestRevocationScenario2(t *testing.T) {
 	// Ensure user can see ch1 (via role)
 	// Verify history
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 
@@ -1497,12 +1496,12 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -1572,11 +1571,11 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(user.ChannelHistory()))
 
@@ -1605,14 +1604,14 @@ func TestRevocationScenario3(t *testing.T) {
 
 	userRoleHistory, ok = aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[1])
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
 
 	assert.Equal(t, 0, len(user.ChannelHistory()))
 }
@@ -1684,7 +1683,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1711,11 +1710,11 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[1])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
@@ -1800,10 +1799,10 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
@@ -1877,7 +1876,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -1891,11 +1890,11 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
 
@@ -1970,11 +1969,11 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
@@ -2061,7 +2060,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -2210,7 +2209,7 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }
@@ -2286,11 +2285,11 @@ func TestRevocationScenario11(t *testing.T) {
 
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 75, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 }
@@ -2366,7 +2365,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, ChannelOrRoleHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
+	assert.Equal(t, TimeSetHistoryEntry{Seq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
 }

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -35,7 +35,7 @@ type Principal interface {
 
 	GetChannelInvalSeq() uint64
 
-	SetChannelInvaliSeq(uint64)
+	SetChannelInvalSeq(uint64)
 
 	// The set of invalidated channels
 	// Returns nil if not invalidated
@@ -111,7 +111,7 @@ type User interface {
 
 	GetRoleInvalSeq() uint64
 
-	SetRoleInvaliSeq(uint64)
+	SetRoleInvalSeq(uint64)
 
 	// The set of invalidated roles
 	// Returns nil if not invalidated

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -33,10 +33,14 @@ type Principal interface {
 	SetExplicitChannels(ch.TimedSet)
 
 	// The previous set of channels the Principal was granted.  Used to maintain sequence history.
-	PreviousChannels() ch.TimedSet
+	PreviousChannels() *PreviousChannelsOrRole
 
 	// Sets the previous set of channels the Principal has access to.
-	SetPreviousChannels(ch.TimedSet)
+	SetPreviousChannels(*PreviousChannelsOrRole)
+
+	ChannelHistory() ChannelOrRoleHistory
+
+	SetChannelHistory(history ChannelOrRoleHistory)
 
 	// Returns true if the Principal has access to the given channel.
 	CanSeeChannel(channel string) bool
@@ -100,6 +104,14 @@ type User interface {
 
 	// Sets the explicit roles the user belongs to.
 	SetExplicitRoles(ch.TimedSet)
+
+	PreviousRoles() *PreviousChannelsOrRole
+
+	SetPreviousRoles(set *PreviousChannelsOrRole)
+
+	SetRoleHistory(history ChannelOrRoleHistory)
+
+	RoleHistory() ChannelOrRoleHistory
 
 	// Every channel the user has access to, including those inherited from Roles.
 	InheritedChannels() ch.TimedSet

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -24,6 +24,7 @@ type Principal interface {
 	SetSequence(sequence uint64)
 
 	// The set of channels the Principal belongs to, and what sequence access was granted.
+	// Returns nil if invalidated
 	Channels() ch.TimedSet
 
 	// The channels the Principal was explicitly granted access to thru the admin API.
@@ -32,15 +33,17 @@ type Principal interface {
 	// Sets the explicit channels the Principal has access to.
 	SetExplicitChannels(ch.TimedSet)
 
-	// The previous set of channels the Principal was granted.  Used to maintain sequence history.
-	PreviousChannels() *PreviousChannelsOrRole
+	GetChannelInvalSeq() uint64
 
-	// Sets the previous set of channels the Principal has access to.
-	SetPreviousChannels(*PreviousChannelsOrRole)
+	SetChannelInvaliSeq(uint64)
 
-	ChannelHistory() ChannelOrRoleHistory
+	// The set of invalidated channels
+	// Returns nil if not invalidated
+	InvalidatedChannels() ch.TimedSet
 
-	SetChannelHistory(history ChannelOrRoleHistory)
+	ChannelHistory() TimeSetHistory
+
+	SetChannelHistory(history TimeSetHistory)
 
 	// Returns true if the Principal has access to the given channel.
 	CanSeeChannel(channel string) bool
@@ -97,6 +100,7 @@ type User interface {
 	SetPassword(password string)
 
 	// The set of Roles the user belongs to (including ones given to it by the sync function)
+	// Returns nil if invalidated
 	RoleNames() ch.TimedSet
 
 	// The roles the user was explicitly granted access to thru the admin API.
@@ -105,13 +109,17 @@ type User interface {
 	// Sets the explicit roles the user belongs to.
 	SetExplicitRoles(ch.TimedSet)
 
-	PreviousRoles() *PreviousChannelsOrRole
+	GetRoleInvalSeq() uint64
 
-	SetPreviousRoles(set *PreviousChannelsOrRole)
+	SetRoleInvaliSeq(uint64)
 
-	SetRoleHistory(history ChannelOrRoleHistory)
+	// The set of invalidated roles
+	// Returns nil if not invalidated
+	InvalidatedRoles() ch.TimedSet
 
-	RoleHistory() ChannelOrRoleHistory
+	SetRoleHistory(history TimeSetHistory)
+
+	RoleHistory() TimeSetHistory
 
 	// Every channel the user has access to, including those inherited from Roles.
 	InheritedChannels() ch.TimedSet

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -41,9 +41,9 @@ type Principal interface {
 	// Returns nil if not invalidated
 	InvalidatedChannels() ch.TimedSet
 
-	ChannelHistory() TimeSetHistory
+	ChannelHistory() TimedSetHistory
 
-	SetChannelHistory(history TimeSetHistory)
+	SetChannelHistory(history TimedSetHistory)
 
 	// Returns true if the Principal has access to the given channel.
 	CanSeeChannel(channel string) bool
@@ -117,9 +117,9 @@ type User interface {
 	// Returns nil if not invalidated
 	InvalidatedRoles() ch.TimedSet
 
-	SetRoleHistory(history TimeSetHistory)
+	SetRoleHistory(history TimedSetHistory)
 
-	RoleHistory() TimeSetHistory
+	RoleHistory() TimedSetHistory
 
 	// Every channel the user has access to, including those inherited from Roles.
 	InheritedChannels() ch.TimedSet

--- a/auth/role.go
+++ b/auth/role.go
@@ -125,7 +125,7 @@ func (role *roleImpl) GetChannelInvalSeq() uint64 {
 	return role.ChannelInvalSeq
 }
 
-func (role *roleImpl) SetChannelInvaliSeq(invalSeq uint64) {
+func (role *roleImpl) SetChannelInvalSeq(invalSeq uint64) {
 	role.ChannelInvalSeq = invalSeq
 }
 

--- a/auth/role.go
+++ b/auth/role.go
@@ -30,14 +30,14 @@ type roleImpl struct {
 	cas               uint64
 }
 
-type TimedSetHistory map[string]TimedSetHistoryEntries
+type TimedSetHistory map[string]GrantHistory
 
-type TimedSetHistoryEntries struct {
-	UpdatedAt int64                  `json:"updated_at"` // Timestamp at which history was last updated, allows for pruning
-	Entries   []TimedSetHistoryEntry `json:"entries"`    // Entry for a specific grant period
+type GrantHistory struct {
+	UpdatedAt int64               `json:"updated_at"` // Timestamp at which history was last updated, allows for pruning
+	Entries   []GrantHistoryEntry `json:"entries"`    // Entry for a specific grant period
 }
 
-type TimedSetHistoryEntry struct {
+type GrantHistoryEntry struct {
 	Seq    uint64 `json:"seq"`     // Sequence at which a grant was performed to give access to a role / channel. Only populated once endSeq is available.
 	EndSeq uint64 `json:"end_seq"` // Sequence when access to a role / channel was revoked.
 }

--- a/auth/role.go
+++ b/auth/role.go
@@ -20,13 +20,31 @@ import (
 
 /** A group that users can belong to, with associated channel permissions. */
 type roleImpl struct {
-	Name_             string      `json:"name,omitempty"`
-	ExplicitChannels_ ch.TimedSet `json:"admin_channels,omitempty"`
-	Channels_         ch.TimedSet `json:"all_channels"`
-	Sequence_         uint64      `json:"sequence"`
-	PreviousChannels_ ch.TimedSet `json:"previous_channels,omitempty"`
+	Name_             string                  `json:"name,omitempty"`
+	ExplicitChannels_ ch.TimedSet             `json:"admin_channels,omitempty"`
+	Channels_         ch.TimedSet             `json:"all_channels"`
+	Sequence_         uint64                  `json:"sequence"`
+	PreviousChannels_ *PreviousChannelsOrRole `json:"previous_channels,omitempty"`
+	ChannelHistory_   ChannelOrRoleHistory    `json:"channel_history,omitempty"`
 	vbNo              *uint16
 	cas               uint64
+}
+
+type PreviousChannelsOrRole struct {
+	InvalSeq uint64      `json:"inval_seq"`
+	Entries  ch.TimedSet `json:"entries"`
+}
+
+type ChannelOrRoleHistory map[string]ChannelOrRoleHistoryEntries
+
+type ChannelOrRoleHistoryEntries struct {
+	UpdatedAt int64                       `json:"updated_at"`
+	Entries   []ChannelOrRoleHistoryEntry `json:"entries"`
+}
+
+type ChannelOrRoleHistoryEntry struct {
+	Seq    uint64 `json:"seq"`
+	EndSeq uint64 `json:"end_seq"`
 }
 
 var kValidNameRegexp = regexp.MustCompile(`^[-+.@%\w]*$`)
@@ -105,12 +123,20 @@ func (role *roleImpl) SetExplicitChannels(channels ch.TimedSet) {
 	role.setChannels(nil)
 }
 
-func (role *roleImpl) PreviousChannels() ch.TimedSet {
+func (role *roleImpl) PreviousChannels() *PreviousChannelsOrRole {
 	return role.PreviousChannels_
 }
 
-func (role *roleImpl) SetPreviousChannels(channels ch.TimedSet) {
+func (role *roleImpl) SetPreviousChannels(channels *PreviousChannelsOrRole) {
 	role.PreviousChannels_ = channels
+}
+
+func (role *roleImpl) SetChannelHistory(history ChannelOrRoleHistory) {
+	role.ChannelHistory_ = history
+}
+
+func (role *roleImpl) ChannelHistory() ChannelOrRoleHistory {
+	return role.ChannelHistory_
 }
 
 // Checks whether this role object contains valid data; if not, returns an error.

--- a/auth/role.go
+++ b/auth/role.go
@@ -43,13 +43,13 @@ type GrantHistory struct {
 // Struct is for ease of internal use
 // Bucket store has each entry as a string "seq-endSeq"
 type GrantHistorySequencePair struct {
-	Seq    uint64 // Sequence at which a grant was performed to give access to a role / channel. Only populated once endSeq is available.
-	EndSeq uint64 // Sequence when access to a role / channel was revoked.
+	StartSeq uint64 // Sequence at which a grant was performed to give access to a role / channel. Only populated once endSeq is available.
+	EndSeq   uint64 // Sequence when access to a role / channel was revoked.
 }
 
 // MarshalJSON will handle conversion from having a seq / endSeq struct to the bucket format of "seq-endSeq"
 func (pair *GrantHistorySequencePair) MarshalJSON() ([]byte, error) {
-	stringPair := fmt.Sprintf("%d-%d", pair.Seq, pair.EndSeq)
+	stringPair := fmt.Sprintf("%d-%d", pair.StartSeq, pair.EndSeq)
 	return base.JSONMarshal(stringPair)
 }
 
@@ -63,8 +63,11 @@ func (pair *GrantHistorySequencePair) UnmarshalJSON(data []byte) error {
 	}
 
 	splitPair := strings.Split(stringPair, "-")
+	if len(splitPair) != 2 {
+		return fmt.Errorf("unexpected sequence pair length")
+	}
 
-	pair.Seq, err = strconv.ParseUint(splitPair[0], 10, 64)
+	pair.StartSeq, err = strconv.ParseUint(splitPair[0], 10, 64)
 	if err != nil {
 		return err
 	}

--- a/auth/role.go
+++ b/auth/role.go
@@ -20,24 +20,24 @@ import (
 
 /** A group that users can belong to, with associated channel permissions. */
 type roleImpl struct {
-	Name_             string         `json:"name,omitempty"`
-	ExplicitChannels_ ch.TimedSet    `json:"admin_channels,omitempty"`
-	Channels_         ch.TimedSet    `json:"all_channels"`
-	Sequence_         uint64         `json:"sequence"`
-	ChannelHistory_   TimeSetHistory `json:"channel_history,omitempty"`
-	ChannelInvalSeq   uint64         `json:"channel_inval_seq"`
+	Name_             string          `json:"name,omitempty"`
+	ExplicitChannels_ ch.TimedSet     `json:"admin_channels,omitempty"`
+	Channels_         ch.TimedSet     `json:"all_channels"`
+	Sequence_         uint64          `json:"sequence"`
+	ChannelHistory_   TimedSetHistory `json:"channel_history,omitempty"`
+	ChannelInvalSeq   uint64          `json:"channel_inval_seq"`
 	vbNo              *uint16
 	cas               uint64
 }
 
-type TimeSetHistory map[string]TimeSetHistoryEntries
+type TimedSetHistory map[string]TimedSetHistoryEntries
 
-type TimeSetHistoryEntries struct {
-	UpdatedAt int64                 `json:"updated_at"` // Timestamp at which history was last updated, allows for pruning
-	Entries   []TimeSetHistoryEntry `json:"entries"`    // Entry for a specific grant period
+type TimedSetHistoryEntries struct {
+	UpdatedAt int64                  `json:"updated_at"` // Timestamp at which history was last updated, allows for pruning
+	Entries   []TimedSetHistoryEntry `json:"entries"`    // Entry for a specific grant period
 }
 
-type TimeSetHistoryEntry struct {
+type TimedSetHistoryEntry struct {
 	Seq    uint64 `json:"seq"`     // Sequence at which a grant was performed to give access to a role / channel. Only populated once endSeq is available.
 	EndSeq uint64 `json:"end_seq"` // Sequence when access to a role / channel was revoked.
 }
@@ -136,11 +136,11 @@ func (role *roleImpl) InvalidatedChannels() ch.TimedSet {
 	return nil
 }
 
-func (role *roleImpl) SetChannelHistory(history TimeSetHistory) {
+func (role *roleImpl) SetChannelHistory(history TimedSetHistory) {
 	role.ChannelHistory_ = history
 }
 
-func (role *roleImpl) ChannelHistory() TimeSetHistory {
+func (role *roleImpl) ChannelHistory() TimedSetHistory {
 	return role.ChannelHistory_
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -32,14 +32,14 @@ type userImpl struct {
 // Marshallable data is stored in separate struct from userImpl,
 // to work around limitations of JSON marshaling.
 type userImplBody struct {
-	Email_           string                  `json:"email,omitempty"`
-	Disabled_        bool                    `json:"disabled,omitempty"`
-	PasswordHash_    []byte                  `json:"passwordhash_bcrypt,omitempty"`
-	OldPasswordHash_ interface{}             `json:"passwordhash,omitempty"` // For pre-beta compatibility
-	ExplicitRoles_   ch.TimedSet             `json:"explicit_roles,omitempty"`
-	RolesSince_      ch.TimedSet             `json:"rolesSince"`
-	PreviousRoles_   *PreviousChannelsOrRole `json:"previous_roles,omitempty"`
-	RoleHistory_     ChannelOrRoleHistory    `json:"role_history,omitempty"`
+	Email_           string         `json:"email,omitempty"`
+	Disabled_        bool           `json:"disabled,omitempty"`
+	PasswordHash_    []byte         `json:"passwordhash_bcrypt,omitempty"`
+	OldPasswordHash_ interface{}    `json:"passwordhash,omitempty"` // For pre-beta compatibility
+	ExplicitRoles_   ch.TimedSet    `json:"explicit_roles,omitempty"`
+	RolesSince_      ch.TimedSet    `json:"rolesSince"`
+	RoleInvalSeq     uint64         `json:"role_inval_seq"`
+	RoleHistory_     TimeSetHistory `json:"role_history,omitempty"`
 
 	OldExplicitRoles_ []string `json:"admin_roles,omitempty"` // obsolete; declared for migration
 }
@@ -140,20 +140,15 @@ func (user *userImpl) SetEmail(email string) error {
 }
 
 func (user *userImpl) RoleNames() ch.TimedSet {
+	if user.RoleInvalSeq != 0 {
+		return nil
+	}
 	return user.RolesSince_
 }
 
 func (user *userImpl) setRolesSince(rolesSince ch.TimedSet) {
 	user.RolesSince_ = rolesSince
 	user.roles = nil // invalidate in-memory cache list of Role objects
-}
-
-func (user *userImpl) PreviousRoles() *PreviousChannelsOrRole {
-	return user.PreviousRoles_
-}
-
-func (user *userImpl) SetPreviousRoles(roles *PreviousChannelsOrRole) {
-	user.PreviousRoles_ = roles
 }
 
 func (user *userImpl) ExplicitRoles() ch.TimedSet {
@@ -165,11 +160,26 @@ func (user *userImpl) SetExplicitRoles(roles ch.TimedSet) {
 	user.setRolesSince(nil) // invalidate persistent cache of role names
 }
 
-func (user *userImpl) SetRoleHistory(history ChannelOrRoleHistory) {
+func (user *userImpl) GetRoleInvalSeq() uint64 {
+	return user.RoleInvalSeq
+}
+
+func (user *userImpl) SetRoleInvaliSeq(invalSeq uint64) {
+	user.RoleInvalSeq = invalSeq
+}
+
+func (user *userImpl) InvalidatedRoles() ch.TimedSet {
+	if user.RoleInvalSeq != 0 {
+		return user.RolesSince_
+	}
+	return nil
+}
+
+func (user *userImpl) SetRoleHistory(history TimeSetHistory) {
 	user.RoleHistory_ = history
 }
 
-func (user *userImpl) RoleHistory() ChannelOrRoleHistory {
+func (user *userImpl) RoleHistory() TimeSetHistory {
 	return user.RoleHistory_
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -164,7 +164,7 @@ func (user *userImpl) GetRoleInvalSeq() uint64 {
 	return user.RoleInvalSeq
 }
 
-func (user *userImpl) SetRoleInvaliSeq(invalSeq uint64) {
+func (user *userImpl) SetRoleInvalSeq(invalSeq uint64) {
 	user.RoleInvalSeq = invalSeq
 }
 
@@ -240,8 +240,8 @@ func (user *userImpl) SetPassword(password string) {
 
 func (user *userImpl) GetRoles() []Role {
 	if user.roles == nil {
-		roles := make([]Role, 0, len(user.RolesSince_))
-		for name := range user.RolesSince_ {
+		roles := make([]Role, 0, len(user.RoleNames()))
+		for name := range user.RoleNames() {
 			role, err := user.auth.GetRole(name)
 			//base.Infof(base.KeyAccess, "User %s role %q = %v", base.UD(user.Name_), base.UD(name), base.UD(role))
 			if err != nil {
@@ -288,7 +288,7 @@ func (user *userImpl) AuthorizeAnyChannel(channels base.Set) error {
 func (user *userImpl) InheritedChannels() ch.TimedSet {
 	channels := user.Channels().Copy()
 	for _, role := range user.GetRoles() {
-		roleSince := user.RolesSince_[role.Name()]
+		roleSince := user.RoleNames()[role.Name()]
 		channels.AddAtSequence(role.Channels(), roleSince.Sequence)
 	}
 	return channels

--- a/auth/user.go
+++ b/auth/user.go
@@ -32,14 +32,14 @@ type userImpl struct {
 // Marshallable data is stored in separate struct from userImpl,
 // to work around limitations of JSON marshaling.
 type userImplBody struct {
-	Email_           string         `json:"email,omitempty"`
-	Disabled_        bool           `json:"disabled,omitempty"`
-	PasswordHash_    []byte         `json:"passwordhash_bcrypt,omitempty"`
-	OldPasswordHash_ interface{}    `json:"passwordhash,omitempty"` // For pre-beta compatibility
-	ExplicitRoles_   ch.TimedSet    `json:"explicit_roles,omitempty"`
-	RolesSince_      ch.TimedSet    `json:"rolesSince"`
-	RoleInvalSeq     uint64         `json:"role_inval_seq"`
-	RoleHistory_     TimeSetHistory `json:"role_history,omitempty"`
+	Email_           string          `json:"email,omitempty"`
+	Disabled_        bool            `json:"disabled,omitempty"`
+	PasswordHash_    []byte          `json:"passwordhash_bcrypt,omitempty"`
+	OldPasswordHash_ interface{}     `json:"passwordhash,omitempty"` // For pre-beta compatibility
+	ExplicitRoles_   ch.TimedSet     `json:"explicit_roles,omitempty"`
+	RolesSince_      ch.TimedSet     `json:"rolesSince"`
+	RoleInvalSeq     uint64          `json:"role_inval_seq"`
+	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`
 
 	OldExplicitRoles_ []string `json:"admin_roles,omitempty"` // obsolete; declared for migration
 }
@@ -175,11 +175,11 @@ func (user *userImpl) InvalidatedRoles() ch.TimedSet {
 	return nil
 }
 
-func (user *userImpl) SetRoleHistory(history TimeSetHistory) {
+func (user *userImpl) SetRoleHistory(history TimedSetHistory) {
 	user.RoleHistory_ = history
 }
 
-func (user *userImpl) RoleHistory() TimeSetHistory {
+func (user *userImpl) RoleHistory() TimedSetHistory {
 	return user.RoleHistory_
 }
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -32,12 +32,14 @@ type userImpl struct {
 // Marshallable data is stored in separate struct from userImpl,
 // to work around limitations of JSON marshaling.
 type userImplBody struct {
-	Email_           string      `json:"email,omitempty"`
-	Disabled_        bool        `json:"disabled,omitempty"`
-	PasswordHash_    []byte      `json:"passwordhash_bcrypt,omitempty"`
-	OldPasswordHash_ interface{} `json:"passwordhash,omitempty"` // For pre-beta compatibility
-	ExplicitRoles_   ch.TimedSet `json:"explicit_roles,omitempty"`
-	RolesSince_      ch.TimedSet `json:"rolesSince"`
+	Email_           string                  `json:"email,omitempty"`
+	Disabled_        bool                    `json:"disabled,omitempty"`
+	PasswordHash_    []byte                  `json:"passwordhash_bcrypt,omitempty"`
+	OldPasswordHash_ interface{}             `json:"passwordhash,omitempty"` // For pre-beta compatibility
+	ExplicitRoles_   ch.TimedSet             `json:"explicit_roles,omitempty"`
+	RolesSince_      ch.TimedSet             `json:"rolesSince"`
+	PreviousRoles_   *PreviousChannelsOrRole `json:"previous_roles,omitempty"`
+	RoleHistory_     ChannelOrRoleHistory    `json:"role_history,omitempty"`
 
 	OldExplicitRoles_ []string `json:"admin_roles,omitempty"` // obsolete; declared for migration
 }
@@ -146,6 +148,14 @@ func (user *userImpl) setRolesSince(rolesSince ch.TimedSet) {
 	user.roles = nil // invalidate in-memory cache list of Role objects
 }
 
+func (user *userImpl) PreviousRoles() *PreviousChannelsOrRole {
+	return user.PreviousRoles_
+}
+
+func (user *userImpl) SetPreviousRoles(roles *PreviousChannelsOrRole) {
+	user.PreviousRoles_ = roles
+}
+
 func (user *userImpl) ExplicitRoles() ch.TimedSet {
 	return user.ExplicitRoles_
 }
@@ -153,6 +163,14 @@ func (user *userImpl) ExplicitRoles() ch.TimedSet {
 func (user *userImpl) SetExplicitRoles(roles ch.TimedSet) {
 	user.ExplicitRoles_ = roles
 	user.setRolesSince(nil) // invalidate persistent cache of role names
+}
+
+func (user *userImpl) SetRoleHistory(history ChannelOrRoleHistory) {
+	user.RoleHistory_ = history
+}
+
+func (user *userImpl) RoleHistory() ChannelOrRoleHistory {
+	return user.RoleHistory_
 }
 
 // Returns true if the given password is correct for this user, and the account isn't disabled.

--- a/db/crud.go
+++ b/db/crud.go
@@ -1900,7 +1900,7 @@ func (db *Database) updateAndReturnDoc(docid string, allowImport bool, expiry ui
 	doc.deleteRemovedRevisionBodies(db.Bucket)
 
 	// Mark affected users/roles as needing to recompute their channel access:
-	db.MarkPrincipalsChanged(docid, newRevID, changedAccessPrincipals, changedRoleAccessUsers)
+	db.MarkPrincipalsChanged(docid, newRevID, changedAccessPrincipals, changedRoleAccessUsers, doc.Sequence)
 	return doc, newRevID, nil
 }
 
@@ -1924,7 +1924,7 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 	}
 }
 
-func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changedPrincipals, changedRoleUsers []string) {
+func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changedPrincipals, changedRoleUsers []string, invalSeq uint64) {
 
 	reloadActiveUser := false
 
@@ -1932,7 +1932,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 	if len(changedPrincipals) > 0 {
 		base.InfofCtx(db.Ctx, base.KeyAccess, "Rev %q / %q invalidates channels of %s", base.UD(docid), newRevID, changedPrincipals)
 		for _, changedAccessPrincipalName := range changedPrincipals {
-			db.invalUserOrRoleChannels(changedAccessPrincipalName)
+			db.invalUserOrRoleChannels(changedAccessPrincipalName, invalSeq)
 			// Check whether the active user needs to be recalculated.  Skip check if reload has already been identified
 			// as required for a previous changedPrincipal
 			if db.user != nil && reloadActiveUser == false {
@@ -1959,7 +1959,7 @@ func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changed
 	if len(changedRoleUsers) > 0 {
 		base.InfofCtx(db.Ctx, base.KeyAccess, "Rev %q / %q invalidates roles of %s", base.UD(docid), newRevID, base.UD(changedRoleUsers))
 		for _, name := range changedRoleUsers {
-			db.invalUserRoles(name)
+			db.invalUserRoles(name, invalSeq)
 			//If this is the current in memory db.user, reload to generate updated roles
 			if db.user != nil && db.user.Name() == name {
 				base.DebugfCtx(db.Ctx, base.KeyAccess, "Role set for active user has been modified - user %q will be reloaded.", base.UD(db.user.Name()))

--- a/db/database.go
+++ b/db/database.go
@@ -1322,49 +1322,49 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) 
 		base.Infof(base.KeyAll, "Invalidating channel caches of users/roles...")
 		users, roles, _ := db.AllPrincipalIDs()
 		for _, name := range users {
-			db.invalUserChannels(name)
+			db.invalUserChannels(name, endSeq)
 		}
 		for _, name := range roles {
-			db.invalRoleChannels(name)
+			db.invalRoleChannels(name, endSeq)
 		}
 	}
 	return docsChanged, nil
 }
 
-func (db *Database) invalUserRoles(username string) {
+func (db *Database) invalUserRoles(username string, invalSeq uint64) {
 	authr := db.Authenticator()
 	if user, _ := authr.GetUser(username); user != nil {
-		if err := authr.InvalidateRoles(user); err != nil {
+		if err := authr.InvalidateRoles(user, invalSeq); err != nil {
 			base.Warnf("Error invalidating roles for user %s: %v", base.UD(username), err)
 		}
 	}
 }
 
-func (db *Database) invalUserChannels(username string) {
+func (db *Database) invalUserChannels(username string, invalSeq uint64) {
 	authr := db.Authenticator()
 	if user, _ := authr.GetUser(username); user != nil {
-		if err := authr.InvalidateChannels(user); err != nil {
+		if err := authr.InvalidateChannels(user, invalSeq); err != nil {
 			base.Warnf("Error invalidating channels for user %s: %v", base.UD(username), err)
 		}
 	}
 }
 
-func (db *Database) invalRoleChannels(rolename string) {
+func (db *Database) invalRoleChannels(rolename string, invalSeq uint64) {
 	authr := db.Authenticator()
 	if role, _ := authr.GetRole(rolename); role != nil {
-		if err := authr.InvalidateChannels(role); err != nil {
+		if err := authr.InvalidateChannels(role, invalSeq); err != nil {
 			base.Warnf("Error invalidating channels for role %s: %v", base.UD(rolename), err)
 		}
 	}
 }
 
-func (db *Database) invalUserOrRoleChannels(name string) {
+func (db *Database) invalUserOrRoleChannels(name string, invalSeq uint64) {
 
 	principalName, isRole := channels.AccessNameToPrincipalName(name)
 	if isRole {
-		db.invalRoleChannels(principalName)
+		db.invalRoleChannels(principalName, invalSeq)
 	} else {
-		db.invalUserChannels(principalName)
+		db.invalUserChannels(principalName, invalSeq)
 	}
 }
 


### PR DESCRIPTION
~~- Store previous channels / roles on principal docs at inval~~
~~- At rebuildRoles/ rebuildChannels use previous channels / roles to build out channel history struct~~
- Bunch of auth level tests following Google Sheets plan verifying history


Updated:
 - At invalidation time we set either ChannelInvalSeq in the case of channel invalidation or RoleInvalSeq in the case of role invalidations to the sequence at which the principal was invalidated. Note we no longer will set the Channels / Roles to nil, we retain the information, InvalSeq is used to specify whether they are invalidated.
 - The Channels() / RoleNames() function returns nil if invalid, allowing existing null checks to be maintained. 
 - At rebuildRoles / rebuildChannels we use the Channels / Roles property to build out history. InvalSeq is used as endSeq in history.
 - Channels / Roles are updated following rebuild and the invalSeq is removed.