### PR TITLE
CBG-1505: Specify permissions on handler and check

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -191,6 +191,10 @@ func UnitTestUrl() string {
 
 // UnitTestUrlIsWalrus returns true if we're running with a Walrus test URL.
 func UnitTestUrlIsWalrus() bool {
-	unitTestUrl := UnitTestUrl()
-	return strings.Contains(unitTestUrl, kTestWalrusURL)
+	return ServerIsWalrus(UnitTestUrl())
+}
+
+// ServerIsWalrus returns true if the given server is a Walrus URL.
+func ServerIsWalrus(server string) bool {
+	return strings.HasPrefix(server, kTestWalrusURL)
 }

--- a/db/database.go
+++ b/db/database.go
@@ -1381,6 +1381,25 @@ func (context *DatabaseContext) ObtainManagementEndpoints() ([]string, error) {
 	return base.GoCBBucketMgmtEndpoints(gocbBucket.Bucket)
 }
 
+func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
+	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	if !ok {
+		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
+		return nil, nil, nil
+	}
+
+	endpoints, err := base.GoCBBucketMgmtEndpoints(gocbBucket.Bucket)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	httpClient := &http.Client{
+		Transport: gocbBucket.Bucket.IoRouter().HttpClient().Transport,
+	}
+
+	return endpoints, httpClient, nil
+}
+
 func (context *DatabaseContext) GetUserViewsEnabled() bool {
 	if context.Options.UnsupportedOptions.UserViews.Enabled != nil {
 		return *context.Options.UnsupportedOptions.UserViews.Enabled

--- a/db/database.go
+++ b/db/database.go
@@ -1393,8 +1393,11 @@ func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]stri
 		return nil, nil, err
 	}
 
+	// Clone HTTP transport for use in our httpClient
+	transport := gocbBucket.Bucket.IoRouter().HttpClient().Transport.(*http.Transport).Clone()
+
 	httpClient := &http.Client{
-		Transport: gocbBucket.Bucket.IoRouter().HttpClient().Transport,
+		Transport: transport,
 	}
 
 	return endpoints, httpClient, nil

