### PR TITLE
CBG-1262 Add xattr support for gocb v2

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -21,11 +21,12 @@ import (
 	"time"
 
 	"github.com/couchbase/go-couchbase"
+	"github.com/couchbase/gocbcore/memd"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
-	"gopkg.in/couchbase/gocb.v1"
+	gocbV1 "gopkg.in/couchbase/gocb.v1"
 	"gopkg.in/couchbaselabs/gocbconnstr.v1"
 )
 
@@ -341,7 +342,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		}
 
 		if err != nil {
-			if pkgerrors.Cause(err) == gocb.ErrAuthError {
+			if pkgerrors.Cause(err) == gocbV1.ErrAuthError {
 				Warnf("Unable to authenticate as user %q: %v", UD(username), err)
 				return nil, ErrFatalBucketConnection
 			}
@@ -393,7 +394,12 @@ func IsCasMismatch(err error) bool {
 	unwrappedErr := pkgerrors.Cause(err)
 
 	// GoCB handling
-	if unwrappedErr == gocb.ErrKeyExists {
+	if unwrappedErr == gocbV1.ErrKeyExists {
+		return true
+	}
+
+	// GoCB V2 handling
+	if isKVError(unwrappedErr, memd.StatusKeyExists) {
 		return true
 	}
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -11,6 +11,7 @@ package base
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -444,59 +445,58 @@ func TestXattrWriteCasSimple(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		valBytes, marshalErr := JSONMarshal(val)
+		assert.NoError(t, marshalErr, "Error marshalling document body")
 
-	valBytes, marshalErr := JSONMarshal(val)
-	assert.NoError(t, marshalErr, "Error marshalling document body")
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(123)
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(123)
-	xattrVal["rev"] = "1-1234"
+		var existsVal map[string]interface{}
+		_, err := bucket.Get(key, existsVal)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			err = bucket.DeleteWithXattr(key, xattrName)
+		}
 
-	var existsVal map[string]interface{}
-	_, err := bucket.Get(key, existsVal)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		err = bucket.DeleteWithXattr(key, xattrName)
-	}
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		assert.NoError(t, err, "WriteCasWithXattr error")
+		log.Printf("Post-write, cas is %d", cas)
 
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	assert.NoError(t, err, "WriteCasWithXattr error")
-	log.Printf("Post-write, cas is %d", cas)
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
 
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		macroCasString, ok := retrievedXattr[xattrMacroCas].(string)
+		assert.True(t, ok, "Unable to retrieve xattrMacroCas as string")
+		goassert.Equals(t, HexCasToUint64(macroCasString), cas)
+		macroBodyHashString, ok := retrievedXattr[xattrMacroValueCrc32c].(string)
+		assert.True(t, ok, "Unable to retrieve xattrMacroValueCrc32c as string")
+		goassert.Equals(t, macroBodyHashString, Crc32cHashString(valBytes))
 
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
-	macroCasString, ok := retrievedXattr[xattrMacroCas].(string)
-	assert.True(t, ok, "Unable to retrieve xattrMacroCas as string")
-	goassert.Equals(t, HexCasToUint64(macroCasString), cas)
-	macroBodyHashString, ok := retrievedXattr[xattrMacroValueCrc32c].(string)
-	assert.True(t, ok, "Unable to retrieve xattrMacroValueCrc32c as string")
-	goassert.Equals(t, macroBodyHashString, Crc32cHashString(valBytes))
+		// Validate against $document.value_crc32c
+		var retrievedVxattr map[string]interface{}
+		_, err = bucket.GetWithXattr(key, "$document", "", retrievedVal, &retrievedVxattr, nil)
+		vxattrCrc32c, ok := retrievedVxattr["value_crc32c"].(string)
+		assert.True(t, ok, "Unable to retrieve virtual xattr crc32c as string")
 
-	// Validate against $document.value_crc32c
-	var retrievedVxattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, "$document", "", retrievedVal, &retrievedVxattr, nil)
-	vxattrCrc32c, ok := retrievedVxattr["value_crc32c"].(string)
-	assert.True(t, ok, "Unable to retrieve virtual xattr crc32c as string")
-
-	goassert.Equals(t, vxattrCrc32c, Crc32cHashString(valBytes))
-	goassert.Equals(t, vxattrCrc32c, macroBodyHashString)
+		goassert.Equals(t, vxattrCrc32c, Crc32cHashString(valBytes))
+		goassert.Equals(t, vxattrCrc32c, macroBodyHashString)
+	})
 
 }
 
@@ -505,70 +505,63 @@ func TestXattrWriteCasUpsert(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
-	bucket.SetTranscoder(SGTranscoder{})
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(123)
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(123)
-	xattrVal["rev"] = "1-1234"
+		var existsVal map[string]interface{}
+		_, err := bucket.Get(key, existsVal)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			err = bucket.DeleteWithXattr(key, xattrName)
+		}
 
-	var existsVal map[string]interface{}
-	_, err := bucket.Get(key, existsVal)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		err = bucket.DeleteWithXattr(key, xattrName)
-	}
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		assert.NoError(t, err, "WriteCasWithXattr error")
+		log.Printf("Post-write, cas is %d", cas)
 
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	assert.NoError(t, err, "WriteCasWithXattr error")
-	log.Printf("Post-write, cas is %d", cas)
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		// TODO: Cas check fails, pending xattr code to make it to gocb master
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
 
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	// TODO: Cas check fails, pending xattr code to make it to gocb master
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		val2 := make(map[string]interface{})
+		val2["body_field"] = "5678"
+		xattrVal2 := make(map[string]interface{})
+		xattrVal2["seq"] = float64(124)
+		xattrVal2["rev"] = "2-5678"
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, getCas, val2, xattrVal2)
+		assert.NoError(t, err, "WriteCasWithXattr error")
+		log.Printf("Post-write, cas is %d", cas)
 
-	val2 := make(map[string]interface{})
-	val2["body_field"] = "5678"
-	xattrVal2 := make(map[string]interface{})
-	xattrVal2["seq"] = float64(124)
-	xattrVal2["rev"] = "2-5678"
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, getCas, val2, xattrVal2)
-	assert.NoError(t, err, "WriteCasWithXattr error")
-	log.Printf("Post-write, cas is %d", cas)
-
-	var retrievedVal2 map[string]interface{}
-	var retrievedXattr2 map[string]interface{}
-	getCas, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal2, &retrievedXattr2, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal2, retrievedXattr2)
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal2["body_field"], val2["body_field"])
-	goassert.Equals(t, retrievedXattr2["seq"], xattrVal2["seq"])
-	goassert.Equals(t, retrievedXattr2["rev"], xattrVal2["rev"])
+		var retrievedVal2 map[string]interface{}
+		var retrievedXattr2 map[string]interface{}
+		getCas, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal2, &retrievedXattr2, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal2, retrievedXattr2)
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal2["body_field"], val2["body_field"])
+		goassert.Equals(t, retrievedXattr2["seq"], xattrVal2["seq"])
+		goassert.Equals(t, retrievedXattr2["rev"], xattrVal2["rev"])
+	})
 
 }
 
@@ -577,65 +570,65 @@ func TestXattrWriteCasWithXattrCasCheck(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["sg_field"] = "sg_value"
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["sg_field"] = "sg_value"
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(123)
-	xattrVal["rev"] = "1-1234"
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(123)
+		xattrVal["rev"] = "1-1234"
 
-	var existsVal map[string]interface{}
-	_, err := bucket.Get(key, existsVal)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		err = bucket.DeleteWithXattr(key, xattrName)
-	}
+		var existsVal map[string]interface{}
+		_, err := bucket.Get(key, existsVal)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			err = bucket.DeleteWithXattr(key, xattrName)
+		}
 
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	assert.NoError(t, err, "WriteCasWithXattr error")
-	log.Printf("Post-write, cas is %d", cas)
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		assert.NoError(t, err, "WriteCasWithXattr error")
+		log.Printf("Post-write, cas is %d", cas)
 
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, "")
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal["sg_field"], val["sg_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, "")
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal["sg_field"], val["sg_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
 
-	// Simulate an SDK update
-	updatedVal := make(map[string]interface{})
-	updatedVal["sdk_field"] = "abc"
-	require.NoError(t, bucket.Set(key, 0, updatedVal))
+		// Simulate an SDK update
+		updatedVal := make(map[string]interface{})
+		updatedVal["sdk_field"] = "abc"
+		require.NoError(t, bucket.Set(key, 0, updatedVal))
 
-	// Attempt to update with the previous CAS
-	val["sg_field"] = "sg_value_mod"
-	xattrVal["rev"] = "2-1234"
-	_, err = bucket.WriteCasWithXattr(key, xattrName, 0, getCas, val, xattrVal)
-	goassert.Equals(t, pkgerrors.Cause(err), gocb.ErrKeyExists)
+		// Attempt to update with the previous CAS
+		val["sg_field"] = "sg_value_mod"
+		xattrVal["rev"] = "2-1234"
+		_, err = bucket.WriteCasWithXattr(key, xattrName, 0, getCas, val, xattrVal)
+		assert.True(t, IsCasMismatch(err))
 
-	// Retrieve again, ensure we get the SDK value, SG xattr
-	retrievedVal = nil
-	retrievedXattr = nil
-	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, retrievedVal["sg_field"], nil)
-	goassert.Equals(t, retrievedVal["sdk_field"], updatedVal["sdk_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], "1-1234")
+		// Retrieve again, ensure we get the SDK value, SG xattr
+		retrievedVal = nil
+		retrievedXattr = nil
+		_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, retrievedVal["sg_field"], nil)
+		goassert.Equals(t, retrievedVal["sdk_field"], updatedVal["sdk_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], "1-1234")
+	})
 
 }
 
@@ -644,52 +637,49 @@ func TestXattrWriteCasRaw(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
-	bucket.SetTranscoder(SGTranscoder{})
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
+		valRaw, _ := JSONMarshal(val)
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
-	valRaw, _ := JSONMarshal(val)
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(123)
+		xattrVal["rev"] = "1-1234"
+		xattrValRaw, _ := JSONMarshal(xattrVal)
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(123)
-	xattrVal["rev"] = "1-1234"
-	xattrValRaw, _ := JSONMarshal(xattrVal)
+		var existsVal map[string]interface{}
+		_, err := bucket.Get(key, existsVal)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			err = bucket.DeleteWithXattr(key, xattrName)
+		}
 
-	var existsVal map[string]interface{}
-	_, err := bucket.Get(key, existsVal)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		err = bucket.DeleteWithXattr(key, xattrName)
-	}
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, valRaw, xattrValRaw)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, valRaw, xattrValRaw)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		var retrievedValByte []byte
+		var retrievedXattrByte []byte
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedValByte, &retrievedXattrByte, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
 
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	// TODO: Fails until https://issues.couchbase.com/browse/GOCBC-183 is available
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		_ = json.Unmarshal(retrievedValByte, &retrievedVal)
+		_ = json.Unmarshal(retrievedXattrByte, &retrievedXattr)
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+	})
 }
 
 // TestWriteCasTombstoneResurrect.  Verifies writing a new document body and xattr to a logically deleted document (xattr still exists)
@@ -697,80 +687,73 @@ func TestXattrWriteCasTombstoneResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
-	bucket.SetTranscoder(SGTranscoder{})
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(123)
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(123)
-	xattrVal["rev"] = "1-1234"
+		var existsVal map[string]interface{}
+		_, err := bucket.Get(key, existsVal)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			err = bucket.DeleteWithXattr(key, xattrName)
+		}
 
-	var existsVal map[string]interface{}
-	_, err := bucket.Get(key, existsVal)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		err = bucket.DeleteWithXattr(key, xattrName)
-	}
+		// Write document with xattr
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+		log.Printf("Post-write, cas is %d", cas)
 
-	// Write document with xattr
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-	log.Printf("Post-write, cas is %d", cas)
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		// TODO: Cas check fails, pending xattr code to make it to gocb master
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
 
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	// TODO: Cas check fails, pending xattr code to make it to gocb master
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		// Delete the body (retains xattr)
+		err = bucket.Delete(key)
+		if err != nil {
+			t.Errorf("Error doing Delete: %+v", err)
+		}
 
-	// Delete the body (retains xattr)
-	err = bucket.Delete(key)
-	if err != nil {
-		t.Errorf("Error doing Delete: %+v", err)
-	}
+		// Update the doc and xattr
+		val = make(map[string]interface{})
+		val["body_field"] = "5678"
+		xattrVal = make(map[string]interface{})
+		xattrVal["seq"] = float64(456)
+		xattrVal["rev"] = "2-2345"
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	// Update the doc and xattr
-	val = make(map[string]interface{})
-	val["body_field"] = "5678"
-	xattrVal = make(map[string]interface{})
-	xattrVal["seq"] = float64(456)
-	xattrVal["rev"] = "2-2345"
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-
-	// Verify retrieval
-	getCas, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	// TODO: Cas check fails, pending xattr code to make it to gocb master
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		// Verify retrieval
+		getCas, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		// TODO: Cas check fails, pending xattr code to make it to gocb master
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+	})
 
 }
 
@@ -781,83 +764,75 @@ func TestXattrWriteCasTombstoneUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
-	bucket.SetTranscoder(SGTranscoder{})
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(123)
+		xattrVal["rev"] = "1-1234"
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		var existsVal map[string]interface{}
+		_, err := bucket.Get(key, existsVal)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			err = bucket.DeleteWithXattr(key, xattrName)
+		}
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(123)
-	xattrVal["rev"] = "1-1234"
+		// Write document with xattr
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+		log.Printf("Wrote document")
+		log.Printf("Post-write, cas is %d", cas)
 
-	var existsVal map[string]interface{}
-	_, err := bucket.Get(key, existsVal)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		err = bucket.DeleteWithXattr(key, xattrName)
-	}
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		log.Printf("Retrieved document")
+		// TODO: Cas check fails, pending xattr code to make it to gocb master
+		log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
+		goassert.Equals(t, getCas, cas)
+		goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
+		goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
 
-	// Write document with xattr
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-	log.Printf("Wrote document")
-	log.Printf("Post-write, cas is %d", cas)
+		err = bucket.Delete(key)
+		if err != nil {
+			t.Errorf("Error doing Delete: %+v", err)
+		}
 
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	log.Printf("Retrieved document")
-	// TODO: Cas check fails, pending xattr code to make it to gocb master
-	log.Printf("TestWriteCasXATTR retrieved: %s, %s", retrievedVal, retrievedXattr)
-	goassert.Equals(t, getCas, cas)
-	goassert.Equals(t, retrievedVal["body_field"], val["body_field"])
-	goassert.Equals(t, retrievedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, retrievedXattr["rev"], xattrVal["rev"])
+		log.Printf("Deleted document")
+		// Update the xattr
+		xattrVal = make(map[string]interface{})
+		xattrVal["seq"] = float64(456)
+		xattrVal["rev"] = "2-2345"
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, nil, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	err = bucket.Delete(key)
-	if err != nil {
-		t.Errorf("Error doing Delete: %+v", err)
-	}
-
-	log.Printf("Deleted document")
-	// Update the xattr
-	xattrVal = make(map[string]interface{})
-	xattrVal["seq"] = float64(456)
-	xattrVal["rev"] = "2-2345"
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, nil, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-
-	log.Printf("Updated tombstoned document")
-	// Verify retrieval
-	var modifiedVal map[string]interface{}
-	var modifiedXattr map[string]interface{}
-	getCas, err = bucket.GetWithXattr(key, xattrName, "", &modifiedVal, &modifiedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	log.Printf("Retrieved tombstoned document")
-	// TODO: Cas check fails, pending xattr code to make it to gocb master
-	log.Printf("TestWriteCasXATTR retrieved modified: %s, %s", modifiedVal, modifiedXattr)
-	goassert.Equals(t, modifiedXattr["seq"], xattrVal["seq"])
-	goassert.Equals(t, modifiedXattr["rev"], xattrVal["rev"])
+		log.Printf("Updated tombstoned document")
+		// Verify retrieval
+		var modifiedVal map[string]interface{}
+		var modifiedXattr map[string]interface{}
+		getCas, err = bucket.GetWithXattr(key, xattrName, "", &modifiedVal, &modifiedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		log.Printf("Retrieved tombstoned document")
+		// TODO: Cas check fails, pending xattr code to make it to gocb master
+		log.Printf("TestWriteCasXATTR retrieved modified: %s, %s", modifiedVal, modifiedXattr)
+		goassert.Equals(t, modifiedXattr["seq"], xattrVal["seq"])
+		goassert.Equals(t, modifiedXattr["rev"], xattrVal["rev"])
+	})
 
 }
 
