### PR TITLE
CBG-1477: Only send revocations if user has no access

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -311,13 +311,13 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 					changeRow := bh.buildChangesRow(change, item["rev"])
 
 					if bh.purgeOnRemoval && len(change.Removed) > 0 && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
-						userMaintainsAccessToDoc, err := UserHasDocAccess(bh.db, change.ID, item["rev"])
+						userHasAccessToDoc, err := UserHasDocAccess(bh.db, change.ID, item["rev"])
 						if err != nil {
 							base.InfofCtx(bh.loggingCtx, base.KeySync, "Unable to obtain the doc: %s %s to verify user access: %v", base.UD(change.ID), item["rev"], err)
 							continue
 						}
 
-						if userMaintainsAccessToDoc {
+						if userHasAccessToDoc {
 							continue
 						}
 					}

--- a/db/changes.go
+++ b/db/changes.go
@@ -228,8 +228,6 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 					TriggeredBy: triggeredBy,
 				}
 
-				idOnlyRevocation := false
-
 				// We need to check whether a change / document sequence is greater than since.
 				// If its less than we can send a standard revocation with Sequence ID as above.
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
@@ -247,14 +245,26 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 					if !requiresRevocation {
 						return
 					}
-
-					idOnlyRevocation = true
 				}
 
-				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelName(), idOnlyRevocation)
+				userMaintainsAccessToDoc, err := UserStillMaintainsAccessToDoc(db, logEntry.DocID, logEntry.RevID)
+				if err != nil {
+					change := ChangeEntry{
+						Err: base.ErrChannelFeed,
+					}
+					feed <- &change
+					return
+				}
+
+				if userMaintainsAccessToDoc {
+					paginationOptions.Since.Seq = lastSeq
+					continue
+				}
+
+				change := makeRevocationChangeEntry(logEntry, seqID, singleChannelCache.ChannelName())
 				lastSeq = logEntry.Sequence
 
-				base.DebugfCtx(db.Ctx, base.KeyChanges, "Channel feed processing seq: %v in channel %s with omit revID %t", seqID, base.UD(singleChannelCache.ChannelName()), idOnlyRevocation)
+				base.DebugfCtx(db.Ctx, base.KeyChanges, "Channel feed processing revocation seq: %v in channel %s ", seqID, base.UD(singleChannelCache.ChannelName()))
 
 				select {
 				case <-options.Terminator:
@@ -280,6 +290,20 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 	}()
 
 	return feed
+}
+
+func UserStillMaintainsAccessToDoc(db *Database, docID, revID string) (bool, error) {
+	rev, err := db.revisionCache.Get(docID, revID, false, false)
+	if err != nil {
+		return false, err
+	}
+
+	isAuthorized, _ := db.authorizeUserForChannels(rev.DocID, rev.RevID, rev.Channels, rev.Deleted, nil)
+	if isAuthorized {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Checks if a document needs to be revoked. This is used in the case where the since < doc sequence
@@ -431,13 +455,9 @@ func makeChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) C
 	return change
 }
 
-func makeRevocationChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string, omitRevID bool) ChangeEntry {
+func makeRevocationChangeEntry(logEntry *LogEntry, seqID SequenceID, channelName string) ChangeEntry {
 	entry := makeChangeEntry(logEntry, seqID, channelName)
 	entry.Revoked = true
-
-	if omitRevID {
-		entry.Changes = nil
-	}
 
 	return entry
 }

--- a/db/changes.go
+++ b/db/changes.go
@@ -247,7 +247,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 					}
 				}
 
