### PR TITLE
CBG-1546 - Fix for -defaultLogFilePath not being initialized properly

### DIFF
--- a/base/logging_config_test.go
+++ b/base/logging_config_test.go
@@ -28,13 +28,3 @@ func TestValidateLogFileOutput(t *testing.T) {
 	err = validateLogFileOutput(logFileOutput)
 	assert.NoError(t, err, "log file output path should be validated")
 }
-
-func TestHasLogFilePath(t *testing.T) {
-	defaultLogFilePath := "/var/log/sync_gateway/sglogfile.log"
-	emptyLogFilePath := ""
-	var logFilePath *string
-	assert.True(t, hasLogFilePath(logFilePath, defaultLogFilePath))
-	assert.True(t, hasLogFilePath(&emptyLogFilePath, defaultLogFilePath))
-	assert.False(t, hasLogFilePath(logFilePath, emptyLogFilePath))
-	assert.False(t, hasLogFilePath(&emptyLogFilePath, emptyLogFilePath))
-}

--- a/rest/config.go
+++ b/rest/config.go
@@ -752,14 +752,16 @@ func envDefaultExpansion(key string, getEnvFn func(string) string) (value string
 	return value, nil
 }
 
-// setupAndValidateLogging sets up and validates logging,
-// and returns a slice of deferred logs to execute later.
+// SetupAndValidateLogging validates logging config and initializes all logging.
 func (sc *StartupConfig) SetupAndValidateLogging() (err error) {
 
 	base.SetRedaction(sc.Logging.RedactionLevel)
 
+	if sc.Logging.LogFilePath == "" {
+		sc.Logging.LogFilePath = defaultLogFilePath
+	}
+
 	return base.InitLogging(
-		defaultLogFilePath,
 		sc.Logging.LogFilePath,
 		sc.Logging.Console,
 		sc.Logging.Error,


### PR DESCRIPTION
This was accidentally broken as part of #5043 by changing a `logFilePath` type from `*string` to `string`, resulting in the function responsible for setting "defaultLogFilePath" being unable to set the server's config outside of its scope.

- To fix, simplified the `defaultLogFilePath` fallback to use an explicit override up in `StartupConfig.SetupAndValidateLogging()` rather than down inside `validateLogFilePath()`