### PR TITLE
CBG-1484 - All of persistent config now uses 'omitempty' tag, and bools are bool pointers

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -823,6 +823,14 @@ func BoolPtr(b bool) *bool {
 	return &b
 }
 
+// BoolDefault returns ifNil if b is nil, or else returns dereferenced value of b
+func BoolDefault(b *bool, ifNil bool) bool {
+	if b != nil {
+		return *b
+	}
+	return ifNil
+}
+
 // Convert a Bucket, or a Couchbase URI (eg, couchbase://host1,host2) to a list of HTTP URLs with ports (eg, ["http://host1:8091", "http://host2:8091"])
 // connSpec can be optionally passed in if available, to prevent unnecessary double-parsing of connstr
 // Primary use case is for backwards compatibility with go-couchbase, cbdatasource, and CBGT. Supports secure URI's as well (couchbases://).

--- a/db/database.go
+++ b/db/database.go
@@ -171,14 +171,14 @@ type APIEndpoints struct {
 }
 
 type UnsupportedOptions struct {
-	UserViews                 UserViewsOptions        `json:"user_views,omitempty"`                  // Config settings for user views
-	OidcTestProvider          OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`          // Config settings for OIDC Provider
-	APIEndpoints              APIEndpoints            `json:"api_endpoints,omitempty"`               // Config settings for API endpoints
-	WarningThresholds         WarningThresholds       `json:"warning_thresholds,omitempty"`          // Warning thresholds related to _sync size
-	DisableCleanSkippedQuery  bool                    `json:"disable_clean_skipped_query,omitempty"` // Clean skipped sequence processing bypasses final check
-	OidcTlsSkipVerify         bool                    `json:"oidc_tls_skip_verify"`                  // Config option to enable self-signed certs for OIDC testing.
-	SgrTlsSkipVerify          bool                    `json:"sgr_tls_skip_verify"`                   // Config option to enable self-signed certs for SG-Replicate testing.
-	RemoteConfigTlsSkipVerify bool                    `json:"remote_config_tls_skip_verify"`         // Config option to enable self signed certificates for external JavaScript load.
+	UserViews                 UserViewsOptions        `json:"user_views,omitempty"`                    // Config settings for user views
+	OidcTestProvider          OidcTestProviderOptions `json:"oidc_test_provider,omitempty"`            // Config settings for OIDC Provider
+	APIEndpoints              APIEndpoints            `json:"api_endpoints,omitempty"`                 // Config settings for API endpoints
+	WarningThresholds         WarningThresholds       `json:"warning_thresholds,omitempty"`            // Warning thresholds related to _sync size
+	DisableCleanSkippedQuery  bool                    `json:"disable_clean_skipped_query,omitempty"`   // Clean skipped sequence processing bypasses final check
+	OidcTlsSkipVerify         bool                    `json:"oidc_tls_skip_verify,omitempty"`          // Config option to enable self-signed certs for OIDC testing.
+	SgrTlsSkipVerify          bool                    `json:"sgr_tls_skip_verify,omitempty"`           // Config option to enable self-signed certs for SG-Replicate testing.
+	RemoteConfigTlsSkipVerify bool                    `json:"remote_config_tls_skip_verify,omitempty"` // Config option to enable self signed certificates for external JavaScript load.
 }
 
 type WarningThresholds struct {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -324,7 +324,7 @@ func TestUserPasswordValidation(t *testing.T) {
 func TestUserAllowEmptyPassword(t *testing.T) {
 
 	// PUT a user
-	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{AllowEmptyPassword: true}})
+	rt := NewRestTester(t, &RestTesterConfig{DatabaseConfig: &DbConfig{AllowEmptyPassword: base.BoolPtr(true)}})
 	defer rt.Close()
 
 	response := rt.SendAdminRequest("PUT", "/db/_user/snej", `{"email":"jens@couchbase.com", "password":"letmein", "admin_channels":["foo", "bar"]}`)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5307,7 +5307,7 @@ func TestAttachmentContentType(t *testing.T) {
 	}
 
 	// Ran against allow insecure
-	rt.DatabaseConfig.ServeInsecureAttachmentTypes = true
+	rt.DatabaseConfig.ServeInsecureAttachmentTypes = base.BoolPtr(true)
 	for index, _ := range tests {
 		response := rt.SendRequest("GET", fmt.Sprintf("/db/doc_allow_insecure_%d/login.aspx", index), "")
 		contentDisposition := response.Header().Get("Content-Disposition")

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -219,7 +219,8 @@ func TestSetupAndValidate(t *testing.T) {
 		assert.Equal(t, "Administrator", db.Username)
 
 		assert.Equal(t, "password", db.Password)
-		assert.False(t, db.UseViews)
+		require.NotNil(t, db.UseViews)
+		assert.False(t, *db.UseViews)
 
 		assert.NotNil(t, db.RevsLimit)
 		assert.Equal(t, 200, int(*db.RevsLimit))

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3630,7 +3630,7 @@ func TestChangesLargeSequences(t *testing.T) {
 			 channel(doc.channel)
 		 }`,
 		InitSyncSeq:    initialSeq,
-		DatabaseConfig: &DbConfig{UseViews: true},
+		DatabaseConfig: &DbConfig{UseViews: base.BoolPtr(true)},
 	}
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()

