### PR TITLE
Turn on useTLSServer for X509 tests

### DIFF
--- a/rest/x509_test.go
+++ b/rest/x509_test.go
@@ -30,7 +30,7 @@ func TestX509RoundtripUsingIP(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
 	defer rt.Close()
 
 	// write a doc to ensure bucket ops work
@@ -51,7 +51,7 @@ func TestX509RoundtripUsingDomain(t *testing.T) {
 	defer tb.Close()
 	defer teardownFn()
 
-	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb})
+	rt := NewRestTester(t, &RestTesterConfig{TestBucket: tb, useTLSServer: true})
 	defer rt.Close()
 
 	// write a doc to ensure bucket ops work


### PR DESCRIPTION
Just need to turn on the useTLSServer option for X509 testing rest testers.