### PR TITLE
Fix incorrect buckets being used for multiple databases in fetchConfigs 

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -932,8 +932,10 @@ func (sc *ServerContext) fetchConfigs() (bucketToDatabaseConfig map[string]*Data
 
 		// inherit properties the bootstrap config
 		cnf.Server = &sc.config.Bootstrap.Server
-		cnf.Bucket = &bucket
 		cnf.CACertPath = sc.config.Bootstrap.CACertPath
+		// copy loop variable
+		bucketCopy := bucket
+		cnf.Bucket = &bucketCopy
 
 		// any authentication fields defined on the dbconfig take precedence over any in the bootstrap config
 		if cnf.Username == "" && cnf.Password == "" && cnf.CertPath == "" && cnf.KeyPath == "" {


### PR DESCRIPTION
Take a copy of the "bucket" loop variable in fetchConfigs to avoid the bucket from being changed when iterating over multiple databases