### PR TITLE
Bump gocb/gocbcore to uptake GOCBC-1122

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -49,8 +49,9 @@ func NewCouchbaseCluster(server, username, password,
 	}
 
 	err = cluster.WaitUntilReady(time.Second*5, &gocb.WaitUntilReadyOptions{
-		DesiredState: gocb.ClusterStateOnline,
-		ServiceTypes: []gocb.ServiceType{gocb.ServiceTypeManagement},
+		DesiredState:  gocb.ClusterStateOnline,
+		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
+		RetryStrategy: &goCBv2FailFastRetryStrategy{},
 	})
 	if err != nil {
 		return nil, err

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,8 +45,8 @@ licenses/APL2.txt.
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
   <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="9ced163b8225c08922af38c3678dd0980b32f01f" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="7c907ab1fb8eca0b3d46f23fa4f9608e4706f360"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="476b7f38842457a34d0d8a69332d190223a82651" />
+  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="a5315eea8af138a600c2c3b8061fe13d956254b7"/>
   <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
 
   <!-- gocb v1 -->

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1146,8 +1146,10 @@ func initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPat
 	}
 
 	config := gocbcore.AgentConfig{
-		Auth:              authenticator,
-		TLSRootCAProvider: tlsRootCAProvider,
+		SecurityConfig: gocbcore.SecurityConfig{
+			TLSRootCAProvider: tlsRootCAProvider,
+			Auth:              authenticator,
+		},
 	}
 
 	err = config.FromConnStr(clusterAddress)


### PR DESCRIPTION
Allows `WaitUntilReady` to take a `RetryStrategy` to allow fast-fail and retrieve authentication errors - plus some minor `gocbcore.AgentConfig` changes.

## Integration Test
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/856/ 
  - Flaky unit test reported here: [CBG-1545](https://issues.couchbase.com/browse/CBG-1545)