--- a/rest/config.go
+++ b/rest/config.go
@@ -68,41 +68,43 @@ const (
 
 // JSON object that defines the server configuration.
 type ServerConfig struct {
-	TLSMinVersion              *string                  `json:"tls_minimum_version,omitempty"`    // Set TLS Version
-	Interface                  *string                  `json:",omitempty"`                       // Interface to bind REST API to, default ":4984"
-	SSLCert                    *string                  `json:",omitempty"`                       // Path to SSL cert file, or nil
-	SSLKey                     *string                  `json:",omitempty"`                       // Path to SSL private key file, or nil
-	ServerReadTimeout          *int                     `json:",omitempty"`                       // maximum duration.Second before timing out read of the HTTP(S) request
-	ServerWriteTimeout         *int                     `json:",omitempty"`                       // maximum duration.Second before timing out write of the HTTP(S) response
-	ReadHeaderTimeout          *int                     `json:",omitempty"`                       // The amount of time allowed to read request headers.
-	IdleTimeout                *int                     `json:",omitempty"`                       // The maximum amount of time to wait for the next request when keep-alives are enabled.
-	AdminInterface             *string                  `json:",omitempty"`                       // Interface to bind admin API to, default "localhost:4985"
-	AdminUI                    *string                  `json:",omitempty"`                       // Path to Admin HTML page, if omitted uses bundled HTML
-	ProfileInterface           *string                  `json:",omitempty"`                       // Interface to bind Go profile API to (no default)
-	ConfigServer               *string                  `json:",omitempty"`                       // URL of config server (for dynamic db discovery)
-	Facebook                   *FacebookConfig          `json:",omitempty"`                       // Configuration for Facebook validation
-	Google                     *GoogleConfig            `json:",omitempty"`                       // Configuration for Google validation
-	CORS                       *CORSConfig              `json:",omitempty"`                       // Configuration for allowing CORS
-	DeprecatedLog              []string                 `json:"log,omitempty"`                    // Log keywords to enable
-	DeprecatedLogFilePath      *string                  `json:"logFilePath,omitempty"`            // Path to log file, if missing write to stderr
-	Logging                    *base.LoggingConfig      `json:",omitempty"`                       // Configuration for logging with optional log file rotation
-	Pretty                     bool                     `json:",omitempty"`                       // Pretty-print JSON responses?
-	DeploymentID               *string                  `json:",omitempty"`                       // Optional customer/deployment ID for stats reporting
-	StatsReportInterval        *float64                 `json:",omitempty"`                       // Optional stats report interval (0 to disable)
-	CouchbaseKeepaliveInterval *int                     `json:",omitempty"`                       // TCP keep-alive interval between SG and Couchbase server
-	SlowQueryWarningThreshold  *int                     `json:",omitempty"`                       // Log warnings if N1QL queries take this many ms
-	MaxIncomingConnections     *int                     `json:",omitempty"`                       // Max # of incoming HTTP connections to accept
-	MaxFileDescriptors         *uint64                  `json:",omitempty"`                       // Max # of open file descriptors (RLIMIT_NOFILE)
-	CompressResponses          *bool                    `json:",omitempty"`                       // If false, disables compression of HTTP responses
-	Databases                  DbConfigMap              `json:",omitempty"`                       // Pre-configured databases, mapped by name
-	Replications               []*ReplicateV1Config     `json:",omitempty"`                       // sg-replicate replication definitions
-	MaxHeartbeat               uint64                   `json:",omitempty"`                       // Max heartbeat value for _changes request (seconds)
-	ClusterConfig              *ClusterConfig           `json:"cluster_config,omitempty"`         // Bucket and other config related to CBGT
-	Unsupported                *UnsupportedServerConfig `json:"unsupported,omitempty"`            // Config for unsupported features
-	ReplicatorCompression      *int                     `json:"replicator_compression,omitempty"` // BLIP data compression level (0-9)
-	BcryptCost                 int                      `json:"bcrypt_cost,omitempty"`            // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
-	MetricsInterface           *string                  `json:"metricsInterface,omitempty"`       // Interface to bind metrics to. If not set then metrics isn't accessible
-	HideProductVersion         bool                     `json:"hide_product_version,omitempty"`   // Determines whether product versions removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
+	TLSMinVersion                  *string                  `json:"tls_minimum_version,omitempty"`              // Set TLS Version
+	Interface                      *string                  `json:",omitempty"`                                 // Interface to bind REST API to, default ":4984"
+	SSLCert                        *string                  `json:",omitempty"`                                 // Path to SSL cert file, or nil
+	SSLKey                         *string                  `json:",omitempty"`                                 // Path to SSL private key file, or nil
+	ServerReadTimeout              *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out read of the HTTP(S) request
+	ServerWriteTimeout             *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out write of the HTTP(S) response
+	ReadHeaderTimeout              *int                     `json:",omitempty"`                                 // The amount of time allowed to read request headers.
+	IdleTimeout                    *int                     `json:",omitempty"`                                 // The maximum amount of time to wait for the next request when keep-alives are enabled.
+	AdminInterface                 *string                  `json:",omitempty"`                                 // Interface to bind admin API to, default "localhost:4985"
+	AdminUI                        *string                  `json:",omitempty"`                                 // Path to Admin HTML page, if omitted uses bundled HTML
+	ProfileInterface               *string                  `json:",omitempty"`                                 // Interface to bind Go profile API to (no default)
+	ConfigServer                   *string                  `json:",omitempty"`                                 // URL of config server (for dynamic db discovery)
+	Facebook                       *FacebookConfig          `json:",omitempty"`                                 // Configuration for Facebook validation
+	Google                         *GoogleConfig            `json:",omitempty"`                                 // Configuration for Google validation
+	CORS                           *CORSConfig              `json:",omitempty"`                                 // Configuration for allowing CORS
+	DeprecatedLog                  []string                 `json:"log,omitempty"`                              // Log keywords to enable
+	DeprecatedLogFilePath          *string                  `json:"logFilePath,omitempty"`                      // Path to log file, if missing write to stderr
+	Logging                        *base.LoggingConfig      `json:",omitempty"`                                 // Configuration for logging with optional log file rotation
+	Pretty                         bool                     `json:",omitempty"`                                 // Pretty-print JSON responses?
+	DeploymentID                   *string                  `json:",omitempty"`                                 // Optional customer/deployment ID for stats reporting
+	StatsReportInterval            *float64                 `json:",omitempty"`                                 // Optional stats report interval (0 to disable)
+	CouchbaseKeepaliveInterval     *int                     `json:",omitempty"`                                 // TCP keep-alive interval between SG and Couchbase server
+	SlowQueryWarningThreshold      *int                     `json:",omitempty"`                                 // Log warnings if N1QL queries take this many ms
+	MaxIncomingConnections         *int                     `json:",omitempty"`                                 // Max # of incoming HTTP connections to accept
+	MaxFileDescriptors             *uint64                  `json:",omitempty"`                                 // Max # of open file descriptors (RLIMIT_NOFILE)
+	CompressResponses              *bool                    `json:",omitempty"`                                 // If false, disables compression of HTTP responses
+	Databases                      DbConfigMap              `json:",omitempty"`                                 // Pre-configured databases, mapped by name
+	Replications                   []*ReplicateV1Config     `json:",omitempty"`                                 // sg-replicate replication definitions
+	MaxHeartbeat                   uint64                   `json:",omitempty"`                                 // Max heartbeat value for _changes request (seconds)
+	ClusterConfig                  *ClusterConfig           `json:"cluster_config,omitempty"`                   // Bucket and other config related to CBGT
+	Unsupported                    *UnsupportedServerConfig `json:"unsupported,omitempty"`                      // Config for unsupported features
+	ReplicatorCompression          *int                     `json:"replicator_compression,omitempty"`           // BLIP data compression level (0-9)
+	BcryptCost                     int                      `json:"bcrypt_cost,omitempty"`                      // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
+	MetricsInterface               *string                  `json:"metricsInterface,omitempty"`                 // Interface to bind metrics to. If not set then metrics isn't accessible
+	HideProductVersion             bool                     `json:"hide_product_version,omitempty"`             // Determines whether product versions removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
+	AdminInterfaceAuthentication   *bool                    `json:"admin_interface_authentication,omitempty"`   // Defines whether the Admin API will support authentication. Defaults to true.
+	MetricsInterfaceAuthentication *bool                    `json:"metrics_interface_authentication,omitempty"` // Defines whether the Metrics API will support authentication. Defaults to true.
 }
 
 // Bucket configuration elements - used by db, index
@@ -1177,6 +1179,14 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 
 	if config.MetricsInterface == nil {
 		config.MetricsInterface = &DefaultMetricsInterface
+	}
+
+	if config.AdminInterfaceAuthentication == nil {
+		config.AdminInterfaceAuthentication = base.BoolPtr(true)
+	}
+
+	if config.MetricsInterfaceAuthentication == nil {
+		config.MetricsInterfaceAuthentication = base.BoolPtr(true)
 	}
 
 	return config, err

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -89,22 +89,22 @@ const (
 type handlerMethod func(*handler) error
 
 // Creates an http.Handler that will run a handler with the given method
-func makeHandler(server *ServerContext, privs handlerPrivs, checkPermissions []string, storePermissionsResults bool, method handlerMethod) http.Handler {
+func makeHandler(server *ServerContext, privs handlerPrivs, accessPermissions []string, responsePermissions []string, method handlerMethod) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
 		runOffline := false
 		h := newHandler(server, privs, r, rq, runOffline)
-		err := h.invoke(method, checkPermissions, storePermissionsResults)
+		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		h.logDuration(true)
 	})
 }
 
 // Creates an http.Handler that will run a handler with the given method even if the target DB is offline
