### PR TITLE
Only set admin auth flag values if set

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -61,8 +61,14 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	}
 
 	// TODO: Be removed in a future commit once flags are sorted
-	flagStartupConfig.API.AdminInterfaceAuthentication = adminInterfaceAuthFlag
-	flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "api.admin_interface_authentication":
+			flagStartupConfig.API.AdminInterfaceAuthentication = adminInterfaceAuthFlag
+		case "api.metrics_interface_authentication":
+			flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
+		}
+	})
 
 	// Actually hook this up @Isaac
 	_ = useTLSServer


### PR DESCRIPTION
The default value for the auth flags is 'true'. Issue is this will override any config option even if only the default is set.
By using fs.Visit we can ensure we only set these values from flags if the flag is set.