### PR TITLE
CBG-1407 Add opt-in config reload on GET /{db}/_config?refresh_config=true

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -101,6 +101,9 @@ func (h *handler) handleGetDbConfig() error {
 	includeJavascript, _ := h.getOptBoolQuery("include_javascript", true)
 	_ = includeJavascript
 
+	// force an async config update
+	h.server.bootstrapContext.dbUpdateChan <- h.db.Name
+
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {
 		cfg, err := h.server.GetDatabaseConfig(h.db.Name).Redacted()

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -95,7 +95,7 @@ func (h *handler) handleDbOffline() error {
 
 // Get admin database info
 func (h *handler) handleGetDbConfig() error {
-	if h.getBoolQuery("refresh_config") {
+	if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
 		_, err := h.server.fetchAndLoadDatabase(h.db.Name)
 		if err != nil {
 			return err

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -103,6 +103,10 @@ func (h *handler) handleGetDbConfig() error {
 
 	// force an async config update
 	h.server.bootstrapContext.dbUpdateChan <- h.db.Name
+	if !h.getBoolQuery("skip_update") {
+		// force an async config update
+		h.server.bootstrapContext.dbUpdateChan <- h.db.Name
+	}
 
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -95,18 +95,18 @@ func (h *handler) handleDbOffline() error {
 
 // Get admin database info
 func (h *handler) handleGetDbConfig() error {
+	if h.getBoolQuery("refresh_config") {
+		_, err := h.server.fetchAndLoadDatabase(h.db.Name)
+		if err != nil {
+			return err
+		}
+	}
+
 	// TODO: STUBS
 	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
 	_ = includeRuntime
 	includeJavascript, _ := h.getOptBoolQuery("include_javascript", true)
 	_ = includeJavascript
-
-	// force an async config update
-	h.server.bootstrapContext.dbUpdateChan <- h.db.Name
-	if !h.getBoolQuery("skip_update") {
-		// force an async config update
-		h.server.bootstrapContext.dbUpdateChan <- h.db.Name
-	}
 
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {

--- a/rest/config.go
+++ b/rest/config.go
@@ -903,7 +903,6 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 		if sc.config.Bootstrap.ConfigUpdateFrequency.Value() > 0 {
 			sc.bootstrapContext.terminator = make(chan struct{})
 			sc.bootstrapContext.doneChan = make(chan struct{})
-			sc.bootstrapContext.dbUpdateChan = make(chan string)
 
 			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.Value().String())
 			go func() {
@@ -915,12 +914,6 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 						base.Infof(base.KeyConfig, "Stopping background config polling loop")
 						t.Stop()
 						return
-					case dbName := <-sc.bootstrapContext.dbUpdateChan:
-						base.Infof(base.KeyConfig, "Forcing config update for db: %q", dbName)
-						_, err := sc.fetchAndLoadDatabase(dbName)
-						if err != nil {
-							base.Warnf("Couldn't load config for %q from bucket: %v", dbName, err)
-						}
 					case <-t.C:
 						count, err := sc.fetchAndLoadConfigs()
 						if err != nil {

--- a/rest/config.go
+++ b/rest/config.go
@@ -968,7 +968,7 @@ func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err er
 	for _, bucket := range buckets {
 		bucket := bucket
 		var cnf DatabaseConfig
-		cas, err := sc.bootstrapContext.connection.GetConfig(dbName, sc.config.Bootstrap.ConfigGroupID, &cnf)
+		cas, err := sc.bootstrapContext.connection.GetConfig(bucket, sc.config.Bootstrap.ConfigGroupID, &cnf)
 		if err == base.ErrNotFound {
 			base.Debugf(base.KeyConfig, "%q did not contain config in group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
 			continue
@@ -981,6 +981,7 @@ func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err er
 		if cnf.Name == "" {
 			cnf.Name = bucket
 		}
+
 		if cnf.Name != dbName {
 			base.Tracef(base.KeyConfig, "%q did not contain config in group %q for db %q", bucket, sc.config.Bootstrap.ConfigGroupID, dbName)
 			continue
@@ -1002,8 +1003,8 @@ func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err er
 			cnf.CertPath = sc.config.Bootstrap.X509CertPath
 			cnf.KeyPath = sc.config.Bootstrap.X509KeyPath
 		}
-		base.Tracef(base.KeyConfig, "Got config for bucket %q with cas %d", dbName, cas)
-		sc.applyConfigs(map[string]*DatabaseConfig{dbName: &cnf})
+		base.Tracef(base.KeyConfig, "Got config for bucket %q with cas %d", bucket, cas)
+		sc.applyConfigs(map[string]*DatabaseConfig{bucket: &cnf})
 		return true, nil
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1066,6 +1066,7 @@ func (sc *ServerContext) applyConfigs(fetchedConfigs map[string]*DatabaseConfig)
 		// skip if we already have this config loaded
 		foundDbName, ok := sc.bucketDbName[bucket]
 		if ok && sc.dbConfigs[foundDbName].cas >= cnf.cas {
+			base.Debugf(base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, bucket)
 			continue
 		}
 
@@ -1073,7 +1074,7 @@ func (sc *ServerContext) applyConfigs(fetchedConfigs map[string]*DatabaseConfig)
 		if dbc := sc.databases_[cnf.Name]; dbc != nil {
 			runningBucket := dbc.Bucket.GetName()
 			if runningBucket != bucket {
-				base.Errorf("database %q bucket %q cannot be added - already running %q using bucket %q", cnf.Name, bucket, cnf.Name, runningBucket)
+				base.Errorf("Database %q bucket %q cannot be added - already running %q using bucket %q", cnf.Name, bucket, cnf.Name, runningBucket)
 				continue
 			}
 		}
@@ -1084,7 +1085,7 @@ func (sc *ServerContext) applyConfigs(fetchedConfigs map[string]*DatabaseConfig)
 
 		// TODO: Dynamic update instead of reload
 		if _, err := sc._reloadDatabaseFromConfig(cnf.Name); err != nil {
-			base.Errorf("couldn't reload database: %v", err)
+			base.Errorf("Couldn't reload database: %v", err)
 			continue
 		}
 		count++

--- a/rest/config.go
+++ b/rest/config.go
@@ -903,6 +903,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 		if sc.config.Bootstrap.ConfigUpdateFrequency.Value() > 0 {
 			sc.bootstrapContext.terminator = make(chan struct{})
 			sc.bootstrapContext.doneChan = make(chan struct{})
+			sc.bootstrapContext.dbUpdateChan = make(chan string)
 
 			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.Value().String())
 			go func() {
@@ -914,6 +915,12 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 						base.Infof(base.KeyConfig, "Stopping background config polling loop")
 						t.Stop()
 						return
+					case dbName := <-sc.bootstrapContext.dbUpdateChan:
+						base.Infof(base.KeyConfig, "Forcing config update for db: %q", dbName)
+						_, err := sc.fetchAndLoadDatabase(dbName)
+						if err != nil {
+							base.Warnf("Couldn't load config for %q from bucket: %v", dbName, err)
+						}
 					case <-t.C:
 						count, err := sc.fetchAndLoadConfigs()
 						if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -56,10 +56,9 @@ type ServerContext struct {
 }
 
 type bootstrapContext struct {
-	connection   base.BootstrapConnection
-	dbUpdateChan chan string   // dbUpdateChan receives database names to force a config update to happen.
-	terminator   chan struct{} // Used to stop the goroutine handling the stats logging
-	doneChan     chan struct{} // doneChan is closed when the stats logger goroutine finishes.
+	connection base.BootstrapConnection
+	terminator chan struct{} // Used to stop the goroutine handling the stats logging
+	doneChan   chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }
 
 type DatabaseConfig struct {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -56,9 +56,10 @@ type ServerContext struct {
 }
 
 type bootstrapContext struct {
-	connection base.BootstrapConnection
-	terminator chan struct{} // Used to stop the goroutine handling the stats logging
-	doneChan   chan struct{} // doneChan is closed when the stats logger goroutine finishes.
+	connection   base.BootstrapConnection
+	dbUpdateChan chan string   // dbUpdateChan receives database names to force a config update to happen.
+	terminator   chan struct{} // Used to stop the goroutine handling the stats logging
+	doneChan     chan struct{} // doneChan is closed when the stats logger goroutine finishes.
 }
 
 type DatabaseConfig struct {


### PR DESCRIPTION
Forces a synchronous database config reload on `GET /{db}/_config` when the `refresh_config=true` query parameter is supplied.

Changed approach from original async opt-out update to avoid unintentional refreshes from callers.