### PR TITLE
CBG-1470 User xattr and improved error handling for gocb v2

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -366,7 +366,7 @@ func (auth *Authenticator) InvalidateChannels(name string, isUser bool, invalSeq
 
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "channel_inval_seq", 0, invalSeq)
-		if err != nil && !base.IsDocNotFoundError(err) && !base.IsSubDocPathExistsError(err) {
+		if err != nil && err != base.ErrNotFound && err != base.ErrAlreadyExists {
 			return err
 		}
 		return nil
@@ -409,7 +409,7 @@ func (auth *Authenticator) InvalidateRoles(username string, invalSeq uint64) err
 
 	if auth.bucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
 		err := auth.bucket.SubdocInsert(docID, "role_inval_seq", 0, invalSeq)
-		if err != nil && !base.IsDocNotFoundError(err) && !base.IsSubDocPathExistsError(err) {
+		if err != nil && err != base.ErrNotFound && err != base.ErrAlreadyExists {
 			return err
 		}
 		return nil

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -2578,73 +2578,74 @@ func TestInvalidateChannels(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			testBucket := base.GetTestBucket(t)
-			defer testBucket.Close()
+			base.ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-			leakyBucket := base.NewLeakyBucket(testBucket, base.LeakyBucketConfig{})
+				leakyBucket := base.NewLeakyBucket(bucket, base.LeakyBucketConfig{})
 
-			auth := NewAuthenticator(leakyBucket, nil, DefaultAuthenticatorOptions())
+				auth := NewAuthenticator(leakyBucket, nil, DefaultAuthenticatorOptions())
 
-			// Invalidate channels on non-existent user / role and ensure no error
-			err := auth.InvalidateChannels(testCase.name, testCase.isUser, 0)
-			assert.NoError(t, err)
+				// Invalidate channels on non-existent user / role and ensure no error
+				err := auth.InvalidateChannels(testCase.name, testCase.isUser, 0)
+				assert.NoError(t, err)
 
-			// Create user / role
-			var princ Principal
-			if testCase.isUser {
-				princ, err = auth.NewUser(testCase.name, "pass", nil)
-			} else {
-				princ, err = auth.NewRole(testCase.name, nil)
-			}
-			assert.NoError(t, err)
-
-			err = auth.Save(princ)
-			assert.NoError(t, err)
-
-			enableRetry := false
-			leakyBucket.SetUpdateCallback(func(key string) {
-				if enableRetry {
-					enableRetry = false
-					err = auth.InvalidateChannels(testCase.name, testCase.isUser, 5)
-					assert.NoError(t, err)
+				// Create user / role
+				var princ Principal
+				if testCase.isUser {
+					princ, err = auth.NewUser(testCase.name, "pass", nil)
+				} else {
+					princ, err = auth.NewRole(testCase.name, nil)
 				}
+				assert.NoError(t, err)
+
+				err = auth.Save(princ)
+				assert.NoError(t, err)
+
+				// Invalidate channels at invalSeq but cause cas retry by setting to 5
+				enableRetry := false
+				// If subdoc operations are supported, perform an initial invalidation at seq 5
+				if leakyBucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
+					err := auth.InvalidateChannels(testCase.name, testCase.isUser, 5)
+					assert.NoError(t, err)
+
+				} else {
+					// If subdoc ops aren't supported, use leakyBucket to invalidate
+					leakyBucket.SetUpdateCallback(func(key string) {
+						if enableRetry {
+							enableRetry = false
+							err = auth.InvalidateChannels(testCase.name, testCase.isUser, 5)
+							assert.NoError(t, err)
+						}
+					})
+				}
+
+				enableRetry = true
+				err = auth.InvalidateChannels(testCase.name, testCase.isUser, 10)
+				assert.NoError(t, err)
+
+				// Ensure the inval seq was set to 5 (raw get to avoid rebuild)
+				var princCheck Principal
+				var docID string
+				if testCase.isUser {
+					princCheck = &userImpl{}
+					docID = docIDForUser(testCase.name)
+				} else {
+					princCheck = &roleImpl{}
+					docID = docIDForRole(testCase.name)
+				}
+				_, err = leakyBucket.Get(docID, &princCheck)
+				assert.NoError(t, err)
+
+				expectedValue := uint64(5)
+				assert.Equal(t, expectedValue, princCheck.GetChannelInvalSeq())
+
+				// Invalidate again and ensure existing value remains
+				err = auth.InvalidateChannels(testCase.name, testCase.isUser, 20)
+				assert.NoError(t, err)
+
+				_, err = leakyBucket.Get(docID, &princCheck)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedValue, princCheck.GetChannelInvalSeq())
 			})
-
-			// Invalidate channels at invalSeq but cause cas retry by setting to 5
-			enableRetry = true
-			err = auth.InvalidateChannels(testCase.name, testCase.isUser, 10)
-			assert.NoError(t, err)
-
-			// Ensure the inval seq was set to 5 (raw get to avoid rebuild)
-			var princCheck Principal
-			var docID string
-			if testCase.isUser {
-				princCheck = &userImpl{}
-				docID = docIDForUser(testCase.name)
-			} else {
-				princCheck = &roleImpl{}
-				docID = docIDForRole(testCase.name)
-			}
-			_, err = leakyBucket.Get(docID, &princCheck)
-			assert.NoError(t, err)
-
-			var expectedValue uint64
-
-			if leakyBucket.IsSupported(sgbucket.DataStoreFeatureSubdocOperations) {
-				expectedValue = 10
-			} else {
-				expectedValue = 5
-			}
-
-			assert.Equal(t, expectedValue, princCheck.GetChannelInvalSeq())
-
-			// Invalidate again and ensure existing value remains
-			err = auth.InvalidateChannels(testCase.name, testCase.isUser, 20)
-			assert.NoError(t, err)
-
-			_, err = leakyBucket.Get(docID, &princCheck)
-			assert.NoError(t, err)
-			assert.Equal(t, expectedValue, princCheck.GetChannelInvalSeq())
 		})
 	}
 }

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1682,7 +1682,7 @@ func TestGetXattr(t *testing.T) {
 		require.True(t, ok)
 		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
 		assert.Error(t, err)
-		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
 		////Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -947,80 +947,76 @@ func TestXattrWriteUpdateXattr(t *testing.T) {
 func TestWriteUpdateWithXattrUserXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 
-	testBucket := GetTestBucket(t)
-	defer testBucket.Close()
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	gocbBucket, ok := testBucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		t.Skip("Can't cast to bucket")
-		return
-	}
+		key := t.Name()
+		xattrKey := SyncXattrName
+		userXattrKey := "UserXattr"
 
