### PR TITLE
CBG-1386: Handle pruning of history

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -229,7 +229,7 @@ func (auth *Authenticator) calculateHistory(princName string, invalSeq uint64, i
 	}
 
 	if prunedHistory := currentHistory.PruneHistory(auth.ClientPartitionWindow); len(prunedHistory) > 0 {
-		base.Debugf(base.KeyCRUD, "rebuildChannels: Pruned principal history on %s for %s", princName, strings.Join(prunedHistory, ","))
+		base.Debugf(base.KeyCRUD, "rebuildChannels: Pruned principal history on %s for %s", base.UD(princName), base.UD(strings.Join(prunedHistory, ",")))
 	}
 
 	// Ensure no entries are larger than the allowed threshold

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,6 +11,7 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -23,10 +24,15 @@ import (
 
 /** Manages user authentication for a database. */
 type Authenticator struct {
-	bucket                   base.Bucket
-	channelComputer          ChannelComputer
-	sessionCookieName        string // Custom per-database session cookie name
-	channelsWarningThreshold *uint32
+	bucket            base.Bucket
+	channelComputer   ChannelComputer
+	sessionCookieName string // Custom per-database session cookie name
+	AuthenticatorOptions
+}
+
+type AuthenticatorOptions struct {
+	ClientPartitionWindow    time.Duration
+	ChannelsWarningThreshold *uint32
 }
 
 // Interface for deriving the set of channels and roles a User/Role has access to.
@@ -43,11 +49,18 @@ type userByEmailInfo struct {
 const PrincipalUpdateMaxCasRetries = 20 // Maximum number of attempted retries on cas failure updating principal
 
 // Creates a new Authenticator that stores user info in the given Bucket.
-func NewAuthenticator(bucket base.Bucket, channelComputer ChannelComputer) *Authenticator {
+func NewAuthenticator(bucket base.Bucket, channelComputer ChannelComputer, options AuthenticatorOptions) *Authenticator {
 	return &Authenticator{
-		bucket:            bucket,
-		channelComputer:   channelComputer,
-		sessionCookieName: DefaultCookieName,
+		bucket:               bucket,
+		channelComputer:      channelComputer,
+		sessionCookieName:    DefaultCookieName,
+		AuthenticatorOptions: options,
+	}
+}
+
+func DefaultAuthenticatorOptions() AuthenticatorOptions {
+	return AuthenticatorOptions{
+		ClientPartitionWindow: base.DefaultClientPartitionWindow,
 	}
 }
 
@@ -57,14 +70,6 @@ func (auth *Authenticator) SessionCookieName() string {
 
 func (auth *Authenticator) SetSessionCookieName(cookieName string) {
 	auth.sessionCookieName = cookieName
-}
-
-func (auth *Authenticator) ChannelsWarningThreshold() *uint32 {
-	return auth.channelsWarningThreshold
-}
-
-func (auth *Authenticator) SetChannelsWarningThreshold(channelsWarningThreshold *uint32) {
-	auth.channelsWarningThreshold = channelsWarningThreshold
 }
 
 func docIDForUserEmail(email string) string {
@@ -185,7 +190,7 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 	// always grant access to the public document channel
 	channels.AddChannel(ch.DocumentStarChannel, 1)
 
-	channelHistory := auth.calculateHistory(princ.GetChannelInvalSeq(), princ.InvalidatedChannels(), channels, princ.ChannelHistory())
+	channelHistory := auth.calculateHistory(princ.Name(), princ.GetChannelInvalSeq(), princ.InvalidatedChannels(), channels, princ.ChannelHistory())
 
 	if len(channelHistory) != 0 {
 		princ.SetChannelHistory(channelHistory)
@@ -199,7 +204,7 @@ func (auth *Authenticator) rebuildChannels(princ Principal) error {
 }
 
 // Calculates history for either roles or channels
-func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.TimedSet, newGrants ch.TimedSet, currentHistory TimedSetHistory) TimedSetHistory {
+func (auth *Authenticator) calculateHistory(princName string, invalSeq uint64, invalGrants ch.TimedSet, newGrants ch.TimedSet, currentHistory TimedSetHistory) TimedSetHistory {
 	// Initialize history if currently empty
 	if currentHistory == nil {
 		currentHistory = map[string]GrantHistory{}
@@ -222,7 +227,11 @@ func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.Time
 			currentHistoryForGrant = GrantHistory{}
 		}
 
-		// TODO: Will perform pruning here once full
+		// If len of entries is greater than threshold
+		if len(currentHistoryForGrant.Entries) > CalculateMaxHistoryEntriesPerGrant(len(currentHistory)) {
+			currentHistoryForGrant.Entries[1].StartSeq = currentHistoryForGrant.Entries[0].StartSeq
+			currentHistoryForGrant.Entries = currentHistoryForGrant.Entries[1:]
+		}
 
 		// Add grant to history
 		currentHistoryForGrant.UpdatedAt = time.Now().UnixNano()
@@ -233,7 +242,31 @@ func (auth *Authenticator) calculateHistory(invalSeq uint64, invalGrants ch.Time
 		currentHistory[previousName] = currentHistoryForGrant
 	}
 
+	if prunedHistory := currentHistory.PruneHistory(auth.ClientPartitionWindow); len(prunedHistory) > 0 {
+		base.Debugf(base.KeyCRUD, "rebuildChannels: Pruned principal history on %s for %s", princName, strings.Join(prunedHistory, ","))
+	}
+
 	return currentHistory
+}
+
+func CalculateMaxHistoryEntriesPerGrant(historyLength int) int {
+	const maximumHistoryBytes = 1000000   // 1MB
+	const estimatedKeySize = 250          // This is an estimate of key size in bytes, this includes channel name, the unix timestamp, "entries" key
+	const estimatedSizeOfEntriesPair = 14 // Assume each sequence is 7 digits
+
+	maxEntries := 0
+
+	if historyLength != 0 {
+		maxEntries = (maximumHistoryBytes/historyLength - estimatedKeySize) / estimatedSizeOfEntriesPair
+	}
+
+	// Even if we can fit it limit entries to 10
+	maxEntries = base.MinInt(maxEntries, 10)
+
+	// In the event maxEntries is negative we should set a floor of 1 entry
+	maxEntries = base.MaxInt(maxEntries, 1)
+
+	return maxEntries
 }
 
 func (auth *Authenticator) rebuildRoles(user User) error {
@@ -254,7 +287,7 @@ func (auth *Authenticator) rebuildRoles(user User) error {
 		roles.Add(explicit)
 	}
 
-	roleHistory := auth.calculateHistory(user.GetRoleInvalSeq(), user.InvalidatedRoles(), roles, user.RoleHistory())
+	roleHistory := auth.calculateHistory(user.Name(), user.GetRoleInvalSeq(), user.InvalidatedRoles(), roles, user.RoleHistory())
 
 	if len(roleHistory) != 0 {
 		user.SetRoleHistory(roleHistory)
@@ -538,7 +571,7 @@ func (auth *Authenticator) DeleteRole(role Role, purge bool, deleteSeq uint64) e
 		p.setDeleted(true)
 		p.SetSequence(deleteSeq)
 
-		channelHistory := auth.calculateHistory(deleteSeq, p.Channels(), nil, p.ChannelHistory())
+		channelHistory := auth.calculateHistory(p.Name(), deleteSeq, p.Channels(), nil, p.ChannelHistory())
 		if len(channelHistory) != 0 {
 			p.SetChannelHistory(channelHistory)
 		}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,7 +11,6 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
@@ -229,7 +228,7 @@ func (auth *Authenticator) calculateHistory(princName string, invalSeq uint64, i
 	}
 
 	if prunedHistory := currentHistory.PruneHistory(auth.ClientPartitionWindow); len(prunedHistory) > 0 {
-		base.Debugf(base.KeyCRUD, "rebuildChannels: Pruned principal history on %s for %s", base.UD(princName), base.UD(strings.Join(prunedHistory, ",")))
+		base.Debugf(base.KeyCRUD, "rebuildChannels: Pruned principal history on %s for %s", base.UD(princName), base.UD(prunedHistory))
 	}
 
 	// Ensure no entries are larger than the allowed threshold

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2661,8 +2661,28 @@ func TestCalculateMaxHistoryEntriesPerGrant(t *testing.T) {
 			MaxEntriesExpectedOutput: 1,
 		},
 		{
-			Name:                     "Large history length",
-			HistoryLengthInput:       1000,
+			Name:                     "Upper Bound",
+			HistoryLengthInput:       3972,
+			MaxEntriesExpectedOutput: 1,
+		},
+		{
+			Name:                     "Large History Length",
+			HistoryLengthInput:       3330,
+			MaxEntriesExpectedOutput: 4,
+		},
+		{
+			Name:                     "Median history length",
+			HistoryLengthInput:       3250,
+			MaxEntriesExpectedOutput: 5,
+		},
+		{
+			Name:                     "Small history length",
+			HistoryLengthInput:       3010,
+			MaxEntriesExpectedOutput: 7,
+		},
+		{
+			Name:                     "Lower bound",
+			HistoryLengthInput:       2680,
 			MaxEntriesExpectedOutput: 10,
 		},
 		{
@@ -2674,7 +2694,7 @@ func TestCalculateMaxHistoryEntriesPerGrant(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			assert.Equal(t, CalculateMaxHistoryEntriesPerGrant(testCase.HistoryLengthInput), testCase.MaxEntriesExpectedOutput)
+			assert.Equal(t, testCase.MaxEntriesExpectedOutput, CalculateMaxHistoryEntriesPerGrant(testCase.HistoryLengthInput))
 		})
 	}
 }

--- a/auth/auth_time_sensitive_test.go
+++ b/auth/auth_time_sensitive_test.go
@@ -29,7 +29,7 @@ func TestAuthenticationSpeed(t *testing.T) {
 
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket.Bucket, nil)
+	auth := NewAuthenticator(testBucket.Bucket, nil, DefaultAuthenticatorOptions())
 	user, _ := auth.NewUser("me", "goIsKewl", nil)
 	assert.True(t, user.Authenticate("goIsKewl"))
 

--- a/auth/role.go
+++ b/auth/role.go
@@ -39,9 +39,8 @@ type TimedSetHistory map[string]GrantHistory
 func (timedSet TimedSetHistory) PruneHistory(partitionWindow time.Duration) []string {
 	prunedChannelHistory := make([]string, 0)
 	for chanName, grantHistory := range timedSet {
-		grantTime := time.Unix(0, grantHistory.UpdatedAt)
-		if grantTime.Add(partitionWindow).Before(time.Now()) {
-			fmt.Println("x")
+		grantTime := time.Unix(grantHistory.UpdatedAt, 0)
+		if time.Since(grantTime) > partitionWindow {
 			delete(timedSet, chanName)
 			prunedChannelHistory = append(prunedChannelHistory, chanName)
 		}

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -38,7 +38,7 @@ func TestInitRole(t *testing.T) {
 func TestAuthorizeChannelsRole(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	role, err := auth.NewRole("root", channels.SetOf(t, "superuser"))
 	assert.NoError(t, err)

--- a/auth/session.go
+++ b/auth/session.go
@@ -29,7 +29,7 @@ const DefaultCookieName = "SyncGatewaySession"
 
 func (auth *Authenticator) AuthenticateCookie(rq *http.Request, response http.ResponseWriter) (User, error) {
 
-	cookie, _ := rq.Cookie(auth.sessionCookieName)
+	cookie, _ := rq.Cookie(auth.SessionCookieName)
 	if cookie == nil {
 		return nil, nil
 	}
@@ -106,7 +106,7 @@ func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie
 		return nil
 	}
 	return &http.Cookie{
-		Name:     auth.sessionCookieName,
+		Name:     auth.SessionCookieName,
 		Value:    session.ID,
 		Expires:  session.Expiration,
 		Secure:   secureCookie,
@@ -115,7 +115,7 @@ func (auth *Authenticator) MakeSessionCookie(session *LoginSession, secureCookie
 }
 
 func (auth Authenticator) DeleteSessionForCookie(rq *http.Request) *http.Cookie {
-	cookie, _ := rq.Cookie(auth.sessionCookieName)
+	cookie, _ := rq.Cookie(auth.SessionCookieName)
 	if cookie == nil {
 		return nil
 	}

--- a/auth/session_test.go
+++ b/auth/session_test.go
@@ -27,7 +27,7 @@ func TestCreateSession(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	// Create session with a username and valid TTL of 2 hours.
 	session, err := auth.CreateSession(username, 2*time.Hour)
@@ -67,7 +67,7 @@ func TestDeleteSession(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	mockSession := &LoginSession{
 		ID:         base.GenerateRandomSecret(),
@@ -93,7 +93,7 @@ func TestMakeSessionCookie(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	sessionID := base.GenerateRandomSecret()
 	mockSession := &LoginSession{
@@ -118,7 +118,7 @@ func TestMakeSessionCookieProperties(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	sessionID := base.GenerateRandomSecret()
 	mockSession := &LoginSession{
@@ -152,7 +152,7 @@ func TestDeleteSessionForCookie(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	sessionID := base.GenerateRandomSecret()
 	body := strings.NewReader("?")

--- a/auth/user.go
+++ b/auth/user.go
@@ -489,7 +489,7 @@ func (user *userImpl) InheritedChannels() ch.TimedSet {
 	}
 
 	user.warnChanThresholdOnce.Do(func() {
-		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold(); channelsPerUserThreshold != nil {
+		if channelsPerUserThreshold := user.auth.ChannelsWarningThreshold; channelsPerUserThreshold != nil {
 			channelCount := len(channels)
 			if uint32(channelCount) >= *channelsPerUserThreshold {
 				base.Warnf("User ID: %v channel count: %d exceeds %d for channels per user warning threshold",

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -33,7 +33,7 @@ func TestUserAuthenticateDisabled(t *testing.T) {
 	defer bucket.Close()
 
 	// Create user
-	auth := NewAuthenticator(bucket, nil)
+	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
@@ -71,7 +71,7 @@ func TestUserAuthenticatePasswordHashUpgrade(t *testing.T) {
 	defer func() { require.NoError(t, SetBcryptCost(bcryptDefaultCost)) }()
 
 	// Create user
-	auth := NewAuthenticator(bucket, nil)
+	auth := NewAuthenticator(bucket, nil, DefaultAuthenticatorOptions())
 	u, err := auth.NewUser(username, oldPassword, base.Set{})
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
@@ -217,7 +217,7 @@ func TestCanSeeChannelSince(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 	freeChannels := base.SetFromArray([]string{"ESPN", "HBO", "FX", "AMC"})
 	user, err := auth.NewUser("user", "password", freeChannels)
 	assert.Nil(t, err)
@@ -245,7 +245,7 @@ func TestGetAddedChannels(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	role, err := auth.NewRole("music", channels.SetOf(t, "Spotify", "Youtube"))
 	assert.Nil(t, err)
@@ -288,7 +288,7 @@ func TestUserAuthenticateWithDisabledUserAccount(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -310,7 +310,7 @@ func TestUserAuthenticateWithOldPasswordHash(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -331,7 +331,7 @@ func TestUserAuthenticateWithBadPasswordHash(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)
@@ -351,7 +351,7 @@ func TestUserAuthenticateWithNoHashAndBadPassword(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	auth := NewAuthenticator(testBucket, nil)
+	auth := NewAuthenticator(testBucket, nil, DefaultAuthenticatorOptions())
 
 	user, err := auth.NewUser(username, password, base.Set{})
 	assert.NoError(t, err)

--- a/base/constants.go
+++ b/base/constants.go
@@ -169,9 +169,6 @@ var (
 	DefaultWarnThresholdGrantsPerDoc    = uint32(50)
 	DefaultClientPartitionWindow        = time.Hour * 24 * 30
 
-	MinHistoryEntriesPerGrant = 1
-	MaxHistoryEntriesPerGrant = 10
-
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
 	ErrUnknownField = errors.New("unrecognized JSON field")
 )

--- a/base/constants.go
+++ b/base/constants.go
@@ -167,6 +167,8 @@ var (
 	DefaultWarnThresholdChannelsPerDoc  = uint32(50)
 	DefaultWarnThresholdChannelsPerUser = uint32(50000)
 	DefaultWarnThresholdGrantsPerDoc    = uint32(50)
+	DefaultTimedSetHistoryPruneCap      = 10
+	DefaultClientPartitionWindow        = time.Hour * 24 * 30
 
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
 	ErrUnknownField = errors.New("unrecognized JSON field")

--- a/base/constants.go
+++ b/base/constants.go
@@ -167,8 +167,10 @@ var (
 	DefaultWarnThresholdChannelsPerDoc  = uint32(50)
 	DefaultWarnThresholdChannelsPerUser = uint32(50000)
 	DefaultWarnThresholdGrantsPerDoc    = uint32(50)
-	DefaultTimedSetHistoryPruneCap      = 10
 	DefaultClientPartitionWindow        = time.Hour * 24 * 30
+
+	MinHistoryEntriesPerGrant = 1
+	MaxHistoryEntriesPerGrant = 10
 
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
 	ErrUnknownField = errors.New("unrecognized JSON field")

--- a/base/util.go
+++ b/base/util.go
@@ -1383,6 +1383,13 @@ func MinInt(x, y int) int {
 	return y
 }
 
+func MaxInt(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}
+
 func MinUint64(x, y uint64) uint64 {
 	if x < y {
 		return x
@@ -1391,7 +1398,7 @@ func MinUint64(x, y uint64) uint64 {
 }
 
 func MaxUint64(x, y uint64) uint64 {
-	if x < y {
+	if x > y {
 		return x
 	}
 	return y

--- a/db/database.go
+++ b/db/database.go
@@ -701,14 +701,18 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 	context.BucketLock.RLock()
 	defer context.BucketLock.RUnlock()
 
+	sessionCookieName := auth.DefaultCookieName
+	if context.Options.SessionCookieName != "" {
+		sessionCookieName = context.Options.SessionCookieName
+	}
+
 	// Authenticators are lightweight & stateless, so it's OK to return a new one every time
 	authenticator := auth.NewAuthenticator(context.Bucket, context, auth.AuthenticatorOptions{
 		ClientPartitionWindow:    context.Options.ClientPartitionWindow,
 		ChannelsWarningThreshold: context.Options.UnsupportedOptions.WarningThresholds.ChannelsPerUser,
+		SessionCookieName:        sessionCookieName,
 	})
-	if context.Options.SessionCookieName != "" {
-		authenticator.SetSessionCookieName(context.Options.SessionCookieName)
-	}
+
 	return authenticator
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -275,7 +275,7 @@ func TestGetDeleted(t *testing.T) {
 	goassert.Equals(t, doc.SyncData.CurrentRev, rev2id)
 
 	// Try again but with a user who doesn't have access to this revision (see #179)
-	authenticator := auth.NewAuthenticator(db.Bucket, db)
+	authenticator := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 	db.user, err = authenticator.GetUser("")
 	assert.NoError(t, err, "GetUser")
 	db.user.SetExplicitChannels(nil, 1)
@@ -340,7 +340,7 @@ func TestGetRemovedAsUser(t *testing.T) {
 	assert.NoError(t, err, "Purge old revision JSON")
 
 	// Try again with a user who doesn't have access to this revision
-	authenticator := auth.NewAuthenticator(db.Bucket, db)
+	authenticator := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 	db.user, err = authenticator.GetUser("")
 	assert.NoError(t, err, "GetUser")
 
@@ -374,7 +374,7 @@ func TestGetRemovalMultiChannel(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	auth := auth.NewAuthenticator(db.Bucket, db)
+	auth := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 
 	// Create a user who have access to both channel ABC and NBC.
 	userAlice, err := auth.NewUser("alice", "pass", base.SetOf("ABC", "NBC"))
@@ -511,7 +511,7 @@ func TestDeltaSyncWhenFromRevIsChannelRemoval(t *testing.T) {
 
 	// Request delta between rev2ID and rev3ID (toRevision "rev2ID" is channel removal)
 	// as a user who doesn't have access to the removed revision via any other channel.
-	authenticator := auth.NewAuthenticator(db.Bucket, db)
+	authenticator := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 	user, err := authenticator.NewUser("alice", "pass", base.SetOf("NBC"))
 	require.NoError(t, err, "Error creating user")
 
@@ -576,7 +576,7 @@ func TestDeltaSyncWhenToRevIsChannelRemoval(t *testing.T) {
 
 	// Request delta between rev1ID and rev2ID (toRevision "rev2ID" is channel removal)
 	// as a user who doesn't have access to the removed revision via any other channel.
-	authenticator := auth.NewAuthenticator(db.Bucket, db)
+	authenticator := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 	user, err := authenticator.NewUser("alice", "pass", base.SetOf("NBC"))
 	require.NoError(t, err, "Error creating user")
 
@@ -1381,7 +1381,7 @@ func TestAccessFunctionDb(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	authenticator := auth.NewAuthenticator(db.Bucket, db)
+	authenticator := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 
 	var err error
 	db.ChannelMapper = channels.NewChannelMapper(`function(doc){access(doc.users,doc.userChannels);}`)
@@ -1472,7 +1472,7 @@ func TestUpdateDesignDoc(t *testing.T) {
 	goassert.True(t, strings.Contains(retrievedView.Map, "emit()"))
 	goassert.NotEquals(t, retrievedView.Map, mapFunction) // SG should wrap the map function, so they shouldn't be equal
 
-	authenticator := auth.NewAuthenticator(db.Bucket, db)
+	authenticator := auth.NewAuthenticator(db.Bucket, db, auth.DefaultAuthenticatorOptions())
 	db.user, _ = authenticator.NewUser("naomi", "letmein", channels.SetOf(t, "Netflix"))
 	err = db.PutDesignDoc("_design/pwn3d", sgbucket.DesignDoc{})
 	assertHTTPError(t, err, 403)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -838,7 +838,7 @@ func TestSessionTtlGreaterThan30Days(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.Bucket(), nil)
+	a := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
@@ -2535,7 +2535,7 @@ func TestSessionExpirationDateTimeFormat(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	authenticator := auth.NewAuthenticator(rt.Bucket(), nil)
+	authenticator := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	user, err := authenticator.NewUser("alice", "letMe!n", channels.SetOf(t, "*"))
 	assert.NoError(t, err, "Couldn't create new user")
 	assert.NoError(t, authenticator.Save(user), "Couldn't save new user")
@@ -2631,7 +2631,7 @@ func TestUserAndRoleResponseContentType(t *testing.T) {
 	assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 
 	// Create a new user and save to database to create user session.
-	authenticator := auth.NewAuthenticator(rt.Bucket(), nil)
+	authenticator := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	user, err := authenticator.NewUser("eve", "cGFzc3dvcmQ=", channels.SetOf(t, "*"))
 	assert.NoError(t, err, "Couldn't create new user")
 	assert.NoError(t, authenticator.Save(user), "Couldn't save new user")

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1689,7 +1689,7 @@ func TestLogin(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.Bucket(), nil)
+	a := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
@@ -1745,7 +1745,7 @@ func TestCustomCookieName(t *testing.T) {
 	}
 
 	// Disable guest user
-	a := auth.NewAuthenticator(rt.Bucket(), nil)
+	a := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	user, err := a.GetUser("")
 	assert.NoError(t, err)
 	user.SetDisabled(true)
@@ -1862,7 +1862,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	}
 
 	// Create some docs:
-	a := auth.NewAuthenticator(rt.Bucket(), nil)
+	a := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	guest, err := a.GetUser("")
 	assert.NoError(t, err)
 	guest.SetDisabled(false)
@@ -3184,7 +3184,7 @@ func TestStarAccess(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	a := auth.NewAuthenticator(rt.Bucket(), nil)
+	a := auth.NewAuthenticator(rt.Bucket(), nil, auth.DefaultAuthenticatorOptions())
 	var changes struct {
 		Results []db.ChangeEntry
 	}

--- a/rest/config.go
+++ b/rest/config.go
@@ -203,7 +203,7 @@ type DbConfig struct {
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
-	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for, before losing information about principal history. Default 30 days (in seconds)
+	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for without losing replication metadata. Default 30 days (in seconds)
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -203,6 +203,7 @@ type DbConfig struct {
 	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
+	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for, before losing information about principal history. Default 30 days (in seconds)
 }
 
 type DeltaSyncConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -737,6 +737,11 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		return db.DatabaseContextOptions{}, fmt.Errorf("use of user_xattr_key requires shared_bucket_access to be enabled")
 	}
 
+	clientPartitionWindow := base.DefaultClientPartitionWindow
+	if config.ClientPartitionWindowSecs != nil {
+		clientPartitionWindow = time.Duration(*config.ClientPartitionWindowSecs) * time.Second
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		RevisionCacheOptions:      revCacheOptions,
@@ -762,6 +767,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 			WebsocketPingInterval: sgReplicateWebsocketPingInterval,
 		},
 		SlowQueryWarningThreshold: time.Duration(*sc.config.SlowQueryWarningThreshold) * time.Millisecond,
+		ClientPartitionWindow:     clientPartitionWindow,
 	}
 
 	return contextOptions, nil

--- a/rest/session_api.go
+++ b/rest/session_api.go
@@ -218,7 +218,7 @@ func (h *handler) createUserSession() error {
 	}
 	response.SessionID = session.ID
 	response.Expires = session.Expiration.UTC().Format(time.RFC3339)
-	response.CookieName = authenticator.SessionCookieName()
+	response.CookieName = authenticator.SessionCookieName
 	h.writeJSON(response)
 	return nil
 }


### PR DESCRIPTION
Adds pruning to grant history. Rules as follows:

 - If the history entries for a role / channel are not updated in 30 days then the entire history for that role / channel will be removed.
 - Grant Pairs are pruned to maintain a maximum of 10 entries and a minimum of 1 entry. Numbers in between are calculated in order to maintain grant history no larger than 1MB. 
 Note 1MB can be exceeded if an extreme number of channels / roles have history as each requires at least 1 entry.
 
The calculation for the second rule has a unit test.

Created AuthenticatorOptions to pass through options to the Authenticator. Currently has two attributes but allows for easy additions in future.