### PR TITLE
Add clistruct package to map JSON struct tagged fields to command line flags

### DIFF
--- a/base/clistruct/clistruct.go
+++ b/base/clistruct/clistruct.go
@@ -1,4 +1,4 @@
-// Package clistruct provides the ability to assign command line flags to fields in structs that declare `cli` and `help` struct tags.
+// Package clistruct provides the ability to automatically assign command line flags to fields in structs that declare `json` and optionally `help` struct tags.
 package clistruct
 
 import (

--- a/base/clistruct/clistruct.go
+++ b/base/clistruct/clistruct.go
@@ -1,0 +1,224 @@
+// Package clistruct provides the ability to assign command line flags to fields in structs that declare `cli` and `help` struct tags.
+package clistruct
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	jsonStructNameTag = "json"
+	cliStructHelpTag  = "help"
+)
+
+// MustRegisterJSONFlags will register flags on the given FlagSet from json struct tags in the given struct.
+// FlagSet.Parse() must be called _after_ this has been run.
+//
+// Panics if the given struct cannot be assigned to a FlagSet (unsupported types, duplicate flags, etc.)
+func MustRegisterJSONFlags(fs *flag.FlagSet, cliStruct interface{}) {
+	if err := registerFlags(fs, cliStruct, jsonStructNameTag); err != nil {
+		panic("Can't register struct flags: " + err.Error())
+	}
+}
+
+// registerFlags is the non-panicking version of MustRegisterFlags, for testing.
+func registerFlags(fs *flag.FlagSet, cliStruct interface{}, structNameTag string) error {
+	if fs == nil {
+		return errors.New("expected flag.FlagSet in RegisterFlags but got nil")
+	}
+
+	refVal, err := reflectStructValue(cliStruct)
+	if err != nil {
+		return err
+	}
+
+	if err := register(fs, refVal, refVal.Type(), "", structNameTag); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// register recursively assigns flags to any fields that have a cli struct tag, are addressable, and have a supported type.
+func register(fs *flag.FlagSet, val reflect.Value, valType reflect.Type, namePrefix string, structNameTag string) error {
+	for i := 0; i < valType.NumField(); i++ {
+		valTypeField := valType.Field(i)
+
+		// Handle embedded structs without nesting struct tag values
+		if valTypeField.Type.Kind() == reflect.Struct && valTypeField.Anonymous {
+			if err := register(fs, val.Field(i), val.Field(i).Type(), namePrefix, structNameTag); err != nil {
+				return err
+			}
+			continue
+		}
+
+		flagName := valTypeField.Tag.Get(structNameTag)
+
+		// Handle JSON tags as a special case for the options and struct field fallback handling.
+		if structNameTag == jsonStructNameTag {
+			var skip bool
+			flagName, skip = removeJSONTagOpts(flagName)
+			if skip {
+				continue
+			}
+			if flagName == "" {
+				// json.Marshal takes the struct field name in this case
+				flagName = valTypeField.Name
+			}
+		}
+
+		// skip untagged fields
+		if flagName == "" {
+			continue
+		}
+
+		// nest the given flagName under the parent tags
+		if namePrefix != "" {
+			flagName = namePrefix + "." + flagName
+		}
+
+		fieldType := valTypeField.Type
+		fieldValue := val.Field(i)
+
+		if fieldType.Kind() == reflect.Ptr && fieldType.Elem().Kind() == reflect.Struct {
+			// deref pointers to structs in order to recurse
+			fieldType = fieldType.Elem()
+			if fieldValue.IsNil() {
+				fieldValue.Set(reflect.New(fieldType))
+			}
+			fieldValue = fieldValue.Elem()
+		}
+
+		if fieldType.Kind() == reflect.Struct {
+			// recurse for nested structs
+			if err := register(fs, fieldValue, fieldType, flagName, structNameTag); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if !fieldValue.CanSet() {
+			return fmt.Errorf("value %q (%s) can't be set - not addressable or unexported", valTypeField.Name, structNameTag)
+		}
+
+		flagHelp := valTypeField.Tag.Get(cliStructHelpTag)
+		if err := assignFlagToStructFieldVar(fs, fieldValue, flagName, flagHelp); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+// assignFlagToStructFieldVar creates a flag associated with the given struct field, if the type can be set from a flag.
+func assignFlagToStructFieldVar(fs *flag.FlagSet, fieldValue reflect.Value, flagName, flagHelp string) error {
+
+	// get the pointer for non-pointer fields
+	if fieldValue.Kind() != reflect.Ptr && fieldValue.CanAddr() {
+		fieldValue = fieldValue.Addr()
+	}
+
+	// The assignments below take 2 forms:
+	// If v is nil, create a flag var and assign it to the struct
+	// If v is not nil, bind the flag to the variable in the struct
+
+	i := fieldValue.Interface()
+
+	// wrappers for flag.Value/fs.Var handling
+	switch v := i.(type) {
+	// Implement wrapper types in flag_value_wrappers.go for common types and wrap them here.
+	case *[]string:
+		if v == nil {
+			tmp := make(stringSliceValue, 0)
+			i = &tmp
+			fieldValue.Set(reflect.ValueOf((*[]string)(&tmp)))
+		} else {
+			i = (*stringSliceValue)(v)
+		}
+	case *json.Number:
+		if v == nil {
+			tmp := jsonNumberFlagValue("0")
+			i = &tmp
+			fieldValue.Set(reflect.ValueOf((*json.Number)(&tmp)))
+		} else {
+			i = (*jsonNumberFlagValue)(v)
+		}
+	}
+
+	switch v := i.(type) {
+	case flag.Value:
+		fs.Var(v, flagName, flagHelp)
+	case *time.Duration:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Duration(flagName, 0, flagHelp)))
+		} else {
+			fs.DurationVar(v, flagName, *v, flagHelp)
+		}
+	case *bool:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Bool(flagName, false, flagHelp)))
+		} else {
+			fs.BoolVar(v, flagName, *v, flagHelp)
+		}
+	case *int:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Int(flagName, 0, flagHelp)))
+		} else {
+			fs.IntVar(v, flagName, *v, flagHelp)
+		}
+	case *int64:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Int64(flagName, 0, flagHelp)))
+		} else {
+			fs.Int64Var(v, flagName, *v, flagHelp)
+		}
+	case *uint:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Uint(flagName, 0, flagHelp)))
+		} else {
+			fs.UintVar(v, flagName, *v, flagHelp)
+		}
+	case *uint64:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Uint64(flagName, 0, flagHelp)))
+		} else {
+			fs.Uint64Var(v, flagName, *v, flagHelp)
+		}
+	case *float64:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.Float64(flagName, 0, flagHelp)))
+		} else {
+			fs.Float64Var(v, flagName, *v, flagHelp)
+		}
+	case *string:
+		if v == nil {
+			fieldValue.Set(reflect.ValueOf(fs.String(flagName, "", flagHelp)))
+		} else {
+			fs.StringVar(v, flagName, *v, flagHelp)
+		}
+	default:
+		return fmt.Errorf("unsupported type %T to assign flag to struct field %q - try a flag.Value implementing wrapper for the type (e.g: stringSliceValue)", v, flagName)
+	}
+
+	return nil
+}
+
+// removeJSONTagOpts removes JSON tag options like 'omitempty' and 'string' from JSON struct tag values.
+func removeJSONTagOpts(tagVal string) (cleanTagVal string, skip bool) {
+	if idx := strings.Index(tagVal, ","); idx != -1 {
+		// grab the key before opts appear
+		return tagVal[:idx], false
+	}
+	// json:"-," is handled in the above case (where we found a separator)
+	// but this case is an explicitly ignored field
+	if tagVal == "-" {
+		return "", true
+	}
+	// normal key, no opts
+	return tagVal, false
+}

