### PR TITLE
CBG-1542 - Command line flags for persistent config

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -201,6 +201,10 @@ var _ mergo.Transformers = &mergoNilTransformer{}
 
 func (t *mergoNilTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ.Kind() == reflect.Ptr {
+		if typ.Elem().Kind() == reflect.Struct {
+			// skip nilTransformer for structs, to allow recursion
+			return nil
+		}
 		return func(dst, src reflect.Value) error {
 			if dst.CanSet() && !src.IsNil() {
 				dst.Set(src)

--- a/base/bootstrap_test.go
+++ b/base/bootstrap_test.go
@@ -1,0 +1,27 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/imdario/mergo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStructPointer(t *testing.T) {
+	type structPtr struct {
+		I *int
+		S string
+	}
+	type wrap struct {
+		Ptr *structPtr
+	}
+	override := wrap{Ptr: &structPtr{nil, "changed"}}
+
+	source := wrap{Ptr: &structPtr{IntPtr(5), "test"}}
+	err := mergo.Merge(&source, &override, mergo.WithTransformers(&mergoNilTransformer{}), mergo.WithOverride)
+
+	require.Nil(t, err)
+	assert.Equal(t, "changed", source.Ptr.S)
+	assert.Equal(t, IntPtr(5), source.Ptr.I)
+}

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -68,10 +68,10 @@ type FileLoggerConfig struct {
 }
 
 type logRotationConfig struct {
-	MaxSize              *int `json:"max_size,omitempty"`                // The maximum size in MB of the log file before it gets rotated.
-	MaxAge               *int `json:"max_age,omitempty"`                 // The maximum number of days to retain old log files.
-	LocalTime            bool `json:"localtime,omitempty"`               // If true, it uses the computer's local time to format the backup timestamp.
-	RotatedLogsSizeLimit *int `json:"rotated_logs_size_limit,omitempty"` // Max Size of log files before deletion
+	MaxSize              *int  `json:"max_size,omitempty"`                // The maximum size in MB of the log file before it gets rotated.
+	MaxAge               *int  `json:"max_age,omitempty"`                 // The maximum number of days to retain old log files.
+	LocalTime            *bool `json:"localtime,omitempty"`               // If true, it uses the computer's local time to format the backup timestamp.
+	RotatedLogsSizeLimit *int  `json:"rotated_logs_size_limit,omitempty"` // Max Size of log files before deletion
 }
 
 // NewFileLogger returns a new FileLogger from a config.

--- a/base/util.go
+++ b/base/util.go
@@ -1540,17 +1540,8 @@ type ConfigDuration struct {
 	D *time.Duration
 }
 
-// Reimplement common time.Duration methods
-func (d ConfigDuration) String() string      { return d.D.String() }
-func (d ConfigDuration) Nanoseconds() int64  { return d.D.Nanoseconds() }
-func (d ConfigDuration) Microseconds() int64 { return d.D.Microseconds() }
-func (d ConfigDuration) Milliseconds() int64 { return d.D.Milliseconds() }
-func (d ConfigDuration) Seconds() float64    { return d.D.Seconds() }
-func (d ConfigDuration) Minutes() float64    { return d.D.Minutes() }
-func (d ConfigDuration) Hours() float64      { return d.D.Hours() }
-
 func (d *ConfigDuration) Value() time.Duration {
-	if d == nil {
+	if d == nil || d.D == nil {
 		return 0
 	}
 	return *d.D

--- a/base/util.go
+++ b/base/util.go
@@ -1535,24 +1535,34 @@ func IsConnectionRefusedError(err error) bool {
 }
 
 // ConfigDuration is a time.Duration that supports JSON marshalling/unmarshalling.
+// Underlying duration cannot be embedded due to requiring reflect access for mergo.
 type ConfigDuration struct {
-	time.Duration
+	D time.Duration
 }
+
+// Reimplement common time.Duration methods
+func (d ConfigDuration) String() string      { return d.D.String() }
+func (d ConfigDuration) Nanoseconds() int64  { return d.D.Nanoseconds() }
+func (d ConfigDuration) Microseconds() int64 { return d.D.Microseconds() }
+func (d ConfigDuration) Milliseconds() int64 { return d.D.Milliseconds() }
+func (d ConfigDuration) Seconds() float64    { return d.D.Seconds() }
+func (d ConfigDuration) Minutes() float64    { return d.D.Minutes() }
+func (d ConfigDuration) Hours() float64      { return d.D.Hours() }
 
 func (d *ConfigDuration) Value() time.Duration {
 	if d == nil {
 		return 0
 	}
-	return d.Duration
+	return d.D
 }
 
 // NewConfigDuration returns a *ConfigDuration from a time.Duration
 func NewConfigDuration(d time.Duration) *ConfigDuration {
-	return &ConfigDuration{Duration: d}
+	return &ConfigDuration{D: d}
 }
 
 func (d ConfigDuration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
+	return json.Marshal(d.D.String())
 }
 
 func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
@@ -1571,7 +1581,7 @@ func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*d = ConfigDuration{Duration: dur}
+	*d = ConfigDuration{D: dur}
 	return nil
 }
 

--- a/base/util.go
+++ b/base/util.go
@@ -1537,7 +1537,7 @@ func IsConnectionRefusedError(err error) bool {
 // ConfigDuration is a time.Duration that supports JSON marshalling/unmarshalling.
 // Underlying duration cannot be embedded due to requiring reflect access for mergo.
 type ConfigDuration struct {
-	D time.Duration
+	D *time.Duration
 }
 
 // Reimplement common time.Duration methods
@@ -1553,16 +1553,20 @@ func (d *ConfigDuration) Value() time.Duration {
 	if d == nil {
 		return 0
 	}
-	return d.D
+	return *d.D
 }
 
 // NewConfigDuration returns a *ConfigDuration from a time.Duration
 func NewConfigDuration(d time.Duration) *ConfigDuration {
-	return &ConfigDuration{D: d}
+	return &ConfigDuration{D: &d}
 }
 
 func (d ConfigDuration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.D.String())
+	duration := d.D
+	if duration == nil {
+		return nil, fmt.Errorf("cannot marshal nil duration")
+	}
+	return json.Marshal(duration.String())
 }
 
 func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
@@ -1581,7 +1585,7 @@ func (d *ConfigDuration) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	*d = ConfigDuration{D: dur}
+	*d = ConfigDuration{D: &dur}
 	return nil
 }
 

--- a/base/util_test.go
+++ b/base/util_test.go
@@ -1512,13 +1512,13 @@ func TestConfigDuration(t *testing.T) {
 			d = &ConfigDuration{}
 			err = d.UnmarshalJSON(durationJSON)
 			require.NoError(t, err)
-			assert.Equal(t, test.duration, d.Duration)
+			assert.Equal(t, test.duration, d.Value())
 
 			// unmarshal test input
 			d = &ConfigDuration{}
 			err = d.UnmarshalJSON([]byte(test.inputJSON))
 			require.NoError(t, err)
-			assert.Equal(t, test.duration, d.Duration)
+			assert.Equal(t, test.duration, d.Value())
 		})
 	}
 }

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1907,7 +1907,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	goassert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
 
 	// Set max heartbeat in server context, attempt to set heartbeat greater than max
-	h.server.config.Replicator.MaxHeartbeat = base.ConfigDuration{Duration: time.Minute}
+	h.server.config.Replicator.MaxHeartbeat = base.ConfigDuration{D: time.Minute}
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.NoError(t, err)

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1907,7 +1907,7 @@ func TestReadChangesOptionsFromJSON(t *testing.T) {
 	goassert.Equals(t, options.TimeoutMs, uint64(kMaxTimeoutMS))
 
 	// Set max heartbeat in server context, attempt to set heartbeat greater than max
-	h.server.config.Replicator.MaxHeartbeat = base.ConfigDuration{D: time.Minute}
+	h.server.config.Replicator.MaxHeartbeat = base.NewConfigDuration(time.Minute)
 	optStr = `{"feed":"longpoll", "since": "1", "heartbeat":90000}`
 	feed, options, filter, channelsArray, _, _, err = h.readChangesOptionsFromJSON([]byte(optStr))
 	assert.NoError(t, err)

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -133,16 +133,12 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 	}
 
 	if _, ok := values["heartbeat"]; ok {
-		maxHeartbeat := h.server.config.Replicator.MaxHeartbeat
-		if h.server.config.Replicator.MaxHeartbeat == nil {
-			maxHeartbeat = base.NewConfigDuration(0)
-		}
 		options.HeartbeatMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
-			uint64(maxHeartbeat.Milliseconds()),
+			uint64(h.server.config.Replicator.MaxHeartbeat.Value().Milliseconds()),
 			true,
 		)
 	}
