### PR TITLE
Alter CAR work due to unreliable since seq

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1876,7 +1876,8 @@ func TestRevocationScenario6(t *testing.T) {
 	assert.Equal(t, GrantHistorySequencePair{StartSeq: 5, EndSeq: 55}, channelHistory.Entries[0])
 	assert.Equal(t, 0, len(aliceUserPrincipal.ChannelHistory()))
 	revokedChannelsCombined = aliceUserPrincipal.RevokedChannels(25, 0, 0)
-	assert.Len(t, revokedChannelsCombined, 0)
+	assert.Len(t, revokedChannelsCombined, 1)
+	assert.Equal(t, uint64(55), revokedChannelsCombined["ch1"])
 }
 
 // Scenario 7

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -7647,8 +7647,8 @@ func TestChannelHistoryPruning(t *testing.T) {
 		changes = revocationTester.getChanges(0, 2)
 		assert.Len(t, changes.Results, 2)
 		revocationTester.removeRoleChannel("foo", "a")
-		changes = revocationTester.getChanges(0, 1)
-		assert.Len(t, changes.Results, 1)
+		changes = revocationTester.getChanges(0, 2)
+		assert.Len(t, changes.Results, 2)
 		revocationTester.addRoleChannel("foo", "a")
 	}
 


### PR DESCRIPTION
Work is intended to alter the use of since sequence when calculating revocations.
Due to checkpoint persistence as well as other possible factors, occasionally the since sequence can be 'rolled back' meaning it cannot be relied upon to calculate whether a user has received a particular document. 

Changes: Rather than using the sequence to calculate whether a user has received a document and then only revoking if they have, we instead send any revocations that occurred after the supplied sequence number, regardless of whether we think the user has had it.

Due to the above we would 'backfill' all revocations if a new replication was started (from 0). To avoid this we are doing an initial 'activeOnly' check when calculating whether to send revocations. CBL sets this option when performing a first-time replication until the replication is caught up so fits the case well.

In the ISGR case, however, we are going to always perform this revocation 'backfill'. Without this ability the behaviour has the danger of being ambiguous to the customer. We wouldn't expect a replication to start from zero very often and there is already an associated overhead with this when sending tombstones.

A case where we can perform a 'fast first run' where prior revocations aren't sent on the first run can be considered in the future as a possible enhancement if use cases where this would be helpful become apparent. 