### PR TITLE
CBG-1586: Admin Auth - Fix bucket * roles

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -246,6 +246,17 @@ func TestCheckRoles(t *testing.T) {
 			CreateRoles:        []string{fmt.Sprintf("mobile_sync_gateway[%s]", rt.Bucket().GetName())},
 		},
 		{
+			Name:               "CreatedBucketAdminWildcard",
+			Username:           "CreatedBucketAdminWildcard",
+			Password:           "password",
+			BucketName:         rt.Bucket().GetName(),
+			RequestRoles:       []RouteRole{MobileSyncGatewayRole},
+			ExpectedStatusCode: http.StatusOK,
+			CreateUser:         "CreatedBucketAdminWildcard",
+			CreatePassword:     "password",
+			CreateRoles:        []string{"mobile_sync_gateway[*]"},
+		},
+		{
 			Name:               "CreateUserNoRole",
 			Username:           "CreateUserNoRole",
 			Password:           "password",

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -65,6 +65,8 @@ type RouteRole struct {
 	DatabaseScoped bool
 }
 
+const RoleBucketWildcard = "*"
+
 var (
 	MobileSyncGatewayRole = RouteRole{"mobile_sync_gateway", true}
 	BucketFullAccessRole  = RouteRole{"bucket_full_access", true}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -1223,13 +1223,15 @@ func CheckRoles(httpClient *http.Client, managementEndpoints []string, username,
 
 	for _, roleResult := range whoAmIResults.Roles {
 		for _, requireRole := range requestedRoles {
-			requireBucket := ""
+			requireBucketOptions := []string{""}
 			if requireRole.DatabaseScoped {
-				requireBucket = bucketName
+				requireBucketOptions = []string{bucketName, RoleBucketWildcard}
 			}
 
-			if roleResult.BucketName == requireBucket && roleResult.RoleName == requireRole.RoleName {
-				return http.StatusOK, nil
+			for _, requireBucket := range requireBucketOptions {
+				if (roleResult.BucketName == requireBucket) && roleResult.RoleName == requireRole.RoleName {
+					return http.StatusOK, nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When roles are assigned to all buckets they appear in the `whoami` response with `"bucket_name": "*"` meaning our previous logic of checking that this equals the bucket name didn't work. 

Just need to do an additional check for the bucket name being `*` in the db scoped case.