### PR TITLE
Rename Permission Check Config Option

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -846,7 +846,7 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	}
 
 	if !base.IsEnterpriseEdition() && sc.API.EnableAdminAuthenticationPermissionsCheck != nil && *sc.API.EnableAdminAuthenticationPermissionsCheck {
-		errorMessages = multierror.Append(errorMessages, fmt.Errorf("enable_admin_authentication_permissions_check is only supported in enterprise edition"))
+		errorMessages = multierror.Append(errorMessages, fmt.Errorf("enable_advanced_auth_dp is only supported in enterprise edition"))
 	}
 
 	return errorMessages

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -55,7 +55,7 @@ type LegacyServerConfig struct {
 	DisablePersistentConfig                   *bool                          `json:"disable_persistent_config,omitempty" help:"Can be set to true to disable 3.0/persistent config handling."`
 	AdminInterfaceAuthentication              *bool                          `json:"admin_interface_authentication,omitempty" help:"Whether the admin API requires authentication"`
 	MetricsInterfaceAuthentication            *bool                          `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
-	EnableAdminAuthenticationPermissionsCheck *bool                          `json:"enable_admin_authentication_permissions_check" help:"Whether to enable the permissions check feature of admin auth"`
+	EnableAdminAuthenticationPermissionsCheck *bool                          `json:"enable_advanced_auth_dp" help:"Whether to enable the permissions check feature of admin auth"`
 }
 
 type FacebookConfigLegacy struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -97,7 +97,7 @@ type APIConfig struct {
 
 	AdminInterfaceAuthentication              *bool `json:"admin_interface_authentication,omitempty" help:"Whether the admin API requires authentication"`
 	MetricsInterfaceAuthentication            *bool `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
-	EnableAdminAuthenticationPermissionsCheck *bool `json:"enable_admin_authentication_permissions_check" help:"Whether to enable the DP permissions check feature of admin auth"`
+	EnableAdminAuthenticationPermissionsCheck *bool `json:"enable_advanced_auth_dp" help:"Whether to enable the DP permissions check feature of admin auth"`
 
 	ServerReadTimeout  *base.ConfigDuration `json:"server_read_timeout,omitempty"  help:"maximum duration.Second before timing out read of the HTTP(S) request"`
 	ServerWriteTimeout *base.ConfigDuration `json:"server_write_timeout,omitempty" help:"maximum duration.Second before timing out write of the HTTP(S) response"`


### PR DESCRIPTION
Renamed permission check config option to `enable_advanced_auth_dp`.

Have kept internal struct name the same as in my opinion this makes it easier to reason about exactly what it does.