### PR TITLE
CBG-1437: Log error if target ISGR doesn't support CAR

### DIFF
--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -92,6 +92,11 @@ func (apr *ActivePullReplicator) _connect() error {
 	}
 
 	apr.setState(ReplicationStateRunning)
+
+	if apr.blipSyncContext.blipContext.ActiveProtocol() == BlipCBMobileReplicationV2 && apr.config.PurgeOnRemoval {
+		base.ErrorfCtx(apr.config.ActiveDB.Ctx, "Pull replicator ID:%s running with revocations enabled but target does not support revocations. Sync Gateway 3.0 required.", apr.config.ID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If a pull replication is running but is using protocol V2 then it means the target ISGR instance is running 2.8. If this is the case and a user has PurgeOnRemoval enabled then they would expect revocations to occur, however, this is not possible on protocol V2. 

In this case we'll log an error to notify the user of this.

Note: Will require QE testing as it requires cross-version testing.