@@ -203,16 +199,12 @@ func (h *handler) handleChanges() error {
 				docIdsArray = strings.Split(docidsParam, ",")
 			}
 		}
-		maxHeartbeat := h.server.config.Replicator.MaxHeartbeat
-		if h.server.config.Replicator.MaxHeartbeat == nil {
-			maxHeartbeat = base.NewConfigDuration(0)
-		}
 		options.HeartbeatMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
-			uint64(maxHeartbeat.Milliseconds()),
+			uint64(h.server.config.Replicator.MaxHeartbeat.Value().Milliseconds()),
 			true,
 		)
 		options.TimeoutMs = base.GetRestrictedIntQuery(
@@ -603,15 +595,11 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 	}
 
 	docIdsArray = input.DocIds
-	maxHeartbeat := h.server.config.Replicator.MaxHeartbeat
-	if h.server.config.Replicator.MaxHeartbeat == nil {
-		maxHeartbeat = base.NewConfigDuration(0)
-	}
 	options.HeartbeatMs = base.GetRestrictedInt(
 		input.HeartbeatMs,
 		kDefaultHeartbeatMS,
 		kMinHeartbeatMS,
-		uint64(maxHeartbeat.Milliseconds()),
+		uint64(h.server.config.Replicator.MaxHeartbeat.Value().Milliseconds()),
 		true,
 	)
 

--- a/rest/changes_api.go
+++ b/rest/changes_api.go
@@ -133,12 +133,16 @@ func (h *handler) updateChangesOptionsFromQuery(feed *string, options *db.Change
 	}
 
 	if _, ok := values["heartbeat"]; ok {
+		maxHeartbeat := h.server.config.Replicator.MaxHeartbeat
+		if h.server.config.Replicator.MaxHeartbeat == nil {
+			maxHeartbeat = base.NewConfigDuration(0)
+		}
 		options.HeartbeatMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
-			uint64(h.server.config.Replicator.MaxHeartbeat.Milliseconds()),
+			uint64(maxHeartbeat.Milliseconds()),
 			true,
 		)
 	}
@@ -199,13 +203,16 @@ func (h *handler) handleChanges() error {
 				docIdsArray = strings.Split(docidsParam, ",")
 			}
 		}
