### PR TITLE
CBG-1603 CBG-1604 CBG-1605: Implement new /{db}/_config options (include_runtime, include_javascript)

### DIFF
--- a/base/logger_console.go
+++ b/base/logger_console.go
@@ -132,8 +132,12 @@ func (l *ConsoleLogger) shouldLog(logLevel LogLevel, logKey LogKey) bool {
 }
 
 func (l *ConsoleLogger) getConsoleLoggerConfig() *ConsoleLoggerConfig {
-	// Copy config struct to avoid mutating running config
-	c := l.config
+	c := ConsoleLoggerConfig{}
+	if l != nil {
+		// Copy config struct to avoid mutating running config
+		c = l.config
+	}
+
 	c.FileLoggerConfig = *l.getFileLoggerConfig()
 	c.LogLevel = l.LogLevel
 	c.LogKeys = l.LogKeyMask.EnabledLogKeys()

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -157,9 +157,13 @@ func (l *FileLogger) shouldLog(logLevel LogLevel) bool {
 }
 
 func (l *FileLogger) getFileLoggerConfig() *FileLoggerConfig {
-	// Copy config struct to avoid mutating running config
-	fileLoggerConfig := l.config
-	fileLoggerConfig.Enabled = BoolPtr(l.Enabled.IsTrue())
+	fileLoggerConfig := FileLoggerConfig{}
+	if l != nil {
+		// Copy config struct to avoid mutating running config
+		fileLoggerConfig = l.config
+		fileLoggerConfig.Enabled = BoolPtr(l.Enabled.IsTrue())
+	}
+
 	return &fileLoggerConfig
 }
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -159,6 +159,8 @@ func (h *handler) handleGetDbConfig() error {
 
 	// refresh_config=true forces the config loaded out of the bucket to be applied on the node
 	if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
+		// set cas=0 to force a refresh
+		bucketDbConfig.cas = 0
 		h.server.applyConfigs([]DatabaseConfig{*bucketDbConfig})
 	}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -136,21 +136,16 @@ func (h *handler) handleDbOffline() error {
 
 // Get admin database info
 func (h *handler) handleGetDbConfig() error {
-	if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
-		_, err := h.server.fetchAndLoadDatabase(h.db.Name)
-		if err != nil {
-			return err
-		}
-	}
 
-	// TODO: STUBS
-	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
-	_ = includeRuntime
-	includeJavascript, _ := h.getOptBoolQuery("include_javascript", true)
-	_ = includeJavascript
-
+	// load config from bucket once for:
+	// - Populate an up to date ETag header
+	// - Applying if refresh_config is set
+	// - Returning if include_runtime=false
+	var bucketDbConfig *DatabaseConfig
 	if h.server.bootstrapContext.connection != nil {
-		found, dbConfig, err := h.server.fetchDatabase(h.db.Name)
+		var found bool
+		var err error
+		found, bucketDbConfig, err = h.server.fetchDatabase(h.db.Name)
 		if err != nil {
 			return err
 		}
@@ -159,20 +154,47 @@ func (h *handler) handleGetDbConfig() error {
 			return base.HTTPErrorf(http.StatusNotFound, "database config not found")
 		}
 
-		h.response.Header().Set("ETag", dbConfig.Version)
+		h.response.Header().Set("ETag", bucketDbConfig.Version)
 	}
 
+	// refresh_config=true forces the config loaded out of the bucket to be applied on the node
+	if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
+		h.server.applyConfigs([]DatabaseConfig{*bucketDbConfig})
+	}
+
+	// include_runtime controls whether to return the raw bucketDbConfig, or the runtime version populated with default values, etc.
+	var responseConfig *DatabaseConfig
+	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
+	if includeRuntime {
+		responseConfig = h.server.GetDatabaseConfig(h.db.Name)
+	} else {
+		responseConfig = bucketDbConfig
+	}
+
+	// redaction to sensitive config fields
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {
-		cfg, err := h.server.GetDatabaseConfig(h.db.Name).Redacted()
+		var err error
+		responseConfig, err = responseConfig.Redacted()
 		if err != nil {
 			return err
 		}
-		h.writeJSON(cfg)
-	} else {
-		h.writeJSON(h.server.GetDatabaseConfig(h.db.Name))
 	}
 
+	// include_javascript=false omits config fields that contain javascript code
+	includeJavascript, _ := h.getOptBoolQuery("include_javascript", true)
+	if !includeJavascript {
+		responseConfig.Sync = nil
+		responseConfig.ImportFilter = nil
+		for _, evt := range responseConfig.EventHandlers.DBStateChanged {
+			evt.Filter = ""
+		}
+		for _, evt := range responseConfig.EventHandlers.DBStateChanged {
+			evt.Filter = ""
+		}
+	}
+
+	h.writeJSON(responseConfig)
 	return nil
 }
 