@@ -866,114 +841,107 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
-	bucket.SetTranscoder(SGTranscoder{})
+		key := t.Name()
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["counter"] = float64(1)
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["counter"] = float64(1)
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = float64(1)
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = float64(1)
-	xattrVal["rev"] = "1-1234"
+		var existsVal map[string]interface{}
+		var existsXattr map[string]interface{}
+		_, err := bucket.GetWithXattr(key, xattrName, "", &existsVal, &existsXattr, nil)
+		if err == nil {
+			log.Printf("Key should not exist yet, but get succeeded.  Doing cleanup, assuming couchbase bucket testing")
+			err := bucket.DeleteWithXattr(key, xattrName)
+			if err != nil {
+				log.Printf("Got error trying to do pre-test cleanup:%v", err)
+			}
+		}
 
-	var existsVal map[string]interface{}
-	var existsXattr map[string]interface{}
-	_, err := bucket.GetWithXattr(key, xattrName, "", &existsVal, &existsXattr, nil)
-	if err == nil {
-		log.Printf("Key should not exist yet, but get succeeded.  Doing cleanup, assuming couchbase bucket testing")
-		err := bucket.DeleteWithXattr(key, xattrName)
+		// Dummy write update function that increments 'counter' in the doc and 'seq' in the xattr
+		writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (
+			updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
+
+			var docMap map[string]interface{}
+			var xattrMap map[string]interface{}
+			// Marshal the doc
+			if len(doc) > 0 {
+				err = JSONUnmarshal(doc, &docMap)
+				if err != nil {
+					return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming doc")
+				}
+			} else {
+				// No incoming doc, treat as insert.
+				docMap = make(map[string]interface{})
+			}
+
+			// Marshal the xattr
+			if len(xattr) > 0 {
+				err = JSONUnmarshal(xattr, &xattrMap)
+				if err != nil {
+					return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming xattr")
+				}
+			} else {
+				// No incoming xattr, treat as insert.
+				xattrMap = make(map[string]interface{})
+			}
+
+			// Update the doc
+			existingCounter, ok := docMap["counter"].(float64)
+			if ok {
+				docMap["counter"] = existingCounter + float64(1)
+			} else {
+				docMap["counter"] = float64(1)
+			}
+
+			// Update the xattr
+			existingSeq, ok := xattrMap["seq"].(float64)
+			if ok {
+				xattrMap["seq"] = existingSeq + float64(1)
+			} else {
+				xattrMap["seq"] = float64(1)
+			}
+
+			updatedDoc, _ = JSONMarshal(docMap)
+			updatedXattr, _ = JSONMarshal(xattrMap)
+			return updatedDoc, updatedXattr, false, nil, nil
+		}
+
+		// Insert
+		_, err = bucket.WriteUpdateWithXattr(key, xattrName, "", 0, nil, writeUpdateFunc)
 		if err != nil {
-			log.Printf("Got error trying to do pre-test cleanup:%v", err)
-		}
-	}
-
-	// Dummy write update function that increments 'counter' in the doc and 'seq' in the xattr
-	writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (
-		updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
-
-		var docMap map[string]interface{}
-		var xattrMap map[string]interface{}
-		// Marshal the doc
-		if len(doc) > 0 {
-			err = JSONUnmarshal(doc, &docMap)
-			if err != nil {
-				return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming doc")
-			}
-		} else {
-			// No incoming doc, treat as insert.
-			docMap = make(map[string]interface{})
+			t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 		}
 
-		// Marshal the xattr
-		if len(xattr) > 0 {
-			err = JSONUnmarshal(xattr, &xattrMap)
-			if err != nil {
-				return nil, nil, false, nil, pkgerrors.Wrapf(err, "Unable to unmarshal incoming xattr")
-			}
-		} else {
-			// No incoming xattr, treat as insert.
-			xattrMap = make(map[string]interface{})
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		log.Printf("Retrieval after WriteUpdate insert: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
 		}
+		goassert.Equals(t, retrievedVal["counter"], float64(1))
+		goassert.Equals(t, retrievedXattr["seq"], float64(1))
 
-		// Update the doc
-		existingCounter, ok := docMap["counter"].(float64)
-		if ok {
-			docMap["counter"] = existingCounter + float64(1)
-		} else {
-			docMap["counter"] = float64(1)
+		// Update
+		_, err = bucket.WriteUpdateWithXattr(key, xattrName, "", 0, nil, writeUpdateFunc)
+		if err != nil {
+			t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
 		}
-
-		// Update the xattr
-		existingSeq, ok := xattrMap["seq"].(float64)
-		if ok {
-			xattrMap["seq"] = existingSeq + float64(1)
-		} else {
-			xattrMap["seq"] = float64(1)
+		_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
 		}
+		log.Printf("Retrieval after WriteUpdate update: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
 
-		updatedDoc, _ = JSONMarshal(docMap)
-		updatedXattr, _ = JSONMarshal(xattrMap)
-		return updatedDoc, updatedXattr, false, nil, nil
-	}
-
-	// Insert
-	_, err = bucket.WriteUpdateWithXattr(key, xattrName, "", 0, nil, writeUpdateFunc)
-	if err != nil {
-		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
-	}
-
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	log.Printf("Retrieval after WriteUpdate insert: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	goassert.Equals(t, retrievedVal["counter"], float64(1))
-	goassert.Equals(t, retrievedXattr["seq"], float64(1))
-
-	// Update
-	_, err = bucket.WriteUpdateWithXattr(key, xattrName, "", 0, nil, writeUpdateFunc)
-	if err != nil {
-		t.Errorf("Error doing WriteUpdateWithXattr: %+v", err)
-	}
-	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	log.Printf("Retrieval after WriteUpdate update: doc: %v, xattr: %v", retrievedVal, retrievedXattr)
-
-	goassert.Equals(t, retrievedVal["counter"], float64(2))
-	goassert.Equals(t, retrievedXattr["seq"], float64(2))
+		goassert.Equals(t, retrievedVal["counter"], float64(2))
+		goassert.Equals(t, retrievedXattr["seq"], float64(2))
+	})
 
 }
 
@@ -1062,53 +1030,46 @@ func TestXattrDeleteDocument(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+		// Create document with XATTR
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-1234"
 
-	// Create document with XATTR
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		key := t.Name()
+		_, _, err := bucket.GetRaw(key)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			require.NoError(t, bucket.Delete(key))
+		}
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-1234"
+		// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	key := t.Name()
-	_, _, err := bucket.GetRaw(key)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		require.NoError(t, bucket.Delete(key))
-	}
+		// Delete the document.
+		err = bucket.Delete(key)
+		if err != nil {
+			t.Errorf("Error doing Delete: %+v", err)
+		}
 
-	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-
-	// Delete the document.
-	err = bucket.Delete(key)
-	if err != nil {
-		t.Errorf("Error doing Delete: %+v", err)
-	}
-
-	// Verify delete of body was successful, retrieve XATTR
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	goassert.Equals(t, len(retrievedVal), 0)
-	goassert.Equals(t, retrievedXattr["seq"], float64(123))
+		// Verify delete of body was successful, retrieve XATTR
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		_, err = bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		goassert.Equals(t, len(retrievedVal), 0)
+		goassert.Equals(t, retrievedXattr["seq"], float64(123))
+	})
 
 }
 
@@ -1117,126 +1078,113 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		// Create document with XATTR
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	// Create document with XATTR
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 1
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 1
-	xattrVal["rev"] = "1-1234"
+		key := t.Name()
+		_, _, err := bucket.GetRaw(key)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			require.NoError(t, bucket.Delete(key))
+		}
 
-	key := t.Name()
-	_, _, err := bucket.GetRaw(key)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		require.NoError(t, bucket.Delete(key))
-	}
+		// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect success)
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		// Delete the document.
+		err = bucket.Delete(key)
+		if err != nil {
+			t.Errorf("Error doing Delete: %+v", err)
+		}
 
-	// Delete the document.
-	err = bucket.Delete(key)
-	if err != nil {
-		t.Errorf("Error doing Delete: %+v", err)
-	}
+		// Verify delete of body was successful, retrieve XATTR
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		if err != nil {
+			t.Errorf("Error doing GetWithXattr: %+v", err)
+		}
+		goassert.Equals(t, len(retrievedVal), 0)
+		goassert.Equals(t, retrievedXattr["seq"], float64(1))
+		log.Printf("Post-delete xattr (1): %s", retrievedXattr)
+		log.Printf("Post-delete cas (1): %x", getCas)
 
-	// Verify delete of body was successful, retrieve XATTR
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	getCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if err != nil {
-		t.Errorf("Error doing GetWithXattr: %+v", err)
-	}
-	goassert.Equals(t, len(retrievedVal), 0)
-	goassert.Equals(t, retrievedXattr["seq"], float64(1))
-	log.Printf("Post-delete xattr (1): %s", retrievedXattr)
-	log.Printf("Post-delete cas (1): %x", getCas)
+		// Update the xattr only
+		xattrVal["seq"] = 2
+		xattrVal["rev"] = "1-1234"
+		casOut, writeErr := bucket.WriteCasWithXattr(key, xattrName, 0, getCas, nil, xattrVal)
+		assert.NoError(t, writeErr, "Error updating xattr post-delete")
+		log.Printf("WriteCasWithXattr cas: %d", casOut)
 
-	// Update the xattr only
-	xattrVal["seq"] = 2
-	xattrVal["rev"] = "1-1234"
-	casOut, writeErr := bucket.WriteCasWithXattr(key, xattrName, 0, getCas, nil, xattrVal)
-	assert.NoError(t, writeErr, "Error updating xattr post-delete")
-	log.Printf("WriteCasWithXattr cas: %d", casOut)
-
-	// Retrieve the document, validate cas values
-	var postDeleteVal map[string]interface{}
-	var postDeleteXattr map[string]interface{}
-	getCas2, err := bucket.GetWithXattr(key, xattrName, "", &postDeleteVal, &postDeleteXattr, nil)
-	assert.NoError(t, err, "Error getting document post-delete")
-	goassert.Equals(t, postDeleteXattr["seq"], float64(2))
-	goassert.Equals(t, len(postDeleteVal), 0)
-	log.Printf("Post-delete xattr (2): %s", postDeleteXattr)
-	log.Printf("Post-delete cas (2): %x", getCas2)
+		// Retrieve the document, validate cas values
+		var postDeleteVal map[string]interface{}
+		var postDeleteXattr map[string]interface{}
+		getCas2, err := bucket.GetWithXattr(key, xattrName, "", &postDeleteVal, &postDeleteXattr, nil)
+		assert.NoError(t, err, "Error getting document post-delete")
+		goassert.Equals(t, postDeleteXattr["seq"], float64(2))
+		goassert.Equals(t, len(postDeleteVal), 0)
+		log.Printf("Post-delete xattr (2): %s", postDeleteXattr)
+		log.Printf("Post-delete cas (2): %x", getCas2)
+	})
 
 }
 
-// TestXattrDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.  Pending https://issues.couchbase.com/browse/MB-24098
+// TestXattrDeleteDocumentAndUpdateXATTR.  Delete the document body and update the xattr.
 func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+		// Create document with XATTR
+		xattrName := SyncXattrName
+		val := make(map[string]interface{})
+		val["body_field"] = "1234"
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		t.Error("Can't cast to bucket")
-	}
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-1234"
 
-	// Create document with XATTR
-	xattrName := SyncXattrName
-	val := make(map[string]interface{})
-	val["body_field"] = "1234"
+		key := t.Name()
+		_, _, err := bucket.GetRaw(key)
+		if err == nil {
+			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
+			require.NoError(t, bucket.DeleteWithXattr(key, xattrName))
+		}
 
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-1234"
+		// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	key := t.Name()
-	_, _, err := bucket.GetRaw(key)
-	if err == nil {
-		log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
-		require.NoError(t, bucket.DeleteWithXattr(key, xattrName))
-	}
+		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
+		require.True(t, ok)
 
-	// Create w/ XATTR, delete doc and XATTR, retrieve doc (expect fail), retrieve XATTR (expect fail)
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		_, mutateErr := subdocXattrStore.SubdocUpdateXattrDeleteBody(key, xattrName, 0, cas, xattrVal)
+		assert.NoError(t, mutateErr)
 
-	_, mutateErr := bucket.Bucket.MutateInEx(key, gocb.SubdocDocFlagNone, gocb.Cas(cas), uint32(0)).
-		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                                 // Update the xattr
-		UpsertEx(SyncPropertyName+".cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
-		RemoveEx("", gocb.SubdocFlagNone).                                                                   // Delete the document body
-		Execute()
-
-	log.Printf("MutateInEx error: %v", mutateErr)
-	// Verify delete of body and XATTR
-	var retrievedVal map[string]interface{}
-	var retrievedXattr map[string]interface{}
-	mutateCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	goassert.Equals(t, len(retrievedVal), 0)
-	goassert.Equals(t, retrievedXattr["seq"], float64(123))
-	log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
-	log.Printf("MutateInEx cas: %v", mutateCas)
+		// Verify delete of body and update of XATTR
+		var retrievedVal map[string]interface{}
+		var retrievedXattr map[string]interface{}
+		mutateCas, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+		goassert.Equals(t, len(retrievedVal), 0)
+		goassert.Equals(t, retrievedXattr["seq"], float64(123))
+		log.Printf("value: %v, xattr: %v", retrievedVal, retrievedXattr)
+		log.Printf("MutateInEx cas: %v", mutateCas)
+	})
 
 }
 
@@ -1247,96 +1195,92 @@ func TestXattrTombstoneDocAndUpdateXattr(t *testing.T) {
 
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		key1 := t.Name() + "DocExistsXattrExists"
+		key2 := t.Name() + "DocExistsNoXattr"
+		key3 := t.Name() + "XattrExistsNoDoc"
+		key4 := t.Name() + "NoDocNoXattr"
 
-	key1 := t.Name() + "DocExistsXattrExists"
-	key2 := t.Name() + "DocExistsNoXattr"
-	key3 := t.Name() + "XattrExistsNoDoc"
-	key4 := t.Name() + "NoDocNoXattr"
+		// 1. Create document with XATTR
+		val := make(map[string]interface{})
+		val["type"] = key1
 
-	// 1. Create document with XATTR
-	val := make(map[string]interface{})
-	val["type"] = key1
+		xattrName := SyncXattrName
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-1234"
 
-	xattrName := SyncXattrName
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-1234"
+		var err error
 
-	var err error
+		// Create w/ XATTR
+		cas1 := uint64(0)
+		cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	// Create w/ XATTR
-	cas1 := uint64(0)
-	cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		// 2. Create document with no XATTR
+		val = make(map[string]interface{})
+		val["type"] = key2
+		cas2, writeErr := bucket.WriteCas(key2, 0, 0, 0, val, 0)
+		assert.NoError(t, writeErr)
 
-	// 2. Create document with no XATTR
-	val = make(map[string]interface{})
-	val["type"] = key2
-	cas2, err := bucket.Bucket.Insert(key2, val, uint32(0))
+		// 3. Xattr, no document
+		val = make(map[string]interface{})
+		val["type"] = key3
 
-	// 3. Xattr, no document
-	val = make(map[string]interface{})
-	val["type"] = key3
+		xattrVal = make(map[string]interface{})
+		xattrVal["seq"] = 456
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal = make(map[string]interface{})
-	xattrVal["seq"] = 456
-	xattrVal["rev"] = "1-1234"
+		// Create w/ XATTR
+		cas3int := uint64(0)
+		cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+		// Delete the doc body
+		cas3, removeErr := bucket.Remove(key3, cas3int)
+		if removeErr != nil {
+			t.Errorf("Error removing doc body: %+v.  Cas: %v", removeErr, cas3)
+		}
 
-	// Create w/ XATTR
-	cas3int := uint64(0)
-	cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-	// Delete the doc body
-	var cas3 gocb.Cas
-	cas3, err = bucket.Bucket.Remove(key3, 0)
-	if err != nil {
-		t.Errorf("Error removing doc body: %+v.  Cas: %v", err, cas3)
-	}
+		// 4. No xattr, no document
+		updatedVal := make(map[string]interface{})
+		updatedVal["type"] = "updated"
 
-	// 4. No xattr, no document
-	updatedVal := make(map[string]interface{})
-	updatedVal["type"] = "updated"
+		updatedXattrVal := make(map[string]interface{})
+		updatedXattrVal["seq"] = 123
+		updatedXattrVal["rev"] = "2-1234"
 
-	updatedXattrVal := make(map[string]interface{})
-	updatedXattrVal["seq"] = 123
-	updatedXattrVal["rev"] = "2-1234"
+		// Attempt to delete DocExistsXattrExists, DocExistsNoXattr, and XattrExistsNoDoc
+		// No errors should be returned when deleting these.
+		keys := []string{key1, key2, key3}
+		casValues := []uint64{cas1, cas2, cas3}
+		shouldDeleteBody := []bool{true, true, false}
+		subdocStore, ok := AsSubdocXattrStore(bucket)
+		require.True(t, ok)
+		for i, key := range keys {
 
-	// Attempt to delete DocExistsXattrExists, DocExistsNoXattr, and XattrExistsNoDoc
-	// No errors should be returned when deleting these.
-	keys := []string{key1, key2, key3}
-	casValues := []gocb.Cas{gocb.Cas(cas1), cas2, cas3}
-	shouldDeleteBody := []bool{true, true, false}
-	for i, key := range keys {
+			log.Printf("Delete testing for key: %v", key)
+			// First attempt to update with a bad cas value, and ensure we're getting the expected error
+			_, errCasMismatch := UpdateTombstoneXattr(subdocStore, key, xattrName, 0, uint64(1234), &updatedXattrVal, shouldDeleteBody[i])
+			assert.True(t, IsCasMismatch(errCasMismatch), fmt.Sprintf("Expected cas mismatch for %s", key))
 
-		log.Printf("Delete testing for key: %v", key)
-		// First attempt to update with a bad cas value, and ensure we're getting the expected error
-		_, errCasMismatch := bucket.UpdateXattr(key, xattrName, 0, uint64(1234), &updatedXattrVal, shouldDeleteBody[i], false)
-		assert.Equal(t, gocb.ErrKeyExists, pkgerrors.Cause(errCasMismatch), fmt.Sprintf("Expected cas mismatch error, got: %v", err))
+			_, errDelete := UpdateTombstoneXattr(subdocStore, key, xattrName, 0, uint64(casValues[i]), &updatedXattrVal, shouldDeleteBody[i])
+			log.Printf("Delete error: %v", errDelete)
 
-		_, errDelete := bucket.UpdateXattr(key, xattrName, 0, uint64(casValues[i]), &updatedXattrVal, shouldDeleteBody[i], false)
-		log.Printf("Delete error: %v", errDelete)
+			assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+			assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrName), fmt.Sprintf("Expected doc %s to be deleted", key))
+		}
 