-func makeOfflineHandler(server *ServerContext, privs handlerPrivs, checkPermissions []string, storePermissionsResults bool, method handlerMethod) http.Handler {
+func makeOfflineHandler(server *ServerContext, privs handlerPrivs, accessPermissions []string, responsePermissions []string, method handlerMethod) http.Handler {
 	return http.HandlerFunc(func(r http.ResponseWriter, rq *http.Request) {
 		runOffline := true
 		h := newHandler(server, privs, r, rq, runOffline)
-		err := h.invoke(method, checkPermissions, storePermissionsResults)
+		err := h.invoke(method, accessPermissions, responsePermissions)
 		h.writeError(err)
 		h.logDuration(true)
 	})
@@ -124,7 +124,7 @@ func newHandler(server *ServerContext, privs handlerPrivs, r http.ResponseWriter
 }
 
 // Top-level handler call. It's passed a pointer to the specific method to run.
-func (h *handler) invoke(method handlerMethod, checkPermissions []string, storePermissionsResults bool) error {
+func (h *handler) invoke(method handlerMethod, accessPermissions []string, responsePermissions []string) error {
 
 	var err error
 	if h.server.config.CompressResponses == nil || *h.server.config.CompressResponses {
@@ -204,14 +204,20 @@ func (h *handler) invoke(method handlerMethod, checkPermissions []string, storeP
 	}
 
 	// If an Admin Request we need to check the user credentials
-	// FIXME: Temporarily disable this
-	if false {
-		clusterAddress, _, _, _, _, _ := tempConnectionDetailsForManagementEndpoints()
-		if !base.ServerIsWalrus(clusterAddress) && ((h.privs == adminPrivs && *h.server.config.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.MetricsInterfaceAuthentication)) {
-			if err = h.checkAdminAuth(dbContext, checkPermissions, storePermissionsResults); err != nil {
-				return err
-			}
+	if h.shouldCheckAdminAuth() {
+		username, password := h.getBasicAuth()
+		statusCode, err := h.checkAdminAuth(dbContext, username, password, accessPermissions, responsePermissions)
+		if err != nil {
+			base.Warnf("An error occurred whilst checking whether a user was authorized: %v", err)
+			return base.HTTPErrorf(http.StatusInternalServerError, "")
 		}
+
+		if statusCode != http.StatusOK {
+			base.Infof(base.KeyAuth, "User %s failed to auth as an admin statusCode: %d", username, statusCode)
+			return base.HTTPErrorf(statusCode, "")
+		}
+
+		base.Infof(base.KeyAuth, "User %s was successfully authorized as an admin", username)
 	}
 
 	h.logRequestLine()
@@ -241,6 +247,12 @@ func (h *handler) invoke(method handlerMethod, checkPermissions []string, storeP
 	}
 
 	return method(h) // Call the actual handler code
+}
+
+// FIXME: Temporarily disable admin auth check (return false)
+func (h *handler) shouldCheckAdminAuth() bool {
+	clusterAddress, _, _, _, _, _ := tempConnectionDetailsForManagementEndpoints()
+	return false && !base.ServerIsWalrus(clusterAddress) && ((h.privs == adminPrivs && *h.server.config.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.MetricsInterfaceAuthentication))
 }
 
 func (h *handler) logRequestLine() {
@@ -400,38 +412,32 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 	return nil
 }
 
-func (h *handler) checkAdminAuth(dbContext *db.DatabaseContext, checkPermissions []string, storePermissionsResults bool) error {
+func (h *handler) checkAdminAuth(dbContext *db.DatabaseContext, basicAuthUsername, basicAuthPassword string, accessPermissions []string, responsePermissions []string) (statusCode int, err error) {
 	var managementEndpoints []string
-	var err error
 	var httpClient *http.Client
 
 	if dbContext != nil {
 		managementEndpoints, httpClient, err = dbContext.ObtainManagementEndpointsAndHTTPClient()
 		if err != nil {
-			return base.HTTPErrorf(http.StatusInternalServerError, "")
+			return http.StatusInternalServerError, err
 		}
 	} else {
 		managementEndpoints, httpClient, err = h.server.ObtainManagementEndpointsAndHTTPClient()
 		if err != nil {
-			return base.HTTPErrorf(http.StatusInternalServerError, "")
+			return http.StatusInternalServerError, err
 		}
 	}
 
-	username, password := h.getBasicAuth()
-	statusCode, permResults, err := h.server.CheckPermissions(httpClient, managementEndpoints, username, password, checkPermissions)
+	statusCode, permResults, err := h.server.CheckPermissions(httpClient, managementEndpoints, basicAuthUsername, basicAuthPassword, accessPermissions, responsePermissions)
 	if err != nil {
-		return base.HTTPErrorf(http.StatusInternalServerError, "")
+		return http.StatusInternalServerError, err
 	}
 
-	if storePermissionsResults {
+	if len(responsePermissions) > 0 {
 		h.permissionsResults = permResults
 	}
 
-	if statusCode != http.StatusOK {
-		return base.HTTPErrorf(statusCode, "")
-	}
-
-	return nil
+	return statusCode, nil
 }
 
 func (h *handler) assertAdminOnly() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -427,8 +427,10 @@ func (h *handler) checkAdminAuth(dbContext *db.DatabaseContext, checkPermissions
 		h.permissionsResults = permResults
 	}
 
-	fmt.Println(statusCode)
-	fmt.Println(permResults)
+	if statusCode != http.StatusOK {
+		return base.HTTPErrorf(statusCode, "")
+	}
+
 	return nil
 }
 

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -41,74 +41,68 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mu
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 	// Global operations:
-	r.Handle("/", makeHandler(sc, privs, (*handler).handleRoot)).Methods("GET", "HEAD")
+	r.Handle("/", makeHandler(sc, privs, nil, false, (*handler).handleRoot)).Methods("GET", "HEAD")
 
 	// Operations on databases:
-	r.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, (*handler).handleGetDB)).Methods("GET", "HEAD")
-	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, (*handler).handlePostDoc)).Methods("POST")
+	r.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, nil, false, (*handler).handleGetDB)).Methods("GET", "HEAD")
+	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, nil, false, (*handler).handlePostDoc)).Methods("POST")
 
 	// Special database URLs:
 	dbr := r.PathPrefix("/{db:" + dbRegex + "}/").Subrouter()
 	dbr.StrictSlash(true)
-	dbr.Handle("/_all_docs", makeHandler(sc, privs, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_bulk_docs", makeHandler(sc, privs, (*handler).handleBulkDocs)).Methods("POST")
-	dbr.Handle("/_bulk_get", makeHandler(sc, privs, (*handler).handleBulkGet)).Methods("POST")
-	dbr.Handle("/_changes", makeHandler(sc, privs, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, (*handler).handlePutDesignDoc)).Methods("PUT")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
-	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, (*handler).handleView)).Methods("GET")
-	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, (*handler).handleEFC)).Methods("POST")
-	dbr.Handle("/_revs_diff", makeHandler(sc, privs, (*handler).handleRevsDiff)).Methods("POST")
+	dbr.Handle("/_all_docs", makeHandler(sc, privs, nil, false, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
+	dbr.Handle("/_bulk_docs", makeHandler(sc, privs, nil, false, (*handler).handleBulkDocs)).Methods("POST")
+	dbr.Handle("/_bulk_get", makeHandler(sc, privs, nil, false, (*handler).handleBulkGet)).Methods("POST")
+	dbr.Handle("/_changes", makeHandler(sc, privs, nil, false, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, false, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, false, (*handler).handlePutDesignDoc)).Methods("PUT")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, false, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
+	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, nil, false, (*handler).handleView)).Methods("GET")
+	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, nil, false, (*handler).handleEFC)).Methods("POST")
+	dbr.Handle("/_revs_diff", makeHandler(sc, privs, nil, false, (*handler).handleRevsDiff)).Methods("POST")
 
 	// Document URLs:
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, (*handler).handlePutLocalDoc)).Methods("PUT")
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, (*handler).handleDelLocalDoc)).Methods("DELETE")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, false, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, false, (*handler).handlePutLocalDoc)).Methods("PUT")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, false, (*handler).handleDelLocalDoc)).Methods("DELETE")
 
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, (*handler).handleGetDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, (*handler).handlePutDoc)).Methods("PUT")
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, (*handler).handleDeleteDoc)).Methods("DELETE")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, false, (*handler).handleGetDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, false, (*handler).handlePutDoc)).Methods("PUT")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, false, (*handler).handleDeleteDoc)).Methods("DELETE")
 