@@ -199,7 +221,7 @@ func (h *handler) handleGetConfig() error {
 			}
 
 			for _, dbName := range allDbNames {
-				databaseMap[dbName], err = h.server.GetDatabaseConfig(dbName).Redacted()
+				databaseMap[dbName], err = h.server.GetDatabaseConfig(dbName).DbConfig.Redacted()
 				if err != nil {
 					return err
 				}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2245,7 +2245,8 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 	// Create database with valid JSON config that contains sync function enclosed in backticks.
 	syncFunc := `function(doc, oldDoc) { console.log("foo");}`
 	reqBodyWithBackticks := `{
-    	"bucket": "` + rt.Bucket().GetName() + `",
+        "num_index_replicas": 0,
+        "bucket": "` + rt.Bucket().GetName() + `",
         "sync": ` + "`" + syncFunc + "`" + `
 	}`
 	resp = rt.SendAdminRequest(http.MethodPut, "/backticks/", reqBodyWithBackticks)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1187,7 +1187,7 @@ func TestDBGetConfigNames(t *testing.T) {
 		},
 	}}
 
-	response := rt.SendAdminRequest("GET", "/db/_config", "")
+	response := rt.SendAdminRequest("GET", "/db/_config?include_runtime=true", "")
 	var body DbConfig
 	require.NoError(t, base.JSONUnmarshal(response.Body.Bytes(), &body))
 
@@ -2245,7 +2245,6 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 	// Create database with valid JSON config that contains sync function enclosed in backticks.
 	syncFunc := `function(doc, oldDoc) { console.log("foo");}`
 	reqBodyWithBackticks := `{
-    	"server": "walrus:",
     	"bucket": "backticks",
         "sync": ` + "`" + syncFunc + "`" + `
 	}`
@@ -2253,7 +2252,7 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 	assertStatus(t, resp, http.StatusCreated)
 
 	// Get database config after putting config.
-	resp = rt.SendAdminRequest(http.MethodGet, "/backticks/_config", "")
+	resp = rt.SendAdminRequest(http.MethodGet, "/backticks/_config?include_runtime=true", "")
 	assertStatus(t, resp, http.StatusOK)
 	var respBody db.Body
 	require.NoError(t, respBody.Unmarshal([]byte(resp.Body.String())))
