### PR TITLE
CBG-1392: Support soft role deletion

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -90,6 +90,14 @@ func (auth *Authenticator) GetUser(name string) (User, error) {
 
 // Looks up the information for a role.
 func (auth *Authenticator) GetRole(name string) (Role, error) {
+	role, err := auth.GetRoleIncDeleted(name)
+	if role != nil && role.IsDeleted() {
+		return nil, err
+	}
+	return role, err
+}
+
+func (auth *Authenticator) GetRoleIncDeleted(name string) (Role, error) {
 	princ, err := auth.getPrincipal(docIDForRole(name), func() Principal { return &roleImpl{} })
 	role, _ := princ.(Role)
 	return role, err
@@ -111,7 +119,7 @@ func (auth *Authenticator) getPrincipal(docID string, factory func() Principal) 
 			return nil, nil, false, pkgerrors.WithStack(base.RedactErrorf("base.JSONUnmarshal() error for doc ID: %s in getPrincipal().  Error: %v", base.UD(docID), err))
 		}
 		changed := false
-		if princ.Channels() == nil {
+		if princ.Channels() == nil && !princ.IsDeleted() {
 			// Channel list has been invalidated by a doc update -- rebuild it:
 			if err := auth.rebuildChannels(princ); err != nil {
 				base.Warnf("RebuildChannels returned error: %v", err)
@@ -442,14 +450,41 @@ func (auth *Authenticator) casUpdatePrincipal(p Principal, callback casUpdatePri
 }
 
 // Deletes a user/role.
-func (auth *Authenticator) Delete(p Principal) error {
-	if user, ok := p.(User); ok {
+func (auth *Authenticator) Delete(p Principal, purge bool, deleteSeq uint64) error {
+	user, ok := p.(User)
+	if ok {
 		if user.Email() != "" {
 			if err := auth.bucket.Delete(docIDForUserEmail(user.Email())); err != nil {
 				base.Debugf(base.KeyAuth, "Error deleting document ID for user email %s. Error: %v", base.UD(user.Email()), err)
 			}
 		}
+		return auth.bucket.Delete(p.DocID())
 	}
+
+	// If not a user, ie. a role
+	if purge {
+		return auth.Purge(p)
+	}
+	return auth.casUpdatePrincipal(p, func(p Principal) (updatedPrincipal Principal, err error) {
+		if p == nil || p.IsDeleted() {
+			return p, base.ErrUpdateCancel
+		}
+		p.setDeleted(true)
+		p.SetSequence(deleteSeq)
+
+		channelHistory := auth.calculateHistory(deleteSeq, p.Channels(), nil, p.ChannelHistory())
+		if len(channelHistory) != 0 {
+			p.SetChannelHistory(channelHistory)
+		}
+
+		p.SetChannelInvalSeq(deleteSeq)
+		return p, nil
+
+	})
+}
+
+// Purge a user/role from bucket
+func (auth *Authenticator) Purge(p Principal) error {
 	return auth.bucket.Delete(p.DocID())
 }
 

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -70,6 +70,9 @@ type Principal interface {
 	// Cas value for the associated principal document in the bucket
 	Cas() uint64
 	SetCas(cas uint64)
+
+	setDeleted(bool)
+	IsDeleted() bool
 }
 
 // Role is basically the same as Principal, just concrete. Users can inherit channels from Roles.

--- a/auth/role.go
+++ b/auth/role.go
@@ -99,7 +99,7 @@ func IsValidPrincipalName(name string) bool {
 func (auth *Authenticator) NewRole(name string, channels base.Set) (Role, error) {
 	role := &roleImpl{}
 	existingRole, err := auth.GetRoleIncDeleted(name)
-	if err != nil && !base.IsDocNotFoundError(err) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -432,6 +432,10 @@ func (b *LeakyBucket) SetPostUpdateCallback(callback func(key string)) {
 	b.config.PostUpdateCallback = callback
 }
 
+func (b *LeakyBucket) SetUpdateCallback(callback func(key string)) {
+	b.config.UpdateCallback = callback
+}
+
 func (b *LeakyBucket) IsSupported(feature sgbucket.DataStoreFeature) bool {
 	return b.bucket.IsSupported(feature)
 }

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -52,6 +52,8 @@ type LeakyBucketConfig struct {
 	// tests to trigger CAS retry handling by modifying the underlying document in a UpdateCallback implementation.
 	UpdateCallback func(key string)
 
+	PostUpdateCallback func(key string)
+
 	// WriteWithXattrCallback is ran before WriteWithXattr is called. This can be used to trigger a CAS retry
 	WriteWithXattrCallback func(key string)
 
@@ -130,7 +132,14 @@ func (b *LeakyBucket) Update(k string, exp uint32, callback sgbucket.UpdateFunc)
 		}
 		return b.bucket.Update(k, exp, wrapperCallback)
 	}
-	return b.bucket.Update(k, exp, callback)
+
+	casOut, err = b.bucket.Update(k, exp, callback)
+
+	if b.config.PostUpdateCallback != nil {
+		b.config.PostUpdateCallback(k)
+	}
+
+	return casOut, err
 }
 
 func (b *LeakyBucket) Incr(k string, amt, def uint64, exp uint32) (uint64, error) {
@@ -417,6 +426,10 @@ func (b *LeakyBucket) SetPostQueryCallback(callback func(ddoc, viewName string, 
 
 func (b *LeakyBucket) SetPostN1QLQueryCallback(callback func()) {
 	b.config.PostN1QLQueryCallback = callback
+}
+
+func (b *LeakyBucket) SetPostUpdateCallback(callback func(key string)) {
+	b.config.PostUpdateCallback = callback
 }
 
 func (b *LeakyBucket) IsSupported(feature sgbucket.DataStoreFeature) bool {

--- a/db/users.go
+++ b/db/users.go
@@ -87,11 +87,12 @@ func (db *DatabaseContext) DeleteRole(name string, purge bool) error {
 	authenticator := db.Authenticator()
 
 	role, err := authenticator.GetRole(name)
-	if role == nil {
-		if err == nil {
-			return base.ErrNotFound
-		}
+	if err != nil {
 		return err
+	}
+
+	if role == nil {
+		return base.ErrNotFound
 	}
 
 	seq, err := db.sequences.nextSequence()

--- a/db/users.go
+++ b/db/users.go
@@ -83,23 +83,23 @@ func (dbc *DatabaseContext) GetPrincipal(name string, isUser bool) (info *Princi
 	return
 }
 
-func (db *DatabaseContext) DeleteRole(name string, purge bool) (found bool, err error) {
+func (db *DatabaseContext) DeleteRole(name string, purge bool) error {
 	authenticator := db.Authenticator()
 
 	role, err := authenticator.GetRole(name)
-	if err != nil {
-		return false, err
-	}
 	if role == nil {
-		return false, fmt.Errorf("not found")
+		if err == nil {
+			return base.ErrNotFound
+		}
+		return err
 	}
 
 	seq, err := db.sequences.nextSequence()
 	if err != nil {
-		return true, err
+		return err
 	}
 
-	return true, authenticator.DeleteRole(role, purge, seq)
+	return authenticator.DeleteRole(role, purge, seq)
 }
 
 // Updates or creates a principal from a PrincipalConfig structure.

--- a/db/users.go
+++ b/db/users.go
@@ -83,26 +83,23 @@ func (dbc *DatabaseContext) GetPrincipal(name string, isUser bool) (info *Princi
 	return
 }
 
-func (db *DatabaseContext) DeletePrincipal(name string, isUser bool, purge bool) (found bool, err error) {
+func (db *DatabaseContext) DeleteRole(name string, purge bool) (found bool, err error) {
 	authenticator := db.Authenticator()
 
-	princ, err := authenticator.GetPrincipal(name, isUser)
+	role, err := authenticator.GetRole(name)
 	if err != nil {
 		return false, err
 	}
-	if princ == nil {
+	if role == nil {
 		return false, fmt.Errorf("not found")
 	}
 
-	seq := uint64(0)
-	if !isUser {
-		seq, err = db.sequences.nextSequence()
-		if err != nil {
-			return true, err
-		}
+	seq, err := db.sequences.nextSequence()
+	if err != nil {
+		return true, err
 	}
 
-	return true, authenticator.Delete(princ, purge, seq)
+	return true, authenticator.DeleteRole(role, purge, seq)
 }
 
 // Updates or creates a principal from a PrincipalConfig structure.

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -704,17 +704,20 @@ func (h *handler) deleteUser() error {
 			"The %s user cannot be deleted. Only disabled via an update.", base.GuestUsername)
 	}
 
-	found, err := h.db.DeletePrincipal(mux.Vars(h.rq)["name"], true, false)
-	if !found {
-		return kNotFoundError
+	user, err := h.db.Authenticator().GetUser(username)
+	if user == nil {
+		if err == nil {
+			err = kNotFoundError
+		}
+		return err
 	}
-	return err
+	return h.db.Authenticator().DeleteUser(user)
 }
 
 func (h *handler) deleteRole() error {
 	h.assertAdminOnly()
 	purge := h.getBoolQuery("purge")
-	found, err := h.db.DeletePrincipal(mux.Vars(h.rq)["name"], false, purge)
+	found, err := h.db.DeleteRole(mux.Vars(h.rq)["name"], purge)
 	if !found {
 		return kNotFoundError
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -717,11 +717,8 @@ func (h *handler) deleteUser() error {
 func (h *handler) deleteRole() error {
 	h.assertAdminOnly()
 	purge := h.getBoolQuery("purge")
-	found, err := h.db.DeleteRole(mux.Vars(h.rq)["name"], purge)
-	if !found {
-		return kNotFoundError
-	}
-	return err
+	return h.db.DeleteRole(mux.Vars(h.rq)["name"], purge)
+
 }
 
 func (h *handler) getUserInfo() error {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -704,26 +704,21 @@ func (h *handler) deleteUser() error {
 			"The %s user cannot be deleted. Only disabled via an update.", base.GuestUsername)
 	}
 
-	user, err := h.db.Authenticator().GetUser(username)
-	if user == nil {
-		if err == nil {
-			err = kNotFoundError
-		}
-		return err
+	found, err := h.db.DeletePrincipal(mux.Vars(h.rq)["name"], true, false)
+	if !found {
+		return kNotFoundError
 	}
-	return h.db.Authenticator().Delete(user)
+	return err
 }
 
 func (h *handler) deleteRole() error {
 	h.assertAdminOnly()
-	role, err := h.db.Authenticator().GetRole(mux.Vars(h.rq)["name"])
-	if role == nil {
-		if err == nil {
-			err = kNotFoundError
-		}
-		return err
+	purge := h.getBoolQuery("purge")
+	found, err := h.db.DeletePrincipal(mux.Vars(h.rq)["name"], false, purge)
+	if !found {
+		return kNotFoundError
 	}
-	return h.db.Authenticator().Delete(role)
+	return err
 }
 
 func (h *handler) getUserInfo() error {

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1494,7 +1494,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, usernameExpected, user.Name(), "Username mismatch")
 		assert.Equal(t, email, user.Email(), "Email is not updated")
-		require.NoError(t, authenticator.Delete(user), "Error deleting user %s", user.Name())
+		require.NoError(t, authenticator.Delete(user, true, 0), "Error deleting user %s", user.Name())
 	})
 
 	t.Run("successful registered user auth when neither username_claim nor user_prefix are set", func(t *testing.T) {
@@ -1520,7 +1520,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, usernameExpected, user.Name(), "Username mismatch")
 		assert.Equal(t, email, user.Email(), "Email is not updated")
-		require.NoError(t, authenticator.Delete(user), "Error deleting user %s", user.Name())
+		require.NoError(t, authenticator.Delete(user, true, 0), "Error deleting user %s", user.Name())
 	})
 
 	// If username_claim is set but the specified claim property does not exist in the token, then reject the token.

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1494,7 +1494,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, usernameExpected, user.Name(), "Username mismatch")
 		assert.Equal(t, email, user.Email(), "Email is not updated")
-		require.NoError(t, authenticator.Delete(user, true, 0), "Error deleting user %s", user.Name())
+		require.NoError(t, authenticator.DeleteUser(user), "Error deleting user %s", user.Name())
 	})
 
 	t.Run("successful registered user auth when neither username_claim nor user_prefix are set", func(t *testing.T) {
@@ -1520,7 +1520,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		require.NoError(t, err, "Error getting user from db")
 		assert.Equal(t, usernameExpected, user.Name(), "Username mismatch")
 		assert.Equal(t, email, user.Email(), "Email is not updated")
-		require.NoError(t, authenticator.Delete(user, true, 0), "Error deleting user %s", user.Name())
+		require.NoError(t, authenticator.DeleteUser(user), "Error deleting user %s", user.Name())
 	})
 
 	// If username_claim is set but the specified claim property does not exist in the token, then reject the token.


### PR DESCRIPTION
Changes role deletion to perform a soft delete so that its previous channels can be accessed to calculate revoked channels. Also builds history when role is deleted.
Has REST side and auth side unit test.

- [x] Rebase