### PR TITLE
CBG-1532: Unregister prometheus stats on db close and disable for tests

### DIFF
--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -20,6 +20,8 @@ import (
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
 
+	base.SkipPrometheusStatsRegistration = true
+
 	base.GTestBucketPool = base.NewTestBucketPool(base.FlushBucketEmptierFunc, base.NoopInitFunc)
 
 	status := m.Run()

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -18,6 +18,8 @@ import (
 func TestMain(m *testing.M) {
 	defer SetUpGlobalTestLogging(m)()
 
+	SkipPrometheusStatsRegistration = true
+
 	GTestBucketPool = NewTestBucketPool(FlushBucketEmptierFunc, NoopInitFunc)
 
 	status := m.Run()

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -20,6 +20,8 @@ import (
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
 
+	base.SkipPrometheusStatsRegistration = true
+
 	status := m.Run()
 
 	os.Exit(status)

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -20,6 +20,8 @@ import (
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
 
+	base.SkipPrometheusStatsRegistration = true
+
 	base.GTestBucketPool = base.NewTestBucketPool(ViewsAndGSIBucketReadier, ViewsAndGSIBucketInit)
 
 	status := m.Run()

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3994,6 +3994,7 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(&testProviderOnlyConfig)
 	assert.NoError(t, err, "Error adding testProviderOnly database.")
+	sc._removeDatabase("test_provider_only")
 
 	viewsOnlyJSON := `{"name": "views_only",
         			"server": "walrus:",
@@ -4011,6 +4012,7 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(&viewsOnlyConfig)
 	assert.NoError(t, err, "Error adding viewsOnlyConfig database.")
+	sc._removeDatabase("views_only")
 
 	viewsAndTestJSON := `{"name": "views_and_test",
         			"server": "walrus:",
@@ -4032,6 +4034,7 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(&viewsAndTestConfig)
 	assert.NoError(t, err, "Error adding viewsAndTestConfig database.")
+	sc._removeDatabase("views_and_test")
 
 	sc.Close()
 }
@@ -7298,4 +7301,60 @@ func TestRevocationResumeSameRoleAndLowSeqCheck(t *testing.T) {
 	assert.True(t, changes.Results[0].Revoked)
 	assert.Equal(t, "doc2", changes.Results[1].ID)
 	assert.True(t, changes.Results[1].Revoked)
+}
+
+func TestMetricsHandler(t *testing.T) {
+	base.SkipPrometheusStatsRegistration = false
+	defer func() {
+		base.SkipPrometheusStatsRegistration = true
+	}()
+
+	// Create and remove a database
+	// This ensures that creation and removal of a DB is possible without a re-registration issue ( the below rest tester will re-register "db")
+	context, err := db.NewDatabaseContext("db", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	require.NoError(t, err)
+	context.Close()
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	rt.SendAdminRequest("PUT", "/db/doc", "{}")
+
+	srv := httptest.NewServer(rt.TestMetricsHandler())
+	defer srv.Close()
+
+	httpClient := http.DefaultClient
+
+	// Ensure metrics endpoint is accessible and that db database has entries
+	resp, err := httpClient.Get(srv.URL + "/_metrics")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bodyString, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(bodyString), `database="db"`)
+	err = resp.Body.Close()
+	assert.NoError(t, err)
+
+	// Initialize another database to ensure both are registered successfully
+	context, err = db.NewDatabaseContext("db2", base.GetTestBucket(t), false, db.DatabaseContextOptions{})
+	require.NoError(t, err)
+	defer context.Close()
+
+	// Validate that metrics still works with both db and db2 databases and that they have entries
+	resp, err = httpClient.Get(srv.URL + "/_metrics")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bodyString, err = ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Contains(t, string(bodyString), `database="db"`)
+	assert.Contains(t, string(bodyString), `database="db2"`)
+	err = resp.Body.Close()
+	assert.NoError(t, err)
+
+	// Ensure metrics endpoint is not serving any other routes
+	resp, err = httpClient.Get(srv.URL + "/db/")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	err = resp.Body.Close()
+	assert.NoError(t, err)
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -3994,7 +3994,6 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(&testProviderOnlyConfig)
 	assert.NoError(t, err, "Error adding testProviderOnly database.")
-	sc._removeDatabase("test_provider_only")
 
 	viewsOnlyJSON := `{"name": "views_only",
         			"server": "walrus:",
@@ -4012,7 +4011,6 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(&viewsOnlyConfig)
 	assert.NoError(t, err, "Error adding viewsOnlyConfig database.")
-	sc._removeDatabase("views_only")
 
 	viewsAndTestJSON := `{"name": "views_and_test",
         			"server": "walrus:",
@@ -4034,7 +4032,6 @@ func TestUnsupportedConfig(t *testing.T) {
 
 	_, err = sc.AddDatabaseFromConfig(&viewsAndTestConfig)
 	assert.NoError(t, err, "Error adding viewsAndTestConfig database.")
-	sc._removeDatabase("views_and_test")
 
 	sc.Close()
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -21,6 +21,8 @@ import (
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
 
+	base.SkipPrometheusStatsRegistration = true
+
 	base.GTestBucketPool = base.NewTestBucketPool(db.ViewsAndGSIBucketReadier, db.ViewsAndGSIBucketInit)
 
 	status := m.Run()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -66,6 +66,8 @@ type RestTester struct {
 	adminHandlerOnce        sync.Once
 	PublicHandler           http.Handler
 	publicHandlerOnce       sync.Once
+	MetricsHandler          http.Handler
+	metricsHandlerOnce      sync.Once
 	closed                  bool
 }
 
@@ -307,6 +309,13 @@ func (rt *RestTester) TestPublicHandler() http.Handler {
 		rt.PublicHandler = CreatePublicHandler(rt.ServerContext())
 	})
 	return rt.PublicHandler
+}
+
+func (rt *RestTester) TestMetricsHandler() http.Handler {
+	rt.metricsHandlerOnce.Do(func() {
+		rt.MetricsHandler = CreateMetricHandler(rt.ServerContext())
+	})
+	return rt.MetricsHandler
 }
 
 type changesResults struct {


### PR DESCRIPTION
All the work done here is around properly tearing down prometheus stats on a database close. Previously we were only removing our internal reference to them but they were still initialized in Prometheus.

To properly remove stats we need to 'Unregister' them. 

In order to properly 'Unregister' them they require a 'Desc' which acts as a unique identifier for each stat. Therefore inside of each of the previously unused Describe methods we now send the stats description over the channel.

Our current descriptions were built slightly incorrectly as our labels were being provided through the 'variableLabels' parameter rather than the 'constLabels'. Due to that fact that a metrics labels will not change during its lifetime they should be provided inside of 'constLabels'.

Additionally to avoid test issues an additional variable `SkipPrometheusStatsRegistration` has been implemented. When this is set to true (as is the default case for tests via TestMain) the stat initializations will not register with Prometheus. As `NewSyncGatewayStats()` is called from `init()` this is only applicable to non-global stats but this is fine as if any tests re-initialize those stats those further initializations will be skipped.

To validate this a test has been added which tests:
- Creation of db stats
- Removal of db stats
- Re-Creation of db stats under same name
- Adding a second db

Therefore in summary changes are:
- Modify stat descriptions
- Return descriptions in Describe()
- Unregister stats on ClearDBStats()
- Unit test ability to skip prometheus registration of stats
- Unit test to test functionality