--- a/rest/config.go
+++ b/rest/config.go
@@ -115,13 +115,13 @@ type DbConfig struct {
 	AutoImport                       interface{}                      `json:"import_docs,omitempty"`                          // Whether to automatically import Couchbase Server docs into SG.  Xattrs must be enabled.  true or "continuous" both enable this.
 	ImportPartitions                 *uint16                          `json:"import_partitions,omitempty"`                    // Number of partitions for import sharding.  Impacts the total DCP concurrency for import
 	ImportFilter                     *string                          `json:"import_filter,omitempty"`                        // Filter function (import)
-	ImportBackupOldRev               bool                             `json:"import_backup_old_rev"`                          // Whether import should attempt to create a temporary backup of the previous revision body, when available.
+	ImportBackupOldRev               *bool                            `json:"import_backup_old_rev,omitempty"`                // Whether import should attempt to create a temporary backup of the previous revision body, when available.
 	EventHandlers                    *EventHandlerConfig              `json:"event_handlers,omitempty"`                       // Event handlers (webhook)
 	FeedType                         string                           `json:"feed_type,omitempty"`                            // Feed type - "DCP" or "TAP"; defaults based on Couchbase server version
-	AllowEmptyPassword               bool                             `json:"allow_empty_password,omitempty"`                 // Allow empty passwords?  Defaults to false
+	AllowEmptyPassword               *bool                            `json:"allow_empty_password,omitempty"`                 // Allow empty passwords?  Defaults to false
 	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                                // Cache settings
 	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                       // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
-	StartOffline                     bool                             `json:"offline,omitempty"`                              // start the DB in the offline state, defaults to false
+	StartOffline                     *bool                            `json:"offline,omitempty"`                              // start the DB in the offline state, defaults to false
 	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                          // Config for unsupported features
 	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                 // Config properties for OpenID Connect authentication
 	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`               // The number of seconds before old revs are removed from CBS bucket
@@ -129,11 +129,11 @@ type DbConfig struct {
 	LocalDocExpirySecs               *uint32                          `json:"local_doc_expiry_secs,omitempty"`                // The _local doc expiry time in seconds
 	EnableXattrs                     *bool                            `json:"enable_shared_bucket_access,omitempty"`          // Whether to use extended attributes to store _sync metadata
 	SecureCookieOverride             *bool                            `json:"session_cookie_secure,omitempty"`                // Override cookie secure flag
-	SessionCookieName                string                           `json:"session_cookie_name"`                            // Custom per-database session cookie name
-	SessionCookieHTTPOnly            bool                             `json:"session_cookie_http_only"`                       // HTTP only cookies
+	SessionCookieName                string                           `json:"session_cookie_name,omitempty"`                  // Custom per-database session cookie name
+	SessionCookieHTTPOnly            *bool                            `json:"session_cookie_http_only,omitempty"`             // HTTP only cookies
 	AllowConflicts                   *bool                            `json:"allow_conflicts,omitempty"`                      // False forbids creating conflicts
-	NumIndexReplicas                 *uint                            `json:"num_index_replicas"`                             // Number of GSI index replicas used for core indexes
-	UseViews                         bool                             `json:"use_views"`                                      // Force use of views instead of GSI
+	NumIndexReplicas                 *uint                            `json:"num_index_replicas,omitempty"`                   // Number of GSI index replicas used for core indexes
+	UseViews                         *bool                            `json:"use_views,omitempty"`                            // Force use of views instead of GSI
 	SendWWWAuthenticateHeader        *bool                            `json:"send_www_authenticate_header,omitempty"`         // If false, disables setting of 'WWW-Authenticate' header in 401 responses
 	BucketOpTimeoutMs                *uint32                          `json:"bucket_op_timeout_ms,omitempty"`                 // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	DeltaSync                        *DeltaSyncConfig                 `json:"delta_sync,omitempty"`                           // Config for delta sync
@@ -141,7 +141,7 @@ type DbConfig struct {
 	SGReplicateEnabled               *bool                            `json:"sgreplicate_enabled,omitempty"`                  // When false, node will not be assigned replications
 	SGReplicateWebsocketPingInterval *int                             `json:"sgreplicate_websocket_heartbeat_secs,omitempty"` // If set, uses this duration as a custom heartbeat interval for websocket ping frames
 	Replications                     map[string]*db.ReplicationConfig `json:"replications,omitempty"`                         // sg-replicate replication definitions
-	ServeInsecureAttachmentTypes     bool                             `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
+	ServeInsecureAttachmentTypes     *bool                            `json:"serve_insecure_attachment_types,omitempty"`      // Attachment content type will bypass the content-disposition handling, default false
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for without losing replication metadata. Default 30 days (in seconds)
@@ -162,7 +162,7 @@ type EventHandlerConfig struct {
 }
 
 type EventConfig struct {
-	HandlerType string                 `json:"handler"`           // Handler type
+	HandlerType string                 `json:"handler,omitempty"` // Handler type
 	Url         string                 `json:"url,omitempty"`     // Url (webhook)
 	Filter      string                 `json:"filter,omitempty"`  // Filter function (webhook)
 	Timeout     *uint64                `json:"timeout,omitempty"` // Timeout (webhook)
@@ -170,8 +170,8 @@ type EventConfig struct {
 }
 
 type CacheConfig struct {
-	RevCacheConfig     *RevCacheConfig     `json:"rev_cache"`     // Revision Cache Config Settings
-	ChannelCacheConfig *ChannelCacheConfig `json:"channel_cache"` // Channel Cache Config Settings
+	RevCacheConfig     *RevCacheConfig     `json:"rev_cache,omitempty"`     // Revision Cache Config Settings
+	ChannelCacheConfig *ChannelCacheConfig `json:"channel_cache,omitempty"` // Channel Cache Config Settings
 	DeprecatedCacheConfig
 }
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -114,9 +114,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	sc := StartupConfig{
 		Bootstrap: *bsc,
 		API: APIConfig{
-			Pretty:                                    lc.Pretty,
 			CompressResponses:                         lc.CompressResponses,
-			HideProductVersion:                        lc.HideProductVersion,
 			AdminInterfaceAuthentication:              lc.AdminInterfaceAuthentication,
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
@@ -129,6 +127,14 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			MaxHeartbeat:    base.ConfigDuration{Duration: time.Second * time.Duration(lc.MaxHeartbeat)},
 			BLIPCompression: lc.ReplicatorCompression,
 		},
+	}
+
+	if lc.Pretty {
+		sc.API.Pretty = base.BoolPtr(lc.Pretty)
+	}
+
+	if lc.HideProductVersion {
+		sc.API.HideProductVersion = base.BoolPtr(lc.HideProductVersion)
 	}
 
 	if lc.Facebook != nil || lc.Google != nil {
@@ -208,7 +214,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			sc.Unsupported.StatsLogFrequency = base.NewConfigDuration(time.Second * time.Duration(*lc.Unsupported.StatsLogFrequencySecs))
 		}
 		if lc.Unsupported.UseStdlibJSON != nil {
-			sc.Unsupported.UseStdlibJSON = *lc.Unsupported.UseStdlibJSON
+			sc.Unsupported.UseStdlibJSON = lc.Unsupported.UseStdlibJSON
 		}
 	}
 	if lc.MaxFileDescriptors != nil {

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -130,11 +130,11 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	}
 
 	if lc.Pretty {
-		sc.API.Pretty = base.BoolPtr(lc.Pretty)
+		sc.API.Pretty = &lc.Pretty
 	}
 
 	if lc.HideProductVersion {
-		sc.API.HideProductVersion = base.BoolPtr(lc.HideProductVersion)
+		sc.API.HideProductVersion = &lc.HideProductVersion
 	}
 
 	if lc.Facebook != nil || lc.Google != nil {

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -49,9 +49,9 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		},
 		{
 			name:     "Override bool Pretty",
-			base:     StartupConfig{API: APIConfig{Pretty: true}},
+			base:     StartupConfig{API: APIConfig{Pretty: base.BoolPtr(true)}},
 			input:    LegacyServerConfig{Pretty: false},
-			expected: StartupConfig{API: APIConfig{Pretty: true}},
+			expected: StartupConfig{API: APIConfig{Pretty: base.BoolPtr(true)}},
 		},
 		{
 			name:     "Override *bool(false) CompressResponses",

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -100,10 +100,10 @@ type APIConfig struct {
 	ReadHeaderTimeout  *base.ConfigDuration `json:"read_header_timeout,omitempty"  help:"The amount of time allowed to read request headers"`
 	IdleTimeout        *base.ConfigDuration `json:"idle_timeout,omitempty"         help:"The maximum amount of time to wait for the next request when keep-alives are enabled"`
 
-	Pretty             bool  `json:"pretty,omitempty"               help:"Pretty-print JSON responses"`
+	Pretty             *bool `json:"pretty,omitempty"               help:"Pretty-print JSON responses"`
 	MaximumConnections uint  `json:"max_connections,omitempty"      help:"Max # of incoming HTTP connections to accept"`
 	CompressResponses  *bool `json:"compress_responses,omitempty"   help:"If false, disables compression of HTTP responses"`
-	HideProductVersion bool  `json:"hide_product_version,omitempty" help:"Whether product versions removed from Server headers and REST API responses"`
+	HideProductVersion *bool `json:"hide_product_version,omitempty" help:"Whether product versions removed from Server headers and REST API responses"`
 
 	HTTPS HTTPSConfig `json:"https,omitempty"`
 	CORS  *CORSConfig `json:"cors,omitempty"`
@@ -145,7 +145,7 @@ type ReplicatorConfig struct {
 
 type UnsupportedConfig struct {
 	StatsLogFrequency *base.ConfigDuration `json:"stats_log_frequency,omitempty"    help:"How often should stats be written to stats logs"`
-	UseStdlibJSON     bool                 `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
+	UseStdlibJSON     *bool                `json:"use_stdlib_json,omitempty"        help:"Bypass the jsoniter package and use Go's stdlib instead"`
 
 	HTTP2 *HTTP2Config `json:"http2,omitempty"`
 }
@@ -203,7 +203,7 @@ func setGlobalConfig(sc *StartupConfig) error {
 	}
 
 	// Given unscoped usage of base.JSON functions, this can't be scoped.
-	if sc.Unsupported.UseStdlibJSON {
+	if base.BoolDefault(sc.Unsupported.UseStdlibJSON, false) {
 		base.Infof(base.KeyAll, "Using the stdlib JSON package")
 		base.UseStdlibJSON = true
 	}

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -827,7 +827,7 @@ func TestValidateServerContext(t *testing.T) {
 				Password: tb1Password,
 			},
 			EnableXattrs:     &xattrs,
-			UseViews:         base.TestsDisableGSI(),
+			UseViews:         base.BoolPtr(base.TestsDisableGSI()),
 			NumIndexReplicas: base.UintPtr(0),
 		},
 		"db2": {
@@ -838,7 +838,7 @@ func TestValidateServerContext(t *testing.T) {
 				Password: tb1Password,
 			},
 			EnableXattrs:     &xattrs,
-			UseViews:         base.TestsDisableGSI(),
+			UseViews:         base.BoolPtr(base.TestsDisableGSI()),
 			NumIndexReplicas: base.UintPtr(0),
 		},
 		"db3": {
@@ -849,7 +849,7 @@ func TestValidateServerContext(t *testing.T) {
 				Password: tb2Password,
 			},
 			EnableXattrs:     &xattrs,
-			UseViews:         base.TestsDisableGSI(),
+			UseViews:         base.BoolPtr(base.TestsDisableGSI()),
 			NumIndexReplicas: base.UintPtr(0),
 		},
 	}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -779,7 +779,7 @@ func (h *handler) writeJSONStatus(status int, value interface{}) {
 		h.writeStatus(http.StatusInternalServerError, "JSON serialization failed")
 		return
 	}
-	if h.server.config.API.Pretty {
+	if base.BoolDefault(h.server.config.API.Pretty, false) {
 		var buffer bytes.Buffer
 		_ = json.Indent(&buffer, jsonOut, "", "  ")
 		jsonOut = append(buffer.Bytes(), '\n')
@@ -1032,5 +1032,7 @@ func (h *handler) formatSerialNumber() string {
 // shouldShowProductVersion returns whether the handler should show detailed product info (version).
 // Admin requests can always see this, regardless of the HideProductVersion setting.
 func (h *handler) shouldShowProductVersion() bool {
-	return h.privs == adminPrivs || !h.server.config.API.HideProductVersion
+	hideProductVersion := base.BoolDefault(h.server.config.API.HideProductVersion, false)
+	return h.privs == adminPrivs || !hideProductVersion
+
 }

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1774,7 +1774,7 @@ func TestImportRevisionCopy(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
-			ImportBackupOldRev: true,
+			ImportBackupOldRev: base.BoolPtr(true),
 			AutoImport:         false,
 		},
 	}
@@ -1831,7 +1831,7 @@ func TestImportRevisionCopyUnavailable(t *testing.T) {
 	rtConfig := RestTesterConfig{
 		SyncFn: `function(doc, oldDoc) { channel(doc.channels) }`,
 		DatabaseConfig: &DbConfig{
-			ImportBackupOldRev: true,
+			ImportBackupOldRev: base.BoolPtr(true),
 			AutoImport:         false,
 		},
 	}

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -82,7 +82,7 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 			PublicInterface:  *publicInterface,
 			AdminInterface:   *adminInterface,
 			ProfileInterface: *profileInterface,
-			Pretty:           *pretty,
+			Pretty:           pretty,
 		},
 		Logging: LoggingConfig{
 			LogFilePath: *logFilePath,

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -378,7 +378,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	}
 
 	// If using a walrus bucket, force use of views
-	useViews := config.UseViews
+	useViews := base.BoolDefault(config.UseViews, false)
 	if !useViews && spec.IsWalrusBucket() {
 		base.Warnf("Using GSI is not supported when using a walrus bucket - switching to use views.  Set 'use_views':true in Sync Gateway's database config to avoid this warning.")
 		useViews = true
@@ -490,8 +490,8 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		}
 	}
 
-	dbcontext.AllowEmptyPassword = config.AllowEmptyPassword
-	dbcontext.ServeInsecureAttachmentTypes = config.ServeInsecureAttachmentTypes
+	dbcontext.AllowEmptyPassword = base.BoolDefault(config.AllowEmptyPassword, false)
+	dbcontext.ServeInsecureAttachmentTypes = base.BoolDefault(config.ServeInsecureAttachmentTypes, false)
 
 	if dbcontext.ChannelMapper == nil {
 		base.Infof(base.KeyAll, "Using default sync function 'channel(doc.channels)' for database %q", base.MD(dbName))
@@ -521,7 +521,7 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	// Save the config
 	sc.dbConfigs[dbcontext.Name] = &config
 
-	if config.StartOffline {
+	if base.BoolDefault(config.StartOffline, false) {
 		atomic.StoreUint32(&dbcontext.State, db.DBOffline)
 		_ = dbcontext.EventMgr.RaiseDBStateChangeEvent(dbName, "offline", "DB loaded from config", &sc.config.API.AdminInterface)
 	} else {
@@ -539,7 +539,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 	if config.ImportFilter != nil {
 		importOptions.ImportFilter = db.NewImportFilterFunction(*config.ImportFilter)
 	}
-	importOptions.BackupOldRev = config.ImportBackupOldRev
+	importOptions.BackupOldRev = base.BoolDefault(config.ImportBackupOldRev, false)
 
 	if config.ImportPartitions == nil {
 		importOptions.ImportPartitions = base.DefaultImportPartitions
@@ -707,7 +707,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		EnableXattr:               config.UseXattrs(),
 		SecureCookieOverride:      secureCookieOverride,
 		SessionCookieName:         config.SessionCookieName,
-		SessionCookieHttpOnly:     config.SessionCookieHTTPOnly,
+		SessionCookieHttpOnly:     base.BoolDefault(config.SessionCookieHTTPOnly, false),
 		AllowConflicts:            config.ConflictsAllowed(),
 		SendWWWAuthenticateHeader: config.SendWWWAuthenticateHeader,
 		DeltaSyncOptions:          deltaSyncOptions,

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -114,13 +114,13 @@ func TestAllDatabaseNames(t *testing.T) {
 	defer serverContext.Close()
 
 	xattrs := base.TestUseXattrs()
-	dbConfig := DbConfig{BucketConfig: bucketConfigFromTestBucket(tb1), Name: "imdb1", AllowEmptyPassword: true, NumIndexReplicas: base.UintPtr(0), EnableXattrs: &xattrs}
+	dbConfig := DbConfig{BucketConfig: bucketConfigFromTestBucket(tb1), Name: "imdb1", AllowEmptyPassword: base.BoolPtr(true), NumIndexReplicas: base.UintPtr(0), EnableXattrs: &xattrs}
 	_, err := serverContext.AddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig})
 	assert.NoError(t, err, "No error while adding database to server context")
 	assert.Len(t, serverContext.AllDatabaseNames(), 1)
 	assert.Contains(t, serverContext.AllDatabaseNames(), "imdb1")
 
-	dbConfig = DbConfig{BucketConfig: bucketConfigFromTestBucket(tb2), Name: "imdb2", AllowEmptyPassword: true, NumIndexReplicas: base.UintPtr(0), EnableXattrs: &xattrs}
+	dbConfig = DbConfig{BucketConfig: bucketConfigFromTestBucket(tb2), Name: "imdb2", AllowEmptyPassword: base.BoolPtr(true), NumIndexReplicas: base.UintPtr(0), EnableXattrs: &xattrs}
 	_, err = serverContext.AddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig})
 	assert.NoError(t, err, "No error while adding database to server context")
 	assert.Len(t, serverContext.AllDatabaseNames(), 2)
@@ -168,7 +168,7 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.Error(t, err, "It should throw Unrecognized value for import_docs")
 
 	bucketConfig := BucketConfig{Server: &server, Bucket: &bucketName}
-	dbConfig = DbConfig{BucketConfig: bucketConfig, Name: databaseName, AllowEmptyPassword: true}
+	dbConfig = DbConfig{BucketConfig: bucketConfig, Name: databaseName, AllowEmptyPassword: base.BoolPtr(true)}
 	dbContext, err = serverContext.AddDatabaseFromConfig(DatabaseConfig{DbConfig: dbConfig})
 
 	assert.NoError(t, err, "No error while adding database to server context")

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -137,7 +137,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	sc.Bootstrap.Password = base.TestClusterPassword()
 	sc.API.AdminInterface = *adminInterface
 	sc.API.CORS = corsConfig
-	sc.API.HideProductVersion = rt.RestTesterConfig.hideProductInfo
+	sc.API.HideProductVersion = base.BoolPtr(rt.RestTesterConfig.hideProductInfo)
 	sc.DeprecatedConfig = &DeprecatedConfig{Facebook: &FacebookConfigLegacy{}}
 	sc.API.AdminInterfaceAuthentication = &rt.adminInterfaceAuthentication
 	sc.API.MetricsInterfaceAuthentication = &rt.metricsInterfaceAuthentication
@@ -153,7 +153,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 	}
 
 	if base.TestsDisableGSI() {
-		rt.DatabaseConfig.UseViews = true
+		rt.DatabaseConfig.UseViews = base.BoolPtr(true)
 	}
 
 	// numReplicas set to 0 for test buckets, since it should assume that there may only be one indexing node.


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/926/ (Ran on first commit before commit 61bd9d7 and force push)

Also added new helper function in base called "BoolDefault".