### PR TITLE
CBG-1363: Add revocations option to _changes and subChanges

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -75,6 +75,9 @@ type ActiveReplicatorConfig struct {
 	// Delta sync enabled
 	DeltasEnabled bool
 
+	// Enables the auto purge behaviour which defines whether revoked documents should be purged
+	EnableAutoPurge bool
+
 	// InsecureSkipVerify determines whether the TLS certificate verification should be
 	// disabled during replication. TLS certificate verification is enabled by default.
 	InsecureSkipVerify bool
@@ -167,6 +170,10 @@ func (arc *ActiveReplicatorConfig) Equals(other *ActiveReplicatorConfig) bool {
 	}
 
 	if arc.Continuous != other.Continuous {
+		return false
+	}
+
+	if arc.EnableAutoPurge != other.EnableAutoPurge {
 		return false
 	}
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -71,14 +71,15 @@ func (apr *ActivePullReplicator) _connect() error {
 	}
 
 	subChangesRequest := SubChangesRequest{
-		Continuous:     apr.config.Continuous,
-		Batch:          apr.config.ChangesBatchSize,
-		Since:          apr.Checkpointer.lastCheckpointSeq,
-		Filter:         apr.config.Filter,
-		FilterChannels: apr.config.FilterChannels,
-		DocIDs:         apr.config.DocIDs,
-		ActiveOnly:     apr.config.ActiveOnly,
-		clientType:     clientTypeSGR2,
+		Continuous:      apr.config.Continuous,
+		Batch:           apr.config.ChangesBatchSize,
+		Since:           apr.Checkpointer.lastCheckpointSeq,
+		Filter:          apr.config.Filter,
+		FilterChannels:  apr.config.FilterChannels,
+		DocIDs:          apr.config.DocIDs,
+		ActiveOnly:      apr.config.ActiveOnly,
+		clientType:      clientTypeSGR2,
+		EnableAutoPurge: apr.config.EnableAutoPurge,
 	}
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -71,15 +71,15 @@ func (apr *ActivePullReplicator) _connect() error {
 	}
 
 	subChangesRequest := SubChangesRequest{
-		Continuous:      apr.config.Continuous,
-		Batch:           apr.config.ChangesBatchSize,
-		Since:           apr.Checkpointer.lastCheckpointSeq,
-		Filter:          apr.config.Filter,
-		FilterChannels:  apr.config.FilterChannels,
-		DocIDs:          apr.config.DocIDs,
-		ActiveOnly:      apr.config.ActiveOnly,
-		clientType:      clientTypeSGR2,
-		EnableAutoPurge: apr.config.EnableAutoPurge,
+		Continuous:     apr.config.Continuous,
+		Batch:          apr.config.ChangesBatchSize,
+		Since:          apr.Checkpointer.lastCheckpointSeq,
+		Filter:         apr.config.Filter,
+		FilterChannels: apr.config.FilterChannels,
+		DocIDs:         apr.config.DocIDs,
+		ActiveOnly:     apr.config.ActiveOnly,
+		clientType:     clientTypeSGR2,
+		Revocations:    apr.config.EnableAutoPurge,
 	}
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -111,6 +111,7 @@ func (apr *ActivePushReplicator) _connect() error {
 			continuous:        apr.config.Continuous,
 			activeOnly:        apr.config.ActiveOnly,
 			batchSize:         int(apr.config.ChangesBatchSize),
+			revocations:       apr.config.EnableAutoPurge,
 			channels:          channels,
 			clientType:        clientTypeSGR2,
 			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -220,6 +220,7 @@ func (bh *blipHandler) handleSubChanges(rq *blip.Message) error {
 			activeOnly:        subChangesParams.activeOnly(),
 			batchSize:         subChangesParams.batchSize(),
 			channels:          channels,
+			revocations:       subChangesParams.revocations(),
 			clientType:        clientType,
 			ignoreNoConflicts: clientType == clientTypeSGR2, // force this side to accept a "changes" message, even in no conflicts mode for SGR2.
 		})
@@ -244,6 +245,7 @@ type sendChangesOptions struct {
 	batchSize         int
 	channels          base.Set
 	clientType        clientType
+	revocations       bool
 	ignoreNoConflicts bool
 }
 
@@ -258,13 +260,14 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	base.InfofCtx(bh.loggingCtx, base.KeySync, "Sending changes since %v", opts.since)
 
 	options := ChangesOptions{
-		Since:      opts.since,
-		Conflicts:  false, // CBL 2.0/BLIP don't support branched rev trees (LiteCore #437)
-		Continuous: opts.continuous,
-		ActiveOnly: opts.activeOnly,
-		Terminator: bh.BlipSyncContext.terminator,
-		Ctx:        bh.loggingCtx,
-		clientType: opts.clientType,
+		Since:       opts.since,
+		Conflicts:   false, // CBL 2.0/BLIP don't support branched rev trees (LiteCore #437)
+		Continuous:  opts.continuous,
+		ActiveOnly:  opts.activeOnly,
+		Revocations: opts.revocations,
+		Terminator:  bh.BlipSyncContext.terminator,
+		Ctx:         bh.loggingCtx,
+		clientType:  opts.clientType,
 	}
 
 	channelSet := opts.channels

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -15,14 +15,15 @@ type BLIPMessageSender interface {
 
 // SubChangesRequest is a strongly typed 'subChanges' request.
 type SubChangesRequest struct {
-	Continuous     bool     // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
-	Batch          uint16   // Batch controls the maximum number of changes to send in a single change message (optional)
-	Since          string   // Since represents the latest sequence ID already known to the requester (optional)
-	Filter         string   // Filter is the name of a filter function known to the recipient (optional)
-	FilterChannels []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
-	DocIDs         []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
-	ActiveOnly     bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
-	clientType     clientType
+	Continuous      bool     // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
+	Batch           uint16   // Batch controls the maximum number of changes to send in a single change message (optional)
+	Since           string   // Since represents the latest sequence ID already known to the requester (optional)
+	Filter          string   // Filter is the name of a filter function known to the recipient (optional)
+	FilterChannels  []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
+	DocIDs          []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
+	ActiveOnly      bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
+	EnableAutoPurge bool
+	clientType      clientType
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}
@@ -49,6 +50,7 @@ func (rq *SubChangesRequest) marshalBLIPRequest() (*blip.Message, error) {
 	setOptionalProperty(msg.Properties, SubChangesSince, rq.Since)
 	setOptionalProperty(msg.Properties, SubChangesFilter, rq.Filter)
 	setOptionalProperty(msg.Properties, SubChangesChannels, strings.Join(rq.FilterChannels, ","))
+	setOptionalProperty(msg.Properties, SubChangesRevocations, rq.EnableAutoPurge)
 
 	if len(rq.DocIDs) > 0 {
 		if err := msg.SetJSONBody(map[string]interface{}{

--- a/db/blip_messages.go
+++ b/db/blip_messages.go
@@ -15,15 +15,15 @@ type BLIPMessageSender interface {
 
 // SubChangesRequest is a strongly typed 'subChanges' request.
 type SubChangesRequest struct {
-	Continuous      bool     // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
-	Batch           uint16   // Batch controls the maximum number of changes to send in a single change message (optional)
-	Since           string   // Since represents the latest sequence ID already known to the requester (optional)
-	Filter          string   // Filter is the name of a filter function known to the recipient (optional)
-	FilterChannels  []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
-	DocIDs          []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
-	ActiveOnly      bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
-	EnableAutoPurge bool
-	clientType      clientType
+	Continuous     bool     // Continuous can be set to true if the requester wants change notifications to be sent indefinitely (optional)
+	Batch          uint16   // Batch controls the maximum number of changes to send in a single change message (optional)
+	Since          string   // Since represents the latest sequence ID already known to the requester (optional)
+	Filter         string   // Filter is the name of a filter function known to the recipient (optional)
+	FilterChannels []string // FilterChannels are a set of channels used with a 'sync_gateway/bychannel' filter (optional)
+	DocIDs         []string // DocIDs specifies which doc IDs the recipient should send changes for (optional)
+	ActiveOnly     bool     // ActiveOnly is set to `true` if the requester doesn't want to be sent tombstones. (optional)
+	Revocations    bool     // Revocations is set to `true` if the requester wants to be send revocation messages (optional)
+	clientType     clientType
 }
 
 var _ BLIPMessageSender = &SubChangesRequest{}
@@ -50,7 +50,7 @@ func (rq *SubChangesRequest) marshalBLIPRequest() (*blip.Message, error) {
 	setOptionalProperty(msg.Properties, SubChangesSince, rq.Since)
 	setOptionalProperty(msg.Properties, SubChangesFilter, rq.Filter)
 	setOptionalProperty(msg.Properties, SubChangesChannels, strings.Join(rq.FilterChannels, ","))
-	setOptionalProperty(msg.Properties, SubChangesRevocations, rq.EnableAutoPurge)
+	setOptionalProperty(msg.Properties, SubChangesRevocations, rq.Revocations)
 
 	if len(rq.DocIDs) > 0 {
 		if err := msg.SetJSONBody(map[string]interface{}{

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -43,12 +43,13 @@ const (
 	GetCheckpointClient      = "client"
 
 	// subChanges message properties
-	SubChangesActiveOnly = "activeOnly"
-	SubChangesFilter     = "filter"
-	SubChangesChannels   = "channels"
-	SubChangesSince      = "since"
-	SubChangesContinuous = "continuous"
-	SubChangesBatch      = "batch"
+	SubChangesActiveOnly  = "activeOnly"
+	SubChangesFilter      = "filter"
+	SubChangesChannels    = "channels"
+	SubChangesSince       = "since"
+	SubChangesContinuous  = "continuous"
+	SubChangesBatch       = "batch"
+	SubChangesRevocations = "revocations"
 
 	// rev message properties
 	RevMessageId          = "id"
@@ -169,6 +170,10 @@ func (s *SubChangesParams) continuous() bool {
 		continuous = true
 	}
 	return continuous
+}
+
+func (s *SubChangesParams) revocations() bool {
+	return s.rq.Properties[SubChangesRevocations] == "true"
 }
 
 func (s *SubChangesParams) activeOnly() bool {

--- a/db/changes.go
+++ b/db/changes.go
@@ -36,6 +36,7 @@ type ChangesOptions struct {
 	HeartbeatMs uint64          // How often to send a heartbeat to the client
 	TimeoutMs   uint64          // After this amount of time, close the longpoll connection
 	ActiveOnly  bool            // If true, only return information on non-deleted, non-removed revisions
+	Revocations bool            // Specifies whether revocation messages should be sent on the changes feed
 	clientType  clientType      // Can be used to determine if the replication is being started from a CBL 2.x or SGR2 client
 	Ctx         context.Context // Used for adding context to logs
 }
@@ -592,6 +593,9 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			if db.user != nil {
 				feeds, names = db.appendUserFeed(feeds, names, options)
 			}
+
+			// TODO: Use revocations option here in CBG-1367
+			_ = options.Revocations
 
 			current := make([]*ChangeEntry, len(feeds))
 

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -97,6 +97,7 @@ type ReplicationConfig struct {
 	Cancel                 bool                      `json:"cancel,omitempty"`
 	Adhoc                  bool                      `json:"adhoc,omitempty"`
 	BatchSize              int                       `json:"batch_size,omitempty"`
+	EnableAutoPurge        bool                      `json:"enable_auto_purge,omitempty"`
 }
 
 func DefaultReplicationConfig() ReplicationConfig {
@@ -109,6 +110,7 @@ func DefaultReplicationConfig() ReplicationConfig {
 		Continuous:             false,
 		Adhoc:                  false,
 		BatchSize:              defaultChangesBatchSize,
+		EnableAutoPurge:        false,
 	}
 }
 
@@ -139,6 +141,7 @@ type ReplicationUpsertConfig struct {
 	Cancel                 *bool       `json:"cancel,omitempty"`
 	Adhoc                  *bool       `json:"adhoc,omitempty"`
 	BatchSize              *int        `json:"batch_size,omitempty"`
+	EnableAutoPurge        *bool       `json:"enable_auto_purge,omitempty"`
 	SGR1CheckpointID       *string     `json:"sgr1_checkpoint_id,omitempty"`
 }
 
@@ -285,6 +288,10 @@ func (rc *ReplicationConfig) Upsert(c *ReplicationUpsertConfig) {
 
 	if c.BatchSize != nil {
 		rc.BatchSize = *c.BatchSize
+	}
+
+	if c.EnableAutoPurge != nil {
+		rc.EnableAutoPurge = *c.EnableAutoPurge
 	}
 
 	if c.QueryParams != nil {
@@ -478,6 +485,7 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 		InsecureSkipVerify: m.dbContext.Options.UnsupportedOptions.SgrTlsSkipVerify,
 		SGR1CheckpointID:   config.SGR1CheckpointID,
 		CheckpointInterval: m.CheckpointInterval,
+		EnableAutoPurge:    config.EnableAutoPurge,
 	}
 
 	rc.MaxReconnectInterval = defaultMaxReconnectInterval

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -179,6 +179,7 @@ func (h *handler) handleChanges() error {
 		options.Conflicts = h.getQuery("style") == "all_docs"
 		options.ActiveOnly = h.getBoolQuery("active_only")
 		options.IncludeDocs = h.getBoolQuery("include_docs")
+		options.Revocations = h.getBoolQuery("revocations")
 		filter = h.getQuery("filter")
 		channelsParam := h.getQuery("channels")
 		if channelsParam != "" {


### PR DESCRIPTION
Just allows clients to specify revocations option. Will be used in following PR where this is actually used.
Also added config option for ISGR side which:
- passes option to subChanges too for pull
- sends changes with revocations for push

Wasn't really possible to write tests for it at this stage but was manually tested with breakpoint. Can easily be tested once revocation messages are in.