### PR TITLE
CBG-1608 - Convert http:// server addresses to couchbase:// when upgrading legacy config

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -97,11 +97,16 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 	// find a database's credentials for bootstrap (this isn't the first database config entry due to map iteration)
 	bsc := &BootstrapConfig{}
 	for _, dbConfig := range lc.Databases {
-		if dbConfig.Server == nil || *dbConfig.Server == "" {
+		server := dbConfig.Server
+		if server == nil || *server == "" {
 			continue
 		}
+		if strings.HasPrefix(*server, "http://") {
+			*server = strings.Replace(*server, "http", "couchbase", 1)
+		}
+
 		bsc = &BootstrapConfig{
-			Server:              *dbConfig.Server,
+			Server:              *server,
 			Username:            dbConfig.Username,
 			Password:            dbConfig.Password,
 			CACertPath:          dbConfig.CACertPath,

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcore/v10/connstr"
-
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/hashicorp/go-multierror"
@@ -105,7 +104,8 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 
 		server, username, password, err := legacyServerAddressUpgrade(*dbConfig.Server)
 		if err != nil {
-			return nil, nil, err
+			server = *dbConfig.Server
+			base.Errorf("Error upgrading server address: %v", err)
 		}
 
 		// Prioritise config fields over credentials in host
@@ -284,7 +284,7 @@ func legacyServerAddressUpgrade(server string) (newServer, username, password st
 	if connSpec.Scheme == "http" {
 		connSpec.Scheme = "couchbase"
 		for i, addr := range connSpec.Addresses {
-			if addr.Port != 8091 {
+			if addr.Port != 8091 && addr.Port > 0 {
 				return "", "", "", fmt.Errorf("automatic migration of connection string from http:// to couchbase:// scheme doesn't support non-default ports. " +
 					"Please change the server field to use the couchbase(s):// scheme")
 			}

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -102,7 +102,8 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			continue
 		}
 		if strings.HasPrefix(*server, "http://") {
-			*server = strings.Replace(*server, "http", "couchbase", 1)
+			*server = strings.TrimPrefix(*server, "http://")
+			*server = fmt.Sprintf("couchbase://%s", *server)
 		}
 
 		bsc = &BootstrapConfig{

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -284,13 +284,16 @@ func gocbv1tov2AddressUpgrade(server string) (newServer, username, password stri
 
 	var hosts string
 	for _, addr := range connSpec.Addresses {
-		if addr.Port != -1 && addr.Port != 8091 && connSpec.Scheme == "http" {
-			return "", "", "", fmt.Errorf("automatic connection string conversion does not support non-default host ports. " +
-				"Please change the server field to use the couchbase(s):// scheme")
+		if connSpec.Scheme == "http" {
+			if addr.Port != 8091 {
+				return "", "", "", fmt.Errorf("automatic connection string conversion does not support non-default host ports. " +
+					"Please change the server field to use the couchbase(s):// scheme")
+			}
+			addr.Port = -1
 		}
 
 		var port string
-		if addr.Port != -1 && connSpec.Scheme != "http" {
+		if addr.Port != -1 {
 			port = ":" + strconv.Itoa(addr.Port)
 		}
 

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -105,7 +105,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 
 		server, username, password, err := legacyServerAddressUpgrade(*dbConfig.Server)
 		if err != nil {
-			return nil, DbConfigMap{}, err
+			return nil, nil, err
 		}
 
 		// Prioritise config fields over credentials in host

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -127,10 +127,10 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		expectedPassword string
 	}{
 		{
-			name:             "Keep couchbase ports unless 8091",
+			name:             "Keep couchbase ports",
 			server:           "couchbase://localhost:8091,localhosttwo:1234?network=true",
 			expectError:      false,
-			expectedServer:   "couchbase://localhost,localhosttwo:1234?network=true",
+			expectedServer:   "couchbase://localhost:8091,localhosttwo:1234?network=true",
 			expectedUsername: "",
 			expectedPassword: "",
 		},

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -71,6 +71,12 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 			input:    LegacyServerConfig{},
 			expected: StartupConfig{API: APIConfig{AdminInterfaceAuthentication: base.BoolPtr(true)}},
 		},
+		{
+			name:     "http:// to couchbase://",
+			base:     StartupConfig{},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com")}}}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://http.couchbase.com"}},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -117,7 +117,7 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 	}
 }
 
-func TestGocbv1tov2AddressUpgrade(t *testing.T) {
+func TestLegacyServerAddressUpgrade(t *testing.T) {
 	testCases := []struct {
 		name             string
 		server           string
@@ -204,7 +204,7 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			s, u, p, err := gocbv1tov2AddressUpgrade(test.server)
+			s, u, p, err := legacyServerAddressUpgrade(test.server)
 			assert.Equal(t, test.expectedServer, s)
 			assert.Equal(t, test.expectedUsername, u)
 			assert.Equal(t, test.expectedPassword, p)

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -74,13 +74,13 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "http:// to couchbase://",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com:8091,host2:8091,host1:8091,[2001:db8::8811]:8091,[2001:db8::8822]:8091")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com:8091,host2:8091,host1,[2001:db8::8811],[2001:db8::8822]:8091")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://http.couchbase.com,host2,host1,[2001:db8::8811],[2001:db8::8822]"}},
 		},
 		{
 			name:     "Username and password in server URL",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://foo:bar@[2001:db8::8811]:8091,host2:8091")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://foo:bar@[2001:db8::8811]:8091,host2")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://[2001:db8::8811],host2", Username: "foo", Password: "bar"}},
 		},
 		{
@@ -98,7 +98,7 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "http:// to couchbase:// with args",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://host1:8091,host2:8091?p1=v1&p2=v2;p3=v3")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://host1,host2:8091?p1=v1&p2=v2;p3=v3")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://host1,host2?p1=v1&p2=v2&p3=v3"}},
 		},
 	}
@@ -141,11 +141,6 @@ func TestLegacyServerAddressUpgrade(t *testing.T) {
 			expectedServer: "couchbase://localhost,127.0.0.2",
 		},
 		{
-			name:        "No HTTP port",
-			server:      "http://localhost,127.0.0.2:8091,",
-			expectError: true,
-		},
-		{
 			name:           "Do not keep trailing comma, couchbases://",
 			server:         "couchbases://localhost,127.0.0.2,",
 			expectError:    false,
@@ -153,7 +148,7 @@ func TestLegacyServerAddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Convert, strip ports, parse username and password, keep query params",
-			server:           "http://foo:bar@localhost:8091,127.0.0.2:8091?network=true",
+			server:           "http://foo:bar@localhost,127.0.0.2:8091?network=true",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost,127.0.0.2?network=true",
 			expectedUsername: "foo",
@@ -168,8 +163,8 @@ func TestLegacyServerAddressUpgrade(t *testing.T) {
 			expectedPassword: "bar",
 		},
 		{
-			name:             "Couchbase:// with username but no password (invalid for CBS)",
-			server:           "http://foo@localhost:8091",
+			name:             "http:// with username but no password (invalid for CBS)",
+			server:           "http://foo@localhost",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost",
 			expectedUsername: "",
@@ -185,7 +180,7 @@ func TestLegacyServerAddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Multi params with & and ; separators, alphabetical order",
-			server:           "http://foo:bar@localhost:8091,127.0.0.2:8091?c=3;a=1&b=2",
+			server:           "http://foo:bar@localhost,127.0.0.2?c=3;a=1&b=2",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost,127.0.0.2?a=1&b=2&c=3",
 			expectedUsername: "foo",

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -74,13 +74,13 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "http:// to couchbase://",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com,host2,host1:8091,[2001:db8::8811],[2001:db8::8822]")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com:8091,host2:8091,host1:8091,[2001:db8::8811]:8091,[2001:db8::8822]:8091")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://http.couchbase.com,host2,host1,[2001:db8::8811],[2001:db8::8822]"}},
 		},
 		{
 			name:     "Username and password in server URL",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://foo:bar@[2001:db8::8811]:8091,host2")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://foo:bar@[2001:db8::8811]:8091,host2:8091")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://[2001:db8::8811],host2", Username: "foo", Password: "bar"}},
 		},
 		{
@@ -98,7 +98,7 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "http:// to couchbase:// with args",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://host1,host2:8091?p1=v1&p2=v2;p3=v3")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://host1:8091,host2:8091?p1=v1&p2=v2;p3=v3")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://host1,host2?p1=v1&p2=v2&p3=v3"}},
 		},
 	}
@@ -136,9 +136,14 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		},
 		{
 			name:           "Convert, do not keep trailing comma",
-			server:         "http://localhost,127.0.0.2,",
+			server:         "http://localhost:8091,127.0.0.2:8091,",
 			expectError:    false,
 			expectedServer: "couchbase://localhost,127.0.0.2",
+		},
+		{
+			name:        "No HTTP port",
+			server:      "http://localhost,127.0.0.2:8091,",
+			expectError: true,
 		},
 		{
 			name:           "Do not keep trailing comma, couchbases://",
@@ -148,7 +153,7 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Convert, strip ports, parse username and password, keep query params",
-			server:           "http://foo:bar@localhost:8091,127.0.0.2?network=true",
+			server:           "http://foo:bar@localhost:8091,127.0.0.2:8091?network=true",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost,127.0.0.2?network=true",
 			expectedUsername: "foo",
@@ -156,7 +161,7 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Couchbase:// with username and password",
-			server:           "http://foo:bar@localhost",
+			server:           "http://foo:bar@localhost:8091",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost",
 			expectedUsername: "foo",
@@ -164,7 +169,7 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Couchbase:// with username but no password (invalid for CBS)",
-			server:           "http://foo@localhost",
+			server:           "http://foo@localhost:8091",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost",
 			expectedUsername: "",
@@ -172,7 +177,7 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Couchbase:// with password but no username (invalid for CBS)",
-			server:           "http://:foo@localhost",
+			server:           "http://:foo@localhost:8091",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost",
 			expectedUsername: "",
@@ -180,19 +185,16 @@ func TestGocbv1tov2AddressUpgrade(t *testing.T) {
 		},
 		{
 			name:             "Multi params with & and ; separators, alphabetical order",
-			server:           "http://foo:bar@localhost:8091,127.0.0.2?c=3;a=1&b=2",
+			server:           "http://foo:bar@localhost:8091,127.0.0.2:8091?c=3;a=1&b=2",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost,127.0.0.2?a=1&b=2&c=3",
 			expectedUsername: "foo",
 			expectedPassword: "bar",
 		},
 		{
-			name:             "Error due to unknown port",
-			server:           "http://foo:bar@localhost:8091,127.0.0.2:1234?network=true",
-			expectError:      true,
-			expectedServer:   "",
-			expectedUsername: "",
-			expectedPassword: "",
+			name:        "Error due to unknown port",
+			server:      "http://foo:bar@localhost:8091,127.0.0.2:1234?network=true",
+			expectError: true,
 		},
 		{
 			name:        "Gocbstr bad scheme error",

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -74,8 +74,14 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "http:// to couchbase://",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com")}}}},
-			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://http.couchbase.com"}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://http.couchbase.com:2929,host2,host1:22,[2001:db8::8811],[2001:db8::8822]:888")}}}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://http.couchbase.com,host2,host1,[2001:db8::8811],[2001:db8::8822]"}},
+		},
+		{
+			name:     "Username and password in server URL",
+			base:     StartupConfig{},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://foo:bar@[2001:db8::8811]:8091,host2:123")}}}},
+			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://[2001:db8::8811],host2", Username: "foo", Password: "bar"}},
 		},
 	}
 	for _, test := range tests {

--- a/rest/main.go
+++ b/rest/main.go
@@ -200,9 +200,9 @@ func automaticConfigUpgrade(configPath string) (*StartupConfig, bool, error) {
 		return nil, false, err
 	}
 
-	if legacyServerConfig.DisablePersistentConfig != nil && *legacyServerConfig.DisablePersistentConfig {
-		return nil, true, nil
-	}
+	//if legacyServerConfig.DisablePersistentConfig != nil && *legacyServerConfig.DisablePersistentConfig {
+	//	return nil, true, nil
+	//}
 
 	startupConfig, dbConfigs, err := legacyServerConfig.ToStartupConfig()
 	if err != nil {

--- a/rest/main.go
+++ b/rest/main.go
@@ -200,9 +200,9 @@ func automaticConfigUpgrade(configPath string) (*StartupConfig, bool, error) {
 		return nil, false, err
 	}
 
-	//if legacyServerConfig.DisablePersistentConfig != nil && *legacyServerConfig.DisablePersistentConfig {
-	//	return nil, true, nil
-	//}
+	if legacyServerConfig.DisablePersistentConfig != nil && *legacyServerConfig.DisablePersistentConfig {
+		return nil, true, nil
+	}
 
 	startupConfig, dbConfigs, err := legacyServerConfig.ToStartupConfig()
 	if err != nil {


### PR DESCRIPTION
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/978/
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/993/ (flaky test fail)
- [x] http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/9​97

- Added test cases to test behaviour and test cases to new function
- Added code to convert prefix "http://" to "couchbase://"
- Username and password is handled if in server URL (though username and password fields in db config are prioritised) 
- If port is not 8091 or blank for http then error: `automatic migration of connection string from http:// to couchbase:// scheme doesn't support non-default ports.  Please change the server field to use the couchbase(s):// scheme` is returned. For couchbase:// the port is used.
- Get parameters are preserved (and alphabeticalized by url.Encode() )