-	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
-	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, (*handler).handlePutAttachment)).Methods("PUT")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, false, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, false, (*handler).handlePutAttachment)).Methods("PUT")
 
 	// Session/login URLs are per-database (unlike in CouchDB)
 	// These have public privileges so that they can be called without being logged in already
-	dbr.Handle("/_session", makeHandler(sc, publicPrivs, (*handler).handleSessionGET)).Methods("GET", "HEAD")
+	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, false, (*handler).handleSessionGET)).Methods("GET", "HEAD")
 	if sc.config.Facebook != nil {
-		dbr.Handle("/_facebook", makeHandler(sc, publicPrivs,
-			(*handler).handleFacebookPOST)).Methods("POST")
+		dbr.Handle("/_facebook", makeHandler(sc, publicPrivs, nil, false, (*handler).handleFacebookPOST)).Methods("POST")
 	}
 	if sc.config.Google != nil {
-		dbr.Handle("/_google", makeHandler(sc, publicPrivs,
-			(*handler).handleGooglePOST)).Methods("POST")
+		dbr.Handle("/_google", makeHandler(sc, publicPrivs, nil, false, (*handler).handleGooglePOST)).Methods("POST")
 	}
 
 	// OpenID Connect endpoints
-	dbr.Handle("/_oidc", makeHandler(sc, publicPrivs, (*handler).handleOIDC)).Methods("GET")
-	dbr.Handle("/_oidc_callback", makeHandler(sc, publicPrivs, (*handler).handleOIDCCallback)).Methods("GET")
-	dbr.Handle("/_oidc_refresh", makeHandler(sc, publicPrivs, (*handler).handleOIDCRefresh)).Methods("GET")
-	dbr.Handle("/_oidc_challenge", makeHandler(sc, publicPrivs, (*handler).handleOIDCChallenge)).Methods("GET")
+	dbr.Handle("/_oidc", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDC)).Methods("GET")
+	dbr.Handle("/_oidc_callback", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDCCallback)).Methods("GET")
+	dbr.Handle("/_oidc_refresh", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDCRefresh)).Methods("GET")
+	dbr.Handle("/_oidc_challenge", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDCChallenge)).Methods("GET")
 
 	oidcr := dbr.PathPrefix("/_oidc_testing").Subrouter()
 
 	// Client discovery endpoint
-	oidcr.Handle("/.well-known/openid-configuration", makeHandler(sc, publicPrivs, (*handler).handleOidcProviderConfiguration)).Methods("GET")
+	oidcr.Handle("/.well-known/openid-configuration", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcProviderConfiguration)).Methods("GET")
 
-	oidcr.Handle("/authorize", makeHandler(sc, publicPrivs,
-		(*handler).handleOidcTestProviderAuthorize)).Methods("GET", "POST")
+	oidcr.Handle("/authorize", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderAuthorize)).Methods("GET", "POST")
 
-	oidcr.Handle("/token", makeHandler(sc, publicPrivs,
-		(*handler).handleOidcTestProviderToken)).Methods("POST")
+	oidcr.Handle("/token", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderToken)).Methods("POST")
 
-	oidcr.Handle("/certs", makeHandler(sc, publicPrivs,
-		(*handler).handleOidcTestProviderCerts)).Methods("GET")
+	oidcr.Handle("/certs", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderCerts)).Methods("GET")
 
-	oidcr.Handle("/authenticate", makeHandler(sc, publicPrivs,
-		(*handler).handleOidcTestProviderAuthenticate)).Methods("GET", "POST")
+	oidcr.Handle("/authenticate", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderAuthenticate)).Methods("GET", "POST")
 
-	dbr.Handle("/_blipsync", makeHandler(sc, privs, (*handler).handleBLIPSync)).Methods("GET")
+	dbr.Handle("/_blipsync", makeHandler(sc, privs, nil, false, (*handler).handleBLIPSync)).Methods("GET")
 
 	return r, dbr
 }
@@ -117,15 +111,13 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mu
 func CreatePublicHandler(sc *ServerContext) http.Handler {
 	r, dbr := createCommonRouter(sc, regularPrivs)
 
-	dbr.Handle("/_session", makeHandler(sc, publicPrivs,
-		(*handler).handleSessionPOST)).Methods("POST")
-	dbr.Handle("/_session", makeHandler(sc, regularPrivs,
-		(*handler).handleSessionDELETE)).Methods("DELETE")
+	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, false, (*handler).handleSessionPOST)).Methods("POST")
+	dbr.Handle("/_session", makeHandler(sc, regularPrivs, nil, false, (*handler).handleSessionDELETE)).Methods("DELETE")
 	// The routine below is part of the CouchDB REST API, users can't create DB's via the pblic API
 	// but if the client set the 'createTarget' property of the Replicatior SG should return HTTP status 412
 	// if the db exists, and 403 if it doesn't.
 	r.Handle("/{targetdb:"+dbRegex+"}/",
-		makeHandler(sc, publicPrivs, (*handler).handleCreateTarget)).Methods("PUT")
+		makeHandler(sc, publicPrivs, nil, false, (*handler).handleCreateTarget)).Methods("PUT")
 	return wrapRouter(sc, regularPrivs, r)
 }
 