--- a/base/clistruct/clistruct.go
+++ b/base/clistruct/clistruct.go
@@ -127,30 +127,25 @@ func assignFlagToStructFieldVar(fs *flag.FlagSet, fieldValue reflect.Value, flag
 	// If v is nil, create a flag var and assign it to the struct
 	// If v is not nil, bind the flag to the variable in the struct
 
-	i := fieldValue.Interface()
-
-	// wrappers for flag.Value/fs.Var handling
-	switch v := i.(type) {
-	// Implement wrapper types in flag_value_wrappers.go for common types and wrap them here.
+	switch v := fieldValue.Interface().(type) {
+	// These common types have flag wrappers from flag_value_wrappers.go
 	case *[]string:
 		if v == nil {
 			tmp := make(stringSliceValue, 0)
-			i = &tmp
 			fieldValue.Set(reflect.ValueOf((*[]string)(&tmp)))
+			fs.Var(&tmp, flagName, flagHelp)
 		} else {
-			i = (*stringSliceValue)(v)
+			fs.Var((*stringSliceValue)(v), flagName, flagHelp)
 		}
 	case *json.Number:
 		if v == nil {
 			tmp := jsonNumberFlagValue("0")
-			i = &tmp
 			fieldValue.Set(reflect.ValueOf((*json.Number)(&tmp)))
+			fs.Var(&tmp, flagName, flagHelp)
 		} else {
-			i = (*jsonNumberFlagValue)(v)
+			fs.Var((*jsonNumberFlagValue)(v), flagName, flagHelp)
 		}
-	}
-
-	switch v := i.(type) {
+	// All below types are natively handled by the flag package.
 	case flag.Value:
 		fs.Var(v, flagName, flagHelp)
 	case *time.Duration:

--- a/base/clistruct/clistruct_test.go
+++ b/base/clistruct/clistruct_test.go
@@ -1,0 +1,342 @@
+package clistruct
+
+import (
+	"encoding/json"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	String  string  `json:"string" help:"string field"`
+	Bool    bool    `json:"bool" help:"bool field"`
+	Int     int     `json:"int" help:"int field"`
+	Int64   int64   `json:"int64" help:"int64 field"`
+	Uint    uint    `json:"uint" help:"uint field"`
+	Uint64  uint64  `json:"uint64" help:"uint64 field"`
+	Float64 float64 `json:"float64" help:"float64 field"`
+
+	Struct struct {
+		String string `json:"string" help:"string field"`
+	} `json:"struct" help:"struct field"`
+
+	StringSlice  []string      `json:"stringslice" help:"string slice field"`
+	JSONNumber   json.Number   `json:"jsonnumber" help:"json.Number field"`
+	TimeDuration time.Duration `json:"duration" help:"duration field"`
+
+	pointerStruct // embedded struct with pointer types
+
+	// Intentionally unhandled fields/types - Causes panic in MustRegisterFlags for easy/early detection.
+	// unexported  string            `json:"unexported"`
+	// Int8        int8              `json:"int8" help:"int8 field"`
+	// Int16       int16             `json:"int16" help:"int16 field"`
+	// Int32       int32             `json:"int32" help:"int32 field"`
+	// Uint8       uint8             `json:"uint8" help:"uint8 field"`
+	// Uint16      uint16            `json:"uint16" help:"uint16 field"`
+	// Uint32      uint32            `json:"uint32" help:"uint32 field"`
+	// Float32     float32           `json:"float32" help:"float32 field"`
+	// Map         map[string]string `json:"map" help:"map field"`
+}
+
+type pointerStruct struct {
+	String  *string  `json:"stringptr" help:"string pointer"`
+	Bool    *bool    `json:"boolptr" help:"bool pointer"`
+	Int     *int     `json:"intptr" help:"int pointer"`
+	Int64   *int64   `json:"int64ptr" help:"int64 pointer"`
+	Uint    *uint    `json:"uintptr" help:"uint pointer"`
+	Uint64  *uint64  `json:"uint64ptr" help:"uint64 pointer"`
+	Float64 *float64 `json:"float64ptr" help:"float64 pointer"`
+
+	StringSlice  *[]string      `json:"stringsliceptr" help:"string slice pointer"`
+	JSONNumber   *json.Number   `json:"jsonnumberptr" help:"json.Number pointer"`
+	TimeDuration *time.Duration `json:"durationptr" help:"duration pointer"`
+
+	Struct *stringStruct `json:"structptr" help:"struct pointer"`
+}
+
+type stringStruct struct {
+	String string `json:"string" help:"string field"`
+}
+
+// TestCLIStructTypes tests that all handled types can be assigned values through a mapped cli flag.
+func TestCLIStructTypes(t *testing.T) {
+	tests := map[string]struct {
+		flag   []string // flag.Parse supports `-k v` and `-k=v` style so test both
+		assert func(*testing.T, testStruct)
+	}{
+		"string": {
+			flag: []string{"-string=foo"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, "foo", val.String)
+			},
+		},
+		"bool": {
+			flag: []string{"-bool"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, true, val.Bool)
+			},
+		},
+		"int": {
+			flag: []string{"-int", "42"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, 42, val.Int)
+			},
+		},
+		"int64": {
+			flag: []string{"-int64=-9999999"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, int64(-9999999), val.Int64)
+			},
+		},
+		"uint": {
+			flag: []string{"-uint=42"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, uint(42), val.Uint)
+			},
+		},
+		"uint64": {
+			flag: []string{"-uint64", "99999999"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, uint64(99999999), val.Uint64)
+			},
+		},
+		"float64": {
+			flag: []string{"-float64=1234567890.0123456789"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, 1234567890.0123456789, val.Float64)
+			},
+		},
+		"struct.string": {
+			flag: []string{"-struct.string=structstring"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, "structstring", val.Struct.String)
+			},
+		},
+		"stringslice": {
+			flag: []string{"-stringslice", "a,b,c,d"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, []string{"a", "b", "c", "d"}, val.StringSlice)
+			},
+		},
+		"json.Number": {
+			flag: []string{"-jsonnumber", "3.1415926535897932384626433832795028841971693"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t, json.Number("3.1415926535897932384626433832795028841971693"), val.JSONNumber)
+			},
+		},
+		"time.Duration": {
+			flag: []string{"-duration=25m14s"},
+			assert: func(t *testing.T, val testStruct) {
+				assert.Equal(t,
+					25*time.Minute+
+						14*time.Second,
+					val.TimeDuration)
+			},
+		},
+		"stringptr": {
+			flag: []string{"-stringptr=bar"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.String)
+				assert.Equal(t, "bar", *val.pointerStruct.String)
+			},
+		},
+		"boolptr": {
+			flag: []string{"-boolptr"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Bool)
+				assert.Equal(t, true, *val.pointerStruct.Bool)
+			},
+		},
+		"intptr": {
+			flag: []string{"-intptr", "64"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Int)
+				assert.Equal(t, 64, *val.pointerStruct.Int)
+			},
+		},
+		"int64ptr": {
+			flag: []string{"-int64ptr=-777777777"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Int64)
+				assert.Equal(t, int64(-777777777), *val.pointerStruct.Int64)
+			},
+		},
+		"uintptr": {
+			flag: []string{"-uintptr=128"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Uint)
+				assert.Equal(t, uint(128), *val.pointerStruct.Uint)
+			},
+		},
+		"uint64ptr": {
+			flag: []string{"-uint64ptr", "777777777"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Uint64)
+				assert.Equal(t, uint64(777777777), *val.pointerStruct.Uint64)
+			},
+		},
+		"float64ptr": {
+			flag: []string{"-float64ptr=91234567890.012345678"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Float64)
+				assert.Equal(t, 91234567890.012345678, *val.pointerStruct.Float64)
+			},
+		},
+		"structptr.string": {
+			flag: []string{"-structptr.string=structptrstring"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.Struct)
+				assert.Equal(t, "structptrstring", val.pointerStruct.Struct.String)
+			},
+		},
+		"stringsliceptr": {
+			flag: []string{"-stringsliceptr", "x,y,z"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.StringSlice)
+				assert.Equal(t, []string{"x", "y", "z"}, *val.pointerStruct.StringSlice)
+			},
+		},
+		"json.Numberptr": {
+			flag: []string{"-jsonnumberptr", "3.1415926535897932384626433832795028841971693"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.JSONNumber)
+				assert.Equal(t, json.Number("3.1415926535897932384626433832795028841971693"), *val.pointerStruct.JSONNumber)
+			},
+		},
+		"time.Durationptr": {
+			flag: []string{"-durationptr=3h14m25s15ms"},
+			assert: func(t *testing.T, val testStruct) {
+				require.NotNil(t, val.pointerStruct.TimeDuration)
+				assert.Equal(t,
+					3*time.Hour+
+						14*time.Minute+
+						25*time.Second+
+						15*time.Millisecond,
+					*val.pointerStruct.TimeDuration)
+			},
+		},
+	}
+
+	// cli args as they're seen from os.Args (with no parsing of flag/values)
+	args := make([]string, 0)
+	for _, a := range tests {
+		args = append(args, a.flag...)
+	}
+
+	var val testStruct
+	err := parseTagsForArgs(&val, args)
+	require.NoError(t, err)
+
+	for name, a := range tests {
+		t.Run(name, func(t *testing.T) {
+			a.assert(t, val)
+		})
+	}
+}
+
+func TestSkippedFields(t *testing.T) {
+	type test struct {
+		A string `json:"a" help:"foo"`
+		B string `help:"bar"`
+		C string `json:"-"`
+		D string `json:",omitempty"`
+	}
+
+	var val test
+	err := parseTagsForArgs(&val, []string{"-a=1", "-B", "2", "-D=4"})
+	require.NoError(t, err)
+	assert.Equal(t, "1", val.A)
+	assert.Equal(t, "2", val.B)
+	assert.Equal(t, "", val.C)
+	assert.Equal(t, "4", val.D)
+
+	val = test{}
+	err = parseTagsForArgs(&val, []string{"-C", "3"})
+	require.EqualError(t, err, "flag provided but not defined: -C")
+	assert.Equal(t, "", val.C)
+}
+
+func TestUndefinedFlag(t *testing.T) {
+	var val struct {
+		A bool `json:"a" help:"foo"`
+		B bool `help:"bar"`
+	}
+
+	err := parseTagsForArgs(&val, []string{"-b"})
+	assert.EqualError(t, err, "flag provided but not defined: -b")
+}
+
+func TestEmbeddedStruct(t *testing.T) {
+	type innerStruct struct {
+		C struct {
+			D struct {
+				E bool `json:"e" help:"foo"`
+			}
+		} `json:"c"`
+	}
+
+	var val struct {
+		A struct {
+			innerStruct // b
+		} `json:"a"`
+	}
+
+	err := parseTagsForArgs(&val, []string{"-a.c.D.e"})
+	require.NoError(t, err)
+
+	assert.True(t, val.A.C.D.E)
+}
+
+func TestInvalidTypeErrors(t *testing.T) {
+	var val struct {
+		A map[string]bool `json:"a"`
+	}
+
+	err := parseTagsForArgs(&val, []string{"-a=b"})
+	assert.EqualError(t, err, `unsupported type *map[string]bool to assign flag to struct field "a" - try a flag.Value implementing wrapper for the type (e.g: stringSliceValue)`)
+
+	err = parseTagsForArgs(1234, []string{""})
+	assert.EqualError(t, err, "expected val to be a struct, but was int")
+}
+
+func TestNilFlagSet(t *testing.T) {
+	var val struct{}
+	err := registerFlags(nil, &val, jsonStructNameTag)
+	assert.EqualError(t, err, "expected flag.FlagSet in RegisterFlags but got nil")
+}
+
+// parseTagsForArgs is a convenience function for testing without callers having to deal with their own FlagSets.
+func parseTagsForArgs(val interface{}, args []string) error {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	err := registerFlags(fs, val, jsonStructNameTag)
+	if err != nil {
+		return err
+	}
+	return fs.Parse(args)
+}
+
+func TestRemoveJSONTagOpts(t *testing.T) {
+	tests := []struct {
+		input      string
+		expected   string
+		shouldSkip bool
+	}{
+		{input: "foo", expected: "foo"},
+		{input: "foo,", expected: "foo"},
+		{input: "foo,omitempty", expected: "foo"},
+		{input: "foo,asdf", expected: "foo"},
+		{input: "-", expected: "", shouldSkip: true},
+		{input: "-,", expected: "-"},
+		{input: ",omitempty", expected: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			actual, skip := removeJSONTagOpts(test.input)
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.shouldSkip, skip)
+		})
+	}
+}

