### PR TITLE
CBG-1462: Fix admin roles / channels revocations

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -379,7 +379,7 @@ func TestRebuildUserRoles(t *testing.T) {
 	computer := mockComputer{roles: ch.AtSequence(base.SetOf("role1", "role2"), 3)}
 	auth := NewAuthenticator(bucket, &computer)
 	user, _ := auth.NewUser("testUser", "letmein", nil)
-	user.SetExplicitRoles(ch.TimedSet{"role3": ch.NewVbSimpleSequence(1), "role1": ch.NewVbSimpleSequence(1)})
+	user.SetExplicitRoles(ch.TimedSet{"role3": ch.NewVbSimpleSequence(1), "role1": ch.NewVbSimpleSequence(1)}, 1)
 	err := auth.Save(user)
 	assert.Equal(t, nil, err)
 
@@ -500,7 +500,7 @@ func TestConcurrentUserWrites(t *testing.T) {
 	// Create user
 	auth := NewAuthenticator(bucket, nil)
 	user, _ := auth.NewUser(username, password, ch.SetOf(t, "123", "456"))
-	user.SetExplicitRoles(ch.TimedSet{"role1": ch.NewVbSimpleSequence(1), "role2": ch.NewVbSimpleSequence(1)})
+	user.SetExplicitRoles(ch.TimedSet{"role1": ch.NewVbSimpleSequence(1), "role2": ch.NewVbSimpleSequence(1)}, 1)
 	createErr := auth.Save(user)
 	if createErr != nil {
 		t.Errorf("Error creating user: %v", createErr)

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -31,7 +31,7 @@ type Principal interface {
 	ExplicitChannels() ch.TimedSet
 
 	// Sets the explicit channels the Principal has access to.
-	SetExplicitChannels(ch.TimedSet)
+	SetExplicitChannels(ch.TimedSet, uint64)
 
 	GetChannelInvalSeq() uint64
 
@@ -110,7 +110,7 @@ type User interface {
 	ExplicitRoles() ch.TimedSet
 
 	// Sets the explicit roles the user belongs to.
-	SetExplicitRoles(ch.TimedSet)
+	SetExplicitRoles(ch.TimedSet, uint64)
 
 	GetRoleInvalSeq() uint64
 

--- a/auth/role.go
+++ b/auth/role.go
@@ -173,9 +173,9 @@ func (role *roleImpl) ExplicitChannels() ch.TimedSet {
 	return role.ExplicitChannels_
 }
 
-func (role *roleImpl) SetExplicitChannels(channels ch.TimedSet) {
+func (role *roleImpl) SetExplicitChannels(channels ch.TimedSet, invalSeq uint64) {
 	role.ExplicitChannels_ = channels
-	role.setChannels(nil)
+	role.SetChannelInvalSeq(invalSeq)
 }
 
 func (role *roleImpl) GetChannelInvalSeq() uint64 {

--- a/auth/user.go
+++ b/auth/user.go
@@ -161,9 +161,9 @@ func (user *userImpl) ExplicitRoles() ch.TimedSet {
 	return user.ExplicitRoles_
 }
 
-func (user *userImpl) SetExplicitRoles(roles ch.TimedSet) {
+func (user *userImpl) SetExplicitRoles(roles ch.TimedSet, invalSeq uint64) {
 	user.ExplicitRoles_ = roles
-	user.setRolesSince(nil) // invalidate persistent cache of role names
+	user.SetRoleInvalSeq(invalSeq)
 }
 
 func (user *userImpl) GetRoleInvalSeq() uint64 {

--- a/db/changes.go
+++ b/db/changes.go
@@ -751,7 +751,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 				feeds = db.appendUserFeed(feeds, options)
 			}
 
-			if options.Revocations {
+			if options.Revocations && db.user != nil {
 				channelsToRevoke := db.user.RevokedChannels(options.Since.SafeSequence())
 				for channel, triggeredBy := range channelsToRevoke {
 					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, triggeredBy, to)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -279,7 +279,7 @@ func TestGetDeleted(t *testing.T) {
 	authenticator := auth.NewAuthenticator(db.Bucket, db)
 	db.user, err = authenticator.GetUser("")
 	assert.NoError(t, err, "GetUser")
-	db.user.SetExplicitChannels(nil)
+	db.user.SetExplicitChannels(nil, 1)
 
 	body, err = db.Get1xRevBody("doc1", rev2id, true, nil)
 	assert.NoError(t, err, "Get1xRevBody")
@@ -347,7 +347,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 
 	var chans channels.TimedSet
 	chans = channels.AtSequence(base.SetOf("ABC"), 1)
-	db.user.SetExplicitChannels(chans)
+	db.user.SetExplicitChannels(chans, 1)
 
 	// Get the removal revision with its history; equivalent to GET with ?revs=true
 	body, err = db.Get1xRevBody("doc1", rev2id, true, nil)
@@ -1388,7 +1388,7 @@ func TestAccessFunctionDb(t *testing.T) {
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc){access(doc.users,doc.userChannels);}`)
 
 	user, _ := authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "Netflix"))
-	user.SetExplicitRoles(channels.TimedSet{"animefan": channels.NewVbSimpleSequence(1), "tumblr": channels.NewVbSimpleSequence(1)})
+	user.SetExplicitRoles(channels.TimedSet{"animefan": channels.NewVbSimpleSequence(1), "tumblr": channels.NewVbSimpleSequence(1)}, 1)
 	assert.NoError(t, authenticator.Save(user), "Save")
 
 	body := Body{"users": []string{"naomi"}, "userChannels": []string{"Hulu"}}

--- a/db/users.go
+++ b/db/users.go
@@ -205,12 +205,12 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 
 		// Now update the Principal object from the properties in the request, first the channels:
 		if updatedChannels.UpdateAtSequence(newInfo.ExplicitChannels, nextSeq) {
-			princ.SetExplicitChannels(updatedChannels)
+			princ.SetExplicitChannels(updatedChannels, nextSeq)
 		}
 
 		if isUser {
 			if updatedRoles.UpdateAtSequence(base.SetFromArray(newInfo.ExplicitRoleNames), nextSeq) {
-				user.SetExplicitRoles(updatedRoles)
+				user.SetExplicitRoles(updatedRoles, nextSeq)
 			}
 		}
 		err = authenticator.Save(princ)

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -235,7 +235,7 @@ func (rt *RestTester) SetAdminParty(partyTime bool) {
 	if partyTime {
 		chans = channels.AtSequence(base.SetOf(channels.UserStarChannel), 1)
 	}
-	guest.SetExplicitChannels(chans)
+	guest.SetExplicitChannels(chans, 1)
 	_ = a.Save(guest)
 }
 


### PR DESCRIPTION
- Fixed role / channel invalidation for admin channels / roles
- Also fixed a panic on user being nil (admin repl) in changes