### PR TITLE
Temporarily flip admin auth default to false

### DIFF
--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -36,8 +36,8 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			},
 			ReadHeaderTimeout:              base.NewConfigDuration(base.DefaultReadHeaderTimeout),
 			IdleTimeout:                    base.NewConfigDuration(base.DefaultIdleTimeout),
-			AdminInterfaceAuthentication:   base.BoolPtr(true),
-			MetricsInterfaceAuthentication: base.BoolPtr(true),
+			AdminInterfaceAuthentication:   base.BoolPtr(false),
+			MetricsInterfaceAuthentication: base.BoolPtr(false),
 		},
 		Logging: LoggingConfig{
 			LogFilePath:    defaultLogFilePath,

--- a/rest/main.go
+++ b/rest/main.go
@@ -46,8 +46,8 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	// }
 
 	// TODO: Be removed in a future commit once flags are sorted
-	adminInterfaceAuthFlag := fs.Bool("api.admin_interface_authentication", true, "")
-	metricsInterfaceAuthFlag := fs.Bool("api.metrics_interface_authentication", true, "")
+	adminInterfaceAuthFlag := fs.Bool("api.admin_interface_authentication", false, "")
+	metricsInterfaceAuthFlag := fs.Bool("api.metrics_interface_authentication", false, "")
 
 	allowInsecureServerConnections := fs.Bool("bootstrap.allow_insecure_server_connections", false, "")
 	allowInsecureTLSConnections := fs.Bool("api.https.allow_insecure_tls_connections", false, "")


### PR DESCRIPTION
For QE test case admin auth should be temporarily flipped to false until we get direction on what the default behaviour should be for a legacy config.