### PR TITLE
Bump up go-couchbase SHA to absorb fix for MB-43553

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -44,7 +44,7 @@ licenses/APL2.txt.
 
   <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="aac9eb5d3047d4a74d3e87db231a36e231446dad"/>
 
-  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="f3d612a87e874d357612b571db5768b7ee9a9a24"/>
+  <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="b41ef931ed4678312eb38d465b729a0b1afdebed"/>
 
   <!-- gocb v2 -->
   <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9ced163b8225c08922af38c3678dd0980b32f01f" />


### PR DESCRIPTION
+ The earlier fix I made for MB-43553 had a flaw. Since then,
  I've reverted it and pushed up a more accurate fix -
    http://review.couchbase.org/c/go-couchbase/+/155752