-	key := t.Name()
-	xattrKey := SyncXattrName
-	userXattrKey := "UserXattr"
+		writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
 
-	writeUpdateFunc := func(doc []byte, xattr []byte, userXattr []byte, cas uint64) (updatedDoc []byte, updatedXattr []byte, isDelete bool, updatedExpiry *uint32, err error) {
+			var docMap map[string]interface{}
+			var xattrMap map[string]interface{}
 
-		var docMap map[string]interface{}
-		var xattrMap map[string]interface{}
-
-		if len(doc) > 0 {
-			err = JSONUnmarshal(xattr, &docMap)
-			if err != nil {
-				return nil, nil, false, nil, err
+			if len(doc) > 0 {
+				err = JSONUnmarshal(xattr, &docMap)
+				if err != nil {
+					return nil, nil, false, nil, err
+				}
+			} else {
+				docMap = make(map[string]interface{})
 			}
-		} else {
-			docMap = make(map[string]interface{})
+
+			if len(xattr) > 0 {
+				err = JSONUnmarshal(xattr, &xattrMap)
+				if err != nil {
+					return nil, nil, false, nil, err
+				}
+			} else {
+				xattrMap = make(map[string]interface{})
+			}
+
+			var userXattrMap map[string]interface{}
+			if len(userXattr) > 0 {
+				err = JSONUnmarshal(userXattr, &userXattrMap)
+				if err != nil {
+					return nil, nil, false, nil, err
+				}
+			} else {
+				userXattrMap = nil
+			}
+
+			docMap["userXattrVal"] = userXattrMap
+
+			updatedDoc, _ = JSONMarshal(docMap)
+			updatedXattr, _ = JSONMarshal(xattrMap)
+
+			return updatedDoc, updatedXattr, false, nil, nil
 		}
 
-		if len(xattr) > 0 {
-			err = JSONUnmarshal(xattr, &xattrMap)
-			if err != nil {
-				return nil, nil, false, nil, err
-			}
-		} else {
-			xattrMap = make(map[string]interface{})
-		}
+		_, err := bucket.WriteUpdateWithXattr(key, xattrKey, userXattrKey, 0, nil, writeUpdateFunc)
+		assert.NoError(t, err)
 
-		var userXattrMap map[string]interface{}
-		if len(userXattr) > 0 {
-			err = JSONUnmarshal(userXattr, &userXattrMap)
-			if err != nil {
-				return nil, nil, false, nil, err
-			}
-		} else {
-			userXattrMap = nil
-		}
+		var gotBody map[string]interface{}
+		_, err = bucket.Get(key, &gotBody)
+		assert.NoError(t, err)
+		assert.Equal(t, nil, gotBody["userXattrVal"])
 
-		docMap["userXattrVal"] = userXattrMap
+		userXattrVal := map[string]interface{}{"val": "val"}
 
-		updatedDoc, _ = JSONMarshal(docMap)
-		updatedXattr, _ = JSONMarshal(xattrMap)
+		userXattrStore, ok := AsUserXattrStore(bucket)
+		require.True(t, ok)
+		_, err = userXattrStore.WriteUserXattr(key, userXattrKey, userXattrVal)
+		assert.NoError(t, err)
 
-		return updatedDoc, updatedXattr, false, nil, nil
-	}
+		_, err = bucket.WriteUpdateWithXattr(key, xattrKey, userXattrKey, 0, nil, writeUpdateFunc)
+		assert.NoError(t, err)
 
-	_, err := testBucket.WriteUpdateWithXattr(key, xattrKey, userXattrKey, 0, nil, writeUpdateFunc)
-	assert.NoError(t, err)
+		_, err = bucket.Get(key, &gotBody)
+		assert.NoError(t, err)
 
-	var gotBody map[string]interface{}
-	_, err = testBucket.Get(key, &gotBody)
-	assert.NoError(t, err)
-	assert.Equal(t, nil, gotBody["userXattrVal"])
-
-	userXattrVal := map[string]interface{}{"val": "val"}
-
-	_, err = WriteXattr(gocbBucket, key, userXattrKey, userXattrVal)
-	assert.NoError(t, err)
-
-	_, err = testBucket.WriteUpdateWithXattr(key, xattrKey, userXattrKey, 0, nil, writeUpdateFunc)
-	assert.NoError(t, err)
-
-	_, err = testBucket.Get(key, &gotBody)
-	assert.NoError(t, err)
-
-	assert.Equal(t, userXattrVal, gotBody["userXattrVal"])
+		assert.Equal(t, userXattrVal, gotBody["userXattrVal"])
+	})
 
 }
 
