### PR TITLE
CBG-1535 - Enforce TLS by default

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3435,8 +3435,7 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 		t.Skip("Skip this test under integration testing")
 	}
 
-	allowUnsecureServerConnections := true
-	sc := NewServerContext(&ServerConfig{AllowUnsecureServerConnections: &allowUnsecureServerConnections})
+	sc := NewServerContext(&ServerConfig{})
 
 	// Valid config
 	configJSON := `{"name": "default",

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3435,7 +3435,8 @@ func TestEventConfigValidationSuccess(t *testing.T) {
 		t.Skip("Skip this test under integration testing")
 	}
 
-	sc := NewServerContext(&ServerConfig{})
+	allowUnsecureServerConnections := true
+	sc := NewServerContext(&ServerConfig{AllowUnsecureServerConnections: &allowUnsecureServerConnections})
 
 	// Valid config
 	configJSON := `{"name": "default",
@@ -3975,8 +3976,8 @@ func TestLongpollWithWildcard(t *testing.T) {
 }
 
 func TestUnsupportedConfig(t *testing.T) {
-
-	sc := NewServerContext(&ServerConfig{})
+	allowUnsecureServerConnections := true
+	sc := NewServerContext(&ServerConfig{AllowUnsecureServerConnections: &allowUnsecureServerConnections})
 	testProviderOnlyJSON := `{"name": "test_provider_only",
         			"server": "walrus:",
         			"bucket": "test_provider_only",

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -193,7 +193,8 @@ func TestSetupAndValidate(t *testing.T) {
               ],
               "color_enabled": true
             }
-          }
+          },
+		  "allow_unsecure_connections": true
         }`))
 		defer deleteTempFile(t, configFile)
 		args := []string{"sync_gateway", configFile.Name()}
