### PR TITLE
Improve IsWalrus helper functions

### DIFF
--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -477,3 +477,46 @@ func TestBaseBucket(t *testing.T) {
 		})
 	}
 }
+
+func TestBucketSpecIsWalrusBucket(t *testing.T) {
+	tests := []struct {
+		spec     BucketSpec
+		expected bool
+	}{
+		{
+			spec:     BucketSpec{Server: ""},
+			expected: false,
+		},
+		{
+			spec:     BucketSpec{Server: "walrus:"},
+			expected: true,
+		},
+		{
+			spec:     BucketSpec{Server: "file:"},
+			expected: true,
+		},
+		{
+			spec:     BucketSpec{Server: "/foo"},
+			expected: true,
+		},
+		{
+			spec:     BucketSpec{Server: "./foo"},
+			expected: true,
+		},
+		{
+			spec:     BucketSpec{Server: "couchbase://walrus"},
+			expected: false,
+		},
+		{
+			spec:     BucketSpec{Server: "http://walrus:8091"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.spec.Server, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.spec.IsWalrusBucket())
+		})
+	}
+
+}

--- a/base/constants.go
+++ b/base/constants.go
@@ -194,7 +194,11 @@ func UnitTestUrlIsWalrus() bool {
 	return ServerIsWalrus(UnitTestUrl())
 }
 
-// ServerIsWalrus returns true if the given server is a Walrus URL.
+// ServerIsWalrus returns true when the given server looks like a Walrus URI
+// Equivalent to the old regexp: `^(walrus:|file:|/|\.)`
 func ServerIsWalrus(server string) bool {
-	return strings.HasPrefix(server, kTestWalrusURL)
+	return strings.HasPrefix(server, "walrus:") ||
+		strings.HasPrefix(server, "file:") ||
+		strings.HasPrefix(server, "/") ||
+		strings.HasPrefix(server, ".")
 }

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -247,7 +247,7 @@ func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s Bucke
 
 	// Return a new Walrus bucket when tbp has not been initialized
 	if !tbp.integrationMode {
-		return tbp.GetWalrusTestBucket(t, "walrus:")
+		return tbp.GetWalrusTestBucket(t, kTestWalrusURL)
 	}
 
 	if atomic.LoadUint32(&tbp.preservedBucketCount) >= uint32(cap(tbp.readyBucketPool)) {


### PR DESCRIPTION
Uses `strings.HasPrefix` instead of regular expressions for efficiency
reasons, and also standardises what Sync Gateway considers valid Walrus
URI prefixes:
- `walrus:`
- `file:`
- `/`
- `.`

## Integration Tests
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/842/