### PR TITLE
Fix TestHandleDBConfig unclosed bucket

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2265,10 +2265,9 @@ func TestHandleDBConfig(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	rt := NewRestTester(t, nil)
-	defer rt.Close()
-
 	tb := base.GetTestBucket(t)
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
+	defer rt.Close()
 
 	bucket := tb.GetName()
 	kvTLSPort := 443


### PR DESCRIPTION
- Fixes:
`2021-07-19T16:50:31.103+01:00 TEST: WARNING: TestHandleDBConfig left sg_int_1_1626709258627371031 bucket unclosed!`