### PR TITLE
Replace all LevelTrace test logging with LevelDebug

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -490,7 +490,7 @@ func TestForEachStubAttachmentErrors(t *testing.T) {
 }
 
 func TestGenerateProofOfAttachment(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	attData := []byte(`hello world`)
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -152,7 +152,7 @@ func assertHTTPError(t *testing.T, err error, status int) {
 
 func TestDatabase(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	db := setupTestDB(t)
 	defer db.Close()

--- a/db/event_manager_test.go
+++ b/db/event_manager_test.go
@@ -716,7 +716,7 @@ func TestWebhookTimeout(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	ts, wr := InitWebhookTest()
 	defer ts.Close()
 	url := ts.URL

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -1960,7 +1960,7 @@ func TestBlipDeltaSyncPullResend(t *testing.T) {
 		t.Skip("Enterprise-only test for delta sync")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DbConfig{
@@ -2180,7 +2180,7 @@ func TestBlipDeltaSyncPullTombstoned(t *testing.T) {
 // └──────────────┘           └───────────┘          └───────────┘
 func TestBlipDeltaSyncPullTombstonedStarChan(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyHTTP, base.KeyCache, base.KeySync, base.KeySyncMsg)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{DatabaseConfig: &DbConfig{DeltaSync: &DeltaSyncConfig{Enabled: &sgUseDeltas}}}
@@ -2364,7 +2364,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 		t.Skipf("Skipping enterprise-only delta sync test.")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
@@ -2457,7 +2457,7 @@ func TestBlipDeltaSyncPullRevCache(t *testing.T) {
 // and checks that full body replication is still supported in CE.
 func TestBlipDeltaSyncPush(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	sgUseDeltas := base.IsEnterpriseEdition()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DbConfig{
@@ -2723,7 +2723,7 @@ func TestBlipDeltaSyncNewAttachmentPull(t *testing.T) {
 // Reproduces CBG-617 (a client using activeOnly for the initial replication, and then still expecting to get subsequent tombstones afterwards)
 func TestActiveOnlyContinuous(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
@@ -2759,7 +2759,7 @@ func TestActiveOnlyContinuous(t *testing.T) {
 // Test that exercises Sync Gateway's norev handler
 func TestBlipNorev(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	rt := NewRestTester(t, &RestTesterConfig{guestEnabled: true})
 	defer rt.Close()
@@ -2791,7 +2791,7 @@ func TestBlipNorev(t *testing.T) {
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.
 func TestBlipDeltaSyncPushAttachment(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	if !base.IsEnterpriseEdition() {
 		t.Skip("Delta test requires EE")
@@ -3000,7 +3000,7 @@ func TestUpdateExistingAttachment(t *testing.T) {
 }
 
 func TestRevocationMessage(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	revocationTester, rt := initScenario(t, nil)
 	defer rt.Close()
@@ -3193,7 +3193,7 @@ func TestRevocationNoRev(t *testing.T) {
 
 func TestRemovedMessageWithAlternateAccess(t *testing.T) {
 	defer db.SuspendSequenceBatching()()
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	rt := NewRestTester(t, nil)
 	defer rt.Close()

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -768,7 +768,7 @@ func TestPostChangesAdminChannelGrantRemovalWithLimit(t *testing.T) {
 // TestChangesFromCompoundSinceViaDocGrant ensures that a changes feed with a compound since value returns the correct result after a dynamic channel grant.
 func TestChangesFromCompoundSinceViaDocGrant(t *testing.T) {
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyChanges, base.KeyHTTP)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyChanges, base.KeyHTTP)()
 
 	// Disable sequence batching for multi-RT tests (pending CBG-1000)
 	defer db.SuspendSequenceBatching()()

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -805,7 +805,7 @@ func TestValidateServerContext(t *testing.T) {
 		t.Skip("Skipping this test; requires Couchbase Bucket")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	tb1 := base.GetTestBucket(t)
 	defer tb1.Close()

--- a/rest/doc_api_test.go
+++ b/rest/doc_api_test.go
@@ -101,7 +101,7 @@ func TestDocumentNumbers(t *testing.T) {
 	rt := NewRestTester(t, &rtConfig)
 	defer rt.Close()
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	for _, test := range tests {
 		t.Run(test.name, func(ts *testing.T) {

--- a/rest/import_test.go
+++ b/rest/import_test.go
@@ -1644,7 +1644,7 @@ func TestImportZeroValueDecimalPlaces(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyImport)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DbConfig{
@@ -1709,7 +1709,7 @@ func TestImportZeroValueDecimalPlacesScientificNotation(t *testing.T) {
 
 	SkipImportTestsIfNotEnabled(t)
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyImport)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyImport)()
 
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DbConfig{

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -737,7 +737,7 @@ func TestActiveReplicatorPullFromCheckpointIgnored(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	const (
 		changesBatchSize  = 10
@@ -1602,7 +1602,7 @@ func TestActiveReplicatorPullTombstone(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	// Passive
 	tb2 := base.GetTestBucket(t)
@@ -2763,7 +2763,7 @@ func TestActiveReplicatorRecoverFromRemoteRollback(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -2920,7 +2920,7 @@ func TestActiveReplicatorRecoverFromMismatchedRev(t *testing.T) {
 		t.Skipf("test requires at least 2 usable test buckets")
 	}
 
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyBucket, base.KeyReplicate, base.KeyHTTP, base.KeyHTTPResp, base.KeySync, base.KeySyncMsg)()
 
 	// Passive
 	rt2 := NewRestTester(t, &RestTesterConfig{
@@ -3337,7 +3337,7 @@ func TestActiveReplicatorReconnectOnStart(t *testing.T) {
 			for _, timeoutVal := range timeoutVals {
 				t.Run(test.name+" with timeout "+timeoutVal.String(), func(t *testing.T) {
 
-					defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+					defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 					// Passive
 					tb2 := base.GetTestBucket(t)
@@ -5514,7 +5514,7 @@ func TestReplicatorRevocationsFromZero(t *testing.T) {
 }
 
 func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
-	defer base.SetUpTestLogging(base.LevelTrace, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 
 	defer db.SuspendSequenceBatching()()
 


### PR DESCRIPTION
- Reduces log noise, especially in integration tests from dcp/vbucket map logging.

We shouldn't need trace level logs in tests unless actively diagnosing a flaky test.