-		assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-		assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrName), fmt.Sprintf("Expected doc %s to be deleted", key))
-	}
-
-	// Now attempt to tombstone key4 (NoDocNoXattr), should not return an error (per SG #3307).  Should save xattr metadata.
-	log.Printf("Deleting key: %v", key4)
-	_, errDelete := bucket.UpdateXattr(key4, xattrName, 0, uint64(0), &updatedXattrVal, false, false)
-	assert.NoError(t, errDelete, "Unexpected error tombstoning non-existent doc")
-	assert.True(t, verifyDocDeletedXattrExists(bucket, key4, xattrName), "Expected doc to be deleted, but xattrs to exist")
+		// Now attempt to tombstone key4 (NoDocNoXattr), should not return an error (per SG #3307).  Should save xattr metadata.
+		log.Printf("Deleting key: %v", key4)
+		_, errDelete := UpdateTombstoneXattr(subdocStore, key4, xattrName, 0, uint64(0), &updatedXattrVal, false)
+		assert.NoError(t, errDelete, "Unexpected error tombstoning non-existent doc")
+		assert.True(t, verifyDocDeletedXattrExists(bucket, key4, xattrName), "Expected doc to be deleted, but xattrs to exist")
+	})
 
 }
 
@@ -1347,82 +1291,77 @@ func TestXattrDeleteDocAndXattr(t *testing.T) {
 
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		key1 := t.Name() + "DocExistsXattrExists"
+		key2 := t.Name() + "DocExistsNoXattr"
+		key3 := t.Name() + "XattrExistsNoDoc"
+		key4 := t.Name() + "NoDocNoXattr"
 
-	key1 := t.Name() + "DocExistsXattrExists"
-	key2 := t.Name() + "DocExistsNoXattr"
-	key3 := t.Name() + "XattrExistsNoDoc"
-	key4 := t.Name() + "NoDocNoXattr"
+		// 1. Create document with XATTR
+		val := make(map[string]interface{})
+		val["type"] = key1
 
-	// 1. Create document with XATTR
-	val := make(map[string]interface{})
-	val["type"] = key1
+		xattrName := SyncXattrName
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-1234"
 
-	xattrName := SyncXattrName
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-1234"
+		var err error
 
-	var err error
+		// Create w/ XATTR
+		cas1 := uint64(0)
+		cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	// Create w/ XATTR
-	cas1 := uint64(0)
-	cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		// 2. Create document with no XATTR
+		val = make(map[string]interface{})
+		val["type"] = key2
+		err = bucket.Set(key2, uint32(0), val)
+		assert.NoError(t, err)
 
-	// 2. Create document with no XATTR
-	val = make(map[string]interface{})
-	val["type"] = key2
-	_, err = bucket.Bucket.Insert(key2, val, uint32(0))
+		// 3. Xattr, no document
+		val = make(map[string]interface{})
+		val["type"] = key3
 
-	// 3. Xattr, no document
-	val = make(map[string]interface{})
-	val["type"] = key3
+		xattrVal = make(map[string]interface{})
+		xattrVal["seq"] = 456
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal = make(map[string]interface{})
-	xattrVal["seq"] = 456
-	xattrVal["rev"] = "1-1234"
+		// Create w/ XATTR
+		cas3int := uint64(0)
+		cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+		// Delete the doc body
+		var cas3 gocb.Cas
+		err = bucket.Delete(key3)
+		if err != nil {
+			t.Errorf("Error removing doc body: %+v.  Cas: %v", err, cas3)
+		}
 
-	// Create w/ XATTR
-	cas3int := uint64(0)
-	cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-	// Delete the doc body
-	var cas3 gocb.Cas
-	cas3, err = bucket.Bucket.Remove(key3, 0)
-	if err != nil {
-		t.Errorf("Error removing doc body: %+v.  Cas: %v", err, cas3)
-	}
+		// 4. No xattr, no document
 
-	// 4. No xattr, no document
+		// Attempt to delete DocExistsXattrExists, DocExistsNoXattr, and XattrExistsNoDoc
+		// No errors should be returned when deleting these.
+		keys := []string{key1, key2, key3}
+		for _, key := range keys {
+			log.Printf("Deleting key: %v", key)
+			errDelete := bucket.DeleteWithXattr(key, xattrName)
+			assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+			assert.True(t, verifyDocAndXattrDeleted(bucket, key, xattrName), "Expected doc to be deleted")
+		}
 
-	// Attempt to delete DocExistsXattrExists, DocExistsNoXattr, and XattrExistsNoDoc
-	// No errors should be returned when deleting these.
-	keys := []string{key1, key2, key3}
-	for _, key := range keys {
-		log.Printf("Deleting key: %v", key)
-		errDelete := bucket.DeleteWithXattr(key, xattrName)
-		assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-		assert.True(t, verifyDocAndXattrDeleted(bucket, key, xattrName), "Expected doc to be deleted")
-	}
-
-	// Now attempt to delete key4 (NoDocNoXattr), which is expected to return a Key Not Found error
-	log.Printf("Deleting key: %v", key4)
-	errDelete := bucket.DeleteWithXattr(key4, xattrName)
-	assert.Error(t, errDelete, "Expected error when calling bucket.DeleteWithXattr")
-	assert.Truef(t, bucket.IsKeyNotFoundError(errDelete), "Exepcted keynotfound error but got %v", errDelete)
-	assert.True(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
+		// Now attempt to delete key4 (NoDocNoXattr), which is expected to return a Key Not Found error
+		log.Printf("Deleting key: %v", key4)
+		errDelete := bucket.DeleteWithXattr(key4, xattrName)
+		assert.Error(t, errDelete, "Expected error when calling bucket.DeleteWithXattr")
+		assert.Truef(t, pkgerrors.Cause(errDelete) == ErrNotFound, "Exepcted keynotfound error but got %v", errDelete)
+		assert.True(t, verifyDocAndXattrDeleted(bucket, key4, xattrName), "Expected doc to be deleted")
+	})
 }
 
 // This simulates a race condition by calling deleteWithXattrInternal() and passing a custom
@@ -1431,47 +1370,47 @@ func TestDeleteWithXattrWithSimulatedRaceResurrect(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		key := t.Name()
+		xattrName := SyncXattrName
+		createTombstonedDoc(bucket, key, xattrName)
 
-	key := t.Name()
-	xattrName := SyncXattrName
-	createTombstonedDoc(bucket, key, xattrName)
+		numTimesCalledBack := 0
+		callback := func(k string, xattrKey string) {
 
-	numTimesCalledBack := 0
-	callback := func(b CouchbaseBucketGoCB, k string, xattrKey string) {
+			// Only want the callback to execute once.  Should be called multiple times (twice) due to expected
+			// cas failure due to using stale cas
+			if numTimesCalledBack >= 1 {
+				return
+			}
+			numTimesCalledBack += 1
 
-		// Only want the callback to execute once.  Should be called multiple times (twice) due to expected
-		// cas failure due to using stale cas
-		if numTimesCalledBack >= 1 {
-			return
-		}
-		numTimesCalledBack += 1
+			// Resurrect the doc by updating the doc body
+			updatedVal := map[string]interface{}{}
+			updatedVal["foo"] = "bar"
+			xattrVal := make(map[string]interface{})
+			xattrVal["seq"] = float64(456)
+			xattrVal["rev"] = "2-2345"
+			_, writeErr := bucket.WriteCasWithXattr(k, xattrKey, 0, 0, updatedVal, xattrVal)
+			if writeErr != nil {
+				panic(fmt.Sprintf("Unexpected error in WriteCasWithXattr: %v", writeErr))
 
-		// Resurrect the doc by updating the doc body
-		updatedVal := map[string]interface{}{}
-		updatedVal["foo"] = "bar"
-		xattrVal := make(map[string]interface{})
-		xattrVal["seq"] = float64(456)
-		xattrVal["rev"] = "2-2345"
-		_, writeErr := bucket.WriteCasWithXattr(k, xattrKey, 0, 0, updatedVal, xattrVal)
-		if writeErr != nil {
-			panic(fmt.Sprintf("Unexpected error in WriteCasWithXattr: %v", writeErr))
+			}
 
 		}
 
-	}
+		// Use AsSubdocXattrStore to do the underlying bucket lookup, then switch to KvXattrStore to pass to
+		// deleteWithXattrInternal
+		subdocStore, ok := AsSubdocXattrStore(bucket)
+		require.True(t, ok)
+		kvXattrStore, ok := subdocStore.(KvXattrStore)
+		require.True(t, ok)
+		deleteErr := deleteWithXattrInternal(kvXattrStore, key, xattrName, callback)
 
-	deleteErr := bucket.deleteWithXattrInternal(key, xattrName, callback)
-
-	assert.True(t, deleteErr != nil, "We expected an error here, because deleteWithXattrInternal should have "+
-		" detected that the doc was resurrected during its execution")
+		assert.True(t, deleteErr != nil, "We expected an error here, because deleteWithXattrInternal should have "+
+			" detected that the doc was resurrected during its execution")
+	})
 
 }
 
@@ -1480,90 +1419,84 @@ func TestXattrRetrieveDocumentAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		key1 := t.Name() + "DocExistsXattrExists"
+		key2 := t.Name() + "DocExistsNoXattr"
+		key3 := t.Name() + "XattrExistsNoDoc"
+		key4 := t.Name() + "NoDocNoXattr"
 
-	key1 := t.Name() + "DocExistsXattrExists"
-	key2 := t.Name() + "DocExistsNoXattr"
-	key3 := t.Name() + "XattrExistsNoDoc"
-	key4 := t.Name() + "NoDocNoXattr"
+		// 1. Create document with XATTR
+		val := make(map[string]interface{})
+		val["type"] = key1
 
-	// 1. Create document with XATTR
-	val := make(map[string]interface{})
-	val["type"] = key1
+		xattrName := SyncXattrName
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-1234"
 
-	xattrName := SyncXattrName
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-1234"
+		var err error
 
-	var err error
+		// Create w/ XATTR
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	// Create w/ XATTR
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		// 2. Create document with no XATTR
+		val = make(map[string]interface{})
+		val["type"] = key2
+		_, err = bucket.Add(key2, 0, val)
 
-	// 2. Create document with no XATTR
-	val = make(map[string]interface{})
-	val["type"] = key2
-	_, err = bucket.Add(key2, 0, val)
+		// 3. Xattr, no document
+		val = make(map[string]interface{})
+		val["type"] = key3
 
-	// 3. Xattr, no document
-	val = make(map[string]interface{})
-	val["type"] = key3
+		xattrVal = make(map[string]interface{})
+		xattrVal["seq"] = 456
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal = make(map[string]interface{})
-	xattrVal["seq"] = 456
-	xattrVal["rev"] = "1-1234"
+		// Create w/ XATTR
+		cas = uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+		// Delete the doc
+		require.NoError(t, bucket.Delete(key3))
 
-	// Create w/ XATTR
-	cas = uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-	// Delete the doc
-	require.NoError(t, bucket.Delete(key3))
+		// 4. No xattr, no document
 
-	// 4. No xattr, no document
+		// Attempt to retrieve all 4 docs
+		var key1DocResult map[string]interface{}
+		var key1XattrResult map[string]interface{}
+		_, key1err := bucket.GetWithXattr(key1, xattrName, "", &key1DocResult, &key1XattrResult, nil)
+		assert.NoError(t, key1err, "Unexpected error retrieving doc w/ xattr")
+		assert.Equal(t, key1, key1DocResult["type"])
+		assert.Equal(t, "1-1234", key1XattrResult["rev"])
 
-	// Attempt to retrieve all 4 docs
-	var key1DocResult map[string]interface{}
-	var key1XattrResult map[string]interface{}
-	_, key1err := bucket.GetWithXattr(key1, xattrName, "", &key1DocResult, &key1XattrResult, nil)
-	assert.NoError(t, key1err, "Unexpected error retrieving doc w/ xattr")
-	assert.Equal(t, key1, key1DocResult["type"])
-	assert.Equal(t, "1-1234", key1XattrResult["rev"])
+		var key2DocResult map[string]interface{}
+		var key2XattrResult map[string]interface{}
+		_, key2err := bucket.GetWithXattr(key2, xattrName, "", &key2DocResult, &key2XattrResult, nil)
+		assert.NoError(t, key2err, "Unexpected error retrieving doc w/out xattr")
+		assert.Equal(t, key2, key2DocResult["type"])
+		assert.Nil(t, key2XattrResult)
 
-	var key2DocResult map[string]interface{}
-	var key2XattrResult map[string]interface{}
-	_, key2err := bucket.GetWithXattr(key2, xattrName, "", &key2DocResult, &key2XattrResult, nil)
-	assert.NoError(t, key2err, "Unexpected error retrieving doc w/out xattr")
-	assert.Equal(t, key2, key2DocResult["type"])
-	assert.Nil(t, key2XattrResult)
+		var key3DocResult map[string]interface{}
+		var key3XattrResult map[string]interface{}
+		_, key3err := bucket.GetWithXattr(key3, xattrName, "", &key3DocResult, &key3XattrResult, nil)
+		assert.NoError(t, key3err, "Unexpected error retrieving doc w/out xattr")
+		assert.Nil(t, key3DocResult)
+		assert.Equal(t, "1-1234", key3XattrResult["rev"])
 
-	var key3DocResult map[string]interface{}
-	var key3XattrResult map[string]interface{}
-	_, key3err := bucket.GetWithXattr(key3, xattrName, "", &key3DocResult, &key3XattrResult, nil)
-	assert.NoError(t, key3err, "Unexpected error retrieving doc w/out xattr")
-	assert.Nil(t, key3DocResult)
-	assert.Equal(t, "1-1234", key3XattrResult["rev"])
-
-	var key4DocResult map[string]interface{}
-	var key4XattrResult map[string]interface{}
-	_, key4err := bucket.GetWithXattr(key4, xattrName, "", &key4DocResult, &key4XattrResult, nil)
-	assert.Equal(t, gocb.ErrKeyNotFound, pkgerrors.Cause(key4err))
-	assert.Nil(t, key4DocResult)
-	assert.Nil(t, key4XattrResult)
+		var key4DocResult map[string]interface{}
+		var key4XattrResult map[string]interface{}
+		_, key4err := bucket.GetWithXattr(key4, xattrName, "", &key4DocResult, &key4XattrResult, nil)
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(key4err))
+		assert.Nil(t, key4DocResult)
+		assert.Nil(t, key4XattrResult)
+	})
 
 }
 
