### PR TITLE
Add clistruct package to map struct fields to command line flags

### DIFF
--- a/base/clistruct/clistruct.go
+++ b/base/clistruct/clistruct.go
@@ -32,7 +32,12 @@ func registerFlags(fs *flag.FlagSet, cliStruct interface{}) error {
 		return errors.New("expected flag.FlagSet in RegisterFlags but got nil")
 	}
 
-	if err := register(fs, reflectStructValue(cliStruct), ""); err != nil {
+	refVal, err := reflectStructValue(cliStruct)
+	if err != nil {
+		return err
+	}
+
+	if err := register(fs, refVal, ""); err != nil {
 		return err
 	}
 

--- a/base/clistruct/clistruct.go
+++ b/base/clistruct/clistruct.go
@@ -3,6 +3,7 @@ package clistruct
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"reflect"
@@ -28,11 +29,11 @@ func MustRegisterFlags(fs *flag.FlagSet, cliStruct interface{}) {
 // registerFlags is the non-panicking version of MustRegisterFlags, for testing.
 func registerFlags(fs *flag.FlagSet, cliStruct interface{}) error {
 	if fs == nil {
-		panic("expected flag.FlagSet in RegisterFlags but got nil")
+		return errors.New("expected flag.FlagSet in RegisterFlags but got nil")
 	}
 
 	if err := register(fs, reflectStructValue(cliStruct), ""); err != nil {
-		panic(err.Error())
+		return err
 	}
 
 	return nil

--- a/base/clistruct/clistruct.go
+++ b/base/clistruct/clistruct.go
@@ -1,0 +1,146 @@
+// Package clistruct provides the ability to assign command line flags to fields in structs that declare `cli` and `help` struct tags.
+package clistruct
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"reflect"
+	"time"
+	"unsafe"
+)
+
+const (
+	cliStructNameTag = "cli"
+	cliStructHelpTag = "help"
+)
+
+// MustRegisterFlags will register flags on the given FlagSet from cli struct tags in the given struct.
+// FlagSet.Parse() must be called _after_ this has been run.
+//
+// Panics if the given struct cannot be assigned to a FlagSet (unsupported types, duplicate flags, etc.)
+func MustRegisterFlags(fs *flag.FlagSet, cliStruct interface{}) {
+	if err := registerFlags(fs, cliStruct); err != nil {
+		panic(err.Error())
+	}
+}
+
+// registerFlags is the non-panicking version of MustRegisterFlags, for testing.
+func registerFlags(fs *flag.FlagSet, cliStruct interface{}) error {
+	if fs == nil {
+		panic("expected flag.FlagSet in RegisterFlags but got nil")
+	}
+
+	if err := register(fs, reflectStructValue(cliStruct), ""); err != nil {
+		panic(err.Error())
+	}
+
+	return nil
+}
+
+// register recursively assigns flags to any fields that have a cli struct tag, are addressable, and have a supported type.
+func register(fs *flag.FlagSet, val reflect.Value, namePrefix string) error {
+	for i := 0; i < val.Type().NumField(); i++ {
+		field := val.Type().Field(i)
+
+		flagName, ok := field.Tag.Lookup(cliStructNameTag)
+		if !ok {
+			// skip untagged fields
+			continue
+		}
+
+		// Embed struct types without nesting when `cli:""`
+		if flagName == "" {
+			if field.Type.Kind() != reflect.Struct {
+				return fmt.Errorf("field %q can't embed for a non-struct type: %s", field.Name, field.Type.Kind())
+			}
+
+			// recurse for embedded struct
+			if err := register(fs, val.Field(i), namePrefix); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// nest the given flagName under the parent tags
+		if namePrefix != "" {
+			flagName = namePrefix + "." + flagName
+		}
+
+		fieldType := field.Type
+		fieldValue := val.Field(i)
+
+		switch fieldType.Kind() {
+		case reflect.Struct:
+			// recurse for nested structs
+			if err := register(fs, fieldValue, flagName); err != nil {
+				return err
+			}
+			continue
+		case reflect.Ptr, reflect.Interface:
+			// dereference and see if we can set it below, but it's unlikely if the given struct has not had values assigned to it.
+			fieldValue = fieldValue.Elem()
+		}
+
+		if !fieldValue.CanSet() {
+			return fmt.Errorf("field %q can't be set - not addressable or unexported", field.Name)
+		}
+
+		flagHelp, _ := field.Tag.Lookup(cliStructHelpTag)
+		if err := assignFlagToStructFieldVar(fs, fieldValue, flagName, flagHelp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// assignFlagToStructFieldVar creates a flag associated with the given struct field, if the type can be set from a flag.
+func assignFlagToStructFieldVar(fs *flag.FlagSet, fieldValue reflect.Value, flagName, flagHelp string) error {
+
+	switch v := reflectInterfaceValue(fieldValue).(type) {
+	case flag.Value:
+		fs.Var(v, flagName, flagHelp)
+	case *time.Duration:
+		fs.DurationVar(v, flagName, 0, flagHelp)
+	case *json.Number:
+		fs.Var((*jsonNumberFlagValue)(v), flagName, flagHelp)
+	default:
+		// See docs: unsafe.Pointer (5) Conversion of the result of ... reflect.Value.UnsafeAddr
+		// uintptr -> unsafe.Pointer conversion MUST be done without an intermediate variable
+		p := unsafe.Pointer(fieldValue.UnsafeAddr())
+
+		// we can only map struct field types which have a matching flag var type
+		switch fieldValue.Type().Kind() {
+		case reflect.Bool:
+			fs.BoolVar((*bool)(p), flagName, false, flagHelp)
+		case reflect.Int:
+			fs.IntVar((*int)(p), flagName, 0, flagHelp)
+		case reflect.Int64:
+			fs.Int64Var((*int64)(p), flagName, 0, flagHelp)
+		case reflect.Uint:
+			fs.UintVar((*uint)(p), flagName, 0, flagHelp)
+		case reflect.Uint64:
+			fs.Uint64Var((*uint64)(p), flagName, 0, flagHelp)
+		case reflect.Float64:
+			fs.Float64Var((*float64)(p), flagName, 0, flagHelp)
+		case reflect.String:
+			fs.StringVar((*string)(p), flagName, "", flagHelp)
+		default:
+			return fmt.Errorf("unsupported type %s to assign flag to struct field %q", fieldValue.Type().String(), flagName)
+		}
+	}
+
+	return nil
+}
+
+// jsonNumberFlagValue implements flag.Value for json.Number
+type jsonNumberFlagValue json.Number
+
+func (d *jsonNumberFlagValue) Set(s string) error {
+	*d = jsonNumberFlagValue(s)
+	return nil
+}
+
+func (d *jsonNumberFlagValue) String() string {
+	return (*json.Number)(d).String()
+}

--- a/base/clistruct/clistruct_test.go
+++ b/base/clistruct/clistruct_test.go
@@ -134,6 +134,27 @@ func TestCLIStructTypes(t *testing.T) {
 	}
 }
 
+func TestEmbeddedStructs(t *testing.T) {
+	var val struct {
+		A struct {
+			B struct {
+				C struct {
+					D struct {
+						E struct {
+							F bool `cli:"f" help:"foo"`
+						} `cli:""`
+					} `cli:""`
+				} `cli:"c"`
+			} `cli:""`
+		} `cli:"a"`
+	}
+
+	err := parseTagsForArgs(&val, []string{"-a.c.f"})
+	require.NoError(t, err)
+
+	assert.True(t, val.A.B.C.D.E.F)
+}
+
 // parseTagsForArgs is a convenience function for testing without callers having to deal with their own FlagSets.
 func parseTagsForArgs(val interface{}, args []string) error {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)

--- a/base/clistruct/clistruct_test.go
+++ b/base/clistruct/clistruct_test.go
@@ -1,0 +1,145 @@
+package clistruct
+
+import (
+	"encoding/json"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	String       string        `cli:"string" help:"string field"`
+	Bool         bool          `cli:"bool" help:"bool field"`
+	Int          int           `cli:"int" help:"int field"`
+	Int64        int64         `cli:"int64" help:"int64 field"`
+	Uint         uint          `cli:"uint" help:"uint field"`
+	Uint64       uint64        `cli:"uint64" help:"uint64 field"`
+	Float64      float64       `cli:"float64" help:"float64 field"`
+	JSONNumber   json.Number   `cli:"jsonnumber" help:"json.Number field"`
+	TimeDuration time.Duration `cli:"duration" help:"duration field"`
+	Struct       struct {
+		String string `cli:"string" help:"string field"`
+	} `cli:"struct" help:"struct field"`
+
+	// Intentionally unhandled fields/types - Causes panic in MustRegisterFlags for easy/early detection.
+	// StringSlice []string          `cli:"stringslice" help:"string slice field"`
+	// unexported  string            `cli:"unexported"`
+	// Int8        int8              `cli:"int8" help:"int8 field"`
+	// Int16       int16             `cli:"int16" help:"int16 field"`
+	// Int32       int32             `cli:"int32" help:"int32 field"`
+	// Uint8       uint8             `cli:"uint8" help:"uint8 field"`
+	// Uint16      uint16            `cli:"uint16" help:"uint16 field"`
+	// Uint32      uint32            `cli:"uint32" help:"uint32 field"`
+	// Float32     float32           `cli:"float32" help:"float32 field"`
+	// Map         map[string]string `cli:"map" help:"map field"`
+	// Slice       []string          `cli:"slice" help:"slice field"`
+	// Ptrs        struct {
+	// 	String       *string        `cli:"stringptr" help:"string pointer"`
+	// 	Bool         *bool          `cli:"boolptr" help:"bool pointer"`
+	// 	Int          *int           `cli:"intptr" help:"int pointer"`
+	// 	Int64        *int64         `cli:"int64ptr" help:"int64 pointer"`
+	// 	Uint         *uint          `cli:"uintptr" help:"uint pointer"`
+	// 	Uint64       *uint64        `cli:"uint64ptr" help:"uint64 pointer"`
+	// 	Float64      *float64       `cli:"float64ptr" help:"float64 pointer"`
+	// 	JSONNumber   *json.Number   `cli:"jsonnumberptr" help:"json.Number pointer"`
+	// 	TimeDuration *time.Duration `cli:"durationptr" help:"duration pointer"`
+	// } `cli:"ptrs" help:"pointer types"`
+}
+
+// TestCLIStructTypes tests that all handled types can be assigned values through a mapped cli flag.
+func TestCLIStructTypes(t *testing.T) {
+	tests := map[string]struct {
+		flag   []string // flag.Parse supports `-k v` and `-k=v` style so test both
+		assert func(*testing.T, testStruct)
+	}{
+		"string": {
+			flag: []string{"-string=foo"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, "foo", val.String)
+			},
+		},
+		"bool": {
+			flag: []string{"-bool"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, true, val.Bool)
+			},
+		},
+		"int": {
+			flag: []string{"-int", "42"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, 42, val.Int)
+			},
+		},
+		"int64": {
+			flag: []string{"-int64=-9999999"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, int64(-9999999), val.Int64)
+			},
+		},
+		"uint": {
+			flag: []string{"-uint=42"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, uint(42), val.Uint)
+			},
+		},
+		"uint64": {
+			flag: []string{"-uint64", "99999999"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, uint64(99999999), val.Uint64)
+			},
+		},
+		"float64": {
+			flag: []string{"-float64=1234567890.0123456789"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, 1234567890.0123456789, val.Float64)
+			},
+		},
+		"json.Number": {
+			flag: []string{"-jsonnumber", "3.1415926535897932384626433832795028841971693"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, json.Number("3.1415926535897932384626433832795028841971693"), val.JSONNumber)
+			},
+		},
+		"time.Duration": {
+			flag: []string{"-duration=25m14s"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, 25*time.Minute+14*time.Second, val.TimeDuration)
+			},
+		},
+		"struct.string": {
+			flag: []string{"-struct.string=structstring"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, "structstring", val.Struct.String)
+			},
+		},
+	}
+
+	// cli args as they're seen from os.Args (with no parsing of flag/values)
+	args := make([]string, 0)
+	for _, a := range tests {
+		args = append(args, a.flag...)
+	}
+
+	var val testStruct
+	err := parseTagsForArgs(&val, args)
+	require.NoError(t, err)
+
+	for name, a := range tests {
+		t.Run(name, func(t *testing.T) {
+			a.assert(t, val)
+		})
+	}
+}
+
+// parseTagsForArgs is a convenience function for testing without callers having to deal with their own FlagSets.
+func parseTagsForArgs(val interface{}, args []string) error {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	err := registerFlags(fs, val)
+	if err != nil {
+		return err
+	}
+	return fs.Parse(args)
+}

