### PR TITLE
CBG-1558 - GetDeepMutableBody returns error on invalid JSON

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1068,14 +1068,20 @@ func (db *Database) resolveConflict(localDoc *Document, remoteDoc *Document, doc
 	// TODO: Make doc expiry (_exp) available over replication.
 	// remoteExpiry := remoteDoc.Expiry
 
-	localDocBody := localDoc.GetDeepMutableBody()
+	localDocBody, err := localDoc.GetDeepMutableBody()
+	if err != nil {
+		return "", nil, err
+	}
 	localDocBody[BodyId] = localDoc.ID
 	localDocBody[BodyRev] = localRevID
 	localDocBody[BodyAttachments] = localAttachments
 	localDocBody[BodyExpiry] = localExpiry
 	localDocBody[BodyDeleted] = localDoc.IsDeleted()
 
-	remoteDocBody := remoteDoc.GetDeepMutableBody()
+	remoteDocBody, err := remoteDoc.GetDeepMutableBody()
+	if err != nil {
+		return "", nil, err
+	}
 	remoteDocBody[BodyId] = remoteDoc.ID
 	remoteDocBody[BodyRev] = remoteRevID
 	remoteDocBody[BodyAttachments] = remoteAttachments
@@ -1611,7 +1617,10 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 		return
 	}
 
-	syncFnBody := newDoc.GetDeepMutableBody()
+	syncFnBody, err := newDoc.GetDeepMutableBody()
+	if err != nil {
+		return
+	}
 
 	// TODO: seems a bit late to do this. Could we move it earlier?
 	err = validateNewBody(syncFnBody)

--- a/db/document.go
+++ b/db/document.go
@@ -269,30 +269,26 @@ func (doc *Document) Body() Body {
 }
 
 // Get a deep mutable copy of the body, using _rawBody.  Initializes _rawBody based on _body if not already present.
-func (doc *Document) GetDeepMutableBody() Body {
-
+func (doc *Document) GetDeepMutableBody() (Body, error) {
 	// If doc._rawBody isn't present, marshal from doc.Body
 	if doc._rawBody == nil {
 		if doc._body == nil {
-			return nil
+			return nil, fmt.Errorf("Unable to get document body due to an empty raw body and body in the document")
 		}
 		var err error
 		doc._rawBody, err = base.JSONMarshal(doc._body)
 		if err != nil {
-			base.Warnf("Unable to marshal document body into raw body : %s", err)
-			return nil
+			return nil, fmt.Errorf("Unable to marshal document body into raw body : %w", err)
 		}
-
 	}
 
 	var mutableBody Body
 	err := mutableBody.Unmarshal(doc._rawBody)
 	if err != nil {
-		base.Warnf("Unable to unmarshal document body from raw body : %s", err)
-		return nil
+		return nil, fmt.Errorf("Unable to unmarshal document body into raw body : %w", err)
 	}
 
-	return mutableBody
+	return mutableBody, nil
 }
 
 func (doc *Document) RemoveBody() {

--- a/db/document_test.go
+++ b/db/document_test.go
@@ -232,3 +232,61 @@ func TestParseDocumentCas(t *testing.T) {
 
 	goassert.Equals(t, casInt, uint64(1492749160563736576))
 }
+
+func TestGetDeepMutableBody(t *testing.T) {
+	testCases := []struct {
+		name        string
+		inputDoc    *Document
+		expectError bool
+		expected    *Body
+	}{
+		{
+			name:        "Empty doc",
+			inputDoc:    &Document{},
+			expectError: true,
+			expected:    nil,
+		},
+		{
+			name:        "Raw body",
+			inputDoc:    &Document{_rawBody: []byte(`{"test": true}`)},
+			expectError: false,
+			expected:    &Body{"test": true},
+		},
+		{
+			name:        "Malformed raw body",
+			inputDoc:    &Document{_rawBody: []byte(`{test: true}`)},
+			expectError: true,
+			expected:    nil,
+		},
+		{
+			name:        "Body, no raw body",
+			inputDoc:    &Document{_body: Body{"test": true}},
+			expectError: false,
+			expected:    &Body{"test": true},
+		},
+		{
+			name:        "Inline function in body, no raw body",
+			inputDoc:    &Document{_body: Body{"test": func() bool { return true }}},
+			expectError: true,
+			expected:    nil,
+		},
+		{
+			name:        "Body and raw body",
+			inputDoc:    &Document{_rawBody: []byte(`{"test": true}`), _body: Body{"notTest": false}},
+			expectError: false,
+			expected:    &Body{"test": true},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			body, err := test.inputDoc.GetDeepMutableBody()
+			if test.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, body)
+				return
+			}
+			assert.Nil(t, err)
+			assert.Equal(t, *test.expected, body)
+		})
+	}
+}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -230,7 +230,10 @@ func TestActiveReplicatorPullBasic(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
 }
@@ -318,7 +321,9 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	assert.Equal(t, int64(1), ar.Pull.GetStats().GetAttachment.Value())
 
@@ -337,7 +342,10 @@ func TestActiveReplicatorPullAttachments(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	// Because we're targeting a Hydrogen node that supports proveAttachment, we only end up sending the attachment once.
 	// If targeting a pre-hydrogen node, GetAttachment would be 2.
@@ -642,7 +650,10 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
-		assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+		body, err := doc.GetDeepMutableBody()
+		require.NoError(t, err)
+		assert.Equal(t, "rt2", body["source"])
 	}
 
 	// one _changes from seq:0 with initial number of docs sent
