### PR TITLE
Push query ops default selection to lower level

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -116,7 +116,7 @@ type BucketSpec struct {
 	InitialRetrySleepTimeMS       int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
 	UseXattrs                     bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs          *uint32        // the view query timeout in seconds (default: 75 seconds)
-	MaxConcurrentQueryOps         int            // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
+	MaxConcurrentQueryOps         *int           // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
 	BucketOpTimeout               *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	KvPoolSize                    int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -170,7 +170,12 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 	singleOpsQueue := make(chan struct{}, MaxConcurrentSingleOps*nodeCount*numPools)
 	bucketOpsQueue := make(chan struct{}, MaxConcurrentBulkOps*nodeCount*numPools)
 
-	viewOpsQueue := make(chan struct{}, spec.MaxConcurrentQueryOps)
+	maxConcurrentQueryOps := MaxConcurrentQueryOps
+	if spec.MaxConcurrentQueryOps != nil {
+		maxConcurrentQueryOps = *spec.MaxConcurrentQueryOps
+	}
+
+	viewOpsQueue := make(chan struct{}, maxConcurrentQueryOps)
 
 	bucket = &CouchbaseBucketGoCB{
 		Bucket:                    goCBBucket,

--- a/rest/config.go
+++ b/rest/config.go
@@ -90,11 +90,6 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
-	maxConcurrentQueryOps := base.MaxConcurrentQueryOps
-	if bc.MaxConcurrentQueryOps != nil {
-		maxConcurrentQueryOps = *bc.MaxConcurrentQueryOps
-	}
-
 	return base.BucketSpec{
 		Server:                server,
 		BucketName:            bucketName,
@@ -103,7 +98,7 @@ func (dc *DbConfig) MakeBucketSpec() base.BucketSpec {
 		CACertPath:            bc.CACertPath,
 		KvTLSPort:             tlsPort,
 		Auth:                  bc,
-		MaxConcurrentQueryOps: maxConcurrentQueryOps,
+		MaxConcurrentQueryOps: bc.MaxConcurrentQueryOps,
 	}
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -539,33 +539,3 @@ func TestUseTLSServer(t *testing.T) {
 		})
 	}
 }
-
-func TestViewQueryBucketOptionsOnBucketSpec(t *testing.T) {
-	testCases := []struct {
-		Name              string
-		OperationsPerNode *int
-		ExpectedValue     int
-	}{
-		{
-			Name:              "Set Value",
-			OperationsPerNode: base.IntPtr(10),
-			ExpectedValue:     10,
-		},
-		{
-			Name:              "Set Nil",
-			OperationsPerNode: nil,
-			ExpectedValue:     base.MaxConcurrentQueryOps,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			startupConfig := &StartupConfig{Bootstrap: BootstrapConfig{}}
-			dbConfig := &DbConfig{BucketConfig: BucketConfig{MaxConcurrentQueryOps: testCase.OperationsPerNode}}
-			spec, err := GetBucketSpec(dbConfig, startupConfig)
-			assert.NoError(t, err)
-
-			assert.Equal(t, testCase.ExpectedValue, spec.MaxConcurrentQueryOps)
-		})
-	}
-}


### PR DESCRIPTION
Push down the default check for query ops count down to GetCouchbaseBucketGoCBFromAuthenticatedCluster. 

Current location was causing an issue with integration tests where we call a method lower down to instantiate the cluster. Meaning we'd get the int default of '0' for limit. Alternative was to specify count in `tbpDefaultBucketSpec` but that seemed worse

Test had to be removed as can't realistically verify the value further down.