### PR TITLE
CBG-1533: Specify permissions for each handler

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1364,7 +1364,7 @@ func TestRevocationScenario1(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1377,7 +1377,7 @@ func TestRevocationScenario1(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1396,7 +1396,7 @@ func TestRevocationScenario1(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1455,7 +1455,7 @@ func TestRevocationScenario2(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1552,7 +1552,7 @@ func TestRevocationScenario3(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1658,7 +1658,7 @@ func TestRevocationScenario4(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1751,7 +1751,7 @@ func TestRevocationScenario5(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1828,7 +1828,7 @@ func TestRevocationScenario6(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -1908,7 +1908,7 @@ func TestRevocationScenario7(t *testing.T) {
 
 	// Ensure user can see ch1 (via role)
 	// Verify history
-	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllChannels())
+	assert.ElementsMatch(t, []string{"!", "ch1"}, fooPrincipal.Channels().AllKeys())
 	assert.True(t, aliceUserPrincipal.CanSeeChannel("ch1"))
 	assert.Equal(t, 0, len(aliceUserPrincipal.RoleHistory()))
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
@@ -2381,7 +2381,7 @@ func TestRoleSoftDelete(t *testing.T) {
 	role, err = auth.GetRole(roleName)
 	assert.NoError(t, err)
 	assert.NotNil(t, role)
-	assert.Equal(t, 2, len(role.Channels().AllChannels()))
+	assert.Equal(t, 2, len(role.Channels().AllKeys()))
 	assert.True(t, role.Channels().Contains("channel"))
 
 	// Delete role
@@ -2397,7 +2397,7 @@ func TestRoleSoftDelete(t *testing.T) {
 	role, err = auth.GetRoleIncDeleted(roleName)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(role.ChannelHistory()))
-	assert.Equal(t, 0, len(role.Channels().AllChannels()))
+	assert.Equal(t, 0, len(role.Channels().AllKeys()))
 	require.Equal(t, 1, len(role.ChannelHistory()["channel"].Entries))
 	require.Equal(t, 1, len(role.ChannelHistory()["!"].Entries))
 	assert.Equal(t, expectedChannelHistory, role.ChannelHistory()["channel"].Entries[0])
@@ -2421,7 +2421,7 @@ func TestRoleSoftDelete(t *testing.T) {
 	role, err = auth.GetRole(roleName)
 	assert.NoError(t, err)
 	assert.NotNil(t, role)
-	assert.Equal(t, 2, len(role.Channels().AllChannels()))
+	assert.Equal(t, 2, len(role.Channels().AllKeys()))
 	assert.False(t, role.Channels().Contains("channel"))
 	assert.True(t, role.Channels().Contains("channel2"))
 	assert.Equal(t, 2, len(role.ChannelHistory()))
@@ -2447,7 +2447,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Successfully able to get inherited channels even though role is missing
-			assert.Equal(t, []string{"!"}, user.InheritedChannels().AllChannels())
+			assert.Equal(t, []string{"!"}, user.InheritedChannels().AllKeys())
 		},
 	},
 		{
@@ -2462,7 +2462,7 @@ func TestObtainChannelsForDeletedRole(t *testing.T) {
 				assert.NoError(t, err)
 
 				// Successfully able to get inherited channels even though role is missing
-				assert.Equal(t, []string{"!"}, user.InheritedChannels().AllChannels())
+				assert.Equal(t, []string{"!"}, user.InheritedChannels().AllKeys())
 			},
 		},
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -273,7 +273,7 @@ func (user *userImpl) RevokedChannels(since uint64, lowSeq uint64, triggeredBy u
 		// First check 'current channels' if role isn't deleted
 		// Current roles should be invalidated on deleted anyway but for safety
 		if !role.IsDeleted() {
-			for _, chanName := range role.Channels().AllChannels() {
+			for _, chanName := range role.Channels().AllKeys() {
 				if !accessibleChannels.Contains(chanName) {
 					combinedRevokedChannels.add(chanName, roleRevokeSeq)
 				}

--- a/channels/timed_set.go
+++ b/channels/timed_set.go
@@ -100,7 +100,7 @@ func (set TimedSet) Validate() error {
 	return nil
 }
 
-func (set TimedSet) AllChannels() []string {
+func (set TimedSet) AllKeys() []string {
 	result := make([]string, 0, len(set))
 	for name := range set {
 		result = append(result, name)

--- a/db/crud.go
+++ b/db/crud.go
@@ -2099,7 +2099,7 @@ func makeUserCtx(user auth.User) map[string]interface{} {
 	return map[string]interface{}{
 		"name":     user.Name(),
 		"roles":    user.RoleNames(),
-		"channels": user.InheritedChannels().AllChannels(),
+		"channels": user.InheritedChannels().AllKeys(),
 	}
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -1067,11 +1067,6 @@ func (db *Database) Compact() (int, error) {
 	return purgedDocCount, nil
 }
 
-// Deletes all orphaned CouchDB attachments not used by any revisions.
-func VacuumAttachments(bucket base.Bucket) (int, error) {
-	return 0, base.HTTPErrorf(http.StatusNotImplemented, "Vacuum is temporarily out of order")
-}
-
 //////// SYNC FUNCTION:
 
 // Sets the database context's sync function based on the JS code from config.

--- a/db/users.go
+++ b/db/users.go
@@ -25,7 +25,7 @@ import (
 type PrincipalConfig struct {
 	Name             *string  `json:"name,omitempty"`
 	ExplicitChannels base.Set `json:"admin_channels,omitempty"`
-	Channels         base.Set `json:"all_channels"`
+	Channels         base.Set `json:"all_channels,omitempty"`
 	// Fields below only apply to Users, not Roles:
 	Email             string   `json:"email,omitempty"`
 	Disabled          bool     `json:"disabled,omitempty"`

--- a/db/users.go
+++ b/db/users.go
@@ -85,8 +85,8 @@ func (dbc *DatabaseContext) GetPrincipal(name string, isUser bool) (info *Princi
 		info.Channels = user.InheritedChannels().AsSet()
 		info.Email = user.Email()
 		info.Disabled = user.Disabled()
-		info.ExplicitRoleNames = user.ExplicitRoles().AllChannels()
-		info.RoleNames = user.RoleNames().AllChannels()
+		info.ExplicitRoleNames = user.ExplicitRoles().AllKeys()
+		info.RoleNames = user.RoleNames().AllKeys()
 	} else {
 		info.Channels = princ.Channels().AsSet()
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -716,8 +716,8 @@ func (h *handler) getUserInfo() error {
 		}
 		return err
 	}
-
-	_, includeDynamicGrantInfo := h.permissionsResults[PermReadPrincipalAppData.PermissionName]
+	// If not specified will default to false
+	includeDynamicGrantInfo := h.permissionsResults[PermReadPrincipalAppData.PermissionName]
 	bytes, err := marshalPrincipal(user, includeDynamicGrantInfo)
 	h.writeRawJSON(bytes)
 	return err
@@ -732,7 +732,8 @@ func (h *handler) getRoleInfo() error {
 		}
 		return err
 	}
-	_, includeDynamicGrantInfo := h.permissionsResults[PermReadPrincipalAppData.PermissionName]
+	// If not specified will default to false
+	includeDynamicGrantInfo := h.permissionsResults[PermReadPrincipalAppData.PermissionName]
 	bytes, err := marshalPrincipal(role, includeDynamicGrantInfo)
 	_, _ = h.response.Write(bytes)
 	return err

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -610,10 +610,10 @@ func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) ([]byt
 	if user, ok := princ.(auth.User); ok {
 		info.Email = user.Email()
 		info.Disabled = user.Disabled()
-		info.ExplicitRoleNames = user.ExplicitRoles().AllChannels()
+		info.ExplicitRoleNames = user.ExplicitRoles().AllKeys()
 		if includeDynamicGrantInfo {
 			info.Channels = user.InheritedChannels().AsSet()
-			info.RoleNames = user.RoleNames().AllChannels()
+			info.RoleNames = user.RoleNames().AllKeys()
 		}
 	} else {
 		if includeDynamicGrantInfo {

--- a/rest/admin_api_auth_routing_permissions.go
+++ b/rest/admin_api_auth_routing_permissions.go
@@ -1,0 +1,58 @@
+package rest
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Permission stores the name of a permission along whether it is database scoped. This is used to later obtain a
+// formatted permission string for checking.
+type Permission struct {
+	PermissionName string
+	DatabaseScoped bool
+}
+
+func (perm *Permission) FormattedName(bucketName string) string {
+	if perm.DatabaseScoped {
+		return fmt.Sprintf("cluster.bucket[%s]!%s", bucketName, perm.PermissionName)
+	}
+	return fmt.Sprintf("cluster!%s", perm.PermissionName)
+}
+
+func FormatPermissionNames(perms []Permission, bucketName string) (formattedPerms []string) {
+	formattedPerms = make([]string, 0, len(perms))
+	for _, perm := range perms {
+		formattedPerms = append(formattedPerms, perm.FormattedName(bucketName))
+	}
+	return formattedPerms
+}
+
+func GetPermissionsNameFromFormatted(formattedName string) string {
+	return strings.Split(formattedName, "!")[1]
+}
+
+func GetPermissionNameFromFormattedStrings(formattedNames []string) (perms []string) {
+	perms = make([]string, 0, len(formattedNames))
+	for _, formattedName := range formattedNames {
+		perms = append(perms, GetPermissionsNameFromFormatted(formattedName))
+	}
+	return perms
+}
+
+// Permissions to use with admin handlers
+var (
+	PermCreateDb             = Permission{"sgw_create_db", true}
+	PermDeleteDb             = Permission{"sgw_delete_db", true}
+	PermUpdateDb             = Permission{"sgw_update_db", true}
+	PermConfigureSyncFn      = Permission{"sgw_configure_sync_fn", true}
+	PermConfigureAuth        = Permission{"sgw_configure_auth", true}
+	PermWritePrincipal       = Permission{"sgw_write_principal", true}
+	PermReadPrincipal        = Permission{"sgw_read_principal", true}
+	PermReadAppData          = Permission{"sgw_read_appdata", true}
+	PermReadPrincipalAppData = Permission{"sgw_read_principal_appdata", true}
+	PermWriteAppData         = Permission{"sgw_write_appdata", true}
+	PermWriteReplications    = Permission{"sgw_write_replications", true}
+	PermReadReplications     = Permission{"sgw_read_replications", true}
+	PermDevOps               = Permission{"sgw_dev_ops", true}
+	PermStatsExport          = Permission{"stats_export", true}
+)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -533,10 +533,10 @@ func TestAdminAPIAuth(t *testing.T) {
 	MakeUser(t, eps[0], "noaccess", "password", []string{})
 	defer DeleteUser(t, eps[0], "noaccess")
 
-	MakeUser(t, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", MobileSyncGatewayRole, rt.Bucket().GetName())})
+	MakeUser(t, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", MobileSyncGatewayRole.RoleName, rt.Bucket().GetName())})
 	defer DeleteUser(t, eps[0], "MobileSyncGatewayUser")
 
-	MakeUser(t, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole})
+	MakeUser(t, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole.RoleName})
 	defer DeleteUser(t, eps[0], "ROAdminUser")
 
 	for _, endPoint := range endPoints {

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -1,0 +1,570 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminAPIAuth(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	endPoints := []struct {
+		Method          string
+		DBScoped        bool
+		Endpoint        string
+		SkipSuccessTest bool
+	}{
+		{
+			"POST",
+			true,
+			"/_session",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_session/id",
+			false,
+		},
+		{
+			"DELETE",
+			true,
+			"/_session/id",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_raw/doc",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_user/",
+			false,
+		}, {
+			"POST",
+			true,
+			"/_user/",
+			false,
+		}, {
+			"GET",
+			true,
+			"/_user/user",
+			false,
+		}, {
+			"PUT",
+			true,
+			"/_user/user",
+			false,
+		}, {
+			"DELETE",
+			true,
+			"/_user/user",
+			false,
+		}, {
+			"DELETE",
+			true,
+			"/_user/user/_session",
+			false,
+		}, {
+			"DELETE",
+			true,
+			"/_user/user/_session/id",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_role/",
+			false,
+		}, {
+			"POST",
+			true,
+			"/_role/",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_role/role",
+			false,
+		}, {
+			"PUT",
+			true,
+			"/_role/role",
+			false,
+		}, {
+			"DELETE",
+			true,
+			"/_role/role",
+			false,
+		}, {
+			"GET",
+			true,
+			"/_replication/",
+			false,
+		}, {
+			"POST",
+			true,
+			"/_replication/",
+			false,
+		}, {
+			"GET",
+			true,
+			"/_replication/id",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/_replication/id",
+			false,
+		},
+		{
+			"DELETE",
+			true,
+			"/_replication/id",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_replicationStatus/",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_replicationStatus/id",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/_replicationStatus/id",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_logging",
+			false,
+		},
+		{
+			"PUT",
+			false,
+			"/_logging",
+			false,
+		},
+		{
+			"POST",
+			false,
+			"/_logging",
+			false,
+		},
+		{
+			"POST",
+			false,
+			"/_profile/name",
+			false,
+		},
+		{
+			"POST",
+			false,
+			"/_profile",
+			false,
+		},
+		{
+			"POST",
+			false,
+			"/_heap",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_stats",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_expvar",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_config",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_status",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_sgcollect_info",
+			false,
+		},
+		{
+			"DELETE",
+			false,
+			"/_sgcollect_info",
+			false,
+		},
+		{
+			"POST",
+			false,
+			"/_sgcollect_info",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/goroutine",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/cmdline",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/symbol",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/heap",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/profile",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/block",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/threadcreate",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/mutex",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/pprof/trace",
+			false,
+		},
+		{
+			"GET",
+			false,
+			"/_debug/fgprof",
+			false,
+		},
+		{
+			"POST",
+			false,
+			"/_post_upgrade",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_config",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/_config",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_resync",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_resync",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_purge",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_flush",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_offline",
+			true,
+		},
+		{
+			"POST",
+			true,
+			"/_online",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_dump/view",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_view/view",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_dumpchannel/channel",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_repair",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/db",
+			false,
+		},
+		{
+			"DELETE",
+			true,
+			"/",
+			true,
+		},
+		{
+			"GET",
+			false,
+			"/_all_dbs",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_compact",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/",
+			true,
+		},
+		{
+			"POST",
+			true,
+			"/",
+			true,
+		},
+		{
+			"GET",
+			true,
+			"/_all_docs",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_bulk_docs",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_bulk_get",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_changes",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_design/ddoc",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/_design/ddoc",
+			false,
+		},
+		{
+			"DELETE",
+			true,
+			"/_design/ddoc",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_design/ddoc/_view/view",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_ensure_full_commit",
+			false,
+		},
+		{
+			"POST",
+			true,
+			"/_revs_diff",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_local/docid",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/_local/docid",
+			false,
+		},
+		{
+			"DELETE",
+			true,
+			"/_local/docid",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/docid",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/docid",
+			false,
+		},
+		{
+			"DELETE",
+			true,
+			"/docid",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/docid/attachid",
+			false,
+		},
+		{
+			"PUT",
+			true,
+			"/docid/attachid",
+			false,
+		},
+		{
+			"GET",
+			true,
+			"/_blipsync",
+			false,
+		},
+	}
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		adminInterfaceAuthentication:   true,
+		metricsInterfaceAuthentication: true,
+	})
+	defer rt.Close()
+
+	eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	MakeUser(t, eps[0], "noaccess", "password", []string{})
+	defer DeleteUser(t, eps[0], "noaccess")
+
+	MakeUser(t, eps[0], "MobileSyncGatewayUser", "password", []string{fmt.Sprintf("%s[%s]", MobileSyncGatewayRole, rt.Bucket().GetName())})
+	defer DeleteUser(t, eps[0], "MobileSyncGatewayUser")
+
+	MakeUser(t, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole})
+	defer DeleteUser(t, eps[0], "ROAdminUser")
+
+	for _, endPoint := range endPoints {
+		t.Run(endPoint.Method+endPoint.Endpoint, func(t *testing.T) {
+			formattedEndpoint := endPoint.Endpoint
+			if endPoint.DBScoped {
+				formattedEndpoint = "/db" + formattedEndpoint
+			}
+			resp := rt.SendAdminRequest(endPoint.Method, formattedEndpoint, `{}`)
+			assertStatus(t, resp, http.StatusUnauthorized)
+
+			resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "noaccess", "password")
+			assertStatus(t, resp, http.StatusForbidden)
+
+			if !endPoint.SkipSuccessTest {
+				if endPoint.DBScoped {
+					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "MobileSyncGatewayUser", "password")
+				} else {
+					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "ROAdminUser", "password")
+				}
+
+				// For some of the endpoints they have other requirements, such as setting up users and others require
+				// bodies. Rather than doing a full test of the endpoint itself this will at least confirm that they pass
+				// the auth stage.
+				fmt.Println(resp.Code)
+				assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+			}
+		})
+	}
+
+}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2958,7 +2958,7 @@ func TestObtainUserChannelsForDeletedRoleCasFail(t *testing.T) {
 				triggerCallback = true
 			}
 
-			assert.Equal(t, []string{"!"}, user.InheritedChannels().AllChannels())
+			assert.Equal(t, []string{"!"}, user.InheritedChannels().AllKeys())
 
 			// Ensure callback ran
 			assert.False(t, triggerCallback)

--- a/rest/api.go
+++ b/rest/api.go
@@ -80,16 +80,6 @@ func (h *handler) handleCompact() error {
 	return nil
 }
 
-func (h *handler) handleVacuum() error {
-	attsDeleted, err := db.VacuumAttachments(h.db.Bucket)
-	if err != nil {
-		return err
-	}
-
-	h.writeRawJSON([]byte(`{"atts":` + strconv.Itoa(attsDeleted) + `}`))
-	return nil
-}
-
 func (h *handler) handleFlush() error {
 
 	baseBucket := base.GetBaseBucket(h.db.Bucket)

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -43,34 +43,34 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mu
 	r.Handle("/", makeHandler(sc, privs, nil, nil, (*handler).handleRoot)).Methods("GET", "HEAD")
 
 	// Operations on databases:
-	r.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, nil, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
-	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, nil, nil, (*handler).handlePostDoc)).Methods("POST")
+	r.Handle("/{db:"+dbRegex+"}/", makeOfflineHandler(sc, privs, []Permission{PermDevOps}, nil, (*handler).handleGetDB)).Methods("GET", "HEAD")
+	r.Handle("/{db:"+dbRegex+"}/", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePostDoc)).Methods("POST")
 
 	// Special database URLs:
 	dbr := r.PathPrefix("/{db:" + dbRegex + "}/").Subrouter()
 	dbr.StrictSlash(true)
-	dbr.Handle("/_all_docs", makeHandler(sc, privs, nil, nil, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_bulk_docs", makeHandler(sc, privs, nil, nil, (*handler).handleBulkDocs)).Methods("POST")
-	dbr.Handle("/_bulk_get", makeHandler(sc, privs, nil, nil, (*handler).handleBulkGet)).Methods("POST")
-	dbr.Handle("/_changes", makeHandler(sc, privs, nil, nil, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, nil, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, nil, (*handler).handlePutDesignDoc)).Methods("PUT")
-	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, nil, nil, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
-	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, nil, nil, (*handler).handleView)).Methods("GET")
-	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, nil, nil, (*handler).handleEFC)).Methods("POST")
-	dbr.Handle("/_revs_diff", makeHandler(sc, privs, nil, nil, (*handler).handleRevsDiff)).Methods("POST")
+	dbr.Handle("/_all_docs", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleAllDocs)).Methods("GET", "HEAD", "POST")
+	dbr.Handle("/_bulk_docs", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleBulkDocs)).Methods("POST")
+	dbr.Handle("/_bulk_get", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleBulkGet)).Methods("POST")
+	dbr.Handle("/_changes", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleChanges)).Methods("GET", "HEAD", "POST")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetDesignDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutDesignDoc)).Methods("PUT")
+	dbr.Handle("/_design/{ddoc}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleDeleteDesignDoc)).Methods("DELETE")
+	dbr.Handle("/_design/{ddoc}/_view/{view}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleView)).Methods("GET")
+	dbr.Handle("/_ensure_full_commit", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleEFC)).Methods("POST")
+	dbr.Handle("/_revs_diff", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleRevsDiff)).Methods("POST")
 
 	// Document URLs:
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, nil, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, nil, (*handler).handlePutLocalDoc)).Methods("PUT")
-	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, nil, nil, (*handler).handleDelLocalDoc)).Methods("DELETE")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetLocalDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutLocalDoc)).Methods("PUT")
+	dbr.Handle("/_local/{docid}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleDelLocalDoc)).Methods("DELETE")
 
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, nil, (*handler).handleGetDoc)).Methods("GET", "HEAD")
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, nil, (*handler).handlePutDoc)).Methods("PUT")
-	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, nil, nil, (*handler).handleDeleteDoc)).Methods("DELETE")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetDoc)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutDoc)).Methods("PUT")
+	dbr.Handle("/{docid:"+docRegex+"}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleDeleteDoc)).Methods("DELETE")
 
-	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, nil, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
-	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, nil, nil, (*handler).handlePutAttachment)).Methods("PUT")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, []Permission{PermReadAppData}, nil, (*handler).handleGetAttachment)).Methods("GET", "HEAD")
+	dbr.Handle("/{docid:"+docRegex+"}/{attach}", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handlePutAttachment)).Methods("PUT")
 
 	// Session/login URLs are per-database (unlike in CouchDB)
 	// These have public privileges so that they can be called without being logged in already
