### PR TITLE
CBG-1535 - Better error messages

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -835,11 +835,11 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	// Validate SSL is provided if not allowing unsecure connections
 	if sc.API.HTTPS.UseTLSClient == nil || *sc.API.HTTPS.UseTLSClient {
 		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("TLS key path and cert path must be provided when api.https.use_tls_client is set"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Must supply a TLS key path and cert path, or opt out by setting api.https.use_tls_client to false"))
 		}
 	} else { // Make sure TLS key and cert is not provided
 		if sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot use TLS when api.https.use_tls_client is false"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Cannot use supplied TLS key or cert when api.https.use_tls_client is false"))
 		}
 	}
 	return errorMessages

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1207,8 +1207,8 @@ func TestSetupServerContext(t *testing.T) {
 // CBG-1535 - Test api.http.UseTLSClient option
 func TestUseTLSClient(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
-	errorTLSNotProvided := "TLS key path and cert path must be provided when api.https.use_tls_client is set"
-	errorTLSProvidedButInsecure := "cannot use TLS when api.https.use_tls_client is false"
+	errorTLSNotProvided := "Must supply a TLS key path and cert path, or opt out by setting api.https.use_tls_client to false"
+	errorTLSProvidedButInsecure := "Cannot use supplied TLS key or cert when api.https.use_tls_client is false"
 	testCases := []struct {
 		name         string
 		tlsKey       bool


### PR DESCRIPTION
When TLS key/cert is not provided: `Must supply a TLS key path and cert path, or opt out by setting api.https.use_tls_client to false`

When TLS key/cert is provided but use_tls_client is false: `Cannot use supplied TLS key or cert when api.https.use_tls_client is false`