### PR TITLE
Upgrade to build with Go1.16.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   static-analysis:
+    env:
+      GO111MODULE: off
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
@@ -37,6 +39,8 @@ jobs:
         run: go vet github.com/couchbase/sync_gateway/...
 
   test:
+    env:
+      GO111MODULE: off
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
@@ -52,6 +56,8 @@ jobs:
         run: go test -timeout=30m -count=1 -v github.com/couchbase/sync_gateway/...
 
   test-race:
+    env:
+      GO111MODULE: off
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.13.4
+          go-version: 1.16.6
       - name: Bootstrap
         run: |
           wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.13.4
+          go-version: 1.16.6
       - name: Bootstrap
         run: |
           wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.13.4
+          go-version: 1.16.6
       - name: Bootstrap
         run: |
           wget https://raw.githubusercontent.com/couchbase/sync_gateway/master/bootstrap.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'sync-gateway-pipeline-builder' }
 
     environment {
-        GO_VERSION = 'go1.14'
+        GO_VERSION = 'go1.16.6'
         GVM = "/root/.gvm/bin/gvm"
         GO = "/root/.gvm/gos/${GO_VERSION}/bin"
         GOPATH = "${WORKSPACE}/godeps"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         EE_BUILD_TAG = "cb_sg_enterprise"
         SGW_REPO = "github.com/couchbase/sync_gateway"
         GH_ACCESS_TOKEN_CREDENTIAL = "github_cb-robot-sg_access_token"
+        GO111MODULE = "off"
     }
 
     stages {

--- a/manifest/product-config.json
+++ b/manifest/product-config.json
@@ -6,7 +6,7 @@
             "release_name": "Couchbase Sync Gateway",
             "production": true,
             "interval": 30,
-            "go_version": "1.13.4",
+            "go_version": "1.16.6",
             "trigger_blackduck": true,
             "start_build": 1
         },

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -479,7 +479,8 @@ function(doc, oldDoc) {
 
 			numTries++
 			if numTries > maxTries {
-				t.Fatalf("Giving up trying to receive %d changes.  Only received %d", numExpectedChanges, len(changesAccumulated))
+				t.Errorf("Giving up trying to receive %d changes.  Only received %d", numExpectedChanges, len(changesAccumulated))
+				return
 			}
 
 		}


### PR DESCRIPTION
Updates SGW 3.0 to build with Go 1.16.6
Handles:
 - CBG-765
 - CBG-1170

and allows for M1 silicon as part of:
 - CBG-1251

 - [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration-gotest/5/