### PR TITLE
Reduce log noise from TerminateAndWaitForClose when there's nothing to terminate

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1568,9 +1568,15 @@ func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
 
 // TerminateAndWaitForClose will close the given terminator, and wait up to timeout for the done channel to be closed in response.
 func TerminateAndWaitForClose(terminator chan struct{}, done chan struct{}, timeout time.Duration) error {
+	if terminator == nil && done == nil {
+		// noop
+		return nil
+	}
+
 	if terminator == nil || done == nil {
 		return errors.New("terminateAndWaitForClose requires both terminator and done channels")
 	}
+
 	close(terminator)
 	t := time.NewTimer(timeout)
 	select {
@@ -1579,5 +1585,6 @@ func TerminateAndWaitForClose(terminator chan struct{}, done chan struct{}, time
 	case <-t.C:
 		return fmt.Errorf("terminateAndWaitForClose timed out waiting for done channel after %v", timeout)
 	}
+
 	return nil
 }

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -172,12 +172,12 @@ func (sc *ServerContext) Close() {
 
 	err := base.TerminateAndWaitForClose(sc.statsContext.terminator, sc.statsContext.doneChan, serverContextStopMaxWait)
 	if err != nil {
-		base.Infof(base.KeyAll, "Couldn't stop stats logger:", err)
+		base.Infof(base.KeyAll, "Couldn't stop stats logger: %v", err)
 	}
 
 	err = base.TerminateAndWaitForClose(sc.bootstrapContext.terminator, sc.bootstrapContext.doneChan, serverContextStopMaxWait)
 	if err != nil {
-		base.Infof(base.KeyAll, "Couldn't stop background config update worker:", err)
+		base.Infof(base.KeyAll, "Couldn't stop background config update worker: %v", err)
 	}
 
 	for _, ctx := range sc.databases_ {


### PR DESCRIPTION
- Make TerminateAndWaitForClose noop when both terminator and done channel are nil
- Fix missing `%v` for error log message

Avoids:
```
2021-08-06T16:02:17.852+01:00 [INF] Couldn't stop background config update worker:%!(EXTRA *errors.errorString=terminateAndWaitForClose requires both terminator and done channels)
```