### PR TITLE
CBG-1591: Order expectedSeqs when calculating checkpoint

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -265,7 +265,7 @@ func (c *Checkpointer) _calculateSafeExpectedSeqsIdx() int {
 		seqI, _ := parseIntegerSequenceID(c.expectedSeqs[i])
 		seqJ, _ := parseIntegerSequenceID(c.expectedSeqs[j])
 
-		return seqI.Seq < seqJ.Seq
+		return seqI.Before(seqJ)
 	})
 
 	// iterates over each (ordered) expected sequence and stops when we find the first sequence we've yet to process a rev message for

--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -13,6 +13,7 @@ package db
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -259,6 +260,13 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
 // Returns -1 if no sequence in the list is able to be checkpointed.
 func (c *Checkpointer) _calculateSafeExpectedSeqsIdx() int {
 	safeIdx := -1
+
+	sort.Slice(c.expectedSeqs, func(i, j int) bool {
+		seqI, _ := parseIntegerSequenceID(c.expectedSeqs[i])
+		seqJ, _ := parseIntegerSequenceID(c.expectedSeqs[j])
+
+		return seqI.Seq < seqJ.Seq
+	})
 
 	// iterates over each (ordered) expected sequence and stops when we find the first sequence we've yet to process a rev message for
 	for i, seq := range c.expectedSeqs {

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -91,6 +91,17 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			expectedExpectedSeqs:    []string{},
 			expectedProcessedSeqs:   map[string]struct{}{"4": {}, "5": {}},
 		},
+		{
+			name: "out of order expected seqs",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"3", "2", "1"},
+				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}},
+			},
+			expectedSafeSeq:         "3",
+			expectedExpectedSeqsIdx: 2,
+			expectedExpectedSeqs:    []string{},
+			expectedProcessedSeqs:   map[string]struct{}{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -156,23 +156,12 @@ func (s SequenceID) IsNonZero() bool {
 
 // Equality of sequences, based on seq, triggered by and low hash
 func (s SequenceID) Equals(s2 SequenceID) bool {
-	return s.intEquals(s2)
-}
-
-func (s SequenceID) intEquals(s2 SequenceID) bool {
 	return s.SafeSequence() == s2.SafeSequence() && s.TriggeredBy == s2.TriggeredBy
 }
 
 // The most significant value is TriggeredBy, unless it's zero, in which case use Seq.
 // The tricky part is that "n" sorts after "n:m" for any nonzero m
 func (s SequenceID) Before(s2 SequenceID) bool {
-	return s.intBefore(s2)
-}
-
-// The most significant value is TriggeredBy, unless it's zero, in which case use Seq.
-// The tricky part is that "n" sorts after "n:m" for any nonzero m
-func (s SequenceID) intBefore(s2 SequenceID) bool {
-
 	// using SafeSequence for comparison, which takes the lower of LowSeq and Seq
 	if s.TriggeredBy == s2.TriggeredBy {
 		return s.SafeSequence() < s2.SafeSequence() // the simple case: untriggered, or triggered by same sequence


### PR DESCRIPTION
Order expectedSeqs in `_calculateSafeExpectedSeqsIdx` which is used when calculating checkpoints during replication.

Ordering expectedSeqs when used for checkpoint calculation rather than ordering on insert to cover all possible cases where expectedSeqs is mutated. 
Checkpointing only occurs every 10 seconds whereas inserts happen more often, therefore sorting is more likely to be cheaper when done as part of `_calculateSafeExpectedSeqsIdx` calculation.