### PR TITLE
CBG-1528: Avoid serving public API on metrics port

### DIFF
--- a/base/stats.go
+++ b/base/stats.go
@@ -610,7 +610,9 @@ func (s *SgwStats) NewDBStats(name string, deltaSyncEnabled bool, importEnabled 
 func (s *SgwStats) ClearDBStats(name string) {
 	s.dbStatsMapMutex.Lock()
 	defer s.dbStatsMapMutex.Unlock()
+
 	delete(s.DbStats, name)
+
 }
 
 func (d *DbStats) initCacheStats() {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7296,5 +7296,4 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 	assert.Equal(t, "doc2", changes.Results[1].ID)
 	assert.True(t, changes.Results[1].Revoked)
-
 }


### PR DESCRIPTION
- Rename `createHandler` to `createCommonRouter` to better reflect its function
- Remove use of `createCommonRouter` from `CreateMetricHandler` and create raw handler
- ~~Add a unit test (and required infrastructure) to ensure metrics are accessible on metrics endpoint but not public api endpoints.~~ 
- Some other minor refactoring in routing.go

Testing no longer in this PR due to CBG-1532, will be added back in that PR. Have done manual testing to ensure this fix works.