### PR TITLE
Fix Principal History Pruning

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -251,6 +251,7 @@ func (auth *Authenticator) calculateHistory(princName string, invalSeq uint64, i
 	for grantName, grantHistory := range currentHistory {
 		if len(grantHistory.Entries) > maxHistoryEntriesPerGrant {
 			grantHistory.Entries[1].StartSeq = grantHistory.Entries[0].StartSeq
+			grantHistory.Entries = grantHistory.Entries[1:]
 			currentHistory[grantName] = grantHistory
 		}
 	}


### PR DESCRIPTION
Added tests around principal history pruning. 
Also fix to the history length pruning which would merge old entries but not actually remove the oldest.