### PR TITLE
CBG-1518 - Fixed failing unit tests on Windows

### DIFF
--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -14,7 +14,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -441,12 +440,13 @@ func TestTLSConfig(t *testing.T) {
 	// Check TLSConfig with no certs provided. InsecureSkipVerify should always be false. Should be empty config on Windows CBG-1518
 	spec = BucketSpec{}
 	conf = spec.TLSConfig()
+	assert.NotEmpty(t, conf)
+	assert.False(t, conf.InsecureSkipVerify)
+	require.NotNil(t, conf.RootCAs)
 	if runtime.GOOS != "windows" {
-		assert.NotEmpty(t, conf)
-		assert.False(t, conf.InsecureSkipVerify)
-		assert.NotNil(t, conf.RootCAs)
+		assert.NotEqual(t, x509.NewCertPool(), conf.RootCAs)
 	} else {
-		assert.Equal(t, tls.Config{RootCAs: x509.NewCertPool(), InsecureSkipVerify: false}, *conf)
+		assert.Equal(t, x509.NewCertPool(), conf.RootCAs)
 	}
 
 	// Check TLSConfig by providing invalid root CA certificate; provide root certificate key path

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -14,6 +14,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -437,7 +438,7 @@ func TestTLSConfig(t *testing.T) {
 	assert.Nil(t, conf.RootCAs)
 	assert.Nil(t, conf.Certificates)
 
-	// Check TLSConfig with no certs provided. InsecureSkipVerify should always be false. Should log error on Windows CBG-1518
+	// Check TLSConfig with no certs provided. InsecureSkipVerify should always be false. Should be empty config on Windows CBG-1518
 	spec = BucketSpec{}
 	conf = spec.TLSConfig()
 	if runtime.GOOS != "windows" {
@@ -445,7 +446,7 @@ func TestTLSConfig(t *testing.T) {
 		assert.False(t, conf.InsecureSkipVerify)
 		assert.NotNil(t, conf.RootCAs)
 	} else {
-		assert.Empty(t, conf)
+		assert.Equal(t, tls.Config{RootCAs: x509.NewCertPool(), InsecureSkipVerify: false}, *conf)
 	}
 
 	// Check TLSConfig by providing invalid root CA certificate; provide root certificate key path

--- a/base/gocb_utils_test.go
+++ b/base/gocb_utils_test.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"crypto/x509"
 	"os"
 	"runtime"
 	"testing"
@@ -55,6 +56,13 @@ func TestGoCBv2SecurityConfig(t *testing.T) {
 			expectCertPool: true,
 			expectError:    false,
 		},
+		{
+			name:           "Get root pool",
+			tlsSkipVerify:  nil,
+			caCertPath:     "",
+			expectCertPool: true,
+			expectError:    false,
+		},
 	}
 	//
 	for _, test := range tests {
@@ -75,8 +83,8 @@ func TestGoCBv2SecurityConfig(t *testing.T) {
 			assert.Equal(t, expectTLSSkipVerify, sc.TLSSkipVerify)
 			if test.expectCertPool == false {
 				assert.Nil(t, sc.TLSRootCAs)
-			} else if runtime.GOOS == "windows" { // expect empty cert pool
-				assert.Empty(t, sc.TLSRootCAs)
+			} else if runtime.GOOS == "windows" && test.caCertPath == "" { // expect empty cert pool when getting root pool on windows
+				assert.Equal(t, x509.NewCertPool(), sc.TLSRootCAs)
 			} else { // Expect populated cert pool
 				assert.NotEmpty(t, sc.TLSRootCAs)
 			}


### PR DESCRIPTION
- Fixed the failing unit tests on Windows
- Added new test case to test when no CA provided and TLS skip verify is false (so Root pool will be retrieved except on Windows).

TestTLSConfig was failing due to assert.Empty being used to check if the TLS config was empty but it was not as an empty X509 pool was being passed in, and the TLS Skip Verify value.

TestGoCBv2SecurityConfig was failing due to a CA Cert being provided which meant the returned value would have the CA cert provided and not be empty. The test was asserting this would be empty.