@@ -104,7 +104,7 @@ func createCommonRouter(sc *ServerContext, privs handlerPrivs) (*mux.Router, *mu
 
 	oidcr.Handle("/authenticate", makeHandler(sc, publicPrivs, nil, nil, (*handler).handleOidcTestProviderAuthenticate)).Methods("GET", "POST")
 
-	dbr.Handle("/_blipsync", makeHandler(sc, privs, nil, nil, (*handler).handleBLIPSync)).Methods("GET")
+	dbr.Handle("/_blipsync", makeHandler(sc, privs, []Permission{PermWriteAppData}, nil, (*handler).handleBLIPSync)).Methods("GET")
 
 	return r, dbr
 }
@@ -136,160 +136,159 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	r, dbr := createCommonRouter(sc, adminPrivs)
 
 	dbr.Handle("/_session",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).createUserSession)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).createUserSession)).Methods("POST")
 
 	dbr.Handle("/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getUserSession)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, nil, (*handler).getUserSession)).Methods("GET")
 
 	dbr.Handle("/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUserSession)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_raw/{docid:"+docRegex+"}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleGetRawDoc)).Methods("GET", "HEAD")
 
 	dbr.Handle("/_revtree/{docid:"+docRegex+"}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetRevTree)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleGetRevTree)).Methods("GET")
 
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getUsers)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, []Permission{PermReadPrincipal}, (*handler).getUsers)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putUser)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putUser)).Methods("POST")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getUserInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, (*handler).getUserInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putUser)).Methods("PUT")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putUser)).Methods("PUT")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUser)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteUser)).Methods("DELETE")
 
 	dbr.Handle("/_user/{name}/_session",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUserSessions)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteUserSessions)).Methods("DELETE")
 	dbr.Handle("/_user/{name}/_session/{sessionid}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteUserSession)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getRoles)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, (*handler).getRoles)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putRole)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putRole)).Methods("POST")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getRoleInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, (*handler).getRoleInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putRole)).Methods("PUT")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putRole)).Methods("PUT")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteRole)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteRole)).Methods("DELETE")
 
 	dbr.Handle("/_replication/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplications)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadReplications}, nil, (*handler).getReplications)).Methods("GET", "HEAD")
 	dbr.Handle("/_replication/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putReplication)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermWriteReplications}, nil, (*handler).putReplication)).Methods("POST")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplication)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadReplications}, nil, (*handler).getReplication)).Methods("GET", "HEAD")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putReplication)).Methods("PUT")
+		makeHandler(sc, adminPrivs, []Permission{PermWriteReplications}, nil, (*handler).putReplication)).Methods("PUT")
 	dbr.Handle("/_replication/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).deleteReplication)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermWriteReplications}, nil, (*handler).deleteReplication)).Methods("DELETE")
 
 	dbr.Handle("/_replicationStatus/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadReplications}, nil, (*handler).getReplicationsStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadReplications}, nil, (*handler).getReplicationStatus)).Methods("GET", "HEAD")
 	dbr.Handle("/_replicationStatus/{replicationID}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).putReplicationStatus)).Methods("PUT")
+		makeHandler(sc, adminPrivs, []Permission{PermWriteReplications}, nil, (*handler).putReplicationStatus)).Methods("PUT")
 
 	r.Handle("/_logging",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetLogging)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetLogging)).Methods("GET")
 	r.Handle("/_logging",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSetLogging)).Methods("PUT", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleSetLogging)).Methods("PUT", "POST")
 	r.Handle("/_profile/{profilename}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_profile",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleProfiling)).Methods("POST")
 	r.Handle("/_heap",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleHeapProfiling)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleHeapProfiling)).Methods("POST")
 	r.Handle("/_stats",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleStats)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleExpvar)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 	r.Handle("/_config",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetConfig)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetConfig)).Methods("GET")
 	r.Handle("/_replicate",
 		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleReplicate)).Methods("POST")
 	r.Handle("/_active_tasks",
 		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleActiveTasks)).Methods("GET")
 
 	r.Handle("/_status",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetStatus)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetStatus)).Methods("GET")
 
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSGCollectStatus)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleSGCollectStatus)).Methods("GET")
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSGCollectCancel)).Methods("DELETE")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleSGCollectCancel)).Methods("DELETE")
 	r.Handle("/_sgcollect_info",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleSGCollect)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleSGCollect)).Methods("POST")
 
 	// Debugging handlers
 	r.Handle("/_debug/pprof/goroutine",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofGoroutine)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofGoroutine)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/cmdline",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofCmdline)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofCmdline)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/symbol",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofSymbol)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofSymbol)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/heap",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofHeap)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofHeap)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/profile",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofProfile)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofProfile)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/block",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofBlock)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofBlock)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/threadcreate",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofThreadcreate)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/mutex",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofMutex)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofMutex)).Methods("GET", "POST")
 	r.Handle("/_debug/pprof/trace",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePprofTrace)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePprofTrace)).Methods("GET", "POST")
 	r.Handle("/_debug/fgprof",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleFgprof)).Methods("GET", "POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleFgprof)).Methods("GET", "POST")
 
 	r.Handle("/_post_upgrade",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePostUpgrade)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePostUpgrade)).Methods("POST")
 
 	// Database-relative handlers:
 	dbr.Handle("/_config",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetDbConfig)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfig)).Methods("GET")
