### PR TITLE
Prevent panic on startup without a config file

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -178,23 +178,25 @@ func serverMainPersistentConfig(fs *flag.FlagSet, flagStartupConfig *StartupConf
 	return false, startServer(&sc, ctx)
 }
 
-func getInitialStartupConfig(sc *StartupConfig, flagStartupConfig *StartupConfig) (*StartupConfig, error) {
+func getInitialStartupConfig(fileStartupConfig *StartupConfig, flagStartupConfig *StartupConfig) (*StartupConfig, error) {
 	initialStartupConfigTemp := StartupConfig{}
-	err := initialStartupConfigTemp.Merge(sc)
-	if err != nil {
-		return nil, err
+
+	if fileStartupConfig != nil {
+		if err := initialStartupConfigTemp.Merge(fileStartupConfig); err != nil {
+			return nil, err
+		}
 	}
 
-	err = initialStartupConfigTemp.Merge(flagStartupConfig)
-	if err != nil {
-		return nil, err
+	if flagStartupConfig != nil {
+		if err := initialStartupConfigTemp.Merge(flagStartupConfig); err != nil {
+			return nil, err
+		}
 	}
 
-	// Requires a deep copy of final input as passed in values are pointers. Need to ensure runtime changes don't
-	// affect this
+	// Requires a deep copy of final input as passed in values are pointers.
+	// Need to ensure runtime changes don't affect initialStartupConfig.
 	var initialStartupConfig StartupConfig
-	err = base.DeepCopyInefficient(&initialStartupConfig, initialStartupConfigTemp)
-	if err != nil {
+	if err := base.DeepCopyInefficient(&initialStartupConfig, initialStartupConfigTemp); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
In the scenario SG starts up without a config file, `getInitialStartupConfig` was attempting to merge a nil StartupConfig, resulting in a panic.

## Before

```
$ ./sync_gateway -bootstrap.use_tls_server=false
2021-08-17T18:22:55.165+01:00 ==== Couchbase Sync Gateway/() CE ====
2021-08-17T18:22:55.166+01:00 [ERR] Unexpected panic: reflect: call of reflect.Value.Type on zero Value - stopping process
goroutine 1 [running]:
runtime/debug.Stack(0xc000207170, 0x4b13aa0, 0xc00000f518)
	/usr/local/Cellar/go/1.16.5/libexec/src/runtime/debug/stack.go:24 +0x9f
github.com/couchbase/sync_gateway/base.FatalPanicHandler()
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/base/util.go:1405 +0x5b
panic(0x4b13aa0, 0xc00000f518)
	/usr/local/Cellar/go/1.16.5/libexec/src/runtime/panic.go:965 +0x1b9
reflect.Value.Type(0x0, 0x0, 0x0, 0x4e12b58, 0x4c12a20)
	/usr/local/Cellar/go/1.16.5/libexec/src/reflect/value.go:1908 +0x189
github.com/imdario/mergo.merge(0x4b6f820, 0xc0002a9200, 0x4b6f820, 0x0, 0xc000207520, 0x2, 0x2, 0x1e8, 0x4c12a20)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/imdario/mergo/merge.go:363 +0x218
github.com/imdario/mergo.Merge(...)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/imdario/mergo/merge.go:296
github.com/couchbase/sync_gateway/rest.(*StartupConfig).Merge(0xc0002a9200, 0x0, 0xe0f, 0x1980)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/config_startup.go:207 +0xa5
github.com/couchbase/sync_gateway/rest.getInitialStartupConfig(0x0, 0xc0002a8600, 0x100000005, 0xc000037a40, 0x35)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/main.go:183 +0x65
github.com/couchbase/sync_gateway/rest.serverMainPersistentConfig(0xc00028b3e0, 0xc0002a8600, 0x1, 0x1, 0x0)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/main.go:165 +0x294
github.com/couchbase/sync_gateway/rest.serverMain(0x4e01a08, 0xc00003c0e8, 0xc000032040, 0x2, 0x2, 0x0, 0x0)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/main.go:86 +0x485
github.com/couchbase/sync_gateway/rest.ServerMain()
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/main.go:24 +0x65
main.main()
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/main.go:24 +0x25
 -- base.FatalPanicHandler() at util.go:1405
```

## After
```
$ ./sync_gateway -bootstrap.use_tls_server=false
2021-08-17T18:20:39.257+01:00 ==== Couchbase Sync Gateway/() CE ====
2021-08-17T18:20:39.257+01:00 [INF] Config: Starting in persistent mode using config group "default"
2021-08-17T18:20:39.257+01:00 [INF] Logging: Console to stderr
2021-08-17T18:20:39.257+01:00 [INF] Logging: Files disabled
2021-08-17T18:20:39.257+01:00 [ERR] No log_file_path property specified in config, and --defaultLogFilePath command line flag was not set. Log files required for product support are not being generated.
2021/08/17 18:20:39 Couldn't start Sync Gateway: 1 error occurred:
	* a server must be provided in the Bootstrap configuration
```

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1001/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1002/
