### PR TITLE
CBG-1410: Add document channel history

### DIFF
--- a/auth/role.go
+++ b/auth/role.go
@@ -50,7 +50,12 @@ type GrantHistorySequencePair struct {
 
 // MarshalJSON will handle conversion from having a seq / endSeq struct to the bucket format of "seq-endSeq"
 func (pair *GrantHistorySequencePair) MarshalJSON() ([]byte, error) {
-	stringPair := fmt.Sprintf("%d-%d", pair.StartSeq, pair.EndSeq)
+	var stringPair string
+	if pair.EndSeq != 0 {
+		stringPair = fmt.Sprintf("%d-%d", pair.StartSeq, pair.EndSeq)
+	} else {
+		stringPair = fmt.Sprintf("%d-", pair.StartSeq)
+	}
 	return base.JSONMarshal(stringPair)
 }
 
@@ -71,6 +76,11 @@ func (pair *GrantHistorySequencePair) UnmarshalJSON(data []byte) error {
 	pair.StartSeq, err = strconv.ParseUint(splitPair[0], 10, 64)
 	if err != nil {
 		return err
+	}
+
+	// If no endSeq
+	if splitPair[1] == "" {
+		return nil
 	}
 
 	pair.EndSeq, err = strconv.ParseUint(splitPair[1], 10, 64)

--- a/db/document.go
+++ b/db/document.go
@@ -844,9 +844,17 @@ func (doc *Document) updateChannelHistory(channelName string, seq uint64, additi
 		}
 	}
 
-	// First time addition
-	doc.ChanNames = append(doc.ChanNames, channelName)
-	doc.ChannelHistory = append(doc.ChannelHistory, []auth.GrantHistorySequencePair{{StartSeq: seq}})
+	// Haven't seen this channel before in history
+	// If its an addition go ahead and add an entry
+	// If its not an addition but we've not seen it before then its a legacy document. Add entry with start seq of 1.
+	if addition {
+		doc.ChanNames = append(doc.ChanNames, channelName)
+		doc.ChannelHistory = append(doc.ChannelHistory, []auth.GrantHistorySequencePair{{StartSeq: seq}})
+	} else {
+		doc.ChanNames = append(doc.ChanNames, channelName)
+		doc.ChannelHistory = append(doc.ChannelHistory, []auth.GrantHistorySequencePair{{StartSeq: 1, EndSeq: seq}})
+	}
+
 }
 
 // Updates the Channels property of a document object with current & past channels.


### PR DESCRIPTION
Adds Channel History pairs to document sync data.
Required changes to GrantHistorySequencePair type to allow entries with only start seq.

Added a test for it.

To Change / Why a draft:
Not happy with where the GrantHistorySequencePair type is. Need to move it really but unsure of where best to put it. Maybe channels? Where ChannelMap is now? 