+	// TODO: This config endpoint is being altered in @bbrks admin config PR
 	dbr.Handle("/_config",
-		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handlePutDbConfig)).Methods("PUT")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, (*handler).handlePutDbConfig)).Methods("PUT")
 	dbr.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleGetResync)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")
 	dbr.Handle("/_resync",
-		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handlePostResync)).Methods("POST")
-	dbr.Handle("/_vacuum",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleVacuum)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePostResync)).Methods("POST")
 	dbr.Handle("/_purge",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handlePurge)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermWriteAppData}, nil, (*handler).handlePurge)).Methods("POST")
 	dbr.Handle("/_flush",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleFlush)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleFlush)).Methods("POST")
 	dbr.Handle("/_online",
-		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleDbOnline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleDbOnline)).Methods("POST")
 	dbr.Handle("/_offline",
-		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleDbOffline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleDbOffline)).Methods("POST")
 	dbr.Handle("/_dump/{view}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleDump)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDump)).Methods("GET")
 	dbr.Handle("/_view/{view}", // redundant; just for backward compatibility with 1.0
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleView)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleView)).Methods("GET")
 	dbr.Handle("/_dumpchannel/{channel}",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleDumpChannel)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDumpChannel)).Methods("GET")
 	dbr.Handle("/_repair",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleRepair)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleRepair)).Methods("POST")
 
 	// The routes below are part of the CouchDB REST API but should only be available to admins,
 	// so the handlers are moved to the admin port.
 	r.Handle("/{newdb:"+dbRegex+"}/",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleCreateDB)).Methods("PUT")
