### PR TITLE
Bump go-couchbase to uptake MB-43553

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gocbconnstr" path="godeps/src/gopkg.in/couchbaselabs/gocbconnstr.v1" remote="couchbaselabs" revision="8f9a894d174b836c6362de9af75545cf585fc278"/>
 
-  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="83e1dde05ac9e4861d4d8d4985046e8920c1d760"/>
+  <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
   <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="7a9f15d95f07f7f30f567cf19919f554d14b12d5"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -44,7 +44,7 @@ licenses/APL2.txt.
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="aac9eb5d3047d4a74d3e87db231a36e231446dad"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="ddac38b31c48eeb93df6b3446e68cd0d6786b56d"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="f3d612a87e874d357612b571db5768b7ee9a9a24"/>
 
   <!-- gocb v2 -->
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9e841df93a43dd35e992eb08fe09c5211584d7e0" />


### PR DESCRIPTION
[MB-43553](https://issues.couchbase.com/browse/MB-43553) - Uptake fix for leaked pool used to initialize a Bucket instance

- go-couchbase changelog: https://github.com/couchbase/go-couchbase/compare/ddac38b31c48eeb93df6b3446e68cd0d6786b56d...f3d612a87e874d357612b571db5768b7ee9a9a24
- gomemcached changelog: https://github.com/couchbase/gomemcached/compare/83e1dde05ac9e4861d4d8d4985046e8920c1d760...4201f50df22f08f75a0491451fa6507387d41304