### PR TITLE
CBG-1399: Pre-3.0 config automatic upgrade

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocbcore/memd"
 )
 
 // BootstrapConnection is the interface that can be used to bootstrap Sync Gateway against a Couchbase Server cluster.
@@ -129,6 +130,11 @@ func (cc *CouchbaseCluster) PutConfig(location, groupID string, cas *uint64, val
 	if cas != nil && *cas == 0 {
 		res, err := collection.Insert(docID, value, nil)
 		if err != nil {
+
+			if isKVError(err, memd.StatusKeyExists) {
+				return 0, ErrAlreadyExists
+			}
+
 			return 0, err
 		}
 

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -402,6 +402,10 @@ func isKVError(err error, code memd.StatusCode) bool {
 	return false
 }
 
+func IsAlreadyExistsError(err error) bool {
+	return isKVError(err, memd.StatusKeyExists)
+}
+
 // If v is []byte or *[]byte, converts to json.RawMessage to avoid duplicate marshalling by gocb.
 func bytesToRawMessage(v interface{}) interface{} {
 	switch val := v.(type) {

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -402,10 +402,6 @@ func isKVError(err error, code memd.StatusCode) bool {
 	return false
 }
 
-func IsAlreadyExistsError(err error) bool {
-	return isKVError(err, memd.StatusKeyExists)
-}
-
 // If v is []byte or *[]byte, converts to json.RawMessage to avoid duplicate marshalling by gocb.
 func bytesToRawMessage(v interface{}) interface{} {
 	switch val := v.(type) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -887,12 +887,12 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
 	if sc.persistentConfig {
-		couchbaseCluster, err := EstablishCouchbaseClusterConnection(sc.config)
+		couchbaseCluster, err := establishCouchbaseClusterConnection(sc.config)
 		if err != nil {
 			return nil, err
 		}
 
-		sc.bootstrapContext.connection = base.BootstrapConnection(couchbaseCluster)
+		sc.bootstrapContext.connection = couchbaseCluster
 
 		count, err := sc.fetchAndLoadConfigs()
 		if err != nil {

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutomaticConfigUpgrade(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("CBS required")
+	}
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	rawConfig := `
+	{
+		"databases": {
+			"db": {
+			  "server": "%s",
+			  "username": "%s",
+			  "password": "%s",
+			  "bucket": "%s"
+			}
+		}
+	}`
+
+	config := fmt.Sprintf(rawConfig, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tmpDir, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	require.NoError(t, err)
+
+	startupConfig, err := automaticConfigUpgrade(configPath)
+	assert.NoError(t, err)
+
+	assert.Equal(t, base.UnitTestUrl(), startupConfig.Bootstrap.Server)
+	assert.Equal(t, base.TestClusterUsername(), startupConfig.Bootstrap.Username)
+	assert.Equal(t, base.TestClusterPassword(), startupConfig.Bootstrap.Password)
+
+	cbs, err := EstablishCouchbaseClusterConnection(startupConfig)
+	require.NoError(t, err)
+
+	var dbConfig DbConfig
+	_, err = cbs.GetConfig(tb.GetName(), "default", &dbConfig)
+	assert.NoError(t, err)
+
+	err = cbs.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "db", dbConfig.Name)
+	assert.Equal(t, tb.GetName(), *dbConfig.Bucket)
+	assert.Nil(t, dbConfig.Server)
+	assert.Equal(t, base.TestClusterUsername(), dbConfig.Username)
+	assert.Equal(t, base.TestClusterPassword(), dbConfig.Password)
+}
+
+func TestAutomaticConfigUpgradeError(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("CBS required")
+	}
+
+	testCases := []struct {
+		Name   string
+		Config string
+	}{
+		{
+			"Multiple DBs different servers",
+			`
+				{
+					"databases": {
+						"db": {
+						  "server": "%s",
+						  "username": "%s",
+						  "password": "%s",
+						  "bucket": "%s"
+						},
+						"db2": {
+						  "server": "rand",
+						  "username": "",
+						  "password": "",
+						  "bucket": ""
+						}
+					}
+				}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			tb := base.GetTestBucket(t)
+			defer tb.Close()
+
+			config := fmt.Sprintf(testCase.Config, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+
+			tmpDir, err := ioutil.TempDir("", strings.ReplaceAll(t.Name(), "/", ""))
+			require.NoError(t, err)
+
+			configPath := filepath.Join(tmpDir, "config.json")
+			err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+			require.NoError(t, err)
+
+			_, err = automaticConfigUpgrade(configPath)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -84,7 +84,9 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 
 	cbs, err := establishCouchbaseClusterConnection(startupConfig)
 	require.NoError(t, err)
-	defer cbs.Close()
+	defer func() {
+		_ = cbs.Close()
+	}()
 
 	var dbConfig DbConfig
 	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
@@ -204,7 +206,9 @@ func TestAutomaticConfigUpgradeExistingConfig(t *testing.T) {
 
 	cbs, err := establishCouchbaseClusterConnection(startupConfig)
 	require.NoError(t, err)
-	defer cbs.Close()
+	defer func() {
+		_ = cbs.Close()
+	}()
 
 	var dbConfig DbConfig
 	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -23,6 +23,8 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 
 	rawConfig := `
 	{
+		"interface": ":4444",
+  		"adminInterface": ":4445",
 		"databases": {
 			"db": {
 			  "server": "%s",
@@ -48,8 +50,10 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	assert.Equal(t, base.UnitTestUrl(), startupConfig.Bootstrap.Server)
 	assert.Equal(t, base.TestClusterUsername(), startupConfig.Bootstrap.Username)
 	assert.Equal(t, base.TestClusterPassword(), startupConfig.Bootstrap.Password)
+	assert.Equal(t, ":4444", startupConfig.API.PublicInterface)
+	assert.Equal(t, ":4445", startupConfig.API.AdminInterface)
 
-	cbs, err := EstablishCouchbaseClusterConnection(startupConfig)
+	cbs, err := establishCouchbaseClusterConnection(startupConfig)
 	require.NoError(t, err)
 
 	var dbConfig DbConfig

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -42,7 +42,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 	require.NoError(t, err)
 
-	startupConfig, err := automaticConfigUpgrade(configPath)
+	startupConfig, _, err := automaticConfigUpgrade(configPath)
 	assert.NoError(t, err)
 
 	assert.Equal(t, base.UnitTestUrl(), startupConfig.Bootstrap.Server)
@@ -111,7 +111,7 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 			err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
 			require.NoError(t, err)
 
-			_, err = automaticConfigUpgrade(configPath)
+			_, _, err = automaticConfigUpgrade(configPath)
 			assert.Error(t, err)
 		})
 	}

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -1,7 +1,9 @@
 package rest
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,13 +26,13 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	rawConfig := `
 	{
 		"interface": ":4444",
-  		"adminInterface": ":4445",
+		"adminInterface": ":4445",
 		"databases": {
 			"db": {
-			  "server": "%s",
-			  "username": "%s",
-			  "password": "%s",
-			  "bucket": "%s"
+				"server": "%s",
+				"username": "%s",
+				"password": "%s",
+				"bucket": "%s"
 			}
 		}
 	}`
@@ -53,14 +55,39 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	assert.Equal(t, ":4444", startupConfig.API.PublicInterface)
 	assert.Equal(t, ":4445", startupConfig.API.AdminInterface)
 
-	cbs, err := establishCouchbaseClusterConnection(startupConfig)
-	require.NoError(t, err)
-
-	var dbConfig DbConfig
-	_, err = cbs.GetConfig(tb.GetName(), "default", &dbConfig)
+	writtenNewFile, err := ioutil.ReadFile(configPath)
 	assert.NoError(t, err)
 
-	err = cbs.Close()
+	var writtenFileStartupConfig StartupConfig
+	err = json.Unmarshal(writtenNewFile, &writtenFileStartupConfig)
+	assert.NoError(t, err)
+
+	assert.Equal(t, base.UnitTestUrl(), writtenFileStartupConfig.Bootstrap.Server)
+	assert.Equal(t, base.TestClusterUsername(), writtenFileStartupConfig.Bootstrap.Username)
+	assert.Equal(t, base.TestClusterPassword(), writtenFileStartupConfig.Bootstrap.Password)
+	assert.Equal(t, ":4444", writtenFileStartupConfig.API.PublicInterface)
+	assert.Equal(t, ":4445", writtenFileStartupConfig.API.AdminInterface)
+
+	backupFileName := ""
+	err = filepath.WalkDir(tmpDir, func(path string, d fs.DirEntry, err error) error {
+		if strings.Contains(filepath.Base(path), "backup") {
+			backupFileName = path
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+
+	writtenBackupFile, err := ioutil.ReadFile(backupFileName)
+	assert.NoError(t, err)
+
+	assert.Equal(t, config, string(writtenBackupFile))
+
+	cbs, err := establishCouchbaseClusterConnection(startupConfig)
+	require.NoError(t, err)
+	defer cbs.Close()
+
+	var dbConfig DbConfig
+	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "db", dbConfig.Name)
@@ -85,16 +112,16 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 				{
 					"databases": {
 						"db": {
-						  "server": "%s",
-						  "username": "%s",
-						  "password": "%s",
-						  "bucket": "%s"
+							"server": "%s",
+							"username": "%s",
+							"password": "%s",
+							"bucket": "%s"
 						},
 						"db2": {
-						  "server": "rand",
-						  "username": "",
-						  "password": "",
-						  "bucket": ""
+							"server": "rand",
+							"username": "",
+							"password": "",
+							"bucket": ""
 						}
 					}
 				}`,
@@ -119,4 +146,71 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestAutomaticConfigUpgradeExistingConfig(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("CBS required")
+	}
+
+	configRaw := `
+	{
+		"databases": {
+			"db": {
+				"server": "%s",
+				"username": "%s",
+				"password": "%s",
+				"bucket": "%s"
+			}
+		}
+	}`
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+
+	config := fmt.Sprintf(configRaw, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+	configPath := filepath.Join(tmpDir, "config.json")
+	err = ioutil.WriteFile(configPath, []byte(config), os.FileMode(0644))
+	require.NoError(t, err)
+
+	// Run migration once
+	_, _, err = automaticConfigUpgrade(configPath)
+	require.NoError(t, err)
+
+	updatedConfigRaw := `
+	{
+		"databases": {
+			"db": {
+				"revs_limit": 20000,
+				"server": "%s",
+				"username": "%s",
+				"password": "%s",
+				"bucket": "%s"
+			}
+		}
+	}`
+
+	updatedConfig := fmt.Sprintf(updatedConfigRaw, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+	updatedConfigPath := filepath.Join(tmpDir, "config-updated.json")
+	err = ioutil.WriteFile(updatedConfigPath, []byte(updatedConfig), os.FileMode(0644))
+	require.NoError(t, err)
+
+	// Run migration again to ensure no error and validate it doesn't actually update db
+	startupConfig, _, err := automaticConfigUpgrade(updatedConfigPath)
+	require.NoError(t, err)
+
+	cbs, err := establishCouchbaseClusterConnection(startupConfig)
+	require.NoError(t, err)
+	defer cbs.Close()
+
+	var dbConfig DbConfig
+	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+	assert.NoError(t, err)
+
+	// Ensure that revs limit hasn't actually been set
+	assert.Nil(t, dbConfig.RevsLimit)
+
 }


### PR DESCRIPTION
PR handles automatic migration of pre-3.0 configs to 3.0 persistent configs:
1. Converts config to startup config
2. Validates / sanitizes db config - Verifies servers are all the same and removes unused info like server, users & roles
3. Connects to CBS and uploads the new db configs
4. Saves current config file as a backup 
5. Overwrites old config file with new startup file
6. 
7. Copied out the work done in `setupServerContext` when connecting to the CBS cluster as this is required in `automaticConfigUpgrade`.

Added a basic implementation of PutConfig which works for the required use-case in the PR. Can be updated later down the road by @bbrks for his later requirements.