@@ -1572,201 +1505,189 @@ func TestXattrMutateDocAndXattr(t *testing.T) {
 
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+		key1 := t.Name() + "DocExistsXattrExists"
+		key2 := t.Name() + "DocExistsNoXattr"
+		key3 := t.Name() + "XattrExistsNoDoc"
+		key4 := t.Name() + "NoDocNoXattr"
 
-	key1 := t.Name() + "DocExistsXattrExists"
-	key2 := t.Name() + "DocExistsNoXattr"
-	key3 := t.Name() + "XattrExistsNoDoc"
-	key4 := t.Name() + "NoDocNoXattr"
+		// 1. Create document with XATTR
+		val := make(map[string]interface{})
+		val["type"] = key1
 
-	// 1. Create document with XATTR
-	val := make(map[string]interface{})
-	val["type"] = key1
+		xattrName := SyncXattrName
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-1234"
 
-	xattrName := SyncXattrName
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-1234"
+		var err error
 
-	var err error
+		// Create w/ XATTR
+		cas1 := uint64(0)
+		cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	// Create w/ XATTR
-	cas1 := uint64(0)
-	cas1, err = bucket.WriteCasWithXattr(key1, xattrName, 0, cas1, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		// 2. Create document with no XATTR
+		val = make(map[string]interface{})
+		val["type"] = key2
+		cas2, err := bucket.WriteCas(key2, 0, 0, 0, val, 0)
+		require.NoError(t, err)
 
-	// 2. Create document with no XATTR
-	val = make(map[string]interface{})
-	val["type"] = key2
-	cas2 := gocb.Cas(0)
-	cas2, err = bucket.Bucket.Insert(key2, val, uint32(0))
+		// 3. Xattr, no document
+		val = make(map[string]interface{})
+		val["type"] = key3
 
-	// 3. Xattr, no document
-	val = make(map[string]interface{})
-	val["type"] = key3
+		xattrVal = make(map[string]interface{})
+		xattrVal["seq"] = 456
+		xattrVal["rev"] = "1-1234"
 
-	xattrVal = make(map[string]interface{})
-	xattrVal["seq"] = 456
-	xattrVal["rev"] = "1-1234"
+		// Create w/ XATTR
+		cas3int := uint64(0)
+		cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+		// Delete the doc body
+		var cas3 gocb.Cas
+		err = bucket.Delete(key3)
+		if err != nil {
+			t.Errorf("Error removing doc body: %+v", err)
+		}
 
-	// Create w/ XATTR
-	cas3int := uint64(0)
-	cas3int, err = bucket.WriteCasWithXattr(key3, xattrName, 0, cas3int, val, xattrVal)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
-	// Delete the doc body
-	var cas3 gocb.Cas
-	cas3, err = bucket.Bucket.Remove(key3, 0)
-	if err != nil {
-		t.Errorf("Error removing doc body: %+v", err)
-	}
+		// 4. No xattr, no document
+		cas4 := 0
+		updatedVal := make(map[string]interface{})
+		updatedVal["type"] = "updated"
 
-	// 4. No xattr, no document
-	cas4 := 0
-	updatedVal := make(map[string]interface{})
-	updatedVal["type"] = "updated"
+		updatedXattrVal := make(map[string]interface{})
+		updatedXattrVal["seq"] = 123
+		updatedXattrVal["rev"] = "2-1234"
 
-	updatedXattrVal := make(map[string]interface{})
-	updatedXattrVal["seq"] = 123
-	updatedXattrVal["rev"] = "2-1234"
+		// Attempt to mutate all 4 docs
+		exp := uint32(0)
+		updatedVal["type"] = fmt.Sprintf("updated_%s", key1)
+		_, key1err := bucket.WriteCasWithXattr(key1, xattrName, exp, cas1, &updatedVal, &updatedXattrVal)
+		assert.NoError(t, key1err, fmt.Sprintf("Unexpected error mutating %s", key1))
+		var key1DocResult map[string]interface{}
+		var key1XattrResult map[string]interface{}
+		_, key1err = bucket.GetWithXattr(key1, xattrName, "", &key1DocResult, &key1XattrResult, nil)
+		goassert.Equals(t, key1DocResult["type"], fmt.Sprintf("updated_%s", key1))
+		goassert.Equals(t, key1XattrResult["rev"], "2-1234")
 
-	// Attempt to mutate all 4 docs
-	exp := uint32(0)
-	updatedVal["type"] = fmt.Sprintf("updated_%s", key1)
-	_, key1err := bucket.WriteCasWithXattr(key1, xattrName, exp, cas1, &updatedVal, &updatedXattrVal)
-	assert.NoError(t, key1err, fmt.Sprintf("Unexpected error mutating %s", key1))
-	var key1DocResult map[string]interface{}
-	var key1XattrResult map[string]interface{}
-	_, key1err = bucket.GetWithXattr(key1, xattrName, "", &key1DocResult, &key1XattrResult, nil)
-	goassert.Equals(t, key1DocResult["type"], fmt.Sprintf("updated_%s", key1))
-	goassert.Equals(t, key1XattrResult["rev"], "2-1234")
+		updatedVal["type"] = fmt.Sprintf("updated_%s", key2)
+		_, key2err := bucket.WriteCasWithXattr(key2, xattrName, exp, uint64(cas2), &updatedVal, &updatedXattrVal)
+		assert.NoError(t, key2err, fmt.Sprintf("Unexpected error mutating %s", key2))
+		var key2DocResult map[string]interface{}
+		var key2XattrResult map[string]interface{}
+		_, key2err = bucket.GetWithXattr(key2, xattrName, "", &key2DocResult, &key2XattrResult, nil)
+		goassert.Equals(t, key2DocResult["type"], fmt.Sprintf("updated_%s", key2))
+		goassert.Equals(t, key2XattrResult["rev"], "2-1234")
 
-	updatedVal["type"] = fmt.Sprintf("updated_%s", key2)
-	_, key2err := bucket.WriteCasWithXattr(key2, xattrName, exp, uint64(cas2), &updatedVal, &updatedXattrVal)
-	assert.NoError(t, key2err, fmt.Sprintf("Unexpected error mutating %s", key2))
-	var key2DocResult map[string]interface{}
-	var key2XattrResult map[string]interface{}
-	_, key2err = bucket.GetWithXattr(key2, xattrName, "", &key2DocResult, &key2XattrResult, nil)
-	goassert.Equals(t, key2DocResult["type"], fmt.Sprintf("updated_%s", key2))
-	goassert.Equals(t, key2XattrResult["rev"], "2-1234")
+		updatedVal["type"] = fmt.Sprintf("updated_%s", key3)
+		_, key3err := bucket.WriteCasWithXattr(key3, xattrName, exp, uint64(cas3), &updatedVal, &updatedXattrVal)
+		assert.NoError(t, key3err, fmt.Sprintf("Unexpected error mutating %s", key3))
+		var key3DocResult map[string]interface{}
+		var key3XattrResult map[string]interface{}
+		_, key3err = bucket.GetWithXattr(key3, xattrName, "", &key3DocResult, &key3XattrResult, nil)
+		goassert.Equals(t, key3DocResult["type"], fmt.Sprintf("updated_%s", key3))
+		goassert.Equals(t, key3XattrResult["rev"], "2-1234")
 
-	updatedVal["type"] = fmt.Sprintf("updated_%s", key3)
-	_, key3err := bucket.WriteCasWithXattr(key3, xattrName, exp, uint64(cas3), &updatedVal, &updatedXattrVal)
-	assert.NoError(t, key3err, fmt.Sprintf("Unexpected error mutating %s", key3))
-	var key3DocResult map[string]interface{}
-	var key3XattrResult map[string]interface{}
-	_, key3err = bucket.GetWithXattr(key3, xattrName, "", &key3DocResult, &key3XattrResult, nil)
-	goassert.Equals(t, key3DocResult["type"], fmt.Sprintf("updated_%s", key3))
-	goassert.Equals(t, key3XattrResult["rev"], "2-1234")
-
-	updatedVal["type"] = fmt.Sprintf("updated_%s", key4)
-	_, key4err := bucket.WriteCasWithXattr(key4, xattrName, exp, uint64(cas4), &updatedVal, &updatedXattrVal)
-	assert.NoError(t, key4err, fmt.Sprintf("Unexpected error mutating %s", key4))
-	var key4DocResult map[string]interface{}
-	var key4XattrResult map[string]interface{}
-	_, key4err = bucket.GetWithXattr(key4, xattrName, "", &key4DocResult, &key4XattrResult, nil)
-	goassert.Equals(t, key4DocResult["type"], fmt.Sprintf("updated_%s", key4))
-	goassert.Equals(t, key4XattrResult["rev"], "2-1234")
+		updatedVal["type"] = fmt.Sprintf("updated_%s", key4)
+		_, key4err := bucket.WriteCasWithXattr(key4, xattrName, exp, uint64(cas4), &updatedVal, &updatedXattrVal)
+		assert.NoError(t, key4err, fmt.Sprintf("Unexpected error mutating %s", key4))
+		var key4DocResult map[string]interface{}
+		var key4XattrResult map[string]interface{}
+		_, key4err = bucket.GetWithXattr(key4, xattrName, "", &key4DocResult, &key4XattrResult, nil)
+		goassert.Equals(t, key4DocResult["type"], fmt.Sprintf("updated_%s", key4))
+		goassert.Equals(t, key4XattrResult["rev"], "2-1234")
+	})
 
 }
 
 func TestGetXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
-
 	defer SetUpTestLogging(LevelDebug, KeyAll)()
 
-	bucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		log.Printf("Can't cast to bucket")
-		return
-	}
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	//Doc 1
-	key1 := t.Name() + "DocExistsXattrExists"
-	val1 := make(map[string]interface{})
-	val1["type"] = key1
-	xattrName1 := "sync"
-	xattrVal1 := make(map[string]interface{})
-	xattrVal1["seq"] = float64(1)
-	xattrVal1["rev"] = "1-foo"
+		//Doc 1
+		key1 := t.Name() + "DocExistsXattrExists"
+		val1 := make(map[string]interface{})
+		val1["type"] = key1
+		xattrName1 := "sync"
+		xattrVal1 := make(map[string]interface{})
+		xattrVal1["seq"] = float64(1)
+		xattrVal1["rev"] = "1-foo"
 
-	//Doc 2 - Tombstone
-	key2 := t.Name() + "TombstonedDocXattrExists"
-	val2 := make(map[string]interface{})
-	val2["type"] = key2
-	xattrVal2 := make(map[string]interface{})
-	xattrVal2["seq"] = float64(1)
-	xattrVal2["rev"] = "1-foo"
+		//Doc 2 - Tombstone
+		key2 := t.Name() + "TombstonedDocXattrExists"
+		val2 := make(map[string]interface{})
+		val2["type"] = key2
+		xattrVal2 := make(map[string]interface{})
+		xattrVal2["seq"] = float64(1)
+		xattrVal2["rev"] = "1-foo"
 
-	//Doc 3 - To Delete
-	key3 := t.Name() + "DeletedDocXattrExists"
-	val3 := make(map[string]interface{})
-	val3["type"] = key3
-	xattrName3 := "sync"
-	xattrVal3 := make(map[string]interface{})
-	xattrVal3["seq"] = float64(1)
-	xattrVal3["rev"] = "1-foo"
+		//Doc 3 - To Delete
+		key3 := t.Name() + "DeletedDocXattrExists"
+		val3 := make(map[string]interface{})
+		val3["type"] = key3
+		xattrName3 := "sync"
+		xattrVal3 := make(map[string]interface{})
+		xattrVal3["seq"] = float64(1)
+		xattrVal3["rev"] = "1-foo"
 
-	var err error
+		var err error
 
-	//Create w/ XATTR
-	cas := uint64(0)
-	cas, err = bucket.WriteCasWithXattr(key1, xattrName1, 0, cas, val1, xattrVal1)
-	if err != nil {
-		t.Errorf("Error doing WriteCasWithXattr: %+v", err)
-	}
+		//Create w/ XATTR
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key1, xattrName1, 0, cas, val1, xattrVal1)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
 
-	var response map[string]interface{}
+		var response map[string]interface{}
 
-	//Get Xattr From Existing Doc with Existing Xattr
-	_, err = testBucket.GetXattr(key1, xattrName1, &response)
-	assert.NoError(t, err)
+		//Get Xattr From Existing Doc with Existing Xattr
+		_, err = bucket.GetXattr(key1, xattrName1, &response)
+		assert.NoError(t, err)
 
-	assert.Equal(t, xattrVal1["seq"], response["seq"])
-	assert.Equal(t, xattrVal1["rev"], response["rev"])
+		assert.Equal(t, xattrVal1["seq"], response["seq"])
+		assert.Equal(t, xattrVal1["rev"], response["rev"])
 
-	//Get Xattr From Existing Doc With Non-Existent Xattr -> ErrSubDocBadMulti
-	_, err = testBucket.GetXattr(key1, "non-exist", &response)
-	assert.Error(t, err)
-	assert.Equal(t, gocbcore.ErrSubDocBadMulti, pkgerrors.Cause(err))
+		//Get Xattr From Existing Doc With Non-Existent Xattr -> ErrSubDocBadMulti
+		_, err = bucket.GetXattr(key1, "non-exist", &response)
+		assert.Error(t, err)
+		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
 
-	//Get Xattr From Non-Existent Doc With Non-Existent Xattr
-	_, err = testBucket.GetXattr("non-exist", "non-exist", &response)
-	assert.Error(t, err)
-	assert.Equal(t, gocbcore.ErrKeyNotFound, pkgerrors.Cause(err))
+		//Get Xattr From Non-Existent Doc With Non-Existent Xattr
+		_, err = bucket.GetXattr("non-exist", "non-exist", &response)
+		assert.Error(t, err)
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
-	//Get Xattr From Tombstoned Doc With Existing Xattr
-	cas, err = bucket.WriteCasWithXattr(key2, SyncXattrName, 0, cas, val2, xattrVal2)
-	_, err = bucket.Remove(key2, cas)
-	require.NoError(t, err)
-	_, err = testBucket.GetXattr(key2, SyncXattrName, &response)
-	assert.NoError(t, err)
+		//Get Xattr From Tombstoned Doc With Existing System Xattr
+		cas, err = bucket.WriteCasWithXattr(key2, SyncXattrName, 0, uint64(0), val2, xattrVal2)
+		_, err = bucket.Remove(key2, cas)
+		require.NoError(t, err)
+		_, err = bucket.GetXattr(key2, SyncXattrName, &response)
+		assert.NoError(t, err)
 
-	//Get Xattr From Tombstoned Doc With Non-Existent Xattr
-	_, err = testBucket.GetXattr(key2, "non-exist", &response)
-	assert.Error(t, err)
-	assert.Equal(t, gocbcore.ErrKeyNotFound, pkgerrors.Cause(err))
+		//Get Xattr From Tombstoned Doc With Non-Existent System Xattr -> SubDocMultiPathFailureDeleted
+		_, err = bucket.GetXattr(key2, "_non-exist", &response)
+		assert.Error(t, err)
+		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
 
-	////Get Xattr From Deleted Doc With Deleted Xattr -> SubDocMultiPathFailureDeleted
-	cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)
-	_, err = bucket.Remove(key3, cas)
-	require.NoError(t, err)
-	_, err = testBucket.GetXattr(key3, xattrName3, &response)
-	assert.Error(t, err)
-	assert.Equal(t, gocbcore.ErrKeyNotFound, pkgerrors.Cause(err))
+		////Get Xattr From Tombstoned Doc With Deleted User Xattr
+		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)
+		_, err = bucket.Remove(key3, cas)
+		require.NoError(t, err)
+		_, err = bucket.GetXattr(key3, xattrName3, &response)
+		assert.Error(t, err)
+		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
+	})
 }
 
 func TestApplyViewQueryOptions(t *testing.T) {
@@ -2092,7 +2013,7 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 	return certPath, keyPath, cleanupFn
 }
 
-func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
+func createTombstonedDoc(bucket sgbucket.DataStore, key, xattrName string) {
 
 	// Create document with XATTR
 
@@ -2115,15 +2036,17 @@ func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 		panic(fmt.Sprintf("Error doing WriteCasWithXattr: %+v", err))
 	}
 
-	flags := gocb.SubdocDocFlagAccessDeleted
-
+	subdocStore, _ := AsSubdocXattrStore(bucket)
 	// Create tombstone revision which deletes doc body but preserves XATTR
