### PR TITLE
CBG-1520 Switch to the latest revision of go-blip library

### DIFF
--- a/db/active_replicator_pull.go
+++ b/db/active_replicator_pull.go
@@ -103,7 +103,7 @@ func (apr *ActivePullReplicator) _connect() error {
 
 	apr.setState(ReplicationStateRunning)
 
-	if apr.blipSyncContext.blipContext.ActiveProtocol() == BlipCBMobileReplicationV2 && apr.config.PurgeOnRemoval {
+	if apr.blipSyncContext.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && apr.config.PurgeOnRemoval {
 		base.ErrorfCtx(apr.config.ActiveDB.Ctx, "Pull replicator ID:%s running with revocations enabled but target does not support revocations. Sync Gateway 3.0 required.", apr.config.ID)
 	}
 

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -322,8 +322,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 
 					// If change is a removal and we're running with protocol V3 and change change is not a tombstone
 					// fall into 3.0 removal handling
-					if change.allRemoved && bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV3 && !change.
-						Deleted {
+					if change.allRemoved && bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV3 && !change.Deleted {
 
 						// If client doesn't want removals / revocations, don't send change
 						if !opts.revocations {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -322,7 +322,8 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 
 					// If change is a removal and we're running with protocol V3 and change change is not a tombstone
 					// fall into 3.0 removal handling
-					if change.allRemoved && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 && !change.Deleted {
+					if change.allRemoved && bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV3 && !change.
+						Deleted {
 
 						// If client doesn't want removals / revocations, don't send change
 						if !opts.revocations {
@@ -385,7 +386,7 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 func (bh *blipHandler) buildChangesRow(change *ChangeEntry, revID string) []interface{} {
 	var changeRow []interface{}
 
-	if bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 {
+	if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV3 {
 		deletedFlags := changesDeletedFlag(0)
 		if change.Deleted {
 			deletedFlags |= changesDeletedFlagDeleted
@@ -545,7 +546,7 @@ func (bh *blipHandler) handleChanges(rq *blip.Message) error {
 
 		}
 
-		if bh.purgeOnRemoval && bh.blipContext.ActiveProtocol() == BlipCBMobileReplicationV3 &&
+		if bh.purgeOnRemoval && bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV3 &&
 			(deletedFlags.HasFlag(changesDeletedFlagRevoked) || deletedFlags.HasFlag(changesDeletedFlagRemoved)) {
 			err := bh.db.Purge(docID)
 			if err != nil {

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -109,7 +109,7 @@ licenses/APL2.txt.
 
   <project name="goutils" path="godeps/src/github.com/couchbase/goutils" remote="couchbase" revision="f98adca8eb365032cab838ef4d99453931afa112"/>
 
-  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="b921783f4b3ef90bcc37d1ba8967d522156fdbe4"/>
+  <project name="go-blip" path="godeps/src/github.com/couchbase/go-blip" remote="couchbase" revision="3c4edeb16c47cdb3bcd1eeab3b3c5c87832d4923"/>
 
   <project name="errors" path="godeps/src/github.com/pkg/errors" remote="couchbasedeps" revision="f15c970de5b76fac0b59abb32d62c17cc7bed265"/>
 

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -301,7 +301,7 @@ func (btr *BlipTesterReplicator) initHandlers(btc *BlipTesterClient) {
 					outrq := blip.NewRequest()
 					outrq.SetProfile(db.MessageGetAttachment)
 					outrq.Properties[db.GetAttachmentDigest] = digest
-					if btr.bt.blipContext.ActiveProtocol() == db.BlipCBMobileReplicationV3 {
+					if btr.bt.blipContext.ActiveSubprotocol() == db.BlipCBMobileReplicationV3 {
 						outrq.Properties[db.GetAttachmentID] = docID
 					}
 


### PR DESCRIPTION
A recent change has been included in the go-blip library store the currently used Websocket subprotocol on BLIP context. The ActiveProtocol function exposed on the BLIP context is no more and we should use ActiveSubprotocol instead.