### PR TITLE
CBG-1564: Apply query limit to N1QL and allow configuration

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -106,19 +106,19 @@ type CouchbaseBucketType int
 
 // Full specification of how to connect to a bucket
 type BucketSpec struct {
-	Server, BucketName, FeedType     string
-	Auth                             AuthHandler
-	CouchbaseDriver                  CouchbaseDriver
-	Certpath, Keypath, CACertPath    string         // X.509 auth parameters
-	TLSSkipVerify                    bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
-	KvTLSPort                        int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
-	MaxNumRetries                    int            // max number of retries before giving up
-	InitialRetrySleepTimeMS          int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
-	UseXattrs                        bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
-	ViewQueryTimeoutSecs             *uint32        // the view query timeout in seconds (default: 75 seconds)
-	ViewQueryMaxConcurrentOpsPerNode int            // maximum number of concurrent view / query operations (default: 100)
-	BucketOpTimeout                  *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	KvPoolSize                       int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
+	Server, BucketName, FeedType  string
+	Auth                          AuthHandler
+	CouchbaseDriver               CouchbaseDriver
+	Certpath, Keypath, CACertPath string         // X.509 auth parameters
+	TLSSkipVerify                 bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
+	KvTLSPort                     int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
+	MaxNumRetries                 int            // max number of retries before giving up
+	InitialRetrySleepTimeMS       int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
+	UseXattrs                     bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
+	ViewQueryTimeoutSecs          *uint32        // the view query timeout in seconds (default: 75 seconds)
+	MaxConcurrentQueryOps         int            // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
+	BucketOpTimeout               *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	KvPoolSize                    int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }
 
 // Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -106,18 +106,19 @@ type CouchbaseBucketType int
 
 // Full specification of how to connect to a bucket
 type BucketSpec struct {
-	Server, BucketName, FeedType  string
-	Auth                          AuthHandler
-	CouchbaseDriver               CouchbaseDriver
-	Certpath, Keypath, CACertPath string         // X.509 auth parameters
-	TLSSkipVerify                 bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
-	KvTLSPort                     int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
-	MaxNumRetries                 int            // max number of retries before giving up
-	InitialRetrySleepTimeMS       int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
-	UseXattrs                     bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
-	ViewQueryTimeoutSecs          *uint32        // the view query timeout in seconds (default: 75 seconds)
-	BucketOpTimeout               *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
-	KvPoolSize                    int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
+	Server, BucketName, FeedType     string
+	Auth                             AuthHandler
+	CouchbaseDriver                  CouchbaseDriver
+	Certpath, Keypath, CACertPath    string         // X.509 auth parameters
+	TLSSkipVerify                    bool           // Use insecureSkipVerify when secure scheme (couchbases) is used and cacertpath is undefined
+	KvTLSPort                        int            // Port to use for memcached over TLS.  Required for cbdatasource auth when using TLS
+	MaxNumRetries                    int            // max number of retries before giving up
+	InitialRetrySleepTimeMS          int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
+	UseXattrs                        bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
+	ViewQueryTimeoutSecs             *uint32        // the view query timeout in seconds (default: 75 seconds)
+	ViewQueryMaxConcurrentOpsPerNode int            // maximum number of concurrent view / query operations (default: 100)
+	BucketOpTimeout                  *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
+	KvPoolSize                       int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }
 
 // Create a RetrySleeper based on the bucket spec properties.  Used to retry bucket operations after transient errors.

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -34,7 +34,7 @@ import (
 const (
 	MaxConcurrentSingleOps = 1000 // Max 1000 concurrent single bucket ops
 	MaxConcurrentBulkOps   = 35   // Max 35 concurrent bulk ops
-	MaxConcurrentViewOps   = 100  // Max concurrent view ops
+	MaxConcurrentQueryOps  = 1000 // Max concurrent query ops
 	MaxBulkBatchSize       = 100  // Maximum number of ops per bulk call
 
 	// Causes the write op to block until the change has been replicated to numNodesReplicateTo many nodes.
@@ -169,7 +169,8 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 	// to avoid gocb queue overflow issues
 	singleOpsQueue := make(chan struct{}, MaxConcurrentSingleOps*nodeCount*numPools)
 	bucketOpsQueue := make(chan struct{}, MaxConcurrentBulkOps*nodeCount*numPools)
-	viewOpsQueue := make(chan struct{}, spec.ViewQueryMaxConcurrentOpsPerNode*nodeCount)
+
+	viewOpsQueue := make(chan struct{}, spec.MaxConcurrentQueryOps)
 
 	bucket = &CouchbaseBucketGoCB{
 		Bucket:                    goCBBucket,

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -106,14 +106,16 @@ func (bucket *CouchbaseBucketGoCB) BuildDeferredIndexes(indexSet []string) error
 }
 
 func (bucket *CouchbaseBucketGoCB) executeQuery(statement string) (sgbucket.QueryResultIterator, error) {
+	bucket.waitForAvailViewOp()
+	defer bucket.releaseViewOp()
+
 	n1qlQuery := gocb.NewN1qlQuery(statement)
 	results, err := bucket.ExecuteN1qlQuery(n1qlQuery, nil)
 	return results, err
 }
 
 func (bucket *CouchbaseBucketGoCB) executeStatement(statement string) error {
-	n1qlQuery := gocb.NewN1qlQuery(statement)
-	results, err := bucket.ExecuteN1qlQuery(n1qlQuery, nil)
+	results, err := bucket.executeQuery(statement)
 	if err != nil {
 		return err
 	}

--- a/base/collection.go
+++ b/base/collection.go
@@ -73,16 +73,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		return nil, err
 	}
 
-	nodeCount := 1
-	router, routerErr := bucket.Internal().IORouter()
-	if routerErr == nil {
-		mgmtEps := router.MgmtEps()
-		if mgmtEps != nil && len(mgmtEps) > 0 {
-			nodeCount = len(mgmtEps)
-		}
-	}
-
-	viewOpsQueue := make(chan struct{}, MaxConcurrentViewOps*nodeCount)
+	viewOpsQueue := make(chan struct{}, MaxConcurrentQueryOps)
 	collection := &Collection{
 		Collection: bucket.DefaultCollection(),
 		cluster:    cluster,

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -242,7 +242,7 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 	collection := &Collection{
 		Collection: bucket.DefaultCollection(),
 		cluster:    c.cluster,
-		viewOps:    make(chan struct{}, MaxConcurrentViewOps),
+		viewOps:    make(chan struct{}, MaxConcurrentQueryOps),
 	}
 
 	return collection, nil

--- a/rest/config.go
+++ b/rest/config.go
@@ -60,15 +60,16 @@ const (
 
 // Bucket configuration elements - used by db, index
 type BucketConfig struct {
-	Server         *string `json:"server,omitempty"`      // Couchbase server URL
-	DeprecatedPool *string `json:"pool,omitempty"`        // Couchbase pool name - This is now deprecated and forced to be "default"
-	Bucket         *string `json:"bucket,omitempty"`      // Bucket name
-	Username       string  `json:"username,omitempty"`    // Username for authenticating to server
-	Password       string  `json:"password,omitempty"`    // Password for authenticating to server
-	CertPath       string  `json:"certpath,omitempty"`    // Cert path (public key) for X.509 bucket auth
-	KeyPath        string  `json:"keypath,omitempty"`     // Key path (private key) for X.509 bucket auth
-	CACertPath     string  `json:"cacertpath,omitempty"`  // Root CA cert path for X.509 bucket auth
-	KvTLSPort      int     `json:"kv_tls_port,omitempty"` // Memcached TLS port, if not default (11207)
+	Server                                  *string `json:"server,omitempty"`                                        // Couchbase server URL
+	DeprecatedPool                          *string `json:"pool,omitempty"`                                          // Couchbase pool name - This is now deprecated and forced to be "default"
+	Bucket                                  *string `json:"bucket,omitempty"`                                        // Bucket name
+	Username                                string  `json:"username,omitempty"`                                      // Username for authenticating to server
+	Password                                string  `json:"password,omitempty"`                                      // Password for authenticating to server
+	CertPath                                string  `json:"certpath,omitempty"`                                      // Cert path (public key) for X.509 bucket auth
+	KeyPath                                 string  `json:"keypath,omitempty"`                                       // Key path (private key) for X.509 bucket auth
+	CACertPath                              string  `json:"cacertpath,omitempty"`                                    // Root CA cert path for X.509 bucket auth
+	KvTLSPort                               int     `json:"kv_tls_port,omitempty"`                                   // Memcached TLS port, if not default (11207)
+	MaxConcurrentViewQueryOperationsPerNode *int    `json:"max_concurrent_view_query_operations_per_node,omitempty"` // Max concurrent view / query ops
 }
 
 func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
@@ -89,14 +90,20 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
+	maxConcurrentViewOpsPerNode := base.MaxConcurrentViewOps
+	if bc.MaxConcurrentViewQueryOperationsPerNode != nil {
+		maxConcurrentViewOpsPerNode = *bc.MaxConcurrentViewQueryOperationsPerNode
+	}
+
 	return base.BucketSpec{
-		Server:     server,
-		BucketName: bucketName,
-		Keypath:    bc.KeyPath,
-		Certpath:   bc.CertPath,
-		CACertPath: bc.CACertPath,
-		KvTLSPort:  tlsPort,
-		Auth:       bc,
+		Server:                           server,
+		BucketName:                       bucketName,
+		Keypath:                          bc.KeyPath,
+		Certpath:                         bc.CertPath,
+		CACertPath:                       bc.CACertPath,
+		KvTLSPort:                        tlsPort,
+		Auth:                             bc,
+		ViewQueryMaxConcurrentOpsPerNode: maxConcurrentViewOpsPerNode,
 	}
 }
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -60,16 +60,16 @@ const (
 
 // Bucket configuration elements - used by db, index
 type BucketConfig struct {
-	Server                                  *string `json:"server,omitempty"`                                        // Couchbase server URL
-	DeprecatedPool                          *string `json:"pool,omitempty"`                                          // Couchbase pool name - This is now deprecated and forced to be "default"
-	Bucket                                  *string `json:"bucket,omitempty"`                                        // Bucket name
-	Username                                string  `json:"username,omitempty"`                                      // Username for authenticating to server
-	Password                                string  `json:"password,omitempty"`                                      // Password for authenticating to server
-	CertPath                                string  `json:"certpath,omitempty"`                                      // Cert path (public key) for X.509 bucket auth
-	KeyPath                                 string  `json:"keypath,omitempty"`                                       // Key path (private key) for X.509 bucket auth
-	CACertPath                              string  `json:"cacertpath,omitempty"`                                    // Root CA cert path for X.509 bucket auth
-	KvTLSPort                               int     `json:"kv_tls_port,omitempty"`                                   // Memcached TLS port, if not default (11207)
-	MaxConcurrentViewQueryOperationsPerNode *int    `json:"max_concurrent_view_query_operations_per_node,omitempty"` // Max concurrent view / query ops
+	Server                *string `json:"server,omitempty"`                   // Couchbase server URL
+	DeprecatedPool        *string `json:"pool,omitempty"`                     // Couchbase pool name - This is now deprecated and forced to be "default"
+	Bucket                *string `json:"bucket,omitempty"`                   // Bucket name
+	Username              string  `json:"username,omitempty"`                 // Username for authenticating to server
+	Password              string  `json:"password,omitempty"`                 // Password for authenticating to server
+	CertPath              string  `json:"certpath,omitempty"`                 // Cert path (public key) for X.509 bucket auth
+	KeyPath               string  `json:"keypath,omitempty"`                  // Key path (private key) for X.509 bucket auth
+	CACertPath            string  `json:"cacertpath,omitempty"`               // Root CA cert path for X.509 bucket auth
+	KvTLSPort             int     `json:"kv_tls_port,omitempty"`              // Memcached TLS port, if not default (11207)
+	MaxConcurrentQueryOps *int    `json:"max_concurrent_query_ops,omitempty"` // Max concurrent  query ops
 }
 
 func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
@@ -90,20 +90,20 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
-	maxConcurrentViewOpsPerNode := base.MaxConcurrentViewOps
-	if bc.MaxConcurrentViewQueryOperationsPerNode != nil {
-		maxConcurrentViewOpsPerNode = *bc.MaxConcurrentViewQueryOperationsPerNode
+	maxConcurrentQueryOps := base.MaxConcurrentQueryOps
+	if bc.MaxConcurrentQueryOps != nil {
+		maxConcurrentQueryOps = *bc.MaxConcurrentQueryOps
 	}
 
 	return base.BucketSpec{
-		Server:                           server,
-		BucketName:                       bucketName,
-		Keypath:                          bc.KeyPath,
-		Certpath:                         bc.CertPath,
-		CACertPath:                       bc.CACertPath,
-		KvTLSPort:                        tlsPort,
-		Auth:                             bc,
-		ViewQueryMaxConcurrentOpsPerNode: maxConcurrentViewOpsPerNode,
+		Server:                server,
+		BucketName:            bucketName,
+		Keypath:               bc.KeyPath,
+		Certpath:              bc.CertPath,
+		CACertPath:            bc.CACertPath,
+		KvTLSPort:             tlsPort,
+		Auth:                  bc,
+		MaxConcurrentQueryOps: maxConcurrentQueryOps,
 	}
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -554,18 +554,18 @@ func TestViewQueryBucketOptionsOnBucketSpec(t *testing.T) {
 		{
 			Name:              "Set Nil",
 			OperationsPerNode: nil,
-			ExpectedValue:     base.MaxConcurrentViewOps,
+			ExpectedValue:     base.MaxConcurrentQueryOps,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			startupConfig := &StartupConfig{Bootstrap: BootstrapConfig{}}
-			dbConfig := &DbConfig{BucketConfig: BucketConfig{MaxConcurrentViewQueryOperationsPerNode: testCase.OperationsPerNode}}
+			dbConfig := &DbConfig{BucketConfig: BucketConfig{MaxConcurrentQueryOps: testCase.OperationsPerNode}}
 			spec, err := GetBucketSpec(dbConfig, startupConfig)
 			assert.NoError(t, err)
 
-			assert.Equal(t, testCase.ExpectedValue, spec.ViewQueryMaxConcurrentOpsPerNode)
+			assert.Equal(t, testCase.ExpectedValue, spec.MaxConcurrentQueryOps)
 		})
 	}
 }

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -539,3 +539,33 @@ func TestUseTLSServer(t *testing.T) {
 		})
 	}
 }
+
+func TestViewQueryBucketOptionsOnBucketSpec(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		OperationsPerNode *int
+		ExpectedValue     int
+	}{
+		{
+			Name:              "Set Value",
+			OperationsPerNode: base.IntPtr(10),
+			ExpectedValue:     10,
+		},
+		{
+			Name:              "Set Nil",
+			OperationsPerNode: nil,
+			ExpectedValue:     base.MaxConcurrentViewOps,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			startupConfig := &StartupConfig{Bootstrap: BootstrapConfig{}}
+			dbConfig := &DbConfig{BucketConfig: BucketConfig{MaxConcurrentViewQueryOperationsPerNode: testCase.OperationsPerNode}}
+			spec, err := GetBucketSpec(dbConfig, startupConfig)
+			assert.NoError(t, err)
+
+			assert.Equal(t, testCase.ExpectedValue, spec.ViewQueryMaxConcurrentOpsPerNode)
+		})
+	}
+}


### PR DESCRIPTION
Applies the viewQueryOps limit to N1QL queries and allow this option to be configured by the user.