### PR TITLE
Enable gocb v2 by default

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -360,6 +360,12 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 				return nil, fmt.Errorf("unsupported feed type: %v", spec.FeedType)
 			} else {
 				bucket, err = GetCouchbaseBucketGoCB(spec)
+				if err != nil {
+					if pkgerrors.Cause(err) == gocbV1.ErrAuthError {
+						Warnf("Unable to authenticate as user %q: %v", UD(username), err)
+						return nil, ErrFatalBucketConnection
+					}
+				}
 			}
 		case GoCBv2:
 			bucket, err = GetCouchbaseCollection(spec)
@@ -368,10 +374,6 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		}
 
 		if err != nil {
-			if pkgerrors.Cause(err) == gocbV1.ErrAuthError {
-				Warnf("Unable to authenticate as user %q: %v", UD(username), err)
-				return nil, ErrFatalBucketConnection
-			}
 			return nil, err
 		}
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -11,8 +11,11 @@ package base
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -54,6 +57,29 @@ type WrappingBucket interface {
 	GetUnderlyingBucket() Bucket
 }
 
+// CouchbaseStore defines operations specific to Couchbase data stores
+type CouchbaseStore interface {
+	BucketName() string
+	MgmtEps() ([]string, error)
+	MetadataPurgeInterval() (time.Duration, error)
+	ServerUUID() (uuid string, err error)
+	MaxTTL() (int, error)
+	HttpClient() *http.Client
+	GetExpiry(k string) (expiry uint32, getMetaError error)
+	GetSpec() BucketSpec
+
+	// GetStatsVbSeqno retrieves the high sequence number for all vbuckets and returns
+	// a map of UUIDS and a map of high sequence numbers (map from vbno -> seq)
+	GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error)
+
+	mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error)
+}
+
+func AsCouchbaseStore(b Bucket) (CouchbaseStore, bool) {
+	couchbaseBucket, ok := GetBaseBucket(b).(CouchbaseStore)
+	return couchbaseBucket, ok
+}
+
 // GetBaseBucket returns the lowest level non-wrapping bucket wrapped by one or more WrappingBuckets
 func GetBaseBucket(b Bucket) Bucket {
 	wb, ok := b.(WrappingBucket)
@@ -69,13 +95,13 @@ func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
 	// return DefaultDriverForBucketType[bucketType]
 	switch bucketType {
 	case DataBucket:
-		return GoCBCustomSGTranscoder
+		return GoCBv2
 	case IndexBucket:
-		return GoCB
+		return GoCBv2
 	default:
 		// If a new bucket type is added and this method isn't updated, flag a warning (or, could panic)
 		Warnf("Unexpected bucket type: %v", bucketType)
-		return GoCB
+		return GoCBv2
 	}
 
 }
@@ -419,6 +445,8 @@ func GetFeedType(bucket Bucket) (feedType string) {
 		} else {
 			return DcpFeedType
 		}
+	case *Collection:
+		return DcpFeedType
 	case *LeakyBucket:
 		return GetFeedType(typedBucket.bucket)
 	case *LoggingBucket:
@@ -426,4 +454,115 @@ func GetFeedType(bucket Bucket) (feedType string) {
 	default:
 		return TapFeedType
 	}
