### PR TITLE
Avoid setting file descriptor limits if desired value matches current soft limit

### DIFF
--- a/base/rlimit.go
+++ b/base/rlimit.go
@@ -78,9 +78,9 @@ func getSoftFDLimit(requestedSoftFDLimit uint64, limit syscall.Rlimit) (requires
 	currentHardFdLimit := limit.Max
 
 	// Is the user requesting something that is less than the existing soft limit?
-	if requestedSoftFDLimit < currentSoftFdLimit {
+	if requestedSoftFDLimit <= currentSoftFdLimit {
 		// yep, and there is no point in doing so, so return false for requiresUpdate.
-		Infof(KeyAll, "requestedSoftFDLimit < currentSoftFdLimit (%v < %v) no action needed", requestedSoftFDLimit, currentSoftFdLimit)
+		Debugf(KeyAll, "requestedSoftFDLimit < currentSoftFdLimit (%v <= %v) no action needed", requestedSoftFDLimit, currentSoftFdLimit)
 		return false, currentSoftFdLimit
 	}
 

--- a/base/rlimit_test.go
+++ b/base/rlimit_test.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"testing"
 
-	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +35,7 @@ func TestGetSoftFDLimitWithCurrent(t *testing.T) {
 		requestedSoftFDLimit,
 		limit,
 	)
-	goassert.False(t, requiresUpdate)
+	assert.False(t, requiresUpdate)
 
 	limit.Cur = uint64(512)
 
@@ -44,9 +43,8 @@ func TestGetSoftFDLimitWithCurrent(t *testing.T) {
 		requestedSoftFDLimit,
 		limit,
 	)
-	goassert.True(t, requiresUpdate)
-	goassert.Equals(t, softFDLimit, requestedSoftFDLimit)
-
+	assert.True(t, requiresUpdate)
+	assert.Equal(t, requestedSoftFDLimit, softFDLimit)
 }
 
 func TestSetMaxFileDescriptors(t *testing.T) {
@@ -59,7 +57,7 @@ func TestSetMaxFileDescriptors(t *testing.T) {
 
 	// Set current soft limit to a low-ish known value for testing
 	newLimits := startLimits
-	newLimits.Cur = 500
+	newLimits.Cur = 512
 	syscall.Setrlimit(syscall.RLIMIT_NOFILE, &newLimits)
 	require.NoError(t, err)
 	defer func() {

--- a/base/rlimit_test.go
+++ b/base/rlimit_test.go
@@ -58,10 +58,10 @@ func TestSetMaxFileDescriptors(t *testing.T) {
 	// Set current soft limit to a low-ish known value for testing
 	newLimits := startLimits
 	newLimits.Cur = 512
-	syscall.Setrlimit(syscall.RLIMIT_NOFILE, &newLimits)
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &newLimits)
 	require.NoError(t, err)
 	defer func() {
-		syscall.Setrlimit(syscall.RLIMIT_NOFILE, &startLimits)
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &startLimits)
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
Ran into this when calling `base.SetMaxFileDescriptors()` directly from `rest`