### PR TITLE
Verify that xattrs are enabled for user_xattr_key

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -733,6 +733,10 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		localDocExpirySecs = *config.LocalDocExpirySecs
 	}
 
+	if config.UserXattrKey != "" && !config.UseXattrs() {
+		return db.DatabaseContextOptions{}, fmt.Errorf("use of user_xattr_key requires shared_bucket_access to be enabled")
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		RevisionCacheOptions:      revCacheOptions,


### PR DESCRIPTION
Use of the user_xattr_key / User Xattr Access Grants feature requires xattrs / shared bucket access to also be enabled. Add a simple config validation check.