### PR TITLE
CBG-1599 - Removed use_tls_client

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -834,15 +834,9 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 		errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot skip server TLS validation and use CA Cert"))
 	}
 
-	// Validate SSL is provided if not allowing unsecure connections
-	if sc.API.HTTPS.UseTLSClient == nil || *sc.API.HTTPS.UseTLSClient {
-		if sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Must supply a TLS key path and cert path, or opt out by setting api.https.use_tls_client to false"))
-		}
-	} else { // Make sure TLS key and cert is not provided
-		if sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "" {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Cannot use supplied TLS key or cert when api.https.use_tls_client is false"))
-		}
+	// Make sure if a SSL key or cert is provided, they are both provided
+	if (sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "") && (sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "") {
+		errorMessages = multierror.Append(errorMessages, fmt.Errorf("both TLS Key Path and TLS Cert Path must be provided when using client TLS. Disable client TLS by not providing either of these options"))
 	}
 
 	if !base.IsEnterpriseEdition() && sc.API.EnableAdminAuthenticationPermissionsCheck != nil && *sc.API.EnableAdminAuthenticationPermissionsCheck {

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -17,7 +17,6 @@ import (
 type LegacyServerConfig struct {
 	TLSMinVersion                             *string                        `json:"tls_minimum_version,omitempty"`    // Set TLS Version
 	UseTLSServer                              *bool                          `json:"use_tls_server,omitempty"`         // Use TLS for CBS <> SGW communications
-	UseTLSClient                              *bool                          `json:"use_tls_client,omitempty"`         // Use TLS for REST API
 	Interface                                 *string                        `json:",omitempty"`                       // Interface to bind REST API to, default ":4984"
 	ServerTLSSkipVerify                       *bool                          `json:"server_tls_skip_verify,omitempty"` // Allow empty server CA Cert Path without attempting to use system root pool
 	SSLCert                                   *string                        `json:",omitempty"`                       // Path to SSL cert file, or nil
@@ -121,9 +120,6 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			AdminInterfaceAuthentication:              lc.AdminInterfaceAuthentication,
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
-			HTTPS: HTTPSConfig{
-				UseTLSClient: lc.UseTLSClient,
-			},
 		},
 		Logging: LoggingConfig{},
 		Auth: AuthConfig{
@@ -382,7 +378,6 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 	_ = flagSet.Bool("api.admin_interface_authentication", true, "")
 	_ = flagSet.Bool("api.metrics_interface_authentication", true, "")
 	_ = flagSet.Bool("bootstrap.use_tls_server", true, "")
-	_ = flagSet.Bool("api.https.use_tls_client", true, "")
 
 	addr := flagSet.String("interface", DefaultPublicInterface, "Address to bind to")
 	authAddr := flagSet.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")
@@ -491,7 +486,6 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 
 		config = &LegacyServerConfig{
 			UseTLSServer:     base.BoolPtr(true),
-			UseTLSClient:     base.BoolPtr(true),
 			Interface:        addr,
 			AdminInterface:   authAddr,
 			ProfileInterface: profAddr,

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -35,7 +35,6 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			CompressResponses:  base.BoolPtr(true),
 			HTTPS: HTTPSConfig{
 				TLSMinimumVersion: "tlsv1.2",
-				UseTLSClient:      base.BoolPtr(true),
 			},
 			ReadHeaderTimeout:              base.NewConfigDuration(base.DefaultReadHeaderTimeout),
 			IdleTimeout:                    base.NewConfigDuration(base.DefaultIdleTimeout),
@@ -117,7 +116,6 @@ type HTTPSConfig struct {
 	TLSMinimumVersion string `json:"tls_minimum_version,omitempty" help:"The minimum allowable TLS version for the REST APIs"`
 	TLSCertPath       string `json:"tls_cert_path,omitempty"       help:"The TLS cert file to use for the REST APIs"`
 	TLSKeyPath        string `json:"tls_key_path,omitempty"        help:"The TLS key file to use for the REST APIs"`
-	UseTLSClient      *bool  `json:"use_tls_client,omitempty"      help:"Forces the REST APIs to use TLS/HTTPS"`
 }
 
 type CORSConfig struct {

--- a/rest/main.go
+++ b/rest/main.go
@@ -57,7 +57,6 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	metricsInterfaceAuthFlag := fs.Bool("api.metrics_interface_authentication", true, "")
 
 	useTLSServer := fs.Bool("bootstrap.use_tls_server", true, "")
-	useTLSClient := fs.Bool("api.https.use_tls_client", true, "")
 
 	if err := fs.Parse(osArgs[1:]); err != nil {
 		// Return nil for ErrHelp so the shell exit code is 0
@@ -77,8 +76,6 @@ func serverMain(ctx context.Context, osArgs []string) error {
 			flagStartupConfig.API.MetricsInterfaceAuthentication = metricsInterfaceAuthFlag
 		case "bootstrap.use_tls_server":
 			flagStartupConfig.Bootstrap.UseTLSServer = useTLSServer
-		case "api.https.use_tls_client":
-			flagStartupConfig.API.HTTPS.UseTLSClient = useTLSClient
 		}
 	})
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -303,7 +303,6 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 	config.API.MetricsInterface = "127.0.0.1:24986"
 
 	config.Bootstrap.Server = base.UnitTestUrl()
-	config.API.HTTPS.UseTLSClient = base.BoolPtr(false)
 	config.Bootstrap.Username = base.TestClusterUsername()
 	config.Bootstrap.Password = base.TestClusterPassword()
 


### PR DESCRIPTION
- [x] LiteCore tests depend on https://github.com/couchbaselabs/sg_dev_tools/pull/26 being merged

- Removed use_tls_client config option and flag
- Edited use_tls_client test to instead test if an error is produced properly when either TLS key/cert is not provided
- Validation is done to make sure both TLS key and cert is provided when one is provided