### PR TITLE
Optimise log redaction tagging

### DIFF
--- a/base/redactor_metadata.go
+++ b/base/redactor_metadata.go
@@ -13,8 +13,11 @@ package base
 import (
 	"fmt"
 	"reflect"
+)
 
-	"github.com/couchbase/clog"
+const (
+	metaDataPrefix = "<md>"
+	metaDataSuffix = "</md>"
 )
 
 // RedactMetadata is a global toggle for system data redaction.
@@ -42,7 +45,7 @@ func (md Metadata) Redact() string {
 	if !RedactMetadata {
 		return string(md)
 	}
-	return clog.Tag(clog.MetaData, string(md)).(string)
+	return metaDataPrefix + string(md) + metaDataSuffix
 }
 
 // Compile-time interface check.

--- a/base/redactor_metadata_test.go
+++ b/base/redactor_metadata_test.go
@@ -17,13 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	// This is intentionally brittle (hardcoded redaction tags)
-	// We'd probably want to know if this got changed by accident...
-	metaDataPrefix = "<md>"
-	metaDataSuffix = "</md>"
-)
-
 func TestMetadataRedact(t *testing.T) {
 	clusterName := "My Super Secret Cluster"
 	metadata := Metadata(clusterName)

--- a/base/redactor_systemdata.go
+++ b/base/redactor_systemdata.go
@@ -13,8 +13,11 @@ package base
 import (
 	"fmt"
 	"reflect"
+)
 
-	"github.com/couchbase/clog"
+const (
+	systemDataPrefix = "<sd>"
+	systemDataSuffix = "</sd>"
 )
 
 // RedactSystemData is a global toggle for system data redaction.
@@ -39,7 +42,7 @@ func (sd SystemData) Redact() string {
 	if !RedactSystemData {
 		return string(sd)
 	}
-	return clog.Tag(clog.SystemData, string(sd)).(string)
+	return systemDataPrefix + string(sd) + systemDataSuffix
 }
 
 // Compile-time interface check.

--- a/base/redactor_systemdata_test.go
+++ b/base/redactor_systemdata_test.go
@@ -17,13 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	// This is intentionally brittle (hardcoded redaction tags)
-	// We'd probably want to know if this got changed by accident...
-	systemDataPrefix = "<sd>"
-	systemDataSuffix = "</sd>"
-)
-
 func TestSystemDataRedact(t *testing.T) {
 	clusterName := "My Super Secret IP"
 	systemdata := SystemData(clusterName)

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -13,8 +13,11 @@ package base
 import (
 	"fmt"
 	"reflect"
+)
 
-	"github.com/couchbase/clog"
+const (
+	userDataPrefix = "<ud>"
+	userDataSuffix = "</ud>"
 )
 
 // RedactUserData is a global toggle for user data redaction.
@@ -40,7 +43,7 @@ func (ud UserData) Redact() string {
 	if !RedactUserData {
 		return string(ud)
 	}
-	return clog.Tag(clog.UserData, string(ud)).(string)
+	return userDataPrefix + string(ud) + userDataSuffix
 }
 
 // Compile-time interface check.

--- a/base/redactor_userdata_test.go
+++ b/base/redactor_userdata_test.go
@@ -18,13 +18,6 @@ import (
 	goassert "github.com/couchbaselabs/go.assert"
 )
 
-const (
-	// This is intentionally brittle (hardcoded redaction tags)
-	// We'd probably want to know if this got changed by accident...
-	userDataPrefix = "<ud>"
-	userDataSuffix = "</ud>"
-)
-
 func TestUserDataRedact(t *testing.T) {
 	username := "alice"
 	userdata := UserData(username)


### PR DESCRIPTION
Ahead of enabling tagging by default - this is an easy win for speeding it up (clog does `fmt.Sprintf` under the hood, as well as `interface{}` stuff which has the potential to allocate.

```
$ go1.13.4 test -run=- -bench=^BenchmarkUserDataRedact$ -benchmem -count=10 ./base > new.txt
$ git checkout master
$ go1.13.4 test -run=- -bench=^BenchmarkUserDataRedact$ -benchmem -count=10 ./base > old.txt
$ benchstat -alpha 1 old.txt new.txt
name                            old time/op    new time/op    delta
UserDataRedact/Enabled-12          204ns ± 1%      22ns ± 2%   -89.25%  (p=0.000 n=10+10)
UserDataRedact/EnabledSlice-12    1.28µs ± 1%    0.73µs ± 1%   -42.94%  (p=0.000 n=9+10)
UserDataRedact/Disabled-12        2.18ns ± 1%    0.49ns ± 3%   -77.73%  (p=0.000 n=10+10)

name                            old alloc/op   new alloc/op   delta
UserDataRedact/Enabled-12          64.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
UserDataRedact/EnabledSlice-12      624B ± 0%      480B ± 0%   -23.08%  (p=0.000 n=10+10)
UserDataRedact/Disabled-12         0.00B          0.00B           ~     (all equal)

name                            old allocs/op  new allocs/op  delta
UserDataRedact/Enabled-12           4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
UserDataRedact/EnabledSlice-12      27.0 ± 0%      18.0 ± 0%   -33.33%  (p=0.000 n=10+10)
UserDataRedact/Disabled-12          0.00           0.00           ~     (all equal)
```