### PR TITLE
CBG-1426: Include removed in changes deleted field

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -310,13 +310,13 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 					if bh.db.DatabaseContext.Options.UnsupportedOptions.ForceBLIPV3 {
 						deletedFlags := changesDeletedFlag(0)
 						if change.Deleted {
-							deletedFlags += changesDeletedFlagDeleted
+							deletedFlags |= changesDeletedFlagDeleted
 						}
 						if change.Revoked {
-							deletedFlags += changesDeletedFlagRevoked
+							deletedFlags |= changesDeletedFlagRevoked
 						}
 						if len(change.Removed) > 0 {
-							deletedFlags += changesDeletedFlagRemoved
+							deletedFlags |= changesDeletedFlagRemoved
 						}
 
 						changeRow = []interface{}{change.Seq, change.ID, item["rev"], deletedFlags}

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -306,6 +306,9 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 						if change.Revoked {
 							deleted += 2
 						}
+						if len(change.Removed) > 0 {
+							deleted += 4
+						}
 
 						changeRow = []interface{}{change.Seq, change.ID, item["rev"], deleted}
 						if deleted == 0 {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3127,7 +3127,7 @@ func TestRevocationMessage(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			// Verify the deleted property in the changes message is "2" this indicated a revocation
 			for _, msg := range messages {
-				if msg.Properties["Profile"] == "changes" {
+				if msg.Properties[db.BlipProfile] == db.MessageChanges {
 					var changesMessages [][]interface{}
 					err = msg.ReadJSONBody(&changesMessages)
 					if err != nil {


### PR DESCRIPTION
Include removed in deleted bitfield on changes feed.
Modified existing `TestRevocationMessage` test to check that this field is set correctly.