### PR TITLE
Modified perms to be inline with 7.0.1 and test

### DIFF
--- a/rest/admin_api_auth_routing_permissions.go
+++ b/rest/admin_api_auth_routing_permissions.go
@@ -8,21 +8,13 @@ import (
 // Permission stores the name of a permission along whether it is database scoped. This is used to later obtain a
 // formatted permission string for checking.
 type Permission struct {
-	PermissionName     string
-	DatabaseScoped     bool
-	IsCollectionFormat bool
+	PermissionName string
+	DatabaseScoped bool
 }
 
 func (perm *Permission) FormattedName(bucketName string) string {
-	if perm.IsCollectionFormat {
-		if perm.DatabaseScoped {
-			return fmt.Sprintf("cluster.collection[%s:_default:_default]%s", bucketName, perm.PermissionName)
-		}
-		return fmt.Sprintf("cluster.collection[*:*:*]%s", perm.PermissionName)
-	}
-
 	if perm.DatabaseScoped {
-		return fmt.Sprintf("cluster.bucket[%s]%s", bucketName, perm.PermissionName)
+		return fmt.Sprintf("cluster.collection[%s:_default:_default]%s", bucketName, perm.PermissionName)
 	}
 	return fmt.Sprintf("cluster%s", perm.PermissionName)
 }
@@ -60,18 +52,18 @@ func GetPermissionNameFromFormattedStrings(formattedNames []string) (perms []str
 
 // Permissions to use with admin handlers
 var (
-	PermCreateDb             = Permission{".sgw.db!create", true, true}
-	PermDeleteDb             = Permission{".sgw.db!delete", true, true}
-	PermUpdateDb             = Permission{".sgw.db!update", true, true}
-	PermConfigureSyncFn      = Permission{".sgw.sync_function!configure", true, true}
-	PermConfigureAuth        = Permission{".sgw.auth!configure", true, true}
-	PermWritePrincipal       = Permission{".sgw.principal!write", true, true}
-	PermReadPrincipal        = Permission{".sgw.principal!read", true, true}
-	PermReadAppData          = Permission{".sgw.appdata!read", true, true}
-	PermReadPrincipalAppData = Permission{".sgw.principal_appdata!read", true, true}
-	PermWriteAppData         = Permission{".sgw.appdata!write", true, true}
-	PermWriteReplications    = Permission{".sgw.replications!write", true, true}
-	PermReadReplications     = Permission{".sgw.replications!read", true, true}
-	PermDevOps               = Permission{".sgw.dev_ops!all", false, false}
-	PermStatsExport          = Permission{".admin.stats_export!read", false, false}
+	PermCreateDb             = Permission{".sgw.db!create", true}
+	PermDeleteDb             = Permission{".sgw.db!delete", true}
+	PermUpdateDb             = Permission{".sgw.db!update", true}
+	PermConfigureSyncFn      = Permission{".sgw.sync_function!configure", true}
+	PermConfigureAuth        = Permission{".sgw.auth!configure", true}
+	PermWritePrincipal       = Permission{".sgw.principal!write", true}
+	PermReadPrincipal        = Permission{".sgw.principal!read", true}
+	PermReadAppData          = Permission{".sgw.appdata!read", true}
+	PermReadPrincipalAppData = Permission{".sgw.principal_appdata!read", true}
+	PermWriteAppData         = Permission{".sgw.appdata!write", true}
+	PermWriteReplications    = Permission{".sgw.replications!write", true}
+	PermReadReplications     = Permission{".sgw.replications!read", true}
+	PermDevOps               = Permission{".sgw.dev_ops!all", false}
+	PermStatsExport          = Permission{".admin.stats_export!read", false}
 )

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -29,6 +30,12 @@ func MakeUser(t *testing.T, serverURL, username, password string, roles []string
 	resp, err := httpClient.Do(req)
 	require.NoError(t, err)
 
+	if resp.StatusCode != http.StatusOK {
+		bodyResp, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		fmt.Println(string(bodyResp))
+	}
+
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -50,8 +57,8 @@ func TestCheckPermissions(t *testing.T) {
 		t.Skip("Test requires Couchbase Server")
 	}
 
-	clusterAdminPermission := Permission{"!admin", false}
-	clusterReadOnlyAdminPermission := Permission{"!ro_admin", false}
+	clusterAdminPermission := Permission{"!admin", false, false}
+	clusterReadOnlyAdminPermission := Permission{"!ro_admin", false, false}
 
 	testCases := []struct {
 		Name                      string
@@ -179,7 +186,7 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
-	statusCode, _, err := CheckPermissions(httpClient, eps, "", base.TestClusterUsername(), base.TestClusterPassword(), []Permission{Permission{"!admin", false}}, nil)
+	statusCode, _, err := CheckPermissions(httpClient, eps, "", base.TestClusterUsername(), base.TestClusterPassword(), []Permission{Permission{"!admin", false, false}}, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -306,8 +313,8 @@ func TestAdminAuth(t *testing.T) {
 	defer rt.Close()
 
 	BucketFullAccessRoleTest := fmt.Sprintf("bucket_full_access[%s]", rt.Bucket().GetName())
-	clusterAdminPermission := Permission{"!admin", false}
-	bucketWritePermission := Permission{"!write", true}
+	clusterAdminPermission := Permission{"!admin", false, false}
+	bucketWritePermission := Permission{"!write", true, false}
 
 	testCases := []struct {
 		Name                string
@@ -458,7 +465,7 @@ func TestAdminAuthWithX509(t *testing.T) {
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)
 
-	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), "", httpClient, managementEndpoints, true, []Permission{{"!admin", false}}, nil)
+	_, _, err = checkAdminAuth("", base.TestClusterUsername(), base.TestClusterPassword(), "", httpClient, managementEndpoints, true, []Permission{{"!admin", false, false}}, nil)
 	assert.NoError(t, err)
 }
 
@@ -714,13 +721,13 @@ func TestAdminAPIAuth(t *testing.T) {
 		{
 			"GET",
 			false,
-			"/_debug/pprof/profile",
+			"/_debug/pprof/profile?seconds=1",
 			false,
 		},
 		{
 			"GET",
 			false,
-			"/_debug/pprof/block",
+			"/_debug/pprof/block?seconds=1",
 			false,
 		},
 		{
@@ -732,7 +739,7 @@ func TestAdminAPIAuth(t *testing.T) {
 		{
 			"GET",
 			false,
-			"/_debug/pprof/mutex",
+			"/_debug/pprof/mutex?seconds=1",
 			false,
 		},
 		{
@@ -744,7 +751,7 @@ func TestAdminAPIAuth(t *testing.T) {
 		{
 			"GET",
 			false,
-			"/_debug/fgprof",
+			"/_debug/fgprof?seconds=1",
 			false,
 		},
 		{
@@ -1041,11 +1048,11 @@ func TestDisablePermissionCheck(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
-	clusterAdminPermission := Permission{"!admin", false}
+	clusterAdminPermission := Permission{"!admin", false, false}
 
 	// Some random role and perm
 	viewsAdminRole := RouteRole{RoleName: "views_admin", DatabaseScoped: true}
-	statsReadPermission := Permission{".stats!read", true}
+	statsReadPermission := Permission{".stats!read", true, false}
 
 	testCases := []struct {
 		Name               string
@@ -1100,4 +1107,475 @@ func TestDisablePermissionCheck(t *testing.T) {
 			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
 		})
 	}
+}
+
+func TestNewlyCreateSGWPermissions(t *testing.T) {
+	// t.Skip("Requires DP 7.0.1")
+
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	mobileSyncGateway := "mobile_sync_gateway"
+	syncGatewayDevOps := "sync_gateway_dev_ops"
+	syncGatewayApp := "sync_gateway_app"
+	syncGatewayAppRo := "sync_gateway_app_ro"
+	syncGatewayConfigurator := "sync_gateway_configurator"
+	syncGatewayReplicator := "sync_gateway_replicator"
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		adminInterfaceAuthentication:    true,
+		enableAdminAuthPermissionsCheck: true,
+	})
+	defer rt.Close()
+
+	eps, _, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	MakeUser(t, eps[0], mobileSyncGateway, "password", []string{fmt.Sprintf("%s[*]", mobileSyncGateway)})
+	defer DeleteUser(t, eps[0], mobileSyncGateway)
+	MakeUser(t, eps[0], syncGatewayDevOps, "password", []string{fmt.Sprintf("%s", syncGatewayDevOps)})
+	defer DeleteUser(t, eps[0], syncGatewayDevOps)
+	MakeUser(t, eps[0], syncGatewayApp, "password", []string{fmt.Sprintf("%s[*]", syncGatewayApp)})
+	defer DeleteUser(t, eps[0], syncGatewayApp)
+	MakeUser(t, eps[0], syncGatewayAppRo, "password", []string{fmt.Sprintf("%s[*]", syncGatewayAppRo)})
+	defer DeleteUser(t, eps[0], syncGatewayAppRo)
+	MakeUser(t, eps[0], syncGatewayConfigurator, "password", []string{fmt.Sprintf("%s[*]", syncGatewayConfigurator)})
+	defer DeleteUser(t, eps[0], syncGatewayConfigurator)
+	MakeUser(t, eps[0], syncGatewayReplicator, "password", []string{fmt.Sprintf("%s[*]", syncGatewayReplicator)})
+	defer DeleteUser(t, eps[0], syncGatewayReplicator)
+
+	testUsers := []string{syncGatewayDevOps, syncGatewayApp, syncGatewayAppRo, syncGatewayReplicator, syncGatewayConfigurator}
+
+	endPoints := []struct {
+		Method   string
+		Endpoint string
+		Users    []string
+	}{
+		{
+			Method:   "GET",
+			Endpoint: "/db/",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_all_docs",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_bulk_docs",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/bulk_get",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_changes",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_design/ddoc",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/_design/ddoc",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_design/ddoc",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_design/ddoc/_view/view",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_ensure_full_commit",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_revs_diff",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_local/doc",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/_local/doc",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_local/doc",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/doc",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/doc",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/doc",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/doc/attach",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/doc/attach",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_blipsync",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_session",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_session/session",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_session/session",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_session/session",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_raw/doc",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_revtree/doc",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_user/",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_user/",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_user/user",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/_user/user",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_user/user",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_user/user/_session",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_user/user/_session/session",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_role/",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_role/",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_role/role",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/_role/role",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/_role/role",
+			Users:    []string{syncGatewayConfigurator, syncGatewayApp},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_replicationStatus/",
+			Users:    []string{syncGatewayReplicator},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_replicationStatus/repl",
+			Users:    []string{syncGatewayReplicator},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/_replicationStatus/repl",
+			Users:    []string{syncGatewayReplicator},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_logging",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/_logging",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/_profile/profile",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/_profile",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/_heap",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_stats",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_expvar",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_status",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_sgcollect_info",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/_sgcollect_info",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/_sgcollect_info",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/goroutine",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/cmdline",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/symbol",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/heap",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/profile?seconds=1",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/block?seconds=1",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/threadcreate",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/mutex?seconds=1",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/pprof/trace",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_debug/fgprof?seconds=1",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/_post_upgrade",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_config",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/_config",
+			Users:    []string{syncGatewayApp, syncGatewayConfigurator},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_resync",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_resync",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_purge",
+			Users:    []string{syncGatewayApp},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_flush",
+			Users:    []string{syncGatewayDevOps},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_offline",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_online",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_dump/view",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_view/view",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/db/_dumpchannel/channel",
+			Users:    []string{syncGatewayApp, syncGatewayAppRo},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_repair",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "PUT",
+			Endpoint: "/db/",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "POST",
+			Endpoint: "/db/_compact",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "DELETE",
+			Endpoint: "/db/",
+			Users:    []string{syncGatewayConfigurator},
+		},
+		{
+			Method:   "GET",
+			Endpoint: "/_all_dbs",
+			Users:    []string{syncGatewayDevOps},
+		},
+	}
+
+	for _, endpoint := range endPoints {
+		endpoint.Users = append(endpoint.Users, mobileSyncGateway)
+
+		for _, testUser := range testUsers {
+			testName := fmt.Sprintf("%s-%s-%s", testUser, endpoint.Method, endpoint.Endpoint)
+			t.Run(testName, func(t *testing.T) {
+				isAllowedUser := false
+				for _, user := range endpoint.Users {
+					if user == testUser {
+						resp := rt.SendAdminRequestWithAuth(endpoint.Method, endpoint.Endpoint, "", user, "password")
+						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+						isAllowedUser = true
+					}
+				}
+
+				if !isAllowedUser {
+					resp := rt.SendAdminRequestWithAuth(endpoint.Method, endpoint.Endpoint, "", testUser, "password")
+					assertStatus(t, resp, http.StatusForbidden)
+				}
+			})
+		}
+
+	}
+
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -209,6 +209,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleStats)).Methods("GET")
 	r.Handle(kDebugURLPathPrefix,
 		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
+	// TODO: Apply perms
 	r.Handle("/_config",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetConfig)).Methods("GET")
 	r.Handle("/_config",


### PR DESCRIPTION
The perms have been added to the latest test version of 7.0.1, however, not in the expected format so had to make some changes to support them here.
Additionally wrote a test for each endpoint exercising the roles, ensuring that the expected role can access and the other SGW roles cannot.

Has been tested on build 6002 of CBS 7.0.1 and proven to work.

- [ ] Integration test (for altered pre-7.0 tests)
http://uberjenkins.sc.couchbase.com:8080/view/All/job/sync-gateway-integration/979/