### PR TITLE
CBG-1602: Add runtime _config flag

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -132,6 +132,7 @@ func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
 }
 
 func (l *ConsoleLogger) getConsoleLoggerConfig() *ConsoleLoggerConfig {
+	// Copy config struct to avoid mutating running config
 	c := l.config
 	c.FileLoggerConfig = *l.getFileLoggerConfig()
 	c.LogLevel = l.LogLevel

--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -32,6 +32,9 @@ type ConsoleLogger struct {
 
 	// isStderr is true when the console logger is configured with no FileOutput
 	isStderr bool
+
+	// ConsoleLoggerConfig stores the initial config used to instantiate ConsoleLogger
+	config ConsoleLoggerConfig
 }
 
 type ConsoleLoggerConfig struct {
@@ -66,8 +69,10 @@ func NewConsoleLogger(shouldLogLocation bool, config *ConsoleLoggerConfig) (*Con
 		FileLogger: FileLogger{
 			Enabled: AtomicBool{},
 			logger:  log.New(config.Output, "", 0),
+			config:  config.FileLoggerConfig,
 		},
 		isStderr: isStderr,
+		config:   *config,
 	}
 	logger.Enabled.Set(*config.Enabled)
 
@@ -124,6 +129,15 @@ func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
 
 	// Finally, check the specific log key is enabled
 	return l.LogKeyMask.Enabled(logKey)
+}
+
+func (l *ConsoleLogger) getConsoleLoggerConfig() *ConsoleLoggerConfig {
+	c := l.config
+	c.FileLoggerConfig = *l.getFileLoggerConfig()
+	c.LogLevel = l.LogLevel
+	c.LogKeys = l.LogKeyMask.EnabledLogKeys()
+
+	return &c
 }
 
 // init validates and sets any defaults for the given ConsoleLoggerConfig

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -54,6 +54,9 @@ type FileLogger struct {
 	output          io.Writer
 	logger          *log.Logger
 	buffer          strings.Builder
+
+	// FileLoggerConfig stores the initial config used to instantiate FileLogger
+	config FileLoggerConfig
 }
 
 type FileLoggerConfig struct {
@@ -89,6 +92,7 @@ func NewFileLogger(config *FileLoggerConfig, level LogLevel, name string, logFil
 		name:    name,
 		output:  config.Output,
 		logger:  log.New(config.Output, "", 0),
+		config:  *config,
 	}
 	logger.Enabled.Set(*config.Enabled)
 
@@ -150,6 +154,12 @@ func (l *FileLogger) shouldLog(logLevel LogLevel) bool {
 		l.Enabled.IsTrue() &&
 		// Check the log level is enabled
 		l.level >= logLevel
+}
+
+func (l *FileLogger) getFileLoggerConfig() *FileLoggerConfig {
+	fileLoggerConfig := l.config
+	fileLoggerConfig.Enabled = BoolPtr(l.Enabled.IsTrue())
+	return &fileLoggerConfig
 }
 
 func (lfc *FileLoggerConfig) init(level LogLevel, name string, logFilePath string, minAge int) error {

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -157,6 +157,7 @@ func (l *FileLogger) shouldLog(logLevel LogLevel) bool {
 }
 
 func (l *FileLogger) getFileLoggerConfig() *FileLoggerConfig {
+	// Copy config struct to avoid mutating running config
 	fileLoggerConfig := l.config
 	fileLoggerConfig.Enabled = BoolPtr(l.Enabled.IsTrue())
 	return &fileLoggerConfig

--- a/base/logging_config.go
+++ b/base/logging_config.go
@@ -230,6 +230,35 @@ func StatsLoggerIsEnabled() bool {
 	return statsLogger.Enabled.IsTrue()
 }
 
+type LoggingConfig struct {
+	LogFilePath    string               `json:"log_file_path,omitempty"   help:"Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file"`
+	RedactionLevel RedactionLevel       `json:"redaction_level,omitempty" help:"Redaction level to apply to log output"`
+	Console        *ConsoleLoggerConfig `json:"console,omitempty"`
+	Error          *FileLoggerConfig    `json:"error,omitempty"`
+	Warn           *FileLoggerConfig    `json:"warn,omitempty"`
+	Info           *FileLoggerConfig    `json:"info,omitempty"`
+	Debug          *FileLoggerConfig    `json:"debug,omitempty"`
+	Trace          *FileLoggerConfig    `json:"trace,omitempty"`
+	Stats          *FileLoggerConfig    `json:"stats,omitempty"`
+}
+
+func BuildLoggingConfigFromLoggers(redactionLevel RedactionLevel, LogFilePath string) *LoggingConfig {
+	config := LoggingConfig{
+		RedactionLevel: redactionLevel,
+		LogFilePath:    LogFilePath,
+	}
+
+	config.Console = consoleLogger.getConsoleLoggerConfig()
+	config.Error = errorLogger.getFileLoggerConfig()
+	config.Warn = warnLogger.getFileLoggerConfig()
+	config.Info = infoLogger.getFileLoggerConfig()
+	config.Debug = debugLogger.getFileLoggerConfig()
+	config.Trace = traceLogger.getFileLoggerConfig()
+	config.Stats = statsLogger.getFileLoggerConfig()
+
+	return &config
+}
+
 // validateLogFilePath ensures the given path is created and is a directory.
 func validateLogFilePath(logFilePath string) error {
 	// Make full directory structure if it doesn't already exist

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -122,14 +122,71 @@ func (h *handler) handleGetDbConfig() error {
 	return nil
 }
 
+type RunTimeServerConfigResponse struct {
+	*StartupConfig
+	Databases map[string]*DbConfig `json:"databases"`
+}
+
 // Get admin config info
 func (h *handler) handleGetConfig() error {
-	// TODO: Include runtime
-
 	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
-	_ = includeRuntime
-
 	redact, _ := h.getOptBoolQuery("redact", true)
+
+	if includeRuntime {
+		cfg := RunTimeServerConfigResponse{}
+		var err error
+
+		allDbNames := h.server.AllDatabaseNames()
+		databaseMap := make(map[string]*DbConfig, len(allDbNames))
+		if redact {
+			cfg.StartupConfig, err = h.server.config.Redacted()
+			if err != nil {
+				return err
+			}
+
+			for _, dbName := range allDbNames {
+				databaseMap[dbName], err = h.server.GetDatabaseConfig(dbName).Redacted()
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			cfg.StartupConfig = h.server.config
+			for _, dbName := range allDbNames {
+				databaseMap[dbName] = &h.server.GetDatabaseConfig(dbName).DbConfig
+			}
+		}
+
+		for dbName, dbConfig := range databaseMap {
+			database, err := h.server.GetDatabase(dbName)
+			if err != nil {
+				return err
+			}
+
+			replications, err := database.SGReplicateMgr.GetReplications()
+			if err != nil {
+				return err
+			}
+
+			dbConfig.Replications = make(map[string]*db.ReplicationConfig, len(replications))
+
+			for replicationName, replicationConfig := range replications {
+				if redact {
+					dbConfig.Replications[replicationName] = replicationConfig.ReplicationConfig.Redacted()
+				} else {
+					dbConfig.Replications[replicationName] = &replicationConfig.ReplicationConfig
+				}
+			}
+		}
+
+		loggingStuff := *base.BuildLoggingConfigFromLoggers(h.server.config.Logging.RedactionLevel, h.server.config.Logging.LogFilePath)
+		cfg.Logging = loggingStuff
+		cfg.Databases = databaseMap
+
+		h.writeJSON(cfg)
+		return nil
+	}
+
 	if redact {
 		cfg, err := h.server.initialStartupConfig.Redacted()
 		if err != nil {
@@ -215,6 +272,8 @@ func (h *handler) handlePutConfig() error {
 	if config.Logging.Stats.Enabled != nil {
 		base.EnableStatsLogger(*config.Logging.Stats.Enabled)
 	}
+
+	h.server.config.Logging = *base.BuildLoggingConfigFromLoggers(h.server.config.Logging.RedactionLevel, h.server.config.Logging.LogFilePath)
 
 	return base.HTTPErrorf(http.StatusOK, "Updated")
 }

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -121,7 +121,7 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			MetricsInterfaceAuthentication:            lc.MetricsInterfaceAuthentication,
 			EnableAdminAuthenticationPermissionsCheck: lc.EnableAdminAuthenticationPermissionsCheck,
 		},
-		Logging: LoggingConfig{},
+		Logging: base.LoggingConfig{},
 		Auth: AuthConfig{
 			BcryptCost: lc.BcryptCost,
 		},

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -43,7 +43,7 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 			// Post-DP this should be set to base.IsEnterpriseEdition as default
 			EnableAdminAuthenticationPermissionsCheck: base.BoolPtr(false),
 		},
-		Logging: LoggingConfig{
+		Logging: base.LoggingConfig{
 			LogFilePath:    defaultLogFilePath,
 			RedactionLevel: base.DefaultRedactionLevel,
 			Console: &base.ConsoleLoggerConfig{
@@ -62,12 +62,12 @@ func DefaultStartupConfig(defaultLogFilePath string) StartupConfig {
 
 // StartupConfig is the config file used by Sync Gateway in 3.0+ to start up with node-specific settings, and then bootstrap databases via Couchbase Server.
 type StartupConfig struct {
-	Bootstrap   BootstrapConfig   `json:"bootstrap,omitempty"`
-	API         APIConfig         `json:"api,omitempty"`
-	Logging     LoggingConfig     `json:"logging,omitempty"`
-	Auth        AuthConfig        `json:"auth,omitempty"`
-	Replicator  ReplicatorConfig  `json:"replicator,omitempty"`
-	Unsupported UnsupportedConfig `json:"unsupported,omitempty"`
+	Bootstrap   BootstrapConfig    `json:"bootstrap,omitempty"`
+	API         APIConfig          `json:"api,omitempty"`
+	Logging     base.LoggingConfig `json:"logging,omitempty"`
+	Auth        AuthConfig         `json:"auth,omitempty"`
+	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
+	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
 
 	MaxFileDescriptors uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 
@@ -123,18 +123,6 @@ type CORSConfig struct {
 	LoginOrigin []string `json:"login_origin,omitempty" help:"List of allowed login origins"`
 	Headers     []string `json:"headers,omitempty"      help:"List of allowed headers"`
 	MaxAge      int      `json:"max_age,omitempty"      help:"Maximum age of the CORS Options request"`
-}
-
-type LoggingConfig struct {
-	LogFilePath    string                    `json:"log_file_path,omitempty"   help:"Absolute or relative path on the filesystem to the log file directory. A relative path is from the directory that contains the Sync Gateway executable file"`
-	RedactionLevel base.RedactionLevel       `json:"redaction_level,omitempty" help:"Redaction level to apply to log output"`
-	Console        *base.ConsoleLoggerConfig `json:"console,omitempty"`
-	Error          *base.FileLoggerConfig    `json:"error,omitempty"`
-	Warn           *base.FileLoggerConfig    `json:"warn,omitempty"`
-	Info           *base.FileLoggerConfig    `json:"info,omitempty"`
-	Debug          *base.FileLoggerConfig    `json:"debug,omitempty"`
-	Trace          *base.FileLoggerConfig    `json:"trace,omitempty"`
-	Stats          *base.FileLoggerConfig    `json:"stats,omitempty"`
 }
 
 type AuthConfig struct {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -554,7 +554,7 @@ func TestSetupAndValidateLoggingWithLoggingConfig(t *testing.T) {
 	t.Skip("Skipping TestSetupAndValidateLoggingWithLoggingConfig")
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 	logFilePath := "/var/log/sync_gateway"
-	sc := &StartupConfig{Logging: LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
+	sc := &StartupConfig{Logging: base.LoggingConfig{LogFilePath: logFilePath, RedactionLevel: base.RedactFull}}
 	err := sc.SetupAndValidateLogging()
 	assert.NoError(t, err, "Setup and validate logging should be successful")
 	assert.Equal(t, base.RedactFull, sc.Logging.RedactionLevel)

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -91,7 +91,7 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 			ProfileInterface: *profileInterface,
 			Pretty:           pretty,
 		},
-		Logging: LoggingConfig{
+		Logging: base.LoggingConfig{
 			LogFilePath: *logFilePath,
 			Console: &base.ConsoleLoggerConfig{
 				LogLevel: logLevel,


### PR DESCRIPTION
CBG-1602
- Store logger config as part of the `ConsoleLogger` or `FileLogger` themselves. This allows config to be easily rebuilt from the running loggers and then we just adjust the fields which can be modified at runtime like enabled, log level etc.
- This re-building of the logger config required `LoggingConfig` to be moved to the base package alongside the loggers.

Otherwise I generally just use already existing functions to read the server config, db configs and replication information.

Tested with a unit test.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/989/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/990/

The above have failures but un-related to this PR