### PR TITLE
CBG-1498: Ensure removed notifications only sent when doc not accessible

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -320,7 +320,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 				for _, item := range change.Changes {
 					changeRow := bh.buildChangesRow(change, item["rev"])
 
-					if opts.revocations && len(change.Removed) > 0 && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
+					if opts.revocations && change.allRemoved && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
 						userHasAccessToDoc, err := UserHasDocAccess(bh.db, change.ID, item["rev"])
 						if err != nil {
 							base.InfofCtx(bh.loggingCtx, base.KeySync, "Unable to obtain the doc: %s %s to verify user access: %v", base.UD(change.ID), item["rev"], err)
@@ -328,7 +328,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 						}
 
 						if userHasAccessToDoc {
-							change.Removed = nil
+							continue
 						}
 					}
 
@@ -377,7 +377,7 @@ func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string) []inte
 		if change.Revoked {
 			deletedFlags |= changesDeletedFlagRevoked
 		}
-		if len(change.Removed) > 0 {
+		if change.allRemoved {
 			deletedFlags |= changesDeletedFlagRemoved
 		}
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -320,7 +320,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 				for _, item := range change.Changes {
 					changeRow := bh.buildChangesRow(change, item["rev"])
 
-					if bh.purgeOnRemoval && len(change.Removed) > 0 && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
+					if opts.revocations && len(change.Removed) > 0 && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
 						userHasAccessToDoc, err := UserHasDocAccess(bh.db, change.ID, item["rev"])
 						if err != nil {
 							base.InfofCtx(bh.loggingCtx, base.KeySync, "Unable to obtain the doc: %s %s to verify user access: %v", base.UD(change.ID), item["rev"], err)
@@ -328,7 +328,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 						}
 
 						if userHasAccessToDoc {
-							continue
+							change.Removed = nil
 						}
 					}
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -320,24 +320,32 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 				for _, item := range change.Changes {
 					changeRow := bh.buildChangesRow(change, item["rev"])
 
-					// If change is a removal and we're operating with protocol V3 and the change is not a tombstone fall
-					// into 3.0 removal handling
+					// If change is a removal and we're running with protocol V3 and change change is not a tombstone
+					// fall into 3.0 removal handling
 					if change.allRemoved && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 && !change.Deleted {
-						// If client requests revocations / removals via subChanges, continue work to possibly send
-						// removal. Otherwise skip sending removals.
-						if opts.revocations {
-							userHasAccessToDoc, err := UserHasDocAccess(bh.db, change.ID, item["rev"])
-							if err != nil {
-								base.InfofCtx(bh.loggingCtx, base.KeySync, "Unable to obtain the doc: %s %s to verify user access: %v", base.UD(change.ID), item["rev"], err)
-								continue
-							}
 
-							if userHasAccessToDoc {
-								continue
-							}
-						} else {
+						// If client doesn't want removals / revocations, don't send change
+						if !opts.revocations {
 							continue
 						}
+
+						// If the user has access to the doc through another channel don't send change
+						userHasAccessToDoc, err := UserHasDocAccess(bh.db, change.ID, item["rev"])
+						if err == nil && userHasAccessToDoc {
+							continue
+						}
+
+						// If we can't determine user access due to an error, log error and fall through to send change anyway.
+						// In the event of an error we should be cautious and send a revocation anyway, even if the user
+						// may actually have an alternate access method. This is the safer approach security-wise and
+						// also allows for a recovery if the user notices they are missing a doc they should have access
+						// to. A recovery option would be to trigger a mutation of the document for it to be sent in a
+						// subsequent changes request. If we were to avoid sending a removal there is no recovery
+						// option to then trigger that removal later on.
+						if err != nil {
+							base.WarnfCtx(bh.loggingCtx, "Unable to determine whether user has access to %s/%s, will send removal: %v", base.UD(change.ID), base.UD(item["rev"]), err)
+						}
+
 					}
 
 					pendingChanges = append(pendingChanges, changeRow)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7155,7 +7155,7 @@ func TestRevocationWithAdminRoles(t *testing.T) {
 	assert.Equal(t, 2, len(changes.Results))
 
 	assert.Equal(t, "doc", changes.Results[1].ID)
-	assert.False(t, changes.Results[0].Revoked)
+	assert.False(t, changes.Results[1].Revoked)
 
 	resp = rt.SendAdminRequest("PUT", "/db/_user/user", `{"admin_roles": []}`)
 	assertStatus(t, resp, http.StatusOK)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3328,19 +3328,12 @@ func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	var messageBody []interface{}
 	err = highestSeqMsg.ReadJSONBody(&messageBody)
 	assert.NoError(t, err)
-	require.Len(t, messageBody, 3)
+	require.Len(t, messageBody, 2)
 	require.Len(t, messageBody[0], 4)
-	require.Len(t, messageBody[1], 4)
-	require.Len(t, messageBody[2], 3)
+	require.Len(t, messageBody[1], 3)
 
 	deletedFlags, err := messageBody[0].([]interface{})[3].(json.Number).Int64()
 	docID := messageBody[0].([]interface{})[1]
-	require.NoError(t, err)
-	assert.Equal(t, "doc", docID)
-	assert.Equal(t, int64(4), deletedFlags)
-
-	deletedFlags, err = messageBody[1].([]interface{})[3].(json.Number).Int64()
-	docID = messageBody[1].([]interface{})[1]
 	require.NoError(t, err)
 	assert.Equal(t, "doc", docID)
 	assert.Equal(t, int64(4), deletedFlags)

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1743,6 +1743,7 @@ func TestGetRemovedDoc(t *testing.T) {
 	btSpec := BlipTesterSpec{
 		connectingUsername: "user1",
 		connectingPassword: "1234",
+		blipProtocols:      []string{db.BlipCBMobileReplicationV2},
 	}
 	bt, err := NewBlipTesterFromSpecWithRT(t, &btSpec, rt)
 	require.NoError(t, err, "Unexpected error creating BlipTester")
@@ -1756,6 +1757,7 @@ func TestGetRemovedDoc(t *testing.T) {
 		connectingUsername:          "user2",
 		connectingPassword:          "1234",
 		connectingUserChannelGrants: []string{"user1"}, // so it can see user1's docs
+		blipProtocols:               []string{db.BlipCBMobileReplicationV2},
 	}
 	bt2, err := NewBlipTesterFromSpecWithRT(t, &btSpec2, rt)
 	require.NoError(t, err, "Unexpected error creating BlipTester")
@@ -2099,9 +2101,10 @@ func TestBlipDeltaSyncPullRemoved(t *testing.T) {
 	defer rt.Close()
 
 	client, err := NewBlipTesterClientOptsWithRT(t, rt, &BlipTesterClientOpts{
-		Username:     "alice",
-		Channels:     []string{"public"},
-		ClientDeltas: true,
+		Username:               "alice",
+		Channels:               []string{"public"},
+		ClientDeltas:           true,
+		SupportedBLIPProtocols: []string{db.BlipCBMobileReplicationV2},
 	})
 	require.NoError(t, err)
 	defer client.Close()


### PR DESCRIPTION
Fixes issue where removals would still be sent when doc is accessible through an alternate channel.

Changes:
 - Swapped `bh.purgeOnRemoval` setting to `opts.revocations` instead. Purge on removal is only set through ISGR config option whereas the revocations option is intended to be used internally and is set when subChanges requests them.
 - When user still has access to doc send the change as non-removal. This is okay to do (and we should do) because the doc has been mutated to trigger the removal so the user needs that change, however, we shouldn't send as a removal because they still have access through another channel.

Added a test which ensures that removals only come over when there is no access left.

Based onto https://github.com/couchbase/sync_gateway/pull/5044
- [x] Merge above