### PR TITLE
CBG-1410: Add document channel history

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -50,24 +50,32 @@ type UserAccessMap map[string]channels.TimedSet
 
 type AttachmentsMeta map[string]interface{} // AttachmentsMeta metadata as included in sync metadata
 
+type DocumentChannelHistoryEntry struct {
+	Name  string `json:"name"`
+	Start uint64 `json:"start"`
+	End   uint64 `json:"end"`
+}
+
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.
 type SyncData struct {
-	CurrentRev      string              `json:"rev"`
-	NewestRev       string              `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
-	Flags           uint8               `json:"flags,omitempty"`
-	Sequence        uint64              `json:"sequence,omitempty"`
-	UnusedSequences []uint64            `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
-	RecentSequences []uint64            `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
-	History         RevTree             `json:"history"`
-	Channels        channels.ChannelMap `json:"channels,omitempty"`
-	Access          UserAccessMap       `json:"access,omitempty"`
-	RoleAccess      UserAccessMap       `json:"role_access,omitempty"`
-	Expiry          *time.Time          `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
-	Cas             string              `json:"cas"`                               // String representation of a cas value, populated via macro expansion
-	Crc32c          string              `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
-	Crc32cUserXattr string              `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
-	TombstonedAt    int64               `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
-	Attachments     AttachmentsMeta     `json:"attachments,omitempty"`
+	CurrentRev        string                        `json:"rev"`
+	NewestRev         string                        `json:"new_rev,omitempty"` // Newest rev, if different from CurrentRev
+	Flags             uint8                         `json:"flags,omitempty"`
+	Sequence          uint64                        `json:"sequence,omitempty"`
+	UnusedSequences   []uint64                      `json:"unused_sequences,omitempty"` // unused sequences due to update conflicts/CAS retry
+	RecentSequences   []uint64                      `json:"recent_sequences,omitempty"` // recent sequences for this doc - used in server dedup handling
+	History           RevTree                       `json:"history"`
+	Channels          channels.ChannelMap           `json:"channels,omitempty"`
+	Access            UserAccessMap                 `json:"access,omitempty"`
+	RoleAccess        UserAccessMap                 `json:"role_access,omitempty"`
+	Expiry            *time.Time                    `json:"exp,omitempty"`                     // Document expiry.  Information only - actual expiry/delete handling is done by bucket storage.  Needs to be pointer for omitempty to work (see https://github.com/golang/go/issues/4357)
+	Cas               string                        `json:"cas"`                               // String representation of a cas value, populated via macro expansion
+	Crc32c            string                        `json:"value_crc32c"`                      // String representation of crc32c hash of doc body, populated via macro expansion
+	Crc32cUserXattr   string                        `json:"user_xattr_value_crc32c,omitempty"` // String representation of crc32c hash of user xattr
+	TombstonedAt      int64                         `json:"tombstoned_at,omitempty"`           // Time the document was tombstoned.  Used for view compaction
+	Attachments       AttachmentsMeta               `json:"attachments,omitempty"`
+	ChannelHistory    []DocumentChannelHistoryEntry `json:"channel_history"`
+	OldChannelHistory []DocumentChannelHistoryEntry `json:"old_channel_history"`
 
 	// Only used for performance metrics:
 	TimeSaved time.Time `json:"time_saved,omitempty"` // Timestamp of save.
@@ -829,6 +837,48 @@ func (doc *Document) UpdateExpiry(expiry uint32) {
 
 //////// CHANNELS & ACCESS:
 
+func (doc *Document) updateChannelHistory(channelName string, seq uint64, addition bool) {
+	// Check if we already have an entry for
+	for idx, historyEntry := range doc.ChannelHistory {
+		if historyEntry.Name == channelName {
+			// If we are here there is an existing entry for this channel
+			// If addition we need to:
+			// - Move existing history entry to old channels
+			// - Remove existing entry from current channels
+			// - Add new entry with start seq
+			// If removal / not addition then we can simply add the end seq
+			if addition {
+				doc.OldChannelHistory = append(doc.OldChannelHistory, historyEntry)
+				doc.ChannelHistory = append(doc.ChannelHistory[:idx], doc.ChannelHistory[idx+1:]...)
+				doc.ChannelHistory = append(doc.ChannelHistory, DocumentChannelHistoryEntry{
+					Name:  channelName,
+					Start: seq,
+				})
+			} else {
+				doc.ChannelHistory[idx].End = seq
+			}
+			return
+		}
+	}
+
+	// If we get to this point there is no existing entry
+	// If addition we can just simply add it
+	// If its a removal / not addition then its a legacy document. Start seq is 1
+	if addition {
+		doc.ChannelHistory = append(doc.ChannelHistory, DocumentChannelHistoryEntry{
+			Name:  channelName,
+			Start: seq,
+		})
+	} else {
+		doc.ChannelHistory = append(doc.ChannelHistory, DocumentChannelHistoryEntry{
+			Name:  channelName,
+			Start: 1,
+			End:   seq,
+		})
+	}
+
+}
+
 // Updates the Channels property of a document object with current & past channels.
 // Returns the set of channels that have changed (document joined or left in this revision)
 func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.Set, err error) {
@@ -846,6 +896,7 @@ func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.
 					Seq:     curSequence,
 					RevID:   doc.CurrentRev,
 					Deleted: doc.hasFlag(channels.Deleted)}
+				doc.updateChannelHistory(channel, curSequence, false)
 				changed = append(changed, channel)
 			}
 		}
@@ -856,6 +907,7 @@ func (doc *Document) updateChannels(newChannels base.Set) (changedChannels base.
 		if value, exists := oldChannels[channel]; value != nil || !exists {
 			oldChannels[channel] = nil
 			changed = append(changed, channel)
+			doc.updateChannelHistory(channel, doc.Sequence, true)
 		}
 	}
 	if changed != nil {

--- a/db/document.go
+++ b/db/document.go
@@ -53,7 +53,7 @@ type AttachmentsMeta map[string]interface{} // AttachmentsMeta metadata as inclu
 type DocumentChannelHistoryEntry struct {
 	Name  string `json:"name"`
 	Start uint64 `json:"start"`
-	End   uint64 `json:"end"`
+	End   uint64 `json:"end,omitempty"`
 }
 
 // The sync-gateway metadata stored in the "_sync" property of a Couchbase document.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6132,9 +6132,9 @@ func TestDocumentChannelHistory(t *testing.T) {
 	syncData, err := rt.GetDatabase().GetDocSyncData("doc")
 	assert.NoError(t, err)
 
-	require.Len(t, syncData.ChannelHistory, 1)
-	assert.Equal(t, syncData.ChannelHistory[0], db.DocumentChannelHistoryEntry{Name: "test", Start: 1, End: 0})
-	assert.Len(t, syncData.OldChannelHistory, 0)
+	require.Len(t, syncData.ChannelSet, 1)
+	assert.Equal(t, syncData.ChannelSet[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 0})
+	assert.Len(t, syncData.ChannelSetHistory, 0)
 
 	// Update doc to remove from channel and ensure a single channel history entry with both start and end sequences
 	// and no old channel history entries
@@ -6145,9 +6145,9 @@ func TestDocumentChannelHistory(t *testing.T) {
 	syncData, err = rt.GetDatabase().GetDocSyncData("doc")
 	assert.NoError(t, err)
 
-	require.Len(t, syncData.ChannelHistory, 1)
-	assert.Equal(t, syncData.ChannelHistory[0], db.DocumentChannelHistoryEntry{Name: "test", Start: 1, End: 2})
-	assert.Len(t, syncData.OldChannelHistory, 0)
+	require.Len(t, syncData.ChannelSet, 1)
+	assert.Equal(t, syncData.ChannelSet[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 2})
+	assert.Len(t, syncData.ChannelSetHistory, 0)
 
 	// Update doc to add to channels test and test2 and ensure a single channel history entry for both test and test2
 	// both with start sequences only and ensure old test entry was moved to old
@@ -6158,11 +6158,11 @@ func TestDocumentChannelHistory(t *testing.T) {
 	syncData, err = rt.GetDatabase().GetDocSyncData("doc")
 	assert.NoError(t, err)
 
-	require.Len(t, syncData.ChannelHistory, 2)
-	assert.Contains(t, syncData.ChannelHistory, db.DocumentChannelHistoryEntry{Name: "test", Start: 3, End: 0})
-	assert.Contains(t, syncData.ChannelHistory, db.DocumentChannelHistoryEntry{Name: "test2", Start: 3, End: 0})
-	require.Len(t, syncData.OldChannelHistory, 1)
-	assert.Equal(t, syncData.OldChannelHistory[0], db.DocumentChannelHistoryEntry{Name: "test", Start: 1, End: 2})
+	require.Len(t, syncData.ChannelSet, 2)
+	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test", Start: 3, End: 0})
+	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{Name: "test2", Start: 3, End: 0})
+	require.Len(t, syncData.ChannelSetHistory, 1)
+	assert.Equal(t, syncData.ChannelSetHistory[0], db.ChannelSetEntry{Name: "test", Start: 1, End: 2})
 }
 
 func TestChannelHistoryLegacyDoc(t *testing.T) {
@@ -6222,11 +6222,11 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 	assert.NoError(t, err)
 	syncData, err := rt.GetDatabase().GetDocSyncData("doc1")
 	assert.NoError(t, err)
-	require.Len(t, syncData.ChannelHistory, 1)
-	assert.Contains(t, syncData.ChannelHistory, db.DocumentChannelHistoryEntry{
+	require.Len(t, syncData.ChannelSet, 1)
+	assert.Contains(t, syncData.ChannelSet, db.ChannelSetEntry{
 		Name:  "test",
 		Start: 1,
 		End:   2,
 	})
-	assert.Len(t, syncData.OldChannelHistory, 0)
+	assert.Len(t, syncData.ChannelSetHistory, 0)
 }


### PR DESCRIPTION
JSON field names need tweaking but putting this up as a draft for quick look over.

Adds channel history as discussed to document sync data with two arrays one being 'current' and another being 'old'.
Has a unit test to verify data is being set correctly. 