### PR TITLE
TestAdminAPIAuth shorten profile times to speed up test

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -714,13 +714,13 @@ func TestAdminAPIAuth(t *testing.T) {
 		{
 			"GET",
 			false,
-			"/_debug/pprof/profile",
+			"/_debug/pprof/profile?seconds=1",
 			false,
 		},
 		{
 			"GET",
 			false,
-			"/_debug/pprof/block",
+			"/_debug/pprof/block?seconds=1",
 			false,
 		},
 		{
@@ -732,7 +732,7 @@ func TestAdminAPIAuth(t *testing.T) {
 		{
 			"GET",
 			false,
-			"/_debug/pprof/mutex",
+			"/_debug/pprof/mutex?seconds=1",
 			false,
 		},
 		{
@@ -744,7 +744,7 @@ func TestAdminAPIAuth(t *testing.T) {
 		{
 			"GET",
 			false,
-			"/_debug/fgprof",
+			"/_debug/fgprof?seconds=1",
 			false,
 		},
 		{


### PR DESCRIPTION
Shortens test by ~240 seconds total