### PR TITLE
CBG-1440 - Old global changeCacheExpvars stat map removed

### DIFF
--- a/base/expvar.go
+++ b/base/expvar.go
@@ -277,36 +277,6 @@ func (s *SequenceTimingExpvar) isCurrentOrNext(vbNo uint16, seq uint64) TimingSt
 	return TimingStatusNone
 }
 
-// IntMax is an expvar.Value that tracks the maximum value it's given.
-type IntMax struct {
-	i  int64
-	mu sync.RWMutex
-}
-
-func (v *IntMax) String() string {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-	return strconv.FormatInt(v.i, 10)
-}
-
-func (v *IntMax) SetIfMax(value int64) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	if value > v.i {
-		v.i = value
-	}
-}
-
-func SetIfMax(expvarMap *expvar.Map, key string, val int64) {
-	if expvarMap == nil {
-		return
-	}
-	mapVar := expvarMap.Get(key)
-	if intMaxVar, ok := mapVar.(*IntMax); ok {
-		intMaxVar.SetIfMax(val)
-	}
-}
-
 // IntMean is an expvar.Value that returns the mean of all values that
 // are sent via AddValue or AddSince.
 type IntMeanVar struct {

--- a/base/stats.go
+++ b/base/stats.go
@@ -198,6 +198,7 @@ type CacheStats struct {
 	RevisionCacheHits                   *SgwIntStat `json:"rev_cache_hits"`
 	RevisionCacheMisses                 *SgwIntStat `json:"rev_cache_misses"`
 	SkippedSeqLen                       *SgwIntStat `json:"skipped_seq_len"`
+	ViewQueries                         *SgwIntStat `json:"view_queries"`
 }
 
 type CBLReplicationPullStats struct {
@@ -641,6 +642,7 @@ func (d *DbStats) initCacheStats() {
 		RevisionCacheHits:                   NewIntStat(SubsystemCacheKey, "rev_cache_hits", labelKeys, labelVals, prometheus.CounterValue, 0),
 		RevisionCacheMisses:                 NewIntStat(SubsystemCacheKey, "rev_cache_misses", labelKeys, labelVals, prometheus.CounterValue, 0),
 		SkippedSeqLen:                       NewIntStat(SubsystemCacheKey, "skipped_seq_len", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		ViewQueries:                         NewIntStat(SubsystemCacheKey, "view_queries", labelKeys, labelVals, prometheus.CounterValue, 0),
 	}
 }
 

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -15,7 +15,6 @@ import (
 	"container/list"
 	"context"
 	"errors"
-	"expvar"
 	"fmt"
 	"math"
 	"strconv"
@@ -41,13 +40,6 @@ var SkippedSeqCleanViewBatch = 50 // Max number of sequences checked per query d
 // Enable keeping a channel-log for the "*" channel (channel.UserStarChannel). The only time this channel is needed is if
 // someone has access to "*" (e.g. admin-party) and tracks its changes feed.
 var EnableStarChannelLog = true
-
-var changeCacheExpvars *expvar.Map
-
-func init() {
-	changeCacheExpvars = expvar.NewMap("syncGateway_changeCache")
-	changeCacheExpvars.Set("maxPending", new(base.IntMax))
-}
 
 // Manages a cache of the recent change history of all channels.
 //

--- a/db/change_cache_test.go
+++ b/db/change_cache_test.go
@@ -999,7 +999,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 
 	// Issue two one-shot since=0 changes request.  Both will attempt a view query.  The first will block based on queryWg,
 	// the second will block waiting for the view lock
-	initialQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	initialQueryCount := db.DbStats.Cache().ViewQueries.Value()
 	changesWg.Add(1)
 	go func() {
 		defer changesWg.Done()
@@ -1058,7 +1058,7 @@ func TestChannelQueryCancellation(t *testing.T) {
 	changesWg.Wait()
 
 	// Validate only a single query was executed
-	finalQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	finalQueryCount := db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initialQueryCount+1, finalQueryCount)
 }
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -317,7 +317,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 		ActiveOnly: true,
 	}
 
-	initQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	initQueryCount := db.DbStats.Cache().ViewQueries.Value()
 
 	// Get changes with active_only=true
 	activeChanges, err := db.GetChanges(base.SetOf("*"), changesOptions)
@@ -325,7 +325,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	require.Equal(t, 5, len(activeChanges))
 
 	// Ensure the test is triggering a query, and not serving from DCP-generated cache
-	postChangesQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	postChangesQueryCount := db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initQueryCount+1, postChangesQueryCount)
 
 	// Get changes with active_only=false, validate that triggers a new query
@@ -334,7 +334,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 10, len(allChanges))
 
