### PR TITLE
CBG-1443: Avoid rebuild on invalidate

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -322,11 +322,14 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, invalSeq
 		docID = docIDForRole(name)
 	}
 
+	base.Infof(base.KeyAccess, "Invalidate access of %q", base.UD(name))
+
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "channel_inval_seq", 0, invalSeq)
-		if base.IsDocNotFoundError(err) {
-			return nil
+		if err != nil && !base.IsDocNotFoundError(err) && !base.IsSubDocPathExistsError(err) {
+			return err
 		}
+		return nil
 	}
 
 	_, err := auth.bucket.Update(docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {
@@ -362,11 +365,14 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, invalSeq
 func (auth *Authenticator) InvalidateRoles(username string, invalSeq uint64) error {
 	docID := docIDForUser(username)
 
+	base.Infof(base.KeyAccess, "Invalidate roles of %q", base.UD(username))
+
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "role_inval_seq", 0, invalSeq)
-		if base.IsDocNotFoundError(err) {
-			return nil
+		if err != nil && !base.IsDocNotFoundError(err) && !base.IsSubDocPathExistsError(err) {
+			return err
 		}
+		return nil
 	}
 
 	_, err := auth.bucket.Update(docID, 0, func(current []byte) (updated []byte, expiry *uint32, delete bool, err error) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -19,7 +19,6 @@ import (
 	ch "github.com/couchbase/sync_gateway/channels"
 	pkgerrors "github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/couchbase/gocb.v1"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -325,7 +324,7 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, invalSeq
 
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "channel_inval_seq", 0, invalSeq)
-		if err == gocb.ErrKeyNotFound {
+		if base.IsDocNotFoundError(err) {
 			return nil
 		}
 	}
@@ -365,7 +364,7 @@ func (auth *Authenticator) InvalidateRoles(username string, invalSeq uint64) err
 
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "role_inval_seq", 0, invalSeq)
-		if err == gocb.ErrKeyNotFound {
+		if base.IsDocNotFoundError(err) {
 			return nil
 		}
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -321,9 +321,10 @@ func TestRebuildUserChannels(t *testing.T) {
 	computer := mockComputer{channels: ch.AtSequence(ch.SetOf(t, "derived1", "derived2"), 1)}
 	auth := NewAuthenticator(bucket, &computer)
 	user, _ := auth.NewUser("testUser", "password", ch.SetOf(t, "explicit1"))
-	err := auth.InvalidateChannels(user, 2)
+	err := auth.Save(user)
 	assert.NoError(t, err)
-	err = auth.Save(user)
+
+	err = auth.InvalidateChannels("testUser", true, 2)
 	assert.NoError(t, err)
 
 	user2, err := auth.GetUser("testUser")
@@ -339,7 +340,10 @@ func TestRebuildRoleChannels(t *testing.T) {
 	auth := NewAuthenticator(bucket, &computer)
 	role, err := auth.NewRole("testRole", ch.SetOf(t, "explicit1"))
 	assert.NoError(t, err)
-	err = auth.InvalidateChannels(role, 1)
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	err = auth.InvalidateChannels("testRole", false, 1)
 	assert.Equal(t, nil, err)
 
 	role2, err := auth.GetRole("testRole")
@@ -355,7 +359,10 @@ func TestRebuildChannelsError(t *testing.T) {
 	auth := NewAuthenticator(bucket, &computer)
 	role, err := auth.NewRole("testRole2", ch.SetOf(t, "explicit1"))
 	assert.NoError(t, err)
-	assert.Equal(t, nil, auth.InvalidateChannels(role, 1))
+	err = auth.Save(role)
+	assert.NoError(t, err)
+
+	assert.Equal(t, nil, auth.InvalidateChannels("testRole2", false, 1))
 
 	computer.err = errors.New("I'm sorry, Dave.")
 
@@ -383,7 +390,7 @@ func TestRebuildUserRoles(t *testing.T) {
 	goassert.DeepEquals(t, user1.RoleNames(), expected)
 
 	// Invalidate the roles, triggers rebuild
-	err = auth.InvalidateRoles(user1, 1)
+	err = auth.InvalidateRoles("testUser", 1)
 	assert.Equal(t, nil, err)
 
 	user2, err := auth.GetUser("testUser")
@@ -522,7 +529,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 			t.Errorf("User is nil prior to invalidate channels, error: %v", getErr)
 		}
 
-		invalidateErr := auth.InvalidateChannels(user, 1)
+		invalidateErr := auth.InvalidateChannels(username, true, 1)
 		if invalidateErr != nil {
 			t.Errorf("Error invalidating user's channels: %v", invalidateErr)
 		}
@@ -554,7 +561,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 			t.Errorf("User is nil prior to invalidate roles, error: %v", getErr)
 		}
 
-		updateErr := auth.InvalidateRoles(user, 1)
+		updateErr := auth.InvalidateRoles(username, 1)
 		if updateErr != nil {
 			t.Errorf("Error invalidating roles: %v", updateErr)
 		}
@@ -1260,43 +1267,35 @@ func (m mockComputerV2) ComputeRolesForUser(user User) (ch.TimedSet, error) {
 	return m.roles[user.Name()].Copy(), nil
 }
 
-func (m mockComputerV2) addRoleChannels(t *testing.T, auth *Authenticator, princ Principal, roleName, channelName string, invalSeq uint64) {
+func (m mockComputerV2) addRoleChannels(t *testing.T, auth *Authenticator, roleName, channelName string, invalSeq uint64) {
 	if _, ok := m.roleChannels[roleName]; !ok {
 		m.roleChannels[roleName] = ch.TimedSet{}
 	}
 
 	m.roleChannels[roleName].Add(ch.AtSequence(ch.SetOf(t, channelName), invalSeq))
-	err := auth.InvalidateChannels(princ, invalSeq)
-	assert.NoError(t, err)
-	err = auth.Save(princ)
+	err := auth.InvalidateChannels(roleName, false, invalSeq)
 	assert.NoError(t, err)
 }
 
-func (m mockComputerV2) removeRoleChannel(t *testing.T, auth *Authenticator, princ Principal, roleName, channelName string, invalSeq uint64) {
+func (m mockComputerV2) removeRoleChannel(t *testing.T, auth *Authenticator, roleName, channelName string, invalSeq uint64) {
 	delete(m.roleChannels[roleName], channelName)
-	err := auth.InvalidateChannels(princ, invalSeq)
-	assert.NoError(t, err)
-	err = auth.Save(princ)
+	err := auth.InvalidateChannels(roleName, false, invalSeq)
 	assert.NoError(t, err)
 }
 
-func (m mockComputerV2) addRole(t *testing.T, auth *Authenticator, user User, userName, roleName string, invalSeq uint64) {
+func (m mockComputerV2) addRole(t *testing.T, auth *Authenticator, userName, roleName string, invalSeq uint64) {
 	if _, ok := m.roles[userName]; !ok {
 		m.roles[userName] = ch.TimedSet{}
 	}
 
 	m.roles[userName].Add(ch.AtSequence(ch.SetOf(t, roleName), invalSeq))
-	err := auth.InvalidateRoles(user, invalSeq)
-	assert.NoError(t, err)
-	err = auth.Save(user)
+	err := auth.InvalidateRoles(userName, invalSeq)
 	assert.NoError(t, err)
 }
 
-func (m mockComputerV2) removeRole(t *testing.T, auth *Authenticator, user User, userName, roleName string, invalSeq uint64) {
+func (m mockComputerV2) removeRole(t *testing.T, auth *Authenticator, userName, roleName string, invalSeq uint64) {
 	delete(m.roles[userName], roleName)
-	err := auth.InvalidateRoles(user, invalSeq)
-	assert.NoError(t, err)
-	err = auth.Save(user)
+	err := auth.InvalidateRoles(userName, invalSeq)
 	assert.NoError(t, err)
 }
 
@@ -1356,8 +1355,8 @@ func TestRevocationScenario1(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1385,11 +1384,11 @@ func TestRevocationScenario1(t *testing.T) {
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
 	// Get Principals / Rebuild Seq 80
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1404,8 +1403,8 @@ func TestRevocationScenario1(t *testing.T) {
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(40)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Get Principals / Rebuild Seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1447,8 +1446,8 @@ func TestRevocationScenario2(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1463,7 +1462,7 @@ func TestRevocationScenario2(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
 
 	// Get Principals / Rebuild Seq 50
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1480,9 +1479,9 @@ func TestRevocationScenario2(t *testing.T) {
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
 	// Get Principals / Rebuild Seq 80
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1496,8 +1495,8 @@ func TestRevocationScenario2(t *testing.T) {
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Get Principals / Rebuild Seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1544,8 +1543,8 @@ func TestRevocationScenario3(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1560,8 +1559,8 @@ func TestRevocationScenario3(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(55)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
 	// Rebuild seq 60
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1583,8 +1582,8 @@ func TestRevocationScenario3(t *testing.T) {
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
 	// Rebuild seq 80
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1599,8 +1598,8 @@ func TestRevocationScenario3(t *testing.T) {
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1650,8 +1649,8 @@ func TestRevocationScenario4(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1666,10 +1665,10 @@ func TestRevocationScenario4(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
 
 	// Get Principals / Rebuild Seq 70
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1686,7 +1685,7 @@ func TestRevocationScenario4(t *testing.T) {
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
 	// Get Principals / Rebuild Seq 80
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1700,8 +1699,8 @@ func TestRevocationScenario4(t *testing.T) {
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Get Principals / Rebuild Seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1743,8 +1742,8 @@ func TestRevocationScenario5(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1759,11 +1758,11 @@ func TestRevocationScenario5(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
 	// Get Principals / Rebuild Seq 80
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1777,8 +1776,8 @@ func TestRevocationScenario5(t *testing.T) {
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Get Principals / Rebuild Seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1820,8 +1819,8 @@ func TestRevocationScenario6(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1836,13 +1835,13 @@ func TestRevocationScenario6(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	require.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
 
 	// Rebuild seq 90
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1852,14 +1851,14 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
 	require.Contains(t, revokedChannelsCombined, "ch1")
-	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
+	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 100
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1873,7 +1872,7 @@ func TestRevocationScenario6(t *testing.T) {
 
 	channelHistory, ok = fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
 	assert.Len(t, revokedChannelsCombined, 0)
@@ -1900,8 +1899,8 @@ func TestRevocationScenario7(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1916,14 +1915,14 @@ func TestRevocationScenario7(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Get Principals / Rebuild Seq 100
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1933,17 +1932,17 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 95}, userRoleHistory.Entries[0])
 
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 85}, channelHistory.Entries[0])
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
 	require.Contains(t, revokedChannelsCombined, "ch1")
-	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
+	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 
 	// Get Principals / Rebuild Seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1978,10 +1977,10 @@ func TestRevocationScenario8(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
 
 	// Get Principals / Rebuild Seq 50
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -1995,13 +1994,13 @@ func TestRevocationScenario8(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(50)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2011,7 +2010,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.False(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
-	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
+	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50)
@@ -2037,11 +2036,11 @@ func TestRevocationScenario9(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
 	// Get Principals / Rebuild Seq 60
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2055,11 +2054,11 @@ func TestRevocationScenario9(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2093,13 +2092,13 @@ func TestRevocationScenario10(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
 
 	// Get Principals / Rebuild Seq 70
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2113,10 +2112,10 @@ func TestRevocationScenario10(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2152,14 +2151,14 @@ func TestRevocationScenario11(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
 	// Get Principals / Rebuild Seq 80
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2173,8 +2172,8 @@ func TestRevocationScenario11(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2217,16 +2216,16 @@ func TestRevocationScenario12(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
 
 	// Get Principals / Rebuild Seq 90
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2240,7 +2239,7 @@ func TestRevocationScenario12(t *testing.T) {
 	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
 	assert.Len(t, revokedChannelsCombined, 0)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Rebuild seq 110
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2276,17 +2275,17 @@ func TestRevocationScenario13(t *testing.T) {
 	auth := NewAuthenticator(testBucket, &testMockComputer)
 	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 55)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
 
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 65)
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 75)
+	testMockComputer.addRole(t, auth, "alice", "foo", 65)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
 
-	testMockComputer.removeRoleChannel(t, auth, fooPrincipal, "foo", "ch1", 85)
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 95)
+	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
 
 	// Get Principals / Rebuild Seq 100
 	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
@@ -2331,18 +2330,18 @@ func TestRevocationScenario14(t *testing.T) {
 	}
 
 	auth := NewAuthenticator(testBucket, &testMockComputer)
-	aliceUserPrincipal, fooPrincipal := initializeScenario(t, auth)
+	aliceUserPrincipal, _ := initializeScenario(t, auth)
 
-	testMockComputer.addRoleChannels(t, auth, fooPrincipal, "foo", "ch1", 5)
-	testMockComputer.addRole(t, auth, aliceUserPrincipal, "alice", "foo", 20)
+	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 5)
+	testMockComputer.addRole(t, auth, "alice", "foo", 20)
 
 	// Get Principals / Rebuild Seq 25
-	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
+	aliceUserPrincipal, _ = getPrincipals(t, auth)
 
-	testMockComputer.removeRole(t, auth, aliceUserPrincipal, "alice", "foo", 45)
+	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
 
 	// Get Principals / Rebuild Seq 45
-	aliceUserPrincipal, fooPrincipal = getPrincipals(t, auth)
+	aliceUserPrincipal, _ = getPrincipals(t, auth)
 	userRoleHistory, ok := aliceUserPrincipal.RoleHistory()["foo"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
@@ -2431,49 +2430,6 @@ func TestRoleSoftDelete(t *testing.T) {
 	assert.Equal(t, expectedChannelHistory, role.ChannelHistory()["!"].Entries[0])
 }
 
-func TestRoleSoftDeleteCasMismatch(t *testing.T) {
-	testBucket := base.GetTestBucket(t)
-	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket, nil)
-
-	const roleName = "role"
-
-	// Instantiate role
-	role, err := auth.NewRole(roleName, ch.SetOf(t, "channel"))
-	assert.NoError(t, err)
-	assert.NotNil(t, role)
-
-	// Save role to bucket
-	err = auth.Save(role)
-	assert.NoError(t, err)
-
-	// Get role to do update on
-	role, err = auth.GetRole(roleName)
-	assert.NoError(t, err)
-
-	// Get cas for later use
-	oldCas := role.Cas()
-
-	// Delete
-	err = auth.DeleteRole(role, false, 2)
-	assert.NoError(t, err)
-
-	// Save current cas for later validation
-	currentCas := role.Cas()
-
-	// Set cas to old one to cause cas retry
-	role.SetCas(oldCas)
-
-	// Trigger an update with will have a cas retry
-	err = auth.InvalidateChannels(role, 3)
-	assert.NoError(t, err)
-
-	// Check no actual update is performed
-	role, err = auth.GetRoleIncDeleted(roleName)
-	assert.NoError(t, err)
-	assert.Equal(t, currentCas, role.Cas())
-}
-
 func TestObtainChannelsForDeletedRole(t *testing.T) {
 	testcases := []struct {
 		Name     string
@@ -2542,8 +2498,8 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Add channel to role and role to user
-			testMockComputer.addRoleChannels(t, auth, role, "role", "chan", 1)
-			testMockComputer.addRole(t, auth, user, "user", "role", 1)
+			testMockComputer.addRoleChannels(t, auth, "role", "chan", 1)
+			testMockComputer.addRole(t, auth, "user", "role", 1)
 
 			testCase.TestFunc(auth, role, t)
 		})

--- a/auth/role.go
+++ b/auth/role.go
@@ -28,7 +28,7 @@ type roleImpl struct {
 	Channels_         ch.TimedSet     `json:"all_channels"`
 	Sequence_         uint64          `json:"sequence"`
 	ChannelHistory_   TimedSetHistory `json:"channel_history,omitempty"`
-	ChannelInvalSeq   uint64          `json:"channel_inval_seq"`
+	ChannelInvalSeq   uint64          `json:"channel_inval_seq,omitempty"`
 	Deleted           bool            `json:"deleted,omitempty"`
 	vbNo              *uint16
 	cas               uint64

--- a/auth/user.go
+++ b/auth/user.go
@@ -38,7 +38,7 @@ type userImplBody struct {
 	OldPasswordHash_ interface{}     `json:"passwordhash,omitempty"` // For pre-beta compatibility
 	ExplicitRoles_   ch.TimedSet     `json:"explicit_roles,omitempty"`
 	RolesSince_      ch.TimedSet     `json:"rolesSince"`
-	RoleInvalSeq     uint64          `json:"role_inval_seq"`
+	RoleInvalSeq     uint64          `json:"role_inval_seq,omitempty"`
 	RoleHistory_     TimedSetHistory `json:"role_history,omitempty"`
 
 	OldExplicitRoles_ []string `json:"admin_roles,omitempty"` // obsolete; declared for migration

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2394,6 +2394,8 @@ func (bucket *CouchbaseBucketGoCB) FormatBinaryDocument(input []byte) interface{
 func (bucket *CouchbaseBucketGoCB) IsSupported(feature sgbucket.DataStoreFeature) bool {
 	major, minor, _ := bucket.CouchbaseServerVersion()
 	switch feature {
+	case sgbucket.DataStoreFeatureSubdocOperations:
+		return isMinimumVersion(major, minor, 4, 5)
 	case sgbucket.DataStoreFeatureXattrs:
 		return isMinimumVersion(major, minor, 5, 0)
 	case sgbucket.DataStoreFeatureN1ql:
@@ -2408,7 +2410,14 @@ func (bucket *CouchbaseBucketGoCB) IsSupported(feature sgbucket.DataStoreFeature
 	default:
 		return false
 	}
+}
 
+func (bucket *CouchbaseBucketGoCB) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
+	_, err := bucket.MutateIn(docID, gocb.Cas(cas), 0).
+		Insert(fieldPath, value, false).
+		Execute()
+
+	return err
 }
 
 func isMinimumVersion(major, minor, requiredMajor, requiredMinor uint64) bool {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1492,7 +1492,7 @@ func (bucket *CouchbaseBucketGoCB) deleteWithXattrInternal(k string, xattrKey st
 		// KeyNotFound indicates there is no doc body.  Try to delete only the xattr.
 		return bucket.deleteDocXattrOnly(k, xattrKey, callback)
 
-	case bucket.IsSubDocPathNotFound(mutateErr):
+	case IsSubDocPathNotFound(mutateErr):
 
 		// Invoke the testing related callback.  This is a no-op in non-test contexts.
 		if callback != nil {
@@ -1958,17 +1958,6 @@ func (bucket *CouchbaseBucketGoCB) IsError(err error, errorType sgbucket.DataSto
 	default:
 		return false
 	}
-}
-
-// Check if this is a SubDocPathNotFound error
-// Pending question to see if there is an easier way: https://forums.couchbase.com/t/checking-for-errsubdocpathnotfound-errors/13492
-func (bucket *CouchbaseBucketGoCB) IsSubDocPathNotFound(err error) bool {
-
-	subdocMutateErr, ok := pkgerrors.Cause(err).(gocbcore.SubDocMutateError)
-	if ok {
-		return subdocMutateErr.Err == gocb.ErrSubDocPathNotFound
-	}
-	return false
 }
 
 func (bucket *CouchbaseBucketGoCB) DeleteDDoc(docname string) error {

--- a/base/collection.go
+++ b/base/collection.go
@@ -406,6 +406,10 @@ func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, userXattrKe
 	return 0, errors.New("WriteUpdateWithXattr not implemented")
 }
 
+func (b *Collection) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
+	return errors.New("SubdocInsert not implemented")
+}
+
 // CouchbaseStore
 
 func (c *Collection) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {

--- a/base/error.go
+++ b/base/error.go
@@ -184,16 +184,21 @@ func IsDocNotFoundError(err error) bool {
 	}
 }
 
+// Check if this is a SubDocPathNotFound error
+func IsSubDocPathNotFound(err error) bool {
+
+	subdocMutateErr, ok := pkgerrors.Cause(err).(gocbcore.SubDocMutateError)
+	if ok {
+		return subdocMutateErr.Err == gocb.ErrSubDocPathNotFound
+	}
+	return false
+}
+
 func IsSubDocPathExistsError(err error) bool {
-	subdocMutateErr, ok := err.(gocbcore.SubDocMutateError)
-	if !ok {
-		return false
-	}
 
-	kvErr, ok := subdocMutateErr.Err.(*gocbcore.KvError)
-	if !ok {
-		return false
+	subdocMutateErr, ok := pkgerrors.Cause(err).(gocbcore.SubDocMutateError)
+	if ok {
+		return subdocMutateErr.Err == gocb.ErrSubDocPathExists
 	}
-
-	return kvErr.Code == gocbcore.StatusSubDocPathExists
+	return false
 }

--- a/base/error.go
+++ b/base/error.go
@@ -19,6 +19,7 @@ import (
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
 	"gopkg.in/couchbase/gocb.v1"
+	"gopkg.in/couchbase/gocbcore.v7"
 )
 
 type sgError struct {
@@ -181,4 +182,18 @@ func IsDocNotFoundError(err error) bool {
 	default:
 		return false
 	}
+}
+
+func IsSubDocPathExistsError(err error) bool {
+	subdocMutateErr, ok := err.(gocbcore.SubDocMutateError)
+	if !ok {
+		return false
+	}
+
+	kvErr, ok := subdocMutateErr.Err.(*gocbcore.KvError)
+	if !ok {
+		return false
+	}
+
+	return kvErr.Code == gocbcore.StatusSubDocPathExists
 }

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -225,6 +225,10 @@ func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey 
 	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
 
+func (b *LeakyBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
+	return b.bucket.SubdocInsert(docID, fieldPath, cas, value)
+}
+
 func (b *LeakyBucket) GetWithXattr(k string, xattr string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
 	return b.bucket.GetWithXattr(k, xattr, userXattrKey, rv, xv, uxv)
 }

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -100,6 +100,12 @@ func (b *LoggingBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKe
 	defer b.log(time.Now(), k, xattr, exp)
 	return b.bucket.WriteUpdateWithXattr(k, xattr, userXattrKey, exp, previous, callback)
 }
+
+func (b *LoggingBucket) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
+	defer b.log(time.Now(), docID, fieldPath)
+	return b.bucket.SubdocInsert(docID, fieldPath, cas, value)
+}
+
 func (b *LoggingBucket) GetWithXattr(k string, xattr string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
 	defer b.log(time.Now(), k, xattr, userXattrKey)
 	return b.bucket.GetWithXattr(k, xattr, userXattrKey, rv, xv, uxv)

--- a/db/database.go
+++ b/db/database.go
@@ -1333,28 +1333,22 @@ func (db *Database) UpdateAllDocChannels(regenerateSequences bool) (int, error) 
 
 func (db *Database) invalUserRoles(username string, invalSeq uint64) {
 	authr := db.Authenticator()
-	if user, _ := authr.GetUser(username); user != nil {
-		if err := authr.InvalidateRoles(user, invalSeq); err != nil {
-			base.Warnf("Error invalidating roles for user %s: %v", base.UD(username), err)
-		}
+	if err := authr.InvalidateRoles(username, invalSeq); err != nil {
+		base.Warnf("Error invalidating roles for user %s: %v", base.UD(username), err)
 	}
 }
 
 func (db *Database) invalUserChannels(username string, invalSeq uint64) {
 	authr := db.Authenticator()
-	if user, _ := authr.GetUser(username); user != nil {
-		if err := authr.InvalidateChannels(user, invalSeq); err != nil {
-			base.Warnf("Error invalidating channels for user %s: %v", base.UD(username), err)
-		}
+	if err := authr.InvalidateChannels(username, true, invalSeq); err != nil {
+		base.Warnf("Error invalidating channels for user %s: %v", base.UD(username), err)
 	}
 }
 
 func (db *Database) invalRoleChannels(rolename string, invalSeq uint64) {
 	authr := db.Authenticator()
-	if role, _ := authr.GetRole(rolename); role != nil {
-		if err := authr.InvalidateChannels(role, invalSeq); err != nil {
-			base.Warnf("Error invalidating channels for role %s: %v", base.UD(rolename), err)
-		}
+	if err := authr.InvalidateChannels(rolename, false, invalSeq); err != nil {
+		base.Warnf("Error invalidating channels for role %s: %v", base.UD(rolename), err)
 	}
 }
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="7b8d0d284a9c06892f696189dcd872612d3ae517"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="aac9eb5d3047d4a74d3e87db231a36e231446dad"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="efa71b3fbf82306d7f3b4c9c631e1b633be551e2"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="7a9f15d95f07f7f30f567cf19919f554d14b12d5"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -31,7 +31,7 @@
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="72357501c5480e59b7fcb059902ebac8f03eb876"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="7b8d0d284a9c06892f696189dcd872612d3ae517"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
@@ -50,7 +50,7 @@
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="70f2d2ed927d3e7b0b1251963168f830a53cc2d9"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="efa71b3fbf82306d7f3b4c9c631e1b633be551e2"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 


### PR DESCRIPTION
Implementation to avoid a GetUser / GetRole operation before performing an invalidation to avoid rebuild work.

If possible performs subdoc operation rather than a Get / Set (Update).

Added unit tests to ensure same behaviour remains.

- [x] https://github.com/couchbaselabs/walrus/pull/57
- [x] https://github.com/couchbase/sg-bucket/pull/63
- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/764/
Couple of failures but ran with no problems locally