### PR TITLE
CBG-1584: Only support user_xattr_key under EE

### DIFF
--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -723,8 +723,14 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		localDocExpirySecs = *config.LocalDocExpirySecs
 	}
 
-	if config.UserXattrKey != "" && !config.UseXattrs() {
-		return db.DatabaseContextOptions{}, fmt.Errorf("use of user_xattr_key requires shared_bucket_access to be enabled")
+	if config.UserXattrKey != "" {
+		if !base.IsEnterpriseEdition() {
+			return db.DatabaseContextOptions{}, fmt.Errorf("user_xattr_key is only supported in enterpise edition")
+		}
+
+		if !config.UseXattrs() {
+			return db.DatabaseContextOptions{}, fmt.Errorf("use of user_xattr_key requires shared_bucket_access to be enabled")
+		}
 	}
 
 	clientPartitionWindow := base.DefaultClientPartitionWindow


### PR DESCRIPTION
We should modify user xattrs to only allow their use for enterprise customers. This can be fairly easily accomplished by limiting the config option.

Manually tested