### PR TITLE
CBG-1488: Fix and test interrupted revocation logic

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -775,7 +775,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 
 			if options.Revocations && db.user != nil {
 				revocationCheckSeq := options.Since.SafeSequence()
-				if options.Since.TriggeredBy > 0 {
+				if options.Since.TriggeredBy > 0 && revocationCheckSeq > options.Since.TriggeredBy-1 {
 					revocationCheckSeq = options.Since.TriggeredBy - 1
 				}
 				channelsToRevoke := db.user.RevokedChannels(revocationCheckSeq)

--- a/db/changes.go
+++ b/db/changes.go
@@ -171,7 +171,7 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 	}
 }
 
-func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, revokedSeq, revocationCheckSeq uint64, to string) <-chan *ChangeEntry {
+func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, revokedSeq, revocationSinceSeq uint64, to string) <-chan *ChangeEntry {
 	feed := make(chan *ChangeEntry, 1)
 	sinceVal := options.Since.Seq
 
@@ -232,7 +232,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 				if logEntry.Sequence > sinceVal {
-					requiresRevocation, err := db.wasDocInChannelAtSeq(logEntry.DocID, singleChannelCache.ChannelName(), revocationCheckSeq)
+					requiresRevocation, err := db.wasDocInChannelAtSeq(logEntry.DocID, singleChannelCache.ChannelName(), revocationSinceSeq)
 					if err != nil {
 						change := ChangeEntry{
 							Err: base.ErrChannelFeed,
@@ -774,13 +774,27 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			}
 
 			if options.Revocations && db.user != nil {
-				revocationCheckSeq := options.Since.SafeSequence()
-				if options.Since.TriggeredBy > 0 && revocationCheckSeq > options.Since.TriggeredBy-1 {
-					revocationCheckSeq = options.Since.TriggeredBy - 1
+
+				// revocationSinceSeq is the earliest (lowest) value inside of the passed in since sequence i.e. lowest
+				// of lowSeq, triggeredBy and Seq. The value is used to denote the point in time we need to diff against
+				// ie. What has changed in the the time since that sequence and now. This will be used to calculate the
+				// channels to revoke and then passed  into "buildRevokedFeed" to validate whether a document was in the
+				// given channel at the sequence.
+				revocationSinceSeq := options.Since.SafeSequence()
+
+				// We need to do this with triggeredBy - 1 because multiple mutations can have the same 'triggeredBy'
+				// and if we're resuming with a triggeredBy we can't be sure that all of the changes with that
+				// 'triggeredBy' have been processed so need to step back and re-process all changes with that
+				// triggeredBy.
+				// The 'if' check here is checking whether we have a triggeredBy and if we do we should use the lowest
+				// value out of triggeredBy - 1 and the above used SafeSeq (lowSeq if there or regular Seq).
+				if options.Since.TriggeredBy > 0 && revocationSinceSeq > options.Since.TriggeredBy-1 {
+					revocationSinceSeq = options.Since.TriggeredBy - 1
 				}
-				channelsToRevoke := db.user.RevokedChannels(revocationCheckSeq)
+
+				channelsToRevoke := db.user.RevokedChannels(revocationSinceSeq)
 				for channel, revokedSeq := range channelsToRevoke {
-					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, revokedSeq, revocationCheckSeq, to)
+					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, revokedSeq, revocationSinceSeq, to)
 					feeds = append(feeds, feed)
 				}
 			}

--- a/db/changes.go
+++ b/db/changes.go
@@ -171,7 +171,7 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 	}
 }
 
