### PR TITLE
CBG-1506: Check for user roles and complete flow

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -472,6 +472,16 @@ func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, htt
 		return nil, http.StatusInternalServerError, err
 	}
 
+	// If a user has access through roles we're going to use this to mean they have access to all of the
+	// responsePermissions too so we'll iterate over these and set them to true.
+	if statusCode == http.StatusOK {
+		responsePermissionResults = make(map[string]bool)
+		for _, responsePerm := range responsePermissions {
+			responsePermissionResults[responsePerm] = true
+		}
+		return responsePermissionResults, statusCode, nil
+	}
+
 	return permResults, statusCode, nil
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1279,7 +1279,7 @@ func CheckPermissions(httpClient *http.Client, managementEndpoints []string, use
 		}
 	}
 
-	return http.StatusForbidden, permissionResults, nil
+	return http.StatusForbidden, nil, nil
 }
 
 func CheckRoles(httpClient *http.Client, managementEndpoints []string, username, password string, requestedRoles []string, bucketName string) (statusCode int, err error) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -508,7 +508,7 @@ func TestCheckPermissions(t *testing.T) {
 				defer DeleteUser(t, eps[0], testCase.CreateUser)
 			}
 
-			statusCode, permResults, err := ctx.CheckPermissions(httpClient, eps, testCase.Username, testCase.Password, testCase.RequestPermissions, testCase.ResponsePermissions)
+			statusCode, permResults, err := CheckPermissions(httpClient, eps, testCase.Username, testCase.Password, testCase.RequestPermissions, testCase.ResponsePermissions)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
 			assert.True(t, reflect.DeepEqual(testCase.ExpectedPermissionResults, permResults))
