### PR TITLE
CBG-1580: Modify Admin Auth Cluster-Level roles

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -415,7 +415,7 @@ func TestAdminAuth(t *testing.T) {
 				defer DeleteUser(t, managementEndpoints[0], testCase.CreateUser)
 			}
 
-			permResults, statusCode, err := checkAdminAuth(testCase.BucketName, testCase.Username, testCase.Password, httpClient, managementEndpoints, true, testCase.CheckPermissions, testCase.ResponsePermissions)
+			permResults, statusCode, err := checkAdminAuth(testCase.BucketName, testCase.Username, testCase.Password, "", httpClient, managementEndpoints, true, testCase.CheckPermissions, testCase.ResponsePermissions)
 
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
@@ -447,7 +447,7 @@ func TestAdminAuthWithX509(t *testing.T) {
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
-	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), httpClient, managementEndpoints, true, []Permission{{"!admin", false}}, nil)
+	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), "", httpClient, managementEndpoints, true, []Permission{{"!admin", false}}, nil)
 	assert.NoError(t, err)
 }
 
@@ -984,6 +984,9 @@ func TestAdminAPIAuth(t *testing.T) {
 	MakeUser(t, eps[0], "ROAdminUser", "password", []string{ReadOnlyAdminRole.RoleName})
 	defer DeleteUser(t, eps[0], "ROAdminUser")
 
+	MakeUser(t, eps[0], "ClusterAdminUser", "password", []string{ClusterAdminRole.RoleName})
+	defer DeleteUser(t, eps[0], "ClusterAdminUser")
+
 	for _, endPoint := range endPoints {
 		t.Run(endPoint.Method+endPoint.Endpoint, func(t *testing.T) {
 			formattedEndpoint := endPoint.Endpoint
@@ -997,17 +1000,25 @@ func TestAdminAPIAuth(t *testing.T) {
 			assertStatus(t, resp, http.StatusForbidden)
 
 			if !endPoint.SkipSuccessTest {
-				if endPoint.DBScoped {
-					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "MobileSyncGatewayUser", "password")
-				} else {
-					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "ROAdminUser", "password")
-				}
 
 				// For some of the endpoints they have other requirements, such as setting up users and others require
 				// bodies. Rather than doing a full test of the endpoint itself this will at least confirm that they pass
 				// the auth stage.
-				fmt.Println(resp.Code)
-				assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+				if endPoint.DBScoped {
+					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "MobileSyncGatewayUser", "password")
+					assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+				} else {
+					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "ROAdminUser", "password")
+					if endPoint.Method == http.MethodPut || endPoint.Method == http.MethodPost {
+						assertStatus(t, resp, http.StatusForbidden)
+					} else {
+						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+					}
+
+					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, `{}`, "ClusterAdminUser", "password")
+					assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+
+				}
 			}
 		})
 	}
@@ -1072,7 +1083,7 @@ func TestDisablePermissionCheck(t *testing.T) {
 			MakeUser(t, eps[0], testCase.CreateUser, "password", []string{fmt.Sprintf("%s[%s]", testCase.CreateUserRole.RoleName, rt.Bucket().GetName())})
 			defer DeleteUser(t, eps[0], testCase.CreateUser)
 
-			_, statusCode, err := checkAdminAuth(rt.Bucket().GetName(), testCase.CreateUser, "password", httpClient, eps, testCase.DoPermissionCheck, testCase.RequirePerms, nil)
+			_, statusCode, err := checkAdminAuth(rt.Bucket().GetName(), testCase.CreateUser, "password", "", httpClient, eps, testCase.DoPermissionCheck, testCase.RequirePerms, nil)
 			assert.NoError(t, err)
 
 			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)

--- a/rest/config.go
+++ b/rest/config.go
@@ -842,6 +842,11 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Cannot use supplied TLS key or cert when api.https.use_tls_client is false"))
 		}
 	}
+
+	if !base.IsEnterpriseEdition() && sc.API.EnableAdminAuthenticationPermissionsCheck != nil && *sc.API.EnableAdminAuthenticationPermissionsCheck {
+		errorMessages = multierror.Append(errorMessages, fmt.Errorf("enable_admin_authentication_permissions_check is only supported in enterprise edition"))
+	}
+
 	return errorMessages
 }
 

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -37,10 +37,11 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 				TLSMinimumVersion: "tlsv1.2",
 				UseTLSClient:      base.BoolPtr(true),
 			},
