### PR TITLE
Fix logging 0kb attachment size for <1024 byte attachments

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -855,7 +855,7 @@ func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
 		return err
 
 	}
-	base.DebugfCtx(bh.loggingCtx, base.KeySync, "Sending attachment with digest=%q (%dkb)", digest, len(attachment)/1024)
+	base.DebugfCtx(bh.loggingCtx, base.KeySync, "Sending attachment with digest=%q (%.2f KB)", digest, float64(len(attachment))/float64(1024))
 	response := rq.Response()
 	response.SetBody(attachment)
 	response.SetCompressed(rq.Properties[BlipCompress] == "true")


### PR DESCRIPTION
Fixes size being rounded down to 0 KB for attachments less than 1024 bytes.

Before

```
[DBG] Sending attachment with digest="sha1-foo=" (0kb)
```

After
```
[DBG] Sending attachment with digest="sha1-foo=" (0.78 KB)
```