### PR TITLE
Temp rename agent label for testing docker builders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     // Build on this uberjenkins node, as it has the Go environment set up in a known-state
     // We could potentially change this to use a dockerfile agent instead so it can be portable.
-    agent { label 'sync-gateway-pipeline-builder' }
+    agent { label 'sync-gateway-pipeline-builder-docker-test' }
 
     environment {
         GO_VERSION = 'go1.14'


### PR DESCRIPTION
- [ ] Get pipeline builds running through docker container (so we're able to run CI jobs on laptops and with more parallelism) 