@@ -150,160 +142,160 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	})
 
 	dbr.Handle("/_session",
-		makeHandler(sc, adminPrivs, (*handler).createUserSession)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).createUserSession)).Methods("POST")
 
 	dbr.Handle("/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, (*handler).getUserSession)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getUserSession)).Methods("GET")
 
 	dbr.Handle("/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, (*handler).deleteUserSession)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_raw/{docid:"+docRegex+"}",
-		makeHandler(sc, adminPrivs, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
 
 	dbr.Handle("/_revtree/{docid:"+docRegex+"}",
-		makeHandler(sc, adminPrivs, (*handler).handleGetRevTree)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetRevTree)).Methods("GET")
 
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, (*handler).getUsers)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getUsers)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, (*handler).putUser)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putUser)).Methods("POST")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, (*handler).getUserInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getUserInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, (*handler).putUser)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putUser)).Methods("PUT")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, (*handler).deleteUser)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUser)).Methods("DELETE")
 
 	dbr.Handle("/_user/{name}/_session",
-		makeHandler(sc, adminPrivs, (*handler).deleteUserSessions)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUserSessions)).Methods("DELETE")
 	dbr.Handle("/_user/{name}/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, (*handler).deleteUserSession)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, (*handler).getRoles)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getRoles)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, (*handler).putRole)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putRole)).Methods("POST")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, (*handler).getRoleInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getRoleInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, (*handler).putRole)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putRole)).Methods("PUT")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, (*handler).deleteRole)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteRole)).Methods("DELETE")
 
 	dbr.Handle("/_replication/",
-		makeHandler(sc, adminPrivs, (*handler).getReplications)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplications)).Methods("GET", "HEAD")
 	dbr.Handle("/_replication/",
-		makeHandler(sc, adminPrivs, (*handler).putReplication)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putReplication)).Methods("POST")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, (*handler).getReplication)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplication)).Methods("GET", "HEAD")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, (*handler).putReplication)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putReplication)).Methods("PUT")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, (*handler).deleteReplication)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteReplication)).Methods("DELETE")
 
 	dbr.Handle("/_replicationStatus/",
-		makeHandler(sc, adminPrivs, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",
-		makeHandler(sc, adminPrivs, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",
-		makeHandler(sc, adminPrivs, (*handler).putReplicationStatus)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).putReplicationStatus)).Methods("PUT")
 
 	r.Handle("/_logging",
-		makeHandler(sc, adminPrivs, (*handler).handleGetLogging)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetLogging)).Methods("GET")
 	r.Handle("/_logging",
-		makeHandler(sc, adminPrivs, (*handler).handleSetLogging)).Methods("PUT", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSetLogging)).Methods("PUT", "POST")
 	r.Handle("/_profile/{profilename}",
-		makeHandler(sc, adminPrivs, (*handler).handleProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_profile",
-		makeHandler(sc, adminPrivs, (*handler).handleProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_heap",
-		makeHandler(sc, adminPrivs, (*handler).handleHeapProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleHeapProfiling)).Methods("POST")
 	r.Handle("/_stats",
-		makeHandler(sc, adminPrivs, (*handler).handleStats)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
-		makeHandler(sc, adminPrivs, (*handler).handleExpvar)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleExpvar)).Methods("GET")
 	r.Handle("/_config",
-		makeHandler(sc, adminPrivs, (*handler).handleGetConfig)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetConfig)).Methods("GET")
 	r.Handle("/_replicate",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handleReplicate)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handleActiveTasks)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleActiveTasks)).Methods("GET")
 
 	r.Handle("/_status",
-		makeHandler(sc, adminPrivs, (*handler).handleGetStatus)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetStatus)).Methods("GET")
 
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, (*handler).handleSGCollectStatus)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSGCollectStatus)).Methods("GET")
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, (*handler).handleSGCollectCancel)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSGCollectCancel)).Methods("DELETE")
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, (*handler).handleSGCollect)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSGCollect)).Methods("POST")
 
 	// Debugging handlers
 	r.Handle("/_debug/pprof/goroutine",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofGoroutine)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofGoroutine)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/cmdline",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofCmdline)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofCmdline)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/symbol",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofSymbol)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofSymbol)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/heap",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofHeap)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofHeap)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/profile",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofProfile)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofProfile)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/block",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofBlock)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofBlock)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/threadcreate",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/mutex",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofMutex)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofMutex)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/trace",
-		makeHandler(sc, adminPrivs, (*handler).handlePprofTrace)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofTrace)).Methods("GET", "POST")
 	r.Handle("/_debug/fgprof",
-		makeHandler(sc, adminPrivs, (*handler).handleFgprof)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleFgprof)).Methods("GET", "POST")
 
 	r.Handle("/_post_upgrade",
-		makeHandler(sc, adminPrivs, (*handler).handlePostUpgrade)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePostUpgrade)).Methods("POST")
 
 	// Database-relative handlers:
 	dbr.Handle("/_config",
-		makeHandler(sc, adminPrivs, (*handler).handleGetDbConfig)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetDbConfig)).Methods("GET")
 	dbr.Handle("/_config",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handlePutDbConfig)).Methods("PUT")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handlePutDbConfig)).Methods("PUT")
 	dbr.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handleGetResync)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleGetResync)).Methods("GET")
 	dbr.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handlePostResync)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handlePostResync)).Methods("POST")
 	dbr.Handle("/_vacuum",
-		makeHandler(sc, adminPrivs, (*handler).handleVacuum)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleVacuum)).Methods("POST")
 	dbr.Handle("/_purge",
-		makeHandler(sc, adminPrivs, (*handler).handlePurge)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePurge)).Methods("POST")
 	dbr.Handle("/_flush",
-		makeHandler(sc, adminPrivs, (*handler).handleFlush)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleFlush)).Methods("POST")
 	dbr.Handle("/_online",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handleDbOnline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleDbOnline)).Methods("POST")
 	dbr.Handle("/_offline",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handleDbOffline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleDbOffline)).Methods("POST")
 	dbr.Handle("/_dump/{view}",
-		makeHandler(sc, adminPrivs, (*handler).handleDump)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleDump)).Methods("GET")
 	dbr.Handle("/_view/{view}", // redundant; just for backward compatibility with 1.0
-		makeHandler(sc, adminPrivs, (*handler).handleView)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleView)).Methods("GET")
 	dbr.Handle("/_dumpchannel/{channel}",
-		makeHandler(sc, adminPrivs, (*handler).handleDumpChannel)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleDumpChannel)).Methods("GET")
 	dbr.Handle("/_repair",
-		makeHandler(sc, adminPrivs, (*handler).handleRepair)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleRepair)).Methods("POST")
 
 	// The routes below are part of the CouchDB REST API but should only be available to admins,
 	// so the handlers are moved to the admin port.
 	r.Handle("/{newdb:"+dbRegex+"}/",
-		makeHandler(sc, adminPrivs, (*handler).handleCreateDB)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleCreateDB)).Methods("PUT")
 	r.Handle("/{db:"+dbRegex+"}/",
-		makeOfflineHandler(sc, adminPrivs, (*handler).handleDeleteDB)).Methods("DELETE")
+		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleDeleteDB)).Methods("DELETE")
 
 	r.Handle("/_all_dbs",
-		makeHandler(sc, adminPrivs, (*handler).handleAllDbs)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleAllDbs)).Methods("GET", "HEAD")
 	dbr.Handle("/_compact",
-		makeHandler(sc, adminPrivs, (*handler).handleCompact)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, false, (*handler).handleCompact)).Methods("POST")
 
 	return r
 }
