### PR TITLE
[WIP] Remove --net=host from Litecore run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -334,7 +334,7 @@ pipeline {
                                 gitStatusWrapper(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", description: 'Running LiteCore Tests', failureDescription: 'EE with LiteCore Test Failed', gitHubContext: 'sgw-pipeline-litecore-ee', successDescription: 'EE with LiteCore Test Passed') {
                                     sh 'touch litecore.out'
                                     //sh 'docker pull couchbase/sg-test-litecore:latest'
-                                    sh 'docker run --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest -legacy-config'
+                                    sh 'docker run --dns 8.8.8.8 --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest -legacy-config'
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -334,7 +334,7 @@ pipeline {
                                 gitStatusWrapper(credentialsId: "${GH_ACCESS_TOKEN_CREDENTIAL}", description: 'Running LiteCore Tests', failureDescription: 'EE with LiteCore Test Failed', gitHubContext: 'sgw-pipeline-litecore-ee', successDescription: 'EE with LiteCore Test Passed') {
                                     sh 'touch litecore.out'
                                     //sh 'docker pull couchbase/sg-test-litecore:latest'
-                                    sh 'docker run --net=host --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest -legacy-config'
+                                    sh 'docker run --rm -v /root/.ssh/id_rsa_ns-buildbot:/root/.ssh/id_rsa -v `pwd`/sync_gateway_ee-linux:/sync_gateway -v `pwd`/litecore.out:/output.out couchbase/sg-test-litecore:latest -legacy-config'
                                 }
                             }
                         }


### PR DESCRIPTION
Recently had an issue where a container failed to stop meaning litecore tests were using that container for tests. This was created Jun 2 therefore when litecore tests ran on `centos-0275` they would always pass. This container is now removed.

This PR intends to fix this by removing the net host option meaning the ports would be scoped inside of the container, therefore even if this occurs again tests will still fail / pass as they should.

WIP due to: 
```
http://uberjenkins.sc.couchbase.com:8080/job/_sync-gateway_github_pipeline/job/sync_gateway/job/PR-5169/3/console
```

```
ssh: Could not resolve hostname github.com: Temporary failure in name resolution
```

This error occurs on `sync_gateway_unit` - Guessing its a network thing messing with the docker bridge. 