### PR TITLE
CBG-1477: Handle omit revID case

### DIFF
--- a/db/document.go
+++ b/db/document.go
@@ -41,6 +41,11 @@ const (
 const (
 	// RemovedRedactedDocument is returned by SG when a given document has been dropped out of a channel
 	RemovedRedactedDocument = `{"` + BodyRemoved + `":true}`
+
+	// RemovedRedactedDocumentFalse is returned by SG when a given document has been dropped out of a channel but the
+	// user still has access to it through another channel.
+	RemovedRedactedDocumentFalse = `{"` + BodyRemoved + `":false}`
+
 	// DeletedDocument is returned by SG when a given document has been deleted
 	DeletedDocument = `{"` + BodyDeleted + `":true}`
 )


### PR DESCRIPTION
PR includes the new work to handle the case where SGW can't determine the revision that was revoked and so has to send "" as the rev.

When this rev is requested by CBL (or ISGR) we will now return a "_removed" body as the rev response. If the active revision for this document is accessible we should return _removed: false otherwise, return _removed:true. 

The client / ISGR will treat _removed: true as they do currently by purging the document. If _removed: false is returned this can be ignored, however, this message is required so the client can be sure they have received a message for this change.

**Remaining:**

Currently I'm still setting the sent revision as "". This is up for debate.