### PR TITLE
Store closable http.Server on ServerContext for graceful shutdown

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -165,7 +165,6 @@ func (sc *ServerContext) Close() {
 		ctx.Close()
 		_ = ctx.EventMgr.RaiseDBStateChangeEvent(ctx.Name, "offline", "Database context closed", &sc.config.API.AdminInterface)
 	}
-
 	sc.databases_ = nil
 
 	for _, s := range sc._httpServers {
@@ -174,6 +173,7 @@ func (sc *ServerContext) Close() {
 			base.Warnf("Error closing HTTP server %q: %v", s.Addr, err)
 		}
 	}
+	sc._httpServers = nil
 
 	if sc.bootstrapConnection != nil {
 		if err := sc.bootstrapConnection.Close(); err != nil {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -729,6 +729,8 @@ func TestAdminAuthWithX509(t *testing.T) {
 }
 
 func TestStartAndStopHTTPServers(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 


### PR DESCRIPTION
Keep references to the underlying `http.Server` in `ServerContext` so they can be closed gracefully on `ServerContext.Close()`

Allows for "end-to-end" type testing (serverMain) for bootstrap config.