### PR TITLE
CBG-1435: Support multiple replication protocols

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -130,6 +130,13 @@ const (
 
 	// Replication filter constants
 	ByChannelFilter = "sync_gateway/bychannel"
+
+	// Blip Context SubProtocols
+
+	// blipCBMobileReplication is the AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore).
+	// At some point this will need to be able to support an array of protocols.  See go-blip/issues/27.
+	BlipCBMobileReplicationV2 = "CBMobile_2"
+	BlipCBMobileReplicationV3 = "CBMobile_3"
 )
 
 const (

--- a/base/constants.go
+++ b/base/constants.go
@@ -130,13 +130,6 @@ const (
 
 	// Replication filter constants
 	ByChannelFilter = "sync_gateway/bychannel"
-
-	// Blip Context SubProtocols
-
-	// blipCBMobileReplication is the AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore).
-	// At some point this will need to be able to support an array of protocols.  See go-blip/issues/27.
-	BlipCBMobileReplicationV2 = "CBMobile_2"
-	BlipCBMobileReplicationV3 = "CBMobile_3"
 )
 
 const (

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -266,8 +266,7 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 		config.Header.Add("Authorization", "Basic "+base64UserInfo(basicAuthCreds))
 	}
 
-	// Ideally we want to talk using V3 so this is supplied first and then V2.
-	return blipContext.DialConfig(config, base.BlipCBMobileReplicationV3, base.BlipCBMobileReplicationV2)
+	return blipContext.DialConfig(config)
 }
 
 // base64UserInfo returns the base64 encoded version of the given UserInfo.

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -185,7 +185,10 @@ func (ar *ActiveReplicator) GetStatus() *ReplicationStatus {
 func connect(arc *activeReplicatorCommon, idSuffix string) (blipSender *blip.Sender, bsc *BlipSyncContext, err error) {
 	arc.replicationStats.NumConnectAttempts.Add(1)
 
-	blipContext := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix)
+	blipContext, err := NewSGBlipContext(arc.ctx, arc.config.ID+idSuffix)
+	if err != nil {
+		return nil, nil, err
+	}
 	blipContext.WebsocketPingInterval = arc.config.WebsocketPingInterval
 	blipContext.OnExitCallback = func() {
 		// fall into a reconnect loop only if the connection is unexpectedly closed.

--- a/db/active_replicator.go
+++ b/db/active_replicator.go
@@ -266,14 +266,8 @@ func blipSync(target url.URL, blipContext *blip.Context, insecureSkipVerify bool
 		config.Header.Add("Authorization", "Basic "+base64UserInfo(basicAuthCreds))
 	}
 
-	// Ideally we want to talk using V3 so we should try this first. If the host only supports V2 we will receive a
-	// websocket.ErrorBadStatus
-	sender, err := blipContext.DialConfig(config, base.BlipCBMobileReplicationV3)
-	if !errors.Is(err, websocket.ErrBadStatus) {
-		return sender, err
-	}
-
-	return blipContext.DialConfig(config, base.BlipCBMobileReplicationV2)
+	// Ideally we want to talk using V3 so this is supplied first and then V2.
+	return blipContext.DialConfig(config, base.BlipCBMobileReplicationV3, base.BlipCBMobileReplicationV2)
 }
 
 // base64UserInfo returns the base64 encoded version of the given UserInfo.

--- a/db/active_replicator_test.go
+++ b/db/active_replicator_test.go
@@ -55,7 +55,10 @@ func TestBlipSyncErrorUserinfo(t *testing.T) {
 			srvURL.Path = "/db1"
 			t.Logf("srvURL: %v", srvURL.String())
 
-			_, err = blipSync(*srvURL, NewSGBlipContext(context.Background(), t.Name()), false)
+			blipContext, err := NewSGBlipContext(context.Background(), t.Name())
+			require.NoError(t, err)
+
+			_, err = blipSync(*srvURL, blipContext, false)
 			require.Error(t, err)
 			t.Logf("error: %v", err)
 			if targetPassword, hasPassword := srvURL.User.Password(); hasPassword {

--- a/db/blip.go
+++ b/db/blip.go
@@ -8,18 +8,12 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
-const (
-	// blipCBMobileReplication is the AppProtocolId part of the BLIP websocket subprotocol.  Must match identically with the peer (typically CBLite / LiteCore).
-	// At some point this will need to be able to support an array of protocols.  See go-blip/issues/27.
-	blipCBMobileReplication = "CBMobile_2"
-)
-
 // NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
 func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context) {
 	if id == "" {
-		bc = blip.NewContext(blipCBMobileReplication)
+		bc = blip.NewContext(base.BlipCBMobileReplicationV2, base.BlipCBMobileReplicationV3)
 	} else {
-		bc = blip.NewContextCustomID(id, blipCBMobileReplication)
+		bc = blip.NewContextCustomID(id, base.BlipCBMobileReplicationV2, base.BlipCBMobileReplicationV3)
 	}
 
 	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)

--- a/db/blip.go
+++ b/db/blip.go
@@ -16,21 +16,21 @@ const (
 )
 
 // NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
-func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context) {
+func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context, err error) {
 	// V3 is first here as it is the preferred communication method
 	// In the host case this means SGW can accept both V3 and V2 clients
 	// In the client case this means we prefer V3 but can fallback to V2
 	if id == "" {
-		bc = blip.NewContext(BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
+		bc, err = blip.NewContext(BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
 	} else {
-		bc = blip.NewContextCustomID(id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
+		bc, err = blip.NewContextCustomID(id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
 	}
 
 	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)
 	bc.LogFrames = base.LogDebugEnabled(base.KeyWebSocketFrame)
 	bc.Logger = defaultBlipLogger(ctx)
 
-	return bc
+	return bc, err
 }
 
 // defaultBlipLogger returns a function that can be set as the blip.Context.Logger for Sync Gateway integrated go-blip logging.

--- a/db/blip.go
+++ b/db/blip.go
@@ -8,15 +8,22 @@ import (
 	"github.com/couchbase/sync_gateway/base"
 )
 
+const (
+	// BlipCBMobileReplicationV2 / BlipCBMobileReplicationV3 is the AppProtocolId part of the BLIP websocket
+	// sub protocol.  One must match identically with one provided by the peer (CBLite / ISGR)
+	BlipCBMobileReplicationV2 = "CBMobile_2"
+	BlipCBMobileReplicationV3 = "CBMobile_3"
+)
+
 // NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
 func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context) {
 	// V3 is first here as it is the preferred communication method
 	// In the host case this means SGW can accept both V3 and V2 clients
 	// In the client case this means we prefer V3 but can fallback to V2
 	if id == "" {
-		bc = blip.NewContext(base.BlipCBMobileReplicationV3, base.BlipCBMobileReplicationV2)
+		bc = blip.NewContext(BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
 	} else {
-		bc = blip.NewContextCustomID(id, base.BlipCBMobileReplicationV3, base.BlipCBMobileReplicationV2)
+		bc = blip.NewContextCustomID(id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
 	}
 
 	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)

--- a/db/blip.go
+++ b/db/blip.go
@@ -10,10 +10,13 @@ import (
 
 // NewSGBlipContext returns a go-blip context with the given ID, initialized for use in Sync Gateway.
 func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context) {
+	// V3 is first here as it is the preferred communication method
+	// In the host case this means SGW can accept both V3 and V2 clients
+	// In the client case this means we prefer V3 but can fallback to V2
 	if id == "" {
-		bc = blip.NewContext(base.BlipCBMobileReplicationV2, base.BlipCBMobileReplicationV3)
+		bc = blip.NewContext(base.BlipCBMobileReplicationV3, base.BlipCBMobileReplicationV2)
 	} else {
-		bc = blip.NewContextCustomID(id, base.BlipCBMobileReplicationV2, base.BlipCBMobileReplicationV3)
+		bc = blip.NewContextCustomID(id, base.BlipCBMobileReplicationV3, base.BlipCBMobileReplicationV2)
 	}
 
 	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -354,7 +354,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string) []interface{} {
 	var changeRow []interface{}
 
-	if bh.db.DatabaseContext.Options.UnsupportedOptions.ForceBLIPV3 {
+	if bh.blipContext.ActiveProtocol() == base.BlipCBMobileReplicationV3 {
 		deletedFlags := changesDeletedFlag(0)
 		if change.Deleted {
 			deletedFlags |= changesDeletedFlagDeleted

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -354,7 +354,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string) []interface{} {
 	var changeRow []interface{}
 
-	if bh.blipContext.ActiveProtocol() == base.BlipCBMobileReplicationV3 {
+	if bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
 		deletedFlags := changesDeletedFlag(0)
 		if change.Deleted {
 			deletedFlags |= changesDeletedFlagDeleted

--- a/db/database.go
+++ b/db/database.go
@@ -179,7 +179,6 @@ type UnsupportedOptions struct {
 	OidcTlsSkipVerify         bool                    `json:"oidc_tls_skip_verify"`                  // Config option to enable self-signed certs for OIDC testing.
 	SgrTlsSkipVerify          bool                    `json:"sgr_tls_skip_verify"`                   // Config option to enable self-signed certs for SG-Replicate testing.
 	RemoteConfigTlsSkipVerify bool                    `json:"remote_config_tls_skip_verify"`         // Config option to enable self signed certificates for external JavaScript load.
-	ForceBLIPV3               bool                    `json:"force_blip_v3"`
 }
 
 type WarningThresholds struct {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,7 +98,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="07da08e1956142b60fbcbd81e163d6053bf68ff5"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="f139f7b59f4d395f205e4b0e1751a57d22fba2db"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,7 +98,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="f139f7b59f4d395f205e4b0e1751a57d22fba2db"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="c7a31b94e131857295ffecdb07540a4084dba7ee"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,7 +98,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="47c39c0328dad04ddac26b85d6bdb7e71820320b"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="06140164d5a3204b60a19a865d7c18d9a6f746a6"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,7 +98,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="c7a31b94e131857295ffecdb07540a4084dba7ee"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="b921783f4b3ef90bcc37d1ba8967d522156fdbe4"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,7 +98,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="5ca0fd356a2a5965f831173141928fcfd8cd2499"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="47c39c0328dad04ddac26b85d6bdb7e71820320b"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -98,7 +98,7 @@
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="06140164d5a3204b60a19a865d7c18d9a6f746a6"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="07da08e1956142b60fbcbd81e163d6053bf68ff5"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6387,7 +6387,6 @@ func initScenario(t *testing.T) (ChannelRevocationTester, *RestTester) {
 					channel(doc.channels);
 				}
 			}`,
-		DatabaseConfig: &DbConfig{Unsupported: db.UnsupportedOptions{ForceBLIPV3: true}},
 	})
 
 	revocationTester := ChannelRevocationTester{

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -29,7 +29,10 @@ func (h *handler) handleBLIPSync() error {
 	}
 
 	// Create a BLIP context:
-	blipContext := db.NewSGBlipContext(h.db.Ctx, "")
+	blipContext, err := db.NewSGBlipContext(h.db.Ctx, "")
+	if err != nil {
+		return err
+	}
 
 	// Overwrite the existing logging context with the blip context ID
 	h.db.Ctx = context.WithValue(h.db.Ctx, base.LogContextKey{},

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -828,7 +828,10 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	u.Scheme = "ws"
 
 	// Make BLIP/Websocket connection
-	bt.blipContext = db.NewSGBlipContext(context.Background(), "")
+	bt.blipContext, err = db.NewSGBlipContext(context.Background(), "")
+	if err != nil {
+		return nil, err
+	}
 
 	origin := "http://localhost" // TODO: what should be used here?
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -843,7 +843,7 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 		}
 	}
 
-	bt.sender, err = bt.blipContext.DialConfig(config, base.BlipCBMobileReplicationV3)
+	bt.sender, err = bt.blipContext.DialConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -843,7 +843,7 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 		}
 	}
 
-	bt.sender, err = bt.blipContext.DialConfig(config)
+	bt.sender, err = bt.blipContext.DialConfig(config, base.BlipCBMobileReplicationV3)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Bring over go-blip changes to allow for multiple protocols.

Included removing the temporary ForceBLIPV3 config option as this functionality is now handled by the set active protocol. 

 - [x] https://github.com/couchbase/go-blip/pull/48
 
 Note: This will require QE testing to ensure that this continues to work with both V2 CBL clients and Pre-3.0 ISGR implementations.