-
+		maxHeartbeat := h.server.config.Replicator.MaxHeartbeat
+		if h.server.config.Replicator.MaxHeartbeat == nil {
+			maxHeartbeat = base.NewConfigDuration(0)
+		}
 		options.HeartbeatMs = base.GetRestrictedIntQuery(
 			h.getQueryValues(),
 			"heartbeat",
 			kDefaultHeartbeatMS,
 			kMinHeartbeatMS,
-			uint64(h.server.config.Replicator.MaxHeartbeat.Milliseconds()),
+			uint64(maxHeartbeat.Milliseconds()),
 			true,
 		)
 		options.TimeoutMs = base.GetRestrictedIntQuery(
@@ -596,12 +603,15 @@ func (h *handler) readChangesOptionsFromJSON(jsonData []byte) (feed string, opti
 	}
 
 	docIdsArray = input.DocIds
-
+	maxHeartbeat := h.server.config.Replicator.MaxHeartbeat
+	if h.server.config.Replicator.MaxHeartbeat == nil {
+		maxHeartbeat = base.NewConfigDuration(0)
+	}
 	options.HeartbeatMs = base.GetRestrictedInt(
 		input.HeartbeatMs,
 		kDefaultHeartbeatMS,
 		kMinHeartbeatMS,
-		uint64(h.server.config.Replicator.MaxHeartbeat.Milliseconds()),
+		uint64(maxHeartbeat.Milliseconds()),
 		true,
 	)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -827,7 +827,7 @@ func SetMaxFileDescriptors(maxP *uint64) error {
 
 func (sc *ServerContext) Serve(config *StartupConfig, addr string, handler http.Handler) error {
 	http2Enabled := false
-	if config.Unsupported.HTTP2 != nil {
+	if config.Unsupported.HTTP2 != nil && config.Unsupported.HTTP2.Enabled != nil {
 		http2Enabled = *config.Unsupported.HTTP2.Enabled
 	}
 
@@ -952,7 +952,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 			sc.bootstrapContext.terminator = make(chan struct{})
 			sc.bootstrapContext.doneChan = make(chan struct{})
 
-			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.Value().String())
+			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.String())
 			go func() {
 				defer close(sc.bootstrapContext.doneChan)
 				t := time.NewTicker(sc.config.Bootstrap.ConfigUpdateFrequency.Value())

--- a/rest/config.go
+++ b/rest/config.go
@@ -952,7 +952,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 			sc.bootstrapContext.terminator = make(chan struct{})
 			sc.bootstrapContext.doneChan = make(chan struct{})
 
-			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.String())
+			base.Infof(base.KeyConfig, "Starting background polling for new configs/buckets: %s", sc.config.Bootstrap.ConfigUpdateFrequency.Value().String())
 			go func() {
 				defer close(sc.bootstrapContext.doneChan)
 				t := time.NewTicker(sc.config.Bootstrap.ConfigUpdateFrequency.Value())

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -1,0 +1,198 @@
+package rest
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/hashicorp/go-multierror"
+)
+
+// configFlag stores the config value, and the corresponding flag value
+type configFlag struct {
+	config    interface{}
+	flagValue interface{}
+}
+
+// setConfigFlags holds a map of the flag values with the configFlag it goes with
+// (which stores the corresponding config field pointer and flag value).
+func setConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]configFlag {
+	return map[string]configFlag{
+		"bootstrap.group_id":                {&config.Bootstrap.ConfigGroupID, fs.String("bootstrap.group_id", "", "The config group ID to use when discovering databases. Allows for non-homogenous configuration")},
+		"bootstrap.config_update_frequency": {&config.Bootstrap.ConfigUpdateFrequency, fs.String("bootstrap.config_update_frequency", persistentConfigDefaultUpdateFrequency.String(), "How often to poll Couchbase Server for new config changes")},
+		"bootstrap.server":                  {&config.Bootstrap.Server, fs.String("bootstrap.server", "", "Couchbase Server connection string/URL")},
+		"bootstrap.username":                {&config.Bootstrap.Username, fs.String("bootstrap.username", "", "Username for authenticating to server")},
+		"bootstrap.password":                {&config.Bootstrap.Password, fs.String("bootstrap.password", "", "Password for authenticating to server")},
+		"bootstrap.ca_cert_path":            {&config.Bootstrap.CACertPath, fs.String("bootstrap.ca_cert_path", "", "Root CA cert path for TLS connection")},
+		"bootstrap.server_tls_skip_verify":  {&config.Bootstrap.ServerTLSSkipVerify, fs.Bool("bootstrap.server_tls_skip_verify", false, "Allow empty server CA Cert Path without attempting to use system root pool")},
+		"bootstrap.x509_cert_path":          {&config.Bootstrap.X509CertPath, fs.String("bootstrap.x509_cert_path", "", "Cert path (public key) for X.509 bucket auth")},
+		"bootstrap.x509_key_path":           {&config.Bootstrap.X509KeyPath, fs.String("bootstrap.x509_key_path", "", "Key path (private key) for X.509 bucket auth")},
+		"bootstrap.use_tls_server":          {&config.Bootstrap.UseTLSServer, fs.Bool("bootstrap.use_tls_server", false, "Forces the connection to Couchbase Server to use TLS")},
+
+		"api.public_interface":                              {&config.API.PublicInterface, fs.String("api.public_interface", "", "Network interface to bind public API to")},
+		"api.admin_interface":                               {&config.API.AdminInterface, fs.String("api.admin_interface", "", "Network interface to bind admin API to")},
+		"api.metrics_interface":                             {&config.API.MetricsInterface, fs.String("api.metrics_interface", "", "Network interface to bind metrics API to")},
+		"api.profile_interface":                             {&config.API.ProfileInterface, fs.String("api.profile_interface", "", "Network interface to bind profiling API to")},
+		"api.admin_interface_authentication":                {&config.API.AdminInterfaceAuthentication, fs.Bool("api.admin_interface_authentication", false, "Whether the admin API requires authentication")},
+		"api.metrics_interface_authentication":              {&config.API.MetricsInterfaceAuthentication, fs.Bool("api.metrics_interface_authentication", false, "Whether the metrics API requires authentication")},
+		"api.enable_admin_authentication_permissions_check": {&config.API.EnableAdminAuthenticationPermissionsCheck, fs.Bool("api.enable_admin_authentication_permissions_check", false, "Whether to enable the DP permissions check feature of admin auth")},
+		"api.server_read_timeout":                           {&config.API.ServerReadTimeout, fs.String("api.server_read_timeout", "", "Maximum duration.Second before timing out read of the HTTP(S) request")},
+		"api.server_write_timeout":                          {&config.API.ServerWriteTimeout, fs.String("api.server_write_timeout", "", "Maximum duration.Second before timing out write of the HTTP(S) response")},
+		"api.read_header_timeout":                           {&config.API.ReadHeaderTimeout, fs.String("api.read_header_timeout", "", "The amount of time allowed to read request headers")},
+		"api.idle_timeout":                                  {&config.API.IdleTimeout, fs.String("api.idle_timeout", "", "The maximum amount of time to wait for the next request when keep-alives are enabled")},
+		"api.pretty":                                        {&config.API.Pretty, fs.Bool("api.pretty", false, "Pretty-print JSON responses")},
+		"api.max_connections":                               {&config.API.MaximumConnections, fs.Uint("api.max_connections", 0, "Max # of incoming HTTP connections to accept")},
+		"api.compress_responses":                            {&config.API.CompressResponses, fs.Bool("api.compress_responses", false, "If false, disables compression of HTTP responses")},
+		"api.hide_product_version":                          {&config.API.CompressResponses, fs.Bool("api.hide_product_version", false, "Whether product versions removed from Server headers and REST API responses")},
+
+		"api.https.tls_minimum_version": {&config.API.HTTPS.TLSMinimumVersion, fs.String("api.https.tls_minimum_version", "", "The minimum allowable TLS version for the REST APIs")},
+		"api.https.tls_cert_path":       {&config.API.HTTPS.TLSCertPath, fs.String("api.https.tls_cert_path", "", "The TLS cert file to use for the REST APIs")},
+		"api.https.tls_key_path":        {&config.API.HTTPS.TLSKeyPath, fs.String("api.https.tls_key_path", "", "The TLS key file to use for the REST APIs")},
+
+		"api.cors.origin":       {&config.API.CORS.Origin, fs.String("api.cors.origin", "", "List of comma seperated allowed origins. Use '*' to allow access from everywhere")},
+		"api.cors.login_origin": {&config.API.CORS.LoginOrigin, fs.String("api.cors.login_origin", "", "List of comma seperated allowed login origins")},
+		"api.cors.headers":      {&config.API.CORS.Headers, fs.String("api.cors.headers", "", "List of comma seperated allowed headers")},
+		"api.cors.max_age":      {&config.API.CORS.MaxAge, fs.Int("api.cors.max_age", 0, "Maximum age of the CORS Options request")},
+
+		"logging.log_file_path":   {&config.Logging.LogFilePath, fs.String("logging.log_file_path", "", "Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file")},
+		"logging.redaction_level": {&config.Logging.RedactionLevel, fs.String("logging.redaction_level", "", "Redaction level to apply to log output. Options: none, partial, full, unset")},
+
+		"logging.console.enabled":                          {&config.Logging.Console.Enabled, fs.Bool("logging.console.enabled", false, "")},
+		"logging.console.rotation.max_size":                {&config.Logging.Console.Rotation.MaxSize, fs.Int("logging.console.rotation.max_size", 0, "")},
+		"logging.console.rotation.max_age":                 {&config.Logging.Console.Rotation.MaxAge, fs.Int("logging.console.rotation.max_age", 0, "")},
+		"logging.console.rotation.localtime":               {&config.Logging.Console.Rotation.LocalTime, fs.Bool("logging.console.rotation.localtime", false, "")},
+		"logging.console.rotation.rotated_logs_size_limit": {&config.Logging.Console.Rotation.RotatedLogsSizeLimit, fs.Int("logging.console.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.console.collation_buffer_size":            {&config.Logging.Console.CollationBufferSize, fs.Int("logging.console.collation_buffer_size", 0, "")},
+		"logging.console.log_level":                        {&config.Logging.Console.LogLevel, fs.String("logging.console.log_level", "", "Options: none, error, warn, info, debug, trace")},
+		"logging.console.log_keys":                         {&config.Logging.Console.LogKeys, fs.String("logging.console.log_keys", "", "Comma seperated log keys")},
+		"logging.console.color_enabled":                    {&config.Logging.Console.ColorEnabled, fs.Bool("logging.console.color_enabled", false, "")},
+		"logging.console.file_output":                      {&config.Logging.Console.FileOutput, fs.String("logging.console.file_output", "", "")}, // can be used to override the default stderr output, and write to the file specified instead.
+
+		"logging.error.enabled":                          {&config.Logging.Error.Enabled, fs.Bool("logging.error.enabled", false, "")},
+		"logging.error.rotation.max_size":                {&config.Logging.Error.Rotation.MaxSize, fs.Int("logging.error.rotation.max_size", 0, "")},
+		"logging.error.rotation.max_age":                 {&config.Logging.Error.Rotation.MaxAge, fs.Int("logging.error.rotation.max_age", 0, "")},
+		"logging.error.rotation.localtime":               {&config.Logging.Error.Rotation.LocalTime, fs.Bool("logging.error.rotation.localtime", false, "")},
+		"logging.error.rotation.rotated_logs_size_limit": {&config.Logging.Error.Rotation.RotatedLogsSizeLimit, fs.Int("logging.error.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.error.collation_buffer_size":            {&config.Logging.Error.CollationBufferSize, fs.Int("logging.error.collation_buffer_size", 0, "")},
+
+		"logging.warn.enabled":                          {&config.Logging.Warn.Enabled, fs.Bool("logging.warn.enabled", false, "")},
+		"logging.warn.rotation.max_size":                {&config.Logging.Warn.Rotation.MaxSize, fs.Int("logging.warn.rotation.max_size", 0, "")},
+		"logging.warn.rotation.max_age":                 {&config.Logging.Warn.Rotation.MaxAge, fs.Int("logging.warn.rotation.max_age", 0, "")},
+		"logging.warn.rotation.localtime":               {&config.Logging.Warn.Rotation.LocalTime, fs.Bool("logging.warn.rotation.localtime", false, "")},
+		"logging.warn.rotation.rotated_logs_size_limit": {&config.Logging.Warn.Rotation.RotatedLogsSizeLimit, fs.Int("logging.warn.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.warn.collation_buffer_size":            {&config.Logging.Warn.CollationBufferSize, fs.Int("logging.warn.collation_buffer_size", 0, "")},
+
+		"logging.info.enabled":                          {&config.Logging.Info.Enabled, fs.Bool("logging.info.enabled", false, "")},
+		"logging.info.rotation.max_size":                {&config.Logging.Info.Rotation.MaxSize, fs.Int("logging.info.rotation.max_size", 0, "")},
+		"logging.info.rotation.max_age":                 {&config.Logging.Info.Rotation.MaxAge, fs.Int("logging.info.rotation.max_age", 0, "")},
+		"logging.info.rotation.localtime":               {&config.Logging.Info.Rotation.LocalTime, fs.Bool("logging.info.rotation.localtime", false, "")},
+		"logging.info.rotation.rotated_logs_size_limit": {&config.Logging.Info.Rotation.RotatedLogsSizeLimit, fs.Int("logging.info.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.info.collation_buffer_size":            {&config.Logging.Info.CollationBufferSize, fs.Int("logging.info.collation_buffer_size", 0, "")},
+
+		"logging.debug.enabled":                          {&config.Logging.Debug.Enabled, fs.Bool("logging.debug.enabled", false, "")},
+		"logging.debug.rotation.max_size":                {&config.Logging.Debug.Rotation.MaxSize, fs.Int("logging.debug.rotation.max_size", 0, "")},
+		"logging.debug.rotation.max_age":                 {&config.Logging.Debug.Rotation.MaxAge, fs.Int("logging.debug.rotation.max_age", 0, "")},
+		"logging.debug.rotation.localtime":               {&config.Logging.Debug.Rotation.LocalTime, fs.Bool("logging.debug.rotation.localtime", false, "")},
+		"logging.debug.rotation.rotated_logs_size_limit": {&config.Logging.Debug.Rotation.RotatedLogsSizeLimit, fs.Int("logging.debug.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.debug.collation_buffer_size":            {&config.Logging.Debug.CollationBufferSize, fs.Int("logging.debug.collation_buffer_size", 0, "")},
+
+		"logging.trace.enabled":                          {&config.Logging.Trace.Enabled, fs.Bool("logging.trace.enabled", false, "")},
+		"logging.trace.rotation.max_size":                {&config.Logging.Trace.Rotation.MaxSize, fs.Int("logging.trace.rotation.max_size", 0, "")},
+		"logging.trace.rotation.max_age":                 {&config.Logging.Trace.Rotation.MaxAge, fs.Int("logging.trace.rotation.max_age", 0, "")},
+		"logging.trace.rotation.localtime":               {&config.Logging.Trace.Rotation.LocalTime, fs.Bool("logging.trace.rotation.localtime", false, "")},
+		"logging.trace.rotation.rotated_logs_size_limit": {&config.Logging.Trace.Rotation.RotatedLogsSizeLimit, fs.Int("logging.trace.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.trace.collation_buffer_size":            {&config.Logging.Trace.CollationBufferSize, fs.Int("logging.trace.collation_buffer_size", 0, "")},
+
+		"logging.stats.enabled":                          {&config.Logging.Stats.Enabled, fs.Bool("logging.stats.enabled", false, "")},
+		"logging.stats.rotation.max_size":                {&config.Logging.Stats.Rotation.MaxSize, fs.Int("logging.stats.rotation.max_size", 0, "")},
+		"logging.stats.rotation.max_age":                 {&config.Logging.Stats.Rotation.MaxAge, fs.Int("logging.stats.rotation.max_age", 0, "")},
+		"logging.stats.rotation.localtime":               {&config.Logging.Stats.Rotation.LocalTime, fs.Bool("logging.stats.rotation.localtime", false, "")},
+		"logging.stats.rotation.rotated_logs_size_limit": {&config.Logging.Stats.Rotation.RotatedLogsSizeLimit, fs.Int("logging.stats.rotation.rotated_logs_size_limit", 0, "")},
+		"logging.stats.collation_buffer_size":            {&config.Logging.Stats.CollationBufferSize, fs.Int("logging.stats.collation_buffer_size", 0, "")},
+
+		"auth.bcrypt_cost": {&config.Auth.BcryptCost, fs.Int("auth.bcrypt_cost", 0, "Cost to use for bcrypt password hashes")},
+
+		"replicator.max_heartbeat":    {&config.Replicator.MaxHeartbeat, fs.String("replicator.max_heartbeat", "", "Max heartbeat value for _changes request")},
+		"replicator.blip_compression": {&config.Replicator.BLIPCompression, fs.Int("replicator.blip_compression", 0, "BLIP data compression level (0-9)")},
+
+		"unsupported.stats_log_frequency": {&config.Unsupported.StatsLogFrequency, fs.String("unsupported.stats_log_frequency", "", "How often should stats be written to stats logs")},
+		"unsupported.use_stdlib_json":     {&config.Unsupported.UseStdlibJSON, fs.Bool("unsupported.use_stdlib_json", false, "Bypass the jsoniter package and use Go's stdlib instead")},
+
+		"unsupported.http2.enabled": {&config.Unsupported.HTTP2.Enabled, fs.Bool("unsupported.http2.enabled", false, "Whether HTTP2 support is enabled")},
+
+		"max_file_descriptors": {&config.MaxFileDescriptors, fs.Uint64("max_file_descriptors", 0, "Max # of open file descriptors (RLIMIT_NOFILE)")},
+	}
+}
+
+// fillConfigWithFlags fills in the config values from setConfigFlags if the user
+// has explicitly set the flags
+func fillConfigWithFlags(fs *flag.FlagSet, flags map[string]configFlag) (errorMessages error) {
+	fs.Visit(func(f *flag.Flag) {
+		if val, exists := flags[f.Name]; exists {
+			rval := reflect.ValueOf(val.config).Elem()
+
+			pointer := true // Distinguish if to use rval.Set or *val.config
+			// Convert to pointer if not already
+			if rval.Kind() != reflect.Ptr && rval.CanAddr() {
+				rval = rval.Addr()
+				pointer = false
+			}
+
+			switch rval.Interface().(type) {
+			case *string:
+				*val.config.(*string) = *val.flagValue.(*string)
+			case *[]string:
+				list := strings.Split(*val.flagValue.(*string), ",")
+				*val.config.(*[]string) = list
+			case *uint:
+				*val.config.(*uint) = *val.flagValue.(*uint)
+			case *uint64:
+				*val.config.(*uint64) = *val.flagValue.(*uint64)
+			case *int:
+				if pointer {
+					rval.Set(reflect.ValueOf(val.flagValue))
+				} else {
+					*val.config.(*int) = *val.flagValue.(*int)
+				}
+			case *bool:
+				rval.Set(reflect.ValueOf(val.flagValue))
+			case *base.ConfigDuration:
+				duration, err := time.ParseDuration(*val.flagValue.(*string))
+				if err != nil {
+					err = fmt.Errorf("flag %s error: %w", f.Name, err)
+					errorMessages = multierror.Append(errorMessages, err)
+					return
+				}
+				if pointer {
+					rval.Set(reflect.ValueOf(&base.ConfigDuration{Duration: duration}))
+				} else {
+					*val.config.(*base.ConfigDuration) = base.ConfigDuration{Duration: duration}
+				}
+			case *base.RedactionLevel:
+				var rl base.RedactionLevel
+				err := rl.UnmarshalText([]byte(*val.flagValue.(*string)))
+				if err != nil {
+					err = fmt.Errorf("flag %s error: %w", f.Name, err)
+					errorMessages = multierror.Append(errorMessages, err)
+					return
+				}
+				*val.config.(*base.RedactionLevel) = rl
+			case *base.LogLevel:
+				var ll base.LogLevel
+				err := ll.UnmarshalText([]byte(*val.flagValue.(*string)))
+				if err != nil {
+					err = fmt.Errorf("flag %s error: %w", f.Name, err)
+					errorMessages = multierror.Append(errorMessages, err)
+					return
+				}
+				rval.Set(reflect.ValueOf(&ll))
+			default:
+				panic(fmt.Sprintf("Error: Unknown type %v for flag %v\n", rval.Type(), f.Name))
+			}
+		}
+	})
+	return errorMessages
+}

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -167,9 +167,9 @@ func fillConfigWithFlags(fs *flag.FlagSet, flags map[string]configFlag) (errorMe
 					return
 				}
 				if pointer {
-					rval.Set(reflect.ValueOf(&base.ConfigDuration{D: duration}))
+					rval.Set(reflect.ValueOf(&base.ConfigDuration{D: &duration}))
 				} else {
-					*val.config.(*base.ConfigDuration) = base.ConfigDuration{D: duration}
+					*val.config.(*base.ConfigDuration) = base.ConfigDuration{D: &duration}
 				}
 			case *base.RedactionLevel:
 				var rl base.RedactionLevel

--- a/rest/config_flags.go
+++ b/rest/config_flags.go
@@ -51,6 +51,7 @@ func setConfigFlags(config *StartupConfig, fs *flag.FlagSet) map[string]configFl
 		"api.https.tls_minimum_version": {&config.API.HTTPS.TLSMinimumVersion, fs.String("api.https.tls_minimum_version", "", "The minimum allowable TLS version for the REST APIs")},
 		"api.https.tls_cert_path":       {&config.API.HTTPS.TLSCertPath, fs.String("api.https.tls_cert_path", "", "The TLS cert file to use for the REST APIs")},
 		"api.https.tls_key_path":        {&config.API.HTTPS.TLSKeyPath, fs.String("api.https.tls_key_path", "", "The TLS key file to use for the REST APIs")},
+		"api.https.use_tls_client":      {&config.API.HTTPS.UseTLSClient, fs.Bool("api.https.use_tls_client", false, "Use TLS for the REST APIs")},
 
 		"api.cors.origin":       {&config.API.CORS.Origin, fs.String("api.cors.origin", "", "List of comma seperated allowed origins. Use '*' to allow access from everywhere")},
 		"api.cors.login_origin": {&config.API.CORS.LoginOrigin, fs.String("api.cors.login_origin", "", "List of comma seperated allowed login origins")},

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -1,0 +1,118 @@
+package rest
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test to make sure that filling all the flags correctly causes no errors or panics
+func TestAllConfigFlags(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	config := NewEmptyStartupConfig()
+
+	flagMap := setConfigFlags(&config, fs)
+
+	flags := []string{}
+	for name, flagConfig := range flagMap {
+		rFlagVal := reflect.ValueOf(flagConfig.flagValue).Elem()
+		switch rFlagVal.Interface().(type) {
+		case string: // Test different types of strings
+			rConfigVal := reflect.ValueOf(flagConfig.config).Elem()
+			if rConfigVal.Kind() != reflect.Ptr && rConfigVal.CanAddr() {
+				rConfigVal = rConfigVal.Addr()
+			}
+			val := "TestString"
+			switch rConfigVal.Interface().(type) {
+			case *base.ConfigDuration:
+				val = "5h2m33s"
+			case *base.RedactionLevel:
+				val = "partial"
+			case *base.LogLevel:
+				val = "trace"
+			}
+			flags = append(flags, "-"+name, val)
+		case bool:
+			flags = append(flags, "-"+name+"=true")
+		case uint, uint64:
+			flags = append(flags, "-"+name, "1234")
+		case int:
+			flags = append(flags, "-"+name, "-5678")
+		default:
+			panic(fmt.Sprintf("Unknown flag type found %v for flag %v! Please add it to this test and config_flags.go if needed", rFlagVal.Type(), name))
+		}
+	}
+	err := fs.Parse(flags)
+	assert.NoError(t, err)
+	err = fillConfigWithFlags(fs, flagMap)
+	assert.NoError(t, err)
+}
+
+// Manually test different types of flags with valid values
+func TestFillConfigWithFlagsValidVals(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	config := NewEmptyStartupConfig()
+
+	flags := setConfigFlags(&config, fs)
+
+	err := fs.Parse([]string{
+		"-bootstrap.server", "testServer", // String
+		"-bootstrap.server_tls_skip_verify=true",   // *bool
+		"-bootstrap.config_update_frequency", "2h", // *base.ConfigDuration
+		"-api.max_connections", "5", // uint
+		"-api.cors.origin", "*,example.com,test.net", // []string
+		"-api.cors.max_age", "-5", // int
+		"-logging.redaction_level", "full", // RedactionLevel
+		"-logging.console.log_level", "warn", // *LogLevel
+		"-replicator.max_heartbeat", "5h2m33s", // base.ConfigDuration
+		"-max_file_descriptors", "12345", //uint64
+	})
+	require.NoError(t, err)
+
+	err = fillConfigWithFlags(fs, flags)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testServer", config.Bootstrap.Server)
+	assert.Equal(t, base.BoolPtr(true), config.Bootstrap.ServerTLSSkipVerify)
+	assert.Equal(t, uint(5), config.API.MaximumConnections)
+	require.NotNil(t, config.Bootstrap.ConfigUpdateFrequency)
+	assert.Equal(t, base.ConfigDuration{Duration: time.Hour * 2}, *config.Bootstrap.ConfigUpdateFrequency)
+	assert.Equal(t, []string{"*", "example.com", "test.net"}, config.API.CORS.Origin)
+	assert.Equal(t, -5, config.API.CORS.MaxAge)
+	assert.Equal(t, "full", config.Logging.RedactionLevel.String())
+	assert.Equal(t, "warn", config.Logging.Console.LogLevel.String())
+	assert.Equal(t, base.ConfigDuration{Duration: time.Hour*5 + time.Minute*2 + time.Second*33}, config.Replicator.MaxHeartbeat)
+	assert.Equal(t, uint64(12345), config.MaxFileDescriptors)
+}
+
+// Manually test different types of flags with invalid values
+func TestFillConfigWithFlagsInvalidVals(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	config := NewEmptyStartupConfig()
+
+	flags := setConfigFlags(&config, fs)
+
+	err := fs.Parse([]string{
+		"-bootstrap.config_update_frequency", "time2h", // *base.ConfigDuration
+		"-logging.redaction_level", "redactnone", // RedactionLevel
+		"-logging.console.log_level", "wrn", // *LogLevel
+		"-replicator.max_heartbeat", "time5h2m", // base.ConfigDuration
+		"-bootstrap.server", "testServer", // String - filled valid so should not error
+	})
+	require.NoError(t, err)
+
+	err = fillConfigWithFlags(fs, flags)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "bootstrap.config_update_frequency")
+	assert.Contains(t, err.Error(), "logging.redaction_level")
+	assert.Contains(t, err.Error(), "logging.console.log_level")
+	assert.Contains(t, err.Error(), "replicator.max_heartbeat")
+	assert.NotContains(t, err.Error(), "bootstrap.server")
+}

--- a/rest/config_flags_test.go
+++ b/rest/config_flags_test.go
@@ -82,12 +82,12 @@ func TestFillConfigWithFlagsValidVals(t *testing.T) {
 	assert.Equal(t, base.BoolPtr(true), config.Bootstrap.ServerTLSSkipVerify)
 	assert.Equal(t, uint(5), config.API.MaximumConnections)
 	require.NotNil(t, config.Bootstrap.ConfigUpdateFrequency)
-	assert.Equal(t, base.ConfigDuration{D: time.Hour * 2}, *config.Bootstrap.ConfigUpdateFrequency)
+	assert.Equal(t, base.NewConfigDuration(time.Hour*2), config.Bootstrap.ConfigUpdateFrequency)
 	assert.Equal(t, []string{"*", "example.com", "test.net"}, config.API.CORS.Origin)
 	assert.Equal(t, -5, config.API.CORS.MaxAge)
 	assert.Equal(t, "full", config.Logging.RedactionLevel.String())
 	assert.Equal(t, "warn", config.Logging.Console.LogLevel.String())
-	assert.Equal(t, base.ConfigDuration{D: time.Hour*5 + time.Minute*2 + time.Second*33}, config.Replicator.MaxHeartbeat)
+	assert.Equal(t, base.NewConfigDuration(time.Hour*5+time.Minute*2+time.Second*33), config.Replicator.MaxHeartbeat)
 	assert.Equal(t, uint64(12345), config.MaxFileDescriptors)
 }
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -126,7 +126,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			BcryptCost: lc.BcryptCost,
 		},
 		Replicator: ReplicatorConfig{
-			MaxHeartbeat:    base.ConfigDuration{Duration: time.Second * time.Duration(lc.MaxHeartbeat)},
+			MaxHeartbeat:    base.ConfigDuration{D: time.Second * time.Duration(lc.MaxHeartbeat)},
 			BLIPCompression: lc.ReplicatorCompression,
 		},
 	}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -44,7 +44,7 @@ type LegacyServerConfig struct {
 	MaxFileDescriptors                        *uint64                        `json:",omitempty"`                       // Max # of open file descriptors (RLIMIT_NOFILE)
 	CompressResponses                         *bool                          `json:",omitempty"`                       // If false, disables compression of HTTP responses
 	Databases                                 DbConfigMap                    `json:",omitempty"`                       // Pre-configured databases, mapped by name
-	MaxHeartbeat                              uint64                         `json:",omitempty"`                       // Max heartbeat value for _changes request (seconds)
+	MaxHeartbeat                              *uint64                        `json:",omitempty"`                       // Max heartbeat value for _changes request (seconds)
 	ClusterConfig                             *ClusterConfigLegacy           `json:"cluster_config,omitempty"`         // Bucket and other config related to CBGT
 	Unsupported                               *UnsupportedServerConfigLegacy `json:"unsupported,omitempty"`            // Config for unsupported features
 	ReplicatorCompression                     *int                           `json:"replicator_compression,omitempty"` // BLIP data compression level (0-9)
@@ -126,7 +126,6 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			BcryptCost: lc.BcryptCost,
 		},
 		Replicator: ReplicatorConfig{
-			MaxHeartbeat:    base.NewConfigDuration(time.Second * time.Duration(lc.MaxHeartbeat)),
 			BLIPCompression: lc.ReplicatorCompression,
 		},
 	}
@@ -152,6 +151,10 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 				Enabled: lc.Unsupported.Http2Config.Enabled,
 			}
 		}
+	}
+
+	if lc.MaxHeartbeat != nil {
+		sc.Replicator.MaxHeartbeat = base.NewConfigDuration(time.Second * time.Duration(*lc.MaxHeartbeat))
 	}
 
 	if lc.Logging != nil {

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -126,7 +126,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			BcryptCost: lc.BcryptCost,
 		},
 		Replicator: ReplicatorConfig{
-			MaxHeartbeat:    base.ConfigDuration{D: time.Second * time.Duration(lc.MaxHeartbeat)},
+			MaxHeartbeat:    base.NewConfigDuration(time.Second * time.Duration(lc.MaxHeartbeat)),
 			BLIPCompression: lc.ReplicatorCompression,
 		},
 	}

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -32,8 +32,8 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "Override duration zero ServerReadTimeout",
 			base:     StartupConfig{API: APIConfig{ServerReadTimeout: base.NewConfigDuration(time.Second * 10)}},
-			input:    LegacyServerConfig{ServerReadTimeout: base.IntPtr(0)},
-			expected: StartupConfig{API: APIConfig{ServerReadTimeout: base.NewConfigDuration(0)}},
+			input:    LegacyServerConfig{ServerReadTimeout: base.IntPtr(1)},
+			expected: StartupConfig{API: APIConfig{ServerReadTimeout: base.NewConfigDuration(time.Second)}},
 		},
 		{
 			name:     "Override duration non-zero ServerWriteTimeout",

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -32,8 +32,8 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "Override duration zero ServerReadTimeout",
 			base:     StartupConfig{API: APIConfig{ServerReadTimeout: base.NewConfigDuration(time.Second * 10)}},
-			input:    LegacyServerConfig{ServerReadTimeout: base.IntPtr(1)},
-			expected: StartupConfig{API: APIConfig{ServerReadTimeout: base.NewConfigDuration(time.Second)}},
+			input:    LegacyServerConfig{ServerReadTimeout: base.IntPtr(0)},
+			expected: StartupConfig{API: APIConfig{ServerReadTimeout: base.NewConfigDuration(0)}},
 		},
 		{
 			name:     "Override duration non-zero ServerWriteTimeout",
@@ -77,6 +77,11 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 			lc := &test.input
 
 			migratedStartupConfig, _, err := lc.ToStartupConfig()
+
+			// lc.MaxHeartbeat is (uint)0 if not set causing Replicator.MaxHeartbeat to always be 0 when migrating
+			if lc.MaxHeartbeat == 0 {
+				test.expected.Replicator.MaxHeartbeat = base.NewConfigDuration(0)
+			}
 
 			config := test.base
 			err = config.Merge(migratedStartupConfig)

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -78,11 +78,6 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 
 			migratedStartupConfig, _, err := lc.ToStartupConfig()
 
-			// lc.MaxHeartbeat is (uint)0 if not set causing Replicator.MaxHeartbeat to always be 0 when migrating
-			if lc.MaxHeartbeat == 0 {
-				test.expected.Replicator.MaxHeartbeat = base.NewConfigDuration(0)
-			}
-
 			config := test.base
 			err = config.Merge(migratedStartupConfig)
 			require.NoError(t, err)

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -128,8 +128,8 @@ type AuthConfig struct {
 }
 
 type ReplicatorConfig struct {
-	MaxHeartbeat    base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
-	BLIPCompression *int                `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
+	MaxHeartbeat    *base.ConfigDuration `json:"max_heartbeat,omitempty"    help:"Max heartbeat value for _changes request"`
+	BLIPCompression *int                 `json:"blip_compression,omitempty" help:"BLIP data compression level (0-9)"`
 }
 
 type UnsupportedConfig struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -96,8 +96,8 @@ type APIConfig struct {
 	MetricsInterfaceAuthentication            *bool `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
 	EnableAdminAuthenticationPermissionsCheck *bool `json:"enable_advanced_auth_dp,omitempty" help:"Whether to enable the DP permissions check feature of admin auth"`
 
-	ServerReadTimeout  *base.ConfigDuration `json:"server_read_timeout,omitempty"  help:"maximum duration.Second before timing out read of the HTTP(S) request"`
-	ServerWriteTimeout *base.ConfigDuration `json:"server_write_timeout,omitempty" help:"maximum duration.Second before timing out write of the HTTP(S) response"`
+	ServerReadTimeout  *base.ConfigDuration `json:"server_read_timeout,omitempty"  help:"Maximum duration.Second before timing out read of the HTTP(S) request"`
+	ServerWriteTimeout *base.ConfigDuration `json:"server_write_timeout,omitempty" help:"Maximum duration.Second before timing out write of the HTTP(S) response"`
 	ReadHeaderTimeout  *base.ConfigDuration `json:"read_header_timeout,omitempty"  help:"The amount of time allowed to read request headers"`
 	IdleTimeout        *base.ConfigDuration `json:"idle_timeout,omitempty"         help:"The maximum amount of time to wait for the next request when keep-alives are enabled"`
 
@@ -172,6 +172,27 @@ func LoadStartupConfigFromPath(path string) (*StartupConfig, error) {
 	var sc StartupConfig
 	err = decodeAndSanitiseConfig(rc, &sc)
 	return &sc, err
+}
+
+// NewEmptyStartupConfig initialises an empty StartupConfig with all struct fields empty
+func NewEmptyStartupConfig() StartupConfig {
+	return StartupConfig{
+		API: APIConfig{
+			CORS: &CORSConfig{},
+		},
+		Logging: LoggingConfig{
+			Console: &base.ConsoleLoggerConfig{},
+			Error:   &base.FileLoggerConfig{},
+			Warn:    &base.FileLoggerConfig{},
+			Info:    &base.FileLoggerConfig{},
+			Debug:   &base.FileLoggerConfig{},
+			Trace:   &base.FileLoggerConfig{},
+			Stats:   &base.FileLoggerConfig{},
+		},
+		Unsupported: UnsupportedConfig{
+			HTTP2: &HTTP2Config{},
+		},
+	}
 }
 
 // setGlobalConfig will set global variables and other settings based on the given StartupConfig.

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -180,7 +180,7 @@ func NewEmptyStartupConfig() StartupConfig {
 		API: APIConfig{
 			CORS: &CORSConfig{},
 		},
-		Logging: LoggingConfig{
+		Logging: base.LoggingConfig{
 			Console: &base.ConsoleLoggerConfig{},
 			Error:   &base.FileLoggerConfig{},
 			Warn:    &base.FileLoggerConfig{},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -221,7 +221,7 @@ func setGlobalConfig(sc *StartupConfig) error {
 	return nil
 }
 
-// Merge applies non-empty fields from new onto non-empty fields on sc.
+// Merge applies non-empty fields from new onto non-empty fields on sc
 func (sc *StartupConfig) Merge(new *StartupConfig) error {
 	return base.ConfigMerge(sc, new)
 }

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -5,28 +5,9 @@ import (
 	"time"
 
 	"github.com/couchbase/sync_gateway/base"
-	"github.com/imdario/mergo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMergeStructPointer(t *testing.T) {
-	type structPtr struct {
-		I *int
-		S string
-	}
-	type wrap struct {
-		Ptr *structPtr
-	}
-	override := wrap{Ptr: &structPtr{nil, "changed"}}
-
-	source := wrap{Ptr: &structPtr{base.IntPtr(5), "test"}}
-	err := mergo.Merge(&source, &override, mergo.WithTransformers(&mergoNilTransformer{}), mergo.WithOverride)
-
-	require.Nil(t, err)
-	assert.Equal(t, "changed", source.Ptr.S)
-	assert.Equal(t, base.IntPtr(5), source.Ptr.I)
-}
 
 // Test merging behaviour with different types orders
 func TestStartupConfigMerge(t *testing.T) {

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -92,14 +92,14 @@ func TestStartupConfigMerge(t *testing.T) {
 		},
 		{
 			name:     "Keep original *ConsoleLoggerConfig",
-			config:   StartupConfig{Logging: LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
-			override: StartupConfig{Logging: LoggingConfig{Console: &base.ConsoleLoggerConfig{}}},
-			expected: StartupConfig{Logging: LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
+			config:   StartupConfig{Logging: base.LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
+			override: StartupConfig{Logging: base.LoggingConfig{Console: &base.ConsoleLoggerConfig{}}},
+			expected: StartupConfig{Logging: base.LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
 		}, {
 			name:     "Override empty logging",
-			config:   StartupConfig{Logging: LoggingConfig{Trace: &base.FileLoggerConfig{}}},
-			override: StartupConfig{Logging: LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
-			expected: StartupConfig{Logging: LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
+			config:   StartupConfig{Logging: base.LoggingConfig{Trace: &base.FileLoggerConfig{}}},
+			override: StartupConfig{Logging: base.LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
+			expected: StartupConfig{Logging: base.LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
 		},
 		{
 			name:     "Keep original *CORSconfig",

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -1,0 +1,131 @@
+package rest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/imdario/mergo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeStructPointer(t *testing.T) {
+	type structPtr struct {
+		I *int
+		S string
+	}
+	type wrap struct {
+		Ptr *structPtr
+	}
+	override := wrap{Ptr: &structPtr{nil, "changed"}}
+
+	source := wrap{Ptr: &structPtr{base.IntPtr(5), "test"}}
+	err := mergo.Merge(&source, &override, mergo.WithTransformers(&mergoNilTransformer{}), mergo.WithOverride)
+
+	require.Nil(t, err)
+	assert.Equal(t, "changed", source.Ptr.S)
+	assert.Equal(t, base.IntPtr(5), source.Ptr.I)
+}
+
+// Test merging behaviour with different types orders
+func TestStartupConfigMerge(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   StartupConfig
+		override StartupConfig
+		expected StartupConfig
+	}{
+		{
+			name:     "Override *ConfigDuration",
+			config:   StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 5)}},
+			override: StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 10)}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 10)}},
+		},
+		{
+			name:     "Override empty *ConfigDuration",
+			config:   StartupConfig{},
+			override: StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 10)}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 10)}},
+		},
+		{
+			name:     "Keep original *ConfigDuration",
+			config:   StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 10)}},
+			override: StartupConfig{},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{ConfigUpdateFrequency: base.NewConfigDuration(time.Second * 10)}},
+		},
+		{
+			name:     "Override string",
+			config:   StartupConfig{Bootstrap: BootstrapConfig{Server: "test.com"}},
+			override: StartupConfig{Bootstrap: BootstrapConfig{Server: "test.net"}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "test.net"}},
+		},
+		{
+			name:     "Override empty string",
+			config:   StartupConfig{},
+			override: StartupConfig{Bootstrap: BootstrapConfig{Server: "test.net"}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "test.net"}},
+		},
+		{
+			name:     "Keep original string",
+			config:   StartupConfig{Bootstrap: BootstrapConfig{Server: "test.net"}},
+			override: StartupConfig{},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "test.net"}},
+		},
+		{
+			name:     "Keep original *bool",
+			config:   StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(true)}},
+			override: StartupConfig{},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(true)}},
+		},
+		{
+			name:     "Override *bool",
+			config:   StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(true)}},
+			override: StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(false)}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(false)}},
+		},
+		{
+			name:     "Override unset *bool",
+			config:   StartupConfig{},
+			override: StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(true)}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{ServerTLSSkipVerify: base.BoolPtr(true)}},
+		},
+		{
+			name:     "Keep original *ConsoleLoggerConfig",
+			config:   StartupConfig{Logging: LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
+			override: StartupConfig{Logging: LoggingConfig{Console: &base.ConsoleLoggerConfig{}}},
+			expected: StartupConfig{Logging: LoggingConfig{Console: &base.ConsoleLoggerConfig{LogKeys: []string{"HTTP", "Config", "CRUD", "DCP", "Sync"}}}},
+		}, {
+			name:     "Override empty logging",
+			config:   StartupConfig{Logging: LoggingConfig{Trace: &base.FileLoggerConfig{}}},
+			override: StartupConfig{Logging: LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
+			expected: StartupConfig{Logging: LoggingConfig{Trace: &base.FileLoggerConfig{Enabled: base.BoolPtr(true)}}},
+		},
+		{
+			name:     "Keep original *CORSconfig",
+			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			override: StartupConfig{API: APIConfig{CORS: &CORSConfig{}}},
+			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+		},
+		{
+			name:     "Keep original *CORSConfig from override nil value",
+			config:   StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+			override: StartupConfig{},
+			expected: StartupConfig{API: APIConfig{CORS: &CORSConfig{MaxAge: 5, Origin: []string{"Test"}}}},
+		},
+		{
+			name:     "Override unset ConfigDuration",
+			config:   StartupConfig{},
+			override: StartupConfig{Replicator: ReplicatorConfig{MaxHeartbeat: base.ConfigDuration{D: time.Second * 5}}},
+			expected: StartupConfig{Replicator: ReplicatorConfig{MaxHeartbeat: base.ConfigDuration{D: time.Second * 5}}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.config.Merge(&test.override)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, test.config)
+		})
+	}
+}

