### PR TITLE
CBG-1622 Add custom cbgt feed type for Sync Gateway

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -17,14 +17,10 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"github.com/couchbase/cbgt"
-	"github.com/couchbase/go-couchbase"
-	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
-	pkgerrors "github.com/pkg/errors"
 )
 
 // vbucketIdStrings is a memorized array of 1024 entries for fast
@@ -256,6 +252,9 @@ func vbNoToPartition(vbNo uint16) string {
 	return vbucketIdStrings[vbNo]
 }
 
+/* Not in use, retaining as reference for future enhancement
+  TODO: remove auth from feedParams and use cbgtFeedParams before re-enabling
+
 // This starts a cbdatasource powered DCP Feed using an entirely separate connection to Couchbase Server than anything the existing
 // bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
 func StartCbgtDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
@@ -282,10 +281,7 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 		return err
 	}
 
-	feedParams, err := cbgtFeedParams(spec)
-	if err != nil {
-		return err
-	}
+	feedParams := cbgt.NewDCPFeedParams()
 
 	bucketUUID, err := bucket.UUID()
 	if err != nil {
@@ -369,6 +365,7 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 	return nil
 
 }
+
 
 // This starts a cbdatasource powered DCP Feed using an entirely separate connection to Couchbase Server than anything the existing
 // bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
@@ -518,6 +515,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	return nil
 
 }
+*/
 
 func makeFeedEventForDest(key []byte, val []byte, cas uint64, vbNo uint16, expiry uint32, dataType uint8, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 	return makeFeedEvent(key, val, dataType, cas, expiry, vbNo, opcode)

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -133,7 +133,7 @@ func addCbgtAuthToDCPParams(dcpParams string) string {
 	username, password, ok := getCbgtCredentials(sgSourceParams.DbName)
 	if !ok {
 		// no stored credentials includes the valid x.509 auth case
-		Infof(KeyImport, "No feed credentials stored for db from sourceParams: %s", sgSourceParams.DbName)
+		Infof(KeyImport, "No feed credentials stored for db from sourceParams: %s", MD(sgSourceParams.DbName))
 		return dcpParams
 	}
 

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -1,0 +1,183 @@
+package base
+
+import (
+	"sync"
+
+	"github.com/couchbase/cbgt"
+)
+
+// cbgtCredentials are global map of dbname to basic auth creds.  Updated on cbgt manager creation, required
+// for couchbase-dcp-sg feed type to retrieve per-db credentials without requiring server context handle
+// Cannot use the serverContext to retrieve this information, as the cbgt manager for a database is initialized
+// before the database is added to the server context's set of databases
+var cbgtCredentials map[string]cbgtCreds
+var cbgtCredentialsLock sync.Mutex
+
+type cbgtCreds struct {
+	username string
+	password string
+}
+
+const SOURCE_GOCOUCHBASE_DCP_SG = "couchbase-dcp-sg"
+
+// When SG isn't using x.509 authentication, it's necessary to pass bucket credentials
+// to cbgt for use when setting up the DCP feed.  These need to be passed as AuthUser and
+// AuthPassword in the DCP source parameters.
+// The dbname is stored in the cfg, and the credentials for that db retrieved from databaseCredentials.
+// The SOURCE_GOCOUCHBASE_DCP_SG feed type is a wrapper for SOURCE_GOCOUCHBASE_DCP that adds
+// the credential information to the DCP parameters before calling the underlying method.
+func init() {
+	cbgtCredentials = make(map[string]cbgtCreds)
+	cbgt.RegisterFeedType(SOURCE_GOCOUCHBASE_DCP_SG, &cbgt.FeedType{
+		Start:           SGFeedStartDCPFeed,
+		Partitions:      SGFeedPartitions,
+		PartitionSeqs:   SGFeedPartitionSeqs,
+		Stats:           SGFeedStats,
+		PartitionLookUp: cbgt.CouchbaseSourceVBucketLookUp,
+		//SourceUUIDLookUp: SGFeedSourceUUIDLookUp,     // TODO: cbgt 1.2.0
+		Public: false, // Won't be listed in /api/managerMeta output.
+		Description: "general/" + SOURCE_GOCOUCHBASE_DCP_SG +
+			" - a Couchbase Server bucket will be the data source," +
+			" via DCP protocol",
+		StartSample: cbgt.NewDCPFeedParams(),
+	})
+}
+
+type SGFeedSourceParams struct {
+	// Used to specify whether the applications are interested
+	// in receiving the xattrs information in a dcp stream.
+	IncludeXAttrs bool `json:"includeXAttrs,omitempty"`
+
+	// Used to pass the SG database name to SGFeed* shims
+	DbName string `json:"sg_dbname,omitempty"`
+}
+
+// cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
+// Used to pass basic auth credentials and xattr flag to cbgt.
+func cbgtFeedParams(spec BucketSpec, dbName string) (string, error) {
+	feedParams := &SGFeedSourceParams{}
+	feedParams.DbName = dbName
+
+	if spec.UseXattrs {
+		feedParams.IncludeXAttrs = true
+	}
+
+	paramBytes, err := JSONMarshal(feedParams)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
+}
+
+// SGFeed* functions add credentials to sourceParams before calling the underlying
+// cbgt function
+func SGFeedStartDCPFeed(mgr *cbgt.Manager, feedName, indexName, indexUUID,
+	sourceType, sourceName, bucketUUID, params string,
+	dests map[string]cbgt.Dest) error {
+
+	paramsWithAuth := addCbgtAuthToDCPParams(params)
+	return cbgt.StartDCPFeed(mgr, feedName, indexName, indexUUID, sourceType, sourceName, bucketUUID,
+		paramsWithAuth, dests)
+}
+
+func SGFeedPartitions(sourceType, sourceName, sourceUUID, sourceParams,
+	serverIn string, options map[string]string) (partitions []string, err error) {
+
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbasePartitions(sourceType, sourceName, sourceUUID, sourceParamsWithAuth,
+		serverIn, options)
+}
+
+func SGFeedPartitionSeqs(sourceType, sourceName, sourceUUID,
+	sourceParams, serverIn string, options map[string]string) (map[string]cbgt.UUIDSeq, error) {
+
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbasePartitionSeqs(sourceType, sourceName, sourceUUID, sourceParamsWithAuth,
+		serverIn, options)
+}
+
+func SGFeedStats(sourceType, sourceName, sourceUUID, sourceParams, serverIn string, options map[string]string,
+	statsKind string) (map[string]interface{}, error) {
+
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbaseStats(sourceType, sourceName, sourceUUID,
+		sourceParamsWithAuth, serverIn, options, statsKind)
+}
+
+/*  TODO: enable when moving to cbgt 1.2.0
+func SGFeedSourceUUIDLookUp(sourceName, sourceParams, serverIn string, options map[string]string) (string, error) {
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbaseSourceUUIDLookUp(sourceName, sourceParamsWithAuth, serverIn, options)
+}
+
+*/
+
+// addCbgtAuthToDCPParams gets the dbName from the incoming dcpParams, and checks for credentials
+// stored in databaseCredentials.  If found, adds those to the params as authUser/authPassword.
+// If dbname is present,
+func addCbgtAuthToDCPParams(dcpParams string) string {
+
+	var sgSourceParams SGFeedSourceParams
+
+	unmarshalErr := JSONUnmarshal([]byte(dcpParams), &sgSourceParams)
+	if unmarshalErr != nil {
+		Warnf("Unable to unmarshal params provided by cbgt as sgSourceParams: %v", unmarshalErr)
+		return dcpParams
+	}
+
+	if sgSourceParams.DbName == "" {
+		Infof(KeyImport, "Database name not specified in dcp params, feed credentials not added")
+		return dcpParams
+	}
+
+	username, password, ok := getCbgtCredentials(sgSourceParams.DbName)
+	if !ok {
+		// no stored credentials includes the valid x.509 auth case
+		Infof(KeyImport, "No feed credentials stored for db from sourceParams: %s", sgSourceParams.DbName)
+		return dcpParams
+	}
+
+	var feedParamsWithAuth cbgt.DCPFeedParams
+	unmarshalDCPErr := JSONUnmarshal([]byte(dcpParams), &feedParamsWithAuth)
+	if unmarshalDCPErr != nil {
+		Warnf("Unable to unmarshal params provided by cbgt as dcpFeedParams: %v", unmarshalDCPErr)
+	}
+
+	// Add creds to params
+	feedParamsWithAuth.AuthUser = username
+	feedParamsWithAuth.AuthPassword = password
+
+	marshalledParamsWithAuth, marshalErr := JSONMarshal(feedParamsWithAuth)
+	if marshalErr != nil {
+		Warnf("Unable to marshal updated cbgt dcp params: %v", marshalErr)
+		return dcpParams
+	}
+
+	return string(marshalledParamsWithAuth)
+}
+
+func addCbgtCredentials(dbName, username, password string) {
+	cbgtCredentialsLock.Lock()
+	cbgtCredentials[dbName] = cbgtCreds{
+		username: username,
+		password: password,
+	}
+	cbgtCredentialsLock.Unlock()
+}
+
+func removeCbgtCredentials(dbName string) {
+	cbgtCredentialsLock.Lock()
+	delete(cbgtCredentials, dbName)
+	cbgtCredentialsLock.Unlock()
+}
+
+func getCbgtCredentials(dbName string) (username, password string, ok bool) {
+	cbgtCredentialsLock.Lock()
+	creds, found := cbgtCredentials[dbName]
+	if found {
+		username = creds.username
+		password = creds.password
+	}
+	cbgtCredentialsLock.Unlock()
+	return username, password, found
+}

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -12,8 +12,8 @@ package base
 
 import (
 	"fmt"
-	"log"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/couchbase/cbgt"
@@ -144,8 +144,9 @@ func TestCBGTIndexCreation(t *testing.T) {
 
 			// Use an in-memory cfg, set up cbgt manager
 			cfg := cbgt.NewCfgMem()
-			context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation")
+			context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation", tc.dbName)
 			assert.NoError(t, err)
+			defer context.RemoveFeedCredentials(tc.dbName)
 
 			// Start Manager
 			registerType := cbgt.NODE_DEFS_WANTED
@@ -161,7 +162,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			if tc.existingLegacyIndex {
 				// Define a CBGT index with legacy naming
 				bucketUUID, _ := bucket.UUID()
-				sourceParams, err := cbgtFeedParams(spec)
+				sourceParams, err := legacyFeedParams(spec)
 				require.NoError(t, err)
 				legacyIndexName := GenerateLegacyIndexName(tc.dbName)
 				indexParams := `{"name": "` + tc.dbName + `"}`
@@ -187,7 +188,7 @@ func TestCBGTIndexCreation(t *testing.T) {
 			if tc.existingCurrentIndex {
 				// Define an existing CBGT index with current naming
 				bucketUUID, _ := bucket.UUID()
-				sourceParams, err := cbgtFeedParams(spec)
+				sourceParams, err := cbgtFeedParams(spec, tc.dbName)
 				require.NoError(t, err)
 				legacyIndexName := GenerateIndexName(tc.dbName)
 				indexParams := `{"name": "` + tc.dbName + `"}`
@@ -197,15 +198,15 @@ func TestCBGTIndexCreation(t *testing.T) {
 				}
 
 				err = context.Manager.CreateIndex(
-					"couchbase",      // sourceType
-					bucket.GetName(), // sourceName
-					bucketUUID,       // sourceUUID
-					sourceParams,     // sourceParams
-					indexType,        // indexType
-					legacyIndexName,  // indexName
-					indexParams,      // indexParams
-					planParams,       // planParams
-					"",               // prevIndexUUID
+					SOURCE_GOCOUCHBASE_DCP_SG, // sourceType
+					bucket.GetName(),          // sourceName
+					bucketUUID,                // sourceUUID
+					sourceParams,              // sourceParams
+					indexType,                 // indexType
+					legacyIndexName,           // indexName
+					indexParams,               // indexParams
+					planParams,                // planParams
+					"",                        // prevIndexUUID
 				)
 				require.NoError(t, err, "Unable to create legacy-style index")
 			}
@@ -218,9 +219,12 @@ func TestCBGTIndexCreation(t *testing.T) {
 			_, indexDefsMap, err := context.Manager.GetIndexDefs(true)
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(indexDefsMap))
-			_, ok := indexDefsMap[tc.expectedIndexName]
+			indexDef, ok := indexDefsMap[tc.expectedIndexName]
 			assert.True(t, ok, "Expected index name"+tc.expectedIndexName+"not found")
-			log.Printf("Index defs: %+v", indexDefsMap)
+
+			assert.False(t, strings.Contains(indexDef.SourceParams, "authUser"), "sourceParams should not include authUser")
+			assert.False(t, strings.Contains(indexDef.SourceParams, "authPassword"), "sourceParams should not include authPassword")
+
 		})
 	}
 }
@@ -234,11 +238,13 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	defer bucket.Close()
 
 	spec := bucket.BucketSpec
+	testDbName := "testDB"
 
 	// Use an in-memory cfg, set up cbgt manager
 	cfg := cbgt.NewCfgMem()
-	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation")
+	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation", testDbName)
 	assert.NoError(t, err)
+	defer context.RemoveFeedCredentials(testDbName)
 
 	// Start Manager
 	registerType := cbgt.NODE_DEFS_WANTED
@@ -246,14 +252,13 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Define index type
-	testDbName := "testDB"
 	indexType := CBGTIndexTypeSyncGatewayImport + testDbName
 	cbgt.RegisterPIndexImplType(indexType,
 		&cbgt.PIndexImplType{})
 
 	// Define a CBGT index with legacy naming within safe limits
 	bucketUUID, _ := bucket.UUID()
-	sourceParams, err := cbgtFeedParams(spec)
+	sourceParams, err := cbgtFeedParams(spec, testDbName)
 	require.NoError(t, err)
 	legacyIndexName := GenerateLegacyIndexName(testDbName)
 	indexParams := `{"name": "` + testDbName + `"}`
@@ -263,15 +268,15 @@ func TestCBGTIndexCreationSafeLegacyName(t *testing.T) {
 	}
 
 	err = context.Manager.CreateIndex(
-		"couchbase",      // sourceType
-		bucket.GetName(), // sourceName
-		bucketUUID,       // sourceUUID
-		sourceParams,     // sourceParams
-		indexType,        // indexType
-		legacyIndexName,  // indexName
-		indexParams,      // indexParams
-		planParams,       // planParams
-		"",               // prevIndexUUID
+		SOURCE_GOCOUCHBASE_DCP_SG, // sourceType
+		bucket.GetName(),          // sourceName
+		bucketUUID,                // sourceUUID
+		sourceParams,              // sourceParams
+		indexType,                 // indexType
+		legacyIndexName,           // indexName
+		indexParams,               // indexParams
+		planParams,                // planParams
+		"",                        // prevIndexUUID
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 
@@ -305,21 +310,21 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	defer bucket.Close()
 
 	spec := bucket.BucketSpec
+	unsafeTestDBName := "testDB" +
+		"01234567890123456789012345678901234567890123456789" +
+		"01234567890123456789012345678901234567890123456789" +
+		"01234567890123456789012345678901234567890123456789"
 
 	// Use an in-memory cfg, set up cbgt manager
 	cfg := cbgt.NewCfgMem()
-	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation")
+	context, err := initCBGTManager(bucket, spec, cfg, "testIndexCreation", unsafeTestDBName)
 	assert.NoError(t, err)
+	defer context.RemoveFeedCredentials(unsafeTestDBName)
 
 	// Start Manager
 	registerType := cbgt.NODE_DEFS_WANTED
 	err = context.Manager.Start(registerType)
 	require.NoError(t, err)
-
-	unsafeTestDBName := "testDB" +
-		"01234567890123456789012345678901234567890123456789" +
-		"01234567890123456789012345678901234567890123456789" +
-		"01234567890123456789012345678901234567890123456789"
 
 	// Define index type
 	indexType := CBGTIndexTypeSyncGatewayImport + unsafeTestDBName
@@ -328,7 +333,7 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 
 	// Define a CBGT index with legacy naming not within safe limits
 	bucketUUID, _ := bucket.UUID()
-	sourceParams, err := cbgtFeedParams(spec)
+	sourceParams, err := cbgtFeedParams(spec, unsafeTestDBName)
 	require.NoError(t, err)
 	legacyIndexName := GenerateLegacyIndexName(unsafeTestDBName)
 	indexParams := `{"name": "` + unsafeTestDBName + `"}`
@@ -338,15 +343,15 @@ func TestCBGTIndexCreationUnsafeLegacyName(t *testing.T) {
 	}
 
 	err = context.Manager.CreateIndex(
-		"couchbase",      // sourceType
-		bucket.GetName(), // sourceName
-		bucketUUID,       // sourceUUID
-		sourceParams,     // sourceParams
-		indexType,        // indexType
-		legacyIndexName,  // indexName
-		indexParams,      // indexParams
-		planParams,       // planParams
-		"",               // prevIndexUUID
+		SOURCE_GOCOUCHBASE_DCP_SG, // sourceType
+		bucket.GetName(),          // sourceName
+		bucketUUID,                // sourceUUID
+		sourceParams,              // sourceParams
+		indexType,                 // indexType
+		legacyIndexName,           // indexName
+		indexParams,               // indexParams
+		planParams,                // planParams
+		"",                        // prevIndexUUID
 	)
 	require.NoError(t, err, "Unable to create legacy-style index")
 
@@ -415,4 +420,26 @@ func BenchmarkPartitionToVbNo(b *testing.B) {
 		}
 	})
 
+}
+
+// legacyFeedParams format with credentials included
+func legacyFeedParams(spec BucketSpec) (string, error) {
+	feedParams := cbgt.NewDCPFeedParams()
+
+	// check for basic auth
+	if spec.Certpath == "" && spec.Auth != nil {
+		username, password, _ := spec.Auth.GetCredentials()
+		feedParams.AuthUser = username
+		feedParams.AuthPassword = password
+	}
+
+	if spec.UseXattrs {
+		feedParams.IncludeXAttrs = true
+	}
+
+	paramBytes, err := JSONMarshal(feedParams)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
 }

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -169,6 +169,7 @@ func (il *importListener) Stop() {
 			}
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed
 			il.cbgtContext.Manager.Stop()
+			il.cbgtContext.RemoveFeedCredentials(il.database.Name)
 
 			// TODO: Shut down the cfg (when cfg supports)
 		}


### PR DESCRIPTION
Wraps cbgt go-couchbase feed definition and supports retrieval of SG db-scoped metadata.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1021/