@@ -1650,6 +1646,8 @@ func TestGetXattr(t *testing.T) {
 
 		var response map[string]interface{}
 
+		subdocStore, ok := AsSubdocXattrStore(bucket)
+
 		//Get Xattr From Existing Doc with Existing Xattr
 		_, err = bucket.GetXattr(key1, xattrName1, &response)
 		assert.NoError(t, err)
@@ -1667,7 +1665,7 @@ func TestGetXattr(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
-		//Get Xattr From Tombstoned Doc With Existing System Xattr
+		//Get Xattr From Tombstoned Doc With Existing System Xattr (ErrSubDocSuccessDeleted)
 		cas, err = bucket.WriteCasWithXattr(key2, SyncXattrName, 0, uint64(0), val2, xattrVal2)
 		_, err = bucket.Remove(key2, cas)
 		require.NoError(t, err)
@@ -1679,6 +1677,13 @@ func TestGetXattr(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
 
+		//Get Xattr and Body From Tombstoned Doc With Non-Existent System Xattr -> SubDocMultiPathFailureDeleted
+		var v, xv, userXv map[string]interface{}
+		require.True(t, ok)
+		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
+		assert.Error(t, err)
+		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
+
 		////Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)
 		_, err = bucket.Remove(key3, cas)
@@ -1686,6 +1691,91 @@ func TestGetXattr(t *testing.T) {
 		_, err = bucket.GetXattr(key3, xattrName3, &response)
 		assert.Error(t, err)
 		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
+	})
+}
+
+func TestGetXattrAndBody(t *testing.T) {
+	SkipXattrTestsIfNotEnabled(t)
+
+	defer SetUpTestLogging(LevelDebug, KeyAll)()
+
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
+
+		//Doc 1
+		key1 := t.Name() + "DocExistsXattrExists"
+		val1 := make(map[string]interface{})
+		val1["type"] = key1
+		xattrName1 := "sync"
+		xattrVal1 := make(map[string]interface{})
+		xattrVal1["seq"] = float64(1)
+		xattrVal1["rev"] = "1-foo"
+
+		//Doc 2 - Tombstone
+		key2 := t.Name() + "TombstonedDocXattrExists"
+		val2 := make(map[string]interface{})
+		val2["type"] = key2
+		xattrVal2 := make(map[string]interface{})
+		xattrVal2["seq"] = float64(1)
+		xattrVal2["rev"] = "1-foo"
+
+		//Doc 3 - To Delete
+		key3 := t.Name() + "DeletedDocXattrExists"
+		val3 := make(map[string]interface{})
+		val3["type"] = key3
+		xattrName3 := "sync"
+		xattrVal3 := make(map[string]interface{})
+		xattrVal3["seq"] = float64(1)
+		xattrVal3["rev"] = "1-foo"
+
+		var err error
+
+		//Create w/ XATTR
+		cas := uint64(0)
+		cas, err = bucket.WriteCasWithXattr(key1, xattrName1, 0, cas, val1, xattrVal1)
+		if err != nil {
+			t.Errorf("Error doing WriteCasWithXattr: %+v", err)
+		}
+
+		subdocStore, ok := AsSubdocXattrStore(bucket)
+		require.True(t, ok)
+
+		//Get Xattr From Existing Doc with Existing Xattr
+		var v, xv, userXv map[string]interface{}
+		_, err = subdocStore.SubdocGetBodyAndXattr(key1, xattrName1, "", &v, &xv, &userXv)
+		assert.NoError(t, err)
+
+		assert.Equal(t, xattrVal1["seq"], xv["seq"])
+		assert.Equal(t, xattrVal1["rev"], xv["rev"])
+
+		//Get body and Xattr From Existing Doc With Non-Existent Xattr -> returns body only
+		_, err = subdocStore.SubdocGetBodyAndXattr(key1, "non-exist", "", &v, &xv, &userXv)
+		assert.NoError(t, err)
+		assert.Equal(t, val1["type"], v["type"])
+
+		//Get Xattr From Non-Existent Doc With Non-Existent Xattr
+		_, err = subdocStore.SubdocGetBodyAndXattr("non-exist", "non-exist", "", &v, &xv, &userXv)
+		assert.Error(t, err)
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
+
+		//Get Xattr From Tombstoned Doc With Existing System Xattr (ErrSubDocSuccessDeleted)
+		cas, err = bucket.WriteCasWithXattr(key2, SyncXattrName, 0, uint64(0), val2, xattrVal2)
+		_, err = bucket.Remove(key2, cas)
+		require.NoError(t, err)
+		_, err = subdocStore.SubdocGetBodyAndXattr(key2, SyncXattrName, "", &v, &xv, &userXv)
+		assert.NoError(t, err)
+
+		//Get Xattr From Tombstoned Doc With Non-Existent System Xattr -> returns not found
+		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
+		assert.Error(t, err)
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
+
+		////Get Xattr From Tombstoned Doc With Deleted User Xattr -> returns not found
+		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)
+		_, err = bucket.Remove(key3, cas)
+		require.NoError(t, err)
+		_, err = subdocStore.SubdocGetBodyAndXattr(key3, xattrName3, "", &v, &xv, &userXv)
+		assert.Error(t, err)
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 	})
 }
 
