### PR TITLE
Fix incorrect config property in grants per doc warning threshold

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1915,7 +1915,7 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 	}
 
 	// Warn when grants are larger than a configured threshold
-	if grantThreshold := db.Options.UnsupportedOptions.WarningThresholds.ChannelsPerDoc; grantThreshold != nil {
+	if grantThreshold := db.Options.UnsupportedOptions.WarningThresholds.GrantsPerDoc; grantThreshold != nil {
 		grantCount := len(accessGrants) + len(roleGrants)
 		if uint32(grantCount) >= *grantThreshold {
 			db.DbStats.Database().WarnGrantsPerDocCount.Add(1)


### PR DESCRIPTION
We were looking at the wrong config option for this warning.