-	_, mutateErr := bucket.Bucket.MutateInEx(key, flags, gocb.Cas(cas), uint32(0)).
-		UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                              // Update the xattr
-		UpsertEx(SyncXattrName+".cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
-		RemoveEx("", gocb.SubdocFlagNone).                                                                // Delete the document body
-		Execute()
-
+	_, mutateErr := subdocStore.SubdocDeleteBody(key, xattrName, 0, cas)
+	/*
+		flags := gocb.SubdocDocFlagAccessDeleted
+		_, mutateErr := bucket.Bucket.MutateInEx(key, flags, gocb.Cas(cas), uint32(0)).
+			UpsertEx(xattrName, xattrVal, gocb.SubdocFlagXattr).                                              // Update the xattr
+			UpsertEx(SyncXattrName+".cas", "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+			RemoveEx("", gocb.SubdocFlagNone).                                                                // Delete the document body
+			Execute()
+	*/
 	if mutateErr != nil {
 		panic(fmt.Sprintf("Unexpected mutateErr: %v", mutateErr))
 	}
@@ -2143,20 +2066,19 @@ func createTombstonedDoc(bucket *CouchbaseBucketGoCB, key, xattrName string) {
 
 }
 
-func verifyDocAndXattrDeleted(bucket *CouchbaseBucketGoCB, key, xattrName string) bool {
+func verifyDocAndXattrDeleted(store sgbucket.XattrStore, key, xattrName string) bool {
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
-	if pkgerrors.Cause(err) != gocbcore.ErrKeyNotFound {
-		return false
-	}
-	return true
+	_, err := store.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+	notFound := pkgerrors.Cause(err) == ErrNotFound
+
+	return notFound
 }
 
-func verifyDocDeletedXattrExists(bucket *CouchbaseBucketGoCB, key, xattrName string) bool {
+func verifyDocDeletedXattrExists(store sgbucket.XattrStore, key, xattrName string) bool {
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err := bucket.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
+	_, err := store.GetWithXattr(key, xattrName, "", &retrievedVal, &retrievedXattr, nil)
 
 	log.Printf("verification for key: %s   body: %s  xattr: %s", key, retrievedVal, retrievedXattr)
 	if err != nil || len(retrievedVal) > 0 || len(retrievedXattr) == 0 {
@@ -2168,83 +2090,44 @@ func verifyDocDeletedXattrExists(bucket *CouchbaseBucketGoCB, key, xattrName str
 func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
 
-	bucketGoCB, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
-	require.True(t, ok, "Can't cast to bucket")
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	// Create a document with extended attributes
-	key := "DocWithXattrAndIsDelete"
-	val := make(map[string]interface{})
-	val["type"] = key
+		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
+		require.True(t, ok)
 
-	xattrKey := SyncXattrName
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-EmDC"
+		// Create a document with extended attributes
+		key := "DocWithXattrAndIsDelete"
+		val := make(map[string]interface{})
+		val["type"] = key
 
-	cas := uint64(0)
-	// CAS-safe write of the document and it's associated named extended attributes
-	cas, err := bucket.WriteCasWithXattr(key, xattrKey, 0, cas, val, xattrVal)
-	require.NoError(t, err, "Error doing WriteCasWithXattr")
+		xattrKey := SyncXattrName
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-EmDC"
 
-	updatedXattrVal := make(map[string]interface{})
-	updatedXattrVal["seq"] = 123
-	updatedXattrVal["rev"] = "2-EmDC"
+		cas := uint64(0)
+		// CAS-safe write of the document and it's associated named extended attributes
+		cas, err := bucket.WriteCasWithXattr(key, xattrKey, 0, cas, val, xattrVal)
+		require.NoError(t, err, "Error doing WriteCasWithXattr")
 
-	// Attempt to delete the document body (deleteBody = true); isDelete is true to mark this doc as a tombstone.
-	_, errDelete := bucketGoCB.UpdateXattr(key, xattrKey, 0, cas, &updatedXattrVal, true, true)
-	assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-	assert.True(t, verifyDocDeletedXattrExists(bucketGoCB, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
+		updatedXattrVal := make(map[string]interface{})
+		updatedXattrVal["seq"] = 123
+		updatedXattrVal["rev"] = "2-EmDC"
 
-	var docResult map[string]interface{}
-	var xattrResult map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrKey, "", &docResult, &xattrResult, nil)
-	assert.Len(t, docResult, 0)
-	assert.Equal(t, "2-EmDC", xattrResult["rev"])
-	assert.Equal(t, DeleteCrc32c, xattrResult[xattrMacroValueCrc32c])
-}
+		// Attempt to delete the document body (deleteBody = true); isDelete is true to mark this doc as a tombstone.
+		_, errDelete := UpdateTombstoneXattr(subdocXattrStore, key, xattrKey, 0, cas, &updatedXattrVal, true)
+		assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+		assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
 
-func TestUpdateXattrWithDeleteBodyAndIsNotDelete(t *testing.T) {
-	SkipXattrTestsIfNotEnabled(t)
-	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
-
-	bucketGoCB, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
-	require.True(t, ok, "Can't cast to bucket")
-
-	// Create a document with extended attributes
-	key := "DocWithXattrAndIsNotDelete"
-	val := make(map[string]interface{})
-	val["type"] = key
-
-	xattrKey := SyncXattrName
-	xattrVal := make(map[string]interface{})
-	xattrVal["seq"] = 123
-	xattrVal["rev"] = "1-EmDC"
-
-	cas := uint64(0)
-	// CAS-safe write of the document and it's associated named extended attributes
-	cas, err := bucket.WriteCasWithXattr(key, xattrKey, 0, cas, val, xattrVal)
-	require.NoError(t, err, "Error doing WriteCasWithXattr")
-
-	updatedXattrVal := make(map[string]interface{})
-	updatedXattrVal["seq"] = 123
-	updatedXattrVal["rev"] = "2-EmDC"
-
-	// Attempt to delete the document body (deleteBody = true); isDelete is false
-	_, errDelete := bucketGoCB.UpdateXattr(key, xattrKey, 0, cas, &updatedXattrVal, true, false)
-	assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
-	assert.True(t, verifyDocDeletedXattrExists(bucketGoCB, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
-
-	var docResult map[string]interface{}
-	var xattrResult map[string]interface{}
-	_, err = bucket.GetWithXattr(key, xattrKey, "", &docResult, &xattrResult, nil)
-	assert.Len(t, docResult, 0)
-	assert.Equal(t, "2-EmDC", xattrResult["rev"])
-	assert.NotEqual(t, DeleteCrc32c, xattrResult[xattrMacroValueCrc32c])
+		var docResult map[string]interface{}
+		var xattrResult map[string]interface{}
+		_, err = bucket.GetWithXattr(key, xattrKey, "", &docResult, &xattrResult, nil)
+		assert.NoError(t, err)
+		assert.Len(t, docResult, 0)
+		assert.Equal(t, "2-EmDC", xattrResult["rev"])
+		assert.Equal(t, "0x00000000", xattrResult[xattrMacroValueCrc32c])
+	})
 }
 
 func TestUserXattrGetWithXattr(t *testing.T) {
@@ -2308,4 +2191,39 @@ func TestUserXattrGetWithXattrNil(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, docVal, docValRet)
 	assert.Equal(t, syncXattrVal, syncXattrValRet)
+}
+
+func TestInsertTombstoneWithXattr(t *testing.T) {
+	SkipXattrTestsIfNotEnabled(t)
+	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
+
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+
+		subdocXattrStore, ok := AsSubdocXattrStore(bucket)
+		require.True(t, ok)
+
+		// Create a document with extended attributes
+		key := "InsertedTombstoneDoc"
+		val := make(map[string]interface{})
+		val["type"] = key
+
+		xattrKey := SyncXattrName
+		xattrVal := make(map[string]interface{})
+		xattrVal["seq"] = 123
+		xattrVal["rev"] = "1-EmDC"
+
+		cas := uint64(0)
+		// Attempt to delete the document body (deleteBody = true); isDelete is true to mark this doc as a tombstone.
+		_, errDelete := UpdateTombstoneXattr(subdocXattrStore, key, xattrKey, 0, cas, &xattrVal, false)
+		assert.NoError(t, errDelete, fmt.Sprintf("Unexpected error deleting %s", key))
+		assert.True(t, verifyDocDeletedXattrExists(bucket, key, xattrKey), fmt.Sprintf("Expected doc %s to be deleted", key))
+
+		var docResult map[string]interface{}
+		var xattrResult map[string]interface{}
+		_, err := bucket.GetWithXattr(key, xattrKey, "", &docResult, &xattrResult, nil)
+		assert.NoError(t, err)
+		assert.Len(t, docResult, 0)
+		assert.Equal(t, "1-EmDC", xattrResult["rev"])
+		assert.Equal(t, "0x00000000", xattrResult[xattrMacroValueCrc32c])
+	})
 }

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -147,10 +147,10 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetBodyAndXattr(k string, xattrKey stri
 			case gocb.ErrKeyNotFound:
 				// If key not found it has been deleted in between the first op and this op.
 				return false, ErrNotFound, userXattrCas
-
 			case gocb.ErrSubDocBadMulti:
 				// Xattr doesn't exist, can skip
-
+			case ErrXattrNotFound:
+				// Xattr doesn't exist, can skip
 			case nil:
 				if cas != userXattrCas {
 					return true, errors.New("cas mismatch between user xattr and document body"), uint64(0)

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -1,0 +1,359 @@
+package base
+
+import (
+	"errors"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
+	"gopkg.in/couchbase/gocbcore.v7"
+)
+
+var _ SubdocXattrStore = &CouchbaseBucketGoCB{}
+
+func (bucket *CouchbaseBucketGoCB) WriteCasWithXattr(k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+	return WriteCasWithXattr(bucket, k, xattrKey, exp, cas, v, xv)
+}
+
+func (bucket *CouchbaseBucketGoCB) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, v []byte, xv []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) { // If this is a tombstone, we want to delete the document and update the xattr
+	return WriteWithXattr(bucket, k, xattrKey, exp, cas, v, xv, isDelete, deleteBody)
+}
+
+func (bucket *CouchbaseBucketGoCB) DeleteWithXattr(k string, xattrKey string) error {
+	return DeleteWithXattr(bucket, k, xattrKey)
+}
+
+func (bucket *CouchbaseBucketGoCB) GetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
+	return bucket.SubdocGetXattr(k, xattrKey, xv)
+}
+
+func (bucket *CouchbaseBucketGoCB) GetWithXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
+	return bucket.SubdocGetBodyAndXattr(k, xattrKey, userXattrKey, rv, xv, uxv)
+}
+
+func (bucket *CouchbaseBucketGoCB) WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+	return WriteUpdateWithXattr(bucket, k, xattrKey, userXattrKey, exp, previous, callback)
+}
+
+func (bucket *CouchbaseBucketGoCB) UpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}, deleteBody bool, isDelete bool) (casOut uint64, err error) {
+	return UpdateTombstoneXattr(bucket, k, xattrKey, exp, cas, xv, deleteBody)
+}
+
+// SubdocGetXattr retrieves the named xattr
+func (bucket *CouchbaseBucketGoCB) SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
+
+	worker := func() (shouldRetry bool, err error, value interface{}) {
+		res, lookupErr := bucket.Bucket.LookupInEx(k, gocb.SubdocDocFlagAccessDeleted).
+			GetEx(xattrKey, gocb.SubdocFlagXattr).Execute()
+		switch lookupErr {
+		case nil:
+			xattrContErr := res.Content(xattrKey, xv)
+			if xattrContErr != nil {
+				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
+			}
+			cas := uint64(res.Cas())
+			return false, err, cas
+		case gocbcore.ErrSubDocBadMulti:
+			xattrErr := res.Content(xattrKey, xv)
+			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrErr)
+			cas := uint64(res.Cas())
+			return false, ErrXattrNotFound, cas
+		case gocbcore.ErrKeyNotFound:
+			Debugf(KeyCRUD, "No document found for key=%s", UD(k))
+			return false, ErrNotFound, 0
+		case gocbcore.ErrSubDocMultiPathFailureDeleted, gocb.ErrSubDocSuccessDeleted:
+			xattrContentErr := res.Content(xattrKey, xv)
+			if xattrContentErr != nil {
+				return false, ErrXattrNotFound, uint64(0)
+			}
+			cas := uint64(res.Cas())
+			return false, nil, cas
+		default:
+			shouldRetry = bucket.isRecoverableReadError(lookupErr)
+			return shouldRetry, lookupErr, uint64(0)
+		}
+
+	}
+
+	err, result := RetryLoop("SubdocGetXattr", worker, bucket.Spec.RetrySleeper())
+	if err != nil {
+		err = pkgerrors.Wrapf(err, "SubdocGetXattr %s", UD(k).Redact())
+	}
+
+	if result == nil {
+		return 0, err
+	}
+
+	cas, ok := result.(uint64)
+	if !ok {
+		return 0, RedactErrorf("SubdocGetXattr: Error doing type assertion of %v (%T) into uint64, Key %v", UD(result), result, UD(k))
+	}
+
+	return cas, err
+}
+
+// Retrieve a document and it's associated named xattr
+func (bucket *CouchbaseBucketGoCB) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
+
+	worker := func() (shouldRetry bool, err error, value uint64) {
+
+		// First, attempt to get the document and xattr in one shot. We can't set SubdocDocFlagAccessDeleted when attempting
+		// to retrieve the full doc body, so need to retry that scenario below.
+		res, lookupErr := bucket.Bucket.LookupInEx(k, gocb.SubdocDocFlagAccessDeleted).
+			GetEx(xattrKey, gocb.SubdocFlagXattr). // Get the xattr
+			GetEx("", gocb.SubdocFlagNone).        // Get the document body
+			Execute()
+
+		// There are two 'partial success' error codes:
+		//   ErrSubDocBadMulti - one of the subdoc operations failed.  Occurs when doc exists but xattr does not
+		//   ErrSubDocMultiPathFailureDeleted - one of the subdoc operations failed, and the doc is deleted.  Occurs when xattr exists but doc is deleted (tombstone)
+		switch lookupErr {
+		case nil, gocbcore.ErrSubDocBadMulti:
+			// Attempt to retrieve the document body, if present
+			docContentErr := res.Content("", rv)
+			if docContentErr != nil {
+				Debugf(KeyCRUD, "No document body found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), docContentErr)
+			}
+			// Attempt to retrieve the xattr, if present
+			xattrContentErr := res.Content(xattrKey, xv)
+			if xattrContentErr != nil {
+				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+			}
+			cas = uint64(res.Cas())
+
+		case gocbcore.ErrSubDocMultiPathFailureDeleted:
+			//   ErrSubDocMultiPathFailureDeleted - one of the subdoc operations failed, and the doc is deleted.  Occurs when xattr may exist but doc is deleted (tombstone)
+			xattrContentErr := res.Content(xattrKey, xv)
+			cas = uint64(res.Cas())
+			if xattrContentErr != nil {
+				// No doc, no xattr means the doc isn't found
+				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				return false, ErrNotFound, cas
+			}
+			return false, nil, cas
+		case gocb.ErrKeyNotFound:
+			return false, ErrNotFound, cas
+		default:
+			shouldRetry = bucket.isRecoverableReadError(lookupErr)
+			return shouldRetry, lookupErr, uint64(0)
+		}
+
+		// TODO: We may be able to improve in the future by having this secondary op as part of the first. At present
+		// there is no support to obtain more than one xattr in a single operation however MB-28041 is filed for this.
+		if userXattrKey != "" {
+			userXattrCas, err := bucket.SubdocGetXattr(k, userXattrKey, uxv)
+			switch pkgerrors.Cause(err) {
+
+			case gocb.ErrKeyNotFound:
+				// If key not found it has been deleted in between the first op and this op.
+				return false, ErrNotFound, userXattrCas
+
+			case gocb.ErrSubDocBadMulti:
+				// Xattr doesn't exist, can skip
+
+			case nil:
+				if cas != userXattrCas {
+					return true, errors.New("cas mismatch between user xattr and document body"), uint64(0)
+				}
+			default:
+				// Unknown error occurred
+				// Shouldn't retry as any recoverable error will have been retried already in SubdocGetXattr
+				return false, err, uint64(0)
+			}
+		}
+
+		return false, nil, cas
+
+	}
+
+	// Kick off retry loop
+	err, cas = RetryLoopCas("SubdocGetBodyAndXattr", worker, bucket.Spec.RetrySleeper())
+	if err != nil {
+		err = pkgerrors.Wrapf(err, "SubdocGetBodyAndXattr %v", UD(k).Redact())
+	}
+
+	return cas, err
+
+}
+
+// SubdocDeleteXattr removes the specified xattr.  Used to remove xattr from Couchbase Server
+// tombstones.
+func (bucket *CouchbaseBucketGoCB) SubdocDeleteXattr(k string, xattrKey string, cas uint64) error {
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+	// Cas-safe delete of just the XATTR.  Use SubdocDocFlagAccessDeleted since presumably the document body
+	// has been deleted.
+	_, mutateErrDeleteXattr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagAccessDeleted, gocb.Cas(cas), uint32(0)).
+		RemoveEx(xattrKey, gocb.SubdocFlagXattr). // Remove the xattr
+		Execute()
+
+	// If no error, or it was just a ErrSubDocSuccessDeleted error, we're done.
+	// ErrSubDocSuccessDeleted is a "success error" that means "operation was on a tombstoned document"
+	if mutateErrDeleteXattr == nil || mutateErrDeleteXattr == gocbcore.ErrSubDocSuccessDeleted {
+		return nil
+	}
+	return mutateErrDeleteXattr
+}
+
+// SubdocDeleteBodyAndXattr removes the body and specified xattr for a document.  Used
+// when purging a document
+func (bucket *CouchbaseBucketGoCB) SubdocDeleteBodyAndXattr(k string, xattrKey string) error {
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+
+	_, mutateErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(0), uint32(0)).
+		RemoveEx(xattrKey, gocb.SubdocFlagXattr). // Remove the xattr
+		RemoveEx("", gocb.SubdocFlagNone).        // Delete the document body
+		Execute()
+
+	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
+		Debugf(KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
+		return nil
+	}
+
+	if pkgerrors.Cause(mutateErr) == gocb.ErrKeyNotFound {
+		return ErrNotFound
+	}
+
+	// If mutate fails due to missing xattr, return ErrXattrNotFound
+	subdocMutateErr, ok := pkgerrors.Cause(mutateErr).(gocbcore.SubDocMutateError)
+	if ok && subdocMutateErr.Err == gocb.ErrSubDocPathNotFound {
+		return ErrXattrNotFound
+	}
+
+	return mutateErr
+}
+
+// SubdocRemoveBody removes the document body, and updates the cas and crc32c on the specified xattr
+func (bucket *CouchbaseBucketGoCB) SubdocDeleteBody(k string, xattrKey string, exp uint32, cas uint64) (casOut uint64, err error) {
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+
+	docFragment, mutateErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(cas), exp).
+		UpsertEx(xattrCasPath(xattrKey), "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+		UpsertEx(xattrCrc32cPath(xattrKey), DeleteCrc32c, gocb.SubdocFlagXattr).                            // Stamp crc32c on the xattr
+		RemoveEx("", gocb.SubdocFlagNone).                                                                  // Delete the document body
+		Execute()
+
+	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
+		Debugf(KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
+		return uint64(docFragment.Cas()), nil
+	}
+
+	return uint64(0), mutateErr
+}
+
+// SubdocUpdateXattrRemoveBody upserts the xattr and removes the document body.  Used when tombstoning a
+// document.
+func (bucket *CouchbaseBucketGoCB) SubdocUpdateXattrDeleteBody(k, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error) {
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+
+	docFragment, mutateErr := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagNone, gocb.Cas(cas), exp).
+		UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                       // Update the xattr
+		UpsertEx(xattrCasPath(xattrKey), "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+		UpsertEx(xattrCrc32cPath(xattrKey), DeleteCrc32c, gocb.SubdocFlagXattr).                            // Stamp crc32c on the xattr
+		RemoveEx("", gocb.SubdocFlagNone).                                                                  // Remove the body
+		Execute()
+
+	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
+		Debugf(KeyCRUD, "No error or ErrSubDocSuccessDeleted.  We're done.")
+		return uint64(docFragment.Cas()), nil
+	}
+
+	return uint64(0), mutateErr
+}
+
+// Inserts a new server tombstone with xattr.  If tombstone creation is supported by server, body of created document
+// will be nil.  If unsupported, document body will be {}
+func (bucket *CouchbaseBucketGoCB) SubdocInsertXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error) {
+	bucket.singleOps <- struct{}{}
+	defer func() {
+		<-bucket.singleOps
+	}()
+
+	// Check whether server supports creation of tombstone in a single operation
+	supportsTombstoneCreation := bucket.IsSupported(sgbucket.DataStoreFeatureCreateDeletedWithXattr)
+
+	var mutateFlag gocb.SubdocDocFlag
+	if supportsTombstoneCreation {
+		mutateFlag = SubdocDocFlagCreateAsDeleted | gocb.SubdocDocFlagAccessDeleted | gocb.SubdocDocFlagReplaceDoc
+	} else {
+		mutateFlag = gocb.SubdocDocFlagMkDoc
+	}
+	builder := bucket.Bucket.MutateInEx(k, mutateFlag, gocb.Cas(cas), exp).
+		UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                       // Update the xattr
+		UpsertEx(xattrCasPath(xattrKey), "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros). // Stamp the cas on the xattr
+		UpsertEx(xattrCrc32cPath(xattrKey), DeleteCrc32c, gocb.SubdocFlagXattr)                             // Stamp the body hash on the xattr
+
+	docFragment, err := builder.Execute()
+	if err != nil {
+		return uint64(0), err
+	}
+	return uint64(docFragment.Cas()), nil
+}
+
+// SubdocInsertBodyAndXattr creates a document with xattr.  Fails if document already exists
+func (bucket *CouchbaseBucketGoCB) SubdocInsertBodyAndXattr(k string, xattrKey string, exp uint32, v interface{}, xv interface{}) (casOut uint64, err error) {
+
+	mutateInBuilder := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagReplaceDoc, 0, exp).
+		UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                      // Update the xattr
+		UpsertEx(xattrCasPath(xattrKey), "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros) // Stamp the cas on the xattr
+	if bucket.IsSupported(sgbucket.DataStoreFeatureCrc32cMacroExpansion) {
+		mutateInBuilder.UpsertEx(xattrCrc32cPath(xattrKey), "${Mutation.value_crc32c}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros) // Stamp the body hash on the xattr
+	}
+	mutateInBuilder.UpsertEx("", v, gocb.SubdocFlagNone) // Update the document body
+	docFragment, err := mutateInBuilder.Execute()
+	if err != nil {
+		return uint64(0), err
+	}
+	return uint64(docFragment.Cas()), nil
+}
+
+// SubdocUpdateithXattr updates the document body and specified xattr.
+func (bucket *CouchbaseBucketGoCB) SubdocUpdateBodyAndXattr(k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+
+	// Have value and xattr value - update both
+	mutateInBuilder := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagMkDoc, gocb.Cas(cas), exp).
+		UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                      // Update the xattr
+		UpsertEx(xattrCasPath(xattrKey), "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros) // Stamp the cas on the xattr
+	if bucket.IsSupported(sgbucket.DataStoreFeatureCrc32cMacroExpansion) {
+		mutateInBuilder.UpsertEx(xattrCrc32cPath(xattrKey), "${Mutation.value_crc32c}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros) // Stamp the body hash on the xattr
+	}
+	mutateInBuilder.UpsertEx("", v, gocb.SubdocFlagNone) // Update the document body
+	docFragment, err := mutateInBuilder.Execute()
+	if err != nil {
+		return 0, err
+	}
+	return uint64(docFragment.Cas()), nil
+}
+
+// SubdocUpdateithXattrOnly upserts an xattr, does not modify body
+func (bucket *CouchbaseBucketGoCB) SubdocUpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error) {
+
+	// Have value and xattr value - update both
+	mutateInBuilder := bucket.Bucket.MutateInEx(k, gocb.SubdocDocFlagAccessDeleted, gocb.Cas(cas), exp).
+		UpsertEx(xattrKey, xv, gocb.SubdocFlagXattr).                                                      // Update the xattr
+		UpsertEx(xattrCasPath(xattrKey), "${Mutation.CAS}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros) // Stamp the cas on the xattr
+	if bucket.IsSupported(sgbucket.DataStoreFeatureCrc32cMacroExpansion) {
+		mutateInBuilder.UpsertEx(xattrCrc32cPath(xattrKey), "${Mutation.value_crc32c}", gocb.SubdocFlagXattr|gocb.SubdocFlagUseMacros) // Stamp the body hash on the xattr
+	}
+	docFragment, mutateErr := mutateInBuilder.Execute()
+	if mutateErr == nil || mutateErr == gocbcore.ErrSubDocSuccessDeleted {
+		return uint64(docFragment.Cas()), nil
+	}
+
+	return uint64(0), mutateErr
+}
+
+func (bucket *CouchbaseBucketGoCB) GetSpec() BucketSpec {
+	return bucket.Spec
+}

--- a/base/collection.go
+++ b/base/collection.go
@@ -385,27 +385,6 @@ func (c *Collection) Dump() {
 	return
 }
 
-// xattrStore
-
-func (c *Collection) WriteCasWithXattr(k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
-	return 0, errors.New("WriteCasWithXattr not implemented")
-}
-func (c *Collection) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) {
-	return 0, errors.New("WriteWithXattr not implemented")
-}
-func (c *Collection) GetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
-	return 0, errors.New("GetXattr not implemented")
-}
-func (c *Collection) GetWithXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
-	return 0, errors.New("GetWithXattr not implemented")
-}
-func (c *Collection) DeleteWithXattr(k string, xattrKey string) error {
-	return errors.New("DeleteWithXattr not implemented")
-}
-func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
-	return 0, errors.New("WriteUpdateWithXattr not implemented")
-}
-
 func (b *Collection) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
 	return errors.New("SubdocInsert not implemented")
 }