--- a/rest/config_startup_test.go
+++ b/rest/config_startup_test.go
@@ -116,8 +116,8 @@ func TestStartupConfigMerge(t *testing.T) {
 		{
 			name:     "Override unset ConfigDuration",
 			config:   StartupConfig{},
-			override: StartupConfig{Replicator: ReplicatorConfig{MaxHeartbeat: base.ConfigDuration{D: time.Second * 5}}},
-			expected: StartupConfig{Replicator: ReplicatorConfig{MaxHeartbeat: base.ConfigDuration{D: time.Second * 5}}},
+			override: StartupConfig{Replicator: ReplicatorConfig{MaxHeartbeat: base.NewConfigDuration(time.Second * 5)}},
+			expected: StartupConfig{Replicator: ReplicatorConfig{MaxHeartbeat: base.NewConfigDuration(time.Second * 5)}},
 		},
 	}
 	for _, test := range tests {

--- a/rest/main.go
+++ b/rest/main.go
@@ -41,22 +41,14 @@ func serverMain(ctx context.Context, osArgs []string) error {
 
 	disablePersistentConfigFlag := fs.Bool("disable_persistent_config", false, "Can be set to false to disable persistent config handling, and read all configuration from a legacy config file.")
 
+	// register config property flags
+	flagStartupConfig := NewEmptyStartupConfig()
+
 	// TODO: CBG-1542 Merge legacyFlagStartupConfig onto default config before merging others.
 	legacyFlagStartupConfig := registerLegacyFlags(fs)
 	_ = legacyFlagStartupConfig
 
-	// register config property flags
-	var flagStartupConfig StartupConfig
-	// TODO: CBG-1542 Revisit config cli flags after initial persistent config implementation
-	// if err := clistruct.RegisterJSONFlags(fs, &flagStartupConfig); err != nil {
-	// 	return err
-	// }
-
-	// TODO: Be removed in a future commit once flags are sorted
-	adminInterfaceAuthFlag := fs.Bool("api.admin_interface_authentication", true, "")
-	metricsInterfaceAuthFlag := fs.Bool("api.metrics_interface_authentication", true, "")
-
-	useTLSServer := fs.Bool("bootstrap.use_tls_server", true, "")
+	configFlags := setConfigFlags(&flagStartupConfig, fs)
 
 	if err := fs.Parse(osArgs[1:]); err != nil {
 		// Return nil for ErrHelp so the shell exit code is 0
@@ -66,18 +58,10 @@ func serverMain(ctx context.Context, osArgs []string) error {
 		return err
 	}
 
-	// TODO: Be removed in a future commit once flags are sorted
-	// Only override config value if user explicitly set flag
-	fs.Visit(func(f *flag.Flag) {
-		switch f.Name {
-		case "api.admin_interface_authentication":
-			flagStartupConfig.API.AdminInterfaceAuthentication = adminInterfaceAuthFlag
-		case "api.metrics_interface_authentication":
-			flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
-		case "bootstrap.use_tls_server":
-			flagStartupConfig.Bootstrap.UseTLSServer = useTLSServer
-		}
-	})
+	err := fillConfigWithFlags(fs, configFlags)
+	if err != nil {
+		return err
+	}
 
 	if *disablePersistentConfigFlag {
 		return legacyServerMain(osArgs, &flagStartupConfig)

--- a/rest/main.go
+++ b/rest/main.go
@@ -44,11 +44,13 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	// register config property flags
 	flagStartupConfig := NewEmptyStartupConfig()
 
-	// TODO: CBG-1542 Merge legacyFlagStartupConfig onto default config before merging others.
 	legacyFlagStartupConfig := registerLegacyFlags(fs)
-	_ = legacyFlagStartupConfig
+	err := flagStartupConfig.Merge(legacyFlagStartupConfig)
+	if err != nil {
+		return fmt.Errorf("error merging legacy flags on to config: %w", err)
+	}
 
-	configFlags := setConfigFlags(&flagStartupConfig, fs)
+	configFlags := registerConfigFlags(&flagStartupConfig, fs)
 
 	if err := fs.Parse(osArgs[1:]); err != nil {
 		// Return nil for ErrHelp so the shell exit code is 0
@@ -58,7 +60,7 @@ func serverMain(ctx context.Context, osArgs []string) error {
 		return err
 	}
 
-	err := fillConfigWithFlags(fs, configFlags)
+	err = fillConfigWithFlags(fs, configFlags)
 	if err != nil {
 		return err
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -985,14 +985,14 @@ type statsWrapper struct {
 
 func (sc *ServerContext) startStatsLogger() {
 
-	if sc.config.Unsupported.StatsLogFrequency == nil || sc.config.Unsupported.StatsLogFrequency.Duration == 0 {
+	if sc.config.Unsupported.StatsLogFrequency == nil || sc.config.Unsupported.StatsLogFrequency.Value() == 0 {
 		// don't start the stats logger when explicitly zero
 		return
 	}
 
 	interval := sc.config.Unsupported.StatsLogFrequency
 
-	sc.statsContext.statsLoggingTicker = time.NewTicker(interval.Duration)
+	sc.statsContext.statsLoggingTicker = time.NewTicker(interval.Value())
 	sc.statsContext.terminator = make(chan struct{})
 	sc.statsContext.doneChan = make(chan struct{})
 	go func() {


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/963
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/995/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1009/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1011/

- Errors are returned if there is problems parsing the CLI flags (eg. invalid duration)
- Unit tests are done to make sure all the flags work (testing every flag, and every different config type), and error when they should.
- Unit tests to test merging behaviour is done
- Fixed mergo problem with merging struct pointers (with help from Ben) 
- ConfigDuration now has its duration exported (with help from Ben) 
- logRotationConfig.LocalTime has been made a bool*
- MaxHeartbeat is now pointer for ConfigDuration.
- ConfigDuration have a .Value() getter that defaults to 0 if nil
- legacyconfig.MaxHeartbeat is now *uint instead of just uint
- Added test to make sure number of flags match number of config options that are public