-	postChangesQueryCount, _ = base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initQueryCount+2, postChangesQueryCount)
 
 	// Get changes with active_only=false again, verify results are served from the cache
@@ -343,7 +343,7 @@ func TestActiveOnlyCacheUpdate(t *testing.T) {
 	require.NoError(t, err, "Error getting changes with active_only true")
 	require.Equal(t, 10, len(allChanges))
 
-	postChangesQueryCount, _ = base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	postChangesQueryCount = db.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, initQueryCount+2, postChangesQueryCount)
 
 }

--- a/db/changes_view.go
+++ b/db/changes_view.go
@@ -180,7 +180,7 @@ func (dbc *DatabaseContext) getChangesInChannelFromQuery(
 		base.Infof(base.KeyAll, "Channel query took %v to return %d rows.  Channel: %s StartSeq: %d EndSeq: %d Limit: %d",
 			elapsed, len(entries), base.UD(channelName), startSeq, endSeq, limit)
 	}
-	changeCacheExpvars.Add("view_queries", 1)
+	dbc.DbStats.Cache().ViewQueries.Add(1)
 	return entries, nil
 }
 

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -2206,7 +2206,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	}
 
 	// Initialize query count
-	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there is a view-based backfill
 	changes.Results = nil
@@ -2219,7 +2219,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there has been a view query
-	secondQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount+1, secondQueryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
@@ -2231,7 +2231,7 @@ func TestChangesViewBackfillFromQueryOnly(t *testing.T) {
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
-	thirdQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	thirdQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, secondQueryCount, thirdQueryCount)
 
 }
@@ -2290,7 +2290,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 
-	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
 	// Issue another since=0, limit 5 changes request.  Validate that there is another a view-based backfill
@@ -2303,7 +2303,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there has been one more view query
-	secondQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount+1, secondQueryCount)
 
 	// Issue a since=20, limit 5 changes request.  Results should be prepended to the cache (seqs 23, 26, 29)
@@ -2317,7 +2317,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there has been one more view query
-	thirdQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	thirdQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, secondQueryCount+1, thirdQueryCount)
 
 	// Issue a since=20, limit 5 changes request again.  Results should be served from the cache (seqs 23, 26, 29)
@@ -2331,7 +2331,7 @@ func TestChangesViewBackfillNonContiguousQueryResults(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there hasn't been another view query
-	fourthQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	fourthQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, thirdQueryCount, fourthQueryCount)
 }
 
@@ -2387,7 +2387,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 
-	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
 	// Issue a since=0 changes request.  Expect a second view query to retrieve the additional results
@@ -2401,7 +2401,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there has been one more view query
-	secondQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount+1, secondQueryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
@@ -2414,7 +2414,7 @@ func TestChangesViewBackfillFromPartialQueryOnly(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there haven't been any more view queries
-	thirdQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	thirdQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, secondQueryCount, thirdQueryCount)
 
 }
@@ -2486,7 +2486,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 
-	queryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	log.Printf("After initial changes request, query count is :%d", queryCount)
 
 	// Issue the same changes request.  Validate that there is not another a view-based backfill
