### PR TITLE
CBG-1530 - Fixed 500 error calling /_config endpoint

### DIFF
--- a/base/redactor.go
+++ b/base/redactor.go
@@ -137,14 +137,14 @@ func (l *RedactionLevel) MarshalText() ([]byte, error) {
 // UnmarshalText unmarshals text to a RedactionLevel.
 func (l *RedactionLevel) UnmarshalText(text []byte) error {
 	switch strings.ToLower(string(text)) {
-	case "unset":
-		*l = RedactionLevelDefault
 	case "none":
 		*l = RedactNone
 	case "partial":
 		*l = RedactPartial
 	case "full":
 		*l = RedactFull
+	case "unset":
+		*l = RedactUnset
 	default:
 		return fmt.Errorf("unrecognized redaction level: %q", text)
 	}

--- a/base/redactor.go
+++ b/base/redactor.go
@@ -137,6 +137,8 @@ func (l *RedactionLevel) MarshalText() ([]byte, error) {
 // UnmarshalText unmarshals text to a RedactionLevel.
 func (l *RedactionLevel) UnmarshalText(text []byte) error {
 	switch strings.ToLower(string(text)) {
+	case "unset":
+		*l = RedactionLevelDefault
 	case "none":
 		*l = RedactNone
 	case "partial":

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -100,7 +100,7 @@ func TestRedactionLevelUnmarshalText(t *testing.T) {
 
 	err = level.UnmarshalText([]byte("unset"))
 	assert.NoError(t, err)
-	goassert.Equals(t, level, RedactionLevelDefault)
+	goassert.Equals(t, level, RedactUnset)
 
 	err = level.UnmarshalText([]byte("asdf"))
 	goassert.Equals(t, err.Error(), "unrecognized redaction level: \"asdf\"")

--- a/base/redactor_test.go
+++ b/base/redactor_test.go
@@ -98,6 +98,10 @@ func TestRedactionLevelUnmarshalText(t *testing.T) {
 	assert.NoError(t, err)
 	goassert.Equals(t, level, RedactFull)
 
+	err = level.UnmarshalText([]byte("unset"))
+	assert.NoError(t, err)
+	goassert.Equals(t, level, RedactionLevelDefault)
+
 	err = level.UnmarshalText([]byte("asdf"))
 	goassert.Equals(t, err.Error(), "unrecognized redaction level: \"asdf\"")
 }


### PR DESCRIPTION
Caused by missing case in the redactor Unmarshall Text function. 
Rectified issue and modified unit test to test for this case in future.