--- a/base/clistruct/clistruct_test.go
+++ b/base/clistruct/clistruct_test.go
@@ -158,24 +158,26 @@ func TestUndefinedFlag(t *testing.T) {
 }
 
 func TestEmbeddedStructs(t *testing.T) {
+	type innerStruct struct {
+		C struct {
+			D struct {
+				E struct {
+					F bool `cli:"f" help:"foo"`
+				} `cli:""`
+			} `cli:""`
+		} `cli:"c"`
+	}
+
 	var val struct {
 		A struct {
-			B struct {
-				C struct {
-					D struct {
-						E struct {
-							F bool `cli:"f" help:"foo"`
-						} `cli:""`
-					} `cli:""`
-				} `cli:"c"`
-			} `cli:""`
+			innerStruct `cli:""`
 		} `cli:"a"`
 	}
 
 	err := parseTagsForArgs(&val, []string{"-a.c.f"})
 	require.NoError(t, err)
 
-	assert.True(t, val.A.B.C.D.E.F)
+	assert.True(t, val.A.C.D.E.F)
 }
 
 func TestEmbeddedInvalidType(t *testing.T) {

--- a/base/clistruct/clistruct_test.go
+++ b/base/clistruct/clistruct_test.go
@@ -197,7 +197,7 @@ func TestInvalidTypeErrors(t *testing.T) {
 	}
 
 	err := parseTagsForArgs(&val, []string{"-a=b"})
-	assert.EqualError(t, err, `unsupported type []string to assign flag to struct field "a"`)
+	assert.EqualError(t, err, `unsupported type *[]string to assign flag to struct field "a"`)
 
 	err = parseTagsForArgs(1234, []string{""})
 	assert.EqualError(t, err, "expected val to be a struct, but was int")

--- a/base/clistruct/reflect.go
+++ b/base/clistruct/reflect.go
@@ -1,24 +1,25 @@
 package clistruct
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
 
 // reflectStructValue returns the reflect.Value of the given val struct, also following pointers.
 // Panics if the given val was nil or not a struct.
-func reflectStructValue(val interface{}) (refVal reflect.Value) {
+func reflectStructValue(val interface{}) (refVal reflect.Value, err error) {
 	refVal = reflect.ValueOf(val)
 	if refVal.IsZero() {
-		panic("can't get reflect.Value of nil")
+		return refVal, errors.New("can't get reflect.Value of nil")
 	}
 
 	derefVal := reflect.Indirect(refVal)
 	if derefVal.Kind() != reflect.Struct {
-		panic(fmt.Sprintf("expected val to be a struct, but was %s", derefVal.Kind()))
+		return refVal, fmt.Errorf("expected val to be a struct, but was %s", derefVal.Kind())
 	}
 
-	return derefVal
+	return derefVal, nil
 }
 
 // reflectInterfaceValue returns the underlying value as an untyped interface{},

--- a/base/clistruct/reflect.go
+++ b/base/clistruct/reflect.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-// reflectStructValue returns the reflect.Value of the given val struct, also following pointers.
+// reflectStructValue returns the reflect.Value of the given val struct, also dereferencing pointers.
 // Panics if the given val was nil or not a struct.
 func reflectStructValue(val interface{}) (refVal reflect.Value, err error) {
 	refVal = reflect.ValueOf(val)
@@ -20,14 +20,4 @@ func reflectStructValue(val interface{}) (refVal reflect.Value, err error) {
 	}
 
 	return derefVal, nil
-}
-
-// reflectInterfaceValue returns the underlying value as an untyped interface{},
-// always returning a pointer value.
-func reflectInterfaceValue(v reflect.Value) interface{} {
-	if v.Type().Kind() == reflect.Interface {
-		return v.Interface()
-	} else {
-		return v.Addr().Interface()
-	}
 }

--- a/base/clistruct/reflect.go
+++ b/base/clistruct/reflect.go
@@ -1,0 +1,32 @@
+package clistruct
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// reflectStructValue returns the reflect.Value of the given val struct, also following pointers.
+// Panics if the given val was nil or not a struct.
+func reflectStructValue(val interface{}) (refVal reflect.Value) {
+	refVal = reflect.ValueOf(val)
+	if refVal.IsZero() {
+		panic("can't get reflect.Value of nil")
+	}
+
+	derefVal := reflect.Indirect(refVal)
+	if derefVal.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("expected val to be a struct, but was %s", derefVal.Kind()))
+	}
+
+	return derefVal
+}
+
+// reflectInterfaceValue returns the underlying value as an untyped interface{},
+// always returning a pointer value.
+func reflectInterfaceValue(v reflect.Value) interface{} {
+	if v.Type().Kind() == reflect.Interface {
+		return v.Interface()
+	} else {
+		return v.Addr().Interface()
+	}
+}


### PR DESCRIPTION
Not wired up to SG yet - but this PR adds a package to support future functionality.

### Usage

- Use `cli:"foo"` struct tag to create a flag called `-foo`
- Optionally specify help using `help:"foo is something"` to describe the flag.

Fields must be exported, and of a concrete type. Does not currently support slices or maps.

`MustRegisterFlags` panics for structs that try to map invalid fields or types to allow early detection of invalid usages.

---

### Example

Supports nested structs, and dot-separates flags:
```go
struct{
  A struct {
    B bool `cli:"b"`
  } `cli:"a"`
}
```
results in a flag called `-a.b`

Tags can empty to allow for "embedding" the child flags:
```go
struct {
  A struct {
    B bool `cli:"b"`
  } `cli:""`
}
```
results in a flag called `-b`

---

### Doc

![Screenshot 2021-05-07 at 17 28 10](https://user-images.githubusercontent.com/1525809/117480529-a3345c80-af59-11eb-8be9-6c1ccd63681f.png)