@@ -2500,7 +2500,7 @@ func TestChangesViewBackfillNoOverlap(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there has been one more view query
-	secondQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	secondQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 	assert.Equal(t, queryCount, secondQueryCount)
 
 }
@@ -2559,8 +2559,8 @@ func TestChangesViewBackfill(t *testing.T) {
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
-	queryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
-	log.Printf("After initial changes request, query count is :%s", queryCount)
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
+	log.Printf("After initial changes request, query count is: %d", queryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
 	changes.Results = nil
@@ -2572,7 +2572,7 @@ func TestChangesViewBackfill(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there haven't been any more view queries
-	assert.Equal(t, base.GetExpvarAsString("syncGateway_changeCache", "view_queries"), queryCount)
+	assert.Equal(t, testDb.DbStats.Cache().ViewQueries.Value(), queryCount)
 
 }
 
@@ -2633,8 +2633,8 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 		assert.Equal(t, uint64(index+1), entry.Seq.Seq)
 		log.Printf("Entry:%+v", entry)
 	}
-	queryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
-	log.Printf("After initial changes request, query count is :%s", queryCount)
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
+	log.Printf("After initial changes request, query count is: %d", queryCount)
 
 	// Issue another since=0 changes request.  Validate that there is not another a view-based backfill
 	changes.Results = nil
@@ -2648,7 +2648,7 @@ func TestChangesViewBackfillStarChannel(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there haven't been any more view queries
-	assert.Equal(t, queryCount, base.GetExpvarAsString("syncGateway_changeCache", "view_queries"))
+	assert.Equal(t, queryCount, testDb.DbStats.Cache().ViewQueries.Value())
 
 }
 
@@ -2922,7 +2922,7 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 
 	// Flush the channel cache
 	assert.NoError(t, testDb.FlushChannelCache())
-	startQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
+	startQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
 
 	// Issue a since=0 changes request.  Validate that there's a view-based backfill
 	var changes struct {
@@ -2935,8 +2935,8 @@ func TestChangesQueryStarChannelBackfillLimit(t *testing.T) {
 	err = base.JSONUnmarshal(changesResponse.Body.Bytes(), &changes)
 	assert.NoError(t, err, "Error unmarshalling changes response")
 	require.Equal(t, len(changes.Results), 7)
-	finalQueryCount, _ := base.GetExpvarAsInt("syncGateway_changeCache", "view_queries")
-	assert.Equal(t, 2, finalQueryCount-startQueryCount)
+	finalQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
+	assert.Equal(t, int64(2), finalQueryCount-startQueryCount)
 }
 
 // Tests view backfill with slow query, checks duplicate handling for cache entries if a document is updated after query runs, but before document is
@@ -3030,8 +3030,8 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 	for _, entry := range changes.Results {
 		log.Printf("Entry:%+v", entry)
 	}
-	queryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
-	log.Printf("After initial changes request, query count is :%s", queryCount)
+	queryCount := testDb.DbStats.Cache().ViewQueries.Value()
+	log.Printf("After initial changes request, query count is: %d", queryCount)
 
 	leakyBucket.SetPostQueryCallback(nil)
 
@@ -3045,8 +3045,8 @@ func TestChangesViewBackfillSlowQuery(t *testing.T) {
 		log.Printf("Entry:%+v", entry)
 	}
 	// Validate that there haven't been any more view queries
-	updatedQueryCount := base.GetExpvarAsString("syncGateway_changeCache", "view_queries")
-	log.Printf("After second changes request, query count is :%s", updatedQueryCount)
+	updatedQueryCount := testDb.DbStats.Cache().ViewQueries.Value()
+	log.Printf("After second changes request, query count is: %d", updatedQueryCount)
 	assert.Equal(t, queryCount, updatedQueryCount)
 
 }


### PR DESCRIPTION
Removed IntMax struct and functions
Added view_queries as a Database cache stat
Removed changeCacheExpvars
All tests now check the new view_queries stat instead of the old ExpVar
TestChangesQueryStarChannelBackfillLimit converts int to int64 to check if type matches