### PR TITLE
CBG-1391 Recover from concurrent cbgt index creation error

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -349,8 +349,12 @@ func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec
 	// Add the index definition for this feed to the cbgt cfg, in case it's not already present.
 	err = createCBGTIndex(c, dbName, bucket, spec, numPartitions)
 	if err != nil {
-		Errorf("cbgt index creation failed: %v", err)
-		return err
+		if strings.Contains(err.Error(), "an index with the same name already exists") {
+			Infof(KeyCluster, "Duplicate cbgt index detected during index creation (concurrent creation), using existing")
+		} else {
+			Errorf("cbgt index creation failed: %v", err)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
On cbgt index creation, SG retrieves the existing index UUID if present, and passes to cbgt for index creation/update.  During concurrent index creation by multiple SG nodes, a node can retrieve an empty UUID and subsequently hit an 'index already exists' error.  This should be treated as a non-fatal error, as SG will use the existing index.