### PR TITLE
CBG-1390 Add warning threshold for excessively large number of channels per user

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -24,9 +24,10 @@ import (
 
 /** Manages user authentication for a database. */
 type Authenticator struct {
-	bucket            base.Bucket
-	channelComputer   ChannelComputer
-	sessionCookieName string // Custom per-database session cookie name
+	bucket                   base.Bucket
+	channelComputer          ChannelComputer
+	sessionCookieName        string // Custom per-database session cookie name
+	channelsWarningThreshold *uint32
 }
 
 // Interface for deriving the set of channels and roles a User/Role has access to.
@@ -57,6 +58,14 @@ func (auth *Authenticator) SessionCookieName() string {
 
 func (auth *Authenticator) SetSessionCookieName(cookieName string) {
 	auth.sessionCookieName = cookieName
+}
+
+func (auth *Authenticator) ChannelsWarningThreshold() *uint32 {
+	return auth.channelsWarningThreshold
+}
+
+func (auth *Authenticator) SetChannelsWarningThreshold(channelsWarningThreshold *uint32) {
+	auth.channelsWarningThreshold = channelsWarningThreshold
 }
 
 func docIDForUserEmail(email string) string {
@@ -394,7 +403,7 @@ func (auth *Authenticator) InvalidateRoles(username string, invalSeq uint64) err
 
 		user.SetRoleInvalSeq(invalSeq)
 
-		updated, err = base.JSONMarshal(user)
+		updated, err = base.JSONMarshal(&user)
 		return updated, nil, false, err
 	})
 

--- a/base/constants.go
+++ b/base/constants.go
@@ -153,9 +153,10 @@ var (
 	}
 
 	// Default warning thresholds
-	DefaultWarnThresholdXattrSize      = 0.9 * float64(couchbaseMaxSystemXattrSize)
-	DefaultWarnThresholdChannelsPerDoc = uint32(50)
-	DefaultWarnThresholdGrantsPerDoc   = uint32(50)
+	DefaultWarnThresholdXattrSize       = 0.9 * float64(couchbaseMaxSystemXattrSize)
+	DefaultWarnThresholdChannelsPerDoc  = uint32(50)
+	DefaultWarnThresholdChannelsPerUser = uint32(50000)
+	DefaultWarnThresholdGrantsPerDoc    = uint32(50)
 
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
 	ErrUnknownField = errors.New("unrecognized JSON field")

--- a/db/database.go
+++ b/db/database.go
@@ -183,9 +183,10 @@ type UnsupportedOptions struct {
 }
 
 type WarningThresholds struct {
-	XattrSize      *uint32 `json:"xattr_size_bytes,omitempty"`               // Number of bytes to be used as a threshold for xattr size limit warnings
-	ChannelsPerDoc *uint32 `json:"channels_per_doc,omitempty"`               // Number of channels per document to be used as a threshold for channel count warnings
-	GrantsPerDoc   *uint32 `json:"access_and_role_grants_per_doc,omitempty"` // Number of access and role grants per document to be used as a threshold for grant count warnings
+	XattrSize       *uint32 `json:"xattr_size_bytes,omitempty"`               // Number of bytes to be used as a threshold for xattr size limit warnings
+	ChannelsPerDoc  *uint32 `json:"channels_per_doc,omitempty"`               // Number of channels per document to be used as a threshold for channel count warnings
+	GrantsPerDoc    *uint32 `json:"access_and_role_grants_per_doc,omitempty"` // Number of access and role grants per document to be used as a threshold for grant count warnings
+	ChannelsPerUser *uint32 `json:"channels_per_user,omitempty"`              // Number of channels per user to be used as a threshold for channel count warnings
 }
 
 // Options associated with the import of documents not written by Sync Gateway
@@ -706,6 +707,7 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 	if context.Options.SessionCookieName != "" {
 		authenticator.SetSessionCookieName(context.Options.SessionCookieName)
 	}
+	authenticator.SetChannelsWarningThreshold(context.Options.UnsupportedOptions.WarningThresholds.ChannelsPerUser)
 	return authenticator
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -402,6 +402,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
+	if config.Unsupported.WarningThresholds.ChannelsPerUser == nil {
+		config.Unsupported.WarningThresholds.ChannelsPerUser = &base.DefaultWarnThresholdChannelsPerUser
+	}
+
 	if config.Unsupported.WarningThresholds.GrantsPerDoc == nil {
 		config.Unsupported.WarningThresholds.GrantsPerDoc = &base.DefaultWarnThresholdGrantsPerDoc
 	} else {


### PR DESCRIPTION
Changes to add a new warning about channel count per user, to give early warning about running into memory issues with extremely high numbers of channels per user.