### PR TITLE
Allow BLIP Tester Client to support setting its supported BLIP protocols

### DIFF
--- a/db/blip.go
+++ b/db/blip.go
@@ -30,10 +30,14 @@ func NewSGBlipContext(ctx context.Context, id string) (bc *blip.Context, err err
 	// V3 is first here as it is the preferred communication method
 	// In the host case this means SGW can accept both V3 and V2 clients
 	// In the client case this means we prefer V3 but can fallback to V2
+	return NewSGBlipContextWithProtocols(ctx, id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
+}
+
+func NewSGBlipContextWithProtocols(ctx context.Context, id string, protocol ...string) (bc *blip.Context, err error) {
 	if id == "" {
-		bc, err = blip.NewContext(BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
+		bc, err = blip.NewContext(protocol...)
 	} else {
-		bc, err = blip.NewContextCustomID(id, BlipCBMobileReplicationV3, BlipCBMobileReplicationV2)
+		bc, err = blip.NewContextCustomID(id, protocol...)
 	}
 
 	bc.LogMessages = base.LogDebugEnabled(base.KeyWebSocket)

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -27,10 +27,12 @@ import (
 )
 
 type BlipTesterClientOpts struct {
-	ClientDeltas          bool // Support deltas on the client side
-	Username              string
-	Channels              []string
-	SendRevocations       bool
+	ClientDeltas           bool // Support deltas on the client side
+	Username               string
+	Channels               []string
+	SendRevocations        bool
+	SupportedBLIPProtocols []string
+
 	rejectDeltasForSrcRev string // a deltaSrc rev ID for which to reject a delta
 	protocol              string // BlipCBMobileReplication version
 }
@@ -448,6 +450,7 @@ func newBlipTesterReplication(tb testing.TB, id string, btc *BlipTesterClient) (
 		connectingPassword:          "test",
 		connectingUsername:          btc.Username,
 		connectingUserChannelGrants: btc.Channels,
+		blipProtocols:               btc.SupportedBLIPProtocols,
 	}, btc.rt)
 	if err != nil {
 		return nil, err

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -34,7 +34,6 @@ type BlipTesterClientOpts struct {
 	SupportedBLIPProtocols []string
 
 	rejectDeltasForSrcRev string // a deltaSrc rev ID for which to reject a delta
-	protocol              string // BlipCBMobileReplication version
 }
 
 // BlipTesterClient is a fully fledged client to emulate CBL behaviour on both push and pull replications through methods on this type.
@@ -302,7 +301,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					outrq := blip.NewRequest()
 					outrq.SetProfile(db.MessageGetAttachment)
 					outrq.Properties[db.GetAttachmentDigest] = digest
-					if btc.GetProtocol() == db.BlipCBMobileReplicationV3 {
+					if btr.bt.blipContext.ActiveProtocol() == db.BlipCBMobileReplicationV3 {
 						outrq.Properties[db.GetAttachmentID] = docID
 					}
 
@@ -823,11 +822,4 @@ func (btc *BlipTesterClient) GetBlipRevMessage(docId, revId string) (msg *blip.M
 	}
 
 	return nil, false
-}
-
-func (btc *BlipTesterClient) GetProtocol() string {
-	if btc.protocol != "" {
-		return btc.protocol
-	}
-	return db.BlipCBMobileReplicationV3
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -710,6 +710,9 @@ type BlipTesterSpec struct {
 	// those properties only affect the creation of the RestTester.
 	// If nil, a default restTester will be created based on the properties in this spec
 	// restTester *RestTester
+
+	// Supported blipProtocols for the client to use in order of preference
+	blipProtocols []string
 }
 
 // State associated with a BlipTester
@@ -839,8 +842,14 @@ func createBlipTesterWithSpec(tb testing.TB, spec BlipTesterSpec, rt *RestTester
 	}
 	u.Scheme = "ws"
 
+	// If protocols are not set use V3 as a V3 client would
+	protocols := spec.blipProtocols
+	if len(protocols) == 0 {
+		protocols = []string{db.BlipCBMobileReplicationV3}
+	}
+
 	// Make BLIP/Websocket connection
-	bt.blipContext, err = db.NewSGBlipContext(context.Background(), "")
+	bt.blipContext, err = db.NewSGBlipContextWithProtocols(context.Background(), "", protocols...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allows the BLIP tester client to specify which BLIP sub protocols it supports. This improves our ability to test V2 and V3 replication behaviour. 