### PR TITLE
CBG-1487: Skip TestUserXattrsRawGet under non-xattr test

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2768,6 +2768,10 @@ func TestAdhocReplicationStatus(t *testing.T) {
 }
 
 func TestUserXattrsRawGet(t *testing.T) {
+	if !base.TestUseXattrs() {
+		t.Skip("Test requires xattrs to be enabled")
+	}
+
 	docKey := t.Name()
 	xattrKey := "xattrKey"
 


### PR DESCRIPTION
Skip TestUserXattrsRawGet under non-xattr test as shared_bucket_access is a requirement.