### PR TITLE
Switch manifest and imports to using versioned path for gocb, gocbcore

### DIFF
--- a/base/bootstrap.go
+++ b/base/bootstrap.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore/memd"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10/memd"
 )
 
 // BootstrapConnection is the interface that can be used to bootstrap Sync Gateway against a Couchbase Server cluster.

--- a/base/bucket.go
+++ b/base/bucket.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/couchbase/go-couchbase"
-	"github.com/couchbase/gocbcore/memd"
+	"github.com/couchbase/gocbcore/v10/memd"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/couchbase/gocbcore/memd"
+	"github.com/couchbase/gocbcore/v10/memd"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 	"gopkg.in/couchbase/gocb.v1"

--- a/base/collection.go
+++ b/base/collection.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )

--- a/base/collection_n1ql.go
+++ b/base/collection_n1ql.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )

--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocb/v2"
 
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"

--- a/base/collection_view.go
+++ b/base/collection_view.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )

--- a/base/collection_xattr.go
+++ b/base/collection_xattr.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore"
-	"github.com/couchbase/gocbcore/memd"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10"
+	"github.com/couchbase/gocbcore/v10/memd"
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )

--- a/base/error.go
+++ b/base/error.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore/memd"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10/memd"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbaselabs/walrus"

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10"
 )
 
 // GoCBv2SecurityConfig returns a gocb.SecurityConfig to use when connecting given a CA Cert path.

--- a/base/logger_external.go
+++ b/base/logger_external.go
@@ -15,8 +15,8 @@ import (
 	"os"
 
 	"github.com/couchbase/clog"
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10"
 	"github.com/couchbase/goutils/logging"
 	gocbv1 "gopkg.in/couchbase/gocb.v1"
 	gocbcorev7 "gopkg.in/couchbase/gocbcore.v7"

--- a/base/logger_external_test.go
+++ b/base/logger_external_test.go
@@ -3,8 +3,8 @@ package base
 import (
 	"testing"
 
-	"github.com/couchbase/gocb"
-	"github.com/couchbase/gocbcore"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbase/gocbcore/v10"
 	"github.com/stretchr/testify/assert"
 	gocbv1 "gopkg.in/couchbase/gocb.v1"
 	gocbcorev7 "gopkg.in/couchbase/gocbcore.v7"

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocb/v2"
 	gocbv1 "gopkg.in/couchbase/gocb.v1"
 )
 

--- a/db/design_doc.go
+++ b/db/design_doc.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/couchbase/gocb"
+	"github.com/couchbase/gocb/v2"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/auth"
 	"github.com/couchbase/sync_gateway/base"

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,8 +45,8 @@ licenses/APL2.txt.
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
   <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb" remote="couchbase" revision="7edf8dda70989588940f2649d6ba72b9253aab12" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore" remote="couchbase" revision="e0632bbd0c3dabf618b8170eb3bffb0862b9ee9a"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="7edf8dda70989588940f2649d6ba72b9253aab12" />
+  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="e0632bbd0c3dabf618b8170eb3bffb0862b9ee9a"/>
   <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
 
   <!-- gocb v1 -->

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/couchbase/gocbcore"
+	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/couchbase/gocbcore/connstr"
+	"github.com/couchbase/gocbcore/v10/connstr"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Follows the approach used in the server manifest for projects not using go modules (not planned for SG until post-Lithium).

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/991/
