### PR TITLE
Couple of integration test fixes

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2653,6 +2653,10 @@ func TestUserXattrsRawGet(t *testing.T) {
 		t.Skip("Test requires xattrs to be enabled")
 	}
 
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
 	docKey := t.Name()
 	xattrKey := "xattrKey"
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -5630,6 +5630,10 @@ func TestUserXattrAutoImport(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	docKey := t.Name()
@@ -5746,6 +5750,10 @@ func TestUserXattrOnDemandImportGET(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	docKey := t.Name()
@@ -5840,6 +5848,10 @@ func TestUserXattrOnDemandImportWrite(t *testing.T) {
 		t.Skip("This test only works with XATTRS enabled")
 	}
 
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
+	}
+
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	docKey := t.Name()
@@ -5919,6 +5931,10 @@ func TestRemovingUserXattr(t *testing.T) {
 
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
 	}
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
@@ -6030,6 +6046,10 @@ func TestUserXattrAvoidRevisionIDGeneration(t *testing.T) {
 
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
 	}
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
@@ -7737,6 +7757,10 @@ func TestRevocationWithUserXattrs(t *testing.T) {
 
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
+	}
+
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("test is EE only - user xattrs")
 	}
 
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -69,7 +68,8 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	assert.Equal(t, ":4445", writtenFileStartupConfig.API.AdminInterface)
 
 	backupFileName := ""
-	err = filepath.WalkDir(tmpDir, func(path string, d fs.DirEntry, err error) error {
+
+	err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
 		if strings.Contains(filepath.Base(path), "backup") {
 			backupFileName = path
 		}


### PR DESCRIPTION
- Fix user xattr tests. Recent change to only allow that in EE had a couple user xattr tests failing
- Modified a test func to use a 1.13 compatible version (integration tests currently running go 1.13)
	- Should also bump that

- [ ] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/953/