@@ -536,8 +536,248 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
-	statusCode, _, err := ctx.CheckPermissions(httpClient, eps, base.TestClusterUsername(), base.TestClusterPassword(), []string{"cluster!admin"}, nil)
+	statusCode, _, err := CheckPermissions(httpClient, eps, base.TestClusterUsername(), base.TestClusterPassword(), []string{"cluster!admin"}, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, statusCode)
+}
+
+func TestCheckRoles(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	testCases := []struct {
+		Name               string
+		Username           string
+		Password           string
+		BucketName         string
+		RequestRoles       []string
+		ExpectedStatusCode int
+		CreateUser         string
+		CreatePassword     string
+		CreateRoles        []string
+	}{
+		{
+			Name:               "ClusterAdmin",
+			Username:           base.TestClusterUsername(),
+			Password:           base.TestClusterPassword(),
+			BucketName:         "",
+			RequestRoles:       []string{"admin"},
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "CreatedAdmin",
+			Username:           "CreatedAdmin",
+			Password:           "password",
+			BucketName:         "",
+			RequestRoles:       []string{"admin"},
+			ExpectedStatusCode: http.StatusOK,
+			CreateUser:         "CreatedAdmin",
+			CreatePassword:     "password",
+			CreateRoles:        []string{"admin"},
+		},
+		{
+			Name:               "ReadOnlyAdmin",
+			Username:           "ReadOnlyAdmin",
+			Password:           "password",
+			BucketName:         "",
+			RequestRoles:       []string{"ro_admin"},
+			ExpectedStatusCode: http.StatusOK,
+			CreateUser:         "ReadOnlyAdmin",
+			CreatePassword:     "password",
+			CreateRoles:        []string{"ro_admin"},
+		},
+		{
+			Name:               "CreatedBucketAdmin",
+			Username:           "CreatedBucketAdmin",
+			Password:           "password",
+			BucketName:         rt.Bucket().GetName(),
+			RequestRoles:       []string{"mobile_sync_gateway"},
+			ExpectedStatusCode: http.StatusOK,
+			CreateUser:         "CreatedBucketAdmin",
+			CreatePassword:     "password",
+			CreateRoles:        []string{fmt.Sprintf("mobile_sync_gateway[%s]", rt.Bucket().GetName())},
+		},
+		{
+			Name:               "CreateUserNoRole",
+			Username:           "CreateUserNoRole",
+			Password:           "password",
+			BucketName:         "",
+			RequestRoles:       []string{"ro_admin"},
+			ExpectedStatusCode: http.StatusForbidden,
+			CreateUser:         "CreateUserNoRole",
+			CreatePassword:     "password",
+			CreateRoles:        []string{""},
+		},
+		{
+			Name:               "CreateUserInsufficientRole",
+			Username:           "CreateUserInsufficientRole",
+			Password:           "password",
+			BucketName:         "",
+			RequestRoles:       []string{"mobile_sync_gateway"},
+			ExpectedStatusCode: http.StatusForbidden,
+			CreateUser:         "CreateUserInsufficientRole",
+			CreatePassword:     "password",
+			CreateRoles:        []string{fmt.Sprintf("bucket_full_access[%s]", rt.Bucket().GetName())},
+		},
+	}
+
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.CreateUser != "" {
+				MakeUser(t, eps[0], testCase.CreateUser, testCase.CreatePassword, testCase.CreateRoles)
+				defer DeleteUser(t, eps[0], testCase.CreateUser)
+			}
+
+			statusCode, err := CheckRoles(httpClient, eps, testCase.Username, testCase.Password, testCase.RequestRoles, testCase.BucketName)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
+		})
+	}
+}
+
+func TestAdminAuth(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Test requires Couchbase Server")
+	}
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	testCases := []struct {
+		Name               string
+		Username           string
+		Password           string
+		CheckPermissions   []string
+		ExpectedStatusCode int
+		CreateUser         string
+		CreatePassword     string
+		CreateRoles        []string
+		DatabaseScoped     bool
+	}{
+		{
+			Name:               "ClusterAdmin",
+			Username:           base.TestClusterUsername(),
+			Password:           base.TestClusterPassword(),
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusOK,
+			DatabaseScoped:     false,
+		},
+		{
+			Name:               "ClusterAdminWrongPassword",
+			Username:           "ClusterAdminWrongPassword",
+			Password:           "wrongpassword",
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusUnauthorized,
+			CreateUser:         "ClusterAdminWrongPassword",
+			CreatePassword:     "password",
+			CreateRoles:        []string{"admin"},
+			DatabaseScoped:     false,
+		},
+		{
+			Name:               "NoUser",
+			Username:           "IDontExist",
+			Password:           "password",
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusUnauthorized,
+			DatabaseScoped:     false,
+		},
+		{
+			Name:               "MissingPermissionAndRole",
+			Username:           "MissingPermissionAndRole",
+			Password:           "password",
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusForbidden,
+			CreateUser:         "MissingPermissionAndRole",
+			CreatePassword:     "password",
+			CreateRoles:        []string{""},
+			DatabaseScoped:     false,
+		},
+		{
+			Name:               "MissingPermissionAndRoleDBScoped",
+			Username:           "MissingPermissionAndRoleDBScoped",
+			Password:           "password",
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusForbidden,
+			CreateUser:         "MissingPermissionAndRoleDBScoped",
+			CreatePassword:     "password",
+			CreateRoles:        []string{""},
+			DatabaseScoped:     true,
+		},
+		{
+			Name:               "MissingPermissionHasRole",
+			Username:           "MissingPermissionHasRole",
+			Password:           "password",
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusOK,
+			CreateUser:         "MissingPermissionHasRole",
+			CreatePassword:     "password",
+			CreateRoles:        []string{"ro_admin"},
+			DatabaseScoped:     false,
+		},
+		{
+			Name:               "MissingPermissionHasDBScoped",
+			Username:           "MissingPermissionHasDBScoped",
+			Password:           "password",
+			CheckPermissions:   []string{"cluster!admin"},
+			ExpectedStatusCode: http.StatusOK,
+			CreateUser:         "MissingPermissionHasDBScoped",
+			CreatePassword:     "password",
+			CreateRoles:        []string{fmt.Sprintf("bucket_full_access[%s]", rt.Bucket().GetName())},
+			DatabaseScoped:     true,
+		},
+	}
+
+	eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if testCase.CreateUser != "" {
+				MakeUser(t, eps[0], testCase.CreateUser, testCase.CreatePassword, testCase.CreateRoles)
+				defer DeleteUser(t, eps[0], testCase.CreateUser)
+			}
+
+			var err error
+			var statusCode int
+
+			if testCase.DatabaseScoped {
+				_, statusCode, err = checkAdminAuth(rt.ServerContext(), rt.GetDatabase(), testCase.Username, testCase.Password, testCase.CheckPermissions, nil)
+			} else {
+				_, statusCode, err = checkAdminAuth(rt.ServerContext(), nil, testCase.Username, testCase.Password, testCase.CheckPermissions, nil)
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
+		})
+
+	}
+}
+
+func TestAdminAuthWithX509(t *testing.T) {
+	tb, teardownFn, caCertPath, certPath, keyPath := setupX509Tests(t, true)
+	defer tb.Close()
+	defer teardownFn()
+
+	original := tempConnectionDetailsForManagementEndpoints
+	defer func() {
+		tempConnectionDetailsForManagementEndpoints = original
+	}()
+
+	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
+		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
+	}
+
+	ctx := NewServerContext(&ServerConfig{})
+	defer ctx.Close()
+
+	_, _, err := checkAdminAuth(ctx, nil, base.TestClusterUsername(), base.TestClusterPassword(), []string{"cluster!admin"}, nil)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
- Add check for roles based on whether db scoped or not
- Refactor to allow for easier testing of checkAdminAuth
- Like above, removed CheckRoles and CheckPermissions from ServerContext

- Tested with unit tests for both CheckRoles and full checkAdminAuth
- Has a small single X509 test for checkAdminAuth to verify it works

Based on https://github.com/couchbase/sync_gateway/pull/5055
- [x] Merge https://github.com/couchbase/sync_gateway/pull/5055