@@ -2610,7 +2609,7 @@ func TestConfigRedaction(t *testing.T) {
 
 	// Test default db config redaction
 	var unmarshaledConfig DbConfig
-	response := rt.SendAdminRequest("GET", "/db/_config", "")
+	response := rt.SendAdminRequest("GET", "/db/_config?include_runtime=true", "")
 	err := json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
@@ -2618,7 +2617,7 @@ func TestConfigRedaction(t *testing.T) {
 	assert.Equal(t, "xxxxx", *unmarshaledConfig.Users["alice"].Password)
 
 	// Test default db config redaction when redaction disabled
-	response = rt.SendAdminRequest("GET", "/db/_config?redact=false", "")
+	response = rt.SendAdminRequest("GET", "/db/_config?include_runtime=true&redact=false", "")
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
@@ -2627,7 +2626,7 @@ func TestConfigRedaction(t *testing.T) {
 
 	// Test default server config redaction
 	var unmarshaledServerConfig StartupConfig
-	response = rt.SendAdminRequest("GET", "/_config", "")
+	response = rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
 	require.NoError(t, err)
 
@@ -2635,7 +2634,7 @@ func TestConfigRedaction(t *testing.T) {
 
 	// Test default server config redaction when redaction disabled
 	unmarshaledServerConfig = StartupConfig{}
-	response = rt.SendAdminRequest("GET", "/_config?redact=false", "")
+	response = rt.SendAdminRequest("GET", "/_config?include_runtime=true&redact=false", "")
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
 	require.NoError(t, err)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2245,7 +2245,7 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 	// Create database with valid JSON config that contains sync function enclosed in backticks.
 	syncFunc := `function(doc, oldDoc) { console.log("foo");}`
 	reqBodyWithBackticks := `{
-    	"bucket": "backticks",
+    	"bucket": "` + rt.Bucket().GetName() + `",
         "sync": ` + "`" + syncFunc + "`" + `
 	}`
 	resp = rt.SendAdminRequest(http.MethodPut, "/backticks/", reqBodyWithBackticks)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2245,8 +2245,8 @@ func TestHandlePutDbConfigWithBackticks(t *testing.T) {
 	// Create database with valid JSON config that contains sync function enclosed in backticks.
 	syncFunc := `function(doc, oldDoc) { console.log("foo");}`
 	reqBodyWithBackticks := `{
-        "num_index_replicas": 0,
-        "bucket": "` + rt.Bucket().GetName() + `",
+        "server": "walrus:",
+        "bucket": "backticks",
         "sync": ` + "`" + syncFunc + "`" + `
 	}`
 	resp = rt.SendAdminRequest(http.MethodPut, "/backticks/", reqBodyWithBackticks)

--- a/rest/config.go
+++ b/rest/config.go
@@ -718,10 +718,14 @@ func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
 // redactInPlace modifies the given config to redact the fields inside it.
 func (config *DbConfig) redactInPlace() error {
 
-	config.Password = "xxxxx"
+	if config.Password != "" {
+		config.Password = "xxxxx"
+	}
 
 	for i := range config.Users {
-		config.Users[i].Password = base.StringPtr("xxxxx")
+		if config.Users[i].Password != nil && *config.Users[i].Password != "" {
+			config.Users[i].Password = base.StringPtr("xxxxx")
+		}
 	}
 
 	for i, _ := range config.Replications {

--- a/rest/config.go
+++ b/rest/config.go
@@ -711,6 +711,13 @@ func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
 		return nil, err
 	}
 
+	err = config.redactInPlace()
+	return &config, err
+}
+
+// redactInPlace modifies the given config to redact the fields inside it.
+func (config *DbConfig) redactInPlace() error {
+
 	config.Password = "xxxxx"
 
 	for i := range config.Users {
@@ -721,7 +728,7 @@ func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
 		config.Replications[i] = config.Replications[i].Redacted()
 	}
 
-	return &config, nil
+	return nil
 }
 
 // decodeAndSanitiseConfig will sanitise a config from an io.Reader and unmarshal it into the given config parameter.
@@ -1063,7 +1070,6 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 			cnf.KeyPath = sc.config.Bootstrap.X509KeyPath
 		}
 		base.Tracef(base.KeyConfig, "Got config for bucket %q with cas %d", bucket, cas)
-
 		return true, &cnf, nil
 	}
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1144,9 +1144,9 @@ func (sc *ServerContext) applyConfigs(fetchedConfigs []DatabaseConfig) (count in
 }
 
 func (sc *ServerContext) _applyConfig(cnf DatabaseConfig) (applied bool, err error) {
-	// skip if we already have this config loaded
+	// skip if we already have this config loaded, and we've got a cas value to compare with
 	foundDbName, ok := sc.bucketDbName[*cnf.Bucket]
-	if ok && sc.dbConfigs[foundDbName].cas >= cnf.cas {
+	if ok && cnf.cas != 0 && sc.dbConfigs[foundDbName].cas >= cnf.cas {
 		base.Debugf(base.KeyConfig, "Database %q bucket %q config has not changed since last update", cnf.Name, *cnf.Bucket)
 		return false, nil
 	}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -30,7 +30,7 @@ func (dbc *DatabaseConfig) Redacted() (*DatabaseConfig, error) {
 		return nil, err
 	}
 
-	if config.Guest != nil {
+	if config.Guest != nil && config.Guest.Password != nil && *config.Guest.Password != "" {
 		config.Guest.Password = base.StringPtr("xxxxx")
 	}
 

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -9,6 +9,8 @@ import (
 // TODO: Review whether DatabaseConfig should maintain its own list of valid config options, or should just continue inheriting them from DbConfig
 type DatabaseConfig struct {
 	// cas is the Couchbase Server CAS of the database config in the bucket
+	// value is used to skip applying configs to SG nodes that already have
+	// an up to date config. This value can be explicitly set to 0 before applyConfig to force a reload.
 	cas uint64
 
 	Guest *db.PrincipalConfig `json:"guest,omitempty"`

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -17,6 +17,26 @@ type DatabaseConfig struct {
 	DbConfig
 }
 
+func (dbc *DatabaseConfig) Redacted() (*DatabaseConfig, error) {
+	var config DatabaseConfig
+
+	err := base.DeepCopyInefficient(&config, dbc)
+	if err != nil {
+		return nil, err
+	}
+
+	err = config.DbConfig.redactInPlace()
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Guest != nil {
+		config.Guest.Password = base.StringPtr("xxxxx")
+	}
+
+	return &config, nil
+}
+
 func GenerateDatabaseConfigVersionID(previousRevID string, databaseConfig *DatabaseConfig) (string, error) {
 	databaseConfig.Version = ""
 


### PR DESCRIPTION
CBG-1603 CBG-1604 CBG-1605

Implement new /{db}/_config options:
- `include_runtime` determines whether the config returned is from the bucket, or from the loaded in-memory config
- `include_javascript` determines whether config fields containing javascript are included in the response

Utilises existing dbconfig bucket load from CBG-1452 for optimistic concurrency control ETag header to reduce number of bucket ops to 1 for all scenarios.

## Dependencies (if applicable)
- [x] PR #5155
  - [x] PR #5176

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