+}
+
+// Gets the bucket max TTL, or 0 if no TTL was set.  Sync gateway should fail to bring the DB online if this is non-zero,
+// since it's not meant to operate against buckets that auto-delete data.
+func getMaxTTL(store CouchbaseStore) (int, error) {
+	var bucketResponseWithMaxTTL struct {
+		MaxTTLSeconds int `json:"maxTTL,omitempty"`
+	}
+
+	uri := fmt.Sprintf("/pools/default/buckets/%s", store.GetSpec().BucketName)
+	resp, err := store.mgmtRequest(http.MethodGet, uri, "application/json", nil)
+	if err != nil {
+		return -1, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return -1, err
+	}
+
+	if err := JSONUnmarshal(respBytes, &bucketResponseWithMaxTTL); err != nil {
+		return -1, err
+	}
+
+	return bucketResponseWithMaxTTL.MaxTTLSeconds, nil
+}
+
+// Get the Server UUID of the bucket, this is also known as the Cluster UUID
+func getServerUUID(store CouchbaseStore) (uuid string, err error) {
+	resp, err := store.mgmtRequest(http.MethodGet, "/pools", "application/json", nil)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var responseJson struct {
+		ServerUUID string `json:"uuid"`
+	}
+
+	if err := JSONUnmarshal(respBytes, &responseJson); err != nil {
+		return "", err
+	}
+
+	return responseJson.ServerUUID, nil
+}
+
+// Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
+// found, retrieves the cluster-wide value.
+func getMetadataPurgeInterval(store CouchbaseStore) (time.Duration, error) {
+
+	// Bucket-specific settings
+	uri := fmt.Sprintf("/pools/default/buckets/%s", store.BucketName())
+	bucketPurgeInterval, err := retrievePurgeInterval(store, uri)
+	if bucketPurgeInterval > 0 || err != nil {
+		return bucketPurgeInterval, err
+	}
+
+	// Cluster-wide settings
+	uri = fmt.Sprintf("/settings/autoCompaction")
+	clusterPurgeInterval, err := retrievePurgeInterval(store, uri)
+	if clusterPurgeInterval > 0 || err != nil {
+		return clusterPurgeInterval, err
+	}
+
+	return 0, nil
+
+}
+
+// Helper function to retrieve a Metadata Purge Interval from server and convert to hours.  Works for any uri
+// that returns 'purgeInterval' as a root-level property (which includes the two server endpoints for
+// bucket and server purge intervals).
+func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, error) {
+
+	// Both of the purge interval endpoints (cluster and bucket) return purgeInterval in the same way
+	var purgeResponse struct {
+		PurgeInterval float64 `json:"purgeInterval,omitempty"`
+	}
+
+	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusForbidden {
+		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
+	} else if resp.StatusCode != http.StatusOK {
+		return 0, errors.New(resp.Status)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
+		return 0, err
+	}
+
+	// Server purge interval is a float value, in days.  Round up to hours
+	purgeIntervalHours := int(purgeResponse.PurgeInterval*24 + 0.5)
+	return time.Duration(purgeIntervalHours) * time.Hour, nil
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -112,6 +112,8 @@ func (couchbaseDriver CouchbaseDriver) String() string {
 		return "GoCB"
 	case GoCBCustomSGTranscoder:
 		return "GoCBCustomSGTranscoder"
+	case GoCBv2:
+		return "GoCBv2"
 	default:
 		return "UnknownCouchbaseDriver"
 	}
@@ -451,6 +453,8 @@ func GetFeedType(bucket Bucket) (feedType string) {
 		return GetFeedType(typedBucket.bucket)
 	case *LoggingBucket:
 		return GetFeedType(typedBucket.bucket)
+	case *TestBucket:
+		return GetFeedType(typedBucket.Bucket)
 	default:
 		return TapFeedType
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -827,7 +827,7 @@ func (bucket *CouchbaseBucketGoCB) Add(k string, exp uint32, v interface{}) (add
 
 // GoCB AddRaw writes as BinaryDocument, which results in the document having the
 // binary doc common flag set.  Callers that want to write JSON documents as raw bytes should
-// pass v as []byte to the stanard bucket.Add
+// pass v as []byte to the standard bucket.Add
 func (bucket *CouchbaseBucketGoCB) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	bucket.singleOps <- struct{}{}
 	defer func() {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1954,7 +1954,6 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 	return AsGoCBBucket(underlyingBucket)
 }
 
-<<<<<<< HEAD
 // AsLeakyBucket tries to return the given bucket as a LeakyBucket.
 func AsLeakyBucket(bucket Bucket) (*LeakyBucket, bool) {
 
@@ -1973,7 +1972,6 @@ func AsLeakyBucket(bucket Bucket) (*LeakyBucket, bool) {
 
 	return AsLeakyBucket(underlyingBucket)
 }
-
 
 func (bucket *CouchbaseBucketGoCB) MgmtEps() (url []string, err error) {
 	mgmtEps := bucket.Bucket.IoRouter().MgmtEps()

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -58,7 +58,7 @@ var recoverableGocbV1Errors = map[string]struct{}{
 	gocbcore.ErrTmpFail.Error():  {},
 }
 
-// Implementation of sgbucket.Bucket that talks to a Couchbase server and uses gocb
+// Implementation of sgbucket.Bucket that talks to a Couchbase server and useAsGocs gocb
 type CouchbaseBucketGoCB struct {
 	*gocb.Bucket               // the underlying gocb bucket
 	Spec         BucketSpec    // keep a copy of the BucketSpec for DCP usage
@@ -70,6 +70,7 @@ type CouchbaseBucketGoCB struct {
 }
 
 var _ sgbucket.KVStore = &CouchbaseBucketGoCB{}
+var _ CouchbaseStore = &CouchbaseBucketGoCB{}
 
 // Creates a Bucket that talks to a real live Couchbase server.
 func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err error) {
@@ -188,7 +189,6 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 }
 
 func (bucket *CouchbaseBucketGoCB) GetBucketCredentials() (username, password string) {
-
 	if bucket.Spec.Auth != nil {
 		username, password, _ = bucket.Spec.Auth.GetCredentials()
 	}
@@ -197,113 +197,19 @@ func (bucket *CouchbaseBucketGoCB) GetBucketCredentials() (username, password st
 
 // Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
 // found, retrieves the cluster-wide value.
-func (bucket *CouchbaseBucketGoCB) GetMetadataPurgeInterval() (time.Duration, error) {
-
-	// Bucket-specific settings
-	uri := fmt.Sprintf("/pools/default/buckets/%s", bucket.Name())
-	bucketPurgeInterval, err := bucket.retrievePurgeInterval(uri)
-	if bucketPurgeInterval > 0 || err != nil {
-		return bucketPurgeInterval, err
-	}
-
-	// Cluster-wide settings
-	uri = fmt.Sprintf("/settings/autoCompaction")
-	clusterPurgeInterval, err := bucket.retrievePurgeInterval(uri)
-	if clusterPurgeInterval > 0 || err != nil {
-		return clusterPurgeInterval, err
-	}
-
-	return 0, nil
-
-}
-
-// Helper function to retrieve a Metadata Purge Interval from server and convert to hours.  Works for any uri
-// that returns 'purgeInterval' as a root-level property (which includes the two server endpoints for
-// bucket and server purge intervals).
-func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (time.Duration, error) {
-
-	// Both of the purge interval endpoints (cluster and bucket) return purgeInterval in the same way
-	var purgeResponse struct {
-		PurgeInterval float64 `json:"purgeInterval,omitempty"`
-	}
-
-	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
-	if err != nil {
-		return 0, err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusForbidden {
-		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
-	} else if resp.StatusCode != http.StatusOK {
-		return 0, errors.New(resp.Status)
-	}
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
-
-	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
-		return 0, err
-	}
-
-	// Server purge interval is a float value, in days.  Round up to hours
-	purgeIntervalHours := int(purgeResponse.PurgeInterval*24 + 0.5)
-	return time.Duration(purgeIntervalHours) * time.Hour, nil
+func (bucket *CouchbaseBucketGoCB) MetadataPurgeInterval() (time.Duration, error) {
+	return getMetadataPurgeInterval(bucket)
 }
 
 // Get the Server UUID of the bucket, this is also known as the Cluster UUID
-func (bucket *CouchbaseBucketGoCB) GetServerUUID() (uuid string, err error) {
-	resp, err := bucket.mgmtRequest(http.MethodGet, "/pools", "application/json", nil)
-	if err != nil {
-		return "", err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var responseJson struct {
-		ServerUUID string `json:"uuid"`
-	}
-
-	if err := JSONUnmarshal(respBytes, &responseJson); err != nil {
-		return "", err
-	}
-
-	return responseJson.ServerUUID, nil
+func (bucket *CouchbaseBucketGoCB) ServerUUID() (uuid string, err error) {
+	return getServerUUID(bucket)
 }
 
 // Gets the bucket max TTL, or 0 if no TTL was set.  Sync gateway should fail to bring the DB online if this is non-zero,
 // since it's not meant to operate against buckets that auto-delete data.
-func (bucket *CouchbaseBucketGoCB) GetMaxTTL() (int, error) {
-	var bucketResponseWithMaxTTL struct {
-		MaxTTLSeconds int `json:"maxTTL,omitempty"`
-	}
-
-	uri := fmt.Sprintf("/pools/default/buckets/%s", bucket.Spec.BucketName)
-	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
-	if err != nil {
-		return -1, err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return -1, err
-	}
-
-	if err := JSONUnmarshal(respBytes, &bucketResponseWithMaxTTL); err != nil {
-		return -1, err
-	}
-
-	return bucketResponseWithMaxTTL.MaxTTLSeconds, nil
+func (bucket *CouchbaseBucketGoCB) MaxTTL() (int, error) {
+	return getMaxTTL(bucket)
 }
 
 // mgmtRequest is a re-implementation of gocb's mgmtRequest
@@ -315,7 +221,7 @@ func (bucket *CouchbaseBucketGoCB) mgmtRequest(method, uri, contentType string, 
 		panic("Content-type must be specified for non-null body.")
 	}
 
-	mgmtEp, err := GoCBBucketMgmtEndpoint(bucket.Bucket)
+	mgmtEp, err := GoCBBucketMgmtEndpoint(bucket)
 	if err != nil {
 		return nil, err
 	}
@@ -1610,10 +1516,6 @@ func (bucket *CouchbaseBucketGoCB) GetMaxVbno() (uint16, error) {
 	return 0, fmt.Errorf("Unable to determine vbucket count")
 }
 
-func (bucket *CouchbaseBucketGoCB) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	return bucket.clusterCompatMajorVersion, bucket.clusterCompatMinorVersion, ""
-}
-
 func (bucket *CouchbaseBucketGoCB) UUID() (string, error) {
 	return bucket.Bucket.IoRouter().BucketUUID(), nil
 }
@@ -1812,7 +1714,9 @@ func (bucket *CouchbaseBucketGoCB) FormatBinaryDocument(input []byte) interface{
 }
 
 func (bucket *CouchbaseBucketGoCB) IsSupported(feature sgbucket.DataStoreFeature) bool {
-	major, minor, _ := bucket.CouchbaseServerVersion()
+
+	major := bucket.clusterCompatMajorVersion
+	minor := bucket.clusterCompatMinorVersion
 	switch feature {
 	case sgbucket.DataStoreFeatureSubdocOperations:
 		return isMinimumVersion(major, minor, 4, 5)
@@ -2050,6 +1954,7 @@ func AsGoCBBucket(bucket Bucket) (*CouchbaseBucketGoCB, bool) {
 	return AsGoCBBucket(underlyingBucket)
 }
 
+<<<<<<< HEAD
 // AsLeakyBucket tries to return the given bucket as a LeakyBucket.
 func AsLeakyBucket(bucket Bucket) (*LeakyBucket, bool) {
 
@@ -2069,17 +1974,30 @@ func AsLeakyBucket(bucket Bucket) (*LeakyBucket, bool) {
 	return AsLeakyBucket(underlyingBucket)
 }
 
-func GoCBBucketMgmtEndpoints(bucket *gocb.Bucket) (url []string, err error) {
-	mgmtEps := bucket.IoRouter().MgmtEps()
+
+func (bucket *CouchbaseBucketGoCB) MgmtEps() (url []string, err error) {
+	mgmtEps := bucket.Bucket.IoRouter().MgmtEps()
 	if len(mgmtEps) == 0 {
 		return nil, fmt.Errorf("No available Couchbase Server nodes")
 	}
 	return mgmtEps, nil
 }
 
+func (bucket *CouchbaseBucketGoCB) HttpClient() *http.Client {
+	return bucket.Bucket.IoRouter().HttpClient()
+}
+
+func (bucket *CouchbaseBucketGoCB) BucketName() string {
+	return bucket.Bucket.Name()
+}
+
+func GoCBBucketMgmtEndpoints(bucket CouchbaseStore) (url []string, err error) {
+	return bucket.MgmtEps()
+}
+
 // Get one of the management endpoints.  It will be a string such as http://couchbase
-func GoCBBucketMgmtEndpoint(bucket *gocb.Bucket) (url string, err error) {
-	mgmtEps, err := GoCBBucketMgmtEndpoints(bucket)
+func GoCBBucketMgmtEndpoint(bucket CouchbaseStore) (url string, err error) {
+	mgmtEps, err := bucket.MgmtEps()
 	if err != nil {
 		return "", err
 	}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1960,21 +1960,6 @@ func TestApplyViewQueryStaleOptions(t *testing.T) {
 
 }
 
-// Make sure that calling CouchbaseServerVersion against actual couchbase server does not return an error
-func TestCouchbaseServerVersion(t *testing.T) {
-
-	if UnitTestUrlIsWalrus() {
-		t.Skip("This test only works against Couchbase Server")
-	}
-
-	bucket := GetTestBucket(t)
-	defer bucket.Close()
-
-	major, _, _ := bucket.CouchbaseServerVersion()
-	assert.NotZero(t, major)
-
-}
-
 func TestCouchbaseServerMaxTTL(t *testing.T) {
 	if UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -1983,8 +1968,9 @@ func TestCouchbaseServerMaxTTL(t *testing.T) {
 	bucket := GetTestBucket(t)
 	defer bucket.Close()
 
-	gocbBucket := bucket.Bucket.(*CouchbaseBucketGoCB)
-	maxTTL, err := gocbBucket.GetMaxTTL()
+	cbStore, ok := AsCouchbaseStore(bucket)
+	require.True(t, ok)
+	maxTTL, err := GetMaxTTL(cbStore)
 	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, maxTTL, 0)
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1682,7 +1682,7 @@ func TestGetXattr(t *testing.T) {
 		require.True(t, ok)
 		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
 		assert.Error(t, err)
-		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
 		////Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -88,7 +88,8 @@ func TestSetGetRaw(t *testing.T) {
 		key := t.Name()
 		val := []byte("bar")
 
-		_, _, err := bucket.GetRaw(key)
+		var body []byte
+		_, err := bucket.Get(key, &body)
 		if err == nil {
 			t.Errorf("Key should not exist yet, expected error but got nil")
 		}
@@ -113,11 +114,6 @@ func TestAddRaw(t *testing.T) {
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 		key := t.Name()
 		val := []byte("bar")
-
-		_, _, err := bucket.GetRaw(key)
-		if err == nil {
-			t.Errorf("Key should not exist yet, expected error but got nil")
-		}
 
 		added, err := bucket.AddRaw(key, 0, val)
 		if err != nil {
@@ -184,7 +180,8 @@ func TestWriteCasBasic(t *testing.T) {
 		key := t.Name()
 		val := []byte("bar2")
 
-		_, _, err := bucket.GetRaw(key)
+		var body []byte
+		_, err := bucket.Get(key, &body)
 		if err == nil {
 			t.Errorf("Key should not exist yet, expected error but got nil")
 		}
@@ -219,7 +216,8 @@ func TestWriteCasAdvanced(t *testing.T) {
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 		key := t.Name()
 
-		_, _, err := bucket.GetRaw(key)
+		var body []byte
+		_, err := bucket.Get(key, &body)
 		if err == nil {
 			t.Errorf("Key should not exist yet, expected error but got nil")
 		}
@@ -1036,7 +1034,8 @@ func TestXattrDeleteDocument(t *testing.T) {
 		xattrVal["rev"] = "1-1234"
 
 		key := t.Name()
-		_, _, err := bucket.GetRaw(key)
+		var body []byte
+		_, err := bucket.Get(key, &body)
 		if err == nil {
 			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
 			require.NoError(t, bucket.Delete(key))
@@ -1085,7 +1084,8 @@ func TestXattrDeleteDocumentUpdate(t *testing.T) {
 		xattrVal["rev"] = "1-1234"
 
 		key := t.Name()
-		_, _, err := bucket.GetRaw(key)
+		var body []byte
+		_, err := bucket.Get(key, &body)
 		if err == nil {
 			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
 			require.NoError(t, bucket.Delete(key))
@@ -1152,7 +1152,8 @@ func TestXattrDeleteDocumentAndUpdateXattr(t *testing.T) {
 		xattrVal["rev"] = "1-1234"
 
 		key := t.Name()
-		_, _, err := bucket.GetRaw(key)
+		var body []byte
+		_, err := bucket.Get(key, &body)
 		if err == nil {
 			log.Printf("Key should not exist yet, expected error but got nil.  Doing cleanup, assuming couchbase bucket testing")
 			require.NoError(t, bucket.DeleteWithXattr(key, xattrName))
@@ -2099,7 +2100,8 @@ func createTombstonedDoc(bucket sgbucket.DataStore, key, xattrName string) {
 	xattrVal["seq"] = 123
 	xattrVal["rev"] = "1-1234"
 
-	_, _, err := bucket.GetRaw(key)
+	var body []byte
+	_, err := bucket.Get(key, &body)
 	if err == nil {
 		panic(fmt.Sprintf("Expected empty bucket"))
 	}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1682,7 +1682,7 @@ func TestGetXattr(t *testing.T) {
 		require.True(t, ok)
 		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
 		assert.Error(t, err)
-		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
+		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
 
 		////Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1970,7 +1970,7 @@ func TestCouchbaseServerMaxTTL(t *testing.T) {
 
 	cbStore, ok := AsCouchbaseStore(bucket)
 	require.True(t, ok)
-	maxTTL, err := GetMaxTTL(cbStore)
+	maxTTL, err := cbStore.MaxTTL()
 	assert.NoError(t, err, "Unexpected error")
 	goassert.Equals(t, maxTTL, 0)
 

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -141,3 +141,27 @@ func (bucket *CouchbaseBucketGoCB) DropIndex(indexName string) error {
 func (bucket *CouchbaseBucketGoCB) IsErrNoResults(err error) bool {
 	return err == gocb.ErrNoResults
 }
+
+// Get a list of all index names in the bucket
+func (bucket *CouchbaseBucketGoCB) getIndexes() (indexes []string, err error) {
+
+	indexes = []string{}
+
+	manager, err := bucket.getBucketManager()
+	if err != nil {
+		return indexes, err
+	}
+
+	indexInfo, err := manager.GetIndexes()
+	if err != nil {
+		return indexes, err
+	}
+
+	for _, indexInfo := range indexInfo {
+		if indexInfo.Keyspace == bucket.GetName() {
+			indexes = append(indexes, indexInfo.Name)
+		}
+	}
+
+	return indexes, nil
+}

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -266,9 +266,9 @@ func TestGetStatsVbSeqno(t *testing.T) {
 
 func TestChooseCouchbaseDriver(t *testing.T) {
 	assert.Equal(t, GoCBCustomSGTranscoder, ChooseCouchbaseDriver(DataBucket))
-	assert.Equal(t, GoCB, ChooseCouchbaseDriver(IndexBucket))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(IndexBucket))
 	unknownCouchbaseBucketType := CouchbaseBucketType(math.MaxInt8)
-	assert.Equal(t, GoCB, ChooseCouchbaseDriver(unknownCouchbaseBucketType))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(unknownCouchbaseBucketType))
 }
 
 func TestCouchbaseDriverToString(t *testing.T) {

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -265,7 +265,7 @@ func TestGetStatsVbSeqno(t *testing.T) {
 }
 
 func TestChooseCouchbaseDriver(t *testing.T) {
-	assert.Equal(t, GoCBCustomSGTranscoder, ChooseCouchbaseDriver(DataBucket))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(DataBucket))
 	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(IndexBucket))
 	unknownCouchbaseBucketType := CouchbaseBucketType(math.MaxInt8)
 	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(unknownCouchbaseBucketType))

--- a/base/collection.go
+++ b/base/collection.go
@@ -181,9 +181,10 @@ func (c *Collection) GetRaw(k string) (rv []byte, cas uint64, err error) {
 	return rv, uint64(getRawResult.Cas()), err
 }
 
+// TODO: Refactor to GetAndTouch, since the only use case isn't working with binary data
 func (c *Collection) GetAndTouchRaw(k string, exp uint32) (rv []byte, cas uint64, err error) {
 	getAndTouchOptions := &gocb.GetAndTouchOptions{
-		Transcoder: gocb.NewRawBinaryTranscoder(),
+		Transcoder: getTranscoder(rv),
 	}
 	getAndTouchRawResult, getErr := c.Collection.GetAndTouch(k, expAsDuration(exp), getAndTouchOptions)
 	if getErr != nil {

--- a/base/collection.go
+++ b/base/collection.go
@@ -638,5 +638,4 @@ func (c *Collection) mgmtRequest(method, uri, contentType string, body io.Reader
 	}
 
 	return c.HttpClient().Do(req)
->>>>>>> Support running w/ gocb V2
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -13,15 +13,27 @@ package base
 import (
 	"errors"
 	"expvar"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
 	"time"
+
+	"github.com/couchbase/gocbcore"
 
 	"github.com/couchbase/gocb"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )
 
+var _ sgbucket.KVStore = &Collection{}
+var _ CouchbaseStore = &Collection{}
+
 // Connect to the default collection for the specified bucket
 func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
+
+	log.Printf("getting collection with spec: %+v", spec)
+
 	connString, err := spec.GetGoCBConnString()
 	if err != nil {
 		Warnf("Unable to parse server value: %s error: %v", SD(spec.Server), err)
@@ -85,6 +97,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 	viewOpsQueue := make(chan struct{}, MaxConcurrentViewOps*nodeCount)
 	collection := &Collection{
 		Collection: bucket.DefaultCollection(),
+		Spec:       spec,
 		cluster:    cluster,
 		viewOps:    viewOpsQueue,
 	}
@@ -101,12 +114,18 @@ type Collection struct {
 
 // DataStore
 func (c *Collection) GetName() string {
-	return c.Collection.Name()
+	// Returning bucket name until full collection support is implemented
+	return c.Collection.Bucket().Name()
 }
 
 func (c *Collection) UUID() (string, error) {
-	return "", errors.New("Not implemented")
+	config, configErr := c.getConfigSnapshot()
+	if configErr != nil {
+		return "", fmt.Errorf("Unable to determine bucket UUID: %w", configErr)
+	}
+	return config.BucketUUID(), nil
 }
+
 func (c *Collection) Close() {
 	// No close handling for collection
 	return
@@ -119,7 +138,10 @@ func (c *Collection) IsSupported(feature sgbucket.DataStoreFeature) bool {
 // KV store
 
 func (c *Collection) Get(k string, rv interface{}) (cas uint64, err error) {
-	getResult, err := c.Collection.Get(k, nil)
+	getOptions := &gocb.GetOptions{
+		Transcoder: getTranscoder(rv),
+	}
+	getResult, err := c.Collection.Get(k, getOptions)
 	if err != nil {
 		return 0, err
 	}
@@ -163,7 +185,8 @@ func (c *Collection) Touch(k string, exp uint32) (cas uint64, err error) {
 
 func (c *Collection) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	opts := &gocb.InsertOptions{
-		Expiry: expAsDuration(exp),
+		Expiry:     expAsDuration(exp),
+		Transcoder: getTranscoder(v),
 	}
 	_, gocbErr := c.Collection.Insert(k, v, opts)
 	if gocbErr != nil {
@@ -194,8 +217,13 @@ func (c *Collection) AddRaw(k string, exp uint32, v []byte) (added bool, err err
 
 func (c *Collection) Set(k string, exp uint32, v interface{}) error {
 	upsertOptions := &gocb.UpsertOptions{
-		Expiry: expAsDuration(exp),
+		Expiry:     expAsDuration(exp),
+		Transcoder: getTranscoder(v),
 	}
+	if _, ok := v.([]byte); ok {
+		upsertOptions.Transcoder = gocb.NewRawJSONTranscoder()
+	}
+
 	_, err := c.Collection.Upsert(k, v, upsertOptions)
 	return err
 }
@@ -213,7 +241,8 @@ func (c *Collection) WriteCas(k string, flags int, exp uint32, cas uint64, v int
 	var result *gocb.MutationResult
 	if cas == 0 {
 		insertOpts := &gocb.InsertOptions{
-			Expiry: expAsDuration(exp),
+			Expiry:     expAsDuration(exp),
+			Transcoder: getTranscoder(v),
 		}
 		if opt == sgbucket.Raw {
 			insertOpts.Transcoder = gocb.NewRawBinaryTranscoder()
@@ -221,8 +250,9 @@ func (c *Collection) WriteCas(k string, flags int, exp uint32, cas uint64, v int
 		result, err = c.Collection.Insert(k, v, insertOpts)
 	} else {
 		replaceOpts := &gocb.ReplaceOptions{
-			Cas:    gocb.Cas(cas),
-			Expiry: expAsDuration(exp),
+			Cas:        gocb.Cas(cas),
+			Expiry:     expAsDuration(exp),
+			Transcoder: getTranscoder(v),
 		}
 		if opt == sgbucket.Raw {
 			replaceOpts.Transcoder = gocb.NewRawBinaryTranscoder()
@@ -351,7 +381,7 @@ func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 }
 
 func (c *Collection) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	return errors.New("StartDCPFeed not implemented")
+	return StartDCPFeed(c, c.Spec, args, callback, dbStats)
 }
 func (c *Collection) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 	return nil, errors.New("StartTapFeed not implemented")
@@ -362,14 +392,35 @@ func (c *Collection) Dump() {
 
 // CouchbaseStore
 
-func (c *Collection) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	return 0, 0, ""
-}
 func (c *Collection) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
 	return nil, nil, nil
 }
 func (c *Collection) GetMaxVbno() (uint16, error) {
-	return 0, nil
+
+	config, configErr := c.getConfigSnapshot()
+	if configErr != nil {
+		return 0, fmt.Errorf("Unable to determine vbucket count: %w", configErr)
+	}
+
+	vbNo, err := config.NumVbuckets()
+	if err != nil {
+		return 0, fmt.Errorf("Unable to determine vbucket count: %w", err)
+	}
+
+	return uint16(vbNo), nil
+}
+
+func (c *Collection) getConfigSnapshot() (*gocbcore.ConfigSnapshot, error) {
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		return nil, fmt.Errorf("no router: %w", routerErr)
+	}
+
+	config, configErr := router.ConfigSnapshot()
+	if configErr != nil {
+		return nil, fmt.Errorf("no router config snapshot: %w", configErr)
+	}
+	return config, nil
 }
 
 func expAsDuration(exp uint32) time.Duration {
@@ -476,4 +527,97 @@ func (c *Collection) BucketItemCount() (itemCount int, err error) {
 	time.Sleep(1 * time.Second)
 	//itemCount, err = bucket.APIBucketItemCount()
 	return 0, err
+}
+
+func (c *Collection) MgmtEps() (url []string, err error) {
+
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		return url, routerErr
+	}
+	mgmtEps := router.MgmtEps()
+	if len(mgmtEps) == 0 {
+		return nil, fmt.Errorf("No available Couchbase Server nodes")
+	}
+	return mgmtEps, nil
+}
+
+// Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
+// found, retrieves the cluster-wide value.
+func (c *Collection) MetadataPurgeInterval() (time.Duration, error) {
+	return getMetadataPurgeInterval(c)
+}
+
+func (c *Collection) ServerUUID() (uuid string, err error) {
+	return getServerUUID(c)
+}
+
+func (c *Collection) MaxTTL() (int, error) {
+	return getMaxTTL(c)
+}
+
+func (c *Collection) HttpClient() *http.Client {
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		Warnf("Unable to obtain router while retrieving httpClient:%v", routerErr)
+		return nil
+	}
+	return router.HTTPClient()
+}
+
+// GetExpiry requires a full document retrieval in order to obtain the expiry, which is reasonable for
+// current use cases (on-demand import).  If there's a need for expiry as part of normal get, this shouldn't be
+// used - an enhanced version of Get() should be implemented to avoid two ops
+func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
+	getOptions := &gocb.GetOptions{
+		WithExpiry: true,
+	}
+	getResult, err := c.Collection.Get(k, getOptions)
+	if err != nil {
+		return 0, err
+	}
+	expiryTime := getResult.ExpiryTime()
+
+	return DurationToCbsExpiry(time.Until(expiryTime)), nil
+}
+
+func (c *Collection) BucketName() string {
+	return c.Bucket().Name()
+}
+
+func getTranscoder(value interface{}) gocb.Transcoder {
+	switch value.(type) {
+	case []byte, *[]byte:
+		return gocb.NewRawJSONTranscoder()
+	default:
+		return nil
+	}
+}
+
+func (c *Collection) mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error) {
+	if contentType == "" && body != nil {
+		panic("Content-type must be specified for non-null body.")
+	}
+
+	mgmtEp, err := GoCBBucketMgmtEndpoint(c)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, mgmtEp+uri, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if contentType != "" {
+		req.Header.Add("Content-Type", contentType)
+	}
+
+	if c.Spec.Auth != nil {
+		username, password, _ := c.Spec.Auth.GetCredentials()
+		req.SetBasicAuth(username, password)
+	}
+
+	return c.HttpClient().Do(req)
+>>>>>>> Support running w/ gocb V2
 }

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -133,3 +133,7 @@ func (c *Collection) executeStatement(statement string) error {
 func (c *Collection) IsErrNoResults(err error) bool {
 	return err == gocb.ErrNoResult
 }
+
+func (c *Collection) getIndexes() (indexes []string, err error) {
+	return nil, errors.New("not implemented")
+}

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -35,6 +35,7 @@ const (
 
 // N1QLStore defines the set of operations Sync Gateway uses to manage and interact with N1QL
 type N1QLStore interface {
+	GetName() string
 	BuildDeferredIndexes(indexSet []string) error
 	CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
 	CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error
@@ -51,6 +52,9 @@ type N1QLStore interface {
 
 	// executeStatement executes the specified statement and closes the response, returning any errors received.
 	executeStatement(statement string) error
+
+	// getIndexes retrieves all index names, used by test harness
+	getIndexes() (indexes []string, err error)
 }
 
 func ExplainQuery(store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {

--- a/base/constants.go
+++ b/base/constants.go
@@ -23,7 +23,7 @@ const (
 	GuestUsername = "GUEST"
 	ISO8601Format = "2006-01-02T15:04:05.000Z07:00"
 
-	kTestCouchbaseServerURL = "http://localhost:8091"
+	kTestCouchbaseServerURL = "couchbase://localhost"
 	kTestWalrusURL          = "walrus:"
 
 	// These settings are used when running unit tests against a live Couchbase Server to create/flush buckets

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"expvar"
 	"fmt"
 	"strconv"
@@ -313,7 +314,12 @@ func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo boo
 // Initializes DCP Feed.  Determines starting position based on feed type.
 func (c *DCPCommon) initFeed(backfillType uint64) error {
 
-	statsUuids, highSeqnos, err := c.bucket.GetStatsVbSeqno(c.maxVbNo, false)
+	couchbaseBucket, ok := AsCouchbaseStore(c.bucket)
+	if !ok {
+		return errors.New("DCP not supported for non-Couchbase data source")
+	}
+
+	statsUuids, highSeqnos, err := couchbaseBucket.GetStatsVbSeqno(c.maxVbNo, false)
 	if err != nil {
 		return pkgerrors.Wrap(err, "Error retrieving stats-vbseqno - DCP not supported")
 	}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"expvar"
+	"log"
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
@@ -217,12 +218,17 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
 	// reusing the bucket connection we've already established.
 	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, &connSpec)
+
+	log.Printf(".....urls: %v", urls)
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}
 
 	poolName := DefaultPool
 	bucketName := spec.BucketName
+
+	log.Printf(".....spec: %v", spec)
+	log.Printf(".....bucketName: %v", bucketName)
 
 	vbucketIdsArr := []uint16(nil) // nil means get all the vbuckets.
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"expvar"
-	"log"
 
 	"github.com/couchbase/go-couchbase"
 	"github.com/couchbase/go-couchbase/cbdatasource"
@@ -219,16 +218,12 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	// reusing the bucket connection we've already established.
 	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, &connSpec)
 
-	log.Printf(".....urls: %v", urls)
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}
 
 	poolName := DefaultPool
 	bucketName := spec.BucketName
-
-	log.Printf(".....spec: %v", spec)
-	log.Printf(".....bucketName: %v", bucketName)
 
 	vbucketIdsArr := []uint16(nil) // nil means get all the vbuckets.
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -37,20 +37,20 @@ type CbgtContext struct {
 
 // StartShardedDCPFeed initializes and starts a CBGT Manager targeting the provided bucket.
 // dbName is used to define a unique path name for local file storage of pindex files
-func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket *CouchbaseBucketGoCB, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
+func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket Bucket, spec BucketSpec, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
 
-	cbgtContext, err := initCBGTManager(bucket, bucket.Spec, cfg, uuid)
+	cbgtContext, err := initCBGTManager(bucket, spec, cfg, uuid)
 	if err != nil {
 		return nil, err
 	}
 
-	dcpContextID := MD(bucket.Spec.BucketName).Redact() + "-" + DCPImportFeedID
+	dcpContextID := MD(spec.BucketName).Redact() + "-" + DCPImportFeedID
 	cbgtContext.loggingCtx = context.WithValue(context.Background(), LogContextKey{},
 		LogContext{CorrelationID: dcpContextID},
 	)
 
 	// Start Manager.  Registers this node in the cfg
-	err = cbgtContext.StartManager(dbName, bucket, bucket.Spec, numPartitions)
+	err = cbgtContext.StartManager(dbName, bucket, spec, numPartitions)
 	if err != nil {
 		return nil, err
 	}

--- a/base/error.go
+++ b/base/error.go
@@ -10,15 +10,17 @@ package base
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/couchbase/gocb"
 
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"
 	pkgerrors "github.com/pkg/errors"
-	"gopkg.in/couchbase/gocb.v1"
-	"gopkg.in/couchbase/gocbcore.v7"
+	gocbv1 "gopkg.in/couchbase/gocb.v1"
 )
 
 type sgError struct {
@@ -84,22 +86,30 @@ func ErrorAsHTTPStatus(err error) (int, string) {
 
 	// Check for SGErrors
 	switch unwrappedErr {
-	case gocb.ErrKeyNotFound:
+	case gocbv1.ErrKeyNotFound, ErrNotFound:
 		return http.StatusNotFound, "missing"
-	case gocb.ErrKeyExists:
+	case gocbv1.ErrKeyExists, ErrAlreadyExists:
 		return http.StatusConflict, "Conflict"
-	case gocb.ErrTimeout:
+	case gocbv1.ErrTimeout, gocb.ErrTimeout:
 		return http.StatusServiceUnavailable, "Database timeout error (gocb.ErrTimeout)"
-	case gocb.ErrOverload:
+	case gocbv1.ErrOverload, gocb.ErrOverload:
 		return http.StatusServiceUnavailable, "Database server is over capacity (gocb.ErrOverload)"
-	case gocb.ErrBusy:
+	case gocbv1.ErrBusy:
 		return http.StatusServiceUnavailable, "Database server is over capacity (gocb.ErrBusy)"
-	case gocb.ErrTmpFail:
+	case gocbv1.ErrTmpFail, gocb.ErrTemporaryFailure:
 		return http.StatusServiceUnavailable, "Database server is over capacity (gocb.ErrTmpFail)"
-	case gocb.ErrTooBig:
+	case gocbv1.ErrTooBig, gocb.ErrValueTooLarge:
 		return http.StatusRequestEntityTooLarge, "Document too large!"
 	case ErrViewTimeoutError:
 		return http.StatusServiceUnavailable, unwrappedErr.Error()
+	}
+
+	if errors.Is(err, gocb.ErrDocumentNotFound) {
+		return http.StatusNotFound, "missing"
+	}
+
+	if errors.Is(err, gocb.ErrDocumentExists) {
+		return http.StatusConflict, "Conflict"
 	}
 
 	switch unwrappedErr := unwrappedErr.(type) {
@@ -175,7 +185,11 @@ func IsDocNotFoundError(err error) bool {
 		return true
 	}
 
-	if unwrappedErr == gocb.ErrKeyNotFound {
+	if unwrappedErr == gocbv1.ErrKeyNotFound {
+		return true
+	}
+
+	if errors.Is(err, gocb.ErrDocumentNotFound) {
 		return true
 	}
 
@@ -189,13 +203,4 @@ func IsDocNotFoundError(err error) bool {
 	default:
 		return false
 	}
-}
-
-func IsSubDocPathExistsError(err error) bool {
-
-	subdocMutateErr, ok := pkgerrors.Cause(err).(gocbcore.SubDocMutateError)
-	if ok {
-		return subdocMutateErr.Err == gocb.ErrSubDocPathExists
-	}
-	return false
 }

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -465,7 +465,8 @@ func (dh *documentBackedListener) updateNodeList(nodeID string, remove bool) err
 
 func (dh *documentBackedListener) loadNodeIDs() error {
 
-	docBytes, cas, err := dh.bucket.GetRaw(dh.nodeListKey)
+	var docBytes []byte
+	cas, err := dh.bucket.Get(dh.nodeListKey, &docBytes)
 	if err != nil {
 		dh.cas = 0
 		dh.nodeIDs = []string{}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -421,10 +421,6 @@ func (b *LeakyBucket) Dump() {
 	b.bucket.Dump()
 }
 
-func (b *LeakyBucket) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	return b.bucket.CouchbaseServerVersion()
-}
-
 func (b *LeakyBucket) UUID() (string, error) {
 	return b.bucket.UUID()
 }
@@ -434,10 +430,6 @@ func (b *LeakyBucket) CloseAndDelete() error {
 		return bucket.CloseAndDelete()
 	}
 	return nil
-}
-
-func (b *LeakyBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
-	return b.bucket.GetStatsVbSeqno(maxVbno, useAbsHighSeqNo)
 }
 
 // Accessors to set leaky bucket config for a running bucket.  Used to tune properties on a walrus bucket created as part of rest tester - it will
@@ -568,6 +560,14 @@ func (b *LeakyBucket) executeStatement(statement string) error {
 		return errors.New("Not N1QL Store")
 	}
 	return n1qlStore.executeStatement(statement)
+}
+
+func (b *LeakyBucket) getIndexes() ([]string, error) {
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return nil, errors.New("Not N1QL Store")
+	}
+	return n1qlStore.getIndexes()
 }
 
 func (b *LeakyBucket) IsErrNoResults(err error) bool {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -186,19 +186,9 @@ func (b *LoggingBucket) GetMaxVbno() (uint16, error) {
 	return b.bucket.GetMaxVbno()
 }
 
-func (b *LoggingBucket) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	defer b.log(time.Now())
-	return b.bucket.CouchbaseServerVersion()
-}
-
 func (b *LoggingBucket) UUID() (string, error) {
 	defer b.log(time.Now())
 	return b.bucket.UUID()
-}
-
-func (b *LoggingBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
-	defer b.log(time.Now())
-	return b.bucket.GetStatsVbSeqno(maxVbno, useAbsHighSeqNo)
 }
 
 // GetUnderlyingBucket returns the underlying bucket for the LoggingBucket.

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -638,7 +638,7 @@ type tbpBucketName string
 
 var tbpDefaultBucketSpec = BucketSpec{
 	Server:          UnitTestUrl(),
-	CouchbaseDriver: GoCBCustomSGTranscoder,
+	CouchbaseDriver: ChooseCouchbaseDriver(DataBucket),
 	Auth: TestAuthenticator{
 		Username: TestClusterUsername(),
 		Password: TestClusterPassword(),

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -192,6 +192,10 @@ func initV2Cluster(server string) *gocb.Cluster {
 	if err != nil {
 		Fatalf("Couldn't connect to %q: %v", server, err)
 	}
+	err = cluster.WaitUntilReady(15*time.Second, nil)
+	if err != nil {
+		Fatalf("Cluster not ready: %v", err)
+	}
 
 	return cluster
 }
@@ -243,6 +247,7 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 		Collection: bucket.DefaultCollection(),
 		cluster:    c.cluster,
 		viewOps:    make(chan struct{}, MaxConcurrentViewOps),
+		Spec:       bucketSpec,
 	}
 
 	return collection, nil

--- a/base/util.go
+++ b/base/util.go
@@ -829,13 +829,10 @@ func BoolPtr(b bool) *bool {
 // Related CBGT ticket: https://issues.couchbase.com/browse/MB-25522
 func CouchbaseURIToHttpURL(bucket Bucket, couchbaseUri string, connSpec *gocbconnstr.ConnSpec) (httpUrls []string, err error) {
 
-	// If we're using a gocb bucket, use the bucket to retrieve the mgmt endpoints.  Note that incoming bucket may be CouchbaseBucketGoCB or *CouchbaseBucketGoCB.
-	typedBucket, ok := AsGoCBBucket(bucket)
+	// If we're using a couchbase bucket, use the bucket to retrieve the mgmt endpoints.
+	cbBucket, ok := bucket.(CouchbaseStore)
 	if ok {
-		if typedBucket.IoRouter() != nil {
-			mgmtEps := typedBucket.IoRouter().MgmtEps()
-			return mgmtEps, nil
-		}
+		return cbBucket.MgmtEps()
 	}
 
 	// No bucket-based handling, fall back to URI parsing
@@ -1486,7 +1483,7 @@ func GetRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64,
 	return value
 }
 
-// GetHttpClient returns a new HTTP client with TLS certificate verification
+// HttpClient returns a new HTTP client with TLS certificate verification
 // disabled when insecureSkipVerify is true and enabled otherwise.
 func GetHttpClient(insecureSkipVerify bool) *http.Client {
 	if insecureSkipVerify {

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -210,10 +210,10 @@ func (t TestAuthenticator) GetCredentials() (username, password, bucketname stri
 }
 
 // Reset bucket state
-func DropAllBucketIndexes(gocbBucket *CouchbaseBucketGoCB) error {
+func DropAllBucketIndexes(bucket N1QLStore) error {
 
 	// Retrieve all indexes
-	indexes, err := getIndexes(gocbBucket)
+	indexes, err := bucket.getIndexes()
 	if err != nil {
 		return err
 	}
@@ -230,14 +230,14 @@ func DropAllBucketIndexes(gocbBucket *CouchbaseBucketGoCB) error {
 
 			defer wg.Done()
 
-			log.Printf("Dropping index %s on bucket %s...", indexToDrop, gocbBucket.Name())
-			dropErr := gocbBucket.DropIndex(indexToDrop)
+			log.Printf("Dropping index %s on bucket %s...", indexToDrop, bucket.GetName())
+			dropErr := bucket.DropIndex(indexToDrop)
 			if dropErr != nil {
 				asyncErrors <- dropErr
-				log.Printf("...failed to drop index %s on bucket %s: %s", indexToDrop, gocbBucket.Name(), dropErr)
+				log.Printf("...failed to drop index %s on bucket %s: %s", indexToDrop, bucket.GetName(), dropErr)
 				return
 			}
-			log.Printf("...successfully dropped index %s on bucket %s", indexToDrop, gocbBucket.Name())
+			log.Printf("...successfully dropped index %s on bucket %s", indexToDrop, bucket.GetName())
 		}(index)
 
 	}
@@ -253,30 +253,6 @@ func DropAllBucketIndexes(gocbBucket *CouchbaseBucketGoCB) error {
 	}
 
 	return nil
-}
-
-// Get a list of all index names in the bucket
-func getIndexes(gocbBucket *CouchbaseBucketGoCB) (indexes []string, err error) {
-
-	indexes = []string{}
-
-	manager, err := gocbBucket.getBucketManager()
-	if err != nil {
-		return indexes, err
-	}
-
-	indexInfo, err := manager.GetIndexes()
-	if err != nil {
-		return indexes, err
-	}
-
-	for _, indexInfo := range indexInfo {
-		if indexInfo.Keyspace == gocbBucket.GetName() {
-			indexes = append(indexes, indexInfo.Name)
-		}
-	}
-
-	return indexes, nil
 }
 
 // Generates a string of size int

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -54,6 +54,10 @@ func (tb TestBucket) Close() {
 	tb.closeFn()
 }
 
+func (tb *TestBucket) GetUnderlyingBucket() Bucket {
+	return tb.Bucket
+}
+
 // LeakyBucketClone wraps the underlying bucket on the TestBucket with a LeakyBucket and returns a new TestBucket handle.
 func (tb *TestBucket) LeakyBucketClone(c LeakyBucketConfig) *TestBucket {
 	return &TestBucket{

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -116,8 +116,6 @@ func GetPersistentWalrusBucket(t testing.TB) (*TestBucket, func()) {
 
 func GetTestBucketForDriver(t testing.TB, driver CouchbaseDriver) *TestBucket {
 	if driver == GoCBv2 {
-		// TODO: add GoCBv2 support to TestBucketPool.
-
 		// Reserve test bucket from pool
 		_, spec, closeFn := GTestBucketPool.GetTestBucketAndSpec(t)
 

--- a/db/changes_test.go
+++ b/db/changes_test.go
@@ -228,12 +228,10 @@ func TestDocDeletionFromChannelCoalescedRemoved(t *testing.T) {
 	lastSeq := getLastSeq(changes)
 	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
 
-	// Get raw document from the bucket
-	rv, _, _ := db.Bucket.GetRaw("alpha") // cas, err
-
-	//Unmarshall into nested maps
+	// Get document from the bucket
 	var x map[string]interface{}
-	assert.NoError(t, base.JSONUnmarshal(rv, &x))
+	_, err = db.Bucket.Get("alpha", &x) // cas, err
+	assert.NoError(t, err)
 
 	sync := x[base.SyncXattrName].(map[string]interface{})
 	sync["sequence"] = 3
@@ -313,12 +311,10 @@ func TestDocDeletionFromChannelCoalesced(t *testing.T) {
 	lastSeq := getLastSeq(changes)
 	lastSeq, _ = db.ParseSequenceID(lastSeq.String())
 
-	// Get raw document from the bucket
-	rv, _, _ := db.Bucket.GetRaw("alpha") // cas, err
-
-	//Unmarshall into nested maps
+	// Get document from the bucket
 	var x map[string]interface{}
-	assert.NoError(t, base.JSONUnmarshal(rv, &x))
+	_, err = db.Bucket.Get("alpha", &x) // cas, err
+	assert.NoError(t, err)
 
 	sync := x[base.SyncXattrName].(map[string]interface{})
 	sync["sequence"] = 3

--- a/db/crud.go
+++ b/db/crud.go
@@ -74,7 +74,8 @@ func (db *DatabaseContext) GetDocument(docid string, unmarshalLevel DocumentUnma
 			return nil, base.HTTPErrorf(404, "Not imported")
 		}
 	} else {
-		rawDoc, _, getErr := db.Bucket.GetRaw(key)
+		var rawDoc []byte
+		_, getErr := db.Bucket.Get(key, &rawDoc)
 		if getErr != nil {
 			return nil, getErr
 		}
@@ -157,7 +158,9 @@ func (db *DatabaseContext) GetDocSyncData(docid string) (SyncData, error) {
 
 	} else {
 		// Non-xattr.  Retrieve doc from bucket, unmarshal metadata only.
-		rawDocBytes, _, err := db.Bucket.GetRaw(key)
+
+		var rawDocBytes []byte
+		_, err := db.Bucket.Get(key, &rawDocBytes)
 		if err != nil {
 			return emptySyncData, err
 		}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -48,12 +48,11 @@ func getRevTreeList(bucket base.Bucket, key string, useXattrs bool) (revTreeList
 		return treeMeta.RevTree, nil
 
 	default:
-		rawDoc, _, err := bucket.GetRaw(key)
+		var doc treeDoc
+		_, err := bucket.Get(key, &doc)
 		if err != nil {
 			return revTreeList{}, err
 		}
-		var doc treeDoc
-		err = base.JSONUnmarshal(rawDoc, &doc)
 		return doc.Meta.RevTree, err
 	}
 

--- a/db/database.go
+++ b/db/database.go
@@ -486,9 +486,9 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	if dbContext.UseXattrs() {
 		// Set the purge interval for tombstone compaction
 		dbContext.PurgeInterval = DefaultPurgeInterval
-		gocbBucket, ok := base.AsGoCBBucket(bucket)
+		cbStore, ok := base.AsCouchbaseStore(bucket)
 		if ok {
-			serverPurgeInterval, err := gocbBucket.GetMetadataPurgeInterval()
+			serverPurgeInterval, err := cbStore.MetadataPurgeInterval()
 			if err != nil {
 				base.Warnf("Unable to retrieve server's metadata purge interval - will use default value. %s", err)
 			} else if serverPurgeInterval > 0 {
@@ -519,10 +519,9 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	}
 
 	// Make sure there is no MaxTTL set on the bucket (SG #3314)
-	gocbBucket, ok := base.AsGoCBBucket(bucket)
+	cbs, ok := base.AsCouchbaseStore(bucket)
 	if ok {
-		maxTTL, err := gocbBucket.GetMaxTTL()
-
+		maxTTL, err := cbs.MaxTTL()
 		if err != nil {
 			return nil, err
 		}
@@ -581,13 +580,13 @@ func (context *DatabaseContext) GetServerUUID() string {
 
 	// Lazy load the server UUID, if we can get it.
 	if context.serverUUID == "" {
-		b, ok := base.AsGoCBBucket(context.Bucket)
+		cbs, ok := base.AsCouchbaseStore(context.Bucket)
 		if !ok {
 			base.Warnf("Database %v: Unable to get server UUID. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
 			return ""
 		}
 
-		uuid, err := b.GetServerUUID()
+		uuid, err := cbs.ServerUUID()
 		if err != nil {
 			base.Warnf("Database %v: Unable to get server UUID: %v", base.MD(context.Name), err)
 			return ""
@@ -680,17 +679,17 @@ func (context *DatabaseContext) RemoveObsoleteDesignDocs(previewOnly bool) (remo
 // Removes previous versions of Sync Gateway's indexes found on the server
 func (context *DatabaseContext) RemoveObsoleteIndexes(previewOnly bool) (removedIndexes []string, err error) {
 
-	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	if !context.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql) {
+		return removedIndexes, nil
+	}
+
+	n1qlStore, ok := base.AsN1QLStore(context.Bucket)
 	if !ok {
 		base.Warnf("Cannot remove obsolete indexes for non-gocb bucket - skipping.")
 		return make([]string, 0), nil
 	}
 
-	if !gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql) {
-		return removedIndexes, nil
-	}
-
-	return removeObsoleteIndexes(gocbBucket, previewOnly, context.UseXattrs(), context.UseViews(), sgIndexes)
+	return removeObsoleteIndexes(n1qlStore, previewOnly, context.UseXattrs(), context.UseViews(), sgIndexes)
 }
 
 // Trigger terminate check handling for connected continuous replications.
@@ -1411,29 +1410,29 @@ func (db *Database) invalUserOrRoleChannels(name string, invalSeq uint64) {
 }
 
 func (context *DatabaseContext) ObtainManagementEndpoints() ([]string, error) {
-	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	cbStore, ok := base.AsCouchbaseStore(context.Bucket)
 	if !ok {
 		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
 		return nil, nil
 	}
 
-	return base.GoCBBucketMgmtEndpoints(gocbBucket.Bucket)
+	return base.GoCBBucketMgmtEndpoints(cbStore)
 }
 
 func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
-	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	cbStore, ok := base.AsCouchbaseStore(context.Bucket)
 	if !ok {
 		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
 		return nil, nil, nil
 	}
 
-	endpoints, err := base.GoCBBucketMgmtEndpoints(gocbBucket.Bucket)
+	endpoints, err := base.GoCBBucketMgmtEndpoints(cbStore)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Clone HTTP transport for use in our httpClient
-	transport := gocbBucket.Bucket.IoRouter().HttpClient().Transport.(*http.Transport).Clone()
+	transport := cbStore.HttpClient().Transport.(*http.Transport).Clone()
 
 	httpClient := &http.Client{
 		Transport: transport,

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -123,9 +123,15 @@ func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyO
 	testBucket := base.GetTestBucket(t)
 	leakyBucket := base.NewLeakyBucket(testBucket, leakyOptions)
 	context, err := NewDatabaseContext("db", leakyBucket, false, dbcOptions)
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
+	if err != nil {
+		testBucket.Close()
+		t.Fatalf("Unable to create database context: %v", err)
+	}
 	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "Couldn't create database 'db'")
+	if err != nil {
+		context.Close()
+		t.Fatalf("Unable to create database: %v", err)
+	}
 	return db
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -981,8 +981,8 @@ func TestConflicts(t *testing.T) {
 
 	cacheWaiter.Add(2)
 
-	rawBody, _, _ := db.Bucket.GetRaw("doc")
-
+	var rawBody []byte
+	_, _ = db.Bucket.Get("doc", &rawBody)
 	log.Printf("got raw body: %s", rawBody)
 
 	// Verify the change with the higher revid won:
@@ -1024,8 +1024,9 @@ func TestConflicts(t *testing.T) {
 	rev3, err := db.DeleteDoc("doc", "2-b")
 	assert.NoError(t, err, "delete 2-b")
 
-	rawBody, _, _ = db.Bucket.GetRaw("doc")
-	log.Printf("post-delete, got raw body: %s", rawBody)
+	var postRawBody []byte
+	_, _ = db.Bucket.Get("doc", &postRawBody)
+	log.Printf("post-delete, got raw body: %s", postRawBody)
 
 	gotBody, err = db.Get1xBody("doc")
 	expectedResult = Body{BodyId: "doc", BodyRev: "2-a", "n": 3, "channels": []string{"all", "2a"}}

--- a/db/import.go
+++ b/db/import.go
@@ -52,8 +52,8 @@ func (db *Database) ImportDocRaw(docid string, value []byte, xattrValue []byte, 
 
 	// Get the doc expiry if it wasn't passed in
 	if expiry == nil {
-		gocbBucket, _ := base.AsGoCBBucket(db.Bucket)
-		getExpiry, getExpiryErr := gocbBucket.GetExpiry(docid)
+		cbStore, _ := base.AsCouchbaseStore(db.Bucket)
+		getExpiry, getExpiryErr := cbStore.GetExpiry(docid)
 		if getExpiryErr != nil {
 			return nil, getExpiryErr
 		}
@@ -79,8 +79,8 @@ func (db *Database) ImportDoc(docid string, existingDoc *Document, isDelete bool
 
 	// Get the doc expiry if it wasn't passed in
 	if expiry == nil {
-		gocbBucket, _ := base.AsGoCBBucket(db.Bucket)
-		getExpiry, getExpiryErr := gocbBucket.GetExpiry(docid)
+		cbStore, _ := base.AsCouchbaseStore(db.Bucket)
+		getExpiry, getExpiryErr := cbStore.GetExpiry(docid)
 		if getExpiryErr != nil {
 			return nil, getExpiryErr
 		}
@@ -161,8 +161,8 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 				}
 
 				// Reload the doc expiry
-				gocbBucket, _ := base.AsGoCBBucket(db.Bucket)
-				expiry, getExpiryErr := gocbBucket.GetExpiry(newDoc.ID)
+				cbStore, _ := base.AsCouchbaseStore(db.Bucket)
+				expiry, getExpiryErr := cbStore.GetExpiry(newDoc.ID)
 				if getExpiryErr != nil {
 					return nil, nil, false, nil, getExpiryErr
 				}

--- a/db/import.go
+++ b/db/import.go
@@ -35,6 +35,7 @@ func (db *Database) ImportDocRaw(docid string, value []byte, xattrValue []byte, 
 	var body Body
 	if isDelete {
 		body = Body{}
+		expiry = base.Uint32Ptr(0)
 	} else {
 		err := body.Unmarshal(value)
 		if err != nil {
@@ -50,7 +51,7 @@ func (db *Database) ImportDocRaw(docid string, value []byte, xattrValue []byte, 
 		return nil, base.ErrImportCancelledPurged
 	}
 
-	// Get the doc expiry if it wasn't passed in
+	// Get the doc expiry if it wasn't passed in, and this isn't a server tombstone
 	if expiry == nil {
 		cbStore, _ := base.AsCouchbaseStore(db.Bucket)
 		getExpiry, getExpiryErr := cbStore.GetExpiry(docid)

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -59,12 +59,12 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
 
 	// TODO: need to clean up StartDCPFeed to push bucket dependencies down
-	gocbBucket, ok := base.AsGoCBBucket(bucket)
+	cbStore, ok := base.AsCouchbaseStore(bucket)
 	if !ok || !base.IsEnterpriseEdition() {
-		// Non-gocb bucket or CE, start a non-sharded feed
+		// Non-couchbase bucket or CE, start a non-sharded feed
 		return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
 	} else {
-		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.UUID, dbContext.Heartbeater, gocbBucket, dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
+		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.UUID, dbContext.Heartbeater, bucket, cbStore.GetSpec(), dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
 		return err
 	}
 

--- a/db/import_test.go
+++ b/db/import_test.go
@@ -182,8 +182,8 @@ func TestImportWithStaleBucketDocCorrectExpiry(t *testing.T) {
 			assertXattrSyncMetaRevGeneration(t, db.Bucket, key, testCase.expectedGeneration)
 
 			// Verify the expiry has been preserved after the import
-			gocbBucket, _ := base.AsGoCBBucket(db.Bucket)
-			expiry, err := gocbBucket.GetExpiry(key)
+			cbStore, _ := base.AsCouchbaseStore(db.Bucket)
+			expiry, err := cbStore.GetExpiry(key)
 			assert.NoError(t, err, "Error calling GetExpiry()")
 			goassert.True(t, expiry == uint32(laterSyncMetaExpiry.Unix()))
 

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -58,7 +58,7 @@ func validateAllIndexesOnline(bucket base.Bucket) error {
 	}
 
 	// Retrieve all indexes
-	getIndexesStatement := fmt.Sprintf("SELECT indexes.name, indexes.state from system:indexes where keyspace_id = %q", n1ql.GetName())
+	getIndexesStatement := fmt.Sprintf("SELECT indexes.name, indexes.state from system:indexes where keyspace_id = %q", n1QLStore.GetName())
 	results, err := n1QLStore.Query(getIndexesStatement, nil, base.RequestPlus, true)
 	if err != nil {
 		return err

--- a/db/indexes_test.go
+++ b/db/indexes_test.go
@@ -21,7 +21,6 @@ import (
 	goassert "github.com/couchbaselabs/go.assert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/couchbase/gocb.v1"
 )
 
 func TestInitializeIndexes(t *testing.T) {
@@ -32,17 +31,17 @@ func TestInitializeIndexes(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	goCbBucket, isGoCBBucket := base.AsGoCBBucket(db.Bucket)
+	n1qlStore, isGoCBBucket := base.AsN1QLStore(db.Bucket)
 	require.True(t, isGoCBBucket)
 
-	dropErr := base.DropAllBucketIndexes(goCbBucket)
+	dropErr := base.DropAllBucketIndexes(n1qlStore)
 	assert.NoError(t, dropErr, "Error dropping all indexes")
 
-	initErr := InitializeIndexes(db.Bucket, db.UseXattrs(), 0)
+	initErr := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
 	assert.NoError(t, initErr, "Error initializing all indexes")
 
 	// Recreate the primary index required by the test bucket pooling framework
-	err := goCbBucket.CreatePrimaryIndex(base.PrimaryIndexName, nil)
+	err := n1qlStore.CreatePrimaryIndex(base.PrimaryIndexName, nil)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -53,15 +52,14 @@ func TestInitializeIndexes(t *testing.T) {
 // Reset bucket state
 func validateAllIndexesOnline(bucket base.Bucket) error {
 
-	gocbBucket, ok := base.AsGoCBBucket(bucket)
+	n1QLStore, ok := base.AsN1QLStore(bucket)
 	if !ok {
 		return fmt.Errorf("Bucket is not gocb bucket: %T", bucket)
 	}
 
 	// Retrieve all indexes
-	getIndexesStatement := fmt.Sprintf("SELECT indexes.name, indexes.state from system:indexes where keyspace_id = %q", gocbBucket.GetName())
-	n1qlQuery := gocb.NewN1qlQuery(getIndexesStatement)
-	results, err := gocbBucket.ExecuteN1qlQuery(n1qlQuery, nil)
+	getIndexesStatement := fmt.Sprintf("SELECT indexes.name, indexes.state from system:indexes where keyspace_id = %q", n1ql.GetName())
+	results, err := n1QLStore.Query(getIndexesStatement, nil, base.RequestPlus, true)
 	if err != nil {
 		return err
 	}
@@ -91,9 +89,10 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
+	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
+
+	n1qlStore, ok := base.AsN1QLStore(db.Bucket)
 	assert.True(t, ok)
-	require.True(t, gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	// We have one xattr-only index - adjust expected indexes accordingly
 	expectedIndexes := int(indexTypeCount)
@@ -103,30 +102,30 @@ func TestPostUpgradeIndexesSimple(t *testing.T) {
 
 	// We don't know the current state of the bucket (may already have xattrs enabled), so run
 	// an initial cleanup to remove existing obsolete indexes
-	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(n1qlStore, false, db.UseXattrs(), db.UseViews(), sgIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in setup case")
 
-	err := InitializeIndexes(db.Bucket, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 
 	// Running w/ opposite xattrs flag should preview removal of the indexes associated with this db context
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, true, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in preview mode")
 
 	// Running again w/ preview=false to perform cleanup
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	goassert.Equals(t, len(removedIndexes), int(expectedIndexes))
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in non-preview mode")
 
 	// One more time to make sure they are actually gone
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, false, !db.UseXattrs(), db.UseViews(), sgIndexes)
 	goassert.Equals(t, len(removedIndexes), 0)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in post-cleanup no-op")
 
 	// Restore indexes after test
-	err = InitializeIndexes(db.Bucket, db.UseXattrs(), 0)
+	err = InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 }
 
@@ -138,14 +137,14 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
+	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
+	n1qlStore, ok := base.AsN1QLStore(db.Bucket)
 	assert.True(t, ok)
-	require.True(t, gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
 	copiedIndexes := copySGIndexes(sgIndexes)
 
 	// Validate that removeObsoleteIndexes is a no-op for the default case
-	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 0)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes in no-op case")
@@ -162,13 +161,13 @@ func TestPostUpgradeIndexesVersionChange(t *testing.T) {
 	copiedIndexes[IndexAccess] = accessIndex
 
 	// Validate that removeObsoleteIndexes now triggers removal of one index
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(n1qlStore, true, db.UseXattrs(), db.UseViews(), copiedIndexes)
 	log.Printf("removedIndexes: %+v", removedIndexes)
 	goassert.Equals(t, len(removedIndexes), 1)
 	assert.NoError(t, removeErr, "Unexpected error running removeObsoleteIndexes with hacked sgIndexes")
 
 	// Restore indexes after test
-	err := InitializeIndexes(db.Bucket, db.UseXattrs(), 0)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -186,13 +185,13 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 
 	copiedIndexes := copySGIndexes(sgIndexes)
 
-	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
+	require.True(t, db.Bucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
+	n1QLStore, ok := base.AsN1QLStore(db.Bucket)
 	assert.True(t, ok)
-	require.True(t, gocbBucket.IsSupported(sgbucket.DataStoreFeatureN1ql))
 
-	_, err := removeObsoleteDesignDocs(gocbBucket, !db.UseXattrs(), db.UseViews())
+	_, err := removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(gocbBucket, !db.UseXattrs(), !db.UseViews())
+	_, err = removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
 
 	expectedIndexes := int(indexTypeCount)
@@ -201,30 +200,30 @@ func TestRemoveIndexesUseViewsTrueAndFalse(t *testing.T) {
 		expectedIndexes--
 	}
 
-	removedIndexes, removeErr := removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), true, copiedIndexes)
+	removedIndexes, removeErr := removeObsoleteIndexes(n1QLStore, false, db.UseXattrs(), true, copiedIndexes)
 	assert.Equal(t, expectedIndexes, len(removedIndexes))
 	assert.NoError(t, removeErr)
 
-	removedIndexes, removeErr = removeObsoleteIndexes(gocbBucket, false, db.UseXattrs(), false, copiedIndexes)
+	removedIndexes, removeErr = removeObsoleteIndexes(n1QLStore, false, db.UseXattrs(), false, copiedIndexes)
 	require.Len(t, removedIndexes, 0)
 	assert.NoError(t, removeErr)
 
 	// Cleanup design docs created during test
-	_, err = removeObsoleteDesignDocs(gocbBucket, db.UseXattrs(), db.UseViews())
+	_, err = removeObsoleteDesignDocs(db.Bucket, db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(gocbBucket, db.UseXattrs(), !db.UseViews())
+	_, err = removeObsoleteDesignDocs(db.Bucket, db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(gocbBucket, !db.UseXattrs(), db.UseViews())
+	_, err = removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), db.UseViews())
 	assert.NoError(t, err)
-	_, err = removeObsoleteDesignDocs(gocbBucket, !db.UseXattrs(), !db.UseViews())
+	_, err = removeObsoleteDesignDocs(db.Bucket, !db.UseXattrs(), !db.UseViews())
 	assert.NoError(t, err)
 
 	// Restore ddocs after test
-	err = InitializeViews(gocbBucket)
+	err = InitializeViews(db.Bucket)
 	assert.NoError(t, err)
 
 	// Restore indexes after test
-	err = InitializeIndexes(db.Bucket, db.UseXattrs(), 0)
+	err = InitializeIndexes(n1QLStore, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)
@@ -270,7 +269,8 @@ func TestRemoveObsoleteIndexOnError(t *testing.T) {
 	}
 
 	// Restore indexes after test
-	err := InitializeIndexes(db.Bucket, db.UseXattrs(), 0)
+	n1qlStore, _ := base.AsN1QLStore(db.Bucket)
+	err := InitializeIndexes(n1qlStore, db.UseXattrs(), 0)
 	assert.NoError(t, err)
 
 	validateErr := validateAllIndexesOnline(db.Bucket)

--- a/db/query.go
+++ b/db/query.go
@@ -242,14 +242,14 @@ func (context *DatabaseContext) N1QLQueryWithStats(queryName string, statement s
 		defer base.SlowQueryLog(startTime, threshold, "N1QL Query(%q)", queryName)
 	}
 
-	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	n1QLStore, ok := base.AsN1QLStore(context.Bucket)
 	if !ok {
 		return nil, errors.New("Cannot perform N1QL query on non-Couchbase bucket.")
 	}
 
 	queryStat := context.DbStats.Query(queryName)
 
-	results, err = gocbBucket.Query(statement, params, consistency, adhoc)
+	results, err = n1QLStore.Query(statement, params, consistency, adhoc)
 	if err != nil {
 		queryStat.QueryErrorCount.Add(1)
 	}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -313,14 +313,14 @@ func TestCoveringQueries(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
+	n1QLStore, ok := base.AsN1QLStore(db.Bucket)
 	if !ok {
-		t.Errorf("Unable to get gocbBucket for testBucket")
+		t.Errorf("Unable to get n1QLStore for testBucket")
 	}
 
 	// channels
 	channelsStatement, params := db.buildChannelsQuery("ABC", 0, 10, 100, false)
-	plan, explainErr := gocbBucket.ExplainQuery(channelsStatement, params)
+	plan, explainErr := n1QLStore.ExplainQuery(channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := isCovered(plan)
 	planJSON, err := base.JSONMarshal(plan)
@@ -329,7 +329,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// star channel
 	channelStarStatement, params := db.buildChannelsQuery("*", 0, 10, 100, false)
-	plan, explainErr = gocbBucket.ExplainQuery(channelStarStatement, params)
+	plan, explainErr = n1QLStore.ExplainQuery(channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -340,7 +340,7 @@ func TestCoveringQueries(t *testing.T) {
 	// in the SELECT.
 	// Including here for ease-of-conversion when we get an indexing enhancement to support covered queries.
 	accessStatement := db.buildAccessQuery("user1")
-	plan, explainErr = gocbBucket.ExplainQuery(accessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -349,7 +349,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// roleAccess
 	roleAccessStatement := db.buildRoleAccessQuery("user1")
-	plan, explainErr = gocbBucket.ExplainQuery(roleAccessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(roleAccessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for roleAccess query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)

--- a/db/special_docs.go
+++ b/db/special_docs.go
@@ -43,7 +43,7 @@ func (db *DatabaseContext) GetSpecialBytes(doctype string, docid string) ([]byte
 	if doctype == "local" && db.Options.LocalDocExpirySecs > 0 {
 		rawDocBytes, _, err = db.Bucket.GetAndTouchRaw(key, base.SecondsToCbsExpiry(int(db.Options.LocalDocExpirySecs)))
 	} else {
-		rawDocBytes, _, err = db.Bucket.GetRaw(key)
+		_, err = db.Bucket.Get(key, &rawDocBytes)
 	}
 	if err != nil {
 		return nil, err

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="7a9f15d95f07f7f30f567cf19919f554d14b12d5"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="3f290c1ec18cd8dbf967af8183a64801a8cf5db1"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2783,7 +2783,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	})
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -2793,7 +2793,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	_, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 	assert.NoError(t, err)
 
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, "val")
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "val")
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1640,11 +1640,11 @@ func TestLocalDocExpiry(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"hi": "there"}`)
 	assertStatus(t, response, 201)
 
-	goCBBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	cbStore, ok := base.AsCouchbaseStore(rt.Bucket())
 	require.True(t, ok)
 
 	localDocKey := db.RealSpecialDocID(db.DocTypeLocal, "loc1")
-	expiry, getMetaError := goCBBucket.GetExpiry(localDocKey)
+	expiry, getMetaError := cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after PUT is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -1653,7 +1653,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	// Retrieve local doc, ensure non-zero expiry is preserved
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
 	assertStatus(t, response, 200)
-	expiry, getMetaError = goCBBucket.GetExpiry(localDocKey)
+	expiry, getMetaError = cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after GET is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -3908,10 +3908,10 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 
 	// Fetch the xattr and make sure it contains the above value
 	baseBucket := rt.GetDatabase().Bucket
-	gocbBucket, _ := base.AsGoCBBucket(baseBucket)
+	subdocXattrStore, _ := base.AsSubdocXattrStore(baseBucket)
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = gocbBucket.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
+	_, err = subdocXattrStore.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
 	assert.NoError(t, err, "Unexpected Error")
 	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedXattr["rev"])
 
@@ -5484,12 +5484,13 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 	})
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	bucket := rt.Bucket()
+	_, ok := base.AsCouchbaseStore(bucket)
 	if !ok {
 		t.Skip("Requires Couchbase bucket")
 	}
 
-	_, err := gocbBucket.Bucket.Insert(t.Name(), map[string]interface{}{"val": "val"}, 0)
+	_, err := bucket.Add(t.Name(), 0, map[string]interface{}{"val": "val"})
 	require.NoError(t, err)
 
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"`+t.Name()+`": ["*"]}`)
@@ -5522,7 +5523,7 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	gocbBucket, ok := base.AsGoCBBucket(bucket)
+	_, ok := base.AsCouchbaseStore(bucket)
 	if !ok {
 		t.Skip("Requires Couchbase bucket")
 	}
@@ -5530,11 +5531,11 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 	// Create the document to trigger cas failure
 	value := make(map[string]interface{})
 	value["foo"] = "bar"
-	insCas, err := gocbBucket.Bucket.Insert(t.Name(), value, 0)
+	insCas, err := bucket.WriteCas(t.Name(), 0, 0, 0, value, 0)
 	require.NoError(t, err)
 
 	// Delete document
-	_, err = gocbBucket.Bucket.Remove(t.Name(), insCas)
+	_, err = bucket.Remove(t.Name(), insCas)
 	require.NoError(t, err)
 
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"new_edits": false, "docs": [{"_id":"`+t.Name()+`", "_deleted": true, "_revisions":{"start":9, "ids":["c45c049b7fe6cf64cd8595c1990f6504", "6e01ac52ffd5ce6a4f7f4024c08d296f"]}}]}`)
@@ -5652,7 +5653,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -5662,7 +5663,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 
 	// Add xattr to doc
-	_, err := gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for doc to be imported
@@ -5676,13 +5677,15 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	// Get Xattr and ensure channel value set correctly
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 	// Update xattr again but same value and ensure it isn't imported again (crc32 hash should match)
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5691,7 +5694,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData2 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
@@ -5700,7 +5703,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
 	// Update body but same value and ensure it isn't imported again (crc32 hash should match)
-	err = gocbBucket.Set(docKey, 0, map[string]interface{}{})
+	err = rt.Bucket().Set(docKey, 0, map[string]interface{}{})
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5709,7 +5712,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData3 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData3)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData3)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData2.Crc32c, syncData3.Crc32c)
@@ -5719,7 +5722,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	// Update body and ensure import occurs
 	updateVal := []byte(`{"prop":"val"}`)
-	err = gocbBucket.Set(docKey, 0, updateVal)
+	err = rt.Bucket().Set(docKey, 0, updateVal)
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5730,7 +5733,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	var syncData4 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData4)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData4)
 	assert.NoError(t, err)
 
 	assert.Equal(t, base.Crc32cHashString(updateVal), syncData4.Crc32c)
@@ -5768,13 +5771,15 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
 
 	// Add doc with SDK
-	err := gocbBucket.Set(docKey, 0, []byte(`{}`))
+	err := rt.Bucket().Set(docKey, 0, []byte(`{}`))
 	assert.NoError(t, err)
 
 	// GET to trigger import
@@ -5791,7 +5796,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	// Write user xattr
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// GET to trigger import
@@ -5809,13 +5814,13 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// Get sync data for doc and ensure user xattr has been used correctly to set channel
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	cas, err := subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 	// Write same xattr value
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Perform GET and ensure import isn't triggered as crc32 hash is the same
@@ -5823,7 +5828,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 
 	var syncData2 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
@@ -5862,7 +5867,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -5872,7 +5877,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 
 	// SDK PUT
-	err := gocbBucket.Set(docKey, 0, []byte(`{"update": "update"}`))
+	err := rt.Bucket().Set(docKey, 0, []byte(`{"update": "update"}`))
 	assert.NoError(t, err)
 
 	// Trigger Import
@@ -5889,7 +5894,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	// Write user xattr
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Trigger import
@@ -5905,8 +5910,10 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	// Ensure sync function has ran on import
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -5975,7 +5982,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			defer rt.Close()
 
-			gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+			gocbBucket, ok := base.AsUserXattrStore(rt.Bucket())
 			if !ok {
 				t.Skip("Test requires Couchbase Bucket")
 			}
@@ -5997,7 +6004,9 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Get sync data for doc and ensure user xattr has been used correctly to set channel
 			var syncData db.SyncData
-			_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+			subdocStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+			require.True(t, ok)
+			_, err = subdocStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 			assert.NoError(t, err)
 
 			assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -6015,7 +6024,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Ensure old channel set with user xattr has been removed
 			var syncData2 db.SyncData
-			_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+			_, err = subdocStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 			assert.NoError(t, err)
 
 			assert.Equal(t, uint64(3), syncData2.Channels[channelName].Seq)
@@ -6055,10 +6064,13 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
+
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
 
 	// Initial PUT
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, `{}`)
@@ -6069,7 +6081,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Get current sync data
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	docRev, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
@@ -6078,7 +6090,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
 
 	// Write xattr to trigger import of user xattr
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for import
@@ -6089,7 +6101,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Ensure import worked and sequence incremented but that sequence did not
 	var syncData2 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	docRev2, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
@@ -6101,7 +6113,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, []string{channelName}, syncData2.Channels.KeySet())
 	assert.Equal(t, syncData2.Channels.KeySet(), docRev2.Channels.ToArray())
 
-	err = gocbBucket.Set(docKey, 0, `{"update": "update"}`)
+	err = rt.Bucket().Set(docKey, 0, `{"update": "update"}`)
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -6110,7 +6122,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData3 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, syncData2.CurrentRev, syncData3.CurrentRev)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5814,7 +5814,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// Get sync data for doc and ensure user xattr has been used correctly to set channel
 	var syncData db.SyncData
-	cas, err := subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -605,7 +605,8 @@ func TestXattrImportMultipleActorOnDemandGet(t *testing.T) {
 	assert.True(t, ok, "No rev included in response")
 
 	// Go get the cas for the doc to use for update
-	_, cas, getErr := bucket.GetRaw(mobileKey)
+	var casCheck []byte
+	cas, getErr := bucket.Get(mobileKey, &casCheck)
 	assert.NoError(t, getErr, "Error retrieving cas for multi-actor document")
 
 	// Modify the document via the SDK to add a new, non-mobile xattr
@@ -661,7 +662,8 @@ func TestXattrImportMultipleActorOnDemandPut(t *testing.T) {
 	assert.True(t, ok, "No rev included in response")
 
 	// Go get the cas for the doc to use for update
-	_, cas, getErr := bucket.GetRaw(mobileKey)
+	var casCheck []byte
+	cas, getErr := bucket.Get(mobileKey, &casCheck)
 	assert.NoError(t, getErr, "Error retrieving cas for multi-actor document")
 
 	// Modify the document via the SDK to add a new, non-mobile xattr
@@ -719,7 +721,8 @@ func TestXattrImportMultipleActorOnDemandFeed(t *testing.T) {
 	assert.True(t, ok, "No rev included in response")
 
 	// Go get the cas for the doc to use for update
-	_, cas, getErr := bucket.GetRaw(mobileKey)
+	var casCheck []byte
+	cas, getErr := bucket.Get(mobileKey, &casCheck)
 	assert.NoError(t, getErr, "Error retrieving cas for multi-actor document")
 
 	// Check expvars before update

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2785,7 +2785,8 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	cID := ar.Push.CheckpointID
 	checkpointDocID := base.SyncPrefix + "local:checkpoint/" + cID
 
-	firstCheckpoint, _, err := rt2.Bucket().GetRaw(checkpointDocID)
+	var firstCheckpoint []byte
+	_, err = rt2.Bucket().Get(checkpointDocID, &firstCheckpoint)
 	require.NoError(t, err)
 
 	// Create doc2 on rt1
@@ -2815,7 +2816,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.NoError(t, ar.Stop())
 
 	// roll back checkpoint value to first one and remove the associated doc
-	err = rt2.Bucket().SetRaw(checkpointDocID, 0, firstCheckpoint)
+	err = rt2.Bucket().Set(checkpointDocID, 0, firstCheckpoint)
 	assert.NoError(t, err)
 
 	rt2db, err := db.GetDatabase(rt2.GetDatabase(), nil)
@@ -2905,13 +2906,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 	pushCheckpointID := ar.Push.CheckpointID
 	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
-	err = rt2.Bucket().SetRaw(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	err = rt2.Bucket().Set(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
 	require.NoError(t, err)
 
 	pullCheckpointID := ar.Pull.CheckpointID
 	require.NoError(t, err)
 	pullCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pullCheckpointID
-	err = rt1.Bucket().SetRaw(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	err = rt1.Bucket().Set(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
 	require.NoError(t, err)
 
 	// Create doc1 on rt1

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -398,8 +398,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		if config.NumIndexReplicas != nil {
 			numReplicas = *config.NumIndexReplicas
 		}
+		n1qlStore, ok := base.AsN1QLStore(bucket)
+		if !ok {
+			return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
 
-		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
+		}
+		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas)
 		if indexErr != nil {
 			return nil, indexErr
 		}


### PR DESCRIPTION
Enables gocb v2 by default for everything except DCP.  Includes refactoring of CouchbaseStore to handle operations common to Couchbase-backed stores that aren't part of the bucket interface.  