### PR TITLE
CBG-1497: Test and fix wasDocInChannelAtSeq check

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1406,7 +1406,7 @@ func MinUint64(x, y uint64) uint64 {
 }
 
 func MaxUint64(x, y uint64) uint64 {
-	if x < y {
+	if x > y {
 		return x
 	}
 	return y

--- a/db/changes.go
+++ b/db/changes.go
@@ -242,7 +242,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 					}
 
 					if !requiresRevocation {
-						return
+						continue
 					}
 				}
 
@@ -338,7 +338,7 @@ func (db *Database) wasDocInChannelAtSeq(docID, chanName string, since uint64) (
 			// If there is some overlap we can quit out as we know user has had access to the doc at the since seq
 			start := base.MaxUint64(docHistoryEntry.Start, accessPeriod.StartSeq)
 			end := base.MinUint64(docHistoryEntry.End, accessPeriod.EndSeq)
-			if start < end || end == 0 {
+			if start < end || (start <= since && end == 0) {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
Switches the `if !requiresRevocation` to a continue from a return.
Fixes the `wasDocInChannelAtSeq` check where a non-overlapping channel has no endseq.

Both tested with a unit test.