### PR TITLE
[2.8.3] CBG-1454: Removal messages are not sent on push replications

### DIFF
--- a/db/active_replicator_push.go
+++ b/db/active_replicator_push.go
@@ -90,14 +90,15 @@ func (apr *ActivePushReplicator) _connect() error {
 
 	go func(s *blip.Sender) {
 		isComplete := bh.sendChanges(s, &sendChangesOptions{
-			docIDs:            apr.config.DocIDs,
-			since:             seq,
-			continuous:        apr.config.Continuous,
-			activeOnly:        apr.config.ActiveOnly,
-			batchSize:         int(apr.config.ChangesBatchSize),
-			channels:          channels,
-			clientType:        clientTypeSGR2,
-			ignoreNoConflicts: true, // force the passive side to accept a "changes" message, even in no conflicts mode.
+			docIDs:                 apr.config.DocIDs,
+			since:                  seq,
+			continuous:             apr.config.Continuous,
+			activeOnly:             apr.config.ActiveOnly,
+			batchSize:              int(apr.config.ChangesBatchSize),
+			channels:               channels,
+			disableRemovalMessages: true,
+			clientType:             clientTypeSGR2,
+			ignoreNoConflicts:      true, // force the passive side to accept a "changes" message, even in no conflicts mode.
 		})
 		// On a normal completion, call complete for the replication
 		if isComplete {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -235,14 +235,15 @@ const (
 )
 
 type sendChangesOptions struct {
-	docIDs            []string
-	since             SequenceID
-	continuous        bool
-	activeOnly        bool
-	batchSize         int
-	channels          base.Set
-	clientType        clientType
-	ignoreNoConflicts bool
+	docIDs                 []string
+	since                  SequenceID
+	continuous             bool
+	activeOnly             bool
+	batchSize              int
+	channels               base.Set
+	clientType             clientType
+	ignoreNoConflicts      bool
+	disableRemovalMessages bool // stops returning a document removal message when the channels are not any of the filtered channels
 }
 
 // Sends all changes since the given sequence
@@ -292,6 +293,9 @@ func (bh *blipHandler) sendChanges(sender *blip.Sender, opts *sendChangesOptions
 			if !strings.HasPrefix(change.ID, "_") {
 				for _, item := range change.Changes {
 					changeRow := []interface{}{change.Seq, change.ID, item["rev"], change.Deleted}
+					if opts.disableRemovalMessages && change.allRemoved {
+						continue
+					}
 					if !change.Deleted {
 						changeRow = changeRow[0:3]
 					}


### PR DESCRIPTION
Removal messages are not sent on push replicates when no filtered channels are in the document channels.
Added a unit test to test this behaviour with and without the document channels being one of the filtered channels.