### PR TITLE
Fix TestHandlePprofs in Go 1.14+ by asserting on Content-Disposition prefix

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5154,15 +5154,17 @@ func TestHandlePprofs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.inputProfile, func(t *testing.T) {
-			expectedContentDisposition := fmt.Sprintf(`attachment; filename="%v"`, tc.inputProfile)
+			expectedContentDispositionPrefix := fmt.Sprintf(`attachment; filename="%v`, tc.inputProfile)
 			response := rt.SendAdminRequest(http.MethodGet, tc.inputResource, "")
-			assert.Equal(t, expectedContentDisposition, response.Header().Get("Content-Disposition"))
+			cdHeader := response.Header().Get("Content-Disposition")
+			assert.Truef(t, strings.HasPrefix(cdHeader, expectedContentDispositionPrefix), "Expected header prefix: %q but got %q", expectedContentDispositionPrefix, cdHeader)
 			assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
 			assertStatus(t, response, http.StatusOK)
 
 			response = rt.SendAdminRequest(http.MethodPost, tc.inputResource, "")
-			assert.Equal(t, expectedContentDisposition, response.Header().Get("Content-Disposition"))
+			cdHeader = response.Header().Get("Content-Disposition")
+			assert.Truef(t, strings.HasPrefix(cdHeader, expectedContentDispositionPrefix), "Expected header prefix: %q but got %q", expectedContentDispositionPrefix, cdHeader)
 			assert.Equal(t, "application/octet-stream", response.Header().Get("Content-Type"))
 			assert.Equal(t, "nosniff", response.Header().Get("X-Content-Type-Options"))
 			assertStatus(t, response, http.StatusOK)


### PR DESCRIPTION
Go 1.14+ treats some profiles with a "seconds" parameter as "delta" profiles, rather than a historic profile, which results in a file name like `"heap-delta"` vs. `"heap"` prior to 1.14.

https://github.com/golang/go/issues/23401
https://go-review.googlesource.com/c/go/+/147598/

Go master (1.17?) contains a change which standardises this across ALL profile types.

https://go-review.googlesource.com/c/go/+/229537/
