### PR TITLE
CBG-1412 - JSON strings in some responses not being correctly escaped

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -39,44 +39,44 @@ func TestPutDocSpecialChar(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 	testCases := []struct {
-		name string
-		pathDocID string
-		method string
-		body string
+		name         string
+		pathDocID    string
+		method       string
+		body         string
 		expectedResp int
-		eeOnly bool
+		eeOnly       bool
 	}{
 		{
-			name: "Double quote PUT",
-			pathDocID: `doc"55"`,
-			method: "PUT",
-			body: "{}",
+			name:         "Double quote PUT",
+			pathDocID:    `doc"55"`,
+			method:       "PUT",
+			body:         "{}",
 			expectedResp: http.StatusCreated,
-			eeOnly: false,
+			eeOnly:       false,
 		},
 		{
-			name: "Double quote PUT for replicator2",
-			pathDocID: `doc"77"?replicator2=true`,
-			method: "PUT",
-			body: "{}",
+			name:         "Double quote PUT for replicator2",
+			pathDocID:    `doc"77"?replicator2=true`,
+			method:       "PUT",
+			body:         "{}",
 			expectedResp: http.StatusCreated,
-			eeOnly: true,
+			eeOnly:       true,
 		},
 		{
-			name: "Local double quote PUT",
-			pathDocID: `_local/doc"57"`,
-			method: "PUT",
-			body: "{}",
+			name:         "Local double quote PUT",
+			pathDocID:    `_local/doc"57"`,
+			method:       "PUT",
+			body:         "{}",
 			expectedResp: http.StatusCreated,
-			eeOnly: false,
+			eeOnly:       false,
 		},
 		{
-			name: "Double quote PUT with attachment",
-			pathDocID: `doc"59"/attachMe`,
-			method: "PUT",
-			body: "{}",
+			name:         "Double quote PUT with attachment",
+			pathDocID:    `doc"59"/attachMe`,
+			method:       "PUT",
+			body:         "{}",
 			expectedResp: http.StatusCreated, // Admin Docs expected response http.StatusOK
-			eeOnly: false,
+			eeOnly:       false,
 		},
 	}
 	for _, testCase := range testCases {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -34,6 +34,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPutDocSpecialChar(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+	testCases := []struct {
+		name string
+		docID string
+	}{
+		{
+			name: "Double quote",
+			docID: `doc"55"`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", testCase.docID), "{}")
+			assertStatus(t, tr, http.StatusCreated)
+			var body map[string]interface{}
+			err := json.Unmarshal(tr.BodyBytes(), &body)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 // Reproduces #3048 Panic when attempting to make invalid update to a conflicting document
 func TestNoPanicInvalidUpdate(t *testing.T) {
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -73,13 +73,6 @@ func TestPutDocSpecialChar(t *testing.T) {
 			body: "{}",
 			expectedResp: http.StatusCreated, // Admin Docs expected response http.StatusOK
 		},
-		{
-			name: "Double quote POST",
-			pathDocID: ``,
-			method: "POST",
-			body: fmt.Sprintf(`{"_id": "doc%s"}`, `"56"`),
-			expectedResp: http.StatusBadRequest, // Not allowed to be created
-		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -44,6 +44,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 		method string
 		body string
 		expectedResp int
+		eeOnly bool
 	}{
 		{
 			name: "Double quote PUT",
@@ -51,6 +52,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 			method: "PUT",
 			body: "{}",
 			expectedResp: http.StatusCreated,
+			eeOnly: false,
 		},
 		{
 			name: "Double quote PUT for replicator2",
@@ -58,6 +60,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 			method: "PUT",
 			body: "{}",
 			expectedResp: http.StatusCreated,
+			eeOnly: true,
 		},
 		{
 			name: "Local double quote PUT",
@@ -65,6 +68,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 			method: "PUT",
 			body: "{}",
 			expectedResp: http.StatusCreated,
+			eeOnly: false,
 		},
 		{
 			name: "Double quote PUT with attachment",
@@ -72,10 +76,14 @@ func TestPutDocSpecialChar(t *testing.T) {
 			method: "PUT",
 			body: "{}",
 			expectedResp: http.StatusCreated, // Admin Docs expected response http.StatusOK
+			eeOnly: false,
 		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.eeOnly && !base.IsEnterpriseEdition() {
+				t.Skipf("Skipping enterprise-only test")
+			}
 			tr := rt.SendAdminRequest(testCase.method, fmt.Sprintf("/db/%s", testCase.pathDocID), testCase.body)
 			assertStatus(t, tr, testCase.expectedResp)
 			var body map[string]interface{}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -71,7 +71,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 			pathDocID: `doc"59"/attachMe`,
 			method: "PUT",
 			body: "{}",
-			expectedResp: http.StatusCreated,
+			expectedResp: http.StatusCreated, // Admin Docs expected response http.StatusOK
 		},
 		{
 			name: "Double quote POST",
@@ -91,7 +91,7 @@ func TestPutDocSpecialChar(t *testing.T) {
 		})
 	}
 
-	t.Run("Delete Double quote Doc ID", func(t *testing.T) {
+	t.Run("Delete Double quote Doc ID", func(t *testing.T) { // Should be done for Local Document deletion when it returns response
 		tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", `del"ete"Me`), "{}") // Create the doc to delete
 		assertStatus(t, tr, http.StatusCreated)
 		var putBody struct {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Reproduces CBG-1412 - JSON strings in some responses not being correctly escaped
 func TestPutDocSpecialChar(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -60,6 +60,13 @@ func TestPutDocSpecialChar(t *testing.T) {
 			expectedResp: http.StatusCreated,
 		},
 		{
+			name: "Double quote PUT with attachment",
+			pathDocID: `doc"59"/attachMe`,
+			method: "PUT",
+			body: "{}",
+			expectedResp: http.StatusCreated,
+		},
+		{
 			name: "Double quote POST",
 			pathDocID: ``,
 			method: "POST",
@@ -78,7 +85,6 @@ func TestPutDocSpecialChar(t *testing.T) {
 	}
 
 	t.Run("Delete Double quote Doc ID", func(t *testing.T) {
-
 		tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", `del"ete"Me`), "{}") // Create the doc to delete
 		assertStatus(t, tr, http.StatusCreated)
 		var putBody struct {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -53,6 +53,13 @@ func TestPutDocSpecialChar(t *testing.T) {
 			expectedResp: http.StatusCreated,
 		},
 		{
+			name: "Double quote PUT for replicator2",
+			pathDocID: `doc"77"?replicator2=true`,
+			method: "PUT",
+			body: "{}",
+			expectedResp: http.StatusCreated,
+		},
+		{
 			name: "Local double quote PUT",
 			pathDocID: `_local/doc"57"`,
 			method: "PUT",

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -76,6 +76,23 @@ func TestPutDocSpecialChar(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+
+	t.Run("Delete Double quote Doc ID", func(t *testing.T) {
+
+		tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", `del"ete"Me`), "{}") // Create the doc to delete
+		assertStatus(t, tr, http.StatusCreated)
+		var putBody struct {
+			Rev string `json:"rev"`
+		}
+		err := json.Unmarshal(tr.BodyBytes(), &putBody)
+		assert.NoError(t, err)
+
+		tr = rt.SendAdminRequest("DELETE", fmt.Sprintf("/db/%s?rev=%s", `del"ete"Me`, putBody.Rev), "{}")
+		assertStatus(t, tr, http.StatusOK)
+		var body map[string]interface{}
+		err = json.Unmarshal(tr.BodyBytes(), &body)
+		assert.NoError(t, err)
+	})
 }
 
 // Reproduces #3048 Panic when attempting to make invalid update to a conflicting document

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -384,7 +384,7 @@ func (h *handler) handlePutDoc() error {
 		}
 	}
 
-	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
+	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	return nil
 }
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -527,7 +527,7 @@ func (h *handler) handlePutLocalDoc() error {
 		var revid string
 		revid, err = h.db.PutSpecial(db.DocTypeLocal, docid, body)
 		if err == nil {
-			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"_local/`+docid+`","ok":true,"rev":"`+revid+`"}`))
+			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString("_local/" + docid)+`,"ok":true,"rev":"`+revid+`"}`))
 		}
 	}
 	return err

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -458,7 +458,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		}
 	}
 
-	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+rev+`"}`))
+	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+rev+`"}`))
 	return nil
 }
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -497,7 +497,7 @@ func (h *handler) handleDeleteDoc() error {
 	}
 	newRev, err := h.db.DeleteDoc(docid, revid)
 	if err == nil {
-		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
+		h.writeRawJSONStatus(http.StatusOK, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	}
 	return err
 }

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -323,7 +323,7 @@ func (h *handler) handlePutAttachment() error {
 	}
 	h.setHeader("Etag", strconv.Quote(newRev))
 
-	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":"`+docid+`","ok":true,"rev":"`+newRev+`"}`))
+	h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString(docid)+`,"ok":true,"rev":"`+newRev+`"}`))
 	return nil
 }
 

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -527,7 +527,7 @@ func (h *handler) handlePutLocalDoc() error {
 		var revid string
 		revid, err = h.db.PutSpecial(db.DocTypeLocal, docid, body)
 		if err == nil {
-			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString("_local/" + docid)+`,"ok":true,"rev":"`+revid+`"}`))
+			h.writeRawJSONStatus(http.StatusCreated, []byte(`{"id":`+base.ConvertToJSONString("_local/"+docid)+`,"ok":true,"rev":"`+revid+`"}`))
 		}
 	}
 	return err

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -393,7 +393,9 @@ func (rt *RestTester) WaitForCondition(successFunc func() bool) error {
 
 func (rt *RestTester) SendAdminRequest(method, resource string, body string) *TestResponse {
 	input := bytes.NewBufferString(body)
-	request, _ := http.NewRequest(method, "http://localhost"+resource, input)
+	request, err := http.NewRequest(method, "http://localhost"+resource, input)
+	require.NoError(rt.tb, err)
+
 	response := &TestResponse{ResponseRecorder: httptest.NewRecorder(), Req: request}
 	response.Code = 200 // doesn't seem to be initialized by default; filed Go bug #4188
 


### PR DESCRIPTION
Implemented fix for PUT (local, replicator2, with attachment, and standard) and DELETE. All fully tested.