### PR TITLE
Added temporary flag overrides for a couple config options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -332,7 +332,7 @@ pipeline {
                                 gitStatusWrapper(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", description: 'Running LiteCore Tests', failureDescription: 'EE with LiteCore Test Failed', gitHubContext: 'sgw-pipeline-litecore-ee', successDescription: 'EE with LiteCore Test Passed') {
                                     sh 'touch litecore.out'
                                     //sh 'docker pull couchbase/sg-test-litecore:latest'
-                                    sh 'docker run --net=host --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest'
+                                    sh 'docker run --net=host --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest -legacy-config'
                                 }
                             }
                         }

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -424,6 +424,11 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 
 	_ = flagSet.Bool("disable_persistent_config", false, "")
 
+	_ = flagSet.Bool("api.admin_interface_authentication", true, "")
+	_ = flagSet.Bool("api.metrics_interface_authentication", true, "")
+	_ = flagSet.Bool("bootstrap.allow_insecure_server_connections", false, "")
+	_ = flagSet.Bool("bootstrap.allow_insecure_tls_connections", false, "")
+
 	addr := flagSet.String("interface", DefaultPublicInterface, "Address to bind to")
 	authAddr := flagSet.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
 	profAddr := flagSet.String("profileInterface", "", "Address to bind profile interface to")

--- a/rest/main.go
+++ b/rest/main.go
@@ -45,6 +45,13 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	// 	return err
 	// }
 
+	// TODO: Be removed in a future commit once flags are sorted
+	adminInterfaceAuthFlag := fs.Bool("api.admin_interface_authentication", true, "")
+	metricsInterfaceAuthFlag := fs.Bool("api.metrics_interface_authentication", true, "")
+
+	allowInsecureServerConnections := fs.Bool("bootstrap.allow_insecure_server_connections", false, "")
+	allowInsecureTLSConnections := fs.Bool("bootstrap.allow_insecure_tls_connections", false, "")
+
 	if err := fs.Parse(osArgs[1:]); err != nil {
 		// Return nil for ErrHelp so the shell exit code is 0
 		if err == flag.ErrHelp {
@@ -53,14 +60,22 @@ func serverMain(ctx context.Context, osArgs []string) error {
 		return err
 	}
 
+	// TODO: Be removed in a future commit once flags are sorted
+	flagStartupConfig.API.AdminInterfaceAuthentication = adminInterfaceAuthFlag
+	flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
+
+	// Actually hook this up @Isaac
+	_ = allowInsecureServerConnections
+	_ = allowInsecureTLSConnections
+
 	if *disablePersistentConfigFlag {
-		return legacyServerMain(osArgs)
+		return legacyServerMain(osArgs, &flagStartupConfig)
 	}
 
 	disablePersistentConfigFallback, err := serverMainPersistentConfig(fs, &flagStartupConfig)
 	if disablePersistentConfigFallback {
 		base.Infof(base.KeyAll, "Falling back to disabled persistent config...")
-		return legacyServerMain(osArgs)
+		return legacyServerMain(osArgs, &flagStartupConfig)
 	}
 
 	return err

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -8,7 +8,7 @@ import (
 )
 
 // legacyServerMain runs the pre-3.0 Sync Gateway server.
-func legacyServerMain(osArgs []string) error {
+func legacyServerMain(osArgs []string, flagStartupConfig *StartupConfig) error {
 	base.Warnf("Running in legacy config mode")
 
 	lc, err := setupServerConfig(osArgs)
@@ -28,6 +28,14 @@ func legacyServerMain(osArgs []string) error {
 	err = sc.Merge(migratedStartupConfig)
 	if err != nil {
 		return err
+	}
+
+	if flagStartupConfig != nil {
+		base.Tracef(base.KeyAll, "got config from flags: %#v", flagStartupConfig)
+		err := sc.Merge(flagStartupConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	ctx, err := setupServerContext(&sc, false)


### PR DESCRIPTION
 - Added some temporary flags which allow us to override a few items which are required to run litecore tests with SGW 3.x
 - Auth ones are hooked up, TLS / Server ones will be hooked up as part of the PR that adds those options
 - Additionally we pass down flag options to legacy config in the same way we do for persistent config
 
 - [x] Merge https://github.com/couchbase/sync_gateway/pull/5094 and rebase