-			ReadHeaderTimeout:                         base.NewConfigDuration(base.DefaultReadHeaderTimeout),
-			IdleTimeout:                               base.NewConfigDuration(base.DefaultIdleTimeout),
-			AdminInterfaceAuthentication:              base.BoolPtr(true),
-			MetricsInterfaceAuthentication:            base.BoolPtr(true),
+			ReadHeaderTimeout:              base.NewConfigDuration(base.DefaultReadHeaderTimeout),
+			IdleTimeout:                    base.NewConfigDuration(base.DefaultIdleTimeout),
+			AdminInterfaceAuthentication:   base.BoolPtr(true),
+			MetricsInterfaceAuthentication: base.BoolPtr(true),
+			// Post-DP this should be set to base.IsEnterpriseEdition as default
 			EnableAdminAuthenticationPermissionsCheck: base.BoolPtr(false),
 		},
 		Logging: LoggingConfig{

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -70,11 +70,13 @@ var (
 	BucketFullAccessRole  = RouteRole{"bucket_full_access", true}
 	BucketAdmin           = RouteRole{"bucket_admin", true}
 	FullAdminRole         = RouteRole{"admin", false}
+	ClusterAdminRole      = RouteRole{"cluster_admin", false}
 	ReadOnlyAdminRole     = RouteRole{"ro_admin", false}
 )
 
-var BucketScopedEndpointRoles = []RouteRole{MobileSyncGatewayRole, BucketFullAccessRole, BucketAdmin, ReadOnlyAdminRole, FullAdminRole}
-var ClusterScopedEndpointRoles = []RouteRole{ReadOnlyAdminRole, FullAdminRole}
+var BucketScopedEndpointRoles = []RouteRole{MobileSyncGatewayRole, BucketFullAccessRole, BucketAdmin, FullAdminRole}
+var ClusterScopedEndpointRolesRead = []RouteRole{ReadOnlyAdminRole, ClusterAdminRole, FullAdminRole}
+var ClusterScopedEndpointRolesWrite = []RouteRole{ClusterAdminRole, FullAdminRole}
 
 // Encapsulates the state of handling an HTTP request.
 type handler struct {
@@ -255,8 +257,9 @@ func (h *handler) invoke(method handlerMethod, accessPermissions []Permission, r
 			return base.HTTPErrorf(http.StatusInternalServerError, "")
 		}
 
-		permissions, statusCode, err := checkAdminAuth(authScope, username, password, httpClient, managementEndpoints,
-			*h.server.config.API.EnableAdminAuthenticationPermissionsCheck, accessPermissions, responsePermissions)
+		permissions, statusCode, err := checkAdminAuth(authScope, username, password, h.rq.Method, httpClient,
+			managementEndpoints, *h.server.config.API.EnableAdminAuthenticationPermissionsCheck, accessPermissions,
+			responsePermissions)
 		if err != nil {
 			base.Warnf("An error occurred whilst checking whether a user was authorized: %v", err)
 			return base.HTTPErrorf(http.StatusInternalServerError, "")
@@ -432,7 +435,7 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 	return nil
 }
 
-func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, httpClient *http.Client, managementEndpoints []string, shouldCheckPermissions bool, accessPermissions []Permission, responsePermissions []Permission) (responsePermissionResults map[string]bool, statusCode int, err error) {
+func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, attemptedHTTPOperation string, httpClient *http.Client, managementEndpoints []string, shouldCheckPermissions bool, accessPermissions []Permission, responsePermissions []Permission) (responsePermissionResults map[string]bool, statusCode int, err error) {
 
 	anyResponsePermFailed := false
 	statusCode, permResults, err := CheckPermissions(httpClient, managementEndpoints, bucketName, basicAuthUsername, basicAuthPassword, accessPermissions, responsePermissions)
@@ -473,7 +476,11 @@ func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, htt
 	if bucketName != "" {
 		requestRoles = BucketScopedEndpointRoles
 	} else {
-		requestRoles = ClusterScopedEndpointRoles
+		if attemptedHTTPOperation == http.MethodPut || attemptedHTTPOperation == http.MethodPost {
+			requestRoles = ClusterScopedEndpointRolesWrite
+		} else {
+			requestRoles = ClusterScopedEndpointRolesRead
+		}
 	}
 
 	statusCode, err = CheckRoles(httpClient, managementEndpoints, basicAuthUsername, basicAuthPassword, requestRoles, bucketName)


### PR DESCRIPTION
Modified cluster-level role access to be:

PUT / POST operations can be performed by:
- Full Admin
- Cluster Admin

All other cluster-level operations can be performed by:
- Full Admin
- Cluster Admin
- Read Only Admin

Bucket level operations have been modified a little (remove read-only admin ):
- Mobile Sync Gateway 
- Bucket Full Access / Application Access
- Bucket Admin
- Full Admin 

Also limited the permissions-based check to only be available to EE.