### PR TITLE
CBG-1617 - use_tls_server validation done on StartupConfig validation

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -135,7 +135,7 @@ func (spec BucketSpec) IsWalrusBucket() bool {
 }
 
 func (spec BucketSpec) IsTLS() bool {
-	return strings.HasPrefix(spec.Server, "couchbases") || strings.HasPrefix(spec.Server, "https")
+	return ServerIsTLS(spec.Server)
 }
 
 func (spec BucketSpec) UseClientCert() bool {

--- a/base/bucket_test.go
+++ b/base/bucket_test.go
@@ -284,8 +284,10 @@ func TestIsTLS(t *testing.T) {
 	fakeBucketSpec.Server = "http://localhost:8091"
 	assert.False(t, fakeBucketSpec.IsTLS())
 	fakeBucketSpec.Server = "https://localhost:443"
-	assert.True(t, fakeBucketSpec.IsTLS())
-	fakeBucketSpec.Server = "couchbases"
+	assert.False(t, fakeBucketSpec.IsTLS())
+	fakeBucketSpec.Server = "couchbase://localhost"
+	assert.False(t, fakeBucketSpec.IsTLS())
+	fakeBucketSpec.Server = "couchbases://localhost"
 	assert.True(t, fakeBucketSpec.IsTLS())
 }
 

--- a/base/constants.go
+++ b/base/constants.go
@@ -197,6 +197,12 @@ func UnitTestUrlIsWalrus() bool {
 	return ServerIsWalrus(UnitTestUrl())
 }
 
+// ServerIsTLS returns true if the server URL is using an accepted secure protocol as it's prefix
+// Prefix checked: couchbases:
+func ServerIsTLS(server string) bool {
+	return strings.HasPrefix(server, "couchbases:")
+}
+
 // ServerIsWalrus returns true when the given server looks like a Walrus URI
 // Equivalent to the old regexp: `^(walrus:|file:|/|\.)`
 func ServerIsWalrus(server string) bool {

--- a/rest/config.go
+++ b/rest/config.go
@@ -56,6 +56,8 @@ const (
 
 	// Default number of index replicas
 	DefaultNumIndexReplicas = uint(1)
+
+	DefaultUseTLSServer = true
 )
 
 // Bucket configuration elements - used by db, index
@@ -832,13 +834,13 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	}
 
 	secureServer := base.ServerIsTLS(sc.Bootstrap.Server)
-	if base.BoolDefault(sc.Bootstrap.UseTLSServer, true) {
+	if base.BoolDefault(sc.Bootstrap.UseTLSServer, DefaultUseTLSServer) {
 		if !secureServer && !base.ServerIsWalrus(sc.Bootstrap.Server) {
-			return fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %s", base.SD(sc.Bootstrap.Server))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %s", base.SD(sc.Bootstrap.Server)))
 		}
 	} else {
 		if secureServer {
-			return fmt.Errorf("Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %s", base.SD(sc.Bootstrap.Server))
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %s", base.SD(sc.Bootstrap.Server)))
 		}
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -830,6 +830,18 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	if sc.Bootstrap.Server == "" {
 		errorMessages = multierror.Append(errorMessages, fmt.Errorf("a server must be provided in the Bootstrap configuration"))
 	}
+
+	secureServer := base.ServerIsTLS(sc.Bootstrap.Server)
+	if base.BoolDefault(sc.Bootstrap.UseTLSServer, true) {
+		if !secureServer && !base.ServerIsWalrus(sc.Bootstrap.Server) {
+			return fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %s", base.SD(sc.Bootstrap.Server))
+		}
+	} else {
+		if secureServer {
+			return fmt.Errorf("Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %s", base.SD(sc.Bootstrap.Server))
+		}
+	}
+
 	if sc.Bootstrap.ServerTLSSkipVerify != nil && *sc.Bootstrap.ServerTLSSkipVerify && sc.Bootstrap.CACertPath != "" {
 		errorMessages = multierror.Append(errorMessages, fmt.Errorf("cannot skip server TLS validation and use CA Cert"))
 	}

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -25,7 +25,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			ConfigGroupID:         persistentConfigDefaultGroupID,
 			ConfigUpdateFrequency: base.NewConfigDuration(persistentConfigDefaultUpdateFrequency),
 			ServerTLSSkipVerify:   base.BoolPtr(false),
-			UseTLSServer:          base.BoolPtr(true),
+			UseTLSServer:          base.BoolPtr(DefaultUseTLSServer),
 		},
 		API: APIConfig{
 			PublicInterface:    DefaultPublicInterface,

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1196,6 +1196,7 @@ func TestSetupServerContext(t *testing.T) {
 	t.Run("Create server context with a valid configuration", func(t *testing.T) {
 		config := DefaultStartupConfig("")
 		config.Bootstrap.Server = base.UnitTestUrl() // Valid config requires server to be explicitly defined
+		config.Bootstrap.UseTLSServer = base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl()))
 		sc, err := setupServerContext(&config, false)
 		require.NoError(t, err)
 		require.NotNil(t, sc)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -360,21 +360,6 @@ func GetBucketSpec(config *DbConfig, serverConfig *StartupConfig) (spec base.Buc
 	return spec, nil
 }
 
-// validateServerTLS checks if a secure protocol should be enforced and then errors if a secure protocol should or shouldn't be used based on the config
-func validateServerTLS(spec base.BucketSpec, config *StartupConfig) (err error) {
-	secure := spec.IsTLS()
-	if config.Bootstrap.UseTLSServer == nil || *config.Bootstrap.UseTLSServer {
-		if !secure && !spec.IsWalrusBucket() {
-			return fmt.Errorf("Must use secure scheme in Couchbase Server URL, or opt out by setting bootstrap.use_tls_server to false. Current URL: %s", spec.Server)
-		}
-	} else {
-		if secure { // If using secure protocol while UseTLSServer flag is set, error as user probably forgot to turn it off
-			return fmt.Errorf("Couchbase server URL cannot use secure protocol when bootstrap.use_tls_server is false. Current URL: %s", spec.Server)
-		}
-	}
-	return nil
-}
-
 // Adds a database to the ServerContext.  Attempts a read after it gets the write
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
@@ -401,10 +386,6 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	}
 
 	if err := db.ValidateDatabaseName(dbName); err != nil {
-		return nil, err
-	}
-
-	if err := validateServerTLS(spec, sc.config); err != nil {
 		return nil, err
 	}
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -303,6 +303,7 @@ func TestStartAndStopHTTPServers(t *testing.T) {
 	config.API.MetricsInterface = "127.0.0.1:24986"
 
 	config.Bootstrap.Server = base.UnitTestUrl()
+	config.Bootstrap.UseTLSServer = base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl()))
 	config.Bootstrap.Username = base.TestClusterUsername()
 	config.Bootstrap.Password = base.TestClusterPassword()
 


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/982

- Added ServerIsTLS to base where ServerIsWalrus is
- Validation now done in StartupConfig.Validation()
- Tests changed to test StartupConfig validation function
- Added SystemData redaction around server URL (let me know if this is unnecessary)
- HTTPS is not considered as a TLS server protocol any more as it is unsupported
- Fixed broken integration tests