### PR TITLE
CBG-1464 Support meta option in Attachment REST API to retrieve doc ID of the attachment blob

### DIFF
--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -205,6 +205,13 @@ func (h *handler) handleGetAttachment() error {
 		return err
 	}
 
+	metaOption := h.getBoolQuery("meta")
+	if metaOption {
+		meta["key"] = attachmentKey
+		h.writeJSONStatus(http.StatusOK, meta)
+		return nil
+	}
+
 	status, start, end := h.handleRange(uint64(len(data)))
 	if status > 299 {
 		return base.HTTPErrorf(status, "")


### PR DESCRIPTION
Changes to include meta option in Attachment REST API to retrieve doc ID of the attachment blob.

From Lithium on, the GET /{db}/{doc}/{attachment} request supports an optional meta boolean parameter in the query string. If it’s specified as true, the response will be just the key including metadata of the attachment blob instead of raw data. 

- [x] Depends on https://github.com/couchbase/sync_gateway/pull/5088