### PR TITLE
CBG-1532: Prometheus fix part2 - Teardown db stats with failed context creation (and other cleanup)

### DIFF
--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1865,6 +1865,12 @@ func mockOIDCOptionsWithBadName() *auth.OIDCOptions {
 }
 
 func TestNewDatabaseContextWithOIDCProviderOptionErrors(t *testing.T) {
+	// Enable prometheus stats. Ensures that we recover / cleanup stats if we fail to initialize a DatabaseContext
+	base.SkipPrometheusStatsRegistration = false
+	defer func() {
+		base.SkipPrometheusStatsRegistration = true
+	}()
+
 	testBucket := base.GetTestBucket(t)
 	tests := []struct {
 		name          string


### PR DESCRIPTION
This is a follow on from https://github.com/couchbase/sync_gateway/pull/5071 but I wanted this separate as not to confuse the other PR any more than it already is.

This covers the case where in the event of `NewDatabaseContext` failing and exiting early we don't clear up the DB stats meaning they will stick around even when the database hasn't been properly created. 

An existing unit test which tests some of the behaviour around an early exit from `NewDatabaseContext` was slightly modified to provide a test for this.

Also took the opportunity to cleanup other things that weren't closed in dbcontext

- [x] Merge https://github.com/couchbase/sync_gateway/pull/5071 and rebase 