### PR TITLE
Enable gocbv2 by default

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -550,7 +550,7 @@ func (auth *Authenticator) casUpdatePrincipal(p Principal, callback casUpdatePri
 		}
 
 		if err != nil {
-			return err
+			return fmt.Errorf("Error reloading principal after CAS failure: %w", err)
 		}
 	}
 	base.Infof(base.KeyAuth, "Unable to update principal after %d attempts.  Principal:%s Error:%v", PrincipalUpdateMaxCasRetries, base.UD(p.Name()), err)

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -72,6 +72,7 @@ type CouchbaseStore interface {
 	// a map of UUIDS and a map of high sequence numbers (map from vbno -> seq)
 	GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error)
 
+	// mgmtRequest uses the CouchbaseStore's http client to make an http request against a management endpoint.
 	mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error)
 }
 

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -11,7 +11,11 @@ package base
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -53,6 +57,29 @@ type WrappingBucket interface {
 	GetUnderlyingBucket() Bucket
 }
 
+// CouchbaseStore defines operations specific to Couchbase data stores
+type CouchbaseStore interface {
+	BucketName() string
+	MgmtEps() ([]string, error)
+	MetadataPurgeInterval() (time.Duration, error)
+	ServerUUID() (uuid string, err error)
+	MaxTTL() (int, error)
+	HttpClient() *http.Client
+	GetExpiry(k string) (expiry uint32, getMetaError error)
+	GetSpec() BucketSpec
+
+	// GetStatsVbSeqno retrieves the high sequence number for all vbuckets and returns
+	// a map of UUIDS and a map of high sequence numbers (map from vbno -> seq)
+	GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error)
+
+	mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error)
+}
+
+func AsCouchbaseStore(b Bucket) (CouchbaseStore, bool) {
+	couchbaseBucket, ok := GetBaseBucket(b).(CouchbaseStore)
+	return couchbaseBucket, ok
+}
+
 // GetBaseBucket returns the lowest level non-wrapping bucket wrapped by one or more WrappingBuckets
 func GetBaseBucket(b Bucket) Bucket {
 	wb, ok := b.(WrappingBucket)
@@ -68,13 +95,13 @@ func ChooseCouchbaseDriver(bucketType CouchbaseBucketType) CouchbaseDriver {
 	// return DefaultDriverForBucketType[bucketType]
 	switch bucketType {
 	case DataBucket:
-		return GoCBCustomSGTranscoder
+		return GoCBv2
 	case IndexBucket:
-		return GoCB
+		return GoCBv2
 	default:
 		// If a new bucket type is added and this method isn't updated, flag a warning (or, could panic)
 		Warnf("Unexpected bucket type: %v", bucketType)
-		return GoCB
+		return GoCBv2
 	}
 
 }
@@ -85,9 +112,25 @@ func (couchbaseDriver CouchbaseDriver) String() string {
 		return "GoCB"
 	case GoCBCustomSGTranscoder:
 		return "GoCBCustomSGTranscoder"
+	case GoCBv2:
+		return "GoCBv2"
 	default:
 		return "UnknownCouchbaseDriver"
 	}
+}
+
+func AsCouchbaseDriver(d string) CouchbaseDriver {
+	switch d {
+	case "GoCB":
+		return GoCB
+	case "GoCBCustomSGTranscoder":
+		return GoCBCustomSGTranscoder
+	case "GoCBv2":
+		return GoCBv2
+	default:
+		return GoCBv2
+	}
+
 }
 
 func init() {
@@ -323,7 +366,7 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		}
 
 		if err != nil {
-			if pkgerrors.Cause(err) == gocbV1.ErrAuthError {
+			if pkgerrors.Cause(err) == ErrAuthError {
 				Warnf("Unable to authenticate as user %q: %v", UD(username), err)
 				return nil, ErrFatalBucketConnection
 			}
@@ -375,12 +418,12 @@ func IsCasMismatch(err error) bool {
 	unwrappedErr := pkgerrors.Cause(err)
 
 	// GoCB handling
-	if unwrappedErr == gocbV1.ErrKeyExists {
+	if unwrappedErr == gocbV1.ErrKeyExists || unwrappedErr == gocbV1.ErrNotStored {
 		return true
 	}
 
 	// GoCB V2 handling
-	if isKVError(unwrappedErr, memd.StatusKeyExists) {
+	if isKVError(unwrappedErr, memd.StatusKeyExists) || isKVError(unwrappedErr, memd.StatusNotStored) {
 		return true
 	}
 
@@ -402,11 +445,126 @@ func GetFeedType(bucket Bucket) (feedType string) {
 		} else {
 			return DcpFeedType
 		}
+	case *Collection:
+		return DcpFeedType
 	case *LeakyBucket:
 		return GetFeedType(typedBucket.bucket)
 	case *LoggingBucket:
 		return GetFeedType(typedBucket.bucket)
+	case *TestBucket:
+		return GetFeedType(typedBucket.Bucket)
 	default:
 		return TapFeedType
 	}
+}
+
+// Gets the bucket max TTL, or 0 if no TTL was set.  Sync gateway should fail to bring the DB online if this is non-zero,
+// since it's not meant to operate against buckets that auto-delete data.
+func getMaxTTL(store CouchbaseStore) (int, error) {
+	var bucketResponseWithMaxTTL struct {
+		MaxTTLSeconds int `json:"maxTTL,omitempty"`
+	}
+
+	uri := fmt.Sprintf("/pools/default/buckets/%s", store.GetSpec().BucketName)
+	resp, err := store.mgmtRequest(http.MethodGet, uri, "application/json", nil)
+	if err != nil {
+		return -1, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return -1, err
+	}
+
+	if err := JSONUnmarshal(respBytes, &bucketResponseWithMaxTTL); err != nil {
+		return -1, err
+	}
+
+	return bucketResponseWithMaxTTL.MaxTTLSeconds, nil
+}
+
+// Get the Server UUID of the bucket, this is also known as the Cluster UUID
+func getServerUUID(store CouchbaseStore) (uuid string, err error) {
+	resp, err := store.mgmtRequest(http.MethodGet, "/pools", "application/json", nil)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var responseJson struct {
+		ServerUUID string `json:"uuid"`
+	}
+
+	if err := JSONUnmarshal(respBytes, &responseJson); err != nil {
+		return "", err
+	}
+
+	return responseJson.ServerUUID, nil
+}
+
+// Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
+// found, retrieves the cluster-wide value.
+func getMetadataPurgeInterval(store CouchbaseStore) (time.Duration, error) {
+
+	// Bucket-specific settings
+	uri := fmt.Sprintf("/pools/default/buckets/%s", store.BucketName())
+	bucketPurgeInterval, err := retrievePurgeInterval(store, uri)
+	if bucketPurgeInterval > 0 || err != nil {
+		return bucketPurgeInterval, err
+	}
+
+	// Cluster-wide settings
+	uri = fmt.Sprintf("/settings/autoCompaction")
+	clusterPurgeInterval, err := retrievePurgeInterval(store, uri)
+	if clusterPurgeInterval > 0 || err != nil {
+		return clusterPurgeInterval, err
+	}
+
+	return 0, nil
+
+}
+
+// Helper function to retrieve a Metadata Purge Interval from server and convert to hours.  Works for any uri
+// that returns 'purgeInterval' as a root-level property (which includes the two server endpoints for
+// bucket and server purge intervals).
+func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, error) {
+
+	// Both of the purge interval endpoints (cluster and bucket) return purgeInterval in the same way
+	var purgeResponse struct {
+		PurgeInterval float64 `json:"purgeInterval,omitempty"`
+	}
+
+	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusForbidden {
+		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
+	} else if resp.StatusCode != http.StatusOK {
+		return 0, errors.New(resp.Status)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
+		return 0, err
+	}
+
+	// Server purge interval is a float value, in days.  Round up to hours
+	purgeIntervalHours := int(purgeResponse.PurgeInterval*24 + 0.5)
+	return time.Duration(purgeIntervalHours) * time.Hour, nil
 }

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -569,3 +569,10 @@ func retrievePurgeInterval(bucket CouchbaseStore, uri string) (time.Duration, er
 	purgeIntervalHours := int(purgeResponse.PurgeInterval*24 + 0.5)
 	return time.Duration(purgeIntervalHours) * time.Hour, nil
 }
+
+func ensureBodyClosed(body io.ReadCloser) {
+	err := body.Close()
+	if err != nil {
+		Debugf(KeyBucket, "Failed to close socket: %v", err)
+	}
+}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -59,7 +59,7 @@ var recoverableGocbV1Errors = map[string]struct{}{
 	gocbcore.ErrTmpFail.Error():  {},
 }
 
-// Implementation of sgbucket.Bucket that talks to a Couchbase server and useAsGocs gocb
+// Implementation of sgbucket.Bucket that talks to a Couchbase server and uses gocb v1
 type CouchbaseBucketGoCB struct {
 	*gocb.Bucket               // the underlying gocb bucket
 	Spec         BucketSpec    // keep a copy of the BucketSpec for DCP usage

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -59,7 +59,7 @@ var recoverableGocbV1Errors = map[string]struct{}{
 	gocbcore.ErrTmpFail.Error():  {},
 }
 
-// Implementation of sgbucket.Bucket that talks to a Couchbase server and uses gocb
+// Implementation of sgbucket.Bucket that talks to a Couchbase server and useAsGocs gocb
 type CouchbaseBucketGoCB struct {
 	*gocb.Bucket               // the underlying gocb bucket
 	Spec         BucketSpec    // keep a copy of the BucketSpec for DCP usage
@@ -71,6 +71,7 @@ type CouchbaseBucketGoCB struct {
 }
 
 var _ sgbucket.KVStore = &CouchbaseBucketGoCB{}
+var _ CouchbaseStore = &CouchbaseBucketGoCB{}
 
 // Creates a Bucket that talks to a real live Couchbase server.
 func GetCouchbaseBucketGoCB(spec BucketSpec) (bucket *CouchbaseBucketGoCB, err error) {
@@ -116,6 +117,9 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 	goCBBucket, err := cluster.OpenBucket(spec.BucketName, bucketPassword)
 	if err != nil {
 		Infof(KeyAll, "Error opening bucket %s: %v", spec.BucketName, err)
+		if pkgerrors.Cause(err) == gocb.ErrAuthError {
+			return nil, ErrAuthError
+		}
 		return nil, pkgerrors.WithStack(err)
 	}
 	Infof(KeyAll, "Successfully opened bucket %s", spec.BucketName)
@@ -195,7 +199,6 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 }
 
 func (bucket *CouchbaseBucketGoCB) GetBucketCredentials() (username, password string) {
-
 	if bucket.Spec.Auth != nil {
 		username, password, _ = bucket.Spec.Auth.GetCredentials()
 	}
@@ -204,113 +207,19 @@ func (bucket *CouchbaseBucketGoCB) GetBucketCredentials() (username, password st
 
 // Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
 // found, retrieves the cluster-wide value.
-func (bucket *CouchbaseBucketGoCB) GetMetadataPurgeInterval() (time.Duration, error) {
-
-	// Bucket-specific settings
-	uri := fmt.Sprintf("/pools/default/buckets/%s", bucket.Name())
-	bucketPurgeInterval, err := bucket.retrievePurgeInterval(uri)
-	if bucketPurgeInterval > 0 || err != nil {
-		return bucketPurgeInterval, err
-	}
-
-	// Cluster-wide settings
-	uri = fmt.Sprintf("/settings/autoCompaction")
-	clusterPurgeInterval, err := bucket.retrievePurgeInterval(uri)
-	if clusterPurgeInterval > 0 || err != nil {
-		return clusterPurgeInterval, err
-	}
-
-	return 0, nil
-
-}
-
-// Helper function to retrieve a Metadata Purge Interval from server and convert to hours.  Works for any uri
-// that returns 'purgeInterval' as a root-level property (which includes the two server endpoints for
-// bucket and server purge intervals).
-func (bucket *CouchbaseBucketGoCB) retrievePurgeInterval(uri string) (time.Duration, error) {
-
-	// Both of the purge interval endpoints (cluster and bucket) return purgeInterval in the same way
-	var purgeResponse struct {
-		PurgeInterval float64 `json:"purgeInterval,omitempty"`
-	}
-
-	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
-	if err != nil {
-		return 0, err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusForbidden {
-		Warnf("403 Forbidden attempting to access %s.  Bucket user must have Bucket Full Access and Bucket Admin roles to retrieve metadata purge interval.", UD(uri))
-	} else if resp.StatusCode != http.StatusOK {
-		return 0, errors.New(resp.Status)
-	}
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
-
-	if err := JSONUnmarshal(respBytes, &purgeResponse); err != nil {
-		return 0, err
-	}
-
-	// Server purge interval is a float value, in days.  Round up to hours
-	purgeIntervalHours := int(purgeResponse.PurgeInterval*24 + 0.5)
-	return time.Duration(purgeIntervalHours) * time.Hour, nil
+func (bucket *CouchbaseBucketGoCB) MetadataPurgeInterval() (time.Duration, error) {
+	return getMetadataPurgeInterval(bucket)
 }
 
 // Get the Server UUID of the bucket, this is also known as the Cluster UUID
-func (bucket *CouchbaseBucketGoCB) GetServerUUID() (uuid string, err error) {
-	resp, err := bucket.mgmtRequest(http.MethodGet, "/pools", "application/json", nil)
-	if err != nil {
-		return "", err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var responseJson struct {
-		ServerUUID string `json:"uuid"`
-	}
-
-	if err := JSONUnmarshal(respBytes, &responseJson); err != nil {
-		return "", err
-	}
-
-	return responseJson.ServerUUID, nil
+func (bucket *CouchbaseBucketGoCB) ServerUUID() (uuid string, err error) {
+	return getServerUUID(bucket)
 }
 
 // Gets the bucket max TTL, or 0 if no TTL was set.  Sync gateway should fail to bring the DB online if this is non-zero,
 // since it's not meant to operate against buckets that auto-delete data.
-func (bucket *CouchbaseBucketGoCB) GetMaxTTL() (int, error) {
-	var bucketResponseWithMaxTTL struct {
-		MaxTTLSeconds int `json:"maxTTL,omitempty"`
-	}
-
-	uri := fmt.Sprintf("/pools/default/buckets/%s", bucket.Spec.BucketName)
-	resp, err := bucket.mgmtRequest(http.MethodGet, uri, "application/json", nil)
-	if err != nil {
-		return -1, err
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return -1, err
-	}
-
-	if err := JSONUnmarshal(respBytes, &bucketResponseWithMaxTTL); err != nil {
-		return -1, err
-	}
-
-	return bucketResponseWithMaxTTL.MaxTTLSeconds, nil
+func (bucket *CouchbaseBucketGoCB) MaxTTL() (int, error) {
+	return getMaxTTL(bucket)
 }
 
 // mgmtRequest is a re-implementation of gocb's mgmtRequest
@@ -322,7 +231,7 @@ func (bucket *CouchbaseBucketGoCB) mgmtRequest(method, uri, contentType string, 
 		panic("Content-type must be specified for non-null body.")
 	}
 
-	mgmtEp, err := GoCBBucketMgmtEndpoint(bucket.Bucket)
+	mgmtEp, err := GoCBBucketMgmtEndpoint(bucket)
 	if err != nil {
 		return nil, err
 	}
@@ -1626,10 +1535,6 @@ func (bucket *CouchbaseBucketGoCB) GetMaxVbno() (uint16, error) {
 	return 0, fmt.Errorf("Unable to determine vbucket count")
 }
 
-func (bucket *CouchbaseBucketGoCB) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	return bucket.clusterCompatMajorVersion, bucket.clusterCompatMinorVersion, ""
-}
-
 func (bucket *CouchbaseBucketGoCB) UUID() (string, error) {
 	return bucket.Bucket.IoRouter().BucketUUID(), nil
 }
@@ -1828,7 +1733,9 @@ func (bucket *CouchbaseBucketGoCB) FormatBinaryDocument(input []byte) interface{
 }
 
 func (bucket *CouchbaseBucketGoCB) IsSupported(feature sgbucket.DataStoreFeature) bool {
-	major, minor, _ := bucket.CouchbaseServerVersion()
+
+	major := bucket.clusterCompatMajorVersion
+	minor := bucket.clusterCompatMinorVersion
 	switch feature {
 	case sgbucket.DataStoreFeatureSubdocOperations:
 		return isMinimumVersion(major, minor, 4, 5)
@@ -2085,17 +1992,29 @@ func AsLeakyBucket(bucket Bucket) (*LeakyBucket, bool) {
 	return AsLeakyBucket(underlyingBucket)
 }
 
-func GoCBBucketMgmtEndpoints(bucket *gocb.Bucket) (url []string, err error) {
-	mgmtEps := bucket.IoRouter().MgmtEps()
+func (bucket *CouchbaseBucketGoCB) MgmtEps() (url []string, err error) {
+	mgmtEps := bucket.Bucket.IoRouter().MgmtEps()
 	if len(mgmtEps) == 0 {
 		return nil, fmt.Errorf("No available Couchbase Server nodes")
 	}
 	return mgmtEps, nil
 }
 
+func (bucket *CouchbaseBucketGoCB) HttpClient() *http.Client {
+	return bucket.Bucket.IoRouter().HttpClient()
+}
+
+func (bucket *CouchbaseBucketGoCB) BucketName() string {
+	return bucket.Bucket.Name()
+}
+
+func GoCBBucketMgmtEndpoints(bucket CouchbaseStore) (url []string, err error) {
+	return bucket.MgmtEps()
+}
+
 // Get one of the management endpoints.  It will be a string such as http://couchbase
-func GoCBBucketMgmtEndpoint(bucket *gocb.Bucket) (url string, err error) {
-	mgmtEps, err := GoCBBucketMgmtEndpoints(bucket)
+func GoCBBucketMgmtEndpoint(bucket CouchbaseStore) (url string, err error) {
+	mgmtEps, err := bucket.MgmtEps()
 	if err != nil {
 		return "", err
 	}

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -1284,14 +1284,11 @@ func putDDocForTombstones(name string, payload []byte, capiEps []string, client 
 		return err
 	}
 
+	defer ensureBodyClosed(resp.Body)
 	if resp.StatusCode != 201 {
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
-		}
-		err = resp.Body.Close()
-		if err != nil {
-			Warnf("Failed to close socket: %v", err)
 		}
 		return fmt.Errorf("Client error: %s", string(data))
 	}

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -62,13 +62,11 @@ func TestSetGet(t *testing.T) {
 		val := make(map[string]interface{}, 0)
 		val["foo"] = "bar"
 
-		rawVal := []byte(`{"foo":"bar"}`)
-
 		var rVal map[string]interface{}
 		_, err := bucket.Get(key, &rVal)
 		assert.Error(t, err, "Key should not exist yet, expected error but got nil")
 
-		err = bucket.Set(key, 0, rawVal)
+		err = bucket.Set(key, 0, val)
 		assert.NoError(t, err, "Error calling Set()")
 
 		_, err = bucket.Get(key, &rVal)
@@ -2476,6 +2474,11 @@ func TestRawBackwardCompatibilityFromBinary(t *testing.T) {
 }
 
 func TestGetExpiry(t *testing.T) {
+
+	if UnitTestUrlIsWalrus() {
+		t.Skip("Walrus doesn't support expiry")
+	}
+
 	ForAllDataStores(t, func(t *testing.T, bucket sgbucket.DataStore) {
 
 		store, ok := AsCouchbaseStore(bucket)
@@ -2485,10 +2488,8 @@ func TestGetExpiry(t *testing.T) {
 		val := make(map[string]interface{}, 0)
 		val["foo"] = "bar"
 
-		rawVal := []byte(`{"foo":"bar"}`)
-
 		expiryValue := uint32(time.Now().Add(1 * time.Minute).Unix())
-		err := bucket.Set(key, expiryValue, rawVal)
+		err := bucket.Set(key, expiryValue, val)
 		assert.NoError(t, err, "Error calling Set()")
 
 		expiry, expiryErr := store.GetExpiry(key)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1682,7 +1682,7 @@ func TestGetXattr(t *testing.T) {
 		require.True(t, ok)
 		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
 		assert.Error(t, err)
-		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
+		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
 
 		////Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -1682,7 +1682,7 @@ func TestGetXattr(t *testing.T) {
 		require.True(t, ok)
 		_, err = subdocStore.SubdocGetBodyAndXattr(key2, "_non-exist", "", &v, &xv, &userXv)
 		assert.Error(t, err)
-		assert.Equal(t, ErrNotFound, pkgerrors.Cause(err))
+		assert.Equal(t, ErrXattrNotFound, pkgerrors.Cause(err))
 
 		////Get Xattr From Tombstoned Doc With Deleted User Xattr
 		cas, err = bucket.WriteCasWithXattr(key3, xattrName3, 0, uint64(0), val3, xattrVal3)

--- a/base/bucket_n1ql.go
+++ b/base/bucket_n1ql.go
@@ -143,3 +143,27 @@ func (bucket *CouchbaseBucketGoCB) DropIndex(indexName string) error {
 func (bucket *CouchbaseBucketGoCB) IsErrNoResults(err error) bool {
 	return err == gocb.ErrNoResults
 }
+
+// Get a list of all index names in the bucket
+func (bucket *CouchbaseBucketGoCB) getIndexes() (indexes []string, err error) {
+
+	indexes = []string{}
+
+	manager, err := bucket.getBucketManager()
+	if err != nil {
+		return indexes, err
+	}
+
+	indexInfo, err := manager.GetIndexes()
+	if err != nil {
+		return indexes, err
+	}
+
+	for _, indexInfo := range indexInfo {
+		if indexInfo.Keyspace == bucket.GetName() {
+			indexes = append(indexes, indexInfo.Name)
+		}
+	}
+
+	return indexes, nil
+}

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -266,10 +266,10 @@ func TestGetStatsVbSeqno(t *testing.T) {
 }
 
 func TestChooseCouchbaseDriver(t *testing.T) {
-	assert.Equal(t, GoCBCustomSGTranscoder, ChooseCouchbaseDriver(DataBucket))
-	assert.Equal(t, GoCB, ChooseCouchbaseDriver(IndexBucket))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(DataBucket))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(IndexBucket))
 	unknownCouchbaseBucketType := CouchbaseBucketType(math.MaxInt8)
-	assert.Equal(t, GoCB, ChooseCouchbaseDriver(unknownCouchbaseBucketType))
+	assert.Equal(t, GoCBv2, ChooseCouchbaseDriver(unknownCouchbaseBucketType))
 }
 
 func TestCouchbaseDriverToString(t *testing.T) {

--- a/base/collection.go
+++ b/base/collection.go
@@ -13,15 +13,24 @@ package base
 import (
 	"errors"
 	"expvar"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
 	"time"
 
 	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocbcore"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )
 
+var _ sgbucket.KVStore = &Collection{}
+var _ CouchbaseStore = &Collection{}
+
 // Connect to the default collection for the specified bucket
 func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
+
 	connString, err := spec.GetGoCBConnString()
 	if err != nil {
 		Warnf("Unable to parse server value: %s error: %v", SD(spec.Server), err)
@@ -33,7 +42,10 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		return nil, err
 	}
 
-	username, password, _ := spec.Auth.GetCredentials()
+	var username, password string
+	if spec.Auth != nil {
+		username, password, _ = spec.Auth.GetCredentials()
+	}
 	authenticatorConfig, isX509, err := GoCBv2AuthenticatorConfig(username, password, spec.Certpath, spec.Keypath)
 	if err != nil {
 		return nil, err
@@ -50,6 +62,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		Authenticator:  authenticatorConfig,
 		SecurityConfig: securityConfig,
 		TimeoutsConfig: timeoutsConfig,
+		RetryStrategy:  &goCBv2FailFastRetryStrategy{},
 	}
 
 	if spec.KvPoolSize > 0 {
@@ -62,7 +75,18 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		return nil, err
 	}
 
-	// TODO: Cluster compatibility not exposed, need to make manual /pools/default/ call?
+	err = cluster.WaitUntilReady(time.Second*5, &gocb.WaitUntilReadyOptions{
+		DesiredState:  gocb.ClusterStateOnline,
+		ServiceTypes:  []gocb.ServiceType{gocb.ServiceTypeManagement},
+		RetryStrategy: &goCBv2FailFastRetryStrategy{},
+	})
+	if err != nil {
+		if errors.Is(err, gocb.ErrAuthenticationFailure) {
+			return nil, ErrAuthError
+		}
+		Warnf("Error waiting for cluster to be ready: %v", err)
+		return nil, err
+	}
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
@@ -76,6 +100,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 	viewOpsQueue := make(chan struct{}, MaxConcurrentQueryOps)
 	collection := &Collection{
 		Collection: bucket.DefaultCollection(),
+		Spec:       spec,
 		cluster:    cluster,
 		viewOps:    viewOpsQueue,
 	}
@@ -92,25 +117,53 @@ type Collection struct {
 
 // DataStore
 func (c *Collection) GetName() string {
-	return c.Collection.Name()
+	// Returning bucket name until full collection support is implemented
+	return c.Collection.Bucket().Name()
 }
 
 func (c *Collection) UUID() (string, error) {
-	return "", errors.New("Not implemented")
+	config, configErr := c.getConfigSnapshot()
+	if configErr != nil {
+		return "", fmt.Errorf("Unable to determine bucket UUID: %w", configErr)
+	}
+	return config.BucketUUID(), nil
 }
+
 func (c *Collection) Close() {
 	// No close handling for collection
 	return
 }
 
 func (c *Collection) IsSupported(feature sgbucket.DataStoreFeature) bool {
-	return true
+
+	switch feature {
+	case sgbucket.DataStoreFeatureSubdocOperations, sgbucket.DataStoreFeatureXattrs, sgbucket.DataStoreFeatureCrc32cMacroExpansion:
+		// Available on all supported server versions
+		return true
+	case sgbucket.DataStoreFeatureN1ql:
+		router, routerErr := c.Bucket().Internal().IORouter()
+		if routerErr != nil {
+			return false
+		}
+		return len(router.N1qlEps()) > 0
+	case sgbucket.DataStoreFeatureCreateDeletedWithXattr:
+		status, err := c.Bucket().Internal().CapabilityStatus(gocb.CapabilityCreateAsDeleted)
+		if err != nil {
+			return false
+		}
+		return status == gocb.CapabilityStatusSupported
+	default:
+		return false
+	}
 }
 
 // KV store
 
 func (c *Collection) Get(k string, rv interface{}) (cas uint64, err error) {
-	getResult, err := c.Collection.Get(k, nil)
+	getOptions := &gocb.GetOptions{
+		Transcoder: NewSGJSONTranscoder(),
+	}
+	getResult, err := c.Collection.Get(k, getOptions)
 	if err != nil {
 		return 0, err
 	}
@@ -120,7 +173,7 @@ func (c *Collection) Get(k string, rv interface{}) (cas uint64, err error) {
 
 func (c *Collection) GetRaw(k string) (rv []byte, cas uint64, err error) {
 	getOptions := &gocb.GetOptions{
-		Transcoder: gocb.NewRawBinaryTranscoder(),
+		Transcoder: NewSGRawTranscoder(),
 	}
 	getRawResult, getErr := c.Collection.Get(k, getOptions)
 	if getErr != nil {
@@ -133,9 +186,9 @@ func (c *Collection) GetRaw(k string) (rv []byte, cas uint64, err error) {
 
 func (c *Collection) GetAndTouchRaw(k string, exp uint32) (rv []byte, cas uint64, err error) {
 	getAndTouchOptions := &gocb.GetAndTouchOptions{
-		Transcoder: gocb.NewRawBinaryTranscoder(),
+		Transcoder: NewSGRawTranscoder(),
 	}
-	getAndTouchRawResult, getErr := c.Collection.GetAndTouch(k, expAsDuration(exp), getAndTouchOptions)
+	getAndTouchRawResult, getErr := c.Collection.GetAndTouch(k, CbsExpiryToDuration(exp), getAndTouchOptions)
 	if getErr != nil {
 		return nil, 0, getErr
 	}
@@ -145,7 +198,7 @@ func (c *Collection) GetAndTouchRaw(k string, exp uint32) (rv []byte, cas uint64
 }
 
 func (c *Collection) Touch(k string, exp uint32) (cas uint64, err error) {
-	result, err := c.Collection.Touch(k, expAsDuration(exp), nil)
+	result, err := c.Collection.Touch(k, CbsExpiryToDuration(exp), nil)
 	if err != nil {
 		return 0, err
 	}
@@ -154,7 +207,8 @@ func (c *Collection) Touch(k string, exp uint32) (cas uint64, err error) {
 
 func (c *Collection) Add(k string, exp uint32, v interface{}) (added bool, err error) {
 	opts := &gocb.InsertOptions{
-		Expiry: expAsDuration(exp),
+		Expiry:     CbsExpiryToDuration(exp),
+		Transcoder: NewSGJSONTranscoder(),
 	}
 	_, gocbErr := c.Collection.Insert(k, v, opts)
 	if gocbErr != nil {
@@ -169,8 +223,8 @@ func (c *Collection) Add(k string, exp uint32, v interface{}) (added bool, err e
 
 func (c *Collection) AddRaw(k string, exp uint32, v []byte) (added bool, err error) {
 	opts := &gocb.InsertOptions{
-		Expiry:     expAsDuration(exp),
-		Transcoder: gocb.NewRawBinaryTranscoder(),
+		Expiry:     CbsExpiryToDuration(exp),
+		Transcoder: NewSGRawTranscoder(),
 	}
 	_, gocbErr := c.Collection.Insert(k, v, opts)
 	if gocbErr != nil {
@@ -185,16 +239,21 @@ func (c *Collection) AddRaw(k string, exp uint32, v []byte) (added bool, err err
 
 func (c *Collection) Set(k string, exp uint32, v interface{}) error {
 	upsertOptions := &gocb.UpsertOptions{
-		Expiry: expAsDuration(exp),
+		Expiry:     CbsExpiryToDuration(exp),
+		Transcoder: NewSGJSONTranscoder(),
 	}
+	if _, ok := v.([]byte); ok {
+		upsertOptions.Transcoder = gocb.NewRawJSONTranscoder()
+	}
+
 	_, err := c.Collection.Upsert(k, v, upsertOptions)
 	return err
 }
 
 func (c *Collection) SetRaw(k string, exp uint32, v []byte) error {
 	upsertOptions := &gocb.UpsertOptions{
-		Expiry:     expAsDuration(exp),
-		Transcoder: gocb.NewRawBinaryTranscoder(),
+		Expiry:     CbsExpiryToDuration(exp),
+		Transcoder: NewSGRawTranscoder(),
 	}
 	_, err := c.Collection.Upsert(k, v, upsertOptions)
 	return err
@@ -204,7 +263,8 @@ func (c *Collection) WriteCas(k string, flags int, exp uint32, cas uint64, v int
 	var result *gocb.MutationResult
 	if cas == 0 {
 		insertOpts := &gocb.InsertOptions{
-			Expiry: expAsDuration(exp),
+			Expiry:     CbsExpiryToDuration(exp),
+			Transcoder: NewSGJSONTranscoder(),
 		}
 		if opt == sgbucket.Raw {
 			insertOpts.Transcoder = gocb.NewRawBinaryTranscoder()
@@ -212,8 +272,9 @@ func (c *Collection) WriteCas(k string, flags int, exp uint32, cas uint64, v int
 		result, err = c.Collection.Insert(k, v, insertOpts)
 	} else {
 		replaceOpts := &gocb.ReplaceOptions{
-			Cas:    gocb.Cas(cas),
-			Expiry: expAsDuration(exp),
+			Cas:        gocb.Cas(cas),
+			Expiry:     CbsExpiryToDuration(exp),
+			Transcoder: NewSGJSONTranscoder(),
 		}
 		if opt == sgbucket.Raw {
 			replaceOpts.Transcoder = gocb.NewRawBinaryTranscoder()
@@ -279,17 +340,20 @@ func (c *Collection) Update(k string, exp uint32, callback sgbucket.UpdateFunc) 
 
 		var casGoCB gocb.Cas
 		var result *gocb.MutationResult
+		casRetry := false
 		if cas == 0 {
 			// If the Get fails, the cas will be 0 and so call Insert().
 			// If we get an error on the insert, due to a race, this will
 			// go back through the cas loop
 			insertOpts := &gocb.InsertOptions{
 				Transcoder: gocb.NewRawJSONTranscoder(),
-				Expiry:     expAsDuration(exp),
+				Expiry:     CbsExpiryToDuration(exp),
 			}
 			result, err = c.Collection.Insert(k, value, insertOpts)
 			if err == nil {
 				casGoCB = result.Cas()
+			} else if errors.Is(err, gocb.ErrDocumentExists) {
+				casRetry = true
 			}
 		} else {
 			if value == nil && isDelete {
@@ -299,6 +363,8 @@ func (c *Collection) Update(k string, exp uint32, callback sgbucket.UpdateFunc) 
 				result, err = c.Collection.Remove(k, removeOptions)
 				if err == nil {
 					casGoCB = result.Cas()
+				} else if errors.Is(err, gocb.ErrCasMismatch) {
+					casRetry = true
 				}
 			} else {
 				// Otherwise, attempt to do a replace.  won't succeed if
@@ -306,16 +372,18 @@ func (c *Collection) Update(k string, exp uint32, callback sgbucket.UpdateFunc) 
 				replaceOptions := &gocb.ReplaceOptions{
 					Transcoder: gocb.NewRawJSONTranscoder(),
 					Cas:        gocb.Cas(cas),
-					Expiry:     expAsDuration(exp),
+					Expiry:     CbsExpiryToDuration(exp),
 				}
 				result, err = c.Collection.Replace(k, value, replaceOptions)
 				if err == nil {
 					casGoCB = result.Cas()
+				} else if errors.Is(err, gocb.ErrCasMismatch) {
+					casRetry = true
 				}
 			}
 		}
 
-		if errors.Is(err, gocb.ErrDocumentExists) {
+		if casRetry {
 			// retry on cas failure
 		} else {
 			// err will be nil if successful
@@ -331,7 +399,7 @@ func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 	incrOptions := gocb.IncrementOptions{
 		Initial: int64(def),
 		Delta:   amt,
-		Expiry:  expAsDuration(exp),
+		Expiry:  CbsExpiryToDuration(exp),
 	}
 	incrResult, err := c.Collection.Binary().Increment(k, &incrOptions)
 	if err != nil {
@@ -342,7 +410,7 @@ func (c *Collection) Incr(k string, amt, def uint64, exp uint32) (uint64, error)
 }
 
 func (c *Collection) StartDCPFeed(args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
-	return errors.New("StartDCPFeed not implemented")
+	return StartDCPFeed(c, c.Spec, args, callback, dbStats)
 }
 func (c *Collection) StartTapFeed(args sgbucket.FeedArguments, dbStats *expvar.Map) (sgbucket.MutationFeed, error) {
 	return nil, errors.New("StartTapFeed not implemented")
@@ -353,18 +421,35 @@ func (c *Collection) Dump() {
 
 // CouchbaseStore
 
-func (c *Collection) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	return 0, 0, ""
-}
 func (c *Collection) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
 	return nil, nil, nil
 }
 func (c *Collection) GetMaxVbno() (uint16, error) {
-	return 0, nil
+
+	config, configErr := c.getConfigSnapshot()
+	if configErr != nil {
+		return 0, fmt.Errorf("Unable to determine vbucket count: %w", configErr)
+	}
+
+	vbNo, err := config.NumVbuckets()
+	if err != nil {
+		return 0, fmt.Errorf("Unable to determine vbucket count: %w", err)
+	}
+
+	return uint16(vbNo), nil
 }
 
-func expAsDuration(exp uint32) time.Duration {
-	return time.Duration(exp) * time.Second
+func (c *Collection) getConfigSnapshot() (*gocbcore.ConfigSnapshot, error) {
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		return nil, fmt.Errorf("no router: %w", routerErr)
+	}
+
+	config, configErr := router.ConfigSnapshot()
+	if configErr != nil {
+		return nil, fmt.Errorf("no router config snapshot: %w", configErr)
+	}
+	return config, nil
 }
 
 func (c *Collection) IsError(err error, errorType sgbucket.DataStoreErrorType) bool {
@@ -469,4 +554,206 @@ func (c *Collection) BucketItemCount() (itemCount int, err error) {
 	time.Sleep(1 * time.Second)
 	//itemCount, err = bucket.APIBucketItemCount()
 	return 0, err
+}
+
+func (c *Collection) MgmtEps() (url []string, err error) {
+
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		return url, routerErr
+	}
+	mgmtEps := router.MgmtEps()
+	if len(mgmtEps) == 0 {
+		return nil, fmt.Errorf("No available Couchbase Server nodes")
+	}
+	return mgmtEps, nil
+}
+
+// Gets the metadata purge interval for the bucket.  First checks for a bucket-specific value.  If not
+// found, retrieves the cluster-wide value.
+func (c *Collection) MetadataPurgeInterval() (time.Duration, error) {
+	return getMetadataPurgeInterval(c)
+}
+
+func (c *Collection) ServerUUID() (uuid string, err error) {
+	return getServerUUID(c)
+}
+
+func (c *Collection) MaxTTL() (int, error) {
+	return getMaxTTL(c)
+}
+
+func (c *Collection) HttpClient() *http.Client {
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		Warnf("Unable to obtain router while retrieving httpClient:%v", routerErr)
+		return nil
+	}
+	return router.HTTPClient()
+}
+
+// GetExpiry requires a full document retrieval in order to obtain the expiry, which is reasonable for
+// current use cases (on-demand import).  If there's a need for expiry as part of normal get, this shouldn't be
+// used - an enhanced version of Get() should be implemented to avoid two ops
+func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
+
+	router, routerErr := c.Bucket().Internal().IORouter()
+	if routerErr != nil {
+		Warnf("Unable to obtain router while retrieving expiry:%v", routerErr)
+		return 0, routerErr
+	}
+	getMetaOptions := gocbcore.GetMetaOptions{
+		Key: []byte(k),
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	getMetaCallback := func(result *gocbcore.GetMetaResult, err error) {
+		defer wg.Done()
+		if err != nil {
+			getMetaError = err
+			return
+		}
+		expiry = result.Expiry
+	}
+
+	router.GetMeta(getMetaOptions, getMetaCallback)
+	wg.Wait()
+
+	return expiry, getMetaError
+}
+
+func (c *Collection) BucketName() string {
+	return c.Bucket().Name()
+}
+
+func getTranscoder(value interface{}) gocb.Transcoder {
+	switch value.(type) {
+	case []byte, *[]byte:
+		return gocb.NewRawJSONTranscoder()
+	default:
+		return nil
+	}
+}
+
+func (c *Collection) mgmtRequest(method, uri, contentType string, body io.Reader) (*http.Response, error) {
+	if contentType == "" && body != nil {
+		panic("Content-type must be specified for non-null body.")
+	}
+
+	mgmtEp, err := GoCBBucketMgmtEndpoint(c)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, mgmtEp+uri, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if contentType != "" {
+		req.Header.Add("Content-Type", contentType)
+	}
+
+	if c.Spec.Auth != nil {
+		username, password, _ := c.Spec.Auth.GetCredentials()
+		req.SetBasicAuth(username, password)
+	}
+
+	return c.HttpClient().Do(req)
+}
+
+// SGJsonTranscoder reads and writes JSON, with relaxed datatype restrictions on decode, and
+// embedded support for writing raw JSON on encode
+type SGJSONTranscoder struct {
+}
+
+func NewSGJSONTranscoder() *SGJSONTranscoder {
+	return &SGJSONTranscoder{}
+}
+
+// SGJSONTranscoder supports reading BinaryType documents as JSON, for backward
+// compatibility with legacy Sync Gateway data
+func (t *SGJSONTranscoder) Decode(bytes []byte, flags uint32, out interface{}) error {
+	valueType, compression := gocbcore.DecodeCommonFlags(flags)
+
+	// Make sure compression is disabled
+	if compression != gocbcore.NoCompression {
+		return errors.New("unexpected value compression")
+	}
+	// Type-based decoding
+	if valueType == gocbcore.BinaryType {
+		switch typedOut := out.(type) {
+		case *[]byte:
+			*typedOut = bytes
+			return nil
+		case *interface{}:
+			*typedOut = bytes
+			return nil
+		case *string:
+			*typedOut = string(bytes)
+			return nil
+		default:
+			return errors.New("you must encode raw JSON data in a byte array or string")
+		}
+	} else if valueType == gocbcore.StringType {
+		return gocb.NewRawStringTranscoder().Decode(bytes, flags, out)
+	} else if valueType == gocbcore.JSONType {
+		switch out.(type) {
+		case []byte, *[]byte:
+			return gocb.NewRawJSONTranscoder().Decode(bytes, flags, out)
+		default:
+			return gocb.NewJSONTranscoder().Decode(bytes, flags, out)
+		}
+	}
+
+	return errors.New("unexpected expectedFlags value")
+}
+
+// SGJSONTranscoder.Encode supports writing JSON as either raw bytes or an unmarshalled interface
+func (t *SGJSONTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
+	switch value.(type) {
+	case []byte, *[]byte:
+		return gocb.NewRawJSONTranscoder().Encode(value)
+	default:
+		return gocb.NewJSONTranscoder().Encode(value)
+	}
+}
+
+// SGBinaryTranscoder uses the appropriate raw transcoder for the data type.  Provides backward compatibility
+// for pre-3.0 documents intended to be binary but written with JSON datatype, and vice versa
+type SGRawTranscoder struct {
+}
+
+// NewRawBinaryTranscoder returns a new RawBinaryTranscoder.
+func NewSGRawTranscoder() *SGRawTranscoder {
+	return &SGRawTranscoder{}
+}
+
+// Decode applies raw binary transcoding behaviour to decode into a Go type.
+func (t *SGRawTranscoder) Decode(bytes []byte, flags uint32, out interface{}) error {
+	valueType, compression := gocbcore.DecodeCommonFlags(flags)
+
+	// Make sure compression is disabled
+	if compression != gocbcore.NoCompression {
+		return errors.New("unexpected value compression")
+	}
+	// Normal types of decoding
+	if valueType == gocbcore.BinaryType {
+		return gocb.NewRawBinaryTranscoder().Decode(bytes, flags, out)
+	} else if valueType == gocbcore.StringType {
+		return gocb.NewRawStringTranscoder().Decode(bytes, flags, out)
+		return errors.New("only binary datatype is supported by RawBinaryTranscoder")
+	} else if valueType == gocbcore.JSONType {
+		return gocb.NewRawJSONTranscoder().Decode(bytes, flags, out)
+	}
+
+	return errors.New("unexpected expectedFlags value")
+}
+
+// Encode applies raw binary transcoding behaviour to encode a Go type.
+func (t *SGRawTranscoder) Encode(value interface{}) ([]byte, uint32, error) {
+	return gocb.NewRawBinaryTranscoder().Encode(value)
+
 }

--- a/base/collection.go
+++ b/base/collection.go
@@ -744,16 +744,16 @@ func (t *SGRawTranscoder) Decode(bytes []byte, flags uint32, out interface{}) er
 		return errors.New("unexpected value compression")
 	}
 	// Normal types of decoding
-	if valueType == gocbcore.BinaryType {
+	switch valueType {
+	case gocbcore.BinaryType:
 		return gocb.NewRawBinaryTranscoder().Decode(bytes, flags, out)
-	} else if valueType == gocbcore.StringType {
+	case gocbcore.StringType:
 		return gocb.NewRawStringTranscoder().Decode(bytes, flags, out)
-		return errors.New("only binary datatype is supported by RawBinaryTranscoder")
-	} else if valueType == gocbcore.JSONType {
+	case gocbcore.JSONType:
 		return gocb.NewRawJSONTranscoder().Decode(bytes, flags, out)
+	default:
+		return errors.New("unexpected expectedFlags value")
 	}
-
-	return errors.New("unexpected expectedFlags value")
 }
 
 // Encode applies raw binary transcoding behaviour to encode a Go type.

--- a/base/collection.go
+++ b/base/collection.go
@@ -618,7 +618,11 @@ func (c *Collection) GetExpiry(k string) (expiry uint32, getMetaError error) {
 		expiry = result.Expiry
 	}
 
-	router.GetMeta(getMetaOptions, getMetaCallback)
+	_, err := router.GetMeta(getMetaOptions, getMetaCallback)
+	if err != nil {
+		wg.Done()
+		return 0, err
+	}
 	wg.Wait()
 
 	return expiry, getMetaError

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -140,3 +140,7 @@ func (c *Collection) executeStatement(statement string) error {
 func (c *Collection) IsErrNoResults(err error) bool {
 	return err == gocb.ErrNoResult
 }
+
+func (c *Collection) getIndexes() (indexes []string, err error) {
+	return nil, errors.New("not implemented")
+}

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -142,5 +142,15 @@ func (c *Collection) IsErrNoResults(err error) bool {
 }
 
 func (c *Collection) getIndexes() (indexes []string, err error) {
-	return nil, errors.New("not implemented")
+
+	indexes = []string{}
+	indexInfo, err := c.cluster.QueryIndexes().GetAllIndexes(c.BucketName(), nil)
+	if err != nil {
+		return indexes, err
+	}
+
+	for _, indexInfo := range indexInfo {
+		indexes = append(indexes, indexInfo.Name)
+	}
+	return indexes, nil
 }

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -35,6 +35,7 @@ const (
 
 // N1QLStore defines the set of operations Sync Gateway uses to manage and interact with N1QL
 type N1QLStore interface {
+	GetName() string
 	BuildDeferredIndexes(indexSet []string) error
 	CreateIndex(indexName string, expression string, filterExpression string, options *N1qlIndexOptions) error
 	CreatePrimaryIndex(indexName string, options *N1qlIndexOptions) error
@@ -51,6 +52,9 @@ type N1QLStore interface {
 
 	// executeStatement executes the specified statement and closes the response, returning any errors received.
 	executeStatement(statement string) error
+
+	// getIndexes retrieves all index names, used by test harness
+	getIndexes() (indexes []string, err error)
 }
 
 func ExplainQuery(store N1QLStore, statement string, params map[string]interface{}) (plan map[string]interface{}, err error) {

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -34,7 +34,7 @@ func (c *Collection) GetDDoc(docname string) (ddoc sgbucket.DesignDoc, err error
 	manager := c.Bucket().ViewIndexes()
 	designDoc, err := manager.GetDesignDocument(docname, gocb.DesignDocumentNamespaceProduction, nil)
 	if err != nil {
-		if strings.Contains(err.Error(), "not_found") {
+		if strings.Contains(err.Error(), "not found") {
 			return ddoc, ErrNotFound
 		}
 		return ddoc, err
@@ -97,8 +97,42 @@ func (c *Collection) PutDDoc(docname string, sgDesignDoc *sgbucket.DesignDoc) er
 // design doc property. XattrEnabledDesignDocV2 extends gocb.DesignDocument to support
 // use of putDDocForTombstones
 type XattrEnabledDesignDocV2 struct {
-	*gocb.DesignDocument
+	*jsonDesignDocument
 	IndexXattrOnTombstones bool `json:"index_xattr_on_deleted_docs,omitempty"`
+}
+
+// gocb's DesignDocument and View aren't directly marshallable for use in viewEp requests - they
+// copy into *private* structs with the correct json annotations.  Cloning those here to support
+// use of index_xattr_on_deleted_docs.
+type jsonView struct {
+	Map    string `json:"map,omitempty"`
+	Reduce string `json:"reduce,omitempty"`
+}
+
+type jsonDesignDocument struct {
+	Views map[string]jsonView `json:"views,omitempty"`
+}
+
+func asJsonDesignDocument(ddoc *gocb.DesignDocument) *jsonDesignDocument {
+	jsonDDoc := &jsonDesignDocument{}
+	jsonDDoc.Views = make(map[string]jsonView, 0)
+	for name, view := range ddoc.Views {
+		jsonDDoc.Views[name] = jsonView{
+			Map:    view.Map,
+			Reduce: view.Reduce,
+		}
+	}
+	return jsonDDoc
+}
+
+type NoNameView struct {
+	Map    string `json:"map,omitempty"`
+	Reduce string `json:"reduce,omitempty"`
+}
+
+type NoNameDesignDocument struct {
+	Name  string                `json:"-"`
+	Views map[string]NoNameView `json:"views"`
 }
 
 func (c *Collection) putDDocForTombstones(ddoc *gocb.DesignDocument) error {
@@ -108,8 +142,10 @@ func (c *Collection) putDDocForTombstones(ddoc *gocb.DesignDocument) error {
 		return fmt.Errorf("Unable to get handle for bucket router: %v", err)
 	}
 
+	jsonDdoc := asJsonDesignDocument(ddoc)
+
 	xattrEnabledDesignDoc := XattrEnabledDesignDocV2{
-		DesignDocument:         ddoc,
+		jsonDesignDocument:     jsonDdoc,
 		IndexXattrOnTombstones: true,
 	}
 	data, err := JSONMarshal(&xattrEnabledDesignDoc)

--- a/base/constants.go
+++ b/base/constants.go
@@ -23,7 +23,7 @@ const (
 	GuestUsername = "GUEST"
 	ISO8601Format = "2006-01-02T15:04:05.000Z07:00"
 
-	kTestCouchbaseServerURL = "http://localhost:8091"
+	kTestCouchbaseServerURL = "couchbase://localhost"
 	kTestWalrusURL          = "walrus:"
 
 	// These settings are used when running unit tests against a live Couchbase Server to create/flush buckets

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"expvar"
 	"fmt"
 	"strconv"
@@ -313,7 +314,12 @@ func (c *DCPCommon) updateSeq(vbucketId uint16, seq uint64, warnOnLowerSeqNo boo
 // Initializes DCP Feed.  Determines starting position based on feed type.
 func (c *DCPCommon) initFeed(backfillType uint64) error {
 
-	statsUuids, highSeqnos, err := c.bucket.GetStatsVbSeqno(c.maxVbNo, false)
+	couchbaseBucket, ok := AsCouchbaseStore(c.bucket)
+	if !ok {
+		return errors.New("DCP not supported for non-Couchbase data source")
+	}
+
+	statsUuids, highSeqnos, err := couchbaseBucket.GetStatsVbSeqno(c.maxVbNo, false)
 	if err != nil {
 		return pkgerrors.Wrap(err, "Error retrieving stats-vbseqno - DCP not supported")
 	}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -217,6 +217,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 	// Recommended usage of cbdatasource is to let it manage it's own dedicated connection, so we're not
 	// reusing the bucket connection we've already established.
 	urls, errConvertServerSpec := CouchbaseURIToHttpURL(bucket, spec.Server, &connSpec)
+
 	if errConvertServerSpec != nil {
 		return errConvertServerSpec
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -37,20 +37,20 @@ type CbgtContext struct {
 
 // StartShardedDCPFeed initializes and starts a CBGT Manager targeting the provided bucket.
 // dbName is used to define a unique path name for local file storage of pindex files
-func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket *CouchbaseBucketGoCB, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
+func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket Bucket, spec BucketSpec, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
 
-	cbgtContext, err := initCBGTManager(bucket, bucket.Spec, cfg, uuid)
+	cbgtContext, err := initCBGTManager(bucket, spec, cfg, uuid)
 	if err != nil {
 		return nil, err
 	}
 
-	dcpContextID := MD(bucket.Spec.BucketName).Redact() + "-" + DCPImportFeedID
+	dcpContextID := MD(spec.BucketName).Redact() + "-" + DCPImportFeedID
 	cbgtContext.loggingCtx = context.WithValue(context.Background(), LogContextKey{},
 		LogContext{CorrelationID: dcpContextID},
 	)
 
 	// Start Manager.  Registers this node in the cfg
-	err = cbgtContext.StartManager(dbName, bucket, bucket.Spec, numPartitions)
+	err = cbgtContext.StartManager(dbName, bucket, spec, numPartitions)
 	if err != nil {
 		return nil, err
 	}

--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -421,10 +421,6 @@ func (b *LeakyBucket) Dump() {
 	b.bucket.Dump()
 }
 
-func (b *LeakyBucket) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	return b.bucket.CouchbaseServerVersion()
-}
-
 func (b *LeakyBucket) UUID() (string, error) {
 	return b.bucket.UUID()
 }
@@ -434,10 +430,6 @@ func (b *LeakyBucket) CloseAndDelete() error {
 		return bucket.CloseAndDelete()
 	}
 	return nil
-}
-
-func (b *LeakyBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
-	return b.bucket.GetStatsVbSeqno(maxVbno, useAbsHighSeqNo)
 }
 
 // Accessors to set leaky bucket config for a running bucket.  Used to tune properties on a walrus bucket created as part of rest tester - it will
@@ -568,6 +560,14 @@ func (b *LeakyBucket) executeStatement(statement string) error {
 		return errors.New("Not N1QL Store")
 	}
 	return n1qlStore.executeStatement(statement)
+}
+
+func (b *LeakyBucket) getIndexes() ([]string, error) {
+	n1qlStore, ok := AsN1QLStore(b.bucket)
+	if !ok {
+		return nil, errors.New("Not N1QL Store")
+	}
+	return n1qlStore.getIndexes()
 }
 
 func (b *LeakyBucket) IsErrNoResults(err error) bool {

--- a/base/logging_bucket.go
+++ b/base/logging_bucket.go
@@ -186,19 +186,9 @@ func (b *LoggingBucket) GetMaxVbno() (uint16, error) {
 	return b.bucket.GetMaxVbno()
 }
 
-func (b *LoggingBucket) CouchbaseServerVersion() (major uint64, minor uint64, micro string) {
-	defer b.log(time.Now())
-	return b.bucket.CouchbaseServerVersion()
-}
-
 func (b *LoggingBucket) UUID() (string, error) {
 	defer b.log(time.Now())
 	return b.bucket.UUID()
-}
-
-func (b *LoggingBucket) GetStatsVbSeqno(maxVbno uint16, useAbsHighSeqNo bool) (uuids map[uint16]uint64, highSeqnos map[uint16]uint64, seqErr error) {
-	defer b.log(time.Now())
-	return b.bucket.GetStatsVbSeqno(maxVbno, useAbsHighSeqNo)
 }
 
 // GetUnderlyingBucket returns the underlying bucket for the LoggingBucket.

--- a/base/main_test_bucket_pool.go
+++ b/base/main_test_bucket_pool.go
@@ -40,6 +40,7 @@ const (
 	DefaultTestClusterUsername = DefaultCouchbaseAdministrator
 	envTestClusterPassword     = "SG_TEST_PASSWORD"
 	DefaultTestClusterPassword = DefaultCouchbasePassword
+	envTestClusterDriver       = "SG_TEST_DRIVER"
 
 	// Creates this many buckets in the backing store to be pooled for testing.
 	tbpDefaultBucketPoolSize = 3
@@ -243,6 +244,7 @@ func (tbp *TestBucketPool) GetTestBucketAndSpec(t testing.TB) (b Bucket, s Bucke
 
 	// Return a new Walrus bucket when tbp has not been initialized
 	if !tbp.integrationMode {
+		tbp.Logf(ctx, "Getting walrus test bucket - tbp.integrationMode is not set")
 		return tbp.GetWalrusTestBucket(t, kTestWalrusURL)
 	}
 
@@ -638,7 +640,7 @@ type tbpBucketName string
 
 var tbpDefaultBucketSpec = BucketSpec{
 	Server:          UnitTestUrl(),
-	CouchbaseDriver: GoCBCustomSGTranscoder,
+	CouchbaseDriver: TestClusterDriver(),
 	Auth: TestAuthenticator{
 		Username: TestClusterUsername(),
 		Password: TestClusterPassword(),
@@ -711,4 +713,12 @@ func TestClusterPassword() string {
 		password = envClusterPassword
 	}
 	return password
+}
+
+func TestClusterDriver() CouchbaseDriver {
+	driver := ChooseCouchbaseDriver(DataBucket)
+	if envClusterDriver := os.Getenv(envTestClusterDriver); envClusterDriver != "" {
+		driver = AsCouchbaseDriver(envClusterDriver)
+	}
+	return driver
 }

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -192,6 +192,10 @@ func initV2Cluster(server string) *gocb.Cluster {
 	if err != nil {
 		Fatalf("Couldn't connect to %q: %v", server, err)
 	}
+	err = cluster.WaitUntilReady(15*time.Second, nil)
+	if err != nil {
+		Fatalf("Cluster not ready: %v", err)
+	}
 
 	return cluster
 }
@@ -243,6 +247,7 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 		Collection: bucket.DefaultCollection(),
 		cluster:    c.cluster,
 		viewOps:    make(chan struct{}, MaxConcurrentQueryOps),
+		Spec:       bucketSpec,
 	}
 
 	return collection, nil

--- a/base/util.go
+++ b/base/util.go
@@ -1498,7 +1498,7 @@ func GetRestrictedInt(rawValue *uint64, defaultValue, minValue, maxValue uint64,
 	return value
 }
 
-// HttpClient returns a new HTTP client with TLS certificate verification
+// GetHttpClient returns a new HTTP client with TLS certificate verification
 // disabled when insecureSkipVerify is true and enabled otherwise.
 func GetHttpClient(insecureSkipVerify bool) *http.Client {
 	if insecureSkipVerify {

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -123,9 +123,15 @@ func setupTestLeakyDBWithCacheOptions(t *testing.T, options CacheOptions, leakyO
 	testBucket := base.GetTestBucket(t)
 	leakyBucket := base.NewLeakyBucket(testBucket, leakyOptions)
 	context, err := NewDatabaseContext("db", leakyBucket, false, dbcOptions)
-	assert.NoError(t, err, "Couldn't create context for database 'db'")
+	if err != nil {
+		testBucket.Close()
+		t.Fatalf("Unable to create database context: %v", err)
+	}
 	db, err := CreateDatabase(context)
-	assert.NoError(t, err, "Couldn't create database 'db'")
+	if err != nil {
+		context.Close()
+		t.Fatalf("Unable to create database: %v", err)
+	}
 	return db
 }
 
@@ -2052,6 +2058,7 @@ func TestConcurrentPushSameNewRevision(t *testing.T) {
 
 	body := Body{"name": "Bob", "age": 52}
 	_, _, err := db.Put("doc1", body)
+	require.Error(t, err)
 	assert.Equal(t, "409 Document exists", err.Error())
 
 	doc, err := db.GetDocument("doc1", DocUnmarshalAll)
@@ -2337,6 +2344,10 @@ func TestRepairUnorderedRecentSequences(t *testing.T) {
 }
 
 func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
+
+	// TODO: re-enable after adding ability to override bucket capabilities
+	t.Skip("GoCB bucket required for cluster compatibility override")
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("Requires gocb bucket")
 	}
@@ -2348,8 +2359,7 @@ func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 	db := setupTestDBWithOptionsAndImport(t, DatabaseContextOptions{})
 	defer db.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
-	require.True(t, ok)
+	gocbBucket, _ := base.AsGoCBBucket(db.Bucket)
 
 	// Set something lower than version required for CreateAsDeleted subdoc flag
 	gocbBucket.OverrideClusterCompatVersion(5, 5)

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2345,7 +2345,7 @@ func TestRepairUnorderedRecentSequences(t *testing.T) {
 
 func TestDeleteWithNoTombstoneCreationSupport(t *testing.T) {
 
-	// TODO: re-enable after adding ability to override bucket capabilities
+	// TODO: re-enable after adding ability to override bucket capabilities (CBG-1593)
 	t.Skip("GoCB bucket required for cluster compatibility override")
 
 	if base.UnitTestUrlIsWalrus() {

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -626,7 +626,10 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 	retrySleep := float64(100)
 	maxRetry := 18
 	for {
-		_, err := bucket.ViewQuery(ddocName, viewName, opts)
+		results, err := bucket.ViewQuery(ddocName, viewName, opts)
+		if results != nil {
+			results.Close()
+		}
 		if err == nil {
 			return nil
 		}

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -628,7 +628,7 @@ func waitForViewIndexing(bucket base.Bucket, ddocName string, viewName string) e
 	for {
 		results, err := bucket.ViewQuery(ddocName, viewName, opts)
 		if results != nil {
-			results.Close()
+			_ = results.Close()
 		}
 		if err == nil {
 			return nil

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -59,12 +59,12 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 	base.Infof(base.KeyDCP, "Starting DCP import feed for bucket: %q ", base.UD(bucket.GetName()))
 
 	// TODO: need to clean up StartDCPFeed to push bucket dependencies down
-	gocbBucket, ok := base.AsGoCBBucket(bucket)
+	cbStore, ok := base.AsCouchbaseStore(bucket)
 	if !ok || !base.IsEnterpriseEdition() {
-		// Non-gocb bucket or CE, start a non-sharded feed
+		// Non-couchbase bucket or CE, start a non-sharded feed
 		return bucket.StartDCPFeed(feedArgs, il.ProcessFeedEvent, importFeedStatsMap.Map)
 	} else {
-		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.UUID, dbContext.Heartbeater, gocbBucket, dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
+		il.cbgtContext, err = base.StartShardedDCPFeed(dbContext.Name, dbContext.UUID, dbContext.Heartbeater, bucket, cbStore.GetSpec(), dbContext.Options.ImportOptions.ImportPartitions, dbContext.CfgSG)
 		return err
 	}
 

--- a/db/query.go
+++ b/db/query.go
@@ -242,14 +242,14 @@ func (context *DatabaseContext) N1QLQueryWithStats(queryName string, statement s
 		defer base.SlowQueryLog(startTime, threshold, "N1QL Query(%q)", queryName)
 	}
 
-	gocbBucket, ok := base.AsGoCBBucket(context.Bucket)
+	n1QLStore, ok := base.AsN1QLStore(context.Bucket)
 	if !ok {
 		return nil, errors.New("Cannot perform N1QL query on non-Couchbase bucket.")
 	}
 
 	queryStat := context.DbStats.Query(queryName)
 
-	results, err = gocbBucket.Query(statement, params, consistency, adhoc)
+	results, err = n1QLStore.Query(statement, params, consistency, adhoc)
 	if err != nil {
 		queryStat.QueryErrorCount.Add(1)
 	}

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -313,14 +313,14 @@ func TestCoveringQueries(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(db.Bucket)
+	n1QLStore, ok := base.AsN1QLStore(db.Bucket)
 	if !ok {
-		t.Errorf("Unable to get gocbBucket for testBucket")
+		t.Errorf("Unable to get n1QLStore for testBucket")
 	}
 
 	// channels
 	channelsStatement, params := db.buildChannelsQuery("ABC", 0, 10, 100, false)
-	plan, explainErr := gocbBucket.ExplainQuery(channelsStatement, params)
+	plan, explainErr := n1QLStore.ExplainQuery(channelsStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for channels query")
 	covered := isCovered(plan)
 	planJSON, err := base.JSONMarshal(plan)
@@ -329,7 +329,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// star channel
 	channelStarStatement, params := db.buildChannelsQuery("*", 0, 10, 100, false)
-	plan, explainErr = gocbBucket.ExplainQuery(channelStarStatement, params)
+	plan, explainErr = n1QLStore.ExplainQuery(channelStarStatement, params)
 	assert.NoError(t, explainErr, "Error generating explain for star channel query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -340,7 +340,7 @@ func TestCoveringQueries(t *testing.T) {
 	// in the SELECT.
 	// Including here for ease-of-conversion when we get an indexing enhancement to support covered queries.
 	accessStatement := db.buildAccessQuery("user1")
-	plan, explainErr = gocbBucket.ExplainQuery(accessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(accessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for access query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)
@@ -349,7 +349,7 @@ func TestCoveringQueries(t *testing.T) {
 
 	// roleAccess
 	roleAccessStatement := db.buildRoleAccessQuery("user1")
-	plan, explainErr = gocbBucket.ExplainQuery(roleAccessStatement, nil)
+	plan, explainErr = n1QLStore.ExplainQuery(roleAccessStatement, nil)
 	assert.NoError(t, explainErr, "Error generating explain for roleAccess query")
 	covered = isCovered(plan)
 	planJSON, err = base.JSONMarshal(plan)

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="7a9f15d95f07f7f30f567cf19919f554d14b12d5"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="c9bd104d8aa3da23fdc843f55c713bad624f4e88"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,8 +45,8 @@ licenses/APL2.txt.
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
   <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="476b7f38842457a34d0d8a69332d190223a82651" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="a5315eea8af138a600c2c3b8061fe13d956254b7"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="7edf8dda70989588940f2649d6ba72b9253aab12" />
+  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="e0632bbd0c3dabf618b8170eb3bffb0862b9ee9a"/>
   <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
 
   <!-- gocb v1 -->

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -59,7 +59,7 @@ licenses/APL2.txt.
 
   <project name="gomemcached" path="godeps/src/github.com/couchbase/gomemcached" remote="couchbase" revision="4201f50df22f08f75a0491451fa6507387d41304"/>
 
-  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="c9bd104d8aa3da23fdc843f55c713bad624f4e88"/>
+  <project name="sg-bucket" path="godeps/src/github.com/couchbase/sg-bucket" remote="couchbase" revision="08f9bc2aa1cb5cb87b9a9bc0f803ddefbc73c5f8"/>
 
   <project name="go-bindata-assetfs" path="godeps/src/github.com/elazarl/go-bindata-assetfs" remote="couchbasedeps" revision="30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"/>
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2262,6 +2262,7 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 }
 
 func TestHandleDBConfig(t *testing.T) {
+	t.Skip("disabled pending CBG-1556")
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
@@ -2274,6 +2275,7 @@ func TestHandleDBConfig(t *testing.T) {
 	defer rt.Close()
 
 	bucket := tb.GetName()
+
 	kvTLSPort := 443
 	certPath := "/etc/ssl/certs/client.cert"
 	keyPath := "/etc/ssl/certs/client.pem"
@@ -2668,7 +2670,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	})
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -2678,7 +2680,7 @@ func TestUserXattrsRawGet(t *testing.T) {
 	_, err := rt.WaitForChanges(1, "/db/_changes", "", true)
 	assert.NoError(t, err)
 
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, "val")
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, "val")
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2262,7 +2262,7 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 }
 
 func TestHandleDBConfig(t *testing.T) {
-	t.Skip("disabled pending CBG-1556")
+	t.Skip("disabled pending CBG-1566")
 	if base.GTestBucketPool.NumUsableBuckets() < 2 {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1640,11 +1640,11 @@ func TestLocalDocExpiry(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/_local/loc1", `{"hi": "there"}`)
 	assertStatus(t, response, 201)
 
-	goCBBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	cbStore, ok := base.AsCouchbaseStore(rt.Bucket())
 	require.True(t, ok)
 
 	localDocKey := db.RealSpecialDocID(db.DocTypeLocal, "loc1")
-	expiry, getMetaError := goCBBucket.GetExpiry(localDocKey)
+	expiry, getMetaError := cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after PUT is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -1653,7 +1653,7 @@ func TestLocalDocExpiry(t *testing.T) {
 	// Retrieve local doc, ensure non-zero expiry is preserved
 	response = rt.SendAdminRequest("GET", "/db/_local/loc1", "")
 	assertStatus(t, response, 200)
-	expiry, getMetaError = goCBBucket.GetExpiry(localDocKey)
+	expiry, getMetaError = cbStore.GetExpiry(localDocKey)
 	log.Printf("Expiry after GET is %v", expiry)
 	assert.True(t, expiry > timeNow, "expiry is not greater than current time")
 	assert.True(t, expiry < oneMoreHour, "expiry is not greater than current time")
@@ -3908,10 +3908,10 @@ func TestWriteTombstonedDocUsingXattrs(t *testing.T) {
 
 	// Fetch the xattr and make sure it contains the above value
 	baseBucket := rt.GetDatabase().Bucket
-	gocbBucket, _ := base.AsGoCBBucket(baseBucket)
+	subdocXattrStore, _ := base.AsSubdocXattrStore(baseBucket)
 	var retrievedVal map[string]interface{}
 	var retrievedXattr map[string]interface{}
-	_, err = gocbBucket.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
+	_, err = subdocXattrStore.SubdocGetBodyAndXattr("-21SK00U-ujxUO9fU2HezxL", base.SyncXattrName, "", &retrievedVal, &retrievedXattr, nil)
 	assert.NoError(t, err, "Unexpected Error")
 	assert.Equal(t, "2-466a1fab90a810dc0a63565b70680e4e", retrievedXattr["rev"])
 
@@ -4733,9 +4733,9 @@ func TestWebhookSpecialProperties(t *testing.T) {
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
 
+	wg.Add(1)
 	res := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"foo": "bar", "_deleted": true}`)
 	assertStatus(t, res, http.StatusCreated)
-	wg.Add(1)
 	wg.Wait()
 }
 
@@ -4785,19 +4785,20 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	defer rt.Close()
 
 	// Create first revision of the document with no attachment.
+	wg.Add(1)
 	response := rt.SendAdminRequest(http.MethodPut, "/db/doc1", `{"foo": "bar"}`)
 	assertStatus(t, response, http.StatusCreated)
 	var body db.Body
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 	require.True(t, body["ok"].(bool))
 	doc1revId := body["rev"].(string)
-	wg.Add(1)
 
 	// Add attachment to the doc.
 	attachmentBody := "this is the body of attachment"
 	attachmentContentType := "content/type"
 	reqHeaders := map[string]string{"Content-Type": attachmentContentType}
 	resource := "/db/doc1/attach1?rev=" + doc1revId
+	wg.Add(1)
 	response = rt.SendAdminRequestWithHeaders(http.MethodPut, resource, attachmentBody, reqHeaders)
 	assertStatus(t, response, http.StatusCreated)
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
@@ -4805,7 +4806,6 @@ func TestWebhookPropsWithAttachments(t *testing.T) {
 	revIdAfterAttachment := body["rev"].(string)
 	assert.NotEmpty(t, revIdAfterAttachment, "No revid in response for PUT attachment")
 	assert.NotEqual(t, revIdAfterAttachment, doc1revId)
-	wg.Add(1)
 	wg.Wait()
 }
 
@@ -4857,44 +4857,44 @@ func TestWebhookWinningRevChangedEvent(t *testing.T) {
 	rt := NewRestTester(t, rtConfig)
 	defer rt.Close()
 
+	wg.Add(2)
 	res := rt.SendAdminRequest("PUT", "/db/doc1", `{"foo":"bar"}`)
 	assertStatus(t, res, http.StatusCreated)
-	wg.Add(2)
 	rev1 := respRevID(t, res)
 	_, rev1Hash := db.ParseRevID(rev1)
 
 	// push winning branch
+	wg.Add(2)
 	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzz","_revisions":{"start":3,"ids":["buzz","bar","`+rev1Hash+`"]}}`)
 	assertStatus(t, res, http.StatusCreated)
-	wg.Add(2)
 
 	// push non-winning branch
+	wg.Add(1)
 	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"buzzzzz","_revisions":{"start":2,"ids":["buzzzzz","`+rev1Hash+`"]}}`)
 	assertStatus(t, res, http.StatusCreated)
-	wg.Add(1)
 
 	wg.Wait()
 	assert.Equal(t, 2, int(atomic.LoadUint32(&WinningRevChangedCount)))
 	assert.Equal(t, 3, int(atomic.LoadUint32(&DocumentChangedCount)))
 
 	// tombstone the winning branch and ensure we get a rev changed message for the promoted branch
+	wg.Add(2)
 	res = rt.SendAdminRequest("DELETE", "/db/doc1?rev=3-buzz", ``)
 	assertStatus(t, res, http.StatusOK)
-	wg.Add(2)
 
 	wg.Wait()
 	assert.Equal(t, 3, int(atomic.LoadUint32(&WinningRevChangedCount)))
 	assert.Equal(t, 4, int(atomic.LoadUint32(&DocumentChangedCount)))
 
 	// push a separate winning branch
+	wg.Add(2)
 	res = rt.SendAdminRequest("PUT", "/db/doc1?new_edits=false", `{"foo":"quux","_revisions":{"start":4,"ids":["quux", "buzz","bar","`+rev1Hash+`"]}}`)
 	assertStatus(t, res, http.StatusCreated)
-	wg.Add(2)
 
 	// tombstone the winning branch, we should get a second webhook fired for rev 2-buzzzzz now it's been resurrected
+	wg.Add(2)
 	res = rt.SendAdminRequest("DELETE", "/db/doc1?rev=4-quux", ``)
 	assertStatus(t, res, http.StatusOK)
-	wg.Add(2)
 
 	wg.Wait()
 	assert.Equal(t, 5, int(atomic.LoadUint32(&WinningRevChangedCount)))
@@ -5224,7 +5224,7 @@ func TestImportOnWriteMigration(t *testing.T) {
 
 	// Put doc with sync data / non-xattr
 	key := "doc1"
-	body := `{"_sync": { "rev": "1-fc2cf22c5e5007bd966869ebfe9e276a", "sequence": 1, "recent_sequences": [ 1 ], "history": { "revs": [ "1-fc2cf22c5e5007bd966869ebfe9e276a" ], "parents": [ -1], "channels": [ null ] }, "cas": "","value_crc32c": "", "time_saved": "2019-04-10T12:40:04.490083+01:00" }, "value": "foo"}`
+	body := []byte(`{"_sync": { "rev": "1-fc2cf22c5e5007bd966869ebfe9e276a", "sequence": 1, "recent_sequences": [ 1 ], "history": { "revs": [ "1-fc2cf22c5e5007bd966869ebfe9e276a" ], "parents": [ -1], "channels": [ null ] }, "cas": "","value_crc32c": "", "time_saved": "2019-04-10T12:40:04.490083+01:00" }, "value": "foo"}`)
 	ok, err := rt.Bucket().Add(key, 0, body)
 	assert.NoError(t, err)
 	assert.True(t, ok)
@@ -5484,12 +5484,13 @@ func TestTombstonedBulkDocsWithPriorPurge(t *testing.T) {
 	})
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	bucket := rt.Bucket()
+	_, ok := base.AsCouchbaseStore(bucket)
 	if !ok {
 		t.Skip("Requires Couchbase bucket")
 	}
 
-	_, err := gocbBucket.Bucket.Insert(t.Name(), map[string]interface{}{"val": "val"}, 0)
+	_, err := bucket.Add(t.Name(), 0, map[string]interface{}{"val": "val"})
 	require.NoError(t, err)
 
 	resp := rt.SendAdminRequest("POST", "/db/_purge", `{"`+t.Name()+`": ["*"]}`)
@@ -5522,7 +5523,7 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 	defer rt.Close()
 
 	bucket := rt.Bucket()
-	gocbBucket, ok := base.AsGoCBBucket(bucket)
+	_, ok := base.AsCouchbaseStore(bucket)
 	if !ok {
 		t.Skip("Requires Couchbase bucket")
 	}
@@ -5530,11 +5531,11 @@ func TestTombstonedBulkDocsWithExistingTombstone(t *testing.T) {
 	// Create the document to trigger cas failure
 	value := make(map[string]interface{})
 	value["foo"] = "bar"
-	insCas, err := gocbBucket.Bucket.Insert(t.Name(), value, 0)
+	insCas, err := bucket.WriteCas(t.Name(), 0, 0, 0, value, 0)
 	require.NoError(t, err)
 
 	// Delete document
-	_, err = gocbBucket.Bucket.Remove(t.Name(), insCas)
+	_, err = bucket.Remove(t.Name(), insCas)
 	require.NoError(t, err)
 
 	response := rt.SendAdminRequest("POST", "/db/_bulk_docs", `{"new_edits": false, "docs": [{"_id":"`+t.Name()+`", "_deleted": true, "_revisions":{"start":9, "ids":["c45c049b7fe6cf64cd8595c1990f6504", "6e01ac52ffd5ce6a4f7f4024c08d296f"]}}]}`)
@@ -5656,7 +5657,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -5666,7 +5667,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 
 	// Add xattr to doc
-	_, err := gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err := userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for doc to be imported
@@ -5680,13 +5681,15 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	// Get Xattr and ensure channel value set correctly
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 	// Update xattr again but same value and ensure it isn't imported again (crc32 hash should match)
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5695,7 +5698,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData2 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
@@ -5704,7 +5707,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 
 	// Update body but same value and ensure it isn't imported again (crc32 hash should match)
-	err = gocbBucket.Set(docKey, 0, map[string]interface{}{})
+	err = rt.Bucket().Set(docKey, 0, map[string]interface{}{})
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5713,7 +5716,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.NoError(t, err)
 
 	var syncData3 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData3)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData3)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData2.Crc32c, syncData3.Crc32c)
@@ -5723,7 +5726,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 
 	// Update body and ensure import occurs
 	updateVal := []byte(`{"prop":"val"}`)
-	err = gocbBucket.Set(docKey, 0, updateVal)
+	err = rt.Bucket().Set(docKey, 0, updateVal)
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
@@ -5734,7 +5737,7 @@ func TestUserXattrAutoImport(t *testing.T) {
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	var syncData4 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData4)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData4)
 	assert.NoError(t, err)
 
 	assert.Equal(t, base.Crc32cHashString(updateVal), syncData4.Crc32c)
@@ -5776,13 +5779,15 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
 
 	// Add doc with SDK
-	err := gocbBucket.Set(docKey, 0, []byte(`{}`))
+	err := rt.Bucket().Set(docKey, 0, []byte(`{}`))
 	assert.NoError(t, err)
 
 	// GET to trigger import
@@ -5799,7 +5804,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	// Write user xattr
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// GET to trigger import
@@ -5817,13 +5822,13 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 
 	// Get sync data for doc and ensure user xattr has been used correctly to set channel
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
 
 	// Write same xattr value
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Perform GET and ensure import isn't triggered as crc32 hash is the same
@@ -5831,7 +5836,7 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 
 	var syncData2 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.Equal(t, syncData.Crc32c, syncData2.Crc32c)
@@ -5874,7 +5879,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
@@ -5884,7 +5889,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 
 	// SDK PUT
-	err := gocbBucket.Set(docKey, 0, []byte(`{"update": "update"}`))
+	err := rt.Bucket().Set(docKey, 0, []byte(`{"update": "update"}`))
 	assert.NoError(t, err)
 
 	// Trigger Import
@@ -5901,7 +5906,7 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	assert.Equal(t, int64(2), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
 	// Write user xattr
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Trigger import
@@ -5917,8 +5922,10 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 	// Ensure sync function has ran on import
 	assert.Equal(t, int64(3), rt.GetDatabase().DbStats.CBLReplicationPush().SyncFunctionCount.Value())
 
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -5991,7 +5998,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			defer rt.Close()
 
-			gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+			gocbBucket, ok := base.AsUserXattrStore(rt.Bucket())
 			if !ok {
 				t.Skip("Test requires Couchbase Bucket")
 			}
@@ -6013,7 +6020,9 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Get sync data for doc and ensure user xattr has been used correctly to set channel
 			var syncData db.SyncData
-			_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+			subdocStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+			require.True(t, ok)
+			_, err = subdocStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 			assert.NoError(t, err)
 
 			assert.Equal(t, []string{channelName}, syncData.Channels.KeySet())
@@ -6031,7 +6040,7 @@ func TestRemovingUserXattr(t *testing.T) {
 
 			// Ensure old channel set with user xattr has been removed
 			var syncData2 db.SyncData
-			_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+			_, err = subdocStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 			assert.NoError(t, err)
 
 			assert.Equal(t, uint64(3), syncData2.Channels[channelName].Seq)
@@ -6075,10 +6084,13 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	defer rt.Close()
 
-	gocbBucket, ok := base.AsGoCBBucket(rt.Bucket())
+	userXattrStore, ok := base.AsUserXattrStore(rt.Bucket())
 	if !ok {
 		t.Skip("Test requires Couchbase Bucket")
 	}
+
+	subdocXattrStore, ok := base.AsSubdocXattrStore(rt.Bucket())
+	require.True(t, ok)
 
 	// Initial PUT
 	resp := rt.SendAdminRequest("PUT", "/db/"+docKey, `{}`)
@@ -6089,7 +6101,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Get current sync data
 	var syncData db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData)
 	assert.NoError(t, err)
 
 	docRev, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
@@ -6098,7 +6110,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, syncData.CurrentRev, docRev.RevID)
 
 	// Write xattr to trigger import of user xattr
-	_, err = gocbBucket.WriteUserXattr(docKey, xattrKey, channelName)
+	_, err = userXattrStore.WriteUserXattr(docKey, xattrKey, channelName)
 	assert.NoError(t, err)
 
 	// Wait for import
@@ -6109,7 +6121,7 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	// Ensure import worked and sequence incremented but that sequence did not
 	var syncData2 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	docRev2, err := rt.GetDatabase().GetRevisionCacheForTest().Get(docKey, syncData.CurrentRev, true, false)
@@ -6121,16 +6133,17 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 	assert.Equal(t, []string{channelName}, syncData2.Channels.KeySet())
 	assert.Equal(t, syncData2.Channels.KeySet(), docRev2.Channels.ToArray())
 
-	err = gocbBucket.Set(docKey, 0, `{"update": "update"}`)
+	err = rt.Bucket().Set(docKey, 0, []byte(`{"update": "update"}`))
 	assert.NoError(t, err)
 
 	err = rt.WaitForCondition(func() bool {
+		log.Printf("Import count is: %v", rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value())
 		return rt.GetDatabase().DbStats.SharedBucketImport().ImportCount.Value() == 2
 	})
 	assert.NoError(t, err)
 
 	var syncData3 db.SyncData
-	_, err = gocbBucket.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
+	_, err = subdocXattrStore.SubdocGetXattr(docKey, base.SyncXattrName, &syncData2)
 	assert.NoError(t, err)
 
 	assert.NotEqual(t, syncData2.CurrentRev, syncData3.CurrentRev)

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2877,7 +2877,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	assert.NoError(t, ar.Stop())
 
 	// roll back checkpoint value to first one and remove the associated doc
-	err = rt2.Bucket().SetRaw(checkpointDocID, 0, firstCheckpoint)
+	err = rt2.Bucket().Set(checkpointDocID, 0, firstCheckpoint)
 	assert.NoError(t, err)
 
 	rt2db, err := db.GetDatabase(rt2.GetDatabase(), nil)
@@ -2970,13 +2970,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 	pushCheckpointID := ar.Push.CheckpointID
 	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
-	err = rt2.Bucket().SetRaw(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	err = rt2.Bucket().Set(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
 	require.NoError(t, err)
 
 	pullCheckpointID := ar.Pull.CheckpointID
 	require.NoError(t, err)
 	pullCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pullCheckpointID
-	err = rt1.Bucket().SetRaw(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	err = rt1.Bucket().Set(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
 	require.NoError(t, err)
 
 	// Create doc1 on rt1
@@ -5684,7 +5684,7 @@ func requireErrorKeyNotFound(t *testing.T, rt *RestTester, docID string) {
 	var body []byte
 	_, err := rt.Bucket().Get(docID, &body)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "key not found")
+	require.True(t, base.IsKeyNotFoundError(rt.Bucket(), err))
 }
 
 // requireRevID asserts that the specified document revision is written to the

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -2844,7 +2844,8 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 	cID := ar.Push.CheckpointID
 	checkpointDocID := base.SyncPrefix + "local:checkpoint/" + cID
 
-	firstCheckpoint, _, err := rt2.Bucket().GetRaw(checkpointDocID)
+	var firstCheckpoint interface{}
+	_, err = rt2.Bucket().Get(checkpointDocID, &firstCheckpoint)
 	require.NoError(t, err)
 
 	// Create doc2 on rt1
@@ -2970,13 +2971,13 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 
 	pushCheckpointID := ar.Push.CheckpointID
 	pushCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pushCheckpointID
-	err = rt2.Bucket().Set(pushCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	err = rt2.Bucket().Set(pushCheckpointDocID, 0, map[string]interface{}{"last_sequence": "0", "_rev": "abc"})
 	require.NoError(t, err)
 
 	pullCheckpointID := ar.Pull.CheckpointID
 	require.NoError(t, err)
 	pullCheckpointDocID := base.SyncPrefix + "local:checkpoint/" + pullCheckpointID
-	err = rt1.Bucket().Set(pullCheckpointDocID, 0, []byte(`{"last_sequence":"0","_rev":"abc"}`))
+	err = rt1.Bucket().Set(pullCheckpointDocID, 0, map[string]interface{}{"last_sequence": "0", "_rev": "abc"})
 	require.NoError(t, err)
 
 	// Create doc1 on rt1

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -433,8 +433,12 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 		if config.NumIndexReplicas != nil {
 			numReplicas = *config.NumIndexReplicas
 		}
+		n1qlStore, ok := base.AsN1QLStore(bucket)
+		if !ok {
+			return nil, errors.New("Cannot create indexes on non-Couchbase data store.")
 
-		indexErr := db.InitializeIndexes(bucket, config.UseXattrs(), numReplicas)
+		}
+		indexErr := db.InitializeIndexes(n1qlStore, config.UseXattrs(), numReplicas)
 		if indexErr != nil {
 			return nil, indexErr
 		}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/couchbase/go-blip"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
@@ -35,6 +33,7 @@ import (
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
 	goassert "github.com/couchbaselabs/go.assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
 )

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -534,7 +534,6 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 }
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
-	t.Skip("Disabling until gocbc-1140 is fixed")
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,

--- a/rest/view_api_test.go
+++ b/rest/view_api_test.go
@@ -534,6 +534,7 @@ func TestViewQueryWithIntKeys(t *testing.T) {
 }
 
 func TestAdminGroupLevelReduceSumQuery(t *testing.T) {
+	t.Skip("Disabling until gocbc-1140 is fixed")
 	rtConfig := RestTesterConfig{
 		SyncFn:       `function(doc) {channel(doc.channel)}`,
 		guestEnabled: true,


### PR DESCRIPTION
Enables gocb v2 by default for everything except DCP.  Testing the full suite in this mode caught a number of bugs in the collection implementation, particularly around standardizing error types.  Beyond bug fixes, created a new CouchbaseStore interface for functionality specific to a backing Couchbase Server, and not already on the bucket interface.

Includes a transcoder for gocb v2 that is backward compatible with the gocb v1 transcoder.  (Attempted to pull that out into a separate PR, but it had too many interdependencies with the rest of the fixes and refactoring in this PR).

Dependencies:
- [x] https://github.com/couchbase/sg-bucket/pull/65

Integration tests:
GSI: http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/957/
Views: http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/958/
Views, no xattrs: http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/959/