### PR TITLE
Extract gocb v2 connect config builders into helper functions

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -1,0 +1,62 @@
+package base
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	"time"
+
+	"github.com/couchbase/gocb"
+)
+
+// GoCBv2SecurityConfig returns a gocb.SecurityConfig to use when connecting given a CA Cert path.
+func GoCBv2SecurityConfig(caCertPath string) (sc gocb.SecurityConfig, err error) {
+	if caCertPath != "" {
+		roots := x509.NewCertPool()
+		cacert, err := ioutil.ReadFile(caCertPath)
+		if err != nil {
+			return sc, err
+		}
+		ok := roots.AppendCertsFromPEM(cacert)
+		if !ok {
+			return sc, errors.New("Invalid CA cert")
+		}
+		sc.TLSRootCAs = roots
+	} else {
+		sc.TLSSkipVerify = true
+	}
+	return sc, nil
+}
+
+// GoCBv2AuthenticatorConfig returns a gocb.Authenticator to use when connecting given a set of credentials.
+func GoCBv2AuthenticatorConfig(username, password, certPath, keyPath string) (a gocb.Authenticator, isX509 bool, err error) {
+	if certPath != "" && keyPath != "" {
+		cert, certLoadErr := tls.LoadX509KeyPair(certPath, keyPath)
+		if certLoadErr != nil {
+			return nil, false, err
+		}
+		return gocb.CertificateAuthenticator{
+			ClientCertificate: &cert,
+		}, true, nil
+	}
+
+	return gocb.PasswordAuthenticator{
+		Username: username,
+		Password: password,
+	}, false, nil
+}
+
+// GoCBv2TimeoutsConfig returns a gocb.TimeoutsConfig to use when connecting.
+func GoCBv2TimeoutsConfig(bucketOpTimeout, viewQueryTimeout *time.Duration) (tc gocb.TimeoutsConfig) {
+	if bucketOpTimeout != nil {
+		tc.KVTimeout = *bucketOpTimeout
+		tc.ManagementTimeout = *bucketOpTimeout
+		tc.ConnectTimeout = *bucketOpTimeout
+	}
+	if viewQueryTimeout != nil {
+		tc.QueryTimeout = *viewQueryTimeout
+		tc.ViewTimeout = *viewQueryTimeout
+	}
+	return tc
+}

--- a/base/util.go
+++ b/base/util.go
@@ -768,6 +768,11 @@ func GetGoCBBucketFromBaseBucket(baseBucket Bucket) (bucket CouchbaseBucketGoCB,
 	}
 }
 
+// DurationPtr returns a pointer to the given time.Duration literal.
+func DurationPtr(value time.Duration) *time.Duration {
+	return &value
+}
+
 // StringPtr returns a pointer to the given string literal.
 func StringPtr(value string) *string {
 	return &value


### PR DESCRIPTION
Extracted gocb connect's config builders into functions so that they are accessible from `rest` when I create a bootstrap connection.