### PR TITLE
Improve LeakyBucket assertion in TestRevocationUserHasDocAccessDocNotFound

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7537,7 +7537,7 @@ func TestRevocationUserHasDocAccessDocNotFound(t *testing.T) {
 	_, err := rt.WaitForChanges(1, fmt.Sprintf("/db/_changes?since=%v", changes.Last_Seq), "", true)
 	assert.NoError(t, err)
 
-	leakyBucket, ok := rt.Bucket().(*base.LeakyBucket)
+	leakyBucket, ok := base.AsLeakyBucket(rt.Bucket())
 	require.True(t, ok)
 
 	leakyBucket.SetGetRawCallback(func(s string) {


### PR DESCRIPTION
- Prevents failure when running with an `SG_TEST_LOG_LEVEL` set (because the bucket is a `LoggingBucket` wrapped around the `LeakyBucket`).