@@ -436,4 +415,34 @@ func (c *Collection) IsError(err error, errorType sgbucket.DataStoreErrorType) b
 	default:
 		return false
 	}
+}
+
+// Recoverable errors or timeouts trigger retry for gocb v2 read operations
+func (c *Collection) isRecoverableReadError(err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	if isGoCBTimeoutError(err) {
+		return true
+	}
+
+	if errors.Is(err, gocb.ErrTemporaryFailure) || errors.Is(err, gocb.ErrOverload) {
+		return true
+	}
+	return false
+}
+
+// Recoverable errors trigger retry for gocb v2 write operations
+func (c *Collection) isRecoverableWriteError(err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, gocb.ErrTemporaryFailure) || errors.Is(err, gocb.ErrOverload) {
+		return true
+	}
+	return false
 }

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -1,0 +1,401 @@
+package base
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocbcore"
+	"github.com/couchbase/gocbcore/memd"
+	sgbucket "github.com/couchbase/sg-bucket"
+	pkgerrors "github.com/pkg/errors"
+)
+
+var GetSpecXattr = &gocb.GetSpecOptions{IsXattr: true}
+var InsertSpecXattr = &gocb.InsertSpecOptions{IsXattr: true}
+var UpsertSpecXattr = &gocb.UpsertSpecOptions{IsXattr: true}
+var RemoveSpecXattr = &gocb.RemoveSpecOptions{IsXattr: true}
+var LookupOptsAccessDeleted *gocb.LookupInOptions
+
+var _ SubdocXattrStore = &Collection{}
+
+func init() {
+	LookupOptsAccessDeleted = &gocb.LookupInOptions{}
+	LookupOptsAccessDeleted.Internal.DocFlags = gocb.SubdocDocFlagAccessDeleted
+}
+
+func (c *Collection) GetSpec() BucketSpec {
+	return c.Spec
+}
+
+// Implementation of the XattrStore interface primarily invokes common wrappers that in turn invoke SDK-specific SubdocXattrStore API
+func (c *Collection) WriteCasWithXattr(k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+	return WriteCasWithXattr(c, k, xattrKey, exp, cas, v, xv)
+}
+
+func (c *Collection) WriteWithXattr(k string, xattrKey string, exp uint32, cas uint64, v []byte, xv []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) { // If this is a tombstone, we want to delete the document and update the xattr
+	return WriteWithXattr(c, k, xattrKey, exp, cas, v, xv, isDelete, deleteBody)
+}
+
+func (c *Collection) DeleteWithXattr(k string, xattrKey string) error {
+	return DeleteWithXattr(c, k, xattrKey)
+}
+
+func (c *Collection) GetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
+	return c.SubdocGetXattr(k, xattrKey, xv)
+}
+
+func (c *Collection) GetWithXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
+	return c.SubdocGetBodyAndXattr(k, xattrKey, userXattrKey, rv, xv, uxv)
+}
+
+func (c *Collection) WriteUpdateWithXattr(k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+	return WriteUpdateWithXattr(c, k, xattrKey, userXattrKey, exp, previous, callback)
+}
+
+func (c *Collection) UpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}, deleteBody bool, isDelete bool) (casOut uint64, err error) {
+	return UpdateTombstoneXattr(c, k, xattrKey, exp, cas, xv, deleteBody)
+}
+
+// SubdocGetXattr retrieves the named xattr
+func (c *Collection) SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
+
+	ops := []gocb.LookupInSpec{
+		gocb.GetSpec(xattrKey, GetSpecXattr),
+	}
+	res, lookupErr := c.LookupIn(k, ops, LookupOptsAccessDeleted)
+
+	if lookupErr == nil {
+		xattrContErr := res.ContentAt(0, xv)
+		if xattrContErr != nil {
+			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
+			return 0, ErrXattrNotFound
+		}
+		cas := uint64(res.Cas())
+		return cas, nil
+	} else if isKVError(lookupErr, memd.StatusSubDocBadMulti) {
+		xattrErr := res.ContentAt(0, xv)
+		if xattrErr != nil {
+			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrErr)
+			return 0, ErrXattrNotFound
+		}
+		cas := uint64(res.Cas())
+		return cas, nil
+	} else if isKVError(lookupErr, memd.StatusKeyNotFound) {
+		Debugf(KeyCRUD, "No document found for key=%s", UD(k))
+		return 0, ErrNotFound
+	} else if isKVError(lookupErr, memd.StatusSubDocMultiPathFailureDeleted) || isKVError(lookupErr, memd.StatusSubDocSuccessDeleted) {
+		xattrContentErr := res.ContentAt(0, xv)
+		if xattrContentErr != nil {
+			return 0, ErrNotFound
+		}
+		cas := uint64(res.Cas())
+		return cas, nil
+	} else {
+		return 0, lookupErr
+	}
+}
+
+// SubdocGetBodyAndXattr retrieves the document body and xattr in a single LookupIn subdoc operation.  Does not require both to exist.
+func (c *Collection) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error) {
+	worker := func() (shouldRetry bool, err error, value uint64) {
+
+		// First, attempt to get the document and xattr in one shot.
+		ops := []gocb.LookupInSpec{
+			gocb.GetSpec(xattrKey, GetSpecXattr),
+			gocb.GetSpec("", &gocb.GetSpecOptions{}),
+		}
+		res, lookupErr := c.LookupIn(k, ops, LookupOptsAccessDeleted)
+
+		// There are two 'partial success' error codes:
+		//   ErrSubDocBadMulti - one of the subdoc operations failed.  Occurs when doc exists but xattr does not
+		//   ErrSubDocMultiPathFailureDeleted - one of the subdoc operations failed, and the doc is deleted.  Occurs when xattr exists but doc is deleted (tombstone)
+		switch lookupErr {
+		case nil, gocbcore.ErrMemdSubDocBadMulti:
+			// Attempt to retrieve the document body, if present
+			docContentErr := res.ContentAt(1, rv)
+			xattrContentErr := res.ContentAt(0, xv)
+			if isKVError(docContentErr, memd.StatusSubDocMultiPathFailureDeleted) && isKVError(xattrContentErr, memd.StatusSubDocMultiPathFailureDeleted) {
+				// No doc, no xattr means the doc isn't found
+				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				return false, ErrNotFound, cas
+			}
+
+			if docContentErr != nil {
+				Debugf(KeyCRUD, "No document body found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), docContentErr)
+			}
+			// Attempt to retrieve the xattr, if present
+			if xattrContentErr != nil {
+				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+			}
+			cas = uint64(res.Cas())
+
+		case gocbcore.ErrMemdSubDocMultiPathFailureDeleted:
+			//   ErrSubDocMultiPathFailureDeleted - one of the subdoc operations failed, and the doc is deleted.  Occurs when xattr may exist but doc is deleted (tombstone)
+			xattrContentErr := res.ContentAt(0, xv)
+			cas = uint64(res.Cas())
+			if xattrContentErr != nil {
+				// No doc, no xattr means the doc isn't found
+				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
+				return false, ErrNotFound, cas
+			}
+			return false, nil, cas
+		default:
+			// KeyNotFound is returned as KVError
+			if isKVError(lookupErr, memd.StatusKeyNotFound) {
+				return false, ErrNotFound, cas
+			}
+			shouldRetry = c.isRecoverableReadError(lookupErr)
+			return shouldRetry, lookupErr, uint64(0)
+		}
+
+		// TODO: We may be able to improve in the future by having this secondary op as part of the first. At present
+		// there is no support to obtain more than one xattr in a single operation however MB-28041 is filed for this.
+		if userXattrKey != "" {
+			userXattrCas, err := c.SubdocGetXattr(k, userXattrKey, uxv)
+			switch pkgerrors.Cause(err) {
+			case gocb.ErrDocumentNotFound:
+				// If key not found it has been deleted in between the first op and this op.
+				return false, err, userXattrCas
+			case gocbcore.ErrMemdSubDocBadMulti:
+				// Xattr doesn't exist, can skip
+			case nil:
+				if cas != userXattrCas {
+					return true, errors.New("cas mismatch between user xattr and document body"), uint64(0)
+				}
+			default:
+				// Unknown error occurred
+				// Shouldn't retry as any recoverable error will have been retried already in SubdocGetXattr
+				return false, err, uint64(0)
+			}
+		}
+		return false, nil, cas
+	}
+
+	// Kick off retry loop
+	err, cas = RetryLoopCas("SubdocGetBodyAndXattr", worker, c.Spec.RetrySleeper())
+	if err != nil {
+		err = pkgerrors.Wrapf(err, "SubdocGetBodyAndXattr %v", UD(k).Redact())
+	}
+
+	return cas, err
+}
+
+// SubdocInsertXattr inserts a new server tombstone with an associated mobile xattr.  Writes cas and crc32c to the xattr using
+// macro expansion.
+func (c *Collection) SubdocInsertXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error) {
+
+	supportsTombstoneCreation := c.IsSupported(sgbucket.DataStoreFeatureCreateDeletedWithXattr)
+
+	var docFlags gocb.SubdocDocFlag
+	if supportsTombstoneCreation {
+		docFlags = gocb.SubdocDocFlagCreateAsDeleted | gocb.SubdocDocFlagAccessDeleted | gocb.SubdocDocFlagAddDoc
+	} else {
+		docFlags = gocb.SubdocDocFlagMkDoc
+	}
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrKey, bytesToRawMessage(xv), UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCasPath(xattrKey), gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCrc32cPath(xattrKey), gocb.MutationMacroValueCRC32c, UpsertSpecXattr),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsUpsert,
+		Expiry:        CbsExpiryToDuration(exp),
+		Cas:           gocb.Cas(cas),
+	}
+	options.Internal.DocFlags = docFlags
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+}
+
+// SubdocInsertXattr inserts a document and associated mobile xattr in a single mutateIn operation.  Writes cas and crc32c to the xattr using
+// macro expansion.
+func (c *Collection) SubdocInsertBodyAndXattr(k string, xattrKey string, exp uint32, v interface{}, xv interface{}) (casOut uint64, err error) {
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrKey, bytesToRawMessage(xv), UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCasPath(xattrKey), gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCrc32cPath(xattrKey), gocb.MutationMacroValueCRC32c, UpsertSpecXattr),
+		gocb.ReplaceSpec("", bytesToRawMessage(v), nil),
+	}
+	options := &gocb.MutateInOptions{
+		Expiry:        CbsExpiryToDuration(exp),
+		StoreSemantic: gocb.StoreSemanticsUpsert,
+	}
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+
+}
+
+// SubdocUpdateXattr updates the xattr on an existing document. Writes cas and crc32c to the xattr using
+// macro expansion.
+func (c *Collection) SubdocUpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrKey, bytesToRawMessage(xv), UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCasPath(xattrKey), gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCrc32cPath(xattrKey), gocb.MutationMacroValueCRC32c, UpsertSpecXattr),
+	}
+	options := &gocb.MutateInOptions{
+		Expiry:        CbsExpiryToDuration(exp),
+		StoreSemantic: gocb.StoreSemanticsUpsert,
+		Cas:           gocb.Cas(cas),
+	}
+	options.Internal.DocFlags = gocb.SubdocDocFlagAccessDeleted
+
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+}
+
+// SubdocUpdateBodyAndXattr updates the document body and xattr of an existing document. Writes cas and crc32c to the xattr using
+// macro expansion.
+func (c *Collection) SubdocUpdateBodyAndXattr(k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrKey, bytesToRawMessage(xv), UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCasPath(xattrKey), gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCrc32cPath(xattrKey), gocb.MutationMacroValueCRC32c, UpsertSpecXattr),
+		gocb.ReplaceSpec("", bytesToRawMessage(v), nil),
+	}
+	options := &gocb.MutateInOptions{
+		Expiry:        CbsExpiryToDuration(exp),
+		StoreSemantic: gocb.StoreSemanticsUpsert,
+		Cas:           gocb.Cas(cas),
+	}
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+}
+
+// SubdocUpdateBodyAndXattr deletes the document body and updates the xattr of an existing document. Writes cas and crc32c to the xattr using
+// macro expansion.
+func (c *Collection) SubdocUpdateXattrDeleteBody(k, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrKey, bytesToRawMessage(xv), UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCasPath(xattrKey), gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCrc32cPath(xattrKey), gocb.MutationMacroValueCRC32c, UpsertSpecXattr),
+		gocb.RemoveSpec("", nil),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsReplace,
+		Expiry:        CbsExpiryToDuration(exp),
+		Cas:           gocb.Cas(cas),
+	}
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+}
+
+// SubdocDeleteXattr deletes an xattr of an existing document (or document tombstone)
+func (c *Collection) SubdocDeleteXattr(k string, xattrKey string, cas uint64) (err error) {
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.RemoveSpec(xattrKey, RemoveSpecXattr),
+	}
+	options := &gocb.MutateInOptions{
+		Cas: gocb.Cas(cas),
+	}
+	options.Internal.DocFlags = gocb.SubdocDocFlagAccessDeleted
+
+	_, mutateErr := c.MutateIn(k, mutateOps, options)
+	return mutateErr
+}
+
+// SubdocDeleteXattr deletes the document body and associated xattr of an existing document.
+func (c *Collection) SubdocDeleteBodyAndXattr(k string, xattrKey string) (err error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.RemoveSpec(xattrKey, RemoveSpecXattr),
+		gocb.RemoveSpec("", nil),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsReplace,
+	}
+	_, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr == nil {
+		return nil
+	}
+
+	// StatusKeyNotFound returned if document doesn't exist
+	if isKVError(mutateErr, memd.StatusKeyNotFound) {
+		return ErrNotFound
+	}
+
+	// StatusSubDocBadMulti returned if xattr doesn't exist
+	if isKVError(mutateErr, memd.StatusSubDocBadMulti) {
+		return ErrXattrNotFound
+	}
+	return mutateErr
+}
+
+// SubdocDeleteXattr deletes the document body of an existing document, and updates cas and crc32c in the associated xattr.
+func (c *Collection) SubdocDeleteBody(k string, xattrKey string, exp uint32, cas uint64) (casOut uint64, err error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrCasPath(xattrKey), gocb.MutationMacroCAS, UpsertSpecXattr),
+		gocb.UpsertSpec(xattrCrc32cPath(xattrKey), gocb.MutationMacroValueCRC32c, UpsertSpecXattr),
+		gocb.RemoveSpec("", nil),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsReplace,
+		Expiry:        CbsExpiryToDuration(exp),
+		Cas:           gocb.Cas(cas),
+	}
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+}
+
+// isKVError compares the status code of a gocb KeyValueError to the provided code.  If the provided error is
+// a gocb.SubDocumentError, checks against that error's InnerError.
+func isKVError(err error, code memd.StatusCode) bool {
+
+	switch typedErr := err.(type) {
+	case gocb.KeyValueError:
+		if typedErr.StatusCode == code {
+			return true
+		}
+	case *gocb.KeyValueError:
+		if typedErr.StatusCode == code {
+			return true
+		}
+	case gocbcore.KeyValueError:
+		if typedErr.StatusCode == code {
+			return true
+		}
+	case *gocbcore.KeyValueError:
+		if typedErr.StatusCode == code {
+			return true
+		}
+	case gocbcore.SubDocumentError:
+		return isKVError(typedErr.InnerError, code)
+	case *gocbcore.SubDocumentError:
+		return isKVError(typedErr.InnerError, code)
+	}
+
+	return false
+}
+
+// If v is []byte or *[]byte, converts to json.RawMessage to avoid duplicate marshalling by gocb.
+func bytesToRawMessage(v interface{}) interface{} {
+	switch val := v.(type) {
+	case []byte:
+		return json.RawMessage(val)
+	case *[]byte:
+		return json.RawMessage(*val)
+	default:
+		return v
+	}
+}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -352,7 +352,7 @@ func AsSubdocXattrStore(bucket Bucket) (SubdocXattrStore, bool) {
 }
 
 func xattrCasPath(xattrKey string) string {
-	return fmt.Sprintf("%s.%s", xattrKey, xattrMacroCas)
+	return xattrKey + "." + xattrMacroCas
 }
 
 func xattrCrc32cPath(xattrKey string) string {

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -1,0 +1,360 @@
+package base
+
+import (
+	"fmt"
+
+	sgbucket "github.com/couchbase/sg-bucket"
+	pkgerrors "github.com/pkg/errors"
+	"gopkg.in/couchbase/gocb.v1"
+)
+
+const (
+	xattrMacroCas         = "cas"
+	xattrMacroValueCrc32c = "value_crc32c"
+)
+
+// SubdocXattrStore interface defines the set of operations Sync Gateway uses to manage and interact with xattrs
+type SubdocXattrStore interface {
+	SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error)
+	SubdocGetBodyAndXattr(k string, xattrKey string, userXattrKey string, rv interface{}, xv interface{}, uxv interface{}) (cas uint64, err error)
+	SubdocInsertXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
+	SubdocInsertBodyAndXattr(k string, xattrKey string, exp uint32, v interface{}, xv interface{}) (casOut uint64, err error)
+	SubdocUpdateXattr(k string, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
+	SubdocUpdateBodyAndXattr(k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error)
+	SubdocUpdateXattrDeleteBody(k, xattrKey string, exp uint32, cas uint64, xv interface{}) (casOut uint64, err error)
+	SubdocDeleteXattr(k string, xattrKey string, cas uint64) error
+	SubdocDeleteBodyAndXattr(k string, xattrKey string) error
+	SubdocDeleteBody(k string, xattrKey string, exp uint32, cas uint64) (casOut uint64, err error)
+	GetSpec() BucketSpec
+	IsSupported(feature sgbucket.DataStoreFeature) bool
+	isRecoverableReadError(err error) bool
+	isRecoverableWriteError(err error) bool
+}
+
+// KvXattrStore is used for xattr_common functions that perform subdoc and standard kv operations
+type KvXattrStore interface {
+	sgbucket.KVStore
+	SubdocXattrStore
+}
+
+// CAS-safe write of a document and it's associated named xattr
+func WriteCasWithXattr(store SubdocXattrStore, k string, xattrKey string, exp uint32, cas uint64, v interface{}, xv interface{}) (casOut uint64, err error) {
+
+	worker := func() (shouldRetry bool, err error, value uint64) {
+
+		// cas=0 specifies an insert
+		if cas == 0 {
+			casOut, err = store.SubdocInsertBodyAndXattr(k, xattrKey, exp, v, xv)
+			if err != nil {
+				shouldRetry = store.isRecoverableWriteError(err)
+				return shouldRetry, err, uint64(0)
+			}
+			return false, nil, casOut
+		}
+
+		// Otherwise, replace existing value
+		if v != nil {
+			// Have value and xattr value - update both
+			casOut, err = store.SubdocUpdateBodyAndXattr(k, xattrKey, exp, cas, v, xv)
+			if err != nil {
+				shouldRetry = store.isRecoverableWriteError(err)
+				return shouldRetry, err, uint64(0)
+			}
+		} else {
+			// Update xattr only
+			casOut, err = store.SubdocUpdateXattr(k, xattrKey, exp, cas, xv)
+			if err != nil {
+				shouldRetry = store.isRecoverableWriteError(err)
+				return shouldRetry, err, uint64(0)
+			}
+		}
+		return false, nil, casOut
+	}
+
+	// Kick off retry loop
+	err, cas = RetryLoopCas("WriteCasWithXattr", worker, store.GetSpec().RetrySleeper())
+	if err != nil {
+		err = pkgerrors.Wrapf(err, "WriteCasWithXattr with key %v", UD(k).Redact())
+	}
+
+	return cas, err
+}
+
+// Single attempt to update a document and xattr.  Setting isDelete=true and value=nil will delete the document body.  Both
+// update types (UpdateTombstoneXattr, WriteCasWithXattr) include recoverable error retry.
+func WriteWithXattr(store SubdocXattrStore, k string, xattrKey string, exp uint32, cas uint64, value []byte, xattrValue []byte, isDelete bool, deleteBody bool) (casOut uint64, err error) { // If this is a tombstone, we want to delete the document and update the xattr
+	if isDelete {
+		return UpdateTombstoneXattr(store, k, xattrKey, exp, cas, xattrValue, deleteBody)
+	} else {
+		// Not a delete - update the body and xattr
+		return WriteCasWithXattr(store, k, xattrKey, exp, cas, value, xattrValue)
+	}
+}
+
+// CAS-safe update of a document's xattr (only).  Deletes the document body if deleteBody is true.
+func UpdateTombstoneXattr(store SubdocXattrStore, k string, xattrKey string, exp uint32, cas uint64, xv interface{}, deleteBody bool) (casOut uint64, err error) {
+
+	// WriteCasWithXattr always stamps the xattr with the new cas using macro expansion, into a top-level property called 'cas'.
+	// This is the only use case for macro expansion today - if more cases turn up, should change the sg-bucket API to handle this more generically.
+	requiresBodyRemoval := false
+	worker := func() (shouldRetry bool, err error, value uint64) {
+
+		var casOut uint64
+		var tombstoneErr error
+
+		// If deleteBody == true, remove the body and update xattr
+		if deleteBody {
+			casOut, tombstoneErr = store.SubdocUpdateXattrDeleteBody(k, xattrKey, exp, cas, xv)
+		} else {
+			if cas == 0 {
+				// if cas == 0, create a new server tombstone with xattr
+				casOut, tombstoneErr = store.SubdocInsertXattr(k, xattrKey, exp, cas, xv)
+				// If one-step tombstone creation is not supported, set flag for document body removal
+				requiresBodyRemoval = !store.IsSupported(sgbucket.DataStoreFeatureCreateDeletedWithXattr)
+			} else {
+				// If cas is non-zero, this is an already existing tombstone.  Update xattr only
+				casOut, tombstoneErr = store.SubdocUpdateXattr(k, xattrKey, exp, cas, xv)
+			}
+		}
+
+		if tombstoneErr != nil {
+			shouldRetry = store.isRecoverableWriteError(tombstoneErr)
+			return shouldRetry, tombstoneErr, uint64(0)
+		}
+		return false, nil, casOut
+	}
+
+	// Kick off retry loop
+	err, cas = RetryLoopCas("UpdateTombstoneXattr", worker, store.GetSpec().RetrySleeper())
+	if err != nil {
+		err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr with key %v", UD(k).Redact())
+		return cas, err
+	}
+
+	// In the case where the SubdocDocFlagCreateAsDeleted is not available and we are performing the creation of a
+	// tombstoned document we need to perform this second operation. This is due to the fact that SubdocDocFlagMkDoc
+	// will have been used above instead which will create an empty body {} which we then need to delete here. If there
+	// is a CAS mismatch we exit the operation as this means there has been a subsequent update to the body.
+	if requiresBodyRemoval {
+		worker := func() (shouldRetry bool, err error, value uint64) {
+
+			casOut, removeErr := store.SubdocDeleteBody(k, xattrKey, exp, cas)
+			if removeErr != nil {
+				// If there is a cas mismatch the body has since been updated and so we don't need to bother removing
+				// body in this operation
+				if IsCasMismatch(removeErr) {
+					return false, nil, cas
+				}
+
+				shouldRetry = store.isRecoverableWriteError(removeErr)
+				return shouldRetry, removeErr, uint64(0)
+			}
+			return false, nil, casOut
+		}
+
+		err, cas = RetryLoopCas("UpdateXattrDeleteBodySecondOp", worker, store.GetSpec().RetrySleeper())
+		if err != nil {
+			err = pkgerrors.Wrapf(err, "Error during UpdateTombstoneXattr delete op with key %v", UD(k).Redact())
+			return cas, err
+		}
+
+	}
+
+	return cas, err
+}
+
+// WriteUpdateWithXattr retrieves the existing doc from the bucket, invokes the callback to update the document, then writes the new document to the bucket.  Will repeat this process on cas
+// failure.  If previousValue/xattr/cas are provided, will use those on the first iteration instead of retrieving from the bucket.
+func WriteUpdateWithXattr(store SubdocXattrStore, k string, xattrKey string, userXattrKey string, exp uint32, previous *sgbucket.BucketDocument, callback sgbucket.WriteUpdateWithXattrFunc) (casOut uint64, err error) {
+
+	var value []byte
+	var xattrValue []byte
+	var userXattrValue []byte
+	var cas uint64
+	emptyCas := uint64(0)
+
+	// If an existing value has been provided, use that as the initial value
+	if previous != nil && previous.Cas > 0 {
+		value = previous.Body
+		xattrValue = previous.Xattr
+		cas = previous.Cas
+		userXattrValue = previous.UserXattr
+	}
+
+	for {
+		var err error
+		// If no existing value has been provided, retrieve the current value from the bucket
+		if cas == 0 {
+			// Load the existing value.
+			cas, err = store.SubdocGetBodyAndXattr(k, xattrKey, userXattrKey, &value, &xattrValue, &userXattrValue)
+
+			if err != nil {
+				if pkgerrors.Cause(err) != ErrNotFound {
+					// Unexpected error, cancel writeupdate
+					Debugf(KeyCRUD, "Retrieval of existing doc failed during WriteUpdateWithXattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), err)
+					return emptyCas, err
+				}
+				// Key not found - initialize values
+				value = nil
+				xattrValue = nil
+			}
+		}
+
+		// Invoke callback to get updated value
+		updatedValue, updatedXattrValue, isDelete, callbackExpiry, err := callback(value, xattrValue, userXattrValue, cas)
+
+		// If it's an ErrCasFailureShouldRetry, then retry by going back through the for loop
+		if err == ErrCasFailureShouldRetry {
+			cas = 0 // force the call to SubdocGetBodyAndXattr() to refresh
+			continue
+		}
+
+		// On any other errors, abort the Write attempt
+		if err != nil {
+			return emptyCas, err
+		}
+		if callbackExpiry != nil {
+			exp = *callbackExpiry
+		}
+
+		// Attempt to write the updated document to the bucket.  Mark body for deletion if previous body was non-empty
+		deleteBody := value != nil
+		casOut, writeErr := WriteWithXattr(store, k, xattrKey, exp, cas, updatedValue, updatedXattrValue, isDelete, deleteBody)
+
+		switch pkgerrors.Cause(writeErr) {
+		case nil:
+			return casOut, nil
+		case gocb.ErrKeyExists, gocb.ErrNotStored:
+			// Retry on cas failure.  ErrNotStored is returned in some concurrent insert races that appear to be related
+			// to the timing of concurrent xattr subdoc operations.  Treating as CAS failure as these will get the usual
+			// conflict/duplicate handling on retry.
+		default:
+			// WriteWithXattr already handles retry on recoverable errors, so fail on any errors other than ErrKeyExists
+			Warnf("Failed to update doc with xattr for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), writeErr)
+			return emptyCas, writeErr
+		}
+
+		// Reset value, xattr, cas for cas retry
+		value = nil
+		xattrValue = nil
+		cas = 0
+
+	}
+}
+
+// Delete a document and it's associated named xattr.  Couchbase server will preserve system xattrs as part of the (CBS)
+// tombstone when a document is deleted.  To remove the system xattr as well, an explicit subdoc delete operation is required.
+// This is currently called only for Purge operations.
+//
+// The doc existing doc is expected to be in one of the following states:
+//   - DocExists and XattrExists
+//   - DocExists but NoXattr
+//   - XattrExists but NoDoc
+//   - NoDoc and NoXattr
+// In all cases, the end state will be NoDoc and NoXattr.
+// Expected errors:
+//    - Temporary server overloaded errors, in which case the caller should retry
+//    - If the doc is in the the NoDoc and NoXattr state, it will return a KeyNotFound error
+func DeleteWithXattr(store KvXattrStore, k string, xattrKey string) error {
+	// Delegate to internal method that can take a testing-related callback
+	return deleteWithXattrInternal(store, k, xattrKey, nil)
+}
+
+// A function that will be called back after the first delete attempt but before second delete attempt
+// to simulate the doc having changed state (artifiically injected race condition)
+type deleteWithXattrRaceInjection func(k string, xattrKey string)
+
+func deleteWithXattrInternal(store KvXattrStore, k string, xattrKey string, callback deleteWithXattrRaceInjection) error {
+
+	Debugf(KeyCRUD, "DeleteWithXattr called with key: %v xattrKey: %v", UD(k), UD(xattrKey))
+
+	// Try to delete body and xattrs in single op
+	// NOTE: ongoing discussion w/ KV Engine team on whether this should handle cases where the body
+	// doesn't exist (eg, a tombstoned xattr doc) by just ignoring the "delete body" mutation, rather
+	// than current behavior of returning gocb.ErrKeyNotFound
+	mutateErr := store.SubdocDeleteBodyAndXattr(k, xattrKey)
+	switch {
+	case mutateErr == ErrNotFound:
+		// Invoke the testing related callback.  This is a no-op in non-test contexts.
+		if callback != nil {
+			callback(k, xattrKey)
+		}
+		// KeyNotFound indicates there is no doc body.  Try to delete only the xattr.
+		return deleteDocXattrOnly(store, k, xattrKey, callback)
+	case mutateErr == ErrXattrNotFound:
+		// Invoke the testing related callback.  This is a no-op in non-test contexts.
+		if callback != nil {
+			callback(k, xattrKey)
+		}
+		// ErrXattrNotFound indicates there is no XATTR.  Try to delete only the body.
+		return store.Delete(k)
+
+	default:
+		// return error
+		return mutateErr
+	}
+
+}
+
+func deleteDocXattrOnly(store SubdocXattrStore, k string, xattrKey string, callback deleteWithXattrRaceInjection) error {
+
+	//  Do get w/ xattr in order to get cas
+	var retrievedVal map[string]interface{}
+	var retrievedXattr map[string]interface{}
+	getCas, err := store.SubdocGetBodyAndXattr(k, xattrKey, "", &retrievedVal, &retrievedXattr, nil)
+	if err != nil {
+		return err
+	}
+
+	// If the doc body is non-empty at this point, then give up because it seems that a doc update has been
+	// interleaved with the purge.  Return error to the caller and cancel the purge.
+	if len(retrievedVal) != 0 {
+		return fmt.Errorf("DeleteWithXattr was unable to delete the doc. Another update " +
+			"was received which resurrected the doc by adding a new revision, in which case this delete operation is " +
+			"considered as cancelled.")
+	}
+
+	// Cas-safe delete of just the XATTR.  Use SubdocDocFlagAccessDeleted since presumably the document body
+	// has been deleted.
+	deleteXattrErr := store.SubdocDeleteXattr(k, xattrKey, getCas)
+	if deleteXattrErr != nil {
+		// If the cas-safe delete of XATTR fails, return an error to the caller.
+		// This might happen if there was a concurrent update interleaved with the purge (someone resurrected doc)
+		return pkgerrors.Wrapf(deleteXattrErr, "DeleteWithXattr was unable to delete the doc.  Another update "+
+			"was received which resurrected the doc by adding a new revision, in which case this delete operation is "+
+			"considered as cancelled. ")
+	}
+	return nil
+
+}
+
+// AsSubdocXattrStore tries to return the given bucket as a SubdocXattrStore, based on underlying buckets.
+func AsSubdocXattrStore(bucket Bucket) (SubdocXattrStore, bool) {
+
+	var underlyingBucket Bucket
+	switch typedBucket := bucket.(type) {
+	case *CouchbaseBucketGoCB:
+		return typedBucket, true
+	case *Collection:
+		return typedBucket, true
+	case *LoggingBucket:
+		underlyingBucket = typedBucket.GetUnderlyingBucket()
+	case *LeakyBucket:
+		underlyingBucket = typedBucket.GetUnderlyingBucket()
+	case *TestBucket:
+		underlyingBucket = typedBucket.Bucket
+	default:
+		// bail out for unrecognised/unsupported buckets
+		return nil, false
+	}
+
+	return AsSubdocXattrStore(underlyingBucket)
+}
+
+func xattrCasPath(xattrKey string) string {
+	return fmt.Sprintf("%s.%s", xattrKey, xattrMacroCas)
+}
+
+func xattrCrc32cPath(xattrKey string) string {
+	return fmt.Sprintf("%s.%s", xattrKey, xattrMacroValueCrc32c)
+}

--- a/base/collection_xattr_common.go
+++ b/base/collection_xattr_common.go
@@ -356,5 +356,5 @@ func xattrCasPath(xattrKey string) string {
 }
 
 func xattrCrc32cPath(xattrKey string) string {
-	return fmt.Sprintf("%s.%s", xattrKey, xattrMacroValueCrc32c)
+	return xattrKey + "." + xattrMacroValueCrc32c
 }

--- a/base/error.go
+++ b/base/error.go
@@ -43,6 +43,7 @@ var (
 	ErrUpdateCancel          = &sgError{"Cancel update"}
 	ErrImportCancelledPurged = &sgError{"Import Cancelled Due to Purge"}
 	ErrChannelFeed           = &sgError{"Error while building channel feed"}
+	ErrXattrNotFound         = &sgError{"Xattr Not Found"}
 
 	// ErrPartialViewErrors is returned if the view call contains any partial errors.
 	// This is more of a warning, and inspecting ViewResult.Errors is required for detail.
@@ -182,16 +183,6 @@ func IsDocNotFoundError(err error) bool {
 	default:
 		return false
 	}
-}
-
-// Check if this is a SubDocPathNotFound error
-func IsSubDocPathNotFound(err error) bool {
-
-	subdocMutateErr, ok := pkgerrors.Cause(err).(gocbcore.SubDocMutateError)
-	if ok {
-		return subdocMutateErr.Err == gocb.ErrSubDocPathNotFound
-	}
-	return false
 }
 
 func IsSubDocPathExistsError(err error) bool {

--- a/base/error.go
+++ b/base/error.go
@@ -168,8 +168,15 @@ func CouchHTTPErrorName(status int) string {
 func IsDocNotFoundError(err error) bool {
 
 	unwrappedErr := pkgerrors.Cause(err)
+	if unwrappedErr == nil {
+		return false
+	}
 
-	if unwrappedErr != nil && unwrappedErr == gocb.ErrKeyNotFound {
+	if unwrappedErr == ErrNotFound {
+		return true
+	}
+
+	if unwrappedErr == gocb.ErrKeyNotFound {
 		return true
 	}
 

--- a/base/util.go
+++ b/base/util.go
@@ -290,9 +290,9 @@ func IsPowerOfTwo(n uint16) bool {
 //of seconds in 30 days); if the number sent by a client is larger than
 //that, the server will consider it to be real Unix time value rather
 //than an offset from current time.
-//
-//This function takes a ttl as a Duration and returns an int
-//formatted as required by CBS expiry processing
+
+// DurationToCbsExpiry takes a ttl as a Duration and returns an int
+// formatted as required by CBS expiry processing
 func DurationToCbsExpiry(ttl time.Duration) uint32 {
 	if ttl <= kMaxDeltaTtlDuration {
 		return uint32(ttl.Seconds())
@@ -301,18 +301,28 @@ func DurationToCbsExpiry(ttl time.Duration) uint32 {
 	}
 }
 
-//This function takes a ttl in seconds and returns an int
-//formatted as required by CBS expiry processing
+// SecondsToCbsExpiry takes a ttl in seconds and returns an int
+// formatted as required by CBS expiry processing
 func SecondsToCbsExpiry(ttl int) uint32 {
 	return DurationToCbsExpiry(time.Duration(ttl) * time.Second)
 }
 
-//This function takes a CBS expiry and returns as a time
+// CbsExpiryToTime takes a CBS expiry and returns as a time
 func CbsExpiryToTime(expiry uint32) time.Time {
 	if expiry <= kMaxDeltaTtl {
 		return time.Now().Add(time.Duration(expiry) * time.Second)
 	} else {
 		return time.Unix(int64(expiry), 0)
+	}
+}
+
+// CbsExpiryToDuration takes a CBS expiry and returns as a duration
+func CbsExpiryToDuration(expiry uint32) time.Duration {
+	if expiry <= kMaxDeltaTtl {
+		return time.Duration(expiry) * time.Second
+	} else {
+		expiryTime := time.Unix(int64(expiry), 0)
+		return time.Until(expiryTime)
 	}
 }
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -480,10 +480,6 @@ type dataStore struct {
 // ForAllDataStores is used to run a test against multiple data stores (gocb bucket, gocb collection)
 func ForAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataStore)) {
 	dataStores := make([]dataStore, 0)
-	dataStores = append(dataStores, dataStore{
-		name:   "gocb.v1",
-		driver: GoCB,
-	})
 
 	if TestUseCouchbaseServer() {
 		dataStores = append(dataStores, dataStore{
@@ -491,6 +487,10 @@ func ForAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataS
 			driver: GoCBv2,
 		})
 	}
+	dataStores = append(dataStores, dataStore{
+		name:   "gocb.v1",
+		driver: GoCB,
+	})
 
 	for _, dataStore := range dataStores {
 		t.Run(dataStore.name, func(t *testing.T) {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -36,8 +36,8 @@
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
 
   <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9e841df93a43dd35e992eb08fe09c5211584d7e0" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="eeb14e0cf41831c798b832cedcbc49eba111d38d"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9ced163b8225c08922af38c3678dd0980b32f01f" />
+  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="7c907ab1fb8eca0b3d46f23fa4f9608e4706f360"/>
   <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
 
   <!-- gocb v1 -->

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5558,7 +5558,7 @@ func TestPutTombstoneWithoutCreateAsDeletedFlagCasFailure(t *testing.T) {
 	// var UpdateXattrCallback func()
 	// ==========================
 
-	// Insert the below into UpdateTombstoneXattr in bucket_gocb.go before the 'if isDelete && !supportsTombstoneCreation' check
+	// Insert the below into UpdateTombstoneXattr in bucket_gocb.go before the 'if requiresBodyRemoval' check
 	// and after the first 'Kick off retry loop' block
 	// ==========================
 	// if RunXattrCallback {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3912,7 +3912,7 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 	gocbBucket, _ := base.AsGoCBBucket(baseBucket)
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = gocbBucket.GetWithXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
+	_, err = gocbBucket.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
 	assert.NoError(t, err, "Unexpected Error")
 	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedXattr["rev"])
 
@@ -5558,7 +5558,7 @@ func TestPutTombstoneWithoutCreateAsDeletedFlagCasFailure(t *testing.T) {
 	// var UpdateXattrCallback func()
 	// ==========================
 
-	// Insert the below into UpdateXattr in bucket_gocb.go before the 'if isDelete && !supportsTombstoneCreation' check
+	// Insert the below into UpdateTombstoneXattr in bucket_gocb.go before the 'if isDelete && !supportsTombstoneCreation' check
 	// and after the first 'Kick off retry loop' block
 	// ==========================
 	// if RunXattrCallback {
@@ -5675,7 +5675,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	// Get Xattr and ensure channel value set correctly
 	var syncData db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -5690,7 +5690,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData2 db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
@@ -5708,7 +5708,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData3 db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData3)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData3)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData2.Crc32c, syncData3.Crc32c)
@@ -5729,7 +5729,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	var syncData4 db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData4)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData4)
 	assert.NoError(t, err)
 
 	assert.Equal(t, base.Crc32cHashString(updateVal), syncData4.Crc32c)
@@ -5808,7 +5808,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// Get sync data for doc and ensure user xattr has been used correctly to set channel
 	var syncData db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -5822,7 +5822,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 
 	var syncData2 db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
@@ -5905,7 +5905,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	var syncData db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -5996,7 +5996,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Get sync data for doc and ensure user xattr has been used correctly to set channel
 			var syncData db.SyncData
-			_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData)
+			_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 			assert.NoError(t, err)
 
 			assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -6014,7 +6014,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Ensure old channel set with user xattr has been removed
 			var syncData2 db.SyncData
-			_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData2)
+			_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 			assert.NoError(t, err)
 
 			assert.Equal(t, uint64(3), syncData2.Channels[channelName].Seq)
@@ -6068,7 +6068,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Get current sync data
 	var syncData db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	docRev, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
@@ -6088,7 +6088,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Ensure import worked and sequence incremented but that sequence did not
 	var syncData2 db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	docRev2, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
@@ -6109,7 +6109,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData3 db.SyncData
-	_, err = gocbBucket.GetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, syncData2.CurrentRev, syncData3.CurrentRev)


### PR DESCRIPTION
The gocb v1 implementation tightly coupled the Sync Gateway application logic with the underlying SDK subdoc operations.  To support gocb v2, this has been split out in the following way:
- The underlying subdoc operations are defined in the new SubdocXattrStore interface, and have been implemented for gocb v1 (CouchbaseBucketGoCB) and v2 (Collection)
- The common xattr handling code has been moved to collection_xattr_common, and requires a SubdocXattrStore that's used for the specific subdoc operations
- CouchbaseBucketGoCB and Collection both continue to implement the existing XattrStore interface, but their implementations are now (mostly) just wrappers for the functions in collection_xattr_common.go.  This allows the rest of the codebase to continue to use the XattrStore interface
- The CouchbaseBucketGoCB implementations of XattrStore and SubdocXattrStore have been moved to bucket_xattr.go, the new Collection implementations of the same are in collection_xattr.go
- Some error checking has been moved to bucket/collection scope to manage differences between SDK versions

All xattr tests in base have been updated to use ForAllDataStores to test against both SDK implementations.

- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/786/