### PR TITLE
CBG-1519: Update Admin Auth details with bootstrap config

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -832,7 +832,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 	sc := NewServerContext(config, persistentConfig)
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
-	if persistentConfig && !base.ServerIsWalrus(sc.config.Bootstrap.Server) {
+	if sc.persistentConfig {
 		err, c := base.RetryLoop("Bootstrap", func() (shouldRetry bool, err error, value interface{}) {
 			cluster, err := base.NewCouchbaseCluster(sc.config.Bootstrap.Server,
 				sc.config.Bootstrap.Username, sc.config.Bootstrap.Password,

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -215,7 +215,7 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []string, respo
 	}
 
 	// If an Admin Request we need to check the user credentials
-	if h.shouldCheckAdminAuth() {
+	if (h.privs == adminPrivs && *h.server.config.API.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.API.MetricsInterfaceAuthentication) {
 		username, password := h.getBasicAuth()
 
 		var managementEndpoints []string
@@ -274,12 +274,6 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []string, respo
 	}
 
 	return method(h) // Call the actual handler code
-}
-
-// FIXME: Temporarily disable admin auth check (return false)
-func (h *handler) shouldCheckAdminAuth() bool {
-	clusterAddress, _, _, _, _, _ := tempConnectionDetailsForManagementEndpoints()
-	return false && !base.ServerIsWalrus(clusterAddress) && ((h.privs == adminPrivs && *h.server.config.API.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.API.MetricsInterfaceAuthentication))
 }
 
 func (h *handler) logRequestLine() {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -227,7 +227,7 @@ func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
-	clusterAddress, _, _, _, _, _ := tempConnectionDetailsForManagementEndpoints()
+	clusterAddress := base.UnitTestUrl()
 	baseSpec, err := connstr.Parse(clusterAddress)
 	require.NoError(t, err)
 
@@ -255,16 +255,14 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	original := tempConnectionDetailsForManagementEndpoints
-	defer func() {
-		tempConnectionDetailsForManagementEndpoints = original
-	}()
-
-	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
-		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
-	}
-
-	ctx := NewServerContext(&StartupConfig{}, false)
+	ctx := NewServerContext(&StartupConfig{
+		Bootstrap: BootstrapConfig{
+			Server:       base.UnitTestUrl(),
+			X509CertPath: certPath,
+			X509KeyPath:  keyPath,
+			CACertPath:   caCertPath,
+		},
+	}, false)
 	defer ctx.Close()
 
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
@@ -442,16 +440,14 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	original := tempConnectionDetailsForManagementEndpoints
-	defer func() {
-		tempConnectionDetailsForManagementEndpoints = original
-	}()
-
-	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
-		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
-	}
-
-	ctx := NewServerContext(&StartupConfig{}, false)
+	ctx := NewServerContext(&StartupConfig{
+		Bootstrap: BootstrapConfig{
+			Server:       base.UnitTestUrl(),
+			X509CertPath: certPath,
+			X509KeyPath:  keyPath,
+			CACertPath:   caCertPath,
+		},
+	}, false)
 	defer ctx.Close()
 
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
@@ -710,16 +706,14 @@ func TestAdminAuthWithX509(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	original := tempConnectionDetailsForManagementEndpoints
-	defer func() {
-		tempConnectionDetailsForManagementEndpoints = original
-	}()
-
-	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
-		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
-	}
-
-	ctx := NewServerContext(&StartupConfig{}, false)
+	ctx := NewServerContext(&StartupConfig{
+		Bootstrap: BootstrapConfig{
+			Server:       base.UnitTestUrl(),
+			X509CertPath: certPath,
+			X509KeyPath:  keyPath,
+			CACertPath:   caCertPath,
+		},
+	}, false)
 	defer ctx.Close()
 
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -42,17 +42,19 @@ import (
 // file, they wouldn't be publicly exported to other packages)
 
 type RestTesterConfig struct {
-	guestEnabled          bool                       // If this is true, Admin Party is in full effect
-	SyncFn                string                     // put the sync() function source in here (optional)
-	DatabaseConfig        *DbConfig                  // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
-	InitSyncSeq           uint64                     // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
-	EnableNoConflictsMode bool                       // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
-	distributedIndex      bool                       // Test with walrus-based index bucket
-	TestBucket            *base.TestBucket           // If set, use this bucket instead of requesting a new one.
-	adminInterface        string                     // adminInterface overrides the default admin interface.
-	sgReplicateEnabled    bool                       // sgReplicateManager disabled by default for RestTester
-	sgr1Replications      []*ReplicateV1ConfigLegacy // sgr1Replications are a list of replications to enable on the server context.
-	hideProductInfo       bool
+	guestEnabled                   bool                       // If this is true, Admin Party is in full effect
+	SyncFn                         string                     // put the sync() function source in here (optional)
+	DatabaseConfig                 *DbConfig                  // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
+	InitSyncSeq                    uint64                     // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
+	EnableNoConflictsMode          bool                       // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
+	distributedIndex               bool                       // Test with walrus-based index bucket
+	TestBucket                     *base.TestBucket           // If set, use this bucket instead of requesting a new one.
+	adminInterface                 string                     // adminInterface overrides the default admin interface.
+	sgReplicateEnabled             bool                       // sgReplicateManager disabled by default for RestTester
+	sgr1Replications               []*ReplicateV1ConfigLegacy // sgr1Replications are a list of replications to enable on the server context.
+	hideProductInfo                bool
+	adminInterfaceAuthentication   bool
+	metricsInterfaceAuthentication bool
 }
 
 type RestTester struct {
@@ -137,6 +139,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.CORS = corsConfig
 	sc.API.HideProductVersion = rt.RestTesterConfig.hideProductInfo
 	sc.DeprecatedConfig = &DeprecatedConfig{Facebook: &FacebookConfigLegacy{}}
+	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
+	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 	rt.RestTesterServerContext.legacyReplications = rt.RestTesterConfig.sgr1Replications


### PR DESCRIPTION
This PR removes the temporary 'tempConnectionDetails'. It also enables the Admin API by default, however, is disabled via the config options under the following conditions:
- If running walrus
- If running with NewRestTester (unless you specifically opt-in)