### PR TITLE
CBG-1544: Handle SyncWriteInProgress as recoverable write error

### DIFF
--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -810,8 +810,19 @@ func (bucket *CouchbaseBucketGoCB) isRecoverableWriteError(err error) bool {
 	}
 
 	_, ok := recoverableGocbV1Errors[pkgerrors.Cause(err).Error()]
+	if ok {
+		return ok
+	}
 
-	return ok
+	// In some circumstances we are unable to supply errors in the recoverable error map so need to check the error
+	// codes
+	gocbcoreKvError, ok := err.(*gocbcore.KvError)
+	// 0xA2 error is "SyncWriteInProgress" error
+	if gocbcoreKvError.Code == 0xA2 {
+		return true
+	}
+
+	return false
 }
 
 func isGoCBTimeoutError(err error) bool {

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/couchbase/gocbcore/memd"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 	"gopkg.in/couchbase/gocb.v1"
@@ -816,9 +817,7 @@ func (bucket *CouchbaseBucketGoCB) isRecoverableWriteError(err error) bool {
 
 	// In some circumstances we are unable to supply errors in the recoverable error map so need to check the error
 	// codes
-	gocbcoreKvError, ok := err.(*gocbcore.KvError)
-	// 0xA2 error is "SyncWriteInProgress" error
-	if gocbcoreKvError.Code == 0xA2 {
+	if isKVError(err, memd.StatusSyncWriteInProgress) {
 		return true
 	}
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -412,6 +412,8 @@ func (c *Collection) isRecoverableWriteError(err error) bool {
 		return false
 	}
 
+	// TODO: CBG-1142 Handle SyncWriteInProgress errors --> Currently gocbv2 retries this internally and returns a
+	//  timeout with KV_SYNC_WRITE_IN_PROGRESS as its reason. Decision on whether to handle inside gocb or retry here
 	if errors.Is(err, gocb.ErrTemporaryFailure) || errors.Is(err, gocb.ErrOverload) {
 		return true
 	}


### PR DESCRIPTION
Adds retry handling for `SyncWriteInProgress` error. Only occurs on write.
This is handled by us in gocbv1 by `isRecoverableWriteError`.
On gocbv2 this is done internally by gocb and they retry up to the timeout. Behaviour will be determined as part of CBG-1142