### PR TITLE
CBG-1583 - Made config Group ID an EE-only feature

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -839,8 +839,15 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 		errorMessages = multierror.Append(errorMessages, fmt.Errorf("both TLS Key Path and TLS Cert Path must be provided when using client TLS. Disable client TLS by not providing either of these options"))
 	}
 
-	if !base.IsEnterpriseEdition() && sc.API.EnableAdminAuthenticationPermissionsCheck != nil && *sc.API.EnableAdminAuthenticationPermissionsCheck {
-		errorMessages = multierror.Append(errorMessages, fmt.Errorf("enable_advanced_auth_dp is only supported in enterprise edition"))
+	// EE only features
+	if !base.IsEnterpriseEdition() {
+		if sc.API.EnableAdminAuthenticationPermissionsCheck != nil && *sc.API.EnableAdminAuthenticationPermissionsCheck {
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("enable_advanced_auth_dp is only supported in enterprise edition"))
+		}
+
+		if sc.Bootstrap.ConfigGroupID != persistentConfigDefaultGroupID {
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("customization of config_group_id is only supported in enterprise edition"))
+		}
 	}
 
 	return errorMessages

--- a/rest/config.go
+++ b/rest/config.go
@@ -846,7 +846,7 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 		}
 
 		if sc.Bootstrap.ConfigGroupID != persistentConfigDefaultGroupID {
-			errorMessages = multierror.Append(errorMessages, fmt.Errorf("customization of config_group_id is only supported in enterprise edition"))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("customization of group_id is only supported in enterprise edition"))
 		}
 	}
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1203,36 +1203,36 @@ func TestSetupServerContext(t *testing.T) {
 	})
 }
 
-// CBG-1583 - config group IDs EE-only
-func TestConfigGroupIDsValidation(t *testing.T) {
+// CBG-1583 - config group ID EE-only
+func TestConfigGroupIDValidation(t *testing.T) {
 	error := "customization of config_group_id is only supported in enterprise edition"
 	testCases := []struct {
 		name        string
-		cfgGroupIDs string
+		cfgGroupID  string
 		eeMode      bool
 		expectError bool
 	}{
 		{
 			name:        "No change, CE mode",
-			cfgGroupIDs: persistentConfigDefaultGroupID,
+			cfgGroupID:  persistentConfigDefaultGroupID,
 			eeMode:      false,
 			expectError: false,
 		},
 		{
 			name:        "No change, EE mode",
-			cfgGroupIDs: persistentConfigDefaultGroupID,
+			cfgGroupID:  persistentConfigDefaultGroupID,
 			eeMode:      true,
 			expectError: false,
 		},
 		{
 			name:        "Changed, EE mode",
-			cfgGroupIDs: "testGroup",
+			cfgGroupID:  "testGroup",
 			eeMode:      true,
 			expectError: false,
 		},
 		{
 			name:        "Changed, CE mode",
-			cfgGroupIDs: "testGroup",
+			cfgGroupID:  "testGroup",
 			eeMode:      false,
 			expectError: true,
 		},
@@ -1246,7 +1246,7 @@ func TestConfigGroupIDsValidation(t *testing.T) {
 				t.Skip("CE mode only test case")
 			}
 
-			sc := StartupConfig{Bootstrap: BootstrapConfig{ConfigGroupID: test.cfgGroupIDs}}
+			sc := StartupConfig{Bootstrap: BootstrapConfig{ConfigGroupID: test.cfgGroupID}}
 			err := sc.validate()
 			if test.expectError {
 				require.Error(t, err)

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1205,7 +1205,7 @@ func TestSetupServerContext(t *testing.T) {
 
 // CBG-1583 - config group ID EE-only
 func TestConfigGroupIDValidation(t *testing.T) {
-	error := "customization of config_group_id is only supported in enterprise edition"
+	error := "customization of group_id is only supported in enterprise edition"
 	testCases := []struct {
 		name        string
 		cfgGroupID  string


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/971/

Error message when setting config group ID: `customization of group_id is only supported in enterprise edition`
Uses US spelling of customisation 