### PR TITLE
Test enhancements related to proveAttachment handling

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3498,8 +3498,10 @@ func TestBlipPushPullNewAttachmentCommonAncestor(t *testing.T) {
 	assert.Equal(t, float64(2), hello["revpos"])
 	assert.True(t, hello["stub"].(bool))
 
-	assert.Equal(t, int64(11), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
-	assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+	// Check the number of sendProveAttachment/sendGetAttachment calls.
+	require.NotNil(t, btc.pushReplication.replicationStats)
+	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
+	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.ProveAttachment.Value())
 }
 
 func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
@@ -3551,6 +3553,9 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	assert.Equal(t, float64(11), hello["length"])
 	assert.Equal(t, float64(4), hello["revpos"])
 	assert.True(t, hello["stub"].(bool))
-	assert.Equal(t, int64(11), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
-	assert.Equal(t, int64(1), btc.rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+
+	// Check the number of sendProveAttachment/sendGetAttachment calls.
+	require.NotNil(t, btc.pushReplication.replicationStats)
+	assert.Equal(t, int64(1), btc.pushReplication.replicationStats.GetAttachment.Value())
+	assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
 }

--- a/rest/blip_client_test.go
+++ b/rest/blip_client_test.go
@@ -574,150 +574,13 @@ func (btr *BlipTesterReplicator) sendMsg(msg *blip.Message) (err error) {
 }
 
 // PushRev creates a revision on the client, and immediately sends a changes request for it.
-// The rev ID is always: "N-abcxyz", where N is rev generation for predictability.
+// The rev ID is always: "N-abc", where N is rev generation for predictability.
 func (btc *BlipTesterClient) PushRev(docID, parentRev string, body []byte) (revID string, err error) {
-
-	// generate fake rev for gen+1
-	parentRevGen, _ := db.ParseRevID(parentRev)
-
-	// Inline attachment processing
-	if bytes.Contains(body, []byte(db.BodyAttachments)) {
-		var newDocJSON map[string]interface{}
-		if err = base.JSONUnmarshal(body, &newDocJSON); err != nil {
-			return "", err
-		}
-		if attachments, ok := newDocJSON[db.BodyAttachments]; ok {
-			if attachmentMap, ok := attachments.(map[string]interface{}); ok {
-				for attachmentName, inlineAttachment := range attachmentMap {
-					inlineAttachmentMap := inlineAttachment.(map[string]interface{})
-					attachmentData, ok := inlineAttachmentMap["data"]
-					if !ok {
-						if isStub, _ := inlineAttachmentMap["stub"].(bool); isStub {
-							// push the stub as-is
-							continue
-						}
-						return "", fmt.Errorf("couldn't find data property for inline attachment")
-					}
-
-					// Transform inline attachment data into metadata
-					data, ok := attachmentData.(string)
-					if !ok {
-						return "", fmt.Errorf("inline attachment data was not a string")
-					}
-
-					contentType, _ := inlineAttachmentMap["content_type"].(string)
-
-					length, digest, err := btc.saveAttachment(contentType, data)
-					if err != nil {
-						return "", err
-					}
-
-					attachmentMap[attachmentName] = map[string]interface{}{
-						"content_type": contentType,
-						"digest":       digest,
-						"length":       length,
-						"revpos":       parentRevGen + 1,
-						"stub":         true,
-					}
-					newDocJSON[db.BodyAttachments] = attachmentMap
-				}
-			}
-			if body, err = base.JSONMarshal(newDocJSON); err != nil {
-				return "", err
-			}
-		}
-	}
-
-	var parentDocBody []byte
-	newRevID := fmt.Sprintf("%d-%s", parentRevGen+1, "abcxyz")
-	btc.docsLock.Lock()
-	if parentRev != "" {
-		if _, ok := btc.docs[docID]; ok {
-			// create new rev if doc and parent rev already exists
-			if parentDoc, okParent := btc.docs[docID][parentRev]; okParent {
-				parentDocBody = parentDoc.body
-				bodyMessagePair := &BodyMessagePair{body: body}
-				btc.docs[docID][newRevID] = bodyMessagePair
-			} else {
-				btc.docsLock.Unlock()
-				return "", fmt.Errorf("docID: %v with parent rev: %v was not found on the client", docID, parentRev)
-			}
-		} else {
-			btc.docsLock.Unlock()
-			return "", fmt.Errorf("docID: %v was not found on the client", docID)
-		}
-	} else {
-		// create new doc + rev
-		bodyMessagePair := &BodyMessagePair{body: body}
-		btc.docs[docID] = map[string]*BodyMessagePair{newRevID: bodyMessagePair}
-	}
-	btc.docsLock.Unlock()
-
-	// send msg proposeChanges with rev
-	proposeChangesRequest := blip.NewRequest()
-	proposeChangesRequest.SetProfile(db.MessageProposeChanges)
-	proposeChangesRequest.SetBody([]byte(fmt.Sprintf(`[["%s","%s","%s"]]`, docID, newRevID, parentRev)))
-	if err := btc.pushReplication.sendMsg(proposeChangesRequest); err != nil {
-		return "", err
-	}
-
-	proposeChangesResponse := proposeChangesRequest.Response()
-	rspBody, err := proposeChangesResponse.Body()
-	if err != nil || string(rspBody) != `[]` {
-		return "", fmt.Errorf("error from proposeChangesResponse: %v %s\n", err, string(rspBody))
-	}
-
-	// send msg rev with new doc
-	revRequest := blip.NewRequest()
-	revRequest.SetProfile(db.MessageRev)
-	revRequest.Properties[db.RevMessageId] = docID
-	revRequest.Properties[db.RevMessageRev] = newRevID
-	revRequest.Properties[db.RevMessageHistory] = parentRev
-
-	if btc.ClientDeltas && proposeChangesResponse.Properties[db.ProposeChangesResponseDeltas] == "true" {
-		base.Debugf(base.KeySync, "TEST: sending deltas from test client")
-		var parentDocJSON, newDocJSON db.Body
-		err := parentDocJSON.Unmarshal(parentDocBody)
-		if err != nil {
-			return "", err
-		}
-
-		err = newDocJSON.Unmarshal(body)
-		if err != nil {
-			return "", err
-		}
-
-		delta, err := base.Diff(parentDocJSON, newDocJSON)
-		if err != nil {
-			return "", err
-		}
-		revRequest.Properties[db.RevMessageDeltaSrc] = parentRev
-		body = delta
-	} else {
-		base.Debugf(base.KeySync, "TEST: not sending deltas from client")
-	}
-
-	revRequest.SetBody(body)
-	if err := btc.pushReplication.sendMsg(revRequest); err != nil {
-		return "", err
-	}
-
-	revResponse := revRequest.Response()
-	rspBody, err = revResponse.Body()
-	if err != nil {
-		return "", fmt.Errorf("error getting body of revResponse: %v", err)
-	}
-
-	if revResponse.Type() == blip.ErrorType {
-		return "", fmt.Errorf("error %s %s from revResponse: %s", revResponse.Properties["Error-Domain"], revResponse.Properties["Error-Code"], rspBody)
-	}
-
-	btc.updateLastReplicatedRev(docID, newRevID)
-	return newRevID, nil
+	return btc.PushRevWithHistory(docID, parentRev, body, 1, 0, false)
 }
 
 // PushRevWithHistory creates a revision on the client with history, and immediately sends a changes request for it.
-func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []byte, revCount, revpos int) (revID string, err error) {
+func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []byte, revCount, revpos int, skipDocNotFoundErr bool) (revID string, err error) {
 	parentRevGen, _ := db.ParseRevID(parentRev)
 	revGen := parentRevGen + revCount
 
@@ -725,6 +588,10 @@ func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []
 	for i := revGen - 1; i > parentRevGen; i-- {
 		rev := fmt.Sprintf("%d-%s", i, "abc")
 		revisionHistory = append(revisionHistory, rev)
+	}
+
+	if revpos == 0 {
+		revpos = revGen
 	}
 
 	// Inline attachment processing
@@ -789,6 +656,11 @@ func (btc *BlipTesterClient) PushRevWithHistory(docID, parentRev string, body []
 			} else {
 				btc.docsLock.Unlock()
 				return "", fmt.Errorf("docID: %v with parent rev: %v was not found on the client", docID, parentRev)
+			}
+		} else {
+			if !skipDocNotFoundErr {
+				btc.docsLock.Unlock()
+				return "", fmt.Errorf("docID: %v was not found on the client", docID)
 			}
 		}
 	} else {


### PR DESCRIPTION
Enhance the unit tests to create a revision on the client with history, and immediately sends a changes request for it. This is specifically for testing proveAttachment handling scenarios.