### PR TITLE
CBG-1473 - Redaction is partial by default

### DIFF
--- a/base/redactor.go
+++ b/base/redactor.go
@@ -104,7 +104,7 @@ func SetRedaction(redactionLevel RedactionLevel) {
 	case RedactNone:
 		RedactUserData = false
 	default:
-		RedactUserData = false
+		RedactUserData = true
 	}
 }
 

--- a/base/redactor.go
+++ b/base/redactor.go
@@ -89,9 +89,11 @@ func buildRedactorFuncSlice(valueOf reflect.Value, function func(interface{}) Re
 
 type RedactionLevel int
 
+const RedactionLevelDefault = RedactPartial
 const (
-	RedactPartial RedactionLevel = iota
+	RedactUnset RedactionLevel = iota
 	RedactNone
+	RedactPartial
 	RedactFull
 )
 
@@ -117,6 +119,8 @@ func (l RedactionLevel) String() string {
 		return "partial"
 	case RedactFull:
 		return "full"
+	case RedactUnset:
+		return "unset"
 	default:
 		return fmt.Sprintf("RedactionLevel(%d)", l)
 	}

--- a/base/redactor.go
+++ b/base/redactor.go
@@ -90,8 +90,8 @@ func buildRedactorFuncSlice(valueOf reflect.Value, function func(interface{}) Re
 type RedactionLevel int
 
 const (
-	RedactNone RedactionLevel = iota
-	RedactPartial
+	RedactPartial RedactionLevel = iota
+	RedactNone
 	RedactFull
 )
 

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -54,7 +54,7 @@ func TestRedactHelper(t *testing.T) {
 func TestSetRedaction(t *testing.T) {
 	// Hits the default case
 	SetRedaction(-1)
-	goassert.Equals(t, RedactUserData, false)
+	goassert.Equals(t, RedactUserData, true)
 
 	SetRedaction(RedactFull)
 	goassert.Equals(t, RedactUserData, true)

--- a/base/redactor_userdata.go
+++ b/base/redactor_userdata.go
@@ -21,7 +21,7 @@ const (
 )
 
 // RedactUserData is a global toggle for user data redaction.
-var RedactUserData = false
+var RedactUserData = true
 
 // UserData is a type which implements the Redactor interface for logging purposes of user data.
 //

--- a/rest/config.go
+++ b/rest/config.go
@@ -890,6 +890,10 @@ func (config *ServerConfig) SetupAndValidateLogging() (err error) {
 	// populate values from deprecated logging config options if not set
 	config.deprecatedConfigLoggingFallback()
 
+	if config.Logging.RedactionLevel == base.RedactUnset {
+		config.Logging.RedactionLevel = base.RedactionLevelDefault
+	}
+
 	base.SetRedaction(config.Logging.RedactionLevel)
 
 	err = config.Logging.Init(defaultLogFilePath)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1315,14 +1315,13 @@ func TestRedactPartialDefault(t *testing.T) {
 	config := &ServerConfig{
 		Logging: &base.LoggingConfig{},
 	}
+	assert.Equal(t, base.RedactUnset, config.Logging.RedactionLevel)
+	assert.Equal(t, true, base.RedactUserData)
+
+	err := config.SetupAndValidateLogging()
+	require.NoError(t, err)
 	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)
 	assert.Equal(t, true, base.RedactUserData)
-	sc, err := setupServerContext(config)
-	require.NoError(t, err)
-	require.NotNil(t, sc)
-	assert.Equal(t, base.RedactPartial, sc.config.Logging.RedactionLevel)
-	assert.Equal(t, true, base.RedactUserData)
-	sc.Close()
 }
 
 func TestSetupServerContext(t *testing.T) {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1310,6 +1310,21 @@ func deleteTempFile(t *testing.T, file *os.File) {
 	require.False(t, base.FileExists(path), "Deleted file %s shouldn't exist", path)
 }
 
+func TestRedactPartialDefault(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	config := &ServerConfig{
+		Logging: &base.LoggingConfig{},
+	}
+	assert.Equal(t, base.RedactPartial, config.Logging.RedactionLevel)
+	assert.Equal(t, true, base.RedactUserData)
+	sc, err := setupServerContext(config)
+	require.NoError(t, err)
+	require.NotNil(t, sc)
+	assert.Equal(t, base.RedactPartial, sc.config.Logging.RedactionLevel)
+	assert.Equal(t, true, base.RedactUserData)
+	sc.Close()
+}
+
 func TestSetupServerContext(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	t.Run("Create server context with a valid configuration", func(t *testing.T) {

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -88,8 +88,8 @@ def create_option_parser():
                       action="store_true", default=False,
                       help=optparse.SUPPRESS_HELP)
     parser.add_option("--log-redaction-level", dest="redact_level",
-                      default="partial",
-                      help="redaction level for the logs collected, none and partial supported (default is partial)")
+                      default="none",
+                      help="redaction level for the logs collected, none and partial supported (default is none)")
     parser.add_option("--log-redaction-salt", dest="salt_value",
                       default=str(uuid.uuid4()),
                       help="Is used to salt the hashing of tagged data, \

--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -88,8 +88,8 @@ def create_option_parser():
                       action="store_true", default=False,
                       help=optparse.SUPPRESS_HELP)
     parser.add_option("--log-redaction-level", dest="redact_level",
-                      default="none",
-                      help="redaction level for the logs collected, none and partial supported (default is none)")
+                      default="partial",
+                      help="redaction level for the logs collected, none and partial supported (default is partial)")
     parser.add_option("--log-redaction-salt", dest="salt_value",
                       default=str(uuid.uuid4()),
                       help="Is used to salt the hashing of tagged data, \


### PR DESCRIPTION
Added unset RedactionLevel which gets changed to RedactPartial (or whatever RedactionLevelDefault) is set to.
~Reordered iota for RedactLevel so RedactPartial is 0, which means if no RedactLevel is set in the logs, RedactPartial is used by default~
RedactUserData is true when a non-redact level number is passed to SetRedaction()
Redact level is set to partial by default in sgcollect_info
Added a test to check redaction level and user data redaction variable is correct