### PR TITLE
CBG-1475 - Added Warning threshold for channel name length

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -167,6 +167,7 @@ var (
 	DefaultWarnThresholdChannelsPerDoc  = uint32(50)
 	DefaultWarnThresholdChannelsPerUser = uint32(50000)
 	DefaultWarnThresholdGrantsPerDoc    = uint32(50)
+	DefaultWarnThresholdChannelNameSize = uint32(250)
 	DefaultClientPartitionWindow        = time.Hour * 24 * 30
 
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields

--- a/base/stats.go
+++ b/base/stats.go
@@ -232,31 +232,32 @@ type CBLReplicationPushStats struct {
 }
 
 type DatabaseStats struct {
-	ConflictWriteCount      *SgwIntStat `json:"conflict_write_count"`
-	Crc32MatchCount         *SgwIntStat `json:"crc32c_match_count"`
-	DCPCachingCount         *SgwIntStat `json:"dcp_caching_count"`
-	DCPCachingTime          *SgwIntStat `json:"dcp_caching_time"`
-	DCPReceivedCount        *SgwIntStat `json:"dcp_received_count"`
-	DCPReceivedTime         *SgwIntStat `json:"dcp_received_time"`
-	DocReadsBytesBlip       *SgwIntStat `json:"doc_reads_bytes_blip"`
-	DocWritesBytes          *SgwIntStat `json:"doc_writes_bytes"`
-	DocWritesBytesBlip      *SgwIntStat `json:"doc_writes_bytes_blip"`
-	DocWritesXattrBytes     *SgwIntStat `json:"doc_writes_xattr_bytes"`
-	HighSeqFeed             *SgwIntStat `json:"high_seq_feed"`
-	NumDocReadsBlip         *SgwIntStat `json:"num_doc_reads_blip"`
-	NumDocReadsRest         *SgwIntStat `json:"num_doc_reads_rest"`
-	NumDocWrites            *SgwIntStat `json:"num_doc_writes"`
-	NumReplicationsActive   *SgwIntStat `json:"num_replications_active"`
-	NumReplicationsTotal    *SgwIntStat `json:"num_replications_total"`
-	NumTombstonesCompacted  *SgwIntStat `json:"num_tombstones_compacted"`
-	SequenceAssignedCount   *SgwIntStat `json:"sequence_assigned_count"`
-	SequenceGetCount        *SgwIntStat `json:"sequence_get_count"`
-	SequenceIncrCount       *SgwIntStat `json:"sequence_incr_count"`
-	SequenceReleasedCount   *SgwIntStat `json:"sequence_released_count"`
-	SequenceReservedCount   *SgwIntStat `json:"sequence_reserved_count"`
-	WarnChannelsPerDocCount *SgwIntStat `json:"warn_channels_per_doc_count"`
-	WarnGrantsPerDocCount   *SgwIntStat `json:"warn_grants_per_doc_count"`
-	WarnXattrSizeCount      *SgwIntStat `json:"warn_xattr_size_count"`
+	ConflictWriteCount       *SgwIntStat `json:"conflict_write_count"`
+	Crc32MatchCount          *SgwIntStat `json:"crc32c_match_count"`
+	DCPCachingCount          *SgwIntStat `json:"dcp_caching_count"`
+	DCPCachingTime           *SgwIntStat `json:"dcp_caching_time"`
+	DCPReceivedCount         *SgwIntStat `json:"dcp_received_count"`
+	DCPReceivedTime          *SgwIntStat `json:"dcp_received_time"`
+	DocReadsBytesBlip        *SgwIntStat `json:"doc_reads_bytes_blip"`
+	DocWritesBytes           *SgwIntStat `json:"doc_writes_bytes"`
+	DocWritesBytesBlip       *SgwIntStat `json:"doc_writes_bytes_blip"`
+	DocWritesXattrBytes      *SgwIntStat `json:"doc_writes_xattr_bytes"`
+	HighSeqFeed              *SgwIntStat `json:"high_seq_feed"`
+	NumDocReadsBlip          *SgwIntStat `json:"num_doc_reads_blip"`
+	NumDocReadsRest          *SgwIntStat `json:"num_doc_reads_rest"`
+	NumDocWrites             *SgwIntStat `json:"num_doc_writes"`
+	NumReplicationsActive    *SgwIntStat `json:"num_replications_active"`
+	NumReplicationsTotal     *SgwIntStat `json:"num_replications_total"`
+	NumTombstonesCompacted   *SgwIntStat `json:"num_tombstones_compacted"`
+	SequenceAssignedCount    *SgwIntStat `json:"sequence_assigned_count"`
+	SequenceGetCount         *SgwIntStat `json:"sequence_get_count"`
+	SequenceIncrCount        *SgwIntStat `json:"sequence_incr_count"`
+	SequenceReleasedCount    *SgwIntStat `json:"sequence_released_count"`
+	SequenceReservedCount    *SgwIntStat `json:"sequence_reserved_count"`
+	WarnChannelsPerDocCount  *SgwIntStat `json:"warn_channels_per_doc_count"`
+	WarnGrantsPerDocCount    *SgwIntStat `json:"warn_grants_per_doc_count"`
+	WarnXattrSizeCount       *SgwIntStat `json:"warn_xattr_size_count"`
+	WarnChannelNameSizeCount *SgwIntStat `json:"warn_channel_name_size_count"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -700,33 +701,34 @@ func (d *DbStats) initDatabaseStats() {
 	labelKeys := []string{DatabaseLabelKey}
 	labelVals := []string{d.dbName}
 	d.DatabaseStats = &DatabaseStats{
-		ConflictWriteCount:      NewIntStat(SubsystemDatabaseKey, "conflict_write_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		Crc32MatchCount:         NewIntStat(SubsystemDatabaseKey, "crc32c_match_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
-		DCPCachingCount:         NewIntStat(SubsystemDatabaseKey, "dcp_caching_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
-		DCPCachingTime:          NewIntStat(SubsystemDatabaseKey, "dcp_caching_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
-		DCPReceivedCount:        NewIntStat(SubsystemDatabaseKey, "dcp_received_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
-		DCPReceivedTime:         NewIntStat(SubsystemDatabaseKey, "dcp_received_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
-		DocReadsBytesBlip:       NewIntStat(SubsystemDatabaseKey, "doc_reads_bytes_blip", labelKeys, labelVals, prometheus.CounterValue, 0),
-		DocWritesBytes:          NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes", labelKeys, labelVals, prometheus.CounterValue, 0),
-		DocWritesXattrBytes:     NewIntStat(SubsystemDatabaseKey, "doc_writes_xattr_bytes", labelKeys, labelVals, prometheus.CounterValue, 0),
-		HighSeqFeed:             NewIntStat(SubsystemDatabaseKey, "high_seq_feed", labelKeys, labelVals, prometheus.CounterValue, 0),
-		DocWritesBytesBlip:      NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes_blip", labelKeys, labelVals, prometheus.CounterValue, 0),
-		NumDocReadsBlip:         NewIntStat(SubsystemDatabaseKey, "num_doc_reads_blip", labelKeys, labelVals, prometheus.CounterValue, 0),
-		NumDocReadsRest:         NewIntStat(SubsystemDatabaseKey, "num_doc_reads_rest", labelKeys, labelVals, prometheus.CounterValue, 0),
-		NumDocWrites:            NewIntStat(SubsystemDatabaseKey, "num_doc_writes", labelKeys, labelVals, prometheus.CounterValue, 0),
-		NumReplicationsActive:   NewIntStat(SubsystemDatabaseKey, "num_replications_active", labelKeys, labelVals, prometheus.GaugeValue, 0),
-		NumReplicationsTotal:    NewIntStat(SubsystemDatabaseKey, "num_replications_total", labelKeys, labelVals, prometheus.CounterValue, 0),
-		NumTombstonesCompacted:  NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SequenceAssignedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SequenceGetCount:        NewIntStat(SubsystemDatabaseKey, "sequence_get_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SequenceIncrCount:       NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SequenceReleasedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_released_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		SequenceReservedCount:   NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		WarnChannelsPerDocCount: NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		WarnGrantsPerDocCount:   NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		WarnXattrSizeCount:      NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		ImportFeedMapStats:      &ExpVarMapWrapper{new(expvar.Map).Init()},
-		CacheFeedMapStats:       &ExpVarMapWrapper{new(expvar.Map).Init()},
+		ConflictWriteCount:       NewIntStat(SubsystemDatabaseKey, "conflict_write_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		Crc32MatchCount:          NewIntStat(SubsystemDatabaseKey, "crc32c_match_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		DCPCachingCount:          NewIntStat(SubsystemDatabaseKey, "dcp_caching_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		DCPCachingTime:           NewIntStat(SubsystemDatabaseKey, "dcp_caching_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		DCPReceivedCount:         NewIntStat(SubsystemDatabaseKey, "dcp_received_count", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		DCPReceivedTime:          NewIntStat(SubsystemDatabaseKey, "dcp_received_time", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		DocReadsBytesBlip:        NewIntStat(SubsystemDatabaseKey, "doc_reads_bytes_blip", labelKeys, labelVals, prometheus.CounterValue, 0),
+		DocWritesBytes:           NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes", labelKeys, labelVals, prometheus.CounterValue, 0),
+		DocWritesXattrBytes:      NewIntStat(SubsystemDatabaseKey, "doc_writes_xattr_bytes", labelKeys, labelVals, prometheus.CounterValue, 0),
+		HighSeqFeed:              NewIntStat(SubsystemDatabaseKey, "high_seq_feed", labelKeys, labelVals, prometheus.CounterValue, 0),
+		DocWritesBytesBlip:       NewIntStat(SubsystemDatabaseKey, "doc_writes_bytes_blip", labelKeys, labelVals, prometheus.CounterValue, 0),
+		NumDocReadsBlip:          NewIntStat(SubsystemDatabaseKey, "num_doc_reads_blip", labelKeys, labelVals, prometheus.CounterValue, 0),
+		NumDocReadsRest:          NewIntStat(SubsystemDatabaseKey, "num_doc_reads_rest", labelKeys, labelVals, prometheus.CounterValue, 0),
+		NumDocWrites:             NewIntStat(SubsystemDatabaseKey, "num_doc_writes", labelKeys, labelVals, prometheus.CounterValue, 0),
+		NumReplicationsActive:    NewIntStat(SubsystemDatabaseKey, "num_replications_active", labelKeys, labelVals, prometheus.GaugeValue, 0),
+		NumReplicationsTotal:     NewIntStat(SubsystemDatabaseKey, "num_replications_total", labelKeys, labelVals, prometheus.CounterValue, 0),
+		NumTombstonesCompacted:   NewIntStat(SubsystemDatabaseKey, "num_tombstones_compacted", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SequenceAssignedCount:    NewIntStat(SubsystemDatabaseKey, "sequence_assigned_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SequenceGetCount:         NewIntStat(SubsystemDatabaseKey, "sequence_get_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SequenceIncrCount:        NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SequenceReleasedCount:    NewIntStat(SubsystemDatabaseKey, "sequence_released_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		SequenceReservedCount:    NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		WarnChannelsPerDocCount:  NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		WarnGrantsPerDocCount:    NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		WarnXattrSizeCount:       NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		WarnChannelNameSizeCount: NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		ImportFeedMapStats:       &ExpVarMapWrapper{new(expvar.Map).Init()},
+		CacheFeedMapStats:        &ExpVarMapWrapper{new(expvar.Map).Init()},
 	}
 }
 

--- a/base/stats.go
+++ b/base/stats.go
@@ -254,10 +254,10 @@ type DatabaseStats struct {
 	SequenceIncrCount        *SgwIntStat `json:"sequence_incr_count"`
 	SequenceReleasedCount    *SgwIntStat `json:"sequence_released_count"`
 	SequenceReservedCount    *SgwIntStat `json:"sequence_reserved_count"`
+	WarnChannelNameSizeCount *SgwIntStat `json:"warn_channel_name_size_count"`
 	WarnChannelsPerDocCount  *SgwIntStat `json:"warn_channels_per_doc_count"`
 	WarnGrantsPerDocCount    *SgwIntStat `json:"warn_grants_per_doc_count"`
 	WarnXattrSizeCount       *SgwIntStat `json:"warn_xattr_size_count"`
-	WarnChannelNameSizeCount *SgwIntStat `json:"warn_channel_name_size_count"`
 
 	// These can be cleaned up in future versions of SGW, implemented as maps to reduce amount of potential risk
 	// prior to Hydrogen release. These are not exported as part of prometheus and only exposed through expvars
@@ -723,10 +723,10 @@ func (d *DbStats) initDatabaseStats() {
 		SequenceIncrCount:        NewIntStat(SubsystemDatabaseKey, "sequence_incr_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		SequenceReleasedCount:    NewIntStat(SubsystemDatabaseKey, "sequence_released_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		SequenceReservedCount:    NewIntStat(SubsystemDatabaseKey, "sequence_reserved_count", labelKeys, labelVals, prometheus.CounterValue, 0),
+		WarnChannelNameSizeCount: NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WarnChannelsPerDocCount:  NewIntStat(SubsystemDatabaseKey, "warn_channels_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WarnGrantsPerDocCount:    NewIntStat(SubsystemDatabaseKey, "warn_grants_per_doc_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		WarnXattrSizeCount:       NewIntStat(SubsystemDatabaseKey, "warn_xattr_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
-		WarnChannelNameSizeCount: NewIntStat(SubsystemDatabaseKey, "warn_channel_name_size_count", labelKeys, labelVals, prometheus.CounterValue, 0),
 		ImportFeedMapStats:       &ExpVarMapWrapper{new(expvar.Map).Init()},
 		CacheFeedMapStats:        &ExpVarMapWrapper{new(expvar.Map).Init()},
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1927,7 +1927,7 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 		for c := range channels {
 			if uint32(len(c)) > *channelNameSizeThreshold {
 				db.DbStats.Database().WarnChannelNameSizeCount.Add(1)
-				base.WarnfCtx(db.Ctx, "Doc id: %v channel name size: %s channel exceeds %d characters for channel name size warning threshold", base.UD(docID), base.UD(c), *channelNameSizeThreshold)
+				base.WarnfCtx(db.Ctx, "Doc: %q channel %q exceeds %d characters for channel name size warning threshold", base.UD(docID), base.UD(c), *channelNameSizeThreshold)
 			}
 		}
 	}

--- a/db/crud.go
+++ b/db/crud.go
@@ -1924,15 +1924,11 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 
 	// Warn when channel names are larger than a configured threshold
 	if channelNameSizeThreshold := db.Options.UnsupportedOptions.WarningThresholds.ChannelNameSize; channelNameSizeThreshold != nil {
-		var channelsOverCount int
 		for c := range channels {
 			if uint32(len(c)) > *channelNameSizeThreshold {
-				channelsOverCount++
+				db.DbStats.Database().WarnChannelNameSizeCount.Add(1)
+				base.WarnfCtx(db.Ctx, "Doc id: %v channel name size: %s channel exceeds %d characters for channel name size warning threshold", base.UD(docID), base.UD(c), *channelNameSizeThreshold)
 			}
-		}
-		if channelsOverCount > 0 {
-			db.DbStats.Database().WarnChannelNameSizeCount.Add(1)
-			base.WarnfCtx(db.Ctx, "Doc id: %v channel name size: %d channel/s exceeds %d characters for channel name size warning threshold", base.UD(docID), channelsOverCount, *channelNameSizeThreshold)
 		}
 	}
 }

--- a/db/crud.go
+++ b/db/crud.go
@@ -1921,6 +1921,20 @@ func (db *Database) checkDocChannelsAndGrantsLimits(docID string, channels base.
 			base.WarnfCtx(db.Ctx, "Doc id: %v access and role grants count: %d exceeds %d for grants per doc warning threshold", base.UD(docID), grantCount, *grantThreshold)
 		}
 	}
+
+	// Warn when channel names are larger than a configured threshold
+	if channelNameSizeThreshold := db.Options.UnsupportedOptions.WarningThresholds.ChannelNameSize; channelNameSizeThreshold != nil {
+		var channelsOverCount int
+		for c := range channels {
+			if uint32(len(c)) > *channelNameSizeThreshold {
+				channelsOverCount++
+			}
+		}
+		if channelsOverCount > 0 {
+			db.DbStats.Database().WarnChannelNameSizeCount.Add(1)
+			base.WarnfCtx(db.Ctx, "Doc id: %v channel name size: %d channel/s exceeds %d characters for channel name size warning threshold", base.UD(docID), channelsOverCount, *channelNameSizeThreshold)
+		}
+	}
 }
 
 func (db *Database) MarkPrincipalsChanged(docid string, newRevID string, changedPrincipals, changedRoleUsers []string, invalSeq uint64) {

--- a/db/database.go
+++ b/db/database.go
@@ -186,6 +186,7 @@ type WarningThresholds struct {
 	ChannelsPerDoc  *uint32 `json:"channels_per_doc,omitempty"`               // Number of channels per document to be used as a threshold for channel count warnings
 	GrantsPerDoc    *uint32 `json:"access_and_role_grants_per_doc,omitempty"` // Number of access and role grants per document to be used as a threshold for grant count warnings
 	ChannelsPerUser *uint32 `json:"channels_per_user,omitempty"`              // Number of channels per user to be used as a threshold for channel count warnings
+	ChannelNameSize *uint32 `json:"channel_name_size,omitempty"`              // Number of channel name characters to be used as a threshold for channel name warnings
 }
 
 // Options associated with the import of documents not written by Sync Gateway

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3063,13 +3063,13 @@ func TestChannelNameSizeWarningUpdateExistingDoc(t *testing.T) {
 	defer rt.Close()
 
 	// Update doc - should warn
-	channelLength := int(base.DefaultWarnThresholdChannelNameSize) + 5
+	channelName := strings.Repeat("B", int(base.DefaultWarnThresholdChannelNameSize)+5)
 	t.Run("Update doc without changing channel", func(t *testing.T) {
-		tr := rt.SendAdminRequest("PUT", "/db/replace", fmt.Sprintf("{\"chan\":\"%s\"}", strings.Repeat("B", channelLength))) // init doc
+		tr := rt.SendAdminRequest("PUT", "/db/replace", fmt.Sprintf("{\"chan\":\"%s\"}", channelName)) // init doc
 		assertStatus(t, tr, http.StatusCreated)
 
 		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		tr = rt.SendAdminRequest("PUT", "/db/replace?rev="+getRespRev(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", strings.Repeat("B", channelLength)))
+		tr = rt.SendAdminRequest("PUT", "/db/replace?rev="+getRespRev(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", channelName))
 		assertStatus(t, tr, http.StatusCreated)
 		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -124,17 +124,7 @@ func TestChannelNameSizeWarning(t *testing.T) {
 
 	// change value to 500 in config
 	warnThreshold := uint32(500)
-	rt = NewRestTester(t, &RestTesterConfig{
-		SyncFn: syncFn,
-		DatabaseConfig: &DbConfig{
-			Unsupported: db.UnsupportedOptions{
-				WarningThresholds: db.WarningThresholds{
-					ChannelNameSize: &warnThreshold,
-				},
-			},
-		},
-	})
-	defer rt.Close()
+	rt.DatabaseConfig.Unsupported.WarningThresholds.ChannelNameSize = &warnThreshold
 	boundaryTest(int(warnThreshold))
 }
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3043,10 +3043,10 @@ func TestChannelNameSizeWarningBoundaries(t *testing.T) {
 			})
 			defer rt.Close()
 
-			chanNameWarnCountBefore := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+			chanNameWarnCountBefore := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 			tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/doc%v", test.channelLength), fmt.Sprintf("{\"chan\":\"%s\"}", strings.Repeat("A", test.channelLength)))
 			assertStatus(t, tr, http.StatusCreated)
-			chanNameWarnCountAfter := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+			chanNameWarnCountAfter := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 			if test.expectWarn {
 				assert.Equal(t, chanNameWarnCountBefore+1, chanNameWarnCountAfter)
 			} else {
@@ -3068,10 +3068,10 @@ func TestChannelNameSizeWarningUpdateExistingDoc(t *testing.T) {
 		tr := rt.SendAdminRequest("PUT", "/db/replace", fmt.Sprintf("{\"chan\":\"%s\"}", strings.Repeat("B", channelLength))) // init doc
 		assertStatus(t, tr, http.StatusCreated)
 
-		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		tr = rt.SendAdminRequest("PUT", "/db/replace?rev="+getRespRev(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", strings.Repeat("B", channelLength)))
 		assertStatus(t, tr, http.StatusCreated)
-		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
 	})
 }
@@ -3088,10 +3088,10 @@ func TestChannelNameSizeWarningDocChannelUpdate(t *testing.T) {
 		tr := rt.SendAdminRequest("PUT", "/db/replaceNewChannel", fmt.Sprintf("{\"chan\":\"%s\"}", strings.Repeat("C", channelLength))) // init doc
 		assertStatus(t, tr, http.StatusCreated)
 
-		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		tr = rt.SendAdminRequest("PUT", "/db/replaceNewChannel?rev="+getRespRev(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", strings.Repeat("D", channelLength+5)))
 		assertStatus(t, tr, http.StatusCreated)
-		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
 	})
 }
@@ -3108,10 +3108,10 @@ func TestChannelNameSizeWarningDeleteChannel(t *testing.T) {
 		tr := rt.SendAdminRequest("PUT", "/db/deleteme", fmt.Sprintf("{\"chan\":\"%s\"}", strings.Repeat("F", channelLength))) // init channel
 		assertStatus(t, tr, http.StatusCreated)
 
-		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		tr = rt.SendAdminRequest("DELETE", "/db/deleteme?rev="+getRespRev(t, tr), "")
 		assertStatus(t, tr, http.StatusOK)
-		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Val
+		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before, after)
 	})
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -33,16 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Get rev from Admin API response
-func getRespRev(t *testing.T, resp *TestResponse) string {
-	var body struct {
-		Rev string `json:"rev"`
-	}
-	err := json.Unmarshal(resp.BodyBytes(), &body)
-	require.NoError(t, err)
-	return body.Rev
-}
-
 // Reproduces CBG-1412 - JSON strings in some responses not being correctly escaped
 func TestPutDocSpecialChar(t *testing.T) {
 	rt := NewRestTester(t, nil)
@@ -3069,7 +3059,7 @@ func TestChannelNameSizeWarningUpdateExistingDoc(t *testing.T) {
 		assertStatus(t, tr, http.StatusCreated)
 
 		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		tr = rt.SendAdminRequest("PUT", "/db/replace?rev="+getRespRev(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", channelName))
+		tr = rt.SendAdminRequest("PUT", "/db/replace?rev="+respRevID(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", channelName))
 		assertStatus(t, tr, http.StatusCreated)
 		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
@@ -3089,7 +3079,7 @@ func TestChannelNameSizeWarningDocChannelUpdate(t *testing.T) {
 		assertStatus(t, tr, http.StatusCreated)
 
 		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		tr = rt.SendAdminRequest("PUT", "/db/replaceNewChannel?rev="+getRespRev(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", strings.Repeat("D", channelLength+5)))
+		tr = rt.SendAdminRequest("PUT", "/db/replaceNewChannel?rev="+respRevID(t, tr), fmt.Sprintf("{\"chan\":\"%s\", \"data\":\"test\"}", strings.Repeat("D", channelLength+5)))
 		assertStatus(t, tr, http.StatusCreated)
 		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before+1, after)
@@ -3109,7 +3099,7 @@ func TestChannelNameSizeWarningDeleteChannel(t *testing.T) {
 		assertStatus(t, tr, http.StatusCreated)
 
 		before := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
-		tr = rt.SendAdminRequest("DELETE", "/db/deleteme?rev="+getRespRev(t, tr), "")
+		tr = rt.SendAdminRequest("DELETE", "/db/deleteme?rev="+respRevID(t, tr), "")
 		assertStatus(t, tr, http.StatusOK)
 		after := rt.ServerContext().Database("db").DbStats.Database().WarnChannelNameSizeCount.Value()
 		assert.Equal(t, before, after)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -84,7 +84,17 @@ func TestChannelNameSizeWarningBoundaries(t *testing.T) {
 
 	// change value to 500 in config
 	warnThreshold := uint32(500)
-	rt.DatabaseConfig.Unsupported.WarningThresholds.ChannelNameSize = &warnThreshold
+	rt = NewRestTester(t, &RestTesterConfig{
+		SyncFn: syncFn,
+		DatabaseConfig: &DbConfig{
+			Unsupported: db.UnsupportedOptions{
+				WarningThresholds: db.WarningThresholds{
+					ChannelNameSize: &warnThreshold,
+				},
+			},
+		},
+	})
+	defer rt.Close()
 	boundaryTest(int(warnThreshold))
 }
 func TestChannelNameSizeWarningUpdateExistingDoc(t *testing.T) {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -414,6 +414,10 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		}
 	}
 
+	if config.Unsupported.WarningThresholds.ChannelNameSize == nil {
+		config.Unsupported.WarningThresholds.ChannelNameSize = &base.DefaultWarnThresholdChannelNameSize
+	}
+
 	autoImport, err := config.AutoImportEnabled()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds configurable warning threshold for max channel name length.

Warning that is logged: "Doc id: _DOC ID_ channel name size: _1_ channel/s exceeds _250_ characters for channel name size warning threshold"