### PR TITLE
CBG-1504: Add ability to obtain mgmt endpoints from cluster

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2037,12 +2037,17 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 	return AsGoCBBucket(underlyingBucket)
 }
 
-// Get one of the management endpoints.  It will be a string such as http://couchbase
-func GoCBBucketMgmtEndpoint(bucket *gocb.Bucket) (url string, err error) {
+func GoCBBucketMgmtEndpoints(bucket *gocb.Bucket) (url []string, err error) {
 	mgmtEps := bucket.IoRouter().MgmtEps()
 	if len(mgmtEps) == 0 {
-		return "", fmt.Errorf("No available Couchbase Server nodes")
+		return nil, fmt.Errorf("No available Couchbase Server nodes")
 	}
+	return mgmtEps, nil
+}
+
+// Get one of the management endpoints.  It will be a string such as http://couchbase
+func GoCBBucketMgmtEndpoint(bucket *gocb.Bucket) (url string, err error) {
+	mgmtEps, err := GoCBBucketMgmtEndpoints(bucket)
 	bucketEp := mgmtEps[rand.Intn(len(mgmtEps))]
 	return bucketEp, nil
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -2048,6 +2048,9 @@ func GoCBBucketMgmtEndpoints(bucket *gocb.Bucket) (url []string, err error) {
 // Get one of the management endpoints.  It will be a string such as http://couchbase
 func GoCBBucketMgmtEndpoint(bucket *gocb.Bucket) (url string, err error) {
 	mgmtEps, err := GoCBBucketMgmtEndpoints(bucket)
+	if err != nil {
+		return "", err
+	}
 	bucketEp := mgmtEps[rand.Intn(len(mgmtEps))]
 	return bucketEp, nil
 }

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -115,6 +115,8 @@ func GoCBCoreTLSRootCAProvider(caCertPath string) (func() *x509.CertPool, error)
 }
 
 func getRootCAs(caCertPath string) (*x509.CertPool, error) {
+	// We're purposefully ignoring the error here and falling back to an empty CertPool. Partly due to the fact that
+	// the main error case is that this call is not supported in Windows.
 	rootCAs, _ := x509.SystemCertPool()
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -102,3 +102,35 @@ func GoCBCoreAuthConfig(username, password, certPath, keyPath string) (a gocbcor
 		Password: password,
 	}, nil
 }
+
+func GoCBCoreTLSRootCAProvider(caCertPath string) (func() *x509.CertPool, error) {
+	rootCAs, err := getRootCAs(caCertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() *x509.CertPool {
+		return rootCAs
+	}, nil
+}
+
+func getRootCAs(caCertPath string) (*x509.CertPool, error) {
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	if caCertPath != "" {
+		caCert, err := ioutil.ReadFile(caCertPath)
+		if err != nil {
+			return nil, err
+		}
+
+		ok := rootCAs.AppendCertsFromPEM(caCert)
+		if !ok {
+			return nil, errors.New("Invalid CA cert")
+		}
+	}
+
+	return rootCAs, nil
+}

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -115,14 +115,9 @@ func GoCBCoreTLSRootCAProvider(caCertPath string) (func() *x509.CertPool, error)
 }
 
 func getRootCAs(caCertPath string) (*x509.CertPool, error) {
-	// We're purposefully ignoring the error here and falling back to an empty CertPool. Partly due to the fact that
-	// the main error case is that this call is not supported in Windows.
-	rootCAs, _ := x509.SystemCertPool()
-	if rootCAs == nil {
-		rootCAs = x509.NewCertPool()
-	}
-
 	if caCertPath != "" {
+		rootCAs := x509.NewCertPool()
+
 		caCert, err := ioutil.ReadFile(caCertPath)
 		if err != nil {
 			return nil, err
@@ -132,7 +127,12 @@ func getRootCAs(caCertPath string) (*x509.CertPool, error) {
 		if !ok {
 			return nil, errors.New("Invalid CA cert")
 		}
+
+		return rootCAs, nil
 	}
 
+	// We're purposefully ignoring the error here Due to the fact that the main error case is that this call is not
+	// supported in Windows.
+	rootCAs, _ := x509.SystemCertPool()
 	return rootCAs, nil
 }

--- a/db/database.go
+++ b/db/database.go
@@ -1370,6 +1370,16 @@ func (db *Database) invalUserOrRoleChannels(name string, invalSeq uint64) {
 	}
 }
 
+func (context *DatabaseContext) ObtainManagementEndpoints() ([]string, error) {
+	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	if !ok {
+		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
+		return nil, nil
+	}
+
+	return base.GoCBBucketMgmtEndpoints(gocbBucket.Bucket)
+}
+
 func (context *DatabaseContext) GetUserViewsEnabled() bool {
 	if context.Options.UnsupportedOptions.UserViews.Enabled != nil {
 		return *context.Options.UnsupportedOptions.UserViews.Enabled

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1191,12 +1191,12 @@ func initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPat
 }
 
 // FIXME: Temporary connection settings. Awaiting bootstrap PR so we can use those details directly from server context
-func (sc *ServerContext) tempConnectionDetails() (serverAddress string, username string, password string, certPath string, keyPath string, caCertPath string) {
+var tempConnectionDetailsForManagementEndpoints = func() (serverAddress string, username string, password string, certPath string, keyPath string, caCertPath string) {
 	return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), "", "", ""
 }
 
 func (sc *ServerContext) ObtainManagementEndpoints() ([]string, error) {
-	clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath := sc.tempConnectionDetails()
+	clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath := tempConnectionDetailsForManagementEndpoints()
 	agent, err := initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath)
 	if err != nil {
 		return nil, err

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -303,15 +303,25 @@ func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 	eps, err := ctx.ObtainManagementEndpoints()
 	assert.NoError(t, err)
 
-	clusterAddress, _, _, _, _ := ctx.tempConnectionDetails()
+	clusterAddress, _, _, _, _, _ := ctx.tempConnectionDetails()
 	baseSpec, err := connstr.Parse(clusterAddress)
 	require.NoError(t, err)
 
 	spec, err := connstr.Resolve(baseSpec)
 	require.NoError(t, err)
 
+	existsOneMatchingEndpoint := false
+
+outerLoop:
 	for _, httpHost := range spec.HttpHosts {
-		formatted := fmt.Sprintf("http://%s:%d", httpHost.Host, httpHost.Port)
-		assert.Contains(t, eps, formatted)
+		for _, ep := range eps {
+			formattedHttpHost := fmt.Sprintf("http://%s:%d", httpHost.Host, httpHost.Port)
+			if formattedHttpHost == ep {
+				existsOneMatchingEndpoint = true
+				break outerLoop
+			}
+		}
 	}
+
+	assert.True(t, existsOneMatchingEndpoint)
 }


### PR DESCRIPTION
Add a function on the ServerContext which connects to a Couchbase Server cluster and obtains the management endpoints.

This currently connects with the test values (serverAddress, serverUsername, serverPassword, certPath, keyPath) from a temporary function `tempConnectionDetails`. Once the bootstrap work is complete for persistent config these will be replaced.

Also added a function on DatabaseContext which can be used in the event that we have an existing bucket connection.

Unit test is currently grabs endpoints and attempts to assert against the formatted connection string.