### PR TITLE
Renamed a temporary flag override for allow_insecure_tls_connections

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -427,7 +427,7 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 	_ = flagSet.Bool("api.admin_interface_authentication", true, "")
 	_ = flagSet.Bool("api.metrics_interface_authentication", true, "")
 	_ = flagSet.Bool("bootstrap.allow_insecure_server_connections", false, "")
-	_ = flagSet.Bool("bootstrap.allow_insecure_tls_connections", false, "")
+	_ = flagSet.Bool("api.https.allow_insecure_tls_connections", false, "")
 
 	addr := flagSet.String("interface", DefaultPublicInterface, "Address to bind to")
 	authAddr := flagSet.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")

--- a/rest/main.go
+++ b/rest/main.go
@@ -50,7 +50,7 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	metricsInterfaceAuthFlag := fs.Bool("api.metrics_interface_authentication", true, "")
 
 	allowInsecureServerConnections := fs.Bool("bootstrap.allow_insecure_server_connections", false, "")
-	allowInsecureTLSConnections := fs.Bool("bootstrap.allow_insecure_tls_connections", false, "")
+	allowInsecureTLSConnections := fs.Bool("api.https.allow_insecure_tls_connections", false, "")
 
 	if err := fs.Parse(osArgs[1:]); err != nil {
 		// Return nil for ErrHelp so the shell exit code is 0


### PR DESCRIPTION
Renamed from boostrap.allow_insecure_tls_connections to api.https.allow_insecure_tls_connections