### PR TITLE
CBG-1535 - Enforce TLS by default

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -35,8 +35,6 @@ import (
 
 // Reproduces CBG-1412 - JSON strings in some responses not being correctly escaped
 func TestPutDocSpecialChar(t *testing.T) {
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
 	testCases := []struct {
 		name         string
 		pathDocID    string
@@ -80,6 +78,8 @@ func TestPutDocSpecialChar(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			rt := NewRestTester(t, nil)
+			defer rt.Close()
 			if testCase.eeOnly && !base.IsEnterpriseEdition() {
 				t.Skipf("Skipping enterprise-only test")
 			}
@@ -92,6 +92,8 @@ func TestPutDocSpecialChar(t *testing.T) {
 	}
 
 	t.Run("Delete Double quote Doc ID", func(t *testing.T) { // Should be done for Local Document deletion when it returns response
+		rt := NewRestTester(t, nil)
+		defer rt.Close()
 		tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", `del"ete"Me`), "{}") // Create the doc to delete
 		assertStatus(t, tr, http.StatusCreated)
 		var putBody struct {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -35,6 +35,8 @@ import (
 
 // Reproduces CBG-1412 - JSON strings in some responses not being correctly escaped
 func TestPutDocSpecialChar(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
 	testCases := []struct {
 		name         string
 		pathDocID    string
@@ -78,8 +80,6 @@ func TestPutDocSpecialChar(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			rt := NewRestTester(t, nil)
-			defer rt.Close()
 			if testCase.eeOnly && !base.IsEnterpriseEdition() {
 				t.Skipf("Skipping enterprise-only test")
 			}
@@ -92,8 +92,6 @@ func TestPutDocSpecialChar(t *testing.T) {
 	}
 
 	t.Run("Delete Double quote Doc ID", func(t *testing.T) { // Should be done for Local Document deletion when it returns response
-		rt := NewRestTester(t, nil)
-		defer rt.Close()
 		tr := rt.SendAdminRequest("PUT", fmt.Sprintf("/db/%s", `del"ete"Me`), "{}") // Create the doc to delete
 		assertStatus(t, tr, http.StatusCreated)
 		var putBody struct {

--- a/rest/config.go
+++ b/rest/config.go
@@ -841,6 +841,11 @@ func (sc *StartupConfig) ValidateInsecureTLSConnection() (err error) {
 			err = fmt.Errorf("a TLS key and cert path must be provided when not allowing insecure TLS connections")
 			return err
 		}
+	} else { // Make sure TLS key and cert is not provided
+		if sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "" {
+			err = fmt.Errorf("cannot use TLS and also use insecure TLS connections")
+			return err
+		}
 	}
 	return nil
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -838,13 +838,11 @@ func (sc *StartupConfig) validateInsecureTLSConnection() (err error) {
 	// Validate SSL is provided if not allowing unsecure connections
 	if sc.API.HTTPS.AllowInsecureTLSConnections == nil || !*sc.API.HTTPS.AllowInsecureTLSConnections {
 		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {
-			err = fmt.Errorf("a TLS key and cert path must be provided when not allowing insecure TLS connections")
-			return err
+			return fmt.Errorf("a TLS key and cert path must be provided when not allowing insecure TLS connections")
 		}
 	} else { // Make sure TLS key and cert is not provided
 		if sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "" {
-			err = fmt.Errorf("cannot use TLS and also use insecure TLS connections")
-			return err
+			return fmt.Errorf("cannot use TLS and also use insecure TLS connections")
 		}
 	}
 	return nil
@@ -862,11 +860,6 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 		return nil, fmt.Errorf("error setting up logging: %v", err)
 	}
 
-	if err := config.validateInsecureTLSConnection(); err != nil {
-		base.Consolef(base.LevelError, base.KeyConfig, err.Error())
-		return nil, err
-	}
-
 	base.FlushLoggerBuffers()
 
 	base.Infof(base.KeyAll, "Logging: Console level: %v", base.ConsoleLogLevel())
@@ -874,6 +867,11 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 	base.Infof(base.KeyAll, "Logging: Redaction level: %s", config.Logging.RedactionLevel)
 
 	if err := setGlobalConfig(config); err != nil {
+		return nil, err
+	}
+
+	if err := config.validateInsecureTLSConnection(); err != nil {
+		base.Consolef(base.LevelError, base.KeyConfig, err.Error())
 		return nil, err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -837,11 +837,11 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	// Validate SSL is provided if not allowing unsecure connections
 	if sc.API.HTTPS.AllowInsecureTLSConnections == nil || !*sc.API.HTTPS.AllowInsecureTLSConnections {
 		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("a TLS key and cert path must be provided when not allowing insecure TLS connections"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("TLS key path and cert path must be provided unless api.https.allow_insecure_tls_connections is set"))
 		}
 	} else { // Make sure TLS key and cert is not provided
 		if sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot use TLS and also use insecure TLS connections"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot use TLS with api.https.allow_insecure_tls_connections set"))
 		}
 	}
 	return errorMessages

--- a/rest/config.go
+++ b/rest/config.go
@@ -830,10 +830,7 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	if sc.Bootstrap.ServerTLSSkipVerify != nil && *sc.Bootstrap.ServerTLSSkipVerify && sc.Bootstrap.CACertPath != "" {
 		errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot skip server TLS validation and use CA Cert"))
 	}
-	return errorMessages
-}
 
-func (sc *StartupConfig) validate() (errorMessages error) {
 	// Validate SSL is provided if not allowing unsecure connections
 	if sc.API.HTTPS.UseTLSClient == nil || *sc.API.HTTPS.UseTLSClient {
 		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {

--- a/rest/config.go
+++ b/rest/config.go
@@ -870,10 +870,6 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 		return nil, err
 	}
 
-	if err := config.validate(); err != nil {
-		return nil, err
-	}
-
 	sc := NewServerContext(config, persistentConfig)
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.

--- a/rest/config.go
+++ b/rest/config.go
@@ -834,7 +834,7 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 }
 
 // Validate insecure connections
-func (sc *StartupConfig) ValidateInsecureTLSConnection() (err error) {
+func (sc *StartupConfig) validateInsecureTLSConnection() (err error) {
 	// Validate SSL is provided if not allowing unsecure connections
 	if sc.API.HTTPS.AllowInsecureTLSConnections == nil || !*sc.API.HTTPS.AllowInsecureTLSConnections {
 		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {
@@ -862,8 +862,8 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 		return nil, fmt.Errorf("error setting up logging: %v", err)
 	}
 
-	if err := config.ValidateInsecureTLSConnection(); err != nil {
-		log.Printf("[ERR] Error validating configuration: %v", err)
+	if err := config.validateInsecureTLSConnection(); err != nil {
+		base.Consolef(base.LevelError, base.KeyConfig, err.Error())
 		return nil, err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -871,7 +871,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 	}
 
 	if err := config.validateInsecureTLSConnection(); err != nil {
-		base.Consolef(base.LevelError, base.KeyConfig, err.Error())
+		base.Errorf("Config: %v", err)
 		return nil, err
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -835,13 +835,13 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 
 func (sc *StartupConfig) validate() (errorMessages error) {
 	// Validate SSL is provided if not allowing unsecure connections
-	if sc.API.HTTPS.AllowInsecureTLSConnections == nil || !*sc.API.HTTPS.AllowInsecureTLSConnections {
+	if sc.API.HTTPS.UseTLSClient == nil || *sc.API.HTTPS.UseTLSClient {
 		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("TLS key path and cert path must be provided unless api.https.allow_insecure_tls_connections is set"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("TLS key path and cert path must be provided when api.https.use_tls_client is set"))
 		}
 	} else { // Make sure TLS key and cert is not provided
 		if sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot use TLS with api.https.allow_insecure_tls_connections set"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot use TLS when api.https.use_tls_client is false"))
 		}
 	}
 	return errorMessages

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -16,6 +16,8 @@ import (
 // JSON object that defines the server configuration.
 type LegacyServerConfig struct {
 	TLSMinVersion                             *string                        `json:"tls_minimum_version,omitempty"`    // Set TLS Version
+	UseTLSServer                              *bool                          `json:"use_tls_server,omitempty"`         // Use TLS for CBS <> SGW communications
+	UseTLSClient                              *bool                          `json:"use_tls_client,omitempty"`         // Use TLS for REST API
 	Interface                                 *string                        `json:",omitempty"`                       // Interface to bind REST API to, default ":4984"
 	ServerTLSSkipVerify                       *bool                          `json:"server_tls_skip_verify,omitempty"` // Allow empty server CA Cert Path without attempting to use system root pool
 	SSLCert                                   *string                        `json:",omitempty"`                       // Path to SSL cert file, or nil
@@ -107,6 +109,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			X509CertPath:        dbConfig.CertPath,
 			X509KeyPath:         dbConfig.KeyPath,
 			ServerTLSSkipVerify: lc.ServerTLSSkipVerify,
+			UseTLSServer:        lc.UseTLSServer,
 		}
 		break
 	}
@@ -120,6 +123,9 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			AdminInterfaceAuthentication:              lc.AdminInterfaceAuthentication,
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
+			HTTPS: HTTPSConfig{
+				UseTLSClient: lc.UseTLSClient,
+			},
 		},
 		Logging: LoggingConfig{},
 		Auth: AuthConfig{
@@ -369,8 +375,8 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 
 	_ = flagSet.Bool("api.admin_interface_authentication", true, "")
 	_ = flagSet.Bool("api.metrics_interface_authentication", true, "")
-	_ = flagSet.Bool("bootstrap.use_tls_server", false, "")
-	_ = flagSet.Bool("api.https.use_tls_client", false, "")
+	_ = flagSet.Bool("bootstrap.use_tls_server", true, "")
+	_ = flagSet.Bool("api.https.use_tls_client", true, "")
 
 	addr := flagSet.String("interface", DefaultPublicInterface, "Address to bind to")
 	authAddr := flagSet.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -100,13 +100,14 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			continue
 		}
 		bsc = &BootstrapConfig{
-			Server:              *dbConfig.Server,
-			Username:            dbConfig.Username,
-			Password:            dbConfig.Password,
-			CACertPath:          dbConfig.CACertPath,
-			X509CertPath:        dbConfig.CertPath,
-			X509KeyPath:         dbConfig.KeyPath,
-			ServerTLSSkipVerify: lc.ServerTLSSkipVerify,
+			Server:                         *dbConfig.Server,
+			Username:                       dbConfig.Username,
+			Password:                       dbConfig.Password,
+			CACertPath:                     dbConfig.CACertPath,
+			X509CertPath:                   dbConfig.CertPath,
+			X509KeyPath:                    dbConfig.KeyPath,
+			ServerTLSSkipVerify:            lc.ServerTLSSkipVerify,
+			AllowInsecureServerConnections: base.BoolPtr(true),
 		}
 		break
 	}
@@ -120,6 +121,9 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			AdminInterfaceAuthentication:              lc.AdminInterfaceAuthentication,
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
+			HTTPS: HTTPSConfig{
+				AllowInsecureTLSConnections: base.BoolPtr(true),
+			},
 		},
 		Logging: LoggingConfig{},
 		Auth: AuthConfig{

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -100,14 +100,13 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			continue
 		}
 		bsc = &BootstrapConfig{
-			Server:                         *dbConfig.Server,
-			Username:                       dbConfig.Username,
-			Password:                       dbConfig.Password,
-			CACertPath:                     dbConfig.CACertPath,
-			X509CertPath:                   dbConfig.CertPath,
-			X509KeyPath:                    dbConfig.KeyPath,
-			ServerTLSSkipVerify:            lc.ServerTLSSkipVerify,
-			AllowInsecureServerConnections: base.BoolPtr(true),
+			Server:              *dbConfig.Server,
+			Username:            dbConfig.Username,
+			Password:            dbConfig.Password,
+			CACertPath:          dbConfig.CACertPath,
+			X509CertPath:        dbConfig.CertPath,
+			X509KeyPath:         dbConfig.KeyPath,
+			ServerTLSSkipVerify: lc.ServerTLSSkipVerify,
 		}
 		break
 	}
@@ -121,9 +120,6 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			AdminInterfaceAuthentication:              lc.AdminInterfaceAuthentication,
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
-			HTTPS: HTTPSConfig{
-				AllowInsecureTLSConnections: base.BoolPtr(true),
-			},
 		},
 		Logging: LoggingConfig{},
 		Auth: AuthConfig{

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -484,6 +484,8 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 		}
 
 		config = &LegacyServerConfig{
+			UseTLSServer:     base.BoolPtr(true),
+			UseTLSClient:     base.BoolPtr(true),
 			Interface:        addr,
 			AdminInterface:   authAddr,
 			ProfileInterface: profAddr,

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -22,9 +22,10 @@ const (
 func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 	return StartupConfig{
 		Bootstrap: BootstrapConfig{
-			ConfigGroupID:         persistentConfigDefaultGroupID,
-			ConfigUpdateFrequency: *base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
-			ServerTLSSkipVerify:   base.BoolPtr(false),
+			ConfigGroupID:                  persistentConfigDefaultGroupID,
+			ConfigUpdateFrequency:          *base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
+			ServerTLSSkipVerify:            base.BoolPtr(false),
+			AllowInsecureServerConnections: base.BoolPtr(false),
 		},
 		API: APIConfig{
 			PublicInterface:    DefaultPublicInterface,
@@ -33,7 +34,8 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			MaximumConnections: DefaultMaxIncomingConnections,
 			CompressResponses:  base.BoolPtr(true),
 			HTTPS: HTTPSConfig{
-				TLSMinimumVersion: "tlsv1.2",
+				TLSMinimumVersion:           "tlsv1.2",
+				AllowInsecureTLSConnections: base.BoolPtr(false),
 			},
 			ReadHeaderTimeout:                         base.NewConfigDuration(base.DefaultReadHeaderTimeout),
 			IdleTimeout:                               base.NewConfigDuration(base.DefaultIdleTimeout),
@@ -74,15 +76,16 @@ type StartupConfig struct {
 
 // BootstrapConfig describes the set of properties required in order to bootstrap config from Couchbase Server.
 type BootstrapConfig struct {
-	ConfigGroupID         string              `json:"group_id,omitempty"                help:"The config group ID to use when discovering databases. Allows for non-homogenous configuration"`
-	ConfigUpdateFrequency base.ConfigDuration `json:"config_update_frequency,omitempty" help:"How often to poll Couchbase Server for new config changes. Default: 10s"`
-	Server                string              `json:"server,omitempty"                  help:"Couchbase Server connection string/URL"`
-	Username              string              `json:"username,omitempty"                help:"Username for authenticating to server"`
-	Password              string              `json:"password,omitempty"                help:"Password for authenticating to server"`
-	CACertPath            string              `json:"ca_cert_path,omitempty"            help:"Root CA cert path for TLS connection"`
-	X509CertPath          string              `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
-	X509KeyPath           string              `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
-	ServerTLSSkipVerify   *bool               `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
+	ConfigGroupID                  string              `json:"group_id,omitempty"                help:"The config group ID to use when discovering databases. Allows for non-homogenous configuration"`
+	ConfigUpdateFrequency          base.ConfigDuration `json:"config_update_frequency,omitempty" help:"How often to poll Couchbase Server for new config changes. Default: 10s"`
+	Server                         string              `json:"server,omitempty"                  help:"Couchbase Server connection string/URL"`
+	Username                       string              `json:"username,omitempty"                help:"Username for authenticating to server"`
+	Password                       string              `json:"password,omitempty"                help:"Password for authenticating to server"`
+	CACertPath                     string              `json:"ca_cert_path,omitempty"            help:"Root CA cert path for TLS connection"`
+	X509CertPath                   string              `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
+	X509KeyPath                    string              `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
+	ServerTLSSkipVerify            *bool               `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
+	AllowInsecureServerConnections *bool               `json:"allow_insecure_server_connections,omitempty" help:"Allow insecure connections to and from Couchbase Server"`
 }
 
 type APIConfig struct {
@@ -110,9 +113,10 @@ type APIConfig struct {
 }
 
 type HTTPSConfig struct {
-	TLSMinimumVersion string `json:"tls_minimum_version,omitempty"     help:"The minimum allowable TLS version for the REST APIs"`
-	TLSCertPath       string `json:"tls_cert_path,omitempty" help:"The TLS cert file to use for the REST APIs"`
-	TLSKeyPath        string `json:"tls_key_path,omitempty"  help:"The TLS key file to use for the REST APIs"`
+	TLSMinimumVersion           string `json:"tls_minimum_version,omitempty"     help:"The minimum allowable TLS version for the REST APIs"`
+	TLSCertPath                 string `json:"tls_cert_path,omitempty" help:"The TLS cert file to use for the REST APIs"`
+	TLSKeyPath                  string `json:"tls_key_path,omitempty"  help:"The TLS key file to use for the REST APIs"`
+	AllowInsecureTLSConnections *bool  `json:"allow_insecure_tls_connections" help:"Allow TLS to be optional for the REST APIs"`
 }
 
 type CORSConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -116,7 +116,7 @@ type HTTPSConfig struct {
 	TLSMinimumVersion           string `json:"tls_minimum_version,omitempty"     help:"The minimum allowable TLS version for the REST APIs"`
 	TLSCertPath                 string `json:"tls_cert_path,omitempty" help:"The TLS cert file to use for the REST APIs"`
 	TLSKeyPath                  string `json:"tls_key_path,omitempty"  help:"The TLS key file to use for the REST APIs"`
-	AllowInsecureTLSConnections *bool  `json:"allow_insecure_tls_connections" help:"Allow TLS to be optional for the REST APIs"`
+	AllowInsecureTLSConnections *bool  `json:"allow_insecure_tls_connections" help:"Allows REST APIs to start without TLS"`
 }
 
 type CORSConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -85,7 +85,7 @@ type BootstrapConfig struct {
 	ServerTLSSkipVerify   *bool               `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
 	X509CertPath          string              `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
 	X509KeyPath           string              `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
-	UseTLSServer          *bool               `json:"use_tls_server,omitempty"          help:"Allow insecure connections to and from Couchbase Server"`
+	UseTLSServer          *bool               `json:"use_tls_server,omitempty"          help:"Forces the connection to Couchbase Server to use TLS"`
 }
 
 type APIConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -116,7 +116,7 @@ type HTTPSConfig struct {
 	TLSMinimumVersion string `json:"tls_minimum_version,omitempty" help:"The minimum allowable TLS version for the REST APIs"`
 	TLSCertPath       string `json:"tls_cert_path,omitempty"       help:"The TLS cert file to use for the REST APIs"`
 	TLSKeyPath        string `json:"tls_key_path,omitempty"        help:"The TLS key file to use for the REST APIs"`
-	UseTLSClient      *bool  `json:"use_tls_client,omitempty"      help:"Allows REST APIs to start without TLS"`
+	UseTLSClient      *bool  `json:"use_tls_client,omitempty"      help:"Forces the REST APIs to use TLS/HTTPS"`
 }
 
 type CORSConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -22,10 +22,10 @@ const (
 func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 	return StartupConfig{
 		Bootstrap: BootstrapConfig{
-			ConfigGroupID:                  persistentConfigDefaultGroupID,
-			ConfigUpdateFrequency:          *base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
-			ServerTLSSkipVerify:            base.BoolPtr(false),
-			AllowInsecureServerConnections: base.BoolPtr(false),
+			ConfigGroupID:         persistentConfigDefaultGroupID,
+			ConfigUpdateFrequency: *base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
+			ServerTLSSkipVerify:   base.BoolPtr(false),
+			UseTLSServer:          base.BoolPtr(true),
 		},
 		API: APIConfig{
 			PublicInterface:    DefaultPublicInterface,
@@ -34,8 +34,8 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			MaximumConnections: DefaultMaxIncomingConnections,
 			CompressResponses:  base.BoolPtr(true),
 			HTTPS: HTTPSConfig{
-				TLSMinimumVersion:           "tlsv1.2",
-				AllowInsecureTLSConnections: base.BoolPtr(false),
+				TLSMinimumVersion: "tlsv1.2",
+				UseTLSClient:      base.BoolPtr(true),
 			},
 			ReadHeaderTimeout:                         base.NewConfigDuration(base.DefaultReadHeaderTimeout),
 			IdleTimeout:                               base.NewConfigDuration(base.DefaultIdleTimeout),
@@ -76,16 +76,16 @@ type StartupConfig struct {
 
 // BootstrapConfig describes the set of properties required in order to bootstrap config from Couchbase Server.
 type BootstrapConfig struct {
-	ConfigGroupID                  string              `json:"group_id,omitempty"                help:"The config group ID to use when discovering databases. Allows for non-homogenous configuration"`
-	ConfigUpdateFrequency          base.ConfigDuration `json:"config_update_frequency,omitempty" help:"How often to poll Couchbase Server for new config changes. Default: 10s"`
-	Server                         string              `json:"server,omitempty"                  help:"Couchbase Server connection string/URL"`
-	Username                       string              `json:"username,omitempty"                help:"Username for authenticating to server"`
-	Password                       string              `json:"password,omitempty"                help:"Password for authenticating to server"`
-	CACertPath                     string              `json:"ca_cert_path,omitempty"            help:"Root CA cert path for TLS connection"`
-	X509CertPath                   string              `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
-	X509KeyPath                    string              `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
-	ServerTLSSkipVerify            *bool               `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
-	AllowInsecureServerConnections *bool               `json:"allow_insecure_server_connections,omitempty" help:"Allow insecure connections to and from Couchbase Server"`
+	ConfigGroupID         string              `json:"group_id,omitempty"                help:"The config group ID to use when discovering databases. Allows for non-homogenous configuration"`
+	ConfigUpdateFrequency base.ConfigDuration `json:"config_update_frequency,omitempty" help:"How often to poll Couchbase Server for new config changes. Default: 10s"`
+	Server                string              `json:"server,omitempty"                  help:"Couchbase Server connection string/URL"`
+	Username              string              `json:"username,omitempty"                help:"Username for authenticating to server"`
+	Password              string              `json:"password,omitempty"                help:"Password for authenticating to server"`
+	CACertPath            string              `json:"ca_cert_path,omitempty"            help:"Root CA cert path for TLS connection"`
+	ServerTLSSkipVerify   *bool               `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
+	X509CertPath          string              `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
+	X509KeyPath           string              `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
+	UseTLSServer          *bool               `json:"use_tls_server,omitempty"          help:"Allow insecure connections to and from Couchbase Server"`
 }
 
 type APIConfig struct {
@@ -113,10 +113,10 @@ type APIConfig struct {
 }
 
 type HTTPSConfig struct {
-	TLSMinimumVersion           string `json:"tls_minimum_version,omitempty"     help:"The minimum allowable TLS version for the REST APIs"`
-	TLSCertPath                 string `json:"tls_cert_path,omitempty" help:"The TLS cert file to use for the REST APIs"`
-	TLSKeyPath                  string `json:"tls_key_path,omitempty"  help:"The TLS key file to use for the REST APIs"`
-	AllowInsecureTLSConnections *bool  `json:"allow_insecure_tls_connections" help:"Allows REST APIs to start without TLS"`
+	TLSMinimumVersion string `json:"tls_minimum_version,omitempty" help:"The minimum allowable TLS version for the REST APIs"`
+	TLSCertPath       string `json:"tls_cert_path,omitempty"       help:"The TLS cert file to use for the REST APIs"`
+	TLSKeyPath        string `json:"tls_key_path,omitempty"        help:"The TLS key file to use for the REST APIs"`
+	UseTLSClient      *bool  `json:"use_tls_client,omitempty"      help:"Allows REST APIs to start without TLS"`
 }
 
 type CORSConfig struct {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -817,7 +817,10 @@ func TestValidateServerContext(t *testing.T) {
 	tb2User, tb2Password, _ := tb2.BucketSpec.Auth.GetCredentials()
 
 	xattrs := base.TestUseXattrs()
-	config := &StartupConfig{Bootstrap: BootstrapConfig{AllowInsecureServerConnections: base.BoolPtr(true)}}
+	config := &StartupConfig{
+		API:       APIConfig{HTTPS: HTTPSConfig{AllowInsecureTLSConnections: base.BoolPtr(true)}},
+		Bootstrap: BootstrapConfig{AllowInsecureServerConnections: base.BoolPtr(true)},
+	}
 	databases := DbConfigMap{
 		"db1": {
 			BucketConfig: BucketConfig{

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1270,6 +1270,7 @@ func TestUseTLSClient(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			config := DefaultStartupConfig("")
 			config.API.HTTPS.UseTLSClient = &test.useTLSClient
+			config.Bootstrap.Server = base.UnitTestUrl()
 			if test.tlsKey {
 				config.API.HTTPS.TLSKeyPath = "test.key"
 			}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1274,7 +1274,8 @@ func TestAllowInsecureTLSConnections(t *testing.T) {
 			}
 			sc, err := setupServerContext(&config, false)
 			if test.expectError != nil {
-				assert.Error(t, err, *test.expectError)
+				assert.Error(t, err)
+				assert.Equal(t, err.Error(), *test.expectError)
 				require.Nil(t, sc)
 			} else {
 				assert.NoError(t, err)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1275,7 +1275,7 @@ func TestAllowInsecureTLSConnections(t *testing.T) {
 			sc, err := setupServerContext(&config, false)
 			if test.expectError != nil {
 				assert.Error(t, err)
-				assert.Equal(t, err.Error(), *test.expectError)
+				assert.Contains(t, err.Error(), *test.expectError)
 				require.Nil(t, sc)
 			} else {
 				assert.NoError(t, err)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1208,8 +1208,8 @@ func TestSetupServerContext(t *testing.T) {
 // CBG-1535
 func TestAllowInsecureTLSConnections(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
-	errorTLSNotProvided := "a TLS key and cert path must be provided when not allowing insecure TLS connections"
-	errorTLSProvidedButInsecure := "cannot use TLS and also use insecure TLS connections"
+	errorTLSNotProvided := "TLS key path and cert path must be provided unless api.https.allow_insecure_tls_connections is set"
+	errorTLSProvidedButInsecure := "cannot use TLS with api.https.allow_insecure_tls_connections set"
 	testCases := []struct {
 		name                        string
 		tlsKey                      bool

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -818,8 +818,8 @@ func TestValidateServerContext(t *testing.T) {
 
 	xattrs := base.TestUseXattrs()
 	config := &StartupConfig{
-		API:       APIConfig{HTTPS: HTTPSConfig{AllowInsecureTLSConnections: base.BoolPtr(true)}},
-		Bootstrap: BootstrapConfig{AllowInsecureServerConnections: base.BoolPtr(true)},
+		API:       APIConfig{HTTPS: HTTPSConfig{UseTLSClient: base.BoolPtr(true)}},
+		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(true)},
 	}
 	databases := DbConfigMap{
 		"db1": {
@@ -1197,7 +1197,7 @@ func TestSetupServerContext(t *testing.T) {
 	t.Run("Create server context with a valid configuration", func(t *testing.T) {
 		config := DefaultStartupConfig("")
 		config.Bootstrap.Server = base.UnitTestUrl() // Valid config requires server to be explicitly defined
-		config.API.HTTPS.AllowInsecureTLSConnections = base.BoolPtr(true)
+		config.API.HTTPS.UseTLSClient = base.BoolPtr(false)
 		sc, err := setupServerContext(&config, false)
 		require.NoError(t, err)
 		require.NotNil(t, sc)
@@ -1205,67 +1205,71 @@ func TestSetupServerContext(t *testing.T) {
 	})
 }
 
-// CBG-1535
-func TestAllowInsecureTLSConnections(t *testing.T) {
+// CBG-1535 - Test api.http.UseTLSClient option
+func TestUseTLSClient(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
-	errorTLSNotProvided := "TLS key path and cert path must be provided unless api.https.allow_insecure_tls_connections is set"
-	errorTLSProvidedButInsecure := "cannot use TLS with api.https.allow_insecure_tls_connections set"
+	errorTLSNotProvided := "TLS key path and cert path must be provided when api.https.use_tls_client is set"
+	errorTLSProvidedButInsecure := "cannot use TLS when api.https.use_tls_client is false"
 	testCases := []struct {
-		name                        string
-		tlsKey                      bool
-		tlsCert                     bool
-		allowInsecureTLSConnections bool
-		expectError                 *string
+		name         string
+		tlsKey       bool
+		tlsCert      bool
+		useTLSClient bool
+		expectError  *string
 	}{
 		{
-			name:        "Nothing provided",
-			expectError: &errorTLSNotProvided,
+			name:         "Nothing provided",
+			useTLSClient: true,
+			expectError:  &errorTLSNotProvided,
 		},
 		{
-			name:                        "No TLS provided, Allowing Insecure",
-			allowInsecureTLSConnections: true,
-			expectError:                 nil,
+			name:         "No TLS provided, Allowing Insecure",
+			useTLSClient: false,
+			expectError:  nil,
 		},
 		{
-			name:        "TLS Key but no cert provided",
-			tlsKey:      true,
-			expectError: &errorTLSNotProvided,
+			name:         "TLS Key but no cert provided",
+			useTLSClient: true,
+			tlsKey:       true,
+			expectError:  &errorTLSNotProvided,
 		},
 		{
-			name:        "TLS Cert but no key provided",
-			tlsCert:     true,
-			expectError: &errorTLSNotProvided,
+			name:         "TLS Cert but no key provided",
+			useTLSClient: true,
+			tlsCert:      true,
+			expectError:  &errorTLSNotProvided,
 		},
 		{
-			name:        "TLS Cert and key provided",
-			tlsKey:      true,
-			tlsCert:     true,
-			expectError: nil,
+			name:         "TLS Cert and key provided",
+			useTLSClient: true,
+			tlsKey:       true,
+			tlsCert:      true,
+			expectError:  nil,
 		},
 		{
-			name:                        "TLS Cert and key provided, and allowing insecure",
-			tlsKey:                      true,
-			tlsCert:                     true,
-			allowInsecureTLSConnections: true,
-			expectError:                 &errorTLSProvidedButInsecure,
+			name:         "TLS Cert and key provided, and allowing insecure",
+			tlsKey:       true,
+			tlsCert:      true,
+			useTLSClient: false,
+			expectError:  &errorTLSProvidedButInsecure,
 		},
 		{
-			name:                        "TLS Key but no cert provided, but allowing insecure",
-			tlsKey:                      true,
-			allowInsecureTLSConnections: true,
-			expectError:                 &errorTLSProvidedButInsecure,
+			name:         "TLS Key but no cert provided, but allowing insecure",
+			tlsKey:       true,
+			useTLSClient: false,
+			expectError:  &errorTLSProvidedButInsecure,
 		},
 		{
-			name:                        "TLS cert but no key provided, but allowing insecure",
-			tlsKey:                      true,
-			allowInsecureTLSConnections: true,
-			expectError:                 &errorTLSProvidedButInsecure,
+			name:         "TLS cert but no key provided, but allowing insecure",
+			tlsKey:       true,
+			useTLSClient: false,
+			expectError:  &errorTLSProvidedButInsecure,
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			config := DefaultStartupConfig("")
-			config.API.HTTPS.AllowInsecureTLSConnections = &test.allowInsecureTLSConnections
+			config.API.HTTPS.UseTLSClient = &test.useTLSClient
 			if test.tlsKey {
 				config.API.HTTPS.TLSKeyPath = "test.key"
 			}
@@ -1274,7 +1278,7 @@ func TestAllowInsecureTLSConnections(t *testing.T) {
 			}
 			sc, err := setupServerContext(&config, false)
 			if test.expectError != nil {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), *test.expectError)
 				require.Nil(t, sc)
 			} else {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -818,8 +818,7 @@ func TestValidateServerContext(t *testing.T) {
 
 	xattrs := base.TestUseXattrs()
 	config := &StartupConfig{
-		API:       APIConfig{HTTPS: HTTPSConfig{UseTLSClient: base.BoolPtr(true)}},
-		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(true)},
+		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(false)},
 	}
 	databases := DbConfigMap{
 		"db1": {

--- a/rest/main.go
+++ b/rest/main.go
@@ -69,10 +69,8 @@ func serverMain(ctx context.Context, osArgs []string) error {
 			flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
 		}
 	})
-
-	// Actually hook this up @Isaac
-	_ = useTLSServer
-	_ = useTLSClient
+	flagStartupConfig.Bootstrap.AllowInsecureServerConnections = useTLSServer
+	flagStartupConfig.API.HTTPS.AllowInsecureTLSConnections = useTLSClient
 
 	if *disablePersistentConfigFlag {
 		return legacyServerMain(osArgs, &flagStartupConfig)

--- a/rest/main.go
+++ b/rest/main.go
@@ -69,8 +69,8 @@ func serverMain(ctx context.Context, osArgs []string) error {
 			flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
 		}
 	})
-	flagStartupConfig.Bootstrap.AllowInsecureServerConnections = useTLSServer
-	flagStartupConfig.API.HTTPS.AllowInsecureTLSConnections = useTLSClient
+	flagStartupConfig.Bootstrap.UseTLSServer = useTLSServer
+	flagStartupConfig.API.HTTPS.UseTLSClient = useTLSClient
 
 	if *disablePersistentConfigFlag {
 		return legacyServerMain(osArgs, &flagStartupConfig)

--- a/rest/main.go
+++ b/rest/main.go
@@ -61,16 +61,19 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	}
 
 	// TODO: Be removed in a future commit once flags are sorted
+	// Only override config value if user explicitly set flag
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "api.admin_interface_authentication":
 			flagStartupConfig.API.AdminInterfaceAuthentication = adminInterfaceAuthFlag
 		case "api.metrics_interface_authentication":
 			flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
+		case "bootstrap.use_tls_server":
+			flagStartupConfig.Bootstrap.UseTLSServer = useTLSServer
+		case "api.https.use_tls_client":
+			flagStartupConfig.API.HTTPS.UseTLSClient = useTLSClient
 		}
 	})
-	flagStartupConfig.Bootstrap.UseTLSServer = useTLSServer
-	flagStartupConfig.API.HTTPS.UseTLSClient = useTLSClient
 
 	if *disablePersistentConfigFlag {
 		return legacyServerMain(osArgs, &flagStartupConfig)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -345,11 +345,11 @@ func validateServerTLS(spec base.BucketSpec, config *StartupConfig) (err error) 
 	secure := spec.IsTLS()
 	if config.Bootstrap.AllowInsecureServerConnections == nil || !*config.Bootstrap.AllowInsecureServerConnections {
 		if !secure && !spec.IsWalrusBucket() {
-			return fmt.Errorf("couchbase server URL must use secure protocol when disallowing insecure server connections. Current URL: %s", spec.Server)
+			return fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out using bootstrap.allow_insecure_server_connections. Current URL: %s", spec.Server)
 		}
 	} else {
 		if secure { // If using secure protocol while AllowInsecureServerConnections flag is set, error as user probably forgot to turn it off
-			return fmt.Errorf("couchbase server URL cannot use secure protocol while allowing insecure server connections. Current URL: %s", spec.Server)
+			return fmt.Errorf("Couchbase server URL cannot use secure protocol while bootstrap.allow_insecure_server_connections is set. Current URL: %s", spec.Server)
 		}
 	}
 	return nil

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -343,13 +343,13 @@ func GetBucketSpec(config *DbConfig, serverConfig *StartupConfig) (spec base.Buc
 // validateServerTLS checks if a secure protocol should be enforced and then errors if a secure protocol should or shouldn't be used based on the config
 func validateServerTLS(spec base.BucketSpec, config *StartupConfig) (err error) {
 	secure := spec.IsTLS()
-	if config.Bootstrap.AllowInsecureServerConnections == nil || !*config.Bootstrap.AllowInsecureServerConnections {
+	if config.Bootstrap.UseTLSServer == nil || *config.Bootstrap.UseTLSServer {
 		if !secure && !spec.IsWalrusBucket() {
-			return fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out using bootstrap.allow_insecure_server_connections. Current URL: %s", spec.Server)
+			return fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %s", spec.Server)
 		}
 	} else {
-		if secure { // If using secure protocol while AllowInsecureServerConnections flag is set, error as user probably forgot to turn it off
-			return fmt.Errorf("Couchbase server URL cannot use secure protocol while bootstrap.allow_insecure_server_connections is set. Current URL: %s", spec.Server)
+		if secure { // If using secure protocol while UseTLSServer flag is set, error as user probably forgot to turn it off
+			return fmt.Errorf("Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %s", spec.Server)
 		}
 	}
 	return nil

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -369,6 +369,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		return nil, err
 	}
 
+	if sc.config.Bootstrap.AllowInsecureServerConnections == nil || !*sc.config.Bootstrap.AllowInsecureServerConnections {
+		if !spec.IsTLS() && !spec.IsWalrusBucket() {
+			return nil, fmt.Errorf("couchbase server URL must use secure protocol when disallowing insecure server connections. Current URL: %s", spec.Server)
+		}
+	}
+
 	// Connect to bucket
 	base.Infof(base.KeyAll, "Opening db /%s as bucket %q, pool %q, server <%s>",
 		base.MD(dbName), base.MD(spec.BucketName), base.SD(base.DefaultPool), base.SD(spec.Server))

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -369,9 +369,14 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		return nil, err
 	}
 
+	secure := spec.IsTLS()
 	if sc.config.Bootstrap.AllowInsecureServerConnections == nil || !*sc.config.Bootstrap.AllowInsecureServerConnections {
-		if !spec.IsTLS() && !spec.IsWalrusBucket() {
+		if !secure && !spec.IsWalrusBucket() {
 			return nil, fmt.Errorf("couchbase server URL must use secure protocol when disallowing insecure server connections. Current URL: %s", spec.Server)
+		}
+	} else {
+		if secure { // If using secure protocol while AllowInsecureServerConnections flag is set, error as user probably forgot to turn it off
+			return nil, fmt.Errorf("couchbase server URL cannot use secure protocol while allowing insecure server connections. Current URL: %s", spec.Server)
 		}
 	}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -516,19 +516,15 @@ func TestAllowInsecureServerConnections(t *testing.T) {
 
 			config.API.HTTPS.AllowInsecureTLSConnections = base.BoolPtr(true)
 			sc := NewServerContext(&config, false)
-			databaseConfig := DatabaseConfig{
-				DbConfig: DbConfig{
-					Name: "test",
-					BucketConfig: BucketConfig{
-						Server:   &test.server,
-						Username: "test",
-						Password: "test",
-						Bucket:   base.StringPtr("test"),
-					},
+			dbConfig := DbConfig{
+				BucketConfig: BucketConfig{
+					Server: &test.server,
 				},
 			}
+			spec, err := GetBucketSpec(&dbConfig)
+			require.Nil(t, err)
 			// Run test
-			_, err := sc._getOrAddDatabaseFromConfig(databaseConfig, false)
+			err = validateServerTLS(spec, &config)
 
 			if test.expectedError != nil {
 				assert.Error(t, err)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -444,8 +444,8 @@ func TestTLSSkipVerifyGetBucketSpec(t *testing.T) {
 
 func TestAllowInsecureServerConnections(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
-	errorMustBeSecure := "couchbase server URL must use secure protocol when disallowing insecure server connections. Current URL: %v"
-	errorAllowInsecureAndBeSecure := "couchbase server URL cannot use secure protocol while allowing insecure server connections. Current URL: %v"
+	errorMustBeSecure := "Must use secure scheme in Couchbase Server URL, or opt out using bootstrap.allow_insecure_server_connections. Current URL: %v"
+	errorAllowInsecureAndBeSecure := "Couchbase server URL cannot use secure protocol while bootstrap.allow_insecure_server_connections is set. Current URL: %v"
 	testCases := []struct {
 		name                           string
 		allowInsecureServerConnections bool

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -110,8 +110,8 @@ func TestAllDatabaseNames(t *testing.T) {
 	defer tb2.Close()
 
 	serverConfig := &StartupConfig{
-		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(true)},
-		API:       APIConfig{HTTPS: HTTPSConfig{UseTLSClient: base.BoolPtr(true)}, CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+		Bootstrap: BootstrapConfig{UseTLSServer: base.BoolPtr(false)},
+		API:       APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(serverConfig, false)
 	defer serverContext.Close()
 
@@ -515,7 +515,6 @@ func TestUseTLSServer(t *testing.T) {
 			config := DefaultStartupConfig("")
 			config.Bootstrap.UseTLSServer = &test.useTLSServer
 
-			config.API.HTTPS.UseTLSClient = base.BoolPtr(true)
 			sc := NewServerContext(&config, false)
 			dbConfig := DbConfig{
 				BucketConfig: BucketConfig{

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -303,6 +303,7 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 	config.API.MetricsInterface = "127.0.0.1:24986"
 
 	config.Bootstrap.Server = base.UnitTestUrl()
+	config.API.HTTPS.UseTLSClient = base.BoolPtr(false)
 	config.Bootstrap.Username = base.TestClusterUsername()
 	config.Bootstrap.Password = base.TestClusterPassword()
 
@@ -521,7 +522,7 @@ func TestUseTLSServer(t *testing.T) {
 					Server: &test.server,
 				},
 			}
-			spec, err := GetBucketSpec(&dbConfig)
+			spec, err := GetBucketSpec(&dbConfig, &config)
 			require.Nil(t, err)
 			// Run test
 			err = validateServerTLS(spec, &config)
@@ -529,11 +530,11 @@ func TestUseTLSServer(t *testing.T) {
 			if test.expectedError != nil {
 				require.Error(t, err)
 				assert.Equal(t, fmt.Sprintf(*test.expectedError, test.server), err.Error())
-			} else {
+			} else if err != nil {
 				// Will still error due to no DB name, or not being able to connect to bucket
 				// So make sure it's not the 2 errors that can happen due to secure protocol
-				assert.NotEqual(t, fmt.Sprintf(errorMustBeSecure, test.server), err)
-				assert.NotEqual(t, fmt.Sprintf(errorAllowInsecureAndBeSecure, test.server), err)
+				assert.NotEqual(t, fmt.Sprintf(errorMustBeSecure, test.server), err.Error())
+				assert.NotEqual(t, fmt.Sprintf(errorAllowInsecureAndBeSecure, test.server), err.Error())
 			}
 			sc.Close()
 		})

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -109,7 +109,9 @@ func TestAllDatabaseNames(t *testing.T) {
 	tb2 := base.GetTestBucket(t)
 	defer tb2.Close()
 
-	serverConfig := &StartupConfig{API: APIConfig{CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
+	serverConfig := &StartupConfig{
+		Bootstrap: BootstrapConfig{AllowInsecureServerConnections: base.BoolPtr(true)},
+		API:       APIConfig{HTTPS: HTTPSConfig{AllowInsecureTLSConnections: base.BoolPtr(true)}, CORS: &CORSConfig{}, AdminInterface: DefaultAdminInterface}}
 	serverContext := NewServerContext(serverConfig, false)
 	defer serverContext.Close()
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -443,7 +443,6 @@ func TestTLSSkipVerifyGetBucketSpec(t *testing.T) {
 }
 
 func TestAllowInsecureServerConnections(t *testing.T) {
-	// Long test as has to wait for retry loop to fail
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	errorMustBeSecure := "couchbase server URL must use secure protocol when disallowing insecure server connections. Current URL: %v"
 	errorAllowInsecureAndBeSecure := "couchbase server URL cannot use secure protocol while allowing insecure server connections. Current URL: %v"

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -55,8 +55,8 @@ type RestTesterConfig struct {
 	adminInterfaceAuthentication    bool
 	metricsInterfaceAuthentication  bool
 	enableAdminAuthPermissionsCheck bool
-	allowInsecureTLSConnections     *bool // If false, TLS will be used with SG. Default (nil): true
-	allowInsecureServerConnections  *bool // If false, TLS will be required for communications with CBS. Default (nil): true
+	useTLSClient                    *bool // If false, TLS will be used with SG. Default (nil): true
+	useTLSServer                    *bool // If false, TLS will be required for communications with CBS. Default (nil): true
 }
 
 type RestTester struct {
@@ -144,17 +144,18 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
 	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
-	allowInsecureServerConnections := true
-	if rt.RestTesterConfig.allowInsecureServerConnections != nil {
-		allowInsecureServerConnections = *rt.RestTesterConfig.allowInsecureServerConnections
-	}
-	sc.Bootstrap.AllowInsecureServerConnections = base.BoolPtr(allowInsecureServerConnections)
 
-	allowInsecureTLSConnections := true
-	if rt.RestTesterConfig.allowInsecureTLSConnections != nil {
-		allowInsecureTLSConnections = *rt.RestTesterConfig.allowInsecureTLSConnections
+	useTLSServer := true
+	if rt.RestTesterConfig.useTLSServer != nil {
+		useTLSServer = *rt.RestTesterConfig.useTLSServer
 	}
-	sc.API.HTTPS.AllowInsecureTLSConnections = base.BoolPtr(allowInsecureTLSConnections)
+	sc.Bootstrap.UseTLSServer = base.BoolPtr(useTLSServer)
+
+	useTLSClient := true
+	if rt.RestTesterConfig.useTLSClient != nil {
+		useTLSClient = *rt.RestTesterConfig.useTLSClient
+	}
+	sc.API.HTTPS.UseTLSClient = base.BoolPtr(useTLSClient)
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -55,6 +55,8 @@ type RestTesterConfig struct {
 	adminInterfaceAuthentication    bool
 	metricsInterfaceAuthentication  bool
 	enableAdminAuthPermissionsCheck bool
+	denyInsecureTLSConnections      bool // If true, TLS will be used with SG
+	denyInsecureServerConnections   bool // If true, TLS will be required for communications with CBS
 }
 
 type RestTester struct {
@@ -142,6 +144,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
 	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
+	sc.Bootstrap.AllowInsecureServerConnections = base.BoolPtr(!rt.RestTesterConfig.denyInsecureServerConnections)
+	sc.API.HTTPS.AllowInsecureTLSConnections = base.BoolPtr(!rt.RestTesterConfig.denyInsecureTLSConnections)
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -55,8 +55,7 @@ type RestTesterConfig struct {
 	adminInterfaceAuthentication    bool
 	metricsInterfaceAuthentication  bool
 	enableAdminAuthPermissionsCheck bool
-	useTLSClient                    *bool // If false, TLS will be used with SG. Default (nil): true
-	useTLSServer                    *bool // If false, TLS will be required for communications with CBS. Default (nil): true
+	useTLSServer                    bool // If true, TLS will be required for communications with CBS. Default: false
 }
 
 type RestTester struct {
@@ -144,18 +143,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
 	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
-
-	useTLSServer := true
-	if rt.RestTesterConfig.useTLSServer != nil {
-		useTLSServer = *rt.RestTesterConfig.useTLSServer
-	}
-	sc.Bootstrap.UseTLSServer = base.BoolPtr(useTLSServer)
-
-	useTLSClient := true
-	if rt.RestTesterConfig.useTLSClient != nil {
-		useTLSClient = *rt.RestTesterConfig.useTLSClient
-	}
-	sc.API.HTTPS.UseTLSClient = base.BoolPtr(useTLSClient)
+	sc.Bootstrap.UseTLSServer = &rt.RestTesterConfig.useTLSServer
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -55,8 +55,8 @@ type RestTesterConfig struct {
 	adminInterfaceAuthentication    bool
 	metricsInterfaceAuthentication  bool
 	enableAdminAuthPermissionsCheck bool
-	denyInsecureTLSConnections      bool // If true, TLS will be used with SG
-	denyInsecureServerConnections   bool // If true, TLS will be required for communications with CBS
+	allowInsecureTLSConnections     *bool // If false, TLS will be used with SG. Default (nil): true
+	allowInsecureServerConnections  *bool // If false, TLS will be required for communications with CBS. Default (nil): true
 }
 
 type RestTester struct {
@@ -144,8 +144,17 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
 	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
 	sc.API.EnableAdminAuthenticationPermissionsCheck = &rt.enableAdminAuthPermissionsCheck
-	sc.Bootstrap.AllowInsecureServerConnections = base.BoolPtr(!rt.RestTesterConfig.denyInsecureServerConnections)
-	sc.API.HTTPS.AllowInsecureTLSConnections = base.BoolPtr(!rt.RestTesterConfig.denyInsecureTLSConnections)
+	allowInsecureServerConnections := true
+	if rt.RestTesterConfig.allowInsecureServerConnections != nil {
+		allowInsecureServerConnections = *rt.RestTesterConfig.allowInsecureServerConnections
+	}
+	sc.Bootstrap.AllowInsecureServerConnections = base.BoolPtr(allowInsecureServerConnections)
+
+	allowInsecureTLSConnections := true
+	if rt.RestTesterConfig.allowInsecureTLSConnections != nil {
+		allowInsecureTLSConnections = *rt.RestTesterConfig.allowInsecureTLSConnections
+	}
+	sc.API.HTTPS.AllowInsecureTLSConnections = base.BoolPtr(allowInsecureTLSConnections)
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/929/ (test TestDBOnlineWithDelayAndImmediate failed on integration but works locally)

https://issues.couchbase.com/browse/CM-837
Default bucket is no server is provided is now couchbases://localhost:8091 regardless of flag
If the server is a Walrus bucket, then this is treated as a secure server meaning UseTLSServer does not need to be set.

See https://docs.google.com/document/d/1Az-Fa75WebU1cokZQ1Xh6EOcL1JeqKcCqKso9rr6Jss/edit for config details