### PR TITLE
Store docID in AllowedAttachment to support CBMobile_2 retrieval

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -984,6 +984,10 @@ func (bh *blipHandler) handleGetAttachment(rq *blip.Message) error {
 		return base.HTTPErrorf(http.StatusForbidden, "Attachment's doc not being synced")
 	}
 
+	if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 {
+		docID = allowedAttachment.docID
+	}
+
 	attachmentKey := MakeAttachmentKey(allowedAttachment.version, docID, digest)
 	attachment, err := bh.db.GetAttachment(attachmentKey)
 	if err != nil {
@@ -1153,6 +1157,7 @@ func (bsc *BlipSyncContext) addAllowedAttachments(docID string, attMeta []Attach
 			bsc.allowedAttachments[key] = AllowedAttachment{
 				version: attachment.version,
 				counter: 1,
+				docID:   docID,
 			}
 		}
 	}

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -129,8 +129,9 @@ type BlipSyncContext struct {
 // AllowedAttachment contains the metadata for handling allowed attachments
 // while replicating over BLIP protocol.
 type AllowedAttachment struct {
-	version int // Version of the attachment
-	counter int // Counter to track allowed attachments
+	version int    // Version of the attachment
+	counter int    // Counter to track allowed attachments
+	docID   string // docID, used for BlipCBMobileReplicationV2 retrieval of V2 attachments
 }
 
 func (bsc *BlipSyncContext) SetClientType(clientType BLIPSyncContextClientType) {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2930,13 +2930,89 @@ func TestBlipDeltaSyncPushPullNewAttachment(t *testing.T) {
 	assert.Equal(t, true, world["stub"])
 }
 
-// Test pushing and pulling v2 attachments
+// Test pushing and pulling v2 attachments with v2 client
 // 1. Create test client.
 // 2. Start continuous push and pull replication in client
 // 3. Create doc with attachment in SGW
 // 4. Update doc in the test client and keep the same attachment stub.
 // 5. Have that update pushed via the continuous replication started in step 2
-func TestBlipPushPullNewAttachmentV2(t *testing.T) {
+func TestBlipPushPullV2AttachmentV2Client(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	rtConfig := RestTesterConfig{
+		DatabaseConfig: &DbConfig{
+			DeltaSync: &DeltaSyncConfig{
+				Enabled: base.BoolPtr(true),
+			},
+		},
+		guestEnabled: true,
+	}
+	rt := NewRestTester(t, &rtConfig)
+	defer rt.Close()
+
+	opts := &BlipTesterClientOpts{}
+	opts.SupportedBLIPProtocols = []string{db.BlipCBMobileReplicationV2}
+	btc, err := NewBlipTesterClientOptsWithRT(t, rt, opts)
+	require.NoError(t, err)
+	defer btc.Close()
+
+	err = btc.StartPull()
+	assert.NoError(t, err)
+	const docId = "doc1"
+
+	// Create doc revision with attachment on SG.
+	bodyText := `{"greetings":[{"hi": "alice"}],"_attachments":{"hello.txt":{"data":"aGVsbG8gd29ybGQ="}}}`
+	response := rt.SendAdminRequest(http.MethodPut, "/db/"+docId, bodyText)
+	assert.Equal(t, http.StatusCreated, response.Code)
+
+	// Wait for the document to be replicated to client.
+	revId := respRevID(t, response)
+	data, ok := btc.WaitForRev(docId, revId)
+	assert.True(t, ok)
+	bodyTextExpected := `{"greetings":[{"hi":"alice"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+	require.JSONEq(t, bodyTextExpected, string(data))
+
+	// Update the replicated doc at client along with keeping the same attachment stub.
+	bodyText = `{"greetings":[{"hi":"bob"}],"_attachments":{"hello.txt":{"revpos":1,"length":11,"stub":true,"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0="}}}`
+	revId, err = btc.PushRev(docId, revId, []byte(bodyText))
+	require.NoError(t, err)
+	assert.Equal(t, "2-abcxyz", revId)
+
+	// Wait for the document to be replicated at SG
+	_, ok = btc.pushReplication.WaitForMessage(2)
+	assert.True(t, ok)
+
+	resp := rt.SendAdminRequest(http.MethodGet, "/db/"+docId+"?rev="+revId, "")
+	assert.Equal(t, http.StatusOK, resp.Code)
+	var respBody db.Body
+	assert.NoError(t, base.JSONUnmarshal(resp.Body.Bytes(), &respBody))
+
+	assert.Equal(t, docId, respBody[db.BodyId])
+	assert.Equal(t, "2-abcxyz", respBody[db.BodyRev])
+	greetings := respBody["greetings"].([]interface{})
+	assert.Len(t, greetings, 1)
+	assert.Equal(t, map[string]interface{}{"hi": "bob"}, greetings[0])
+
+	attachments, ok := respBody[db.BodyAttachments].(map[string]interface{})
+	require.True(t, ok)
+	assert.Len(t, attachments, 1)
+	hello, ok := attachments["hello.txt"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=", hello["digest"])
+	assert.Equal(t, float64(11), hello["length"])
+	assert.Equal(t, float64(1), hello["revpos"])
+	assert.True(t, hello["stub"].(bool))
+
+	assert.Equal(t, int64(1), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushCount.Value())
+	assert.Equal(t, int64(11), rt.GetDatabase().DbStats.CBLReplicationPush().AttachmentPushBytes.Value())
+}
+
+// Test pushing and pulling v2 attachments with v3 client
+// 1. Create test client.
+// 2. Start continuous push and pull replication in client
+// 3. Create doc with attachment in SGW
+// 4. Update doc in the test client and keep the same attachment stub.
+// 5. Have that update pushed via the continuous replication started in step 2
+func TestBlipPushPullV2AttachmentV3Client(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	rtConfig := RestTesterConfig{
 		DatabaseConfig: &DbConfig{


### PR DESCRIPTION
Supports V2 attachment retrieval when clients aren't specifying docID in getAttachment request.