### PR TITLE
CBG-1610 Add new REST API endpoint stubs

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -159,6 +159,22 @@ func (h *handler) handlePutDbConfigSync() error {
 	return base.HTTPErrorf(http.StatusOK, "updated")
 }
 
+// GET database config import filter function
+func (h *handler) handleGetDbConfigImportFilter() error {
+	h.assertAdminOnly()
+	// TODO: STUB
+	h.writeJSONStatus(http.StatusOK, `function(doc) {
+	// this is a stub import filter function
+}`)
+}
+
+// PUT a new database config import filter function
+func (h *handler) handlePutDbConfigImportFilter() error {
+	h.assertAdminOnly()
+	// TODO: STUB
+	return base.HTTPErrorf(http.StatusOK, "updated")
+}
+
 // "Delete" a database (it doesn't actually do anything to the underlying bucket)
 func (h *handler) handleDeleteDB() error {
 	h.assertAdminOnly()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -143,6 +143,22 @@ func (h *handler) handlePutDbConfig() error {
 	return base.HTTPErrorf(http.StatusCreated, "created")
 }
 
+// GET database config sync function
+func (h *handler) handleGetDbConfigSync() error {
+	h.assertAdminOnly()
+	// TODO: STUB
+	h.writeJSONStatus(http.StatusOK, `function(doc, oldDoc) {
+	// this is a stub sync function
+}`)
+}
+
+// PUT a new database config sync function
+func (h *handler) handlePutDbConfigSync() error {
+	h.assertAdminOnly()
+	// TODO: STUB
+	return base.HTTPErrorf(http.StatusOK, "updated")
+}
+
 // "Delete" a database (it doesn't actually do anything to the underlying bucket)
 func (h *handler) handleDeleteDB() error {
 	h.assertAdminOnly()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -95,6 +95,12 @@ func (h *handler) handleDbOffline() error {
 
 // Get admin database info
 func (h *handler) handleGetDbConfig() error {
+	// TODO: STUBS
+	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
+	_ = includeRuntime
+	includeJavascript, _ := h.getOptBoolQuery("include_javascript", true)
+	_ = includeJavascript
+
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {
 		cfg, err := h.server.GetDatabaseConfig(h.db.Name).Redacted()
@@ -110,6 +116,10 @@ func (h *handler) handleGetDbConfig() error {
 
 // Get admin config info
 func (h *handler) handleGetConfig() error {
+	// TODO: STUB
+	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
+	_ = includeRuntime
+
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {
 		cfg, err := h.server.config.Redacted()
@@ -120,6 +130,12 @@ func (h *handler) handleGetConfig() error {
 	} else {
 		h.writeJSON(h.server.config)
 	}
+	return nil
+}
+
+// Put admin config info
+func (h *handler) handlePutConfig() error {
+	h.writeStatus(http.StatusOK, "updated")
 	return nil
 }
 
@@ -150,6 +166,7 @@ func (h *handler) handleGetDbConfigSync() error {
 	h.writeJSONStatus(http.StatusOK, `function(doc, oldDoc) {
 	// this is a stub sync function
 }`)
+	return nil
 }
 
 // PUT a new database config sync function
@@ -166,6 +183,7 @@ func (h *handler) handleGetDbConfigImportFilter() error {
 	h.writeJSONStatus(http.StatusOK, `function(doc) {
 	// this is a stub import filter function
 }`)
+	return nil
 }
 
 // PUT a new database config import filter function

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -253,6 +253,12 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	// TODO: This config endpoint is being altered in @bbrks admin config PR
 	dbr.Handle("/_config",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, (*handler).handlePutDbConfig)).Methods("PUT")
+
+	dbr.Handle("/_config/sync",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigSync)).Methods("GET")
+	dbr.Handle("/_config/sync",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigSync)).Methods("PUT")
+
 	dbr.Handle("/_resync",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")
 	dbr.Handle("/_resync",

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -261,9 +261,9 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_config/sync",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigSync)).Methods("PUT")
 	dbr.Handle("/_config/import_filter",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigImportFilter)).Methods("GET")
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfigImportFilter)).Methods("GET")
 	dbr.Handle("/_config/import_filter",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigImportFilter)).Methods("PUT")
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePutDbConfigImportFilter)).Methods("PUT")
 
 	dbr.Handle("/_resync",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -258,6 +258,10 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigSync)).Methods("GET")
 	dbr.Handle("/_config/sync",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigSync)).Methods("PUT")
+	dbr.Handle("/_config/import_filter",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigImportFilter)).Methods("GET")
+	dbr.Handle("/_config/import_filter",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigImportFilter)).Methods("PUT")
 
 	dbr.Handle("/_resync",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -211,6 +211,8 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermStatsExport}, nil, (*handler).handleExpvar)).Methods("GET")
 	r.Handle("/_config",
 		makeHandler(sc, adminPrivs, nil, nil, (*handler).handleGetConfig)).Methods("GET")
+	r.Handle("/_config",
+		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handlePutConfig)).Methods("PUT")
 
 	r.Handle("/_status",
 		makeHandler(sc, adminPrivs, []Permission{PermDevOps}, nil, (*handler).handleGetStatus)).Methods("GET")


### PR DESCRIPTION
Add:
- `PUT /_config`
- `GET /{db}/_config/sync`
- `PUT /{db}/_config/sync`
- `GET /{db}/_config/import_filter`
- `PUT /{db}/_config/import_filter`

Add `include_runtime` and `include_javascript` query parameter stubs.