-				userMaintainsAccessToDoc, err := UserStillMaintainsAccessToDoc(db, logEntry.DocID, logEntry.RevID)
+				userMaintainsAccessToDoc, err := UserHasDocAccess(db, logEntry.DocID, logEntry.RevID)
 				if err != nil {
 					change := ChangeEntry{
 						Err: base.ErrChannelFeed,
@@ -292,9 +292,12 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 	return feed
 }
 
-func UserStillMaintainsAccessToDoc(db *Database, docID, revID string) (bool, error) {
+func UserHasDocAccess(db *Database, docID, revID string) (bool, error) {
 	rev, err := db.revisionCache.Get(docID, revID, false, false)
 	if err != nil {
+		if base.IsDocNotFoundError(err) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -247,7 +247,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 					}
 				}
 
-				userMaintainsAccessToDoc, err := UserHasDocAccess(db, logEntry.DocID, logEntry.RevID)
+				userHasAccessToDoc, err := UserHasDocAccess(db, logEntry.DocID, logEntry.RevID)
 				if err != nil {
 					change := ChangeEntry{
 						Err: base.ErrChannelFeed,
@@ -256,7 +256,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 					return
 				}
 
-				if userMaintainsAccessToDoc {
+				if userHasAccessToDoc {
 					paginationOptions.Since.Seq = lastSeq
 					continue
 				}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4937,7 +4937,126 @@ func TestReplicatorRevocations(t *testing.T) {
 
 	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
 	assertStatus(t, resp, http.StatusNotFound)
+}
 
+func TestReplicatorRevocationsNoRev(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	// Passive
+	revocationTester, rt2 := initScenario(t)
+	defer rt2.Close()
+
+	// Active
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: base.GetTestBucket(t),
+	})
+	defer rt1.Close()
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "chanA")
+
+	doc1Rev := rt2.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": "chanA"})
+
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	passiveDBURL.User = url.UserPassword("user", "test")
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous:          false,
+		PurgeOnRemoval:      true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+	})
+
+	require.NoError(t, ar.Start())
+	rt1.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	resp := rt1.SendAdminRequest("GET", "/db/doc1", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	revocationTester.removeRole("user", "foo")
+
+	_ = rt2.createDocReturnRev(t, "doc1", doc1Rev, map[string]interface{}{"channels": "chanA", "mutate": "val"})
+
+	require.NoError(t, ar.Start())
+	rt1.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	assertStatus(t, resp, http.StatusNotFound)
+}
+
+func TestReplicatorRevocationsNoRevButAlternateAccess(t *testing.T) {
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	// Passive
+	revocationTester, rt2 := initScenario(t)
+	defer rt2.Close()
+
+	// Active
+	rt1 := NewRestTester(t, &RestTesterConfig{
+		TestBucket: base.GetTestBucket(t),
+	})
+	defer rt1.Close()
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "chanA")
+
+	resp := rt2.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
+	assertStatus(t, resp, http.StatusCreated)
+
+	revocationTester.addRole("user", "foo2")
+	revocationTester.addRoleChannel("foo2", "chanB")
+
+	doc1Rev := rt2.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"chanA", "chanB"}})
+
+	srv := httptest.NewServer(rt2.TestPublicHandler())
+	defer srv.Close()
+
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	passiveDBURL.User = url.UserPassword("user", "test")
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePull,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: rt1.GetDatabase(),
+		},
+		Continuous:          false,
+		PurgeOnRemoval:      true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), false, false, false).DBReplicatorStats(t.Name()),
+	})
+
+	require.NoError(t, ar.Start())
+	rt1.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	revocationTester.removeRole("user", "foo")
+
+	_ = rt2.createDocReturnRev(t, "doc1", doc1Rev, map[string]interface{}{"channels": []string{"chanA", "chanB"}, "mutate": "val"})
+
+	require.NoError(t, ar.Start())
+	rt1.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	resp = rt1.SendAdminRequest("GET", "/db/doc1", "")
+	assertStatus(t, resp, http.StatusOK)
 }
 
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -1557,7 +1557,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeyReplicate)()
+	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
 
 	// Passive
 	tb2 := base.GetTestBucket(t)


### PR DESCRIPTION
Adds calculation to **only** send revocations if the user has completely lost access to the document. Means that we do an additional lookup for revocations to check whether the user has access through an alternative channel. 
This means the `{"_removed": true}` body check is no longer necessary and the document can be immediately purged when a revocation is received. 

Removals also follow same 