### PR TITLE
CBG-1452: Persistent Config optimistic concurrency control

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -390,7 +390,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 				headerVersion := h.rq.Header.Get("If-Match")
 				if headerVersion != "" && headerVersion != bucketDbConfig.Version {
-					return nil, base.HTTPErrorf(http.StatusConflict, "Provided If-Match header does not match current config version")
+					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 				}
 
 				if err := base.ConfigMerge(&bucketDbConfig, dbConfig); err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -161,7 +161,7 @@ func (h *handler) handleGetDbConfig() error {
 		}
 		h.writeJSON(cfg)
 	} else {
-		h.writeJSON(h.server.GetDatabaseConfig(h.db.Name).DbConfig)
+		h.writeJSON(h.server.GetDatabaseConfig(h.db.Name))
 	}
 
 	return nil

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3376,6 +3376,8 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
 	// Start SG with no databases in bucket(s)
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3370,3 +3370,45 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	assert.Equal(t, db.ActiveReplicatorTypePushAndPull, replCfg.Direction)
 
 }
+
+func TestPersistentConfigConcurrency(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	// Start SG with no databases in bucket(s)
+	config := bootstrapStartupConfigForTest(t)
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+	serverErr := make(chan error, 0)
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close()
+	}()
+	resp := adminRequest(t, http.MethodPut, "/db/",
+		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+	)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// Get config
+	resp = adminRequest(t, "GET", "/db/_config?redact=false", "")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	eTag := resp.Header.Get("ETag")
+
+	resp = adminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": eTag})
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	resp = adminRequest(t, "PUT", "/db/_config", "{}")
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	resp = adminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": "x"})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3394,23 +3394,24 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 		fmt.Println("closing test bucket")
 		tb.Close()
 	}()
-	resp := adminRequest(t, http.MethodPut, "/db/",
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
 		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Get config
-	resp = adminRequest(t, "GET", "/db/_config?redact=false", "")
+	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	eTag := resp.Header.Get("ETag")
+	assert.NotEqual(t, "", eTag)
 
-	resp = adminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": eTag})
+	resp = bootstrapAdminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": eTag})
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = adminRequest(t, "PUT", "/db/_config", "{}")
+	resp = bootstrapAdminRequest(t, "PUT", "/db/_config", "{}")
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = adminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": "x"})
+	resp = bootstrapAdminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": "x"})
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -47,12 +47,12 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 		fmt.Println("closing test bucket")
 		tb.Close()
 	}()
-	resp := adminRequest(t, http.MethodPut, "/db1/",
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = adminRequest(t, http.MethodGet, "/db1/", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	var dbRootResp DatabaseRoot
 	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbRootResp))
@@ -61,7 +61,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect the config
-	resp = adminRequest(t, http.MethodGet, "/db1/_config?redact=false", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config?redact=false", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	var dbConfigResp DatabaseConfig
 	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbConfigResp))
@@ -76,9 +76,9 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	require.Nil(t, dbConfigResp.Sync)
 
 	// Sanity check to use the database
-	resp = adminRequest(t, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
 	assertResp(t, resp, http.StatusCreated, `{"id":"doc1","ok":true,"rev":"1-cd809becc169215072fd567eebd8b8de"}`)
-	resp = adminRequest(t, http.MethodGet, "/db1/doc1", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)
 	assertResp(t, resp, http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
 
 	// Restart Sync Gateway
@@ -98,7 +98,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	}()
 
 	// Ensure the database was bootstrapped on startup
-	resp = adminRequest(t, http.MethodGet, "/db1/", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	dbRootResp = DatabaseRoot{}
 	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbRootResp))
@@ -107,7 +107,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect config again, and ensure no changes since bootstrap
-	resp = adminRequest(t, http.MethodGet, "/db1/_config?redact=false", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config?redact=false", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	dbConfigResp = DatabaseConfig{}
 	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbConfigResp))
@@ -122,7 +122,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	require.Nil(t, dbConfigResp.Sync)
 
 	// Ensure it's _actually_ the same bucket
-	resp = adminRequest(t, http.MethodGet, "/db1/doc1", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)
 	assertResp(t, resp, http.StatusOK, `{"_id":"doc1","_rev":"1-cd809becc169215072fd567eebd8b8de","foo":"bar"}`)
 }
 
@@ -152,7 +152,7 @@ func bootstrapStartupConfigForTest(t *testing.T) StartupConfig {
 	return config
 }
 