-func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, triggeredBy uint64, to string) <-chan *ChangeEntry {
+func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, revokedSeq, revocationCheckSeq uint64, to string) <-chan *ChangeEntry {
 	feed := make(chan *ChangeEntry, 1)
 	sinceVal := options.Since.Seq
 
@@ -224,7 +224,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 			for _, logEntry := range changes {
 				seqID := SequenceID{
 					Seq:         logEntry.Sequence,
-					TriggeredBy: triggeredBy,
+					TriggeredBy: revokedSeq,
 				}
 
 				// We need to check whether a change / document sequence is greater than since.
@@ -232,7 +232,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 				// Otherwise: we need to determine whether a previous revision of the document was in the channel prior
 				// to the since value, and only send a revocation if that was the case
 				if logEntry.Sequence > sinceVal {
-					requiresRevocation, err := db.wasDocInChannelAtSeq(logEntry.DocID, singleChannelCache.ChannelName(), sinceVal)
+					requiresRevocation, err := db.wasDocInChannelAtSeq(logEntry.DocID, singleChannelCache.ChannelName(), revocationCheckSeq)
 					if err != nil {
 						change := ChangeEntry{
 							Err: base.ErrChannelFeed,
@@ -774,9 +774,13 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			}
 
 			if options.Revocations && db.user != nil {
-				channelsToRevoke := db.user.RevokedChannels(options.Since.SafeSequence())
-				for channel, triggeredBy := range channelsToRevoke {
-					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, triggeredBy, to)
+				revocationCheckSeq := options.Since.Seq
+				if options.Since.TriggeredBy > 0 {
+					revocationCheckSeq = options.Since.TriggeredBy - 1
+				}
+				channelsToRevoke := db.user.RevokedChannels(revocationCheckSeq)
+				for channel, revokedSeq := range channelsToRevoke {
+					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, revokedSeq, revocationCheckSeq, to)
 					feeds = append(feeds, feed)
 				}
 			}

--- a/db/changes.go
+++ b/db/changes.go
@@ -774,7 +774,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			}
 
 			if options.Revocations && db.user != nil {
-				revocationCheckSeq := options.Since.Seq
+				revocationCheckSeq := options.Since.SafeSequence()
 				if options.Since.TriggeredBy > 0 {
 					revocationCheckSeq = options.Since.TriggeredBy - 1
 				}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6343,11 +6343,11 @@ func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
 	}
 }
 
-func (tester *ChannelRevocationTester) getChanges(sinceSeq uint64, expectedLength int) changesResults {
+func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expectedLength int) changesResults {
 	var changes changesResults
 
 	err := tester.restTester.WaitForCondition(func() bool {
-		resp := tester.restTester.SendUserRequestWithHeaders("GET", fmt.Sprintf("/db/_changes?since=%d&revocations=true", sinceSeq), "", nil, "user", "test")
+		resp := tester.restTester.SendUserRequestWithHeaders("GET", fmt.Sprintf("/db/_changes?since=%v&revocations=true", sinceSeq), "", nil, "user", "test")
 		require.Equal(tester.test, http.StatusOK, resp.Code)
 		err := json.Unmarshal(resp.BodyBytes(), &changes)
 		require.NoError(tester.test, err)
@@ -6355,7 +6355,6 @@ func (tester *ChannelRevocationTester) getChanges(sinceSeq uint64, expectedLengt
 		return len(changes.Results) == expectedLength
 	})
 	assert.NoError(tester.test, err, fmt.Sprintf("Unexpected: %d. Expected %d", len(changes.Results), expectedLength))
-	fmt.Println(changes.Results)
 
 	err = tester.restTester.WaitForPendingChanges()
 	assert.NoError(tester.test, err)
@@ -7193,4 +7192,93 @@ func TestRevocationMutationMovesIntoRevokedChannel(t *testing.T) {
 	assert.Len(t, changes.Results, 1)
 	assert.Equal(t, "doc2", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
+}
+
+func TestRevocationResume(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
+	revocationTester, rt := initScenario(t)
+	defer rt.Close()
+
+	resp := rt.SendAdminRequest("PUT", "/db/_role/foo2", `{}`)
+	assertStatus(t, resp, http.StatusCreated)
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "ch1")
+
+	revocationTester.addRole("user", "foo2")
+	revocationTester.addRoleChannel("foo2", "ch2")
+
+	revocationTester.fillToSeq(9)
+	revIDDoc := rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
+	revIDDoc2 := rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch2"}})
+
+	changes := revocationTester.getChanges(0, 3)
+
+	revocationTester.fillToSeq(19)
+	revocationTester.removeRoleChannel("foo", "ch1")
+
+	revocationTester.fillToSeq(29)
+	revocationTester.removeRoleChannel("foo2", "ch2")
+
+	revocationTester.fillToSeq(39)
+	revIDDoc = rt.createDocReturnRev(t, "doc1", revIDDoc, map[string]interface{}{"channels": []string{"ch1"}, "val": "mutate"})
+
+	revocationTester.fillToSeq(49)
+	revIDDoc2 = rt.createDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
+
+	changes = revocationTester.getChanges(changes.Last_Seq, 2)
+
+	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
+	assert.Equal(t, "doc2", changes.Results[1].ID)
+	assert.True(t, changes.Results[1].Revoked)
+
+	changes = revocationTester.getChanges("20:40", 1)
+
+	assert.Equal(t, "doc2", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
+
+}
+
+func TestRevocationResumeSameRole(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
+	revocationTester, rt := initScenario(t)
+	defer rt.Close()
+
+	revocationTester.addRole("user", "foo")
+	revocationTester.addRoleChannel("foo", "ch1")
+	revocationTester.addRoleChannel("foo", "ch2")
+
+	revocationTester.fillToSeq(9)
+	revIDDoc := rt.createDocReturnRev(t, "doc1", "", map[string]interface{}{"channels": []string{"ch1"}})
+	revIDDoc2 := rt.createDocReturnRev(t, "doc2", "", map[string]interface{}{"channels": []string{"ch2"}})
+
+	changes := revocationTester.getChanges(0, 3)
+
+	revocationTester.fillToSeq(19)
+	revocationTester.removeRoleChannel("foo", "ch1")
+
+	revocationTester.fillToSeq(29)
+	revocationTester.removeRoleChannel("foo", "ch2")
+
+	revocationTester.fillToSeq(39)
+	revIDDoc = rt.createDocReturnRev(t, "doc1", revIDDoc, map[string]interface{}{"channels": []string{"ch1"}, "val": "mutate"})
+
+	revocationTester.fillToSeq(49)
+	revIDDoc2 = rt.createDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
+
+	changes = revocationTester.getChanges(changes.Last_Seq, 2)
+
+	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
+	assert.Equal(t, "doc2", changes.Results[1].ID)
+	assert.True(t, changes.Results[1].Revoked)
+
+	changes = revocationTester.getChanges("20:40", 1)
+
+	assert.Equal(t, "doc2", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
+
 }


### PR DESCRIPTION
Fix logic with interrupted replications. Largely involves utilizing the triggeredBy value to calculate revocations rather than only the Seq value.