### PR TITLE
CBG-1519: Update Admin Auth details with bootstrap config

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -834,7 +834,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 	sc := NewServerContext(config, persistentConfig)
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
-	if persistentConfig && !base.ServerIsWalrus(sc.config.Bootstrap.Server) {
+	if sc.persistentConfig {
 		err, c := base.RetryLoop("Cluster Bootstrap", func() (shouldRetry bool, err error, value interface{}) {
 			cluster, err := base.NewCouchbaseCluster(sc.config.Bootstrap.Server,
 				sc.config.Bootstrap.Username, sc.config.Bootstrap.Password,

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -217,7 +217,8 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []string, respo
 
 	// If an Admin Request and admin auth enabled or a metrics request with metrics auth enabled we need to check the
 	// user credentials
-	if h.shouldCheckAdminAuth() {
+	shouldCheckAdminAuth := (h.privs == adminPrivs && *h.server.config.API.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.API.MetricsInterfaceAuthentication)
+	if shouldCheckAdminAuth {
 
 		// If server is walrus but auth is enabled we should just kick the user out as invalid as we have nothing to
 		// validate credentials against
@@ -292,10 +293,6 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []string, respo
 	}
 
 	return method(h) // Call the actual handler code
-}
-
-func (h *handler) shouldCheckAdminAuth() bool {
-	return (h.privs == adminPrivs && *h.server.config.API.AdminInterfaceAuthentication) || (h.privs == metricsPrivs && *h.server.config.API.MetricsInterfaceAuthentication)
 }
 
 func (h *handler) logRequestLine() {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -60,21 +60,21 @@ var kBadRequestError = base.HTTPErrorf(http.StatusMethodNotAllowed, "Bad Request
 var wwwAuthenticateHeader = `Basic realm="` + base.ProductNameString + `"`
 
 // Admin API Auth Roles
-type Role struct {
+type RouteRole struct {
 	RoleName       string
 	DatabaseScoped bool
 }
 
 var (
-	MobileSyncGatewayRole = Role{"mobile_sync_gateway", true}
-	BucketFullAccessRole  = Role{"bucket_full_access", true}
-	BucketAdmin           = Role{"bucket_admin", true}
-	FullAdminRole         = Role{"admin", false}
-	ReadOnlyAdminRole     = Role{"ro_admin", false}
+	MobileSyncGatewayRole = RouteRole{"mobile_sync_gateway", true}
+	BucketFullAccessRole  = RouteRole{"bucket_full_access", true}
+	BucketAdmin           = RouteRole{"bucket_admin", true}
+	FullAdminRole         = RouteRole{"admin", false}
+	ReadOnlyAdminRole     = RouteRole{"ro_admin", false}
 )
 
-var BucketScopedEndpointRoles = []Role{MobileSyncGatewayRole, BucketFullAccessRole, BucketAdmin, ReadOnlyAdminRole, FullAdminRole}
-var ClusterScopedEndpointRoles = []Role{ReadOnlyAdminRole, FullAdminRole}
+var BucketScopedEndpointRoles = []RouteRole{MobileSyncGatewayRole, BucketFullAccessRole, BucketAdmin, ReadOnlyAdminRole, FullAdminRole}
+var ClusterScopedEndpointRoles = []RouteRole{ReadOnlyAdminRole, FullAdminRole}
 
 // Encapsulates the state of handling an HTTP request.
 type handler struct {
@@ -488,7 +488,7 @@ func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, htt
 		return nil, statusCode, nil
 	}
 
-	var requestRoles []Role
+	var requestRoles []RouteRole
 	if bucketName != "" {
 		requestRoles = BucketScopedEndpointRoles
 	} else {

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -218,6 +218,13 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []string, respo
 	// If an Admin Request and admin auth enabled or a metrics request with metrics auth enabled we need to check the
 	// user credentials
 	if h.shouldCheckAdminAuth() {
+
+		// If server is walrus but auth is enabled we should just kick the user out as invalid as we have nothing to
+		// validate credentials against
+		if base.ServerIsWalrus(h.server.config.Bootstrap.Server) {
+			return base.HTTPErrorf(http.StatusUnauthorized, "Authorization not possible with Walrus server")
+		}
+
 		username, password := h.getBasicAuth()
 		if username == "" {
 			if dbContext == nil || dbContext.Options.SendWWWAuthenticateHeader == nil || *dbContext.Options.SendWWWAuthenticateHeader {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -115,8 +115,10 @@ func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerConte
 
 	if base.ServerIsWalrus(sc.config.Bootstrap.Server) {
 		sc.persistentConfig = false
-		sc.config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
-		sc.config.API.MetricsInterfaceAuthentication = base.BoolPtr(false)
+		if sc.config.API.AdminInterface == DefaultAdminInterface {
+			sc.config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
+			sc.config.API.MetricsInterfaceAuthentication = base.BoolPtr(false)
+		}
 	}
 
 	// TODO: Remove with GoCB DCP switch

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1273,7 +1273,7 @@ func CheckPermissions(httpClient *http.Client, managementEndpoints []string, use
 	return http.StatusForbidden, nil, nil
 }
 
-func CheckRoles(httpClient *http.Client, managementEndpoints []string, username, password string, requestedRoles []Role, bucketName string) (statusCode int, err error) {
+func CheckRoles(httpClient *http.Client, managementEndpoints []string, username, password string, requestedRoles []RouteRole, bucketName string) (statusCode int, err error) {
 	statusCode, bodyResponse, err := doHTTPAuthRequest(httpClient, username, password, "GET", "/whoami", managementEndpoints, nil)
 	if err != nil {
 		return http.StatusInternalServerError, err

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -115,6 +115,9 @@ func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerConte
 
 	if base.ServerIsWalrus(sc.config.Bootstrap.Server) {
 		sc.persistentConfig = false
+
+		// Disable Admin API authentication when running as walrus on the default admin interface to support dev
+		// environments.
 		if sc.config.API.AdminInterface == DefaultAdminInterface {
 			sc.config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
 			sc.config.API.MetricsInterfaceAuthentication = base.BoolPtr(false)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -113,6 +113,12 @@ func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerConte
 		statsContext:     &statsContext{},
 	}
 
+	if base.ServerIsWalrus(sc.config.Bootstrap.Server) {
+		sc.persistentConfig = false
+		sc.config.API.AdminInterfaceAuthentication = base.BoolPtr(false)
+		sc.config.API.MetricsInterfaceAuthentication = base.BoolPtr(false)
+	}
+
 	// TODO: Remove with GoCB DCP switch
 	// if config.CouchbaseKeepaliveInterval != nil {
 	// 	couchbase.SetTcpKeepalive(true, *config.CouchbaseKeepaliveInterval)
@@ -1185,14 +1191,11 @@ func initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPat
 	return agent, nil
 }
 
-// FIXME: Temporary connection settings. Awaiting bootstrap PR so we can use those details directly from server context
-var tempConnectionDetailsForManagementEndpoints = func() (serverAddress string, username string, password string, certPath string, keyPath string, caCertPath string) {
-	return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), "", "", ""
-}
-
 func (sc *ServerContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
-	clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath := tempConnectionDetailsForManagementEndpoints()
-	agent, err := initClusterAgent(clusterAddress, clusterUser, clusterPass, certPath, keyPath, caCertPath, sc.config.API.ServerReadTimeout.Value())
+	agent, err := initClusterAgent(
+		sc.config.Bootstrap.Server, sc.config.Bootstrap.Username, sc.config.Bootstrap.Password,
+		sc.config.Bootstrap.X509CertPath, sc.config.Bootstrap.X509KeyPath, sc.config.Bootstrap.CACertPath,
+		sc.config.API.ServerReadTimeout.Value())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1289,7 +1292,7 @@ func CheckRoles(httpClient *http.Client, managementEndpoints []string, username,
 
 	for _, roleResult := range whoAmIResults.Roles {
 		for _, requireRole := range requestedRoles {
-			if roleResult.BucketName == bucketName && roleResult.RoleName == requireRole {
+			if (roleResult.BucketName == bucketName || roleResult.BucketName == "") && roleResult.RoleName == requireRole {
 				return http.StatusOK, nil
 			}
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1273,7 +1273,7 @@ func CheckPermissions(httpClient *http.Client, managementEndpoints []string, use
 	return http.StatusForbidden, nil, nil
 }
 
-func CheckRoles(httpClient *http.Client, managementEndpoints []string, username, password string, requestedRoles []string, bucketName string) (statusCode int, err error) {
+func CheckRoles(httpClient *http.Client, managementEndpoints []string, username, password string, requestedRoles []Role, bucketName string) (statusCode int, err error) {
 	statusCode, bodyResponse, err := doHTTPAuthRequest(httpClient, username, password, "GET", "/whoami", managementEndpoints, nil)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -1297,7 +1297,12 @@ func CheckRoles(httpClient *http.Client, managementEndpoints []string, username,
 
 	for _, roleResult := range whoAmIResults.Roles {
 		for _, requireRole := range requestedRoles {
-			if (roleResult.BucketName == bucketName || roleResult.BucketName == "") && roleResult.RoleName == requireRole {
+			requireBucket := ""
+			if requireRole.DatabaseScoped {
+				requireBucket = bucketName
+			}
+
+			if roleResult.BucketName == requireBucket && roleResult.RoleName == requireRole.RoleName {
 				return http.StatusOK, nil
 			}
 		}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -221,10 +221,10 @@ func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 		t.Skip("Test requires Couchbase Server")
 	}
 
-	ctx := NewServerContext(&StartupConfig{}, false)
-	defer ctx.Close()
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
 
-	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
+	eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
 	clusterAddress := base.UnitTestUrl()
@@ -414,10 +414,10 @@ func TestCheckPermissions(t *testing.T) {
 		},
 	}
 
-	ctx := NewServerContext(&StartupConfig{}, false)
-	defer ctx.Close()
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
 
-	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
 	for _, testCase := range testCases {
@@ -472,7 +472,7 @@ func TestCheckRoles(t *testing.T) {
 		Username           string
 		Password           string
 		BucketName         string
-		RequestRoles       []string
+		RequestRoles       []Role
 		ExpectedStatusCode int
 		CreateUser         string
 		CreatePassword     string
@@ -483,7 +483,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           base.TestClusterUsername(),
 			Password:           base.TestClusterPassword(),
 			BucketName:         "",
-			RequestRoles:       []string{"admin"},
+			RequestRoles:       []Role{FullAdminRole},
 			ExpectedStatusCode: http.StatusOK,
 		},
 		{
@@ -491,7 +491,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreatedAdmin",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []string{"admin"},
+			RequestRoles:       []Role{FullAdminRole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "CreatedAdmin",
 			CreatePassword:     "password",
@@ -502,7 +502,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "ReadOnlyAdmin",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []string{"ro_admin"},
+			RequestRoles:       []Role{ReadOnlyAdminRole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "ReadOnlyAdmin",
 			CreatePassword:     "password",
@@ -513,7 +513,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreatedBucketAdmin",
 			Password:           "password",
 			BucketName:         rt.Bucket().GetName(),
-			RequestRoles:       []string{"mobile_sync_gateway"},
+			RequestRoles:       []Role{MobileSyncGatewayRole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "CreatedBucketAdmin",
 			CreatePassword:     "password",
@@ -524,7 +524,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreateUserNoRole",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []string{"ro_admin"},
+			RequestRoles:       []Role{ReadOnlyAdminRole},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "CreateUserNoRole",
 			CreatePassword:     "password",
@@ -535,7 +535,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreateUserInsufficientRole",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []string{"mobile_sync_gateway"},
+			RequestRoles:       []Role{MobileSyncGatewayRole},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "CreateUserInsufficientRole",
 			CreatePassword:     "password",

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -227,7 +227,7 @@ func TestObtainManagementEndpointsFromServerContext(t *testing.T) {
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
-	clusterAddress, _, _, _, _, _ := tempConnectionDetailsForManagementEndpoints()
+	clusterAddress := base.UnitTestUrl()
 	baseSpec, err := connstr.Parse(clusterAddress)
 	require.NoError(t, err)
 
@@ -255,16 +255,14 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	original := tempConnectionDetailsForManagementEndpoints
-	defer func() {
-		tempConnectionDetailsForManagementEndpoints = original
-	}()
-
-	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
-		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
-	}
-
-	ctx := NewServerContext(&StartupConfig{}, false)
+	ctx := NewServerContext(&StartupConfig{
+		Bootstrap: BootstrapConfig{
+			Server:       base.UnitTestUrl(),
+			X509CertPath: certPath,
+			X509KeyPath:  keyPath,
+			CACertPath:   caCertPath,
+		},
+	}, false)
 	defer ctx.Close()
 
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
@@ -442,16 +440,14 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	original := tempConnectionDetailsForManagementEndpoints
-	defer func() {
-		tempConnectionDetailsForManagementEndpoints = original
-	}()
-
-	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
-		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
-	}
-
-	ctx := NewServerContext(&StartupConfig{}, false)
+	ctx := NewServerContext(&StartupConfig{
+		Bootstrap: BootstrapConfig{
+			Server:       base.UnitTestUrl(),
+			X509CertPath: certPath,
+			X509KeyPath:  keyPath,
+			CACertPath:   caCertPath,
+		},
+	}, false)
 	defer ctx.Close()
 
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
@@ -710,16 +706,14 @@ func TestAdminAuthWithX509(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	original := tempConnectionDetailsForManagementEndpoints
-	defer func() {
-		tempConnectionDetailsForManagementEndpoints = original
-	}()
-
-	tempConnectionDetailsForManagementEndpoints = func() (string, string, string, string, string, string) {
-		return base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), certPath, keyPath, caCertPath
-	}
-
-	ctx := NewServerContext(&StartupConfig{}, false)
+	ctx := NewServerContext(&StartupConfig{
+		Bootstrap: BootstrapConfig{
+			Server:       base.UnitTestUrl(),
+			X509CertPath: certPath,
+			X509KeyPath:  keyPath,
+			CACertPath:   caCertPath,
+		},
+	}, false)
 	defer ctx.Close()
 
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -472,7 +472,7 @@ func TestCheckRoles(t *testing.T) {
 		Username           string
 		Password           string
 		BucketName         string
-		RequestRoles       []Role
+		RequestRoles       []RouteRole
 		ExpectedStatusCode int
 		CreateUser         string
 		CreatePassword     string
@@ -483,7 +483,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           base.TestClusterUsername(),
 			Password:           base.TestClusterPassword(),
 			BucketName:         "",
-			RequestRoles:       []Role{FullAdminRole},
+			RequestRoles:       []RouteRole{FullAdminRole},
 			ExpectedStatusCode: http.StatusOK,
 		},
 		{
@@ -491,7 +491,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreatedAdmin",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []Role{FullAdminRole},
+			RequestRoles:       []RouteRole{FullAdminRole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "CreatedAdmin",
 			CreatePassword:     "password",
@@ -502,7 +502,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "ReadOnlyAdmin",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []Role{ReadOnlyAdminRole},
+			RequestRoles:       []RouteRole{ReadOnlyAdminRole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "ReadOnlyAdmin",
 			CreatePassword:     "password",
@@ -513,7 +513,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreatedBucketAdmin",
 			Password:           "password",
 			BucketName:         rt.Bucket().GetName(),
-			RequestRoles:       []Role{MobileSyncGatewayRole},
+			RequestRoles:       []RouteRole{MobileSyncGatewayRole},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "CreatedBucketAdmin",
 			CreatePassword:     "password",
@@ -524,7 +524,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreateUserNoRole",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []Role{ReadOnlyAdminRole},
+			RequestRoles:       []RouteRole{ReadOnlyAdminRole},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "CreateUserNoRole",
 			CreatePassword:     "password",
@@ -535,7 +535,7 @@ func TestCheckRoles(t *testing.T) {
 			Username:           "CreateUserInsufficientRole",
 			Password:           "password",
 			BucketName:         "",
-			RequestRoles:       []Role{MobileSyncGatewayRole},
+			RequestRoles:       []RouteRole{MobileSyncGatewayRole},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "CreateUserInsufficientRole",
 			CreatePassword:     "password",

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -42,17 +42,19 @@ import (
 // file, they wouldn't be publicly exported to other packages)
 
 type RestTesterConfig struct {
-	guestEnabled          bool                       // If this is true, Admin Party is in full effect
-	SyncFn                string                     // put the sync() function source in here (optional)
-	DatabaseConfig        *DbConfig                  // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
-	InitSyncSeq           uint64                     // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
-	EnableNoConflictsMode bool                       // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
-	distributedIndex      bool                       // Test with walrus-based index bucket
-	TestBucket            *base.TestBucket           // If set, use this bucket instead of requesting a new one.
-	adminInterface        string                     // adminInterface overrides the default admin interface.
-	sgReplicateEnabled    bool                       // sgReplicateManager disabled by default for RestTester
-	sgr1Replications      []*ReplicateV1ConfigLegacy // sgr1Replications are a list of replications to enable on the server context.
-	hideProductInfo       bool
+	guestEnabled                   bool                       // If this is true, Admin Party is in full effect
+	SyncFn                         string                     // put the sync() function source in here (optional)
+	DatabaseConfig                 *DbConfig                  // Supports additional config options.  BucketConfig, Name, Sync, Unsupported will be ignored (overridden)
+	InitSyncSeq                    uint64                     // If specified, initializes _sync:seq on bucket creation.  Not supported when running against walrus
+	EnableNoConflictsMode          bool                       // Enable no-conflicts mode.  By default, conflicts will be allowed, which is the default behavior
+	distributedIndex               bool                       // Test with walrus-based index bucket
+	TestBucket                     *base.TestBucket           // If set, use this bucket instead of requesting a new one.
+	adminInterface                 string                     // adminInterface overrides the default admin interface.
+	sgReplicateEnabled             bool                       // sgReplicateManager disabled by default for RestTester
+	sgr1Replications               []*ReplicateV1ConfigLegacy // sgr1Replications are a list of replications to enable on the server context.
+	hideProductInfo                bool
+	adminInterfaceAuthentication   bool
+	metricsInterfaceAuthentication bool
 }
 
 type RestTester struct {
@@ -137,6 +139,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.API.CORS = corsConfig
 	sc.API.HideProductVersion = rt.RestTesterConfig.hideProductInfo
 	sc.DeprecatedConfig = &DeprecatedConfig{Facebook: &FacebookConfigLegacy{}}
+	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
+	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 	rt.RestTesterServerContext.legacyReplications = rt.RestTesterConfig.sgr1Replications


### PR DESCRIPTION
This PR removes the temporary 'tempConnectionDetails'. It also enables auth on the Admin API by default, however, is disabled via the config options under the following conditions:
- If running walrus
- If running with NewRestTester (unless you specifically opt-in)

Added WWW-Authenticate header.

Change on admin auth side: Allow global roles to be applied to bucket-level ops. For example it makes sense for Admin to be able to perform all operations on a bucket.