### PR TITLE
CBG-1378 - OIDC client will be initalized until successful

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -649,9 +649,9 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(token string, providers OIDC
 // Returns identity claims extracted from the token if the verification is successful and an identity error if not.
 func verifyToken(token string, provider *OIDCProvider, callbackURLFunc OIDCCallbackURLFunc) (identity *Identity, err error) {
 	// Get client for issuer
-	client := provider.GetClient(callbackURLFunc)
-	if client == nil {
-		return nil, fmt.Errorf("OIDC client was not initialized")
+	client, err := provider.GetClient(callbackURLFunc)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC initialization error: %v", err)
 	}
 
 	// Verify claims and signature on the JWT; ensure that it's been signed by the provider.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -651,7 +651,7 @@ func verifyToken(token string, provider *OIDCProvider, callbackURLFunc OIDCCallb
 	// Get client for issuer
 	client, err := provider.GetClient(callbackURLFunc)
 	if err != nil {
-		return nil, fmt.Errorf("OIDC initialization error: %v", err)
+		return nil, fmt.Errorf("OIDC initialization error: %w", err)
 	}
 
 	// Verify claims and signature on the JWT; ensure that it's been signed by the provider.

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -167,10 +167,13 @@ type OIDCProvider struct {
 	// use the accessor method GetClient() instead.
 	client *OIDCClient
 
-	// clientOnce synchronises access to the GetClient() and ensures that
+	// clientInitLock synchronises access to the GetClient() and ensures that
 	// the OpenID Connect client only gets initialized exactly once when
-	// successfully connected to the OIDC provider
-	clientOnce base.AtomicBool
+	// the client has been successfully initialized.
+	clientInitLock sync.Mutex
+
+	// clientInit tracks whether the client has been successfully initialized or not
+	clientInit base.AtomicBool
 
 	// IsDefault indicates whether this OpenID Connect provider (the current
 	// instance of OIDCProvider is explicitly specified as default provider
@@ -246,20 +249,25 @@ func (opm OIDCProviderMap) Stop() {
 func (op *OIDCProvider) GetClient(buildCallbackURLFunc OIDCCallbackURLFunc) *OIDCClient {
 	// Initialize the client on first request. If the callback URL isn't defined for the provider,
 	// uses buildCallbackURLFunc to construct (based on current request)
-	if op.clientOnce.CompareAndSwap(false, true) { // If false, make true
-		var err error
-		// If the redirect URL is not defined for the provider generate it from the
-		// handler request and set it on the provider
-		if op.CallbackURL == nil || *op.CallbackURL == "" {
-			callbackURL := buildCallbackURLFunc(op.Name, op.IsDefault)
-			if callbackURL != "" {
-				op.CallbackURL = &callbackURL
+	if !op.clientInit.IsTrue() { // If client not initialized
+		op.clientInitLock.Lock()
+		if !op.clientInit.IsTrue() {
+			var err error
+			// If the redirect URL is not defined for the provider generate it from the
+			// handler request and set it on the provider
+			if op.CallbackURL == nil || *op.CallbackURL == "" {
+				callbackURL := buildCallbackURLFunc(op.Name, op.IsDefault)
+				if callbackURL != "" {
+					op.CallbackURL = &callbackURL
+				}
+			}
+			if err = op.initOIDCClient(); err != nil {
+				base.Errorf("Unable to initialize OIDC client: %v", err)
+			} else {
+				op.clientInit.Set(true)
 			}
 		}
-		if err = op.initOIDCClient(); err != nil {
-			base.Errorf("Unable to initialize OIDC client: %v", err)
-			op.clientOnce.Set(false)
-		}
+		op.clientInitLock.Unlock()
 	}
 	return op.client
 }

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -475,7 +475,13 @@ func (op *OIDCProvider) fetchCustomProviderConfig(discoveryURL string) (metadata
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return ProviderMetadata{}, MaxProviderConfigSyncInterval, false, fmt.Errorf("unsuccessful response: %v", err)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			err = fmt.Errorf("unsuccessful response and could not read returned response body: %w", err)
+		} else {
+			err = fmt.Errorf("unsuccessful response: %v", body)
+		}
+		return ProviderMetadata{}, MaxProviderConfigSyncInterval, false, err
 	}
 
 	ttl, _, err = cacheable(resp.Header)

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -250,14 +250,14 @@ func (opm OIDCProviderMap) Stop() {
 func (op *OIDCProvider) GetClient(buildCallbackURLFunc OIDCCallbackURLFunc) (*OIDCClient, error) {
 	// If the callback URL isn't defined for the provider, uses buildCallbackURLFunc to construct (based on current request)
 
-	if op.clientInit.IsTrue() { // If client not initialized
+	if op.clientInit.IsTrue() {
 		return op.client, nil
 	}
-	// Acquire lock
 	op.clientInitLock.Lock()
 	defer op.clientInitLock.Unlock()
 
-	if op.clientInit.IsTrue() { // Make sure past thread didn't init in lock
+	// Check again to see if the previous lock holder initialized the client
+	if op.clientInit.IsTrue() {
 		return op.client, nil
 	}
 

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -95,10 +95,11 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 		return redirectURLString, err
 	}
 
-	client := provider.GetClient(h.getOIDCCallbackURL)
-	if client == nil {
+	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	if err != nil {
+		base.Errorf("OIDC initialization error: %v", err)
 		return redirectURLString, base.HTTPErrorf(
-			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider:%s", providerName))
+			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider: %s", providerName))
 	}
 
 	var redirectURL *url.URL
@@ -168,9 +169,9 @@ func (h *handler) handleOIDCCallback() error {
 		http.SetCookie(h.response, stateCookie)
 	}
 
-	client := provider.GetClient(h.getOIDCCallbackURL)
-	if client == nil {
-		return err
+	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	if err != nil {
+		return fmt.Errorf("OIDC initialization error: %v", err)
 	}
 
 	// Converts the authorization code into a token.
@@ -221,9 +222,9 @@ func (h *handler) handleOIDCRefresh() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to identify provider for callback request")
 	}
 
-	client := provider.GetClient(h.getOIDCCallbackURL)
-	if client == nil {
-		return err
+	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	if err != nil {
+		return fmt.Errorf("OIDC initialization error: %v", err)
 	}
 
 	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -97,9 +97,8 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 
 	client, err := provider.GetClient(h.getOIDCCallbackURL)
 	if err != nil {
-		base.Errorf("OIDC initialization error: %v", err)
 		return redirectURLString, base.HTTPErrorf(
-			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider: %s", providerName))
+			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider: %s - %v", providerName, err))
 	}
 
 	var redirectURL *url.URL
@@ -171,7 +170,7 @@ func (h *handler) handleOIDCCallback() error {
 
 	client, err := provider.GetClient(h.getOIDCCallbackURL)
 	if err != nil {
-		return fmt.Errorf("OIDC initialization error: %v", err)
+		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
 
 	// Converts the authorization code into a token.
@@ -224,7 +223,7 @@ func (h *handler) handleOIDCRefresh() error {
 
 	client, err := provider.GetClient(h.getOIDCCallbackURL)
 	if err != nil {
-		return fmt.Errorf("OIDC initialization error: %v", err)
+		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
 
 	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -2100,7 +2100,8 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 // at a later request
 func TestEventuallyReachableOIDCClient(t *testing.T) {
 	// Modified copy of TestOpenIDConnectImplicitFlow
-	unreachableAddr := "0.0.0.0:1234"
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	unreachableAddr := "http://0.0.0.0"
 	tests := []struct {
 		name                string
 		providers           auth.OIDCProviderMap


### PR DESCRIPTION
- [x]  http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/901/ (1 test failed, runs locally fine, and on integration and EE unit tests so assumed to be racy test).

Sync.once behaviour is copied except the atomic int is only set to 1 when there is no errors from initializing the OIDC client.