### PR TITLE
Skip CE tests for PRs in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -215,6 +215,7 @@ pipeline {
                 stage('Unit') {
                     stages {
                         stage('CE') {
+                            when { branch 'master' }
                             steps{
                                 // Travis-related variables are required as coveralls.io only officially supports a certain set of CI tools.
                                 withEnv(["PATH+=${GO}:${GOTOOLS}/bin", "TRAVIS_BRANCH=${env.BRANCH}", "TRAVIS_PULL_REQUEST=${env.CHANGE_ID}", "TRAVIS_JOB_ID=${env.BUILD_NUMBER}"]) {


### PR DESCRIPTION
We're still running CE tests via GitHub Actions, but this should cut the Jeknins pipeline build time in half.