### PR TITLE
Bump webhook timeout for TestWebhookBasic to help when run on slower hardware

### DIFF
--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -554,7 +554,7 @@ func TestWebhookBasic(t *testing.T) {
 	log.Println("Test queue full, slow webhook, long wait")
 	wr.Clear()
 	em = NewEventManager()
-	em.Start(5, 1100)
+	em.Start(5, 1500)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", nil, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)
 	for i := 0; i < 100; i++ {
@@ -813,7 +813,7 @@ func TestWebhookTimeout(t *testing.T) {
 	wr.Clear()
 	errCount = 0
 	em = NewEventManager()
-	em.Start(1, 1100)
+	em.Start(1, 1500)
 	timeout = uint64(0)
 	webhookHandler, _ = NewWebhook(fmt.Sprintf("%s/slow", url), "", &timeout, nil)
 	em.RegisterEventHandler(webhookHandler, DocumentChange)


### PR DESCRIPTION
- Aims to fix the failing/racy tests on the macOS GitHub builder

The 1 second slow webhook endpoint seemed to be too close to the 1.1 seconds of queue blocking timeout for the test to be reliable under slow hardware. Bumping the timeout to 1.5 seconds seems to have alleviated the issue.

```
2021-08-03T18:51:36.5741660Z     event_manager_test.go:564: 
2021-08-03T18:51:36.5742170Z         	Error Trace:	event_manager_test.go:564
2021-08-03T18:51:36.5742750Z         	Error:      	Received unexpected error:
2021-08-03T18:51:36.5743260Z         	            	Event queue full
2021-08-03T18:51:36.5743730Z         	Test:       	TestWebhookBasic
2021-08-03T18:51:36.5745120Z 2021-08-03T18:50:31.991Z [WRN] Event queue full - discarding event: <ud>Document change event for doc id: 2</ud> -- db.(*EventManager).raiseEvent() at event_manager.go:145
2021-08-03T18:51:36.5746010Z     event_manager_test.go:564: 
2021-08-03T18:51:36.5746520Z         	Error Trace:	event_manager_test.go:564
2021-08-03T18:51:36.5747070Z         	Error:      	Received unexpected error:
2021-08-03T18:51:36.5747580Z         	            	Event queue full
2021-08-03T18:51:36.5748060Z         	Test:       	TestWebhookBasic
2021-08-03T18:51:36.5749520Z 2021-08-03T18:50:45.661Z [WRN] RetryLoop for waitForProcessedTotal(100) giving up after 20 attempts -- base.RetryLoopCtx() at util.go:441
2021-08-03T18:51:36.5750390Z     event_manager_test.go:567: 
2021-08-03T18:51:36.5750910Z         	Error Trace:	event_manager_test.go:567
2021-08-03T18:51:36.5751460Z         	Error:      	Received unexpected error:
2021-08-03T18:51:36.5752220Z         	            	RetryLoop for waitForProcessedTotal(100) giving up after 20 attempts
2021-08-03T18:51:36.5752930Z         	Test:       	TestWebhookBasic
2021-08-03T18:51:36.5753410Z     event_manager_test.go:568: 
2021-08-03T18:51:36.5753910Z         	Error Trace:	event_manager_test.go:568
2021-08-03T18:51:36.5754390Z         	Error:      	Not equal: 
2021-08-03T18:51:36.5754800Z         	            	expected: 100
2021-08-03T18:51:36.5755200Z         	            	actual  : 98
2021-08-03T18:51:36.5755650Z         	Test:       	TestWebhookBasic
2021-08-03T18:51:36.5756850Z --- FAIL: TestWebhookBasic (33.11s)
```