-func adminRequest(t *testing.T, method, path, body string) *http.Response {
+func bootstrapAdminRequest(t *testing.T, method, path, body string) *http.Response {
 	url := "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10) + path
 
 	buf := bytes.NewBufferString(body)
@@ -165,7 +165,7 @@ func adminRequest(t *testing.T, method, path, body string) *http.Response {
 	return resp
 }
 
-func adminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) *http.Response {
+func bootstrapAdminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) *http.Response {
 	url := "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10) + path
 
 	buf := bytes.NewBufferString(body)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -165,6 +165,23 @@ func adminRequest(t *testing.T, method, path, body string) *http.Response {
 	return resp
 }
 
+func adminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) *http.Response {
+	url := "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10) + path
+
+	buf := bytes.NewBufferString(body)
+	req, err := http.NewRequest(method, url, buf)
+	require.NoError(t, err)
+
+	for headerName, headerVal := range headers {
+		req.Header.Set(headerName, headerVal)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	return resp
+}
+
 func assertResp(t *testing.T, resp *http.Response, status int, body string) {
 	assert.Equal(t, status, resp.StatusCode)
 	b, _ := ioutil.ReadAll(resp.Body)

--- a/rest/config.go
+++ b/rest/config.go
@@ -1001,7 +1001,7 @@ func (sc *ServerContext) fetchAndLoadDatabase(dbName string) (found bool, err er
 	}
 	sc.applyConfigs([]DatabaseConfig{*dbConfig})
 
-	return true, err
+	return true, nil
 }
 
 func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *DatabaseConfig, err error) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1142,6 +1142,10 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig) (applied bool, err err
 		}
 	}
 
+	// Strip out version as we have no use for this locally and we want to prevent it being stored and being returned
+	// by any output
+	cnf.Version = ""
+
 	base.Infof(base.KeyConfig, "Updating database %q for bucket %q with new config from bucket", cnf.Name, *cnf.Bucket)
 	sc.bucketDbName[*cnf.Bucket] = cnf.Name
 	sc.dbConfigs[cnf.Name] = &cnf

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -13,7 +13,7 @@ type DatabaseConfig struct {
 
 	Guest *db.PrincipalConfig `json:"guest,omitempty"`
 
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 	DbConfig
 }
 

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
 )
 
@@ -12,5 +13,21 @@ type DatabaseConfig struct {
 
 	Guest *db.PrincipalConfig `json:"guest,omitempty"`
 
+	Version string `json:"version"`
 	DbConfig
+}
+
+func GenerateDatabaseConfigVersionID(previousRevID string, databaseConfig *DatabaseConfig) (string, error) {
+	databaseConfig.Version = ""
+
+	encodedBody, err := base.JSONMarshalCanonical(databaseConfig)
+	if err != nil {
+		return "", err
+	}
+
+	previousGen, previousRev := db.ParseRevID(previousRevID)
+	generation := previousGen + 1
+
+	hash := db.CreateRevIDWithBytes(generation, previousRev, encodedBody)
+	return hash, nil
 }

--- a/rest/main.go
+++ b/rest/main.go
@@ -239,6 +239,12 @@ func automaticConfigUpgrade(configPath string) (*StartupConfig, bool, error) {
 	// Write database configs to CBS with groupID "default"
 	for _, dbConfig := range dbConfigs {
 		dbc := dbConfig.ToDatabaseConfig()
+
+		dbc.Version, err = GenerateDatabaseConfigVersionID("", dbc)
+		if err != nil {
+			return nil, false, err
+		}
+
 		_, err = cluster.InsertConfig(*dbc.Bucket, persistentConfigDefaultGroupID, dbc)
 		if err != nil {
 			// If key already exists just continue


### PR DESCRIPTION
CBG-1452

Adds opt-in concurrency control for persistent config by utilizing rev IDs for configs which are supplied as ETags.

- On GET /db/_config the ETag is supplied
- On a PUT /db/_config the previous provided ETag  can be either emitted which will do an upsert, or can be provided (in the If-Match header) at which point we will first check that the current db config matches the provided ETag.
- Changed `fetchAndLoadDatabase` to split out the fetch work into `fetchDatabase`. Allowing is to obtain the current database config to validate the version.
- Renamed `adminRequest` to `bootstrapAdminRequest` to make its use-case more clear.
- In `_applyConfig` strip out Version

## Dependencies
- [x] PR #5155 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1003/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1004/
Failures look unrelated to this change