@@ -313,15 +305,15 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 // CreateMetricHandler Creates the HTTP handler for the prometheus metrics API of a gateway server.
 func CreateMetricHandler(sc *ServerContext) http.Handler {
 	router := CreateMetricRouter(sc)
-	return wrapRouter(sc, publicPrivs, router)
+	return wrapRouter(sc, metricsPrivs, router)
 }
 
 func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
-	r.Handle("/_metrics", makeHandler(sc, publicPrivs, (*handler).handleMetrics)).Methods("GET")
-	r.Handle(kDebugURLPathPrefix, makeHandler(sc, publicPrivs, (*handler).handleExpvar)).Methods("GET")
+	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, nil, false, (*handler).handleMetrics)).Methods("GET")
+	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, nil, false, (*handler).handleExpvar)).Methods("GET")
 
 	return r
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -41,68 +41,68 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mu
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 	// Global operations:
-	r.Handle("/", makeHandler(sc, privs, nil, false, (*handler).handleRoot)).Methods("GET", "HEAD")
+	r.Handle("/", makeHandler(sc, privs, nil, nil, (*handler).handleRoot)).Methods("GET", "HEAD")
 
 	// Operations on databases:
-	r.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, nil, false, (*handler).handleGetDB)).Methods("GET", "HEAD")
-	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, nil, false, (*handler).handlePostDoc)).Methods("POST")
+	r.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, nil, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
+	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, nil, nil, (*handler).handlePostDoc)).Methods("POST")
 
 	// Special database URLs:
 	dbr := r.PathPrefix("/{db:" + dbRegex + "}/").Subrouter()
 	dbr.StrictSlash(true)
-	dbr.Handle("/_all_docs", makeHandler(sc, privs, nil, false, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_bulk_docs", makeHandler(sc, privs, nil, false, (*handler).handleBulkDocs)).Methods("POST")
-	dbr.Handle("/_bulk_get", makeHandler(sc, privs, nil, false, (*handler).handleBulkGet)).Methods("POST")
-	dbr.Handle("/_changes", makeHandler(sc, privs, nil, false, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, false, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, false, (*handler).handlePutDesignDoc)).Methods("PUT")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, false, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
-	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, nil, false, (*handler).handleView)).Methods("GET")
-	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, nil, false, (*handler).handleEFC)).Methods("POST")
-	dbr.Handle("/_revs_diff", makeHandler(sc, privs, nil, false, (*handler).handleRevsDiff)).Methods("POST")
+	dbr.Handle("/_all_docs", makeHandler(sc, privs, nil, nil, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
+	dbr.Handle("/_bulk_docs", makeHandler(sc, privs, nil, nil, (*handler).handleBulkDocs)).Methods("POST")
+	dbr.Handle("/_bulk_get", makeHandler(sc, privs, nil, nil, (*handler).handleBulkGet)).Methods("POST")
+	dbr.Handle("/_changes", makeHandler(sc, privs, nil, nil, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, nil, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, nil, (*handler).handlePutDesignDoc)).Methods("PUT")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, nil, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
+	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, nil, nil, (*handler).handleView)).Methods("GET")
+	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, nil, nil, (*handler).handleEFC)).Methods("POST")
+	dbr.Handle("/_revs_diff", makeHandler(sc, privs, nil, nil, (*handler).handleRevsDiff)).Methods("POST")
 
 	// Document URLs:
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, false, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, false, (*handler).handlePutLocalDoc)).Methods("PUT")
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, false, (*handler).handleDelLocalDoc)).Methods("DELETE")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, nil, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, nil, (*handler).handlePutLocalDoc)).Methods("PUT")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, nil, (*handler).handleDelLocalDoc)).Methods("DELETE")
 
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, false, (*handler).handleGetDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, false, (*handler).handlePutDoc)).Methods("PUT")
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, false, (*handler).handleDeleteDoc)).Methods("DELETE")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, nil, (*handler).handleGetDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, nil, (*handler).handlePutDoc)).Methods("PUT")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, nil, (*handler).handleDeleteDoc)).Methods("DELETE")
 
-	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, false, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
-	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, false, (*handler).handlePutAttachment)).Methods("PUT")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, nil, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, nil, (*handler).handlePutAttachment)).Methods("PUT")
 
 	// Session/login URLs are per-database (unlike in CouchDB)
 	// These have public privileges so that they can be called without being logged in already
-	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, false, (*handler).handleSessionGET)).Methods("GET", "HEAD")
+	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleSessionGET)).Methods("GET", "HEAD")
 	if sc.config.Facebook != nil {
-		dbr.Handle("/_facebook", makeHandler(sc, publicPrivs, nil, false, (*handler).handleFacebookPOST)).Methods("POST")
+		dbr.Handle("/_facebook", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleFacebookPOST)).Methods("POST")
 	}
 	if sc.config.Google != nil {
-		dbr.Handle("/_google", makeHandler(sc, publicPrivs, nil, false, (*handler).handleGooglePOST)).Methods("POST")
+		dbr.Handle("/_google", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleGooglePOST)).Methods("POST")
 	}
 
 	// OpenID Connect endpoints
-	dbr.Handle("/_oidc", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDC)).Methods("GET")
-	dbr.Handle("/_oidc_callback", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDCCallback)).Methods("GET")
-	dbr.Handle("/_oidc_refresh", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDCRefresh)).Methods("GET")
-	dbr.Handle("/_oidc_challenge", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOIDCChallenge)).Methods("GET")
+	dbr.Handle("/_oidc", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOIDC)).Methods("GET")
+	dbr.Handle("/_oidc_callback", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOIDCCallback)).Methods("GET")
+	dbr.Handle("/_oidc_refresh", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOIDCRefresh)).Methods("GET")
+	dbr.Handle("/_oidc_challenge", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOIDCChallenge)).Methods("GET")
 
 	oidcr := dbr.PathPrefix("/_oidc_testing").Subrouter()
 
 	// Client discovery endpoint
