### PR TITLE
Reduce work TestTLSSkipVerifyCombinations is doing

### DIFF
--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -376,14 +376,8 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			startupConfig := &StartupConfig{
 				Bootstrap: BootstrapConfig{
-					Server:              base.UnitTestUrl(),
 					CACertPath:          test.caCert,
 					ServerTLSSkipVerify: test.serverTLSSkipVerify,
-				},
-				API: APIConfig{
-					HTTPS: HTTPSConfig{
-						UseTLSClient: base.BoolPtr(false),
-					},
 				},
 			}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -391,8 +391,9 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), errorText)
-			} else {
-				assert.NoError(t, err)
+			} else if err != nil {
+				// check if unrelated error
+				assert.NotContains(t, err.Error(), errorText)
 			}
 		})
 	}

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -332,8 +332,6 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 
 // CBG-1518 - Test CA Certificate behaviour with and with Bootstrap.ServerTLSSkipVerify
 func TestTLSSkipVerifyCombinations(t *testing.T) {
-	// Force teardown due to setupServerContext setting up logging
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyNone)()
 	errorText := "cannot skip server TLS validation and use CA Cert"
 	testCases := []struct {
 		name                string
@@ -378,19 +376,23 @@ func TestTLSSkipVerifyCombinations(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			startupConfig := &StartupConfig{
 				Bootstrap: BootstrapConfig{
+					Server:              base.UnitTestUrl(),
 					CACertPath:          test.caCert,
 					ServerTLSSkipVerify: test.serverTLSSkipVerify,
 				},
+				API: APIConfig{
+					HTTPS: HTTPSConfig{
+						UseTLSClient: base.BoolPtr(false),
+					},
+				},
 			}
 
-			sc, err := setupServerContext(startupConfig, false)
+			err := startupConfig.validate()
 			if test.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), errorText)
-				assert.Empty(t, sc)
-			} else if err != nil {
-				// check if unrelated error
-				assert.NotContains(t, err.Error(), errorText)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
Narrows down testing to only the validate function.
This avoids some of the disruptive parts of the test that reset global logging, because we're no longer setting up a full server context.