@@ -692,7 +703,10 @@ func TestActiveReplicatorPullFromCheckpoint(t *testing.T) {
 
 		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
-		assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+		body, err := doc.GetDeepMutableBody()
+		require.NoError(t, err)
+		assert.Equal(t, "rt2", body["source"])
 	}
 
 	// Make sure we've not started any more since:0 replications on rt2 since the first one
@@ -961,7 +975,10 @@ func TestActiveReplicatorPullOneshot(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 	assert.Equal(t, strconv.FormatUint(remoteDoc.Sequence, 10), ar.GetStatus().LastSeqPull)
 }
 
@@ -1047,7 +1064,10 @@ func TestActiveReplicatorPushBasic(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
 }
@@ -1133,7 +1153,10 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	assert.Equal(t, int64(1), ar.Push.GetStats().HandleGetAttachment.Value())
 
@@ -1152,7 +1175,10 @@ func TestActiveReplicatorPushAttachments(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc2.SyncData.CurrentRev)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	// Because we're targeting a Hydrogen node that supports proveAttachment, we only end up sending the attachment once.
 	// If targeting a pre-hydrogen node, HandleGetAttachment would be 2.
@@ -1251,7 +1277,10 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
-		assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+		body, err := doc.GetDeepMutableBody()
+		require.NoError(t, err)
+		assert.Equal(t, "rt1", body["source"])
 	}
 
 	// one _changes from seq:0 with initial number of docs sent
@@ -1299,7 +1328,10 @@ func TestActiveReplicatorPushFromCheckpoint(t *testing.T) {
 
 		doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
-		assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+		body, err := doc.GetDeepMutableBody()
+		require.NoError(t, err)
+		assert.Equal(t, "rt1", body["source"])
 	}
 
 	// Make sure we've not started any more since:0 replications on rt1 since the first one
@@ -1550,7 +1582,10 @@ func TestActiveReplicatorPushOneshot(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	assert.Equal(t, strconv.FormatUint(localDoc.Sequence, 10), ar.GetStatus().LastSeqPush)
 }
@@ -1634,7 +1669,10 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	// Tombstone the doc in rt2
 	resp = rt2.SendAdminRequest(http.MethodDelete, "/db/"+docID+"?rev="+revID, ``)
@@ -1734,7 +1772,10 @@ func TestActiveReplicatorPullPurgeOnRemoval(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	resp = rt2.SendAdminRequest(http.MethodPut, "/db/"+docID+"?rev="+revID, `{"source":"rt2","channels":["bob"]}`)
 	assertStatus(t, resp, http.StatusCreated)
@@ -2310,7 +2351,10 @@ func TestActiveReplicatorPushBasicWithInsecureSkipVerifyEnabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 }
 
 // TestActiveReplicatorPushBasicWithInsecureSkipVerifyDisabled:
@@ -2453,7 +2497,10 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	// one _changes from seq:0 with initial number of docs sent
 	numChangesRequestedFromZeroTotal := rt2.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -2505,7 +2552,10 @@ func TestActiveReplicatorRecoverFromLocalFlush(t *testing.T) {
 
 	doc, err = rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 
 	// one _changes from seq:0 with initial number of docs sent
 	endNumChangesRequestedFromZeroTotal := rt2.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -2606,7 +2656,10 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	doc, err := rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	// one _changes from seq:0 with initial number of docs sent
 	numChangesRequestedFromZeroTotal := rt1.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -2671,7 +2724,10 @@ func TestActiveReplicatorRecoverFromRemoteFlush(t *testing.T) {
 
 	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	// one _changes from seq:0 with initial number of docs sent
 	endNumChangesRequestedFromZeroTotal := rt1.GetDatabase().DbStats.CBLReplicationPull().NumPullReplSinceZero.Value()
@@ -2775,7 +2831,10 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 
 	doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	assert.NoError(t, err)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	// Since we bumped the checkpointer interval, we're only setting checkpoints on replicator close.
 	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
@@ -2806,7 +2865,10 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 
 	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	assert.Equal(t, int64(1), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
@@ -2836,7 +2898,10 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 
 	doc, err = rt2.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 	require.NoError(t, err)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	assert.Equal(t, int64(0), ar.Push.Checkpointer.Stats().SetCheckpointCount)
 	ar.Push.Checkpointer.CheckpointNow()
@@ -3025,7 +3090,10 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, rt1revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt1", doc.GetDeepMutableBody()["source"])
+
+	body, err := doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt1", body["source"])
 
 	// write a doc on rt2 ...
 	rt2docID := t.Name() + "rt2doc1"
@@ -3044,7 +3112,10 @@ func TestActiveReplicatorIgnoreNoConflicts(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, rt2revID, doc.SyncData.CurrentRev)
-	assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+	body, err = doc.GetDeepMutableBody()
+	require.NoError(t, err)
+	assert.Equal(t, "rt2", body["source"])
 }
 
 // TestActiveReplicatorPullFromCheckpointModifiedHash:
@@ -3194,7 +3265,10 @@ func TestActiveReplicatorPullModifiedHash(t *testing.T) {
 
 		doc, err := rt1.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 		assert.NoError(t, err)
-		assert.Equal(t, "rt2", doc.GetDeepMutableBody()["source"])
+
+		body, err := doc.GetDeepMutableBody()
+		require.NoError(t, err)
+		assert.Equal(t, "rt2", body["source"])
 	}
 
 	// Should have two replications since zero


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/935/  (failed test is recurring one)

Did not write unit tests for documentUpdateFunc or resolveConflict due to it being very difficult to get them tested (there are no unit tests that test either of these 2 functions specifically). I did write a unit test for GetDeepMutableBody though.