### PR TITLE
CBG-1461 - Flip disable_persistent_config value to false

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -15,11 +15,6 @@ import (
 	pkgerrors "github.com/pkg/errors"
 )
 
-type LegacyConfig struct {
-	DisablePersistentConfig *bool `json:"disable_persistent_config,omitempty" help:"Can be set to true to disable 3.0/persistent config handling."`
-	LegacyServerConfig
-}
-
 // JSON object that defines the server configuration.
 type LegacyServerConfig struct {
 	TLSMinVersion              *string                        `json:"tls_minimum_version,omitempty"`    // Set TLS Version
@@ -57,6 +52,7 @@ type LegacyServerConfig struct {
 	BcryptCost                 int                            `json:"bcrypt_cost,omitempty"`            // bcrypt cost to use for password hashes - Default: bcrypt.DefaultCost
 	MetricsInterface           *string                        `json:"metricsInterface,omitempty"`       // Interface to bind metrics to. If not set then metrics isn't accessible
 	HideProductVersion         bool                           `json:"hide_product_version,omitempty"`   // Determines whether product versions removed from Server headers and REST API responses. This setting does not apply to the Admin REST API.
+	DisablePersistentConfig    *bool                          `json:"disable_persistent_config,omitempty" help:"Can be set to true to disable 3.0/persistent config handling."`
 }
 
 type FacebookConfigLegacy struct {
@@ -110,9 +106,9 @@ type ReplicateV1ConfigLegacy struct {
 
 type ReplConfigMapLegacy map[string]*ReplicateV1ConfigLegacy
 
-// ToStartupConfig returns the given LegacyConfig as a StartupConfig and a set of DBConfigs.
+// ToStartupConfig returns the given LegacyServerConfig as a StartupConfig and a set of DBConfigs.
 // The returned configs do not contain any default values - only a direct mapping of legacy config options as they were given.
-func (lc *LegacyConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, error) {
+func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, error) {
 
 	// find a database's credentials for bootstrap (this isn't the first database config entry due to map iteration)
 	bsc := &BootstrapConfig{Server: "walrus:"}

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -174,14 +174,15 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 }
 
 func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
-	f, err := os.Open(path)
+	rc, err := readFromPath(path, false)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = f.Close() }()
+
+	defer func() { _ = rc.Close() }()
 
 	var sc StartupConfig
-	err = decodeAndSanitiseConfig(f, &sc)
+	err = decodeAndSanitiseConfig(rc, &sc)
 	return &sc, err
 }
 

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -16,9 +16,8 @@ func legacyServerMain(osArgs []string) error {
 		return err
 	}
 
-	lc := LegacyConfig{
+	lc := LegacyServerConfig{
 		DisablePersistentConfig: base.BoolPtr(true),
-		LegacyServerConfig:      *config,
 	}
 
 	sc, databases, err := lc.ToStartupConfig()


### PR DESCRIPTION
Has the effect that 2.x configs automatically fall back to `disable_persistent_config` mode (until auto-config migration is in place). This is a much nicer default for everybody running SG with 2.x and 3.x configs.

`disable_persistent_config: true` in legacy configs is still not yet supported, but until auto-migration is in place, it doesn't need to be.

## 2.x no flag
![Screenshot 2021-07-13 at 19 47 58](https://user-images.githubusercontent.com/1525809/125508442-e2dfd31d-26c5-4e2a-912b-76e7b6aaf449.png)
## 3.x no flag
![Screenshot 2021-07-13 at 19 49 06](https://user-images.githubusercontent.com/1525809/125508453-892daf05-7703-4439-a77c-a5b97505ffdc.png)
## 2.x opt-out flag
![Screenshot 2021-07-13 at 19 49 41](https://user-images.githubusercontent.com/1525809/125508461-2fcc13b7-beea-4d70-be71-ac00dc24eb74.png)
## 3.x opt-out flag (not supported)
![Screenshot 2021-07-13 at 19 49 29](https://user-images.githubusercontent.com/1525809/125508459-3a766aef-11a8-4897-bd17-78f55bf099be.png)