+		makeHandler(sc, adminPrivs, []Permission{PermCreateDb}, nil, (*handler).handleCreateDB)).Methods("PUT")
 	r.Handle("/{db:"+dbRegex+"}/",
-		makeOfflineHandler(sc, adminPrivs, nil, nil, (*handler).handleDeleteDB)).Methods("DELETE")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
 
 	r.Handle("/_all_dbs",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleAllDbs)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleAllDbs)).Methods("GET", "HEAD")
 	dbr.Handle("/_compact",
-		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleCompact)).Methods("POST")
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleCompact)).Methods("POST")
 
 	return r
 }
@@ -306,8 +305,8 @@ func CreateMetricRouter(sc *ServerContext) *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
-	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, nil, nil, (*handler).handleMetrics)).Methods("GET")
-	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, nil, nil, (*handler).handleExpvar)).Methods("GET")
+	r.Handle("/_metrics", makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleMetrics)).Methods("GET")
+	r.Handle(kDebugURLPathPrefix, makeHandler(sc, metricsPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 
 	return r
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -266,9 +266,9 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_flush",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleFlush)).Methods("POST")
 	dbr.Handle("/_online",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleDbOnline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleDbOnline)).Methods("POST")
 	dbr.Handle("/_offline",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleDbOffline)).Methods("POST")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleDbOffline)).Methods("POST")
 	dbr.Handle("/_dump/{view}",
 		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleDump)).Methods("GET")
 	dbr.Handle("/_view/{view}", // redundant; just for backward compatibility with 1.0

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -155,7 +155,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_user/",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putUser)).Methods("POST")
 	dbr.Handle("/_user/{name}",
-		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, (*handler).getUserInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, []Permission{PermReadPrincipalAppData}, (*handler).getUserInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/{name}",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putUser)).Methods("PUT")
 	dbr.Handle("/_user/{name}",
@@ -167,11 +167,11 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, (*handler).getRoles)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, []Permission{PermReadPrincipal}, (*handler).getRoles)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putRole)).Methods("POST")
 	dbr.Handle("/_role/{name}",
-		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, []Permission{PermReadPrincipal, PermReadPrincipalAppData}, (*handler).getRoleInfo)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, []Permission{PermReadPrincipalAppData}, (*handler).getRoleInfo)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/{name}",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putRole)).Methods("PUT")
 	dbr.Handle("/_role/{name}",

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -410,7 +410,7 @@ func TestCheckPermissions(t *testing.T) {
 			RequestPermissions:        []Permission{clusterAdminPermission},
 			ResponsePermissions:       []Permission{clusterReadOnlyAdminPermission},
 			ExpectedStatusCode:        http.StatusOK,
-			ExpectedPermissionResults: map[string]bool{"cluster!ro_admin": true},
+			ExpectedPermissionResults: map[string]bool{"ro_admin": true},
 			CreateUser:                "ValidateResponsePermission",
 			CreatePassword:            "password",
 			CreateRoles:               []string{"admin"},

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -327,12 +327,15 @@ func TestCheckPermissions(t *testing.T) {
 		t.Skip("Test requires Couchbase Server")
 	}
 
+	clusterAdminPermission := Permission{"admin", false}
+	clusterReadOnlyAdminPermission := Permission{"ro_admin", false}
+
 	testCases := []struct {
 		Name                      string
 		Username                  string
 		Password                  string
-		RequestPermissions        []string
-		ResponsePermissions       []string
+		RequestPermissions        []Permission
+		ResponsePermissions       []Permission
 		ExpectedStatusCode        int
 		ExpectedPermissionResults map[string]bool
 		CreateUser                string
@@ -343,7 +346,7 @@ func TestCheckPermissions(t *testing.T) {
 			Name:                      "ClusterAdminTest",
 			Username:                  base.TestClusterUsername(),
 			Password:                  base.TestClusterPassword(),
-			RequestPermissions:        []string{"cluster!admin"},
+			RequestPermissions:        []Permission{clusterAdminPermission},
 			ExpectedStatusCode:        http.StatusOK,
 			ExpectedPermissionResults: nil,
 		},
@@ -351,7 +354,7 @@ func TestCheckPermissions(t *testing.T) {
 			Name:                      "CreatedAdmin",
 			Username:                  "CreatedAdmin",
 			Password:                  "password",
-			RequestPermissions:        []string{"cluster!admin"},
+			RequestPermissions:        []Permission{clusterAdminPermission},
 			ExpectedStatusCode:        http.StatusOK,
 			ExpectedPermissionResults: nil,
 			CreateUser:                "CreatedAdmin",
@@ -362,7 +365,7 @@ func TestCheckPermissions(t *testing.T) {
 			Name:                      "Non-Existent User",
 			Username:                  "NonExistent",
 			Password:                  "",
-			RequestPermissions:        []string{"cluster!admin"},
+			RequestPermissions:        []Permission{clusterAdminPermission},
 			ExpectedStatusCode:        http.StatusUnauthorized,
 			ExpectedPermissionResults: nil,
 		},
@@ -381,7 +384,7 @@ func TestCheckPermissions(t *testing.T) {
 			Name:                      "Missing Permission",
 			Username:                  "NoPermUser",
 			Password:                  "password",
-			RequestPermissions:        []string{"cluster!admin"},
+			RequestPermissions:        []Permission{clusterAdminPermission},
 			ExpectedStatusCode:        http.StatusForbidden,
 			ExpectedPermissionResults: nil,
 			CreateUser:                "NoPermUser",
@@ -392,8 +395,8 @@ func TestCheckPermissions(t *testing.T) {
 			Name:                      "HasResponsePermissionWithoutAccessPermission",
 			Username:                  "HasResponsePermissionWithoutAccessPermission",
 			Password:                  "password",
-			RequestPermissions:        []string{"cluster!admin"},
-			ResponsePermissions:       []string{"cluster!ro_admin"},
+			RequestPermissions:        []Permission{clusterAdminPermission},
+			ResponsePermissions:       []Permission{clusterReadOnlyAdminPermission},
 			ExpectedStatusCode:        http.StatusForbidden,
 			ExpectedPermissionResults: nil,
 			CreateUser:                "HasResponsePermissionWithoutAccessPermission",
@@ -404,8 +407,8 @@ func TestCheckPermissions(t *testing.T) {
 			Name:                      "ValidateResponsePermission",
 			Username:                  "ValidateResponsePermission",
 			Password:                  "password",
-			RequestPermissions:        []string{"cluster!admin"},
-			ResponsePermissions:       []string{"cluster!ro_admin"},
+			RequestPermissions:        []Permission{clusterAdminPermission},
+			ResponsePermissions:       []Permission{clusterReadOnlyAdminPermission},
 			ExpectedStatusCode:        http.StatusOK,
 			ExpectedPermissionResults: map[string]bool{"cluster!ro_admin": true},
 			CreateUser:                "ValidateResponsePermission",
@@ -427,7 +430,7 @@ func TestCheckPermissions(t *testing.T) {
 				defer DeleteUser(t, eps[0], testCase.CreateUser)
 			}
 
-			statusCode, permResults, err := CheckPermissions(httpClient, eps, testCase.Username, testCase.Password, testCase.RequestPermissions, testCase.ResponsePermissions)
+			statusCode, permResults, err := CheckPermissions(httpClient, eps, "", testCase.Username, testCase.Password, testCase.RequestPermissions, testCase.ResponsePermissions)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
 			assert.True(t, reflect.DeepEqual(testCase.ExpectedPermissionResults, permResults))
@@ -453,7 +456,7 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
-	statusCode, _, err := CheckPermissions(httpClient, eps, base.TestClusterUsername(), base.TestClusterPassword(), []string{"cluster!admin"}, nil)
+	statusCode, _, err := CheckPermissions(httpClient, eps, "", base.TestClusterUsername(), base.TestClusterPassword(), []Permission{Permission{"admin", false}}, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -569,13 +572,15 @@ func TestAdminAuth(t *testing.T) {
 	defer rt.Close()
 
 	BucketFullAccessRoleTest := fmt.Sprintf("bucket_full_access[%s]", rt.Bucket().GetName())
+	clusterAdminPermission := Permission{"admin", false}
+	bucketWritePermission := Permission{"write", true}
 
 	testCases := []struct {
 		Name                string
 		Username            string
 		Password            string
-		CheckPermissions    []string
-		ResponsePermissions []string
+		CheckPermissions    []Permission
+		ResponsePermissions []Permission
 		ExpectedStatusCode  int
 		ExpectedPermResults map[string]bool
 		CreateUser          string
@@ -587,7 +592,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "ClusterAdmin",
 			Username:           base.TestClusterUsername(),
 			Password:           base.TestClusterPassword(),
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusOK,
 			BucketName:         "",
 		},
@@ -595,7 +600,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "ClusterAdminWrongPassword",
 			Username:           "ClusterAdminWrongPassword",
 			Password:           "wrongpassword",
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusUnauthorized,
 			CreateUser:         "ClusterAdminWrongPassword",
 			CreatePassword:     "password",
@@ -606,7 +611,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "NoUser",
 			Username:           "IDontExist",
 			Password:           "password",
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusUnauthorized,
 			BucketName:         "",
 		},
@@ -614,7 +619,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "MissingPermissionAndRole",
 			Username:           "MissingPermissionAndRole",
 			Password:           "password",
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "MissingPermissionAndRole",
 			CreatePassword:     "password",
@@ -625,7 +630,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "MissingPermissionAndRoleDBScoped",
 			Username:           "MissingPermissionAndRoleDBScoped",
 			Password:           "password",
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusForbidden,
 			CreateUser:         "MissingPermissionAndRoleDBScoped",
 			CreatePassword:     "password",
@@ -636,7 +641,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "MissingPermissionHasRole",
 			Username:           "MissingPermissionHasRole",
 			Password:           "password",
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "MissingPermissionHasRole",
 			CreatePassword:     "password",
@@ -647,7 +652,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "MissingPermissionHasDBScoped",
 			Username:           "MissingPermissionHasDBScoped",
 			Password:           "password",
-			CheckPermissions:   []string{"cluster!admin"},
+			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "MissingPermissionHasDBScoped",
 			CreatePassword:     "password",
@@ -658,10 +663,10 @@ func TestAdminAuth(t *testing.T) {
 			Name:                "HasOneAccessPermissionButHasRole",
 			Username:            "HasOneAccessPermissionButHasRole",
 			Password:            "password",
-			CheckPermissions:    []string{fmt.Sprintf("cluster.bucket[%s]!write", rt.Bucket().GetName())},
-			ResponsePermissions: []string{"cluster!admin"},
+			CheckPermissions:    []Permission{bucketWritePermission},
+			ResponsePermissions: []Permission{clusterAdminPermission},
 			ExpectedStatusCode:  http.StatusOK,
-			ExpectedPermResults: map[string]bool{"cluster!admin": true},
+			ExpectedPermResults: map[string]bool{"admin": true},
 			CreateUser:          "HasOneAccessPermissionButHasRole",
 			CreatePassword:      "password",
 			CreateRoles:         []string{BucketFullAccessRoleTest},
@@ -719,6 +724,6 @@ func TestAdminAuthWithX509(t *testing.T) {
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
-	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), httpClient, managementEndpoints, []string{"cluster!admin"}, nil)
+	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), httpClient, managementEndpoints, []Permission{{"admin", false}}, nil)
 	assert.NoError(t, err)
 }

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -295,6 +295,21 @@ func (rt *RestTester) SendUserRequestWithHeaders(method, resource string, body s
 	}
 	return rt.Send(req)
 }
+
+func (rt *RestTester) SendAdminRequestWithAuth(method, resource string, body string, username string, password string) *TestResponse {
+	input := bytes.NewBufferString(body)
+	request, err := http.NewRequest(method, "http://localhost"+resource, input)
+	require.NoError(rt.tb, err)
+
+	request.SetBasicAuth(username, password)
+
+	response := &TestResponse{ResponseRecorder: httptest.NewRecorder(), Req: request}
+	response.Code = 200 // doesn't seem to be initialized by default; filed Go bug #4188
+
+	rt.TestAdminHandler().ServeHTTP(response, request)
+	return response
+}
+
 func (rt *RestTester) Send(request *http.Request) *TestResponse {
 	response := &TestResponse{ResponseRecorder: httptest.NewRecorder(), Req: request}
 	response.Code = 200 // doesn't seem to be initialized by default; filed Go bug #4188


### PR DESCRIPTION
Changes:

- Added new 'Permission' type to facilitate easy conversion between basic name and name required when requesting permission from cluster. These require formatting with cluster! or cluster.bucket[bucketName]!.
- Removed unused Vaccum endpoint
- Added permission requirements to each endpoint
- Added response permission check for /_user and /_role
- Set all response permissions to true if admin auth disabled

- [x] Merge https://github.com/couchbase/sync_gateway/pull/5086 and rebase

Permissions used are as follows:
https://docs.google.com/spreadsheets/d/1cE2MptvrcFF2cVyIGphwWuGERRMrKhuXD5kl8UgqOCY/edit?usp=sharing