### PR TITLE
Admin API Auth: Initial version

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -17,13 +17,12 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"
@@ -31,6 +30,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Reproduces CBG-1412 - JSON strings in some responses not being correctly escaped
@@ -2965,4 +2965,124 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 		})
 
 	}
+}
+
+func HTTPURL() string {
+	url := base.UnitTestUrl()
+	return strings.Replace(url, "couchbase://", "http://", 1)
+}
+
+func MakeUser(t *testing.T, username, password string, roles []string) {
+	httpClient := http.DefaultClient
+
+	form := url.Values{}
+	form.Add("password", password)
+	form.Add("roles", strings.Join(roles, ","))
+
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/settings/rbac/users/local/%s", HTTPURL(), username), strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+
+	req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func DeleteUser(t *testing.T, username string) {
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/settings/rbac/users/local/%s", HTTPURL(), username), nil)
+	require.NoError(t, err)
+
+	req.SetBasicAuth(base.TestClusterUsername(), base.TestClusterPassword())
+
+	httpClient := http.DefaultClient
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestEndpointAuth(t *testing.T) {
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Requires CBS")
+	}
+
+	testCases := []struct {
+		Name                string
+		Username            string
+		Password            string
+		BucketName          string
+		requiredPermissions []string
+		expectedStatus      int
+	}{
+		{
+			Name:                "#1",
+			Username:            "Administrator",
+			Password:            "password",
+			BucketName:          "",
+			requiredPermissions: nil,
+			expectedStatus:      http.StatusOK,
+		},
+		{
+			Name:                "#2",
+			Username:            "fulladmin",
+			Password:            "password",
+			BucketName:          "",
+			requiredPermissions: nil,
+			expectedStatus:      http.StatusOK,
+		},
+		{
+			Name:                "#3",
+			Username:            "bucket",
+			Password:            "password",
+			BucketName:          "",
+			requiredPermissions: nil,
+			expectedStatus:      http.StatusForbidden,
+		},
+		{
+			Name:                "#4",
+			Username:            "readonlyadmin",
+			Password:            "password",
+			BucketName:          "",
+			requiredPermissions: nil,
+			expectedStatus:      http.StatusOK,
+		},
+		{
+			Name:                "#5",
+			Username:            "random",
+			Password:            "",
+			BucketName:          "",
+			requiredPermissions: nil,
+			expectedStatus:      http.StatusUnauthorized,
+		},
+		{
+			Name:                "#6",
+			Username:            "random",
+			Password:            "",
+			BucketName:          "db",
+			requiredPermissions: nil,
+			expectedStatus:      http.StatusUnauthorized,
+		},
+	}
+
+	testBucket := base.GetTestBucket(t)
+	defer testBucket.Close()
+
+	MakeUser(t, "fulladmintest", "password", []string{"ro_admin"})
+	DeleteUser(t, "fulladmintest")
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			statusCode, err := TestAuth(nil, testCase.Username, testCase.Password, testCase.BucketName, testCase.requiredPermissions...)
+			assert.NoError(t, err)
+
+			assert.Equal(t, testCase.expectedStatus, statusCode)
+
+		})
+	}
+
 }


### PR DESCRIPTION
Initial implementation of Admin API auth. Currently missing the ability to grab management endpoints, however, hardcoded with my test server and seems to work.

Tests currently are again, reliant on having the users on the test server however have prepared functions to make and create users for testing.

Can have a discussion / initial review based on this.