### PR TITLE
CBG-1387 / CBG-1411: Channel Access Revocation for ISGR

### DIFF
--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -75,9 +75,6 @@ type ActiveReplicatorConfig struct {
 	// Delta sync enabled
 	DeltasEnabled bool
 
-	// Enables the auto purge behaviour which defines whether revoked documents should be purged
-	EnableAutoPurge bool
-
 	// InsecureSkipVerify determines whether the TLS certificate verification should be
 	// disabled during replication. TLS certificate verification is enabled by default.
 	InsecureSkipVerify bool
@@ -170,10 +167,6 @@ func (arc *ActiveReplicatorConfig) Equals(other *ActiveReplicatorConfig) bool {
 	}
 
 	if arc.Continuous != other.Continuous {
-		return false
-	}
-
-	if arc.EnableAutoPurge != other.EnableAutoPurge {
 		return false
 	}
 

--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -79,7 +79,7 @@ func (apr *ActivePullReplicator) _connect() error {
 		DocIDs:         apr.config.DocIDs,
 		ActiveOnly:     apr.config.ActiveOnly,
 		clientType:     clientTypeSGR2,
-		Revocations:    apr.config.EnableAutoPurge,
+		Revocations:    apr.config.PurgeOnRemoval,
 	}
 
 	if err := subChangesRequest.Send(apr.blipSender); err != nil {

--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -111,7 +111,7 @@ func (apr *ActivePushReplicator) _connect() error {
 			continuous:        apr.config.Continuous,
 			activeOnly:        apr.config.ActiveOnly,
 			batchSize:         int(apr.config.ChangesBatchSize),
-			revocations:       apr.config.EnableAutoPurge,
+			revocations:       apr.config.PurgeOnRemoval,
 			channels:          channels,
 			clientType:        clientTypeSGR2,
 			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -495,20 +495,19 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 			output.Write([]byte(","))
 		}
 
-		// TODO: Change type when CBG-1426 is in
-		deletedFlags := int64(0)
+		deletedFlags := changesDeletedFlag(0)
 		// TODO: Add check for Blip Protocol Version when CBG-1435 is in
 		if len(change) > 3 {
 			var err error
-			deletedFlags, err = change[3].(json.Number).Int64()
+			deletedIntFlag, err := change[3].(json.Number).Int64()
 			if err != nil {
 				base.InfofCtx(bh.loggingCtx, base.KeyAll, "Failed to parse deletedFlags: %v", err)
 				continue
 			}
+			deletedFlags = changesDeletedFlag(deletedIntFlag)
 		}
 
-		// TODO: Change numbers when CBG-1426 is in
-		if missing == nil && deletedFlags&2 != 0 && deletedFlags&4 != 0 {
+		if missing == nil && deletedFlags&changesDeletedFlagRevoked != 0 && deletedFlags&deletedFlags&changesDeletedFlagRemoved != 0 {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -497,11 +497,11 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 		deletedFlags := changesDeletedFlag(0)
 		if len(change) > 3 {
-			switch v := change[3].(type){
+			switch v := change[3].(type) {
 			case json.Number:
 				deletedIntFlag, err := change[3].(json.Number).Int64()
 				if err != nil {
-					base.ErrorfCtx(bh.loggingCtx,  "Failed to parse deletedFlags: %v", err)
+					base.ErrorfCtx(bh.loggingCtx, "Failed to parse deletedFlags: %v", err)
 					continue
 				}
 				deletedFlags = changesDeletedFlag(deletedIntFlag)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -514,7 +514,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 		}
 
-		if missing == nil && deletedFlags&changesDeletedFlagRevoked|changesDeletedFlagRemoved == 0 {
+		if missing == nil && deletedFlags&(changesDeletedFlagRevoked|changesDeletedFlagRemoved) == 0 {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -499,7 +499,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		if len(change) > 3 {
 			switch v := change[3].(type) {
 			case json.Number:
-				deletedIntFlag, err := change[3].(json.Number).Int64()
+				deletedIntFlag, err := v.Int64()
 				if err != nil {
 					base.ErrorfCtx(bh.loggingCtx, "Failed to parse deletedFlags: %v", err)
 					continue
@@ -514,7 +514,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 		}
 
-		if missing == nil && deletedFlags&changesDeletedFlagRevoked == 0 && deletedFlags&deletedFlags&changesDeletedFlagRemoved == 0 {
+		if missing == nil && deletedFlags&changesDeletedFlagRevoked|changesDeletedFlagRemoved == 0 {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -494,7 +494,21 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 		if nWritten > 0 {
 			output.Write([]byte(","))
 		}
-		if missing == nil {
+
+		// TODO: Change type when CBG-1426 is in
+		deletedFlags := int64(0)
+		// TODO: Add check for Blip Protocol Version when CBG-1435 is in
+		if len(change) > 3 {
+			var err error
+			deletedFlags, err = change[3].(json.Number).Int64()
+			if err != nil {
+				base.InfofCtx(bh.loggingCtx, base.KeyAll, "Failed to parse deletedFlags: %v", err)
+				continue
+			}
+		}
+
+		// TODO: Change numbers when CBG-1426 is in
+		if missing == nil && deletedFlags&2 != 0 && deletedFlags&4 != 0 {
 			// already have this rev, tell the peer to skip sending it
 			output.Write([]byte("0"))
 			if bh.sgr2PullAlreadyKnownSeqsCallback != nil {

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -97,7 +97,6 @@ type ReplicationConfig struct {
 	Cancel                 bool                      `json:"cancel,omitempty"`
 	Adhoc                  bool                      `json:"adhoc,omitempty"`
 	BatchSize              int                       `json:"batch_size,omitempty"`
-	EnableAutoPurge        bool                      `json:"enable_auto_purge,omitempty"`
 }
 
 func DefaultReplicationConfig() ReplicationConfig {
@@ -110,7 +109,6 @@ func DefaultReplicationConfig() ReplicationConfig {
 		Continuous:             false,
 		Adhoc:                  false,
 		BatchSize:              defaultChangesBatchSize,
-		EnableAutoPurge:        false,
 	}
 }
 
@@ -141,7 +139,6 @@ type ReplicationUpsertConfig struct {
 	Cancel                 *bool       `json:"cancel,omitempty"`
 	Adhoc                  *bool       `json:"adhoc,omitempty"`
 	BatchSize              *int        `json:"batch_size,omitempty"`
-	EnableAutoPurge        *bool       `json:"enable_auto_purge,omitempty"`
 	SGR1CheckpointID       *string     `json:"sgr1_checkpoint_id,omitempty"`
 }
 
@@ -288,10 +285,6 @@ func (rc *ReplicationConfig) Upsert(c *ReplicationUpsertConfig) {
 
 	if c.BatchSize != nil {
 		rc.BatchSize = *c.BatchSize
-	}
-
-	if c.EnableAutoPurge != nil {
-		rc.EnableAutoPurge = *c.EnableAutoPurge
 	}
 
 	if c.QueryParams != nil {
@@ -485,7 +478,6 @@ func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (
 		InsecureSkipVerify: m.dbContext.Options.UnsupportedOptions.SgrTlsSkipVerify,
 		SGR1CheckpointID:   config.SGR1CheckpointID,
 		CheckpointInterval: m.CheckpointInterval,
-		EnableAutoPurge:    config.EnableAutoPurge,
 	}
 
 	rc.MaxReconnectInterval = defaultMaxReconnectInterval

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4904,7 +4904,7 @@ func TestReplicatorRevocations(t *testing.T) {
 	resp := rt2.SendAdminRequest("PUT", "/db/doc1", `{"channels": "chanA"}`)
 	assertStatus(t, resp, http.StatusCreated)
 
-	srv := httptest.NewTLSServer(rt2.TestPublicHandler())
+	srv := httptest.NewServer(rt2.TestPublicHandler())
 	defer srv.Close()
 
 	passiveDBURL, err := url.Parse(srv.URL + "/db")
@@ -4920,7 +4920,6 @@ func TestReplicatorRevocations(t *testing.T) {
 			DatabaseContext: rt1.GetDatabase(),
 		},
 		Continuous:          false,
-		InsecureSkipVerify:  true,
 		PurgeOnRemoval:      true,
 		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
 	})

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4883,6 +4883,64 @@ func TestReplicatorConflictAttachment(t *testing.T) {
 	}
 }
 
+func TestReplicatorRevocations(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	// Passive
+	revocationTester, rt2 := initScenario(t)
+	defer rt2.Close()
+
+	// Active
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: base.GetTestBucket(t),
+	})
+	defer rt1.Close()
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "chanA")
+
+	resp := rt2.SendAdminRequest("PUT", "/db/doc1", `{"channels": "chanA"}`)
+	assertStatus(t, resp, http.StatusCreated)
+
+	srv := httptest.NewTLSServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	passiveDBURL.User = url.UserPassword("user", "test")
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous:          false,
+		InsecureSkipVerify:  true,
+		PurgeOnRemoval:      true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+	})
+
+	require.NoError(t, ar.Start())
+	rt1.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	revocationTester.removeRole("user", "foo")
+
+	require.NoError(t, ar.Start())
+	rt1.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	assertStatus(t, resp, http.StatusNotFound)
+
+}
+
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {
 	attachments := db.GetBodyAttachments(doc)
 	if attachments == nil {


### PR DESCRIPTION
- Removed enable_auto_purge config option and use the existing purge on removal option
- Utilize changes response

Tested with small unit test

Currently doesn't cover no rev case. Will follow up in a different PR with this - CBG-1477