### PR TITLE
CBG-1601: Return static startup config on /_config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -124,19 +124,21 @@ func (h *handler) handleGetDbConfig() error {
 
 // Get admin config info
 func (h *handler) handleGetConfig() error {
-	// TODO: STUB
+	// TODO: Include runtime
+
 	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
 	_ = includeRuntime
 
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {
-		cfg, err := h.server.config.Redacted()
+		cfg, err := h.server.initialStartupConfig.Redacted()
 		if err != nil {
 			return err
 		}
 		h.writeJSON(cfg)
 	} else {
-		h.writeJSON(h.server.config)
+		h.writeJSON(h.server.initialStartupConfig)
+
 	}
 	return nil
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3204,6 +3204,8 @@ func TestLoggingDeprecationWarning(t *testing.T) {
 }
 
 func TestInitialStartupConfig(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -55,7 +55,7 @@ type LegacyServerConfig struct {
 	DisablePersistentConfig                   *bool                          `json:"disable_persistent_config,omitempty" help:"Can be set to true to disable 3.0/persistent config handling."`
 	AdminInterfaceAuthentication              *bool                          `json:"admin_interface_authentication,omitempty" help:"Whether the admin API requires authentication"`
 	MetricsInterfaceAuthentication            *bool                          `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
-	EnableAdminAuthenticationPermissionsCheck *bool                          `json:"enable_advanced_auth_dp" help:"Whether to enable the permissions check feature of admin auth"`
+	EnableAdminAuthenticationPermissionsCheck *bool                          `json:"enable_advanced_auth_dp,omitempty" help:"Whether to enable the permissions check feature of admin auth"`
 }
 
 type FacebookConfigLegacy struct {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -97,7 +97,7 @@ type APIConfig struct {
 
 	AdminInterfaceAuthentication              *bool `json:"admin_interface_authentication,omitempty" help:"Whether the admin API requires authentication"`
 	MetricsInterfaceAuthentication            *bool `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
-	EnableAdminAuthenticationPermissionsCheck *bool `json:"enable_advanced_auth_dp" help:"Whether to enable the DP permissions check feature of admin auth"`
+	EnableAdminAuthenticationPermissionsCheck *bool `json:"enable_advanced_auth_dp,omitempty" help:"Whether to enable the DP permissions check feature of admin auth"`
 
 	ServerReadTimeout  *base.ConfigDuration `json:"server_read_timeout,omitempty"  help:"maximum duration.Second before timing out read of the HTTP(S) request"`
 	ServerWriteTimeout *base.ConfigDuration `json:"server_write_timeout,omitempty" help:"maximum duration.Second before timing out write of the HTTP(S) response"`

--- a/rest/main.go
+++ b/rest/main.go
@@ -165,18 +165,24 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 	}
 	base.Tracef(base.KeyAll, "final config: %#v", redactedConfig)
 
+	initialStartupConfigTemp, err := getInitialStartupConfig(fileStartupConfig, flagStartupConfig)
+	if err != nil {
+		return false, err
+	}
+
+	var initialStartupConfig StartupConfig
+	err = base.DeepCopyInefficient(&initialStartupConfig, initialStartupConfigTemp)
+	if err != nil {
+		return false, err
+	}
+
 	base.Infof(base.KeyAll, "Config: Starting in persistent mode using config group %q", sc.Bootstrap.ConfigGroupID)
 	ctx, err := setupServerContext(&sc, true)
 	if err != nil {
 		return false, err
 	}
 
-	initialStartupConfig, err := getInitialStartupConfig(fileStartupConfig, flagStartupConfig)
-	if err != nil {
-		return false, err
-	}
-
-	ctx.initialStartupConfig = initialStartupConfig
+	ctx.initialStartupConfig = &initialStartupConfig
 
 	return false, startServer(&sc, ctx)
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -193,7 +193,7 @@ func getInitialStartupConfig(sc *StartupConfig, flagStartupConfig *StartupConfig
 		return nil, err
 	}
 
-	return &initialStartupConfig, err
+	return &initialStartupConfig, nil
 }
 
 // automaticConfigUpgrade takes the config path of the current 2.x config and attempts to perform the update steps to

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -43,6 +43,13 @@ func legacyServerMain(osArgs []string, flagStartupConfig *StartupConfig) error {
 		return err
 	}
 
+	initialStartupConfig, err := getInitialStartupConfig(migratedStartupConfig, flagStartupConfig)
+	if err != nil {
+		return err
+	}
+
+	ctx.initialStartupConfig = initialStartupConfig
+
 	err = ctx.CreateLocalDatabase(databases)
 	if err != nil {
 		return err

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -38,12 +38,12 @@ func legacyServerMain(osArgs []string, flagStartupConfig *StartupConfig) error {
 		}
 	}
 
-	ctx, err := setupServerContext(&sc, false)
+	initialStartupConfig, err := getInitialStartupConfig(migratedStartupConfig, flagStartupConfig)
 	if err != nil {
 		return err
 	}
 
-	initialStartupConfig, err := getInitialStartupConfig(migratedStartupConfig, flagStartupConfig)
+	ctx, err := setupServerContext(&sc, false)
 	if err != nil {
 		return err
 	}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -41,8 +41,8 @@ const KDefaultNumShards = 16
 // This struct is accessed from HTTP handlers running on multiple goroutines, so it needs to
 // be thread-safe.
 type ServerContext struct {
-	config               *StartupConfig
-	initialStartupConfig *StartupConfig
+	config               *StartupConfig // The current runtime configuration of the node
+	initialStartupConfig *StartupConfig // The configuration at startup of the node. Built from config file + flags
 	persistentConfig     bool
 	bucketDbName         map[string]string              // bucketDbName is a map of bucket to database name
 	dbConfigs            map[string]*DatabaseConfig     // dbConfigs is a map of db name to DatabaseConfig

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -41,18 +41,19 @@ const KDefaultNumShards = 16
 // This struct is accessed from HTTP handlers running on multiple goroutines, so it needs to
 // be thread-safe.
 type ServerContext struct {
-	config            *StartupConfig
-	persistentConfig  bool
-	bucketDbName      map[string]string              // bucketDbName is a map of bucket to database name
-	dbConfigs         map[string]*DatabaseConfig     // dbConfigs is a map of db name to DatabaseConfig
-	databases_        map[string]*db.DatabaseContext // databases_ is a map of dbname to db.DatabaseContext
-	lock              sync.RWMutex
-	statsContext      *statsContext
-	bootstrapContext  *bootstrapContext
-	HTTPClient        *http.Client
-	cpuPprofFileMutex sync.Mutex     // Protect cpuPprofFile from concurrent Start and Stop CPU profiling requests
-	cpuPprofFile      *os.File       // An open file descriptor holds the reference during CPU profiling
-	_httpServers      []*http.Server // A list of HTTP servers running under the ServerContext
+	config               *StartupConfig
+	initialStartupConfig *StartupConfig
+	persistentConfig     bool
+	bucketDbName         map[string]string              // bucketDbName is a map of bucket to database name
+	dbConfigs            map[string]*DatabaseConfig     // dbConfigs is a map of db name to DatabaseConfig
+	databases_           map[string]*db.DatabaseContext // databases_ is a map of dbname to db.DatabaseContext
+	lock                 sync.RWMutex
+	statsContext         *statsContext
+	bootstrapContext     *bootstrapContext
+	HTTPClient           *http.Client
+	cpuPprofFileMutex    sync.Mutex     // Protect cpuPprofFile from concurrent Start and Stop CPU profiling requests
+	cpuPprofFile         *os.File       // An open file descriptor holds the reference during CPU profiling
+	_httpServers         []*http.Server // A list of HTTP servers running under the ServerContext
 }
 
 type bootstrapContext struct {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -148,6 +148,20 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 
+	// Copy this startup config at this point into initial startup config
+	var initialStartupConfig StartupConfig
+	scBytes, err := base.JSONMarshal(sc)
+	if err != nil {
+		rt.tb.Fatalf("Unable to marshal initial startup config: %v", err)
+	}
+
+	err = json.Unmarshal(scBytes, &initialStartupConfig)
+	if err != nil {
+		rt.tb.Fatalf("Unable to unmarshal initial startup config: %v", err)
+	}
+
+	rt.RestTesterServerContext.initialStartupConfig = &initialStartupConfig
+
 	useXattrs := base.TestUseXattrs()
 
 	if rt.DatabaseConfig == nil {
@@ -182,7 +196,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	rt.DatabaseConfig.SGReplicateEnabled = base.BoolPtr(rt.RestTesterConfig.sgReplicateEnabled)
 
-	_, err := rt.RestTesterServerContext.AddDatabaseFromConfig(DatabaseConfig{DbConfig: *rt.DatabaseConfig})
+	_, err = rt.RestTesterServerContext.AddDatabaseFromConfig(DatabaseConfig{DbConfig: *rt.DatabaseConfig})
 	if err != nil {
 		rt.tb.Fatalf("Error from AddDatabaseFromConfig: %v", err)
 	}

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -149,18 +149,10 @@ func (rt *RestTester) Bucket() base.Bucket {
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 
 	// Copy this startup config at this point into initial startup config
-	var initialStartupConfig StartupConfig
-	scBytes, err := base.JSONMarshal(sc)
+	err := base.DeepCopyInefficient(&rt.RestTesterServerContext.initialStartupConfig, &sc)
 	if err != nil {
-		rt.tb.Fatalf("Unable to marshal initial startup config: %v", err)
+		rt.tb.Fatalf("Unable to copy initial startup config: %v", err)
 	}
-
-	err = json.Unmarshal(scBytes, &initialStartupConfig)
-	if err != nil {
-		rt.tb.Fatalf("Unable to unmarshal initial startup config: %v", err)
-	}
-
-	rt.RestTesterServerContext.initialStartupConfig = &initialStartupConfig
 
 	useXattrs := base.TestUseXattrs()
 


### PR DESCRIPTION
Node level `GET` `/_config` now returns a static startup config by default. This is the config used to start Sync Gateway without any dynamic information changes such as dynamic logging changes or persisted items like database / replications.

To do this we're storing an additional `StartupConfig` on the `ServerContext` constructed from the startup file and startup flags merged. 

Tested with a unit test to ensure we get a valid config back and that any changes made to the main config do not affect the static config.