### PR TITLE
Fix integration tests from 3.0 config PR

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -37,9 +37,7 @@ func (h *handler) handleCreateDB() error {
 	if err != nil {
 		return err
 	}
-	if config.Server == nil {
-		config.Server = &h.server.config.Bootstrap.Server
-	}
+	config.inheritFromBootstrap(h.server.config.Bootstrap)
 	if err := config.setup(dbName); err != nil {
 		return err
 	}
@@ -137,9 +135,7 @@ func (h *handler) handlePutDbConfig() error {
 	if err != nil {
 		return err
 	}
-	if config.Server == nil {
-		config.Server = &h.server.config.Bootstrap.Server
-	}
+	config.inheritFromBootstrap(h.server.config.Bootstrap)
 	if err := config.setup(dbName); err != nil {
 		return err
 	}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2380,7 +2380,6 @@ func TestHandleDBConfig(t *testing.T) {
 	defer rt.Close()
 
 	tb := base.GetTestBucket(t)
-	defer tb.Close()
 
 	bucket := tb.GetName()
 	kvTLSPort := 443

--- a/rest/config.go
+++ b/rest/config.go
@@ -222,6 +222,25 @@ func GetTLSVersionFromString(stringV *string) uint16 {
 	return uint16(DefaultMinimumTLSVersionConst)
 }
 
+// inheritFromBootstrap sets any empty Couchbase Server values from the given bootstrap config.
+func (dbConfig *DbConfig) inheritFromBootstrap(b BootstrapConfig) {
+	if dbConfig.Server == nil {
+		dbConfig.Server = &b.Server
+	}
+	if dbConfig.Username == "" {
+		dbConfig.Username = b.Username
+	}
+	if dbConfig.Password == "" {
+		dbConfig.Password = b.Password
+	}
+	if dbConfig.CertPath == "" {
+		dbConfig.CertPath = b.X509CertPath
+	}
+	if dbConfig.KeyPath == "" {
+		dbConfig.KeyPath = b.X509KeyPath
+	}
+}
+
 func (dbConfig *DbConfig) setup(name string) error {
 
 	dbConfig.Name = name

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -291,22 +291,11 @@ func setupServerConfig(args []string) (config *LegacyServerConfig, err error) {
 	return config, nil
 }
 
-func (config *LegacyServerConfig) setupAndValidateDatabases() (errs error) {
+func (config *LegacyServerConfig) setupAndValidateDatabases() error {
 	if config == nil {
 		return nil
 	}
-
-	for name, dbConfig := range config.Databases {
-
-		if err := dbConfig.setup(name); err != nil {
-			return err
-		}
-
-		if errs = dbConfig.validateSgDbConfig(); errs != nil {
-			return errs
-		}
-	}
-	return nil
+	return config.Databases.SetupAndValidate()
 }
 
 // validate validates the given server config and returns all invalid options as a slice of errors

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -890,7 +890,7 @@ func TestValidateServerContext(t *testing.T) {
 
 	xattrs := base.TestUseXattrs()
 	config := &StartupConfig{}
-	databases := map[string]*DbConfig{
+	databases := DbConfigMap{
 		"db1": {
 			BucketConfig: BucketConfig{
 				Server:   &tb1.BucketSpec.Server,
@@ -926,9 +926,7 @@ func TestValidateServerContext(t *testing.T) {
 		},
 	}
 
-	// TODO
-	// require.Nil(t, config.validate(), "Unexpected error while validating LegacyServerConfig")
-	// require.Nil(t, config.setupAndValidateDatabases(), "Unexpected error while validating databases")
+	require.Nil(t, databases.SetupAndValidate(), "Unexpected error while validating databases")
 
 	sc := NewServerContext(config, false)
 	defer sc.Close()

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -62,6 +62,18 @@ type DatabaseConfig struct {
 	DbConfig
 }
 
+func (dbs DbConfigMap) SetupAndValidate() error {
+	for name, dbConfig := range dbs {
+		if err := dbConfig.setup(name); err != nil {
+			return err
+		}
+		if err := dbConfig.validateSgDbConfig(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (sc *ServerContext) CreateLocalDatabase(dbs DbConfigMap) error {
 	for _, dbConfig := range dbs {
 		dbc := DatabaseConfig{DbConfig: *dbConfig}


### PR DESCRIPTION
- Fix `TestValidateServerContext` by re-adding the dbConfig SetupAndValidate step
- Fix `TestHandleDBConfig` by inheriting bootstrap credentials 

## Integration tests
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/850/