@@ -2132,64 +2222,61 @@ func TestUpdateXattrWithDeleteBodyAndIsDelete(t *testing.T) {
 func TestUserXattrGetWithXattr(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
 
-	bucketGoCB, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		t.Skip("Can't cast to bucket")
-	}
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	docKey := t.Name()
+		userXattrStore, ok := AsUserXattrStore(bucket)
+		require.True(t, ok)
 
-	docVal := map[string]interface{}{"val": "docVal"}
-	syncXattrVal := map[string]interface{}{"val": "syncVal"}
-	userXattrVal := map[string]interface{}{"val": "userXattrVal"}
+		docKey := t.Name()
 
-	err := bucketGoCB.Set(docKey, 0, docVal)
-	assert.NoError(t, err)
+		docVal := map[string]interface{}{"val": "docVal"}
+		syncXattrVal := map[string]interface{}{"val": "syncVal"}
+		userXattrVal := map[string]interface{}{"val": "userXattrVal"}
 
-	_, err = WriteXattr(bucketGoCB, docKey, "_sync", syncXattrVal)
-	assert.NoError(t, err)
+		err := bucket.Set(docKey, 0, docVal)
+		assert.NoError(t, err)
 
-	_, err = WriteXattr(bucketGoCB, docKey, "test", userXattrVal)
-	assert.NoError(t, err)
+		_, err = userXattrStore.WriteUserXattr(docKey, "_sync", syncXattrVal)
+		assert.NoError(t, err)
 
-	var docValRet, syncXattrValRet, userXattrValRet map[string]interface{}
-	_, err = bucket.GetWithXattr(docKey, SyncXattrName, "test", &docValRet, &syncXattrValRet, &userXattrValRet)
-	assert.NoError(t, err)
-	assert.Equal(t, docVal, docValRet)
-	assert.Equal(t, syncXattrVal, syncXattrValRet)
-	assert.Equal(t, userXattrVal, userXattrValRet)
+		_, err = userXattrStore.WriteUserXattr(docKey, "test", userXattrVal)
+		assert.NoError(t, err)
+
+		var docValRet, syncXattrValRet, userXattrValRet map[string]interface{}
+		_, err = bucket.GetWithXattr(docKey, SyncXattrName, "test", &docValRet, &syncXattrValRet, &userXattrValRet)
+		assert.NoError(t, err)
+		assert.Equal(t, docVal, docValRet)
+		assert.Equal(t, syncXattrVal, syncXattrValRet)
+		assert.Equal(t, userXattrVal, userXattrValRet)
+	})
 }
 
 func TestUserXattrGetWithXattrNil(t *testing.T) {
 	SkipXattrTestsIfNotEnabled(t)
 	defer SetUpTestLogging(LevelDebug, KeyCRUD)()
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
 
-	bucketGoCB, ok := bucket.Bucket.(*CouchbaseBucketGoCB)
-	if !ok {
-		t.Skip("Can't cast to bucket")
-	}
+	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
-	docKey := t.Name()
+		docKey := t.Name()
 
-	docVal := map[string]interface{}{"val": "docVal"}
-	syncXattrVal := map[string]interface{}{"val": "syncVal"}
+		docVal := map[string]interface{}{"val": "docVal"}
+		syncXattrVal := map[string]interface{}{"val": "syncVal"}
 
-	err := bucketGoCB.Set(docKey, 0, docVal)
-	assert.NoError(t, err)
+		err := bucket.Set(docKey, 0, docVal)
+		assert.NoError(t, err)
 
-	_, err = WriteXattr(bucketGoCB, docKey, "_sync", syncXattrVal)
-	assert.NoError(t, err)
+		userXattrStore, ok := AsUserXattrStore(bucket)
+		require.True(t, ok)
+		_, err = userXattrStore.WriteUserXattr(docKey, "_sync", syncXattrVal)
+		assert.NoError(t, err)
 
-	var docValRet, syncXattrValRet, userXattrValRet map[string]interface{}
-	_, err = bucket.GetWithXattr(docKey, SyncXattrName, "test", &docValRet, &syncXattrValRet, &userXattrValRet)
-	assert.NoError(t, err)
-	assert.Equal(t, docVal, docValRet)
-	assert.Equal(t, syncXattrVal, syncXattrValRet)
+		var docValRet, syncXattrValRet, userXattrValRet map[string]interface{}
+		_, err = bucket.GetWithXattr(docKey, SyncXattrName, "test", &docValRet, &syncXattrValRet, &userXattrValRet)
+		assert.NoError(t, err)
+		assert.Equal(t, docVal, docValRet)
+		assert.Equal(t, syncXattrVal, syncXattrValRet)
+	})
 }
 
 func TestInsertTombstoneWithXattr(t *testing.T) {

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -357,3 +357,21 @@ func (bucket *CouchbaseBucketGoCB) SubdocUpdateXattr(k string, xattrKey string, 
 func (bucket *CouchbaseBucketGoCB) GetSpec() BucketSpec {
 	return bucket.Spec
 }
+
+func (bucket *CouchbaseBucketGoCB) WriteUserXattr(docKey string, xattrKey string, xattrVal interface{}) (uint64, error) {
+	docFrag, err := bucket.Bucket.MutateIn(docKey, 0, 0).UpsertEx(xattrKey, xattrVal, gocb.SubdocFlagXattr|gocb.SubdocFlagCreatePath).Execute()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(docFrag.Cas()), nil
+}
+
+func (bucket *CouchbaseBucketGoCB) DeleteUserXattr(docKey string, xattrKey string) (uint64, error) {
+	docFrag, err := bucket.Bucket.MutateIn(docKey, 0, 0).RemoveEx(xattrKey, gocb.SubdocFlagXattr).Execute()
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(docFrag.Cas()), nil
+}

--- a/base/bucket_xattr.go
+++ b/base/bucket_xattr.go
@@ -126,7 +126,7 @@ func (bucket *CouchbaseBucketGoCB) SubdocGetBodyAndXattr(k string, xattrKey stri
 			xattrContentErr := res.Content(xattrKey, xv)
 			cas = uint64(res.Cas())
 			if xattrContentErr != nil {
-				// No doc, no xattr means the doc isn't found
+				// No doc, no xattr can be treated as NotFound from Sync Gateway's perspective, even if it is a server tombstone
 				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
 				return false, ErrNotFound, cas
 			}

--- a/base/collection.go
+++ b/base/collection.go
@@ -113,7 +113,7 @@ func (c *Collection) Close() {
 }
 
 func (c *Collection) IsSupported(feature sgbucket.DataStoreFeature) bool {
-	return false
+	return true
 }
 
 // KV store
@@ -358,10 +358,6 @@ func (c *Collection) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.M
 }
 func (c *Collection) Dump() {
 	return
-}
-
-func (b *Collection) SubdocInsert(docID string, fieldPath string, cas uint64, value interface{}) error {
-	return errors.New("SubdocInsert not implemented")
 }
 
 // CouchbaseStore

--- a/base/collection.go
+++ b/base/collection.go
@@ -242,7 +242,7 @@ func (c *Collection) Delete(k string) error {
 
 func (c *Collection) Remove(k string, cas uint64) (casOut uint64, err error) {
 	result, errRemove := c.Collection.Remove(k, &gocb.RemoveOptions{Cas: gocb.Cas(cas)})
-	if errRemove != nil && result != nil {
+	if errRemove == nil && result != nil {
 		casOut = uint64(result.Cas())
 	}
 	return casOut, errRemove

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -18,6 +18,7 @@ var RemoveSpecXattr = &gocb.RemoveSpecOptions{IsXattr: true}
 var LookupOptsAccessDeleted *gocb.LookupInOptions
 
 var _ SubdocXattrStore = &Collection{}
+var _ UserXattrStore = &Collection{}
 
 func init() {
 	LookupOptsAccessDeleted = &gocb.LookupInOptions{}
@@ -58,39 +59,28 @@ func (c *Collection) UpdateXattr(k string, xattrKey string, exp uint32, cas uint
 }
 
 // SubdocGetXattr retrieves the named xattr
+// Notes on error handling
+//   - gocb v2 returns subdoc errors at the op level, in the ContentAt response
+//   - 'successful' error codes, like SucDocSuccessDeleted, aren't returned, and instead just set the internal.Deleted property on the
+//   response
 func (c *Collection) SubdocGetXattr(k string, xattrKey string, xv interface{}) (casOut uint64, err error) {
 
 	ops := []gocb.LookupInSpec{
 		gocb.GetSpec(xattrKey, GetSpecXattr),
 	}
 	res, lookupErr := c.LookupIn(k, ops, LookupOptsAccessDeleted)
-
 	if lookupErr == nil {
 		xattrContErr := res.ContentAt(0, xv)
+		// On error here, treat as the xattr wasn't found
 		if xattrContErr != nil {
 			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContErr)
 			return 0, ErrXattrNotFound
 		}
 		cas := uint64(res.Cas())
 		return cas, nil
-	} else if isKVError(lookupErr, memd.StatusSubDocBadMulti) {
-		xattrErr := res.ContentAt(0, xv)
-		if xattrErr != nil {
-			Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrErr)
-			return 0, ErrXattrNotFound
-		}
-		cas := uint64(res.Cas())
-		return cas, nil
-	} else if isKVError(lookupErr, memd.StatusKeyNotFound) {
+	} else if errors.Is(lookupErr, gocbcore.ErrDocumentNotFound) {
 		Debugf(KeyCRUD, "No document found for key=%s", UD(k))
 		return 0, ErrNotFound
-	} else if isKVError(lookupErr, memd.StatusSubDocMultiPathFailureDeleted) || isKVError(lookupErr, memd.StatusSubDocSuccessDeleted) {
-		xattrContentErr := res.ContentAt(0, xv)
-		if xattrContentErr != nil {
-			return 0, ErrNotFound
-		}
-		cas := uint64(res.Cas())
-		return cas, nil
 	} else {
 		return 0, lookupErr
 	}
@@ -115,6 +105,7 @@ func (c *Collection) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrK
 			// Attempt to retrieve the document body, if present
 			docContentErr := res.ContentAt(1, rv)
 			xattrContentErr := res.ContentAt(0, xv)
+
 			if isKVError(docContentErr, memd.StatusSubDocMultiPathFailureDeleted) && isKVError(xattrContentErr, memd.StatusSubDocMultiPathFailureDeleted) {
 				// No doc, no xattr means the doc isn't found
 				Debugf(KeyCRUD, "No xattr content found for key=%s, xattrKey=%s: %v", UD(k), UD(xattrKey), xattrContentErr)
@@ -152,12 +143,12 @@ func (c *Collection) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrK
 		// TODO: We may be able to improve in the future by having this secondary op as part of the first. At present
 		// there is no support to obtain more than one xattr in a single operation however MB-28041 is filed for this.
 		if userXattrKey != "" {
-			userXattrCas, err := c.SubdocGetXattr(k, userXattrKey, uxv)
-			switch pkgerrors.Cause(err) {
+			userXattrCas, userXattrErr := c.SubdocGetXattr(k, userXattrKey, uxv)
+			switch pkgerrors.Cause(userXattrErr) {
 			case gocb.ErrDocumentNotFound:
 				// If key not found it has been deleted in between the first op and this op.
 				return false, err, userXattrCas
-			case gocbcore.ErrMemdSubDocBadMulti:
+			case ErrXattrNotFound:
 				// Xattr doesn't exist, can skip
 			case nil:
 				if cas != userXattrCas {
@@ -166,7 +157,7 @@ func (c *Collection) SubdocGetBodyAndXattr(k string, xattrKey string, userXattrK
 			default:
 				// Unknown error occurred
 				// Shouldn't retry as any recoverable error will have been retried already in SubdocGetXattr
-				return false, err, uint64(0)
+				return false, userXattrErr, uint64(0)
 			}
 		}
 		return false, nil, cas
@@ -231,6 +222,29 @@ func (c *Collection) SubdocInsertBodyAndXattr(k string, xattrKey string, exp uin
 		return 0, mutateErr
 	}
 	return uint64(result.Cas()), nil
+
+}
+
+// SubdocInsert performs a subdoc insert operation to the specified path in the document body.
+func (c *Collection) SubdocInsert(k string, fieldPath string, cas uint64, value interface{}) error {
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.InsertSpec(fieldPath, value, nil),
+	}
+	options := &gocb.MutateInOptions{
+		Cas: gocb.Cas(cas),
+	}
+	_, mutateErr := c.MutateIn(k, mutateOps, options)
+
+	if errors.Is(mutateErr, gocbcore.ErrDocumentNotFound) {
+		return ErrNotFound
+	}
+
+	if errors.Is(mutateErr, gocbcore.ErrPathExists) {
+		return ErrAlreadyExists
+	}
+
+	return mutateErr
 
 }
 
@@ -328,7 +342,7 @@ func (c *Collection) SubdocDeleteBodyAndXattr(k string, xattrKey string) (err er
 	}
 
 	// StatusKeyNotFound returned if document doesn't exist
-	if isKVError(mutateErr, memd.StatusKeyNotFound) {
+	if errors.Is(mutateErr, gocbcore.ErrDocumentNotFound) {
 		return ErrNotFound
 	}
 
@@ -358,8 +372,8 @@ func (c *Collection) SubdocDeleteBody(k string, xattrKey string, exp uint32, cas
 	return uint64(result.Cas()), nil
 }
 
-// isKVError compares the status code of a gocb KeyValueError to the provided code.  If the provided error is
-// a gocb.SubDocumentError, checks against that error's InnerError.
+// isKVError compares the status code of a gocb KeyValueError to the provided code.  Used for nested subdoc errors
+// where gocb doesn't return a typed error for the underlying error.
 func isKVError(err error, code memd.StatusCode) bool {
 
 	switch typedErr := err.(type) {
@@ -398,4 +412,36 @@ func bytesToRawMessage(v interface{}) interface{} {
 	default:
 		return v
 	}
+}
+
+func (c *Collection) WriteUserXattr(k string, xattrKey string, xattrVal interface{}) (uint64, error) {
+	mutateOps := []gocb.MutateInSpec{
+		gocb.UpsertSpec(xattrKey, bytesToRawMessage(xattrVal), UpsertSpecXattr),
+	}
+	options := &gocb.MutateInOptions{
+		StoreSemantic: gocb.StoreSemanticsUpsert,
+	}
+
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
+}
+
+func (c *Collection) DeleteUserXattr(k string, xattrKey string) (uint64, error) {
+
+	mutateOps := []gocb.MutateInSpec{
+		gocb.RemoveSpec(xattrKey, RemoveSpecXattr),
+	}
+	options := &gocb.MutateInOptions{
+		Cas: gocb.Cas(0),
+	}
+	options.Internal.DocFlags = gocb.SubdocDocFlagAccessDeleted
+
+	result, mutateErr := c.MutateIn(k, mutateOps, options)
+	if mutateErr != nil {
+		return 0, mutateErr
+	}
+	return uint64(result.Cas()), nil
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -24,10 +24,8 @@ import (
 	"time"
 
 	sgbucket "github.com/couchbase/sg-bucket"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/couchbase/gocb.v1"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Code that is test-related that needs to be accessible from non-base packages, and therefore can't live in
@@ -462,24 +460,6 @@ func WaitForStat(getStatFunc func() int64, expected int64) (int64, bool) {
 	valInt64, ok := val.(int64)
 
 	return valInt64, err == nil && ok
-}
-
-func WriteXattr(gocbBucket *CouchbaseBucketGoCB, docKey string, xattrKey string, xattrVal interface{}) (uint64, error) {
-	docFrag, err := gocbBucket.Bucket.MutateIn(docKey, 0, 0).UpsertEx(xattrKey, xattrVal, gocb.SubdocFlagXattr|gocb.SubdocFlagCreatePath).Execute()
-	if err != nil {
-		return 0, err
-	}
-
-	return uint64(docFrag.Cas()), nil
-}
-
-func DeleteXattr(gocbBucket *CouchbaseBucketGoCB, docKey string, xattrKey string) (uint64, error) {
-	docFrag, err := gocbBucket.Bucket.MutateIn(docKey, 0, 0).RemoveEx(xattrKey, gocb.SubdocFlagXattr).Execute()
-	if err != nil {
-		return 0, err
-	}
-
-	return uint64(docFrag.Cas()), nil
 }
 
 type dataStore struct {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2793,7 +2793,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	_, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 	assert.NoError(t, err)
 
-	_, err = base.WriteXattr(gocbBucket, docKey, xattrKey, "val")
+	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, "val")
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5660,7 +5660,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 
 	// Add xattr to doc
-	_, err := base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+	_, err := gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for doc to be imported
@@ -5680,7 +5680,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 	// Update xattr again but same value and ensure it isn't imported again (crc32 hash should match)
-	_, err = base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5789,7 +5789,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	// Write user xattr
-	_, err = base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// GET to trigger import
@@ -5813,7 +5813,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 	// Write same xattr value
-	_, err = base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Perform GET and ensure import isn't triggered as crc32 hash is the same
@@ -5887,7 +5887,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	// Write user xattr
-	_, err = base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Trigger import
@@ -5983,7 +5983,7 @@ func TestRemovingUserXattr(t *testing.T) {
 			assertStatus(t, resp, http.StatusCreated)
 
 			// Add xattr
-			_, err := base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+			_, err := gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 			assert.NoError(t, err)
 
 			// Trigger import
@@ -6001,7 +6001,7 @@ func TestRemovingUserXattr(t *testing.T) {
 			assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 			// Delete user xattr
-			_, err = base.DeleteXattr(gocbBucket, docKey, xattrKey)
+			_, err = gocbBucket.DeleteUserXattr(docKey, xattrKey)
 			assert.NoError(t, err)
 
 			// Trigger import
@@ -6076,7 +6076,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
 
 	// Write xattr to trigger import of user xattr
-	_, err = base.WriteXattr(gocbBucket, docKey, xattrKey, channelName)
+	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for import


### PR DESCRIPTION
Completes user xattr support for gocb v2, and adds low-level subdoc support for auth package. Also simplifies gocb v2 error checking to use errors.Is() where possible.  

- [x] http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/835/