### PR TITLE
CBG-1465: Fix BLIP revocation message for omit revID

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -315,7 +315,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 				// In the event we were unable to determine what the rev ID was at the time of revocation we have to
 				// send a revocation changes message but without a revID present. This will result in change.Changes
 				// being empty so we need to have this special case.
-				if len(change.Changes) == 0 && change.Revoked == true{
+				if len(change.Changes) == 0 && change.Revoked == true {
 					changeRow := bh.buildChangesRow(change, "")
 					pendingChanges = append(pendingChanges, changeRow)
 					if err := sendPendingChangesAt(opts.batchSize); err != nil {
@@ -351,7 +351,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 	return !forceClose
 }
 
-func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string)[]interface{}{
+func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string) []interface{} {
 	var changeRow []interface{}
 
 	if bh.db.DatabaseContext.Options.UnsupportedOptions.ForceBLIPV3 {

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -362,6 +362,11 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 		response.SetBody(attachment)
 	}
 
+	btr.bt.blipContext.HandlerForProfile[db.MessageNoRev] = func(msg *blip.Message) {
+		// TODO: Support norev messages
+		btr.storeMessage(msg)
+	}
+
 	btr.bt.blipContext.DefaultHandler = func(msg *blip.Message) {
 		btr.storeMessage(msg)
 		base.Panicf("Unknown profile: %s caught by client DefaultHandler - msg: %#v", msg.Profile(), msg)


### PR DESCRIPTION
In the REST case revocation messages with no changes were being handled fine but weren't on the BLIP side due to the iteration over changes. This handles that case.