### PR TITLE
CBG-1401 Start background polling for new buckets/database configs

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1557,3 +1557,19 @@ func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
 	*d = ConfigDuration{Duration: dur}
 	return nil
 }
+
+// TerminateAndWaitForClose will close the given terminator, and wait up to timeout for the done channel to be closed in response.
+func TerminateAndWaitForClose(terminator chan struct{}, done chan struct{}, timeout time.Duration) error {
+	if terminator == nil && done == nil {
+		return errors.New("terminateAndWaitForClose requires both terminator and done channels")
+	}
+	close(terminator)
+	t := time.NewTimer(timeout)
+	select {
+	case <-done:
+		t.Stop()
+	case <-t.C:
+		return fmt.Errorf("terminateAndWaitForClose timed out waiting for done channel after %v", timeout)
+	}
+	return nil
+}

--- a/base/util.go
+++ b/base/util.go
@@ -1560,7 +1560,7 @@ func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
 
 // TerminateAndWaitForClose will close the given terminator, and wait up to timeout for the done channel to be closed in response.
 func TerminateAndWaitForClose(terminator chan struct{}, done chan struct{}, timeout time.Duration) error {
-	if terminator == nil && done == nil {
+	if terminator == nil || done == nil {
 		return errors.New("terminateAndWaitForClose requires both terminator and done channels")
 	}
 	close(terminator)

--- a/rest/config.go
+++ b/rest/config.go
@@ -951,7 +951,7 @@ func (sc *ServerContext) fetchAndLoadConfigs() (count int, err error) {
 // fetchAndLoadDatabase will attempt to find the given database name first in a matching bucket name,
 // but then fall back to searching through configs in each bucket to try and find a config.
 func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err error) {
-	buckets, err := sc.bootstrapConnection.GetConfigBuckets()
+	buckets, err := sc.bootstrapContext.connection.GetConfigBuckets()
 	if err != nil {
 		return false, fmt.Errorf("couldn't get buckets from cluster: %w", err)
 	}
@@ -966,7 +966,7 @@ func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err er
 	for _, bucket := range buckets {
 		bucket := bucket
 		var cnf DatabaseConfig
-		cas, err := sc.bootstrapConnection.GetConfig(dbName, sc.config.Bootstrap.ConfigGroupID, &cnf)
+		cas, err := sc.bootstrapContext.connection.GetConfig(dbName, sc.config.Bootstrap.ConfigGroupID, &cnf)
 		if err == base.ErrNotFound {
 			base.Debugf(base.KeyConfig, "%q did not contain config in group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
 			continue

--- a/rest/config.go
+++ b/rest/config.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -903,6 +904,27 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 		} else {
 			base.Warnf("Config: No database configs for group %q. Continuing startup to allow REST API database creation", sc.config.Bootstrap.ConfigGroupID)
 		}
+
+		go func() {
+			t := time.NewTicker(sc.config.Bootstrap.ConfigUpdateFrequency.Value())
+			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.Value().String())
+			for {
+				select {
+				case <-sc.ctx.Done():
+					base.Infof(base.KeyConfig, "Stopping background config polling loop")
+					t.Stop()
+					return
+				case <-t.C:
+					count, err := sc.fetchAndLoadConfigs()
+					if err != nil {
+						base.Warnf("Couldn't load configs from bucket when polled: %v", err)
+					}
+					if count > 0 {
+						base.Infof(base.KeyConfig, "Successfully fetched %d database configs from buckets in cluster", count)
+					}
+				}
+			}
+		}()
 	}
 
 	return sc, nil

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -23,7 +23,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 	return StartupConfig{
 		Bootstrap: BootstrapConfig{
 			ConfigGroupID:         persistentConfigDefaultGroupID,
-			ConfigUpdateFrequency: *base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
+			ConfigUpdateFrequency: base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
 			ServerTLSSkipVerify:   base.BoolPtr(false),
 			UseTLSServer:          base.BoolPtr(true),
 		},
@@ -76,16 +76,16 @@ type StartupConfig struct {
 
 // BootstrapConfig describes the set of properties required in order to bootstrap config from Couchbase Server.
 type BootstrapConfig struct {
-	ConfigGroupID         string              `json:"group_id,omitempty"                help:"The config group ID to use when discovering databases. Allows for non-homogenous configuration"`
-	ConfigUpdateFrequency base.ConfigDuration `json:"config_update_frequency,omitempty" help:"How often to poll Couchbase Server for new config changes. Default: 10s"`
-	Server                string              `json:"server,omitempty"                  help:"Couchbase Server connection string/URL"`
-	Username              string              `json:"username,omitempty"                help:"Username for authenticating to server"`
-	Password              string              `json:"password,omitempty"                help:"Password for authenticating to server"`
-	CACertPath            string              `json:"ca_cert_path,omitempty"            help:"Root CA cert path for TLS connection"`
-	ServerTLSSkipVerify   *bool               `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
-	X509CertPath          string              `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
-	X509KeyPath           string              `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
-	UseTLSServer          *bool               `json:"use_tls_server,omitempty"          help:"Forces the connection to Couchbase Server to use TLS"`
+	ConfigGroupID         string               `json:"group_id,omitempty"                help:"The config group ID to use when discovering databases. Allows for non-homogenous configuration"`
+	ConfigUpdateFrequency *base.ConfigDuration `json:"config_update_frequency,omitempty" help:"How often to poll Couchbase Server for new config changes. Default: 10s"`
+	Server                string               `json:"server,omitempty"                  help:"Couchbase Server connection string/URL"`
+	Username              string               `json:"username,omitempty"                help:"Username for authenticating to server"`
+	Password              string               `json:"password,omitempty"                help:"Password for authenticating to server"`
+	CACertPath            string               `json:"ca_cert_path,omitempty"            help:"Root CA cert path for TLS connection"`
+	ServerTLSSkipVerify   *bool                `json:"server_tls_skip_verify,omitempty"  help:"Allow empty server CA Cert Path without attempting to use system root pool"`
+	X509CertPath          string               `json:"x509_cert_path,omitempty"          help:"Cert path (public key) for X.509 bucket auth"`
+	X509KeyPath           string               `json:"x509_key_path,omitempty"           help:"Key path (private key) for X.509 bucket auth"`
+	UseTLSServer          *bool                `json:"use_tls_server,omitempty"          help:"Forces the connection to Couchbase Server to use TLS"`
 }
 
 type APIConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -57,7 +57,6 @@ type ServerContext struct {
 
 type bootstrapContext struct {
 	connection base.BootstrapConnection
-	ticker     *time.Ticker
 	terminator chan struct{} // Used to stop the goroutine handling the stats logging
 	doneChan   chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -10,7 +10,6 @@ package rest
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -42,20 +41,25 @@ const KDefaultNumShards = 16
 // This struct is accessed from HTTP handlers running on multiple goroutines, so it needs to
 // be thread-safe.
 type ServerContext struct {
-	config              *StartupConfig
-	persistentConfig    bool
-	bucketDbName        map[string]string              // bucketDbName is a map of bucket to database name
-	dbConfigs           map[string]*DatabaseConfig     // dbConfigs is a map of db name to DatabaseConfig
-	databases_          map[string]*db.DatabaseContext // databases_ is a map of dbname to db.DatabaseContext
-	lock                sync.RWMutex
-	statsContext        *statsContext
-	bootstrapConnection base.BootstrapConnection
-	HTTPClient          *http.Client
-	cpuPprofFileMutex   sync.Mutex     // Protect cpuPprofFile from concurrent Start and Stop CPU profiling requests
-	cpuPprofFile        *os.File       // An open file descriptor holds the reference during CPU profiling
-	_httpServers        []*http.Server // A list of HTTP servers running under the ServerContext
-	ctx                 context.Context
-	ctxCancel           context.CancelFunc
+	config            *StartupConfig
+	persistentConfig  bool
+	bucketDbName      map[string]string              // bucketDbName is a map of bucket to database name
+	dbConfigs         map[string]*DatabaseConfig     // dbConfigs is a map of db name to DatabaseConfig
+	databases_        map[string]*db.DatabaseContext // databases_ is a map of dbname to db.DatabaseContext
+	lock              sync.RWMutex
+	statsContext      *statsContext
+	bootstrapContext  *bootstrapContext
+	HTTPClient        *http.Client
+	cpuPprofFileMutex sync.Mutex     // Protect cpuPprofFile from concurrent Start and Stop CPU profiling requests
+	cpuPprofFile      *os.File       // An open file descriptor holds the reference during CPU profiling
+	_httpServers      []*http.Server // A list of HTTP servers running under the ServerContext
+}
+
+type bootstrapContext struct {
+	connection base.BootstrapConnection
+	ticker     *time.Ticker
+	terminator chan struct{} // Used to stop the goroutine handling the stats logging
+	doneChan   chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }
 
 type DatabaseConfig struct {
@@ -103,7 +107,6 @@ func (sc *ServerContext) CloseCpuPprofFile() {
 }
 
 func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerContext {
-	ctx, ctxCancel := context.WithCancel(context.TODO())
 	sc := &ServerContext{
 		config:           config,
 		persistentConfig: persistentConfig,
@@ -112,8 +115,7 @@ func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerConte
 		databases_:       map[string]*db.DatabaseContext{},
 		HTTPClient:       http.DefaultClient,
 		statsContext:     &statsContext{},
-		ctx:              ctx,
-		ctxCancel:        ctxCancel,
+		bootstrapContext: &bootstrapContext{},
 	}
 
 	if base.ServerIsWalrus(sc.config.Bootstrap.Server) {
@@ -161,13 +163,23 @@ func (sc *ServerContext) PostStartup() {
 
 }
 
+// serverContextStopMaxWait is the maximum amount of time to wait for
+// background goroutines to terminate before the server is stopped.
+const serverContextStopMaxWait = 30 * time.Second
+
 func (sc *ServerContext) Close() {
 	sc.lock.Lock()
 	defer sc.lock.Unlock()
 
-	sc.ctxCancel()
+	err := base.TerminateAndWaitForClose(sc.statsContext.terminator, sc.statsContext.doneChan, serverContextStopMaxWait)
+	if err != nil {
+		base.Infof(base.KeyAll, "Couldn't stop stats logger:", err)
+	}
 
-	sc.stopStatsLogger()
+	err = base.TerminateAndWaitForClose(sc.bootstrapContext.terminator, sc.bootstrapContext.doneChan, serverContextStopMaxWait)
+	if err != nil {
+		base.Infof(base.KeyAll, "Couldn't stop background config update worker:", err)
+	}
 
 	for _, ctx := range sc.databases_ {
 		ctx.Close()
@@ -183,8 +195,8 @@ func (sc *ServerContext) Close() {
 	}
 	sc._httpServers = nil
 
-	if sc.bootstrapConnection != nil {
-		if err := sc.bootstrapConnection.Close(); err != nil {
+	if c := sc.bootstrapContext.connection; c != nil {
+		if err := c.Close(); err != nil {
 			base.Warnf("Error closing bootstrap cluster connection: %v", err)
 		}
 	}
@@ -1007,25 +1019,6 @@ func (sc *ServerContext) startStatsLogger() {
 	}()
 	base.Infof(base.KeyAll, "Logging stats with frequency: %v", interval)
 
-}
-
-// StatsLoggerStopMaxWait is the maximum amount of time to wait for
-// stats logger goroutine to terminate before the server is stopped.
-const StatsLoggerStopMaxWait = 30 * time.Second
-
-// stopStatsLogger stops the stats logger.
-func (sc *ServerContext) stopStatsLogger() {
-	if sc.statsContext.terminator != nil {
-		close(sc.statsContext.terminator)
-
-		waitTime := StatsLoggerStopMaxWait
-		select {
-		case <-sc.statsContext.doneChan:
-			// Stats logger goroutine is terminated and doneChan is already closed.
-		case <-time.After(waitTime):
-			base.Infof(base.KeyAll, "Timeout after %v of waiting for stats logger to terminate", waitTime)
-		}
-	}
 }
 
 func (sc *ServerContext) logStats() error {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -214,7 +214,7 @@ func (sc *ServerContext) GetDatabase(name string) (*db.DatabaseContext, error) {
 		return nil, base.HTTPErrorf(http.StatusBadRequest, "invalid database name %q", name)
 	}
 
-	if sc.bootstrapConnection != nil {
+	if sc.bootstrapContext.connection != nil {
 		// database not loaded, go look for it in the cluster
 		found, err := sc.fetchAndLoadDatabase(name)
 		if err != nil {


### PR DESCRIPTION
Starts a background polling loop on bootstrap that discovers new buckets and new/updated database configs based on the configured interval (default 10s)