### PR TITLE
CBG-1415 - Enable Shared Bucket Access by default

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -67,8 +67,8 @@ const (
 	// Can be used to set a global log level for all tests at runtime.
 	TestEnvGlobalLogLevel = "SG_TEST_LOG_LEVEL"
 
-	DefaultUseXattrs      = false // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
-	DefaultAllowConflicts = true  // Whether Sync Gateway allows revision conflicts, if not specified in the config
+	DefaultUseXattrs      = true // Whether Sync Gateway uses xattrs for metadata storage, if not specified in the config
+	DefaultAllowConflicts = true // Whether Sync Gateway allows revision conflicts, if not specified in the config
 
 	DefaultDropIndexes = false // Whether Sync Gateway drops GSI indexes before each test while running in integration mode
 

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -149,7 +149,6 @@ func GetTestBucketForDriver(t testing.TB, driver CouchbaseDriver) *TestBucket {
 
 // Should Sync Gateway use XATTRS functionality when running unit tests?
 func TestUseXattrs() bool {
-
 	// First check if the SG_TEST_USE_XATTRS env variable is set
 	useXattrs := os.Getenv(TestEnvSyncGatewayUseXattrs)
 	if strings.ToLower(useXattrs) == strings.ToLower(TestEnvSyncGatewayTrue) {
@@ -157,7 +156,7 @@ func TestUseXattrs() bool {
 	}
 
 	// Otherwise fallback to hardcoded default
-	return DefaultUseXattrs
+	return !UnitTestUrlIsWalrus()
 
 }
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -210,6 +210,13 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	// TODO: Translate database configs too?
 	dbs := lc.Databases
 
+	// Follow legacy behaviour of having xattrs false by default
+	for _, database := range dbs {
+		if database.EnableXattrs == nil {
+			database.EnableXattrs = base.BoolPtr(false)
+		}
+	}
+
 	return &sc, dbs, nil
 }
 

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -86,3 +86,36 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		})
 	}
 }
+
+// CBG-1415
+func TestLegacyConfigXattrsDefault(t *testing.T) {
+	tests := []struct {
+		name           string
+		xattrs         *bool
+		expectedXattrs bool
+	}{
+		{
+			name:           "Nil Xattrs",
+			xattrs:         nil,
+			expectedXattrs: false,
+		},
+		{
+			name:           "False Xattrs",
+			xattrs:         base.BoolPtr(false),
+			expectedXattrs: false,
+		},
+		{
+			name:           "True Xattrs",
+			xattrs:         base.BoolPtr(true),
+			expectedXattrs: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lc := LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{EnableXattrs: test.xattrs}}}
+			_, dbcm, err := lc.ToStartupConfig()
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedXattrs, *dbcm["db"].EnableXattrs)
+		})
+	}
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1812,3 +1812,34 @@ func TestJSLoadTypeString(t *testing.T) {
 	// Test out of bounds JSLoadType
 	assert.Equal(t, "JSLoadType(4294967295)", JSLoadType(math.MaxUint32).String())
 }
+
+func TestUseXattrs(t *testing.T) {
+	testCases := []struct {
+		name           string
+		enableXattrs   *bool
+		expectedXattrs bool
+	}{
+		{
+			name:           "Nil Xattrs",
+			enableXattrs:   nil,
+			expectedXattrs: true, // Expects base.DefaultUseXattrs
+		},
+		{
+			name:           "False Xattrs",
+			enableXattrs:   base.BoolPtr(false),
+			expectedXattrs: false,
+		},
+		{
+			name:           "True Xattrs",
+			enableXattrs:   base.BoolPtr(true),
+			expectedXattrs: true,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			dbc := &DbConfig{EnableXattrs: test.enableXattrs}
+			result := dbc.UseXattrs()
+			assert.Equal(t, test.expectedXattrs, result)
+		})
+	}
+}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -245,13 +245,13 @@ func TestConfigValidationImportPartitions(t *testing.T) {
 		err    string
 	}{
 		{
-			name:   "Import enabled, shared bucket not enabled",
-			config: `{"databases": {"db": {"import_docs":true}}}`,
+			name:   "Import enabled, shared bucket disabled",
+			config: `{"databases": {"db": {"import_docs":true, "enable_shared_bucket_access":false}}}`,
 			err:    "Invalid configuration - import_docs enabled, but enable_shared_bucket_access not enabled",
 		},
 		{
-			name:   "Import partitions set, shared bucket not enabled",
-			config: `{"databases": {"db": {"import_partitions":32}}}`,
+			name:   "Import partitions set, shared bucket disabled",
+			config: `{"databases": {"db": {"import_partitions":32, "enable_shared_bucket_access":false}}}`,
 			err:    "Invalid configuration - import_partitions set, but enable_shared_bucket_access not enabled",
 		},
 		{
@@ -272,6 +272,10 @@ func TestConfigValidationImportPartitions(t *testing.T) {
 		{
 			name:   "Valid partitions",
 			config: `{"databases": {"db": {"enable_shared_bucket_access":true,"import_partitions":32}}}`,
+		},
+		{
+			name:   "Valid partitions, enable_shared_bucket_access default value (true)",
+			config: `{"databases": {"db": {"import_partitions":32}}}`,
 		},
 	}
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -312,6 +312,9 @@ func GetBucketSpec(config *DbConfig, serverConfig *StartupConfig) (spec base.Buc
 	}
 
 	spec.UseXattrs = config.UseXattrs()
+	if !spec.UseXattrs {
+		base.Warnf("Deprecation notice: the option to disable Shared Bucket Access is due to be deprecated. It is recommended that this is enabled.")
+	}
 
 	if config.BucketOpTimeoutMs != nil {
 		operationTimeout := time.Millisecond * time.Duration(*config.BucketOpTimeoutMs)


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/923/

Legacy configs will have shared bucket access disabled by default.

The deprecation is logged as a warning when the bucket spec is created even when the bucket is Walrus. The notice that is logged is: "Deprecation notice: the option to disable Shared Bucket Access is due to be deprecated. It is recommended that this is enabled."