-	oidcr.Handle("/.well-known/openid-configuration", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcProviderConfiguration)).Methods("GET")
+	oidcr.Handle("/.well-known/openid-configuration", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOidcProviderConfiguration)).Methods("GET")
 
-	oidcr.Handle("/authorize", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderAuthorize)).Methods("GET", "POST")
+	oidcr.Handle("/authorize", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOidcTestProviderAuthorize)).Methods("GET", "POST")
 
-	oidcr.Handle("/token", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderToken)).Methods("POST")
+	oidcr.Handle("/token", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOidcTestProviderToken)).Methods("POST")
 
-	oidcr.Handle("/certs", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderCerts)).Methods("GET")
+	oidcr.Handle("/certs", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOidcTestProviderCerts)).Methods("GET")
 
-	oidcr.Handle("/authenticate", makeHandler(sc, publicPrivs, nil, false, (*handler).handleOidcTestProviderAuthenticate)).Methods("GET", "POST")
+	oidcr.Handle("/authenticate", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOidcTestProviderAuthenticate)).Methods("GET", "POST")
 
-	dbr.Handle("/_blipsync", makeHandler(sc, privs, nil, false, (*handler).handleBLIPSync)).Methods("GET")
+	dbr.Handle("/_blipsync", makeHandler(sc, privs, nil, nil, (*handler).handleBLIPSync)).Methods("GET")
 
 	return r, dbr
 }
@@ -111,13 +111,13 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mu
 func CreatePublicHandler(sc *ServerContext) http.Handler {
 	r, dbr := createCommonRouter(sc, regularPrivs)
 
-	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, false, (*handler).handleSessionPOST)).Methods("POST")
-	dbr.Handle("/_session", makeHandler(sc, regularPrivs, nil, false, (*handler).handleSessionDELETE)).Methods("DELETE")
+	dbr.Handle("/_session", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleSessionPOST)).Methods("POST")
+	dbr.Handle("/_session", makeHandler(sc, regularPrivs, nil, nil, (*handler).handleSessionDELETE)).Methods("DELETE")
 	// The routine below is part of the CouchDB REST API, users can't create DB's via the pblic API
 	// but if the client set the 'createTarget' property of the Replicatior SG should return HTTP status 412
 	// if the db exists, and 403 if it doesn't.
 	r.Handle("/{targetdb:"+dbRegex+"}/",
-		makeHandler(sc, publicPrivs, nil, false, (*handler).handleCreateTarget)).Methods("PUT")
+		makeHandler(sc, publicPrivs, nil, nil, (*handler).handleCreateTarget)).Methods("PUT")
 	return wrapRouter(sc, regularPrivs, r)
 }
 
@@ -142,160 +142,160 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	})
 
 	dbr.Handle("/_session",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).createUserSession)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).createUserSession)).Methods("POST")
 
 	dbr.Handle("/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getUserSession)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getUserSession)).Methods("GET")
 
 	dbr.Handle("/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUserSession)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_raw/{docid:"+docRegex+"}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
 
 	dbr.Handle("/_revtree/{docid:"+docRegex+"}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetRevTree)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetRevTree)).Methods("GET")
 
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getUsers)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getUsers)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putUser)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putUser)).Methods("POST")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getUserInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getUserInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putUser)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putUser)).Methods("PUT")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUser)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUser)).Methods("DELETE")
 
 	dbr.Handle("/_user/{name}/_session",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUserSessions)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUserSessions)).Methods("DELETE")
 	dbr.Handle("/_user/{name}/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteUserSession)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getRoles)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getRoles)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putRole)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putRole)).Methods("POST")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getRoleInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getRoleInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putRole)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putRole)).Methods("PUT")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteRole)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteRole)).Methods("DELETE")
 
 	dbr.Handle("/_replication/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplications)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplications)).Methods("GET", "HEAD")
 	dbr.Handle("/_replication/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putReplication)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putReplication)).Methods("POST")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplication)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplication)).Methods("GET", "HEAD")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putReplication)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putReplication)).Methods("PUT")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).deleteReplication)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteReplication)).Methods("DELETE")
 
 	dbr.Handle("/_replicationStatus/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).putReplicationStatus)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).putReplicationStatus)).Methods("PUT")
 
 	r.Handle("/_logging",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetLogging)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetLogging)).Methods("GET")
 	r.Handle("/_logging",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSetLogging)).Methods("PUT", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSetLogging)).Methods("PUT", "POST")
 	r.Handle("/_profile/{profilename}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_profile",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_heap",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleHeapProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleHeapProfiling)).Methods("POST")
 	r.Handle("/_stats",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleStats)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleExpvar)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleExpvar)).Methods("GET")
 	r.Handle("/_config",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetConfig)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetConfig)).Methods("GET")
 	r.Handle("/_replicate",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleReplicate)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleActiveTasks)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleActiveTasks)).Methods("GET")
 
 	r.Handle("/_status",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetStatus)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetStatus)).Methods("GET")
 
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSGCollectStatus)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSGCollectStatus)).Methods("GET")
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSGCollectCancel)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSGCollectCancel)).Methods("DELETE")
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleSGCollect)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSGCollect)).Methods("POST")
 
 	// Debugging handlers
 	r.Handle("/_debug/pprof/goroutine",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofGoroutine)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofGoroutine)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/cmdline",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofCmdline)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofCmdline)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/symbol",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofSymbol)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofSymbol)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/heap",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofHeap)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofHeap)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/profile",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofProfile)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofProfile)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/block",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofBlock)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofBlock)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/threadcreate",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/mutex",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofMutex)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofMutex)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/trace",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePprofTrace)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofTrace)).Methods("GET", "POST")
 	r.Handle("/_debug/fgprof",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleFgprof)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleFgprof)).Methods("GET", "POST")
 
 	r.Handle("/_post_upgrade",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePostUpgrade)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePostUpgrade)).Methods("POST")
 
 	// Database-relative handlers:
 	dbr.Handle("/_config",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleGetDbConfig)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetDbConfig)).Methods("GET")
 	dbr.Handle("/_config",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handlePutDbConfig)).Methods("PUT")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handlePutDbConfig)).Methods("PUT")
 	dbr.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleGetResync)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleGetResync)).Methods("GET")
 	dbr.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handlePostResync)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handlePostResync)).Methods("POST")
 	dbr.Handle("/_vacuum",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleVacuum)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleVacuum)).Methods("POST")
 	dbr.Handle("/_purge",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handlePurge)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePurge)).Methods("POST")
 	dbr.Handle("/_flush",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleFlush)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleFlush)).Methods("POST")
 	dbr.Handle("/_online",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleDbOnline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleDbOnline)).Methods("POST")
 	dbr.Handle("/_offline",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleDbOffline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleDbOffline)).Methods("POST")
 	dbr.Handle("/_dump/{view}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleDump)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleDump)).Methods("GET")
 	dbr.Handle("/_view/{view}", // redundant; just for backward compatibility with 1.0
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleView)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleView)).Methods("GET")
 	dbr.Handle("/_dumpchannel/{channel}",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleDumpChannel)).Methods("GET")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleDumpChannel)).Methods("GET")
 	dbr.Handle("/_repair",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleRepair)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleRepair)).Methods("POST")
 
 	// The routes below are part of the CouchDB REST API but should only be available to admins,
 	// so the handlers are moved to the admin port.
 	r.Handle("/{newdb:"+dbRegex+"}/",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleCreateDB)).Methods("PUT")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleCreateDB)).Methods("PUT")
 	r.Handle("/{db:"+dbRegex+"}/",
-		makeOfflineHandler(sc, adminPrivs, nil, false, (*handler).handleDeleteDB)).Methods("DELETE")
+		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleDeleteDB)).Methods("DELETE")
 
 	r.Handle("/_all_dbs",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleAllDbs)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleAllDbs)).Methods("GET", "HEAD")
 	dbr.Handle("/_compact",
-		makeHandler(sc, adminPrivs, nil, false, (*handler).handleCompact)).Methods("POST")
+		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleCompact)).Methods("POST")
 
 	return r
 }
@@ -312,8 +312,8 @@ func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
-	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, nil, false, (*handler).handleMetrics)).Methods("GET")
-	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, nil, false, (*handler).handleExpvar)).Methods("GET")
+	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, nil, nil, (*handler).handleMetrics)).Methods("GET")
+	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, nil, nil, (*handler).handleExpvar)).Methods("GET")
 
 	return r
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -9,9 +9,12 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1204,21 +1207,112 @@ var tempConnectionDetailsForManagementEndpoints = func() (serverAddress string, 
 	return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), "", "", ""
 }
 
-func (sc *ServerContext) ObtainManagementEndpoints() ([]string, error) {
+func (sc *ServerContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
 	clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath := tempConnectionDetailsForManagementEndpoints()
 	agent, err := initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath, sc.config.ServerReadTimeout)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	managementEndpoints := agent.MgmtEps()
 
-	err = agent.Close()
-	if err != nil {
-		return nil, err
+	httpClient := &http.Client{
+		Transport: agent.HTTPClient().Transport,
 	}
 
-	return managementEndpoints, nil
+	err = agent.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return managementEndpoints, httpClient, nil
+}
+
+func (sc *ServerContext) CheckPermissions(httpClient *http.Client, managementEndpoints []string, username, password string, requestedPermissions []string) (statusCode int, permissionResults map[string]bool, err error) {
+	body := []byte(strings.Join(requestedPermissions, ","))
+	statusCode, bodyResponse, err := doHTTPAuthRequest(httpClient, username, password, "POST", "/pools/default/checkPermissions", managementEndpoints, body)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		if statusCode == http.StatusUnauthorized {
+			return http.StatusUnauthorized, nil, nil
+		}
+
+		// If we don't provide permissions we get a BadRequest but know we have successfully authenticated
+		if statusCode == http.StatusBadRequest && len(requestedPermissions) > 0 {
+			return statusCode, nil, nil
+		}
+	}
+
+	// At this point we know the user exists, now check whether they have the required permissions
+	if len(requestedPermissions) > 0 {
+		var permissions map[string]bool
+
+		err = base.JSONUnmarshal(bodyResponse, &permissions)
+		if err != nil {
+			return http.StatusInternalServerError, nil, err
+		}
+
+		for _, permResult := range permissions {
+			if permResult {
+				return http.StatusOK, permissions, nil
+			}
+		}
+	}
+
+	return http.StatusForbidden, permissionResults, nil
+}
+
+func doHTTPAuthRequest(httpClient *http.Client, username, password, method, path string, endpoints []string, requestBody []byte) (statusCode int, responseBody []byte, err error) {
+	var httpResponse *http.Response
+
+	maxRetryCount := 5
+	retryCount := 0
+
+	for {
+		endpointIdx := retryCount % len(endpoints)
+		req, err := http.NewRequest(method, endpoints[endpointIdx]+path, bytes.NewBuffer(requestBody))
+		if err != nil {
+			return 0, nil, err
+		}
+
+		req.SetBasicAuth(username, password)
+
+		httpResponse, err = httpClient.Do(req)
+
+		// If no error on request break out and continue
+		if err == nil {
+			break
+		}
+
+		// If we've reached maximum number of retries fail
+		if retryCount >= maxRetryCount {
+			return 0, nil, err
+		}
+
+		// If error is a timeout we will retry
+		if err, ok := err.(net.Error); ok && err.Timeout() {
+			retryCount++
+			continue
+		}
+
+		// For any other error fail out
+		return 0, nil, err
+	}
+
+	bodyString, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	err = httpResponse.Body.Close()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return httpResponse.StatusCode, bodyString, nil
 }
 
 // For test use

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -480,7 +480,7 @@ func TestCheckPermissions(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			if testCase.CreateUser != "" {
 				MakeUser(t, eps[0], testCase.CreateUser, testCase.CreatePassword, testCase.CreateRoles)
-				defer DeleteUser(t, eps[0], testCase.Username)
+				defer DeleteUser(t, eps[0], testCase.CreateUser)
 			}
 
 			statusCode, permResults, err := ctx.CheckPermissions(httpClient, eps, testCase.Username, testCase.Password, testCase.RequestPermissions)


### PR DESCRIPTION
PR aims to check permissions that are specified by the handler against a user specified user on CBS.
Also adds the config options to enable / disable the feature.

Currently no permissions are specified on the handlers and so the check inside the handler is temporarily disabled.

Builds on existing agent / management endpoint work.

Has unit tests checking whether we can verify a users permissions:
- One with multiple test cases
- One small X509 which just verifies we can check one permission to verify X509 cert use

Based off of https://github.com/couchbase/sync_gateway/pull/5046
- [x] Merge https://github.com/couchbase/sync_gateway/pull/5046 & rebase