--- a/base/clistruct/flag_value_wrappers.go
+++ b/base/clistruct/flag_value_wrappers.go
@@ -1,0 +1,43 @@
+package clistruct
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// stringSliceValue implements flag.Value for []string
+type stringSliceValue []string
+
+func (v *stringSliceValue) Set(s string) error {
+	if v == nil {
+		return fmt.Errorf("nil stringSliceValue reciever")
+	}
+	*v = strings.Split(s, ",")
+	return nil
+}
+
+func (v *stringSliceValue) String() string {
+	if v == nil {
+		return ""
+	}
+	return strings.Join(*v, ",")
+}
+
+// jsonNumberFlagValue implements flag.Value for json.Number
+type jsonNumberFlagValue json.Number
+
+func (v *jsonNumberFlagValue) Set(s string) error {
+	if v == nil {
+		return fmt.Errorf("nil jsonNumberFlagValue reciever")
+	}
+	*v = jsonNumberFlagValue(s)
+	return nil
+}
+
+func (v *jsonNumberFlagValue) String() string {
+	if v == nil {
+		return ""
+	}
+	return (*json.Number)(v).String()
+}

--- a/base/clistruct/reflect.go
+++ b/base/clistruct/reflect.go
@@ -1,0 +1,23 @@
+package clistruct
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// reflectStructValue returns the reflect.Value of the given val struct, also dereferencing pointers.
+// Panics if the given val was nil or not a struct.
+func reflectStructValue(val interface{}) (refVal reflect.Value, err error) {
+	refVal = reflect.ValueOf(val)
+	if refVal.IsZero() {
+		return refVal, errors.New("can't get reflect.Value of nil")
+	}
+
+	derefVal := reflect.Indirect(refVal)
+	if derefVal.Kind() != reflect.Struct {
+		return refVal, fmt.Errorf("expected val to be a struct, but was %s", derefVal.Kind())
+	}
+
+	return derefVal, nil
+}


### PR DESCRIPTION
Mostly the same as the closed #4995 - but uses `json` struct tags instead of explicit `cli` flags.
Also handles a lot more types now (pointers, arbitrary structs, `[]string`) typically seen in config structs.

---

`json:"foo"` struct tag creates a flag called -foo.

Optionally specify help using `json:"foo" help:"foo is something"` to include a textual description of the flag.

Fields must be exported, in the same way that JSON requires. MustRegisterJSONFlags panics for structs that try to map invalid fiels or unknown types.

Supports nested structs, which dot-separates flags:
```go
    struct{
        A struct {
            B bool `json:"b"`
        } `json:"a"`
    }
```
results in a flag called `-a.b`

Embedded structs are also handled as expected:
```go
    struct {
        A bool `json:"a"`
        structB
    }
    type structB struct {
        B bool `cli:"b"`
    }
```
results in flags `-a` and `-b`