### PR TITLE
Implement log wrappers for all versions of gocb and gocbcore

### DIFF
--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -22,18 +22,6 @@ import (
 	gocbcorev7 "gopkg.in/couchbase/gocbcore.v7"
 )
 
-func init() {
-	// Ensure all gocb and gocbcore log levels match between versions, if they don't,
-	// we'll need to revisit the log wrappers below to not just do direct type conversions to implement 4 loggers.
-	if gocb.LogError != gocb.LogLevel(gocbcore.LogError) || gocb.LogLevel(gocbcore.LogError) != gocb.LogLevel(gocbv1.LogError) || gocb.LogLevel(gocbv1.LogError) != gocb.LogLevel(gocbcorev7.LogError) ||
-		gocb.LogWarn != gocb.LogLevel(gocbcore.LogWarn) || gocb.LogLevel(gocbcore.LogWarn) != gocb.LogLevel(gocbv1.LogWarn) || gocb.LogLevel(gocbv1.LogWarn) != gocb.LogLevel(gocbcorev7.LogWarn) ||
-		gocb.LogInfo != gocb.LogLevel(gocbcore.LogInfo) || gocb.LogLevel(gocbcore.LogInfo) != gocb.LogLevel(gocbv1.LogInfo) || gocb.LogLevel(gocbv1.LogInfo) != gocb.LogLevel(gocbcorev7.LogInfo) ||
-		gocb.LogDebug != gocb.LogLevel(gocbcore.LogDebug) || gocb.LogLevel(gocbcore.LogDebug) != gocb.LogLevel(gocbv1.LogDebug) || gocb.LogLevel(gocbv1.LogDebug) != gocb.LogLevel(gocbcorev7.LogDebug) ||
-		gocb.LogTrace != gocb.LogLevel(gocbcore.LogTrace) || gocb.LogLevel(gocbcore.LogTrace) != gocb.LogLevel(gocbv1.LogTrace) || gocb.LogLevel(gocbv1.LogTrace) != gocb.LogLevel(gocbcorev7.LogTrace) {
-		panic("mismatched gocb/gocbcore/gocbv1/gocbcorev7 log level values")
-	}
-}
-
 // This file implements wrappers around the loggers of external packages
 // so that all of SG's logging output is consistent
 func initExternalLoggers() {

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -25,11 +25,11 @@ import (
 func init() {
 	// Ensure all gocb and gocbcore log levels match between versions, if they don't,
 	// we'll need to revisit the log wrappers below to not just do direct type conversions to implement 4 loggers.
-	if gocb.LogError != gocb.LogLevel(gocbcore.LogError) || gocb.LogError != gocb.LogLevel(gocbv1.LogError) || gocb.LogError != gocb.LogLevel(gocbcorev7.LogError) ||
-		gocb.LogWarn != gocb.LogLevel(gocbcore.LogWarn) || gocb.LogWarn != gocb.LogLevel(gocbv1.LogWarn) || gocb.LogWarn != gocb.LogLevel(gocbcorev7.LogWarn) ||
-		gocb.LogInfo != gocb.LogLevel(gocbcore.LogInfo) || gocb.LogInfo != gocb.LogLevel(gocbv1.LogInfo) || gocb.LogInfo != gocb.LogLevel(gocbcorev7.LogInfo) ||
-		gocb.LogDebug != gocb.LogLevel(gocbcore.LogDebug) || gocb.LogDebug != gocb.LogLevel(gocbv1.LogDebug) || gocb.LogDebug != gocb.LogLevel(gocbcorev7.LogDebug) ||
-		gocb.LogTrace != gocb.LogLevel(gocbcore.LogTrace) || gocb.LogTrace != gocb.LogLevel(gocbv1.LogTrace) || gocb.LogTrace != gocb.LogLevel(gocbcorev7.LogTrace) {
+	if gocb.LogError != gocb.LogLevel(gocbcore.LogError) || gocb.LogLevel(gocbcore.LogError) != gocb.LogLevel(gocbv1.LogError) || gocb.LogLevel(gocbv1.LogError) != gocb.LogLevel(gocbcorev7.LogError) ||
+		gocb.LogWarn != gocb.LogLevel(gocbcore.LogWarn) || gocb.LogLevel(gocbcore.LogWarn) != gocb.LogLevel(gocbv1.LogWarn) || gocb.LogLevel(gocbv1.LogWarn) != gocb.LogLevel(gocbcorev7.LogWarn) ||
+		gocb.LogInfo != gocb.LogLevel(gocbcore.LogInfo) || gocb.LogLevel(gocbcore.LogInfo) != gocb.LogLevel(gocbv1.LogInfo) || gocb.LogLevel(gocbv1.LogInfo) != gocb.LogLevel(gocbcorev7.LogInfo) ||
+		gocb.LogDebug != gocb.LogLevel(gocbcore.LogDebug) || gocb.LogLevel(gocbcore.LogDebug) != gocb.LogLevel(gocbv1.LogDebug) || gocb.LogLevel(gocbv1.LogDebug) != gocb.LogLevel(gocbcorev7.LogDebug) ||
+		gocb.LogTrace != gocb.LogLevel(gocbcore.LogTrace) || gocb.LogLevel(gocbcore.LogTrace) != gocb.LogLevel(gocbv1.LogTrace) || gocb.LogLevel(gocbv1.LogTrace) != gocb.LogLevel(gocbcorev7.LogTrace) {
 		panic("mismatched gocb/gocbcore/gocbv1/gocbcorev7 log level values")
 	}
 }

--- a/base/logger_external_test.go
+++ b/base/logger_external_test.go
@@ -1,0 +1,35 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocbcore"
+	"github.com/stretchr/testify/assert"
+	gocbv1 "gopkg.in/couchbase/gocb.v1"
+	gocbcorev7 "gopkg.in/couchbase/gocbcore.v7"
+)
+
+func TestGoCBLogLevelEquality(t *testing.T) {
+	// Ensures all gocb and gocbcore log levels match between versions.
+	// If they don't, we'll need to revisit the log wrappers to not just do direct type conversions to implement 4 loggers.
+	assert.Equal(t, gocb.LogError, gocb.LogLevel(gocbcore.LogError))
+	assert.Equal(t, gocb.LogError, gocb.LogLevel(gocbv1.LogError))
+	assert.Equal(t, gocb.LogError, gocb.LogLevel(gocbcorev7.LogError))
+
+	assert.Equal(t, gocb.LogWarn, gocb.LogLevel(gocbcore.LogWarn))
+	assert.Equal(t, gocb.LogWarn, gocb.LogLevel(gocbv1.LogWarn))
+	assert.Equal(t, gocb.LogWarn, gocb.LogLevel(gocbcorev7.LogWarn))
+
+	assert.Equal(t, gocb.LogInfo, gocb.LogLevel(gocbcore.LogInfo))
+	assert.Equal(t, gocb.LogInfo, gocb.LogLevel(gocbv1.LogInfo))
+	assert.Equal(t, gocb.LogInfo, gocb.LogLevel(gocbcorev7.LogInfo))
+
+	assert.Equal(t, gocb.LogDebug, gocb.LogLevel(gocbcore.LogDebug))
+	assert.Equal(t, gocb.LogDebug, gocb.LogLevel(gocbv1.LogDebug))
+	assert.Equal(t, gocb.LogDebug, gocb.LogLevel(gocbcorev7.LogDebug))
+
+	assert.Equal(t, gocb.LogTrace, gocb.LogLevel(gocbcore.LogTrace))
+	assert.Equal(t, gocb.LogTrace, gocb.LogLevel(gocbv1.LogTrace))
+	assert.Equal(t, gocb.LogTrace, gocb.LogLevel(gocbcorev7.LogTrace))
+}


### PR DESCRIPTION
The test ensures that the values underneath the constants remain matching between packages and versions, which our log wrapper relies on.