### PR TITLE
Log upgradeError in a failed automatic upgrade attempt

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -120,8 +120,9 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 				// the config is actually a 3.x config but with a genuine unknown field, therefore we should  return the
 				// original error from LoadStartupConfigFromPath.
 				if pkgerrors.Cause(upgradeError) == base.ErrUnknownField {
-					base.Errorf("automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
-					return false, err
+					base.Warnf("Automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
+					base.Warnf("Provided config %s not recognized as boostrap startup config format: %v", base.MD(configPath[0]), err)
+					return false, fmt.Errorf("unknown config fields supplied. Unable to continue")
 				}
 
 				return false, upgradeError

--- a/rest/main.go
+++ b/rest/main.go
@@ -121,7 +121,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 				// original error from LoadStartupConfigFromPath.
 				if pkgerrors.Cause(upgradeError) == base.ErrUnknownField {
 					base.Warnf("Automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
-					base.Warnf("Provided config %s not recognized as boostrap startup config format: %v", base.MD(configPath[0]), err)
+					base.Warnf("Provided config %s not recognized as bootstrap config format: %v", base.MD(configPath[0]), err)
 					return false, fmt.Errorf("unknown config fields supplied. Unable to continue")
 				}
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -120,7 +120,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 				// the config is actually a 3.x config but with a genuine unknown field, therefore we should  return the
 				// original error from LoadStartupConfigFromPath.
 				if pkgerrors.Cause(upgradeError) == base.ErrUnknownField {
-					base.Errorf("automatic upgrade attempt failed %s not recognized as a legacy config err: %v", base.MD(configPath[0]), upgradeError)
+					base.Errorf("automatic upgrade attempt failed, %s not recognized as legacy config format: %v", base.MD(configPath[0]), upgradeError)
 					return false, err
 				}
 

--- a/rest/main.go
+++ b/rest/main.go
@@ -120,6 +120,7 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 				// the config is actually a 3.x config but with a genuine unknown field, therefore we should  return the
 				// original error from LoadStartupConfigFromPath.
 				if pkgerrors.Cause(upgradeError) == base.ErrUnknownField {
+					base.Errorf("automatic upgrade attempt failed %s not recognized as a legacy config err: %v", base.MD(configPath[0]), upgradeError)
 					return false, err
 				}
 


### PR DESCRIPTION
Simple logging addition to log the upgrade error in an event we attempt to migrate an unrecognized legacy config.

Output looks like below in the event that a legacy config goes through an attempted upgrade but has an unknown field such as server-level replications:

```
2021-08-18T17:23:00.897+01:00 ==== Couchbase Sync Gateway/() EE ====
2021-08-18T17:23:00.897+01:00 [INF] Loading content from [sg_config_invalid.json] ...
2021-08-18T17:23:00.904+01:00 [INF] Found unknown fields in startup config. Attempting automatic config upgrade.
2021-08-18T17:23:00.904+01:00 [INF] Loading content from [sg_config_invalid.json] ...
2021-08-18T17:23:00.909+01:00 [WRN] Automatic upgrade attempt failed, sg_config_invalid.json not recognized as legacy config format: rest.LegacyServerConfig.Logging: ReadObject: found unknown field: replications, error found in #10 byte of ...|lications": [],
  "l|..., bigger context ...| true,
  "use_tls_server": false,
  "replications": [],
  "logging": {
    "redaction_level": "parti|...: unrecognized JSON field -- rest.serverMainPersistentConfig() at main.go:123
2021-08-18T17:23:00.909+01:00 [WRN] Provided config sg_config_invalid.json not recognized as boostrap startup config format: rest.StartupConfig.Logging: base.LoggingConfig.ReadObject: found unknown field: disable_persistent_config, error found in #10 byte of ...|nt_config": true,
  |..., bigger context ...|{
  "disable_persistent_config": true,
  "interface": ":4984",
  "adminInterface"|...: unrecognized JSON field -- rest.serverMainPersistentConfig() at main.go:124
2021-08-18T17:23:00.909+01:00 [ERR] Couldn't start Sync Gateway: unknown config fields supplied. Unable to continue -- rest.ServerMain() at main.go:25
```

Integration test not necessary for log change.