@@ -242,7 +243,7 @@ func TestSetupAndValidate(t *testing.T) {
 	t.Run("Run setupAndValidate with unknown field in config file", func(t *testing.T) {
 		configFile := createTempFile(t, []byte(`{"unknownKey":"unknownValue"}`))
 		defer deleteTempFile(t, configFile)
-		args := []string{"sync_gateway", configFile.Name()}
+		args := []string{"sync_gateway", "-allowUnsecureConnections", configFile.Name()}
 		config, err := setupServerConfig(args)
 		require.Error(t, err, "Should throw error reading file")
 		assert.Contains(t, err.Error(), "unrecognized JSON field")
@@ -272,7 +273,8 @@ func TestSetupAndValidate(t *testing.T) {
 		  },
 		  "unsupported": {
 		    "stats_log_freq_secs": 1
-		  }
+		  },
+		  "allow_unsecure_connections": true
 		}`))
 		defer deleteTempFile(t, configFile)
 		args := []string{"sync_gateway", configFile.Name()}

--- a/rest/config.go
+++ b/rest/config.go
@@ -68,43 +68,45 @@ const (
 
 // JSON object that defines the server configuration.
 type ServerConfig struct {
-	TLSMinVersion                  *string                  `json:"tls_minimum_version,omitempty"`              // Set TLS Version
-	Interface                      *string                  `json:",omitempty"`                                 // Interface to bind REST API to, default ":4984"
-	SSLCert                        *string                  `json:",omitempty"`                                 // Path to SSL cert file, or nil
-	SSLKey                         *string                  `json:",omitempty"`                                 // Path to SSL private key file, or nil
-	ServerReadTimeout              *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out read of the HTTP(S) request
-	ServerWriteTimeout             *int                     `json:",omitempty"`                                 // maximum duration.Second before timing out write of the HTTP(S) response
-	ReadHeaderTimeout              *int                     `json:",omitempty"`                                 // The amount of time allowed to read request headers.
-	IdleTimeout                    *int                     `json:",omitempty"`                                 // The maximum amount of time to wait for the next request when keep-alives are enabled.
-	AdminInterface                 *string                  `json:",omitempty"`                                 // Interface to bind admin API to, default "localhost:4985"
-	AdminUI                        *string                  `json:",omitempty"`                                 // Path to Admin HTML page, if omitted uses bundled HTML
-	ProfileInterface               *string                  `json:",omitempty"`                                 // Interface to bind Go profile API to (no default)
-	ConfigServer                   *string                  `json:",omitempty"`                                 // URL of config server (for dynamic db discovery)
-	Facebook                       *FacebookConfig          `json:",omitempty"`                                 // Configuration for Facebook validation
-	Google                         *GoogleConfig            `json:",omitempty"`                                 // Configuration for Google validation
-	CORS                           *CORSConfig              `json:",omitempty"`                                 // Configuration for allowing CORS
-	DeprecatedLog                  []string                 `json:"log,omitempty"`                              // Log keywords to enable
-	DeprecatedLogFilePath          *string                  `json:"logFilePath,omitempty"`                      // Path to log file, if missing write to stderr
-	Logging                        *base.LoggingConfig      `json:",omitempty"`                                 // Configuration for logging with optional log file rotation
-	Pretty                         bool                     `json:",omitempty"`                                 // Pretty-print JSON responses?
-	DeploymentID                   *string                  `json:",omitempty"`                                 // Optional customer/deployment ID for stats reporting
-	StatsReportInterval            *float64                 `json:",omitempty"`                                 // Optional stats report interval (0 to disable)
-	CouchbaseKeepaliveInterval     *int                     `json:",omitempty"`                                 // TCP keep-alive interval between SG and Couchbase server
-	SlowQueryWarningThreshold      *int                     `json:",omitempty"`                                 // Log warnings if N1QL queries take this many ms
-	MaxIncomingConnections         *int                     `json:",omitempty"`                                 // Max # of incoming HTTP connections to accept
-	MaxFileDescriptors             *uint64                  `json:",omitempty"`                                 // Max # of open file descriptors (RLIMIT_NOFILE)
-	CompressResponses              *bool                    `json:",omitempty"`                                 // If false, disables compression of HTTP responses
-	Databases                      DbConfigMap              `json:",omitempty"`                                 // Pre-configured databases, mapped by name
-	Replications                   []*ReplicateV1Config     `json:",omitempty"`                                 // sg-replicate replication definitions
-	MaxHeartbeat                   uint64                   `json:",omitempty"`                                 // Max heartbeat value for _changes request (seconds)
-	ClusterConfig                  *ClusterConfig           `json:"cluster_config,omitempty"`                   // Bucket and other config related to CBGT
-	Unsupported                    *UnsupportedServerConfig `json:"unsupported,omitempty"`                      // Config for unsupported features
-	ReplicatorCompression          *int                     `json:"replicator_compression,omitempty"`           // BLIP data compression level (0-9)
-	BcryptCost                     int                      `json:"bcrypt_cost,omitempty"`                      // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
-	MetricsInterface               *string                  `json:"metricsInterface,omitempty"`                 // Interface to bind metrics to. If not set then metrics isn't accessible
-	HideProductVersion             bool                     `json:"hide_product_version,omitempty"`             // Determines whether product versions removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
-	AdminInterfaceAuthentication   *bool                    `json:"admin_interface_authentication,omitempty"`   // Defines whether the Admin API will support authentication. Defaults to true.
-	MetricsInterfaceAuthentication *bool                    `json:"metrics_interface_authentication,omitempty"` // Defines whether the Metrics API will support authentication. Defaults to true.
+	TLSMinVersion                  *string                  `json:"tls_minimum_version,omitempty"`               // Set TLS Version
+	AllowUnsecureServerConnections *bool                    `json:"allow_unsecure_server_connections,omitempty"` // Allow unsecure connections between CBS and SGW (ie. allow http or couchbase://)
+	Interface                      *string                  `json:",omitempty"`                                  // Interface to bind REST API to, default ":4984"
+	SSLCert                        *string                  `json:",omitempty"`                                  // Path to SSL cert file, or nil
+	SSLKey                         *string                  `json:",omitempty"`                                  // Path to SSL private key file, or nil
+	AllowUnsecureConnections       *bool                    `json:"allow_unsecure_connections,omitempty"`        // If true, do not force SSL Key and Cert to be provided (therefore disable SG using TLS for APIs)
+	ServerReadTimeout              *int                     `json:",omitempty"`                                  // maximum duration.Second before timing out read of the HTTP(S) request
+	ServerWriteTimeout             *int                     `json:",omitempty"`                                  // maximum duration.Second before timing out write of the HTTP(S) response
+	ReadHeaderTimeout              *int                     `json:",omitempty"`                                  // The amount of time allowed to read request headers.
+	IdleTimeout                    *int                     `json:",omitempty"`                                  // The maximum amount of time to wait for the next request when keep-alives are enabled.
+	AdminInterface                 *string                  `json:",omitempty"`                                  // Interface to bind admin API to, default "localhost:4985"
+	AdminUI                        *string                  `json:",omitempty"`                                  // Path to Admin HTML page, if omitted uses bundled HTML
+	ProfileInterface               *string                  `json:",omitempty"`                                  // Interface to bind Go profile API to (no default)
+	ConfigServer                   *string                  `json:",omitempty"`                                  // URL of config server (for dynamic db discovery)
+	Facebook                       *FacebookConfig          `json:",omitempty"`                                  // Configuration for Facebook validation
+	Google                         *GoogleConfig            `json:",omitempty"`                                  // Configuration for Google validation
+	CORS                           *CORSConfig              `json:",omitempty"`                                  // Configuration for allowing CORS
+	DeprecatedLog                  []string                 `json:"log,omitempty"`                               // Log keywords to enable
+	DeprecatedLogFilePath          *string                  `json:"logFilePath,omitempty"`                       // Path to log file, if missing write to stderr
+	Logging                        *base.LoggingConfig      `json:",omitempty"`                                  // Configuration for logging with optional log file rotation
+	Pretty                         bool                     `json:",omitempty"`                                  // Pretty-print JSON responses?
+	DeploymentID                   *string                  `json:",omitempty"`                                  // Optional customer/deployment ID for stats reporting
+	StatsReportInterval            *float64                 `json:",omitempty"`                                  // Optional stats report interval (0 to disable)
+	CouchbaseKeepaliveInterval     *int                     `json:",omitempty"`                                  // TCP keep-alive interval between SG and Couchbase server
+	SlowQueryWarningThreshold      *int                     `json:",omitempty"`                                  // Log warnings if N1QL queries take this many ms
+	MaxIncomingConnections         *int                     `json:",omitempty"`                                  // Max # of incoming HTTP connections to accept
+	MaxFileDescriptors             *uint64                  `json:",omitempty"`                                  // Max # of open file descriptors (RLIMIT_NOFILE)
+	CompressResponses              *bool                    `json:",omitempty"`                                  // If false, disables compression of HTTP responses
+	Databases                      DbConfigMap              `json:",omitempty"`                                  // Pre-configured databases, mapped by name
+	Replications                   []*ReplicateV1Config     `json:",omitempty"`                                  // sg-replicate replication definitions
+	MaxHeartbeat                   uint64                   `json:",omitempty"`                                  // Max heartbeat value for _changes request (seconds)
+	ClusterConfig                  *ClusterConfig           `json:"cluster_config,omitempty"`                    // Bucket and other config related to CBGT
+	Unsupported                    *UnsupportedServerConfig `json:"unsupported,omitempty"`                       // Config for unsupported features
+	ReplicatorCompression          *int                     `json:"replicator_compression,omitempty"`            // BLIP data compression level (0-9)
+	BcryptCost                     int                      `json:"bcrypt_cost,omitempty"`                       // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
+	MetricsInterface               *string                  `json:"metricsInterface,omitempty"`                  // Interface to bind metrics to. If not set then metrics isn't accessible
+	HideProductVersion             bool                     `json:"hide_product_version,omitempty"`              // Determines whether product versions removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
+	AdminInterfaceAuthentication   *bool                    `json:"admin_interface_authentication,omitempty"`    // Defines whether the Admin API will support authentication. Defaults to true.
+	MetricsInterfaceAuthentication *bool                    `json:"metrics_interface_authentication,omitempty"`  // Defines whether the Metrics API will support authentication. Defaults to true.
 }
 
 // Bucket configuration elements - used by db, index
@@ -122,7 +124,7 @@ type BucketConfig struct {
 
 func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 
-	server := "http://localhost:8091"
+	server := "couchbases://localhost:8091"
 	bucketName := ""
 	tlsPort := 11207
 
@@ -1040,6 +1042,8 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 	verbose := flagSet.Bool("verbose", false, "Log more info about requests")
 	logKeys := flagSet.String("log", "", "Log keys, comma separated")
 	logFilePath := flagSet.String("logFilePath", "", "Path to log files")
+	allowUnsecureServerConnections := flagSet.Bool("allowUnsecureServerConnections", false, "Allow unsecure communication between Couchbase Server and Sync Gateway")
+	allowUnsecureConnections := flagSet.Bool("allowUnsecureConnections", false, "Allow SSL not to be used for Sync Gateway API")
 	certpath := flagSet.String("certpath", "", "Client certificate path")
 	cacertpath := flagSet.String("cacertpath", "", "Root CA certificate path")
 	keypath := flagSet.String("keypath", "", "Client certificate key path")
@@ -1103,6 +1107,12 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 		if *pretty {
 			config.Pretty = *pretty
 		}
+		if *allowUnsecureConnections {
+			config.AllowUnsecureConnections = allowUnsecureConnections
+		}
+		if *allowUnsecureServerConnections {
+			config.AllowUnsecureServerConnections = allowUnsecureServerConnections
+		}
 
 		// If the interfaces were not specified in either the config file or
 		// on the command line, set them to the default values
@@ -1143,11 +1153,13 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 		}
 
 		config = &ServerConfig{
-			Interface:        addr,
-			AdminInterface:   authAddr,
-			ProfileInterface: profAddr,
-			Pretty:           *pretty,
-			ConfigServer:     configServer,
+			Interface:                      addr,
+			AdminInterface:                 authAddr,
+			ProfileInterface:               profAddr,
+			Pretty:                         *pretty,
+			ConfigServer:                   configServer,
+			AllowUnsecureServerConnections: allowUnsecureServerConnections,
+			AllowUnsecureConnections:       allowUnsecureConnections,
 			Logging: &base.LoggingConfig{
 				Console: base.ConsoleLoggerConfig{
 					// Enable the logger only when log keys have explicitly been set on the command line
@@ -1174,6 +1186,14 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*ServerConfig
 					},
 				},
 			},
+		}
+	}
+
+	// Validate SSL is provided if not allowing unsecure connections
+	if config.AllowUnsecureConnections == nil || !*config.AllowUnsecureConnections {
+		if config.SSLKey == nil || config.SSLCert == nil {
+			err = fmt.Errorf("a SSL key and SSL cert must be provided when Allow Unsecure Connection config or flag options are not true")
+			return nil, err
 		}
 	}
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -989,7 +989,6 @@ func TestConfigToDatabaseOptions(t *testing.T) {
 
 	jsonConfig := []byte(`
 {
-	"allow_unsecure_connections": true,
 	"allow_unsecure_server_connections": true,
 	"databases": {
 		"db": {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -903,7 +903,9 @@ func TestValidateServerContext(t *testing.T) {
 	tb2User, tb2Password, _ := tb2.BucketSpec.Auth.GetCredentials()
 
 	xattrs := base.TestUseXattrs()
+	allowUnsecureServerConnections := true
 	config := &ServerConfig{
+		AllowUnsecureServerConnections: &allowUnsecureServerConnections,
 		Databases: map[string]*DbConfig{
 			"db1": {
 				BucketConfig: BucketConfig{

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -851,6 +851,8 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 		"--pretty",
 		"--verbose",
 		"--profileInterface", profileInterface,
+		"--allowUnsecureServerConnections",
+		"--allowUnsecureConnections",
 		configFile.Name()}
 
 	config, err := ParseCommandLine(args, flag.ContinueOnError)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -346,7 +346,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 	}
 
 	if sc.GetConfig().AllowUnsecureServerConnections == nil || !*sc.GetConfig().AllowUnsecureServerConnections {
-		if !spec.IsTLS() {
+		if !spec.IsTLS() && !spec.IsWalrusBucket() {
 			return nil, fmt.Errorf("couchbase server URL must use secure protocol. Current URL: %s", spec.Server)
 		}
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -345,6 +345,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config *DbConfig, useExisti
 		return nil, err
 	}
 
+	if sc.GetConfig().AllowUnsecureServerConnections == nil || !*sc.GetConfig().AllowUnsecureServerConnections {
+		if !spec.IsTLS() {
+			return nil, fmt.Errorf("couchbase server URL must use secure protocol. Current URL: %s", spec.Server)
+		}
+	}
+
 	// Connect to bucket
 	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
 		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -228,14 +228,8 @@ func TestAllowUnsecureServerConnections(t *testing.T) {
 		expectError                    bool
 	}{
 		{
-			name:                           "Walrus not allowed",
+			name:                           "Walrus allowed without flag",
 			allowUnsecureServerConnections: false,
-			server:                         "walrus://",
-			expectError:                    true,
-		},
-		{
-			name:                           "Walrus allowed",
-			allowUnsecureServerConnections: true,
 			server:                         "walrus://",
 			expectError:                    false,
 		},

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -42,17 +42,19 @@ import (
 // file, they wouldn't be publicly exported to other packages)
 
 type RestTesterConfig struct {
-	guestEnabled          bool                 // If this is true, Admin Party is in full effect
-	SyncFn                string               // put the sync() function source in here (optional)
-	DatabaseConfig        *DbConfig            // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
-	InitSyncSeq           uint64               // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
-	EnableNoConflictsMode bool                 // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
-	distributedIndex      bool                 // Test with walrus-based index bucket
-	TestBucket            *base.TestBucket     // If set, use this bucket instead of requesting a new one.
-	adminInterface        string               // adminInterface overrides the default admin interface.
-	sgReplicateEnabled    bool                 // sgReplicateManager disabled by default for RestTester
-	sgr1Replications      []*ReplicateV1Config // sgr1Replications are a list of replications to enable on the server context.
-	hideProductInfo       bool
+	guestEnabled                  bool                 // If this is true, Admin Party is in full effect
+	SyncFn                        string               // put the sync() function source in here (optional)
+	DatabaseConfig                *DbConfig            // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
+	InitSyncSeq                   uint64               // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
+	EnableNoConflictsMode         bool                 // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
+	distributedIndex              bool                 // Test with walrus-based index bucket
+	TestBucket                    *base.TestBucket     // If set, use this bucket instead of requesting a new one.
+	adminInterface                string               // adminInterface overrides the default admin interface.
+	sgReplicateEnabled            bool                 // sgReplicateManager disabled by default for RestTester
+	sgr1Replications              []*ReplicateV1Config // sgr1Replications are a list of replications to enable on the server context.
+	denyUnsecureConnections       bool                 // If true, TLS will be used with SG
+	denyUnsecureServerConnections bool                 // If true, TLS will be require for communications with CBS
+	hideProductInfo               bool
 }
 
 type RestTester struct {
@@ -127,12 +129,25 @@ func (rt *RestTester) Bucket() base.Bucket {
 	if rt.RestTesterConfig.adminInterface != "" {
 		adminInterface = &rt.RestTesterConfig.adminInterface
 	}
+
+	allowUnsecureConnections := true
+	if rt.RestTesterConfig.denyUnsecureConnections {
+		allowUnsecureConnections = false
+	}
+
+	allowUnsecureServerConnections := true
+	if rt.RestTesterConfig.denyUnsecureServerConnections {
+		allowUnsecureServerConnections = false
+	}
+
 	rt.RestTesterServerContext = NewServerContext(&ServerConfig{
-		CORS:               corsConfig,
-		Facebook:           &FacebookConfig{},
-		AdminInterface:     adminInterface,
-		Replications:       rt.RestTesterConfig.sgr1Replications,
-		HideProductVersion: rt.RestTesterConfig.hideProductInfo,
+		CORS:                           corsConfig,
+		Facebook:                       &FacebookConfig{},
+		AdminInterface:                 adminInterface,
+		Replications:                   rt.RestTesterConfig.sgr1Replications,
+		HideProductVersion:             rt.RestTesterConfig.hideProductInfo,
+		AllowUnsecureConnections:       &allowUnsecureConnections,
+		AllowUnsecureServerConnections: &allowUnsecureServerConnections,
 	})
 
 	useXattrs := base.TestUseXattrs()


### PR DESCRIPTION
https://issues.couchbase.com/browse/CM-837
Default bucket is no server is provided is now couchbases://localhost:8091 regardless of flag
If the server is a Walrus bucket, then this is treated as a secure server meaning AllowUnsecureServerConnections does not need to be set.

AllowUnsecureServerConnections config is to not enforce TLS between CBS and SGW
AllowUnsecureConnections is used not to enforce that a SSL key and cert is provided for the Restful API
Config options: allow_unsecure_server_connections, allow_unsecure_connections
Flag options: allowUnsecureServerConnections, allowUnsecureConnections