### PR TITLE
CBG-1494 - Active sub protocol logged on connection upgrade to BLIP

### DIFF
--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -63,7 +63,7 @@ func (h *handler) handleBLIPSync() error {
 	server := blipContext.WebSocketServer()
 	defaultHandler := server.Handler
 	server.Handler = func(conn *websocket.Conn) {
-		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol which uses subprotocol %s%s", blipContext.ID, blipContext.ActiveSubprotocol(), h.formattedEffectiveUserName()))
+		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to WebSocket protocol %s+%s%s", blipContext.ID, blip.WebSocketSubProtocolPrefix, blipContext.ActiveSubprotocol(), h.formattedEffectiveUserName()))
 		defer func() {
 			_ = conn.Close() // in case it wasn't closed already
 			base.InfofCtx(h.db.Ctx, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())

--- a/rest/blip_sync.go
+++ b/rest/blip_sync.go
@@ -63,7 +63,7 @@ func (h *handler) handleBLIPSync() error {
 	server := blipContext.WebSocketServer()
 	defaultHandler := server.Handler
 	server.Handler = func(conn *websocket.Conn) {
-		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol%s", blipContext.ID, h.formattedEffectiveUserName()))
+		h.logStatus(http.StatusSwitchingProtocols, fmt.Sprintf("[%s] Upgraded to BLIP+WebSocket protocol which uses subprotocol %s%s", blipContext.ID, blipContext.ActiveSubprotocol(), h.formattedEffectiveUserName()))
 		defer func() {
 			_ = conn.Close() // in case it wasn't closed already
 			base.InfofCtx(h.db.Ctx, base.KeyHTTP, "%s:    --> BLIP+WebSocket connection closed", h.formatSerialNumber())


### PR DESCRIPTION
Example from logs:
`2021-06-21T19:43:31.532+01:00 [INF] HTTP+: #004:     --> 101 [742ca3ba] Upgraded to BLIP+WebSocket protocol which uses subprotocol CBMobile_3 (as <ud>user</ud>)  (0.0 ms)`