### PR TITLE
Fix CAR TriggeredBy Behaviour

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1369,7 +1369,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	// Get Principals / Rebuild Seq 40
@@ -1382,7 +1382,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1401,7 +1401,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(40, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(40, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1419,7 +1419,7 @@ func TestRevocationScenario1(t *testing.T) {
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1460,7 +1460,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1476,7 +1476,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1493,7 +1493,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1516,7 +1516,7 @@ func TestRevocationScenario2(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1557,7 +1557,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(55, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(55, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1579,7 +1579,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1596,7 +1596,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1622,7 +1622,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1663,7 +1663,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1682,7 +1682,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
@@ -1697,7 +1697,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1717,7 +1717,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[1])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1756,7 +1756,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1774,7 +1774,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1794,7 +1794,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1833,7 +1833,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	require.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1855,7 +1855,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
@@ -1875,7 +1875,7 @@ func TestRevocationScenario6(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -1913,7 +1913,7 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1941,7 +1941,7 @@ func TestRevocationScenario7(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1955,7 +1955,7 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -1992,7 +1992,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(50, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
@@ -2014,7 +2014,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2052,7 +2052,7 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.addRole(t, auth, "alice", "foo", 65)
@@ -2070,7 +2070,7 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2110,7 +2110,7 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
@@ -2129,7 +2129,7 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2170,7 +2170,7 @@ func TestRevocationScenario11(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -2193,7 +2193,7 @@ func TestRevocationScenario11(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -2237,7 +2237,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
@@ -2253,7 +2253,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(90, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(90, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2297,7 +2297,7 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	// Rebuild seq 110
@@ -2309,7 +2309,7 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2348,7 +2348,7 @@ func TestRevocationScenario14(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	// Ensure that a since 25 shows the revocation
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(25, 0)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(25, 0, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -2356,7 +2356,7 @@ func TestRevocationScenario14(t *testing.T) {
 	aliceUserPrincipal.CanSeeChannel("ch1")
 
 	// Ensure a pull from 45 (same seq as revocation) wouldn't send message
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(45, 0)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(45, 0, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1369,7 +1369,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	// Get Principals / Rebuild Seq 40
@@ -1382,7 +1382,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1401,7 +1401,7 @@ func TestRevocationScenario1(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(40)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(40, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1419,7 +1419,7 @@ func TestRevocationScenario1(t *testing.T) {
 	channelHistory, ok := fooPrincipal.ChannelHistory()["ch1"]
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1460,7 +1460,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1476,7 +1476,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1493,7 +1493,7 @@ func TestRevocationScenario2(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1516,7 +1516,7 @@ func TestRevocationScenario2(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1557,7 +1557,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(55)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(55, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1579,7 +1579,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1596,7 +1596,7 @@ func TestRevocationScenario3(t *testing.T) {
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1622,7 +1622,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1663,7 +1663,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1682,7 +1682,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
@@ -1697,7 +1697,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1717,7 +1717,7 @@ func TestRevocationScenario4(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[1])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1756,7 +1756,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1774,7 +1774,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -1794,7 +1794,7 @@ func TestRevocationScenario5(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 75, EndSeq: 85}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -1833,7 +1833,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	require.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1855,7 +1855,7 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 
@@ -1875,7 +1875,7 @@ func TestRevocationScenario6(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -1913,7 +1913,7 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 45)
@@ -1941,7 +1941,7 @@ func TestRevocationScenario7(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -1955,7 +1955,7 @@ func TestRevocationScenario7(t *testing.T) {
 	assert.Equal(t, 1, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 1, len(fooPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -1992,7 +1992,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(50)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(50, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 55)
@@ -2014,7 +2014,7 @@ func TestRevocationScenario8(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(50, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2052,7 +2052,7 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.addRole(t, auth, "alice", "foo", 65)
@@ -2070,7 +2070,7 @@ func TestRevocationScenario9(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(60, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2110,7 +2110,7 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.addRoleChannels(t, auth, "foo", "ch1", 75)
@@ -2129,7 +2129,7 @@ func TestRevocationScenario10(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(70, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2170,7 +2170,7 @@ func TestRevocationScenario11(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRoleChannel(t, auth, "foo", "ch1", 85)
@@ -2193,7 +2193,7 @@ func TestRevocationScenario11(t *testing.T) {
 
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(80, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(85), revokedChannelsCombined["ch1"])
 }
@@ -2237,7 +2237,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	testMockComputer.removeRole(t, auth, "alice", "foo", 95)
@@ -2253,7 +2253,7 @@ func TestRevocationScenario12(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 65, EndSeq: 95}, userRoleHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(90)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(90, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2297,7 +2297,7 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(5, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 	// Rebuild seq 110
@@ -2309,7 +2309,7 @@ func TestRevocationScenario13(t *testing.T) {
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	assert.Equal(t, 0, len(fooPrincipal.ChannelHistory()))
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(100, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 }
 
@@ -2348,7 +2348,7 @@ func TestRevocationScenario14(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 20, EndSeq: 45}, userRoleHistory.Entries[0])
 
 	// Ensure that a since 25 shows the revocation
-	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(25)
+	revokedChannelsCombined := aliceUserPrincipal.RevokedChannels(25, 0)
 	require.Contains(t, revokedChannelsCombined, "ch1")
 	assert.Equal(t, uint64(45), revokedChannelsCombined["ch1"])
 
@@ -2356,7 +2356,7 @@ func TestRevocationScenario14(t *testing.T) {
 	aliceUserPrincipal.CanSeeChannel("ch1")
 
 	// Ensure a pull from 45 (same seq as revocation) wouldn't send message
-	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(45)
+	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(45, 0)
 	assert.Len(t, revokedChannelsCombined, 0)
 
 }

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -123,7 +123,7 @@ type User interface {
 
 	RoleHistory() TimedSetHistory
 
-	RevokedChannels(since uint64) RevokedChannels
+	RevokedChannels(since uint64, triggeredBy uint64) RevokedChannels
 
 	// Obtains the period over which the user had access to the given channel. Either directly or via a role.
 	ChannelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error)

--- a/auth/principal.go
+++ b/auth/principal.go
@@ -123,7 +123,7 @@ type User interface {
 
 	RoleHistory() TimedSetHistory
 
-	RevokedChannels(since uint64, triggeredBy uint64) RevokedChannels
+	RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels
 
 	// Obtains the period over which the user had access to the given channel. Either directly or via a role.
 	ChannelGrantedPeriods(chanName string) ([]GrantHistorySequencePair, error)

--- a/auth/user.go
+++ b/auth/user.go
@@ -207,14 +207,19 @@ func (revokedChannels RevokedChannels) add(chanName string, triggeredBy uint64) 
 //  - Revoke the role revoked channels
 // Get user:
 //  - Revoke users revoked channels
-func (user *userImpl) RevokedChannels(safeSeq uint64, triggeredBy uint64) RevokedChannels {
+func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy uint64) RevokedChannels {
 	// We always need to check triggeredBy so that we can validate whether we are resuming an interrupted replication
 	// but we also need to calculate another value to check: checkSeq
 	// checkSeq is either the safeSeq which is passed in, or in the event we have a triggeredBy it may mean we need to
 	// resume an interrupted replication so need to 'step back' one sequence. We do, however, need to check the lowest
-	// of the safeSeq and triggeredBy - 1, in case we have a lowSeq.
-	checkSeq := safeSeq
-	if triggeredBy > 0 && checkSeq > triggeredBy-1 {
+	// of the safeSeq and triggeredBy - 1, in the case that we have a lowSeq.
+	checkSeq := since
+
+	if lowSeq > 0 {
+		checkSeq = lowSeq
+	}
+
+	if triggeredBy > 0 && (checkSeq > triggeredBy-1 || lowSeq == 0) {
 		checkSeq = triggeredBy - 1
 	}
 

--- a/db/changes.go
+++ b/db/changes.go
@@ -175,7 +175,8 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 // revokedAt: This is the point at which the channel was revoked from the user. Used here for the triggeredBy value of
 // the.
 // revocationSinceSeq: The point in time at which we need to 'diff' against in order to check what documents we need to
-// revoke. This is used in this function in 'wasDocInChannelAtSeq'.
+// revoke - only documents in the channel at the revocationSinceSeq may have been replicated, and need to be revoked.
+// This is used in this function in 'wasDocInChannelAtSeq'.
 // revokeFrom: This is the point at which we should run the changes feed from to find the documents we should revoke. It
 // is calculated higher up based on whether we are resuming an interrupted feed or not.
 func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {

--- a/db/changes.go
+++ b/db/changes.go
@@ -171,7 +171,14 @@ func (db *Database) AddDocInstanceToChangeEntry(entry *ChangeEntry, doc *Documen
 	}
 }
 
-func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, revokedSeq, revocationSinceSeq uint64, to string) <-chan *ChangeEntry {
+// Parameters
+// revokedAt: This is the point at which the channel was revoked from the user. Used here for the triggeredBy value of
+// the.
+// revocationSinceSeq: The point in time at which we need to 'diff' against in order to check what documents we need to
+// revoke. This is used in this function in 'wasDocInChannelAtSeq'.
+// revokeFrom: This is the point at which we should run the changes feed from to find the documents we should revoke. It
+// is calculated higher up based on whether we are resuming an interrupted feed or not.
+func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, options ChangesOptions, revokedAt, revocationSinceSeq, revokeFrom uint64, to string) <-chan *ChangeEntry {
 	feed := make(chan *ChangeEntry, 1)
 	sinceVal := options.Since.Seq
 
@@ -179,14 +186,12 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 	requestLimit := options.Limit
 
 	paginationOptions := options
-	paginationOptions.Since.Seq = 0
 	paginationOptions.Since.LowSeq = 0
 
-	// If this replication has since been interrupted we'll be given a triggered by seq in the since request and can use
-	// this to resume.
-	if options.Since.TriggeredBy > 0 {
-		paginationOptions.Since.Seq = options.Since.Seq
-	}
+	// For changes feed we can initiate the revocation work from this passed in value.
+	// In the event that we have a interrupted replication we can restart part way through, otherwise we have to
+	// check from 0.
+	paginationOptions.Since.Seq = revokeFrom
 
 	go func() {
 		defer base.FatalPanicHandler()
@@ -224,7 +229,7 @@ func (db *Database) buildRevokedFeed(singleChannelCache SingleChannelCache, opti
 			for _, logEntry := range changes {
 				seqID := SequenceID{
 					Seq:         logEntry.Sequence,
-					TriggeredBy: revokedSeq,
+					TriggeredBy: revokedAt,
 				}
 
 				// We need to check whether a change / document sequence is greater than since.
@@ -778,27 +783,30 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			}
 
 			if options.Revocations && db.user != nil {
-
-				// revocationSinceSeq is the earliest (lowest) value inside of the passed in since sequence i.e. lowest
-				// of lowSeq, triggeredBy and Seq. The value is used to denote the point in time we need to diff against
-				// ie. What has changed in the the time since that sequence and now. This will be used to calculate the
-				// channels to revoke and then passed  into "buildRevokedFeed" to validate whether a document was in the
-				// given channel at the sequence.
-				revocationSinceSeq := options.Since.SafeSequence()
-
-				// We need to do this with triggeredBy - 1 because multiple mutations can have the same 'triggeredBy'
-				// and if we're resuming with a triggeredBy we can't be sure that all of the changes with that
-				// 'triggeredBy' have been processed so need to step back and re-process all changes with that
-				// triggeredBy.
-				// The 'if' check here is checking whether we have a triggeredBy and if we do we should use the lowest
-				// value out of triggeredBy - 1 and the above used SafeSeq (lowSeq if there or regular Seq).
-				if options.Since.TriggeredBy > 0 && revocationSinceSeq > options.Since.TriggeredBy-1 {
-					revocationSinceSeq = options.Since.TriggeredBy - 1
-				}
-
-				channelsToRevoke := db.user.RevokedChannels(revocationSinceSeq)
+				channelsToRevoke := db.user.RevokedChannels(options.Since.SafeSequence(), options.Since.TriggeredBy)
 				for channel, revokedSeq := range channelsToRevoke {
-					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, revokedSeq, revocationSinceSeq, to)
+					revocationSinceSeq := options.Since.SafeSequence()
+					revokeFrom := uint64(0)
+
+					// If we have a triggeredBy sequence:
+					// If channel access was lost at the triggeredBy sequence then replication may have been interrupted
+					// so we need to roll back one sequence to re-send the values with that previous triggeredBy as we
+					// cannot be sure that they were all sent. However, we can get changes from triggeredBy rather than
+					// 0 when finding docs to revoke.
+					// If channel access was after the triggeredBy then we can just use the triggeredBy and need to
+					// check for docs to revoke since 0.
+					if options.Since.TriggeredBy != 0 {
+						if revokedSeq == options.Since.TriggeredBy {
+							revocationSinceSeq = options.Since.TriggeredBy - 1
+							revokeFrom = options.Since.Seq
+						}
+						if revokedSeq > options.Since.TriggeredBy {
+							revocationSinceSeq = options.Since.TriggeredBy
+							revokeFrom = 0
+						}
+					}
+
+					feed := db.buildRevokedFeed(db.changeCache.getChannelCache().getSingleChannelCache(channel), options, revokedSeq, revocationSinceSeq, revokeFrom, to)
 					feeds = append(feeds, feed)
 				}
 			}

--- a/db/changes.go
+++ b/db/changes.go
@@ -783,7 +783,7 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 			}
 
 			if options.Revocations && db.user != nil {
-				channelsToRevoke := db.user.RevokedChannels(options.Since.SafeSequence(), options.Since.TriggeredBy)
+				channelsToRevoke := db.user.RevokedChannels(options.Since.Seq, options.Since.LowSeq, options.Since.TriggeredBy)
 				for channel, revokedSeq := range channelsToRevoke {
 					revocationSinceSeq := options.Since.SafeSequence()
 					revokeFrom := uint64(0)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7711,15 +7711,21 @@ func TestChannelRevocationWithContiguousSequences(t *testing.T) {
 	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate", "channels": "a"})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
 
 	revocationTester.addUserChannel("user", "a")
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.False(t, changes.Results[0].Revoked)
 
 	revocationTester.removeUserChannel("user", "a")
 	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate2", "channels": "a"})
 	changes = revocationTester.getChanges(changes.Last_Seq, 1)
 	assert.Len(t, changes.Results, 1)
+	assert.Equal(t, "doc", changes.Results[0].ID)
+	assert.True(t, changes.Results[0].Revoked)
 }
 
 func TestRevocationWithUserXattrs(t *testing.T) {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7242,14 +7242,14 @@ func TestRevocationResumeAndLowSeqCheck(t *testing.T) {
 	revIDDoc2 = rt.createDocReturnRev(t, "doc2", revIDDoc2, map[string]interface{}{"channels": []string{"ch2"}, "val": "mutate"})
 
 	changes = revocationTester.getChanges(changes.Last_Seq, 2)
-
 	assert.Equal(t, "doc1", changes.Results[0].ID)
+	assert.Equal(t, revIDDoc, changes.Results[0].Changes[0]["rev"])
 	assert.True(t, changes.Results[0].Revoked)
 	assert.Equal(t, "doc2", changes.Results[1].ID)
+	assert.Equal(t, revIDDoc2, changes.Results[1].Changes[0]["rev"])
 	assert.True(t, changes.Results[1].Revoked)
 
 	changes = revocationTester.getChanges("20:40", 1)
-
 	assert.Equal(t, "doc2", changes.Results[0].ID)
 	assert.True(t, changes.Results[0].Revoked)
 
@@ -7590,8 +7590,6 @@ func TestWasDocInChannelAtSeq(t *testing.T) {
 // Test does not directly run ChannelGrantedPeriods but aims to test this through performing revocation operations
 // that will hit the various cases that ChannelGrantedPeriods will handle
 func TestChannelGrantedPeriods(t *testing.T) {
-	t.Skip("Currently hits issue fixed in: https://github.com/couchbase/sync_gateway/pull/5080")
-
 	defer db.SuspendSequenceBatching()()
 	revocationTester, rt := initScenario(t, nil)
 	defer rt.Close()
@@ -7697,6 +7695,89 @@ func TestChannelHistoryPruning(t *testing.T) {
 
 	assert.NotContains(t, role.ChannelHistory(), "a")
 	assert.Contains(t, role.ChannelHistory(), "b")
+}
+
+func TestChannelRevocationWithContiguousSequences(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+	revocationTester, rt := initScenario(t, nil)
+	defer rt.Close()
+
+	revocationTester.addUserChannel("user", "a")
+	revID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": "a"})
+	changes := revocationTester.getChanges(0, 2)
+	assert.Len(t, changes.Results, 2)
+
+	revocationTester.removeUserChannel("user", "a")
+	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate", "channels": "a"})
+	changes = revocationTester.getChanges(changes.Last_Seq, 1)
+	assert.Len(t, changes.Results, 1)
+
+	revocationTester.addUserChannel("user", "a")
+	changes = revocationTester.getChanges(changes.Last_Seq, 1)
+	assert.Len(t, changes.Results, 1)
+
+	revocationTester.removeUserChannel("user", "a")
+	revID = rt.createDocReturnRev(t, "doc", revID, map[string]interface{}{"mutate": "mutate2", "channels": "a"})
+	changes = revocationTester.getChanges(changes.Last_Seq, 1)
+	assert.Len(t, changes.Results, 1)
+}
+
+func TestRevocationWithUserXattrs(t *testing.T) {
+	defer db.SuspendSequenceBatching()()
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	if !base.TestUseXattrs() {
+		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+
+	xattrKey := "channelInfo"
+
+	revocationTester, rt := initScenario(t, &RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			AutoImport:   true,
+			UserXattrKey: xattrKey,
+		},
+		SyncFn: `
+			function (doc, oldDoc, meta){
+				if (doc._id === 'accessDoc' && meta.xattrs.channelInfo !== undefined){
+					for (var key in meta.xattrs.channelInfo.userChannels){
+						access(key, meta.xattrs.channelInfo.userChannels[key]);
+					}
+				}
+				if (doc._id.indexOf("doc") >= 0){				
+					channel(doc.channels);
+				}
+			}`,
+	})
+
+	defer rt.Close()
+
+	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	if !ok {
+		t.Skip("Test requires Couchbase Bucket")
+	}
+
+	resp := rt.SendAdminRequest("PUT", "/db/accessDoc", `{}`)
+	assertStatus(t, resp, http.StatusCreated)
+
+	_, err := gocbBucket.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{"userChannels": map[string]interface{}{"user": "a"}})
+	assert.NoError(t, err)
+
+	_ = rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"channels": []string{"a"}})
+
+	changes := revocationTester.getChanges(0, 2)
+	assert.Len(t, changes.Results, 2)
+
+	_, err = gocbBucket.WriteUserXattr("accessDoc", xattrKey, map[string]interface{}{})
+	assert.NoError(t, err)
+
+	changes = revocationTester.getChanges(changes.Last_Seq, 1)
+	assert.Len(t, changes.Results, 1)
 }
 
 func TestDocChannelSetPruning(t *testing.T) {


### PR DESCRIPTION
Fixes the CAR behaviour when calculating the sequence to 'diff' against when calculating what to revoke and when calculating the value to use in the changes feed for where to revoke from.

Has a couple unit tests to verify this new behaviour.

Also fixes a test currently skipped in https://github.com/couchbase/sync_gateway/pull/5081

http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/860/
One un-related looking test failure.