### PR TITLE
CBG-1618: ObtainManagementAndHTTPClient should re-use http client

### DIFF
--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -162,7 +162,8 @@ func newTestClusterV2(server string, logger clusterLogFunc) *tbpClusterV2 {
 // tbpCluster returns an authenticated gocb Cluster for the given server URL.
 func initV2Cluster(server string) *gocb.Cluster {
 	spec := BucketSpec{
-		Server: server,
+		Server:        server,
+		TLSSkipVerify: true,
 	}
 
 	connStr, err := spec.GetGoCBConnString()

--- a/db/database.go
+++ b/db/database.go
@@ -1432,7 +1432,8 @@ func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]stri
 		return nil, nil, nil
 	}
 
-	// Fairly sure this shouldn't happen as the only place we don't init
+	// This shouldn't happen as the only place we don't initialize this is in the case where we're not using a Couchbase
+	// Bucket. This means the above check should catch it but check just to be safe.
 	if context.GoCBHttpClient == nil {
 		return nil, nil, fmt.Errorf("unable to obtain http client")
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -1421,13 +1421,8 @@ func (context *DatabaseContext) InitializeGoCBHttpClient() (*http.Client, error)
 		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
 		return nil, nil
 	}
-	transport := cbStore.HttpClient().Transport.(*http.Transport).Clone()
 
-	httpClient := &http.Client{
-		Transport: transport,
-	}
-
-	return httpClient, nil
+	return cbStore.HttpClient(), nil
 }
 
 func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
@@ -1435,6 +1430,11 @@ func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]stri
 	if !ok {
 		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
 		return nil, nil, nil
+	}
+
+	// Fairly sure this shouldn't happen as the only place we don't init
+	if context.GoCBHttpClient == nil {
+		return nil, nil, fmt.Errorf("unable to obtain http client")
 	}
 
 	endpoints, err := base.GoCBBucketMgmtEndpoints(cbStore)

--- a/db/database.go
+++ b/db/database.go
@@ -117,6 +117,7 @@ type DatabaseContext struct {
 	SGReplicateMgr               *sgReplicateManager // Manages interactions with sg-replicate replications
 	Heartbeater                  base.Heartbeater    // Node heartbeater for SG cluster awareness
 	ServeInsecureAttachmentTypes bool                // Attachment content type will bypass the content-disposition handling, default false
+	GoCBHttpClient               *http.Client
 }
 
 type DatabaseContextOptions struct {
@@ -1414,6 +1415,21 @@ func (context *DatabaseContext) ObtainManagementEndpoints() ([]string, error) {
 	return base.GoCBBucketMgmtEndpoints(cbStore)
 }
 
+func (context *DatabaseContext) InitializeGoCBHttpClient() (*http.Client, error) {
+	cbStore, ok := base.AsCouchbaseStore(context.Bucket)
+	if !ok {
+		base.Warnf("Database %v: Unable to get server management endpoints. Underlying bucket type was not GoCBBucket.", base.MD(context.Name))
+		return nil, nil
+	}
+	transport := cbStore.HttpClient().Transport.(*http.Transport).Clone()
+
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+
+	return httpClient, nil
+}
+
 func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]string, *http.Client, error) {
 	cbStore, ok := base.AsCouchbaseStore(context.Bucket)
 	if !ok {
@@ -1426,14 +1442,7 @@ func (context *DatabaseContext) ObtainManagementEndpointsAndHTTPClient() ([]stri
 		return nil, nil, err
 	}
 
-	// Clone HTTP transport for use in our httpClient
-	transport := cbStore.HttpClient().Transport.(*http.Transport).Clone()
-
-	httpClient := &http.Client{
-		Transport: transport,
-	}
-
-	return endpoints, httpClient, nil
+	return endpoints, context.GoCBHttpClient, nil
 }
 
 func (context *DatabaseContext) GetUserViewsEnabled() bool {

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -183,9 +183,8 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
-	goCBAgent, goCBHttpClient, err := ctx.initializeGoCBHttpClient()
+	goCBAgent, err := ctx.initializeGoCBHttpClient()
 	require.NoError(t, err)
-	ctx.GoCBHttpClient = goCBHttpClient
 	ctx.GoCBAgent = goCBAgent
 
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
@@ -467,9 +466,8 @@ func TestAdminAuthWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
-	goCBAgent, goCBHttpClient, err := ctx.initializeGoCBHttpClient()
+	goCBAgent, err := ctx.initializeGoCBHttpClient()
 	require.NoError(t, err)
-	ctx.GoCBHttpClient = goCBHttpClient
 	ctx.GoCBAgent = goCBAgent
 
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -183,6 +183,11 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
+	goCBAgent, goCBHttpClient, err := ctx.initializeGoCBHttpClient()
+	require.NoError(t, err)
+	ctx.GoCBHttpClient = goCBHttpClient
+	ctx.GoCBAgent = goCBAgent
+
 	eps, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 
@@ -461,6 +466,11 @@ func TestAdminAuthWithX509(t *testing.T) {
 		},
 	}, false)
 	defer ctx.Close()
+
+	goCBAgent, goCBHttpClient, err := ctx.initializeGoCBHttpClient()
+	require.NoError(t, err)
+	ctx.GoCBHttpClient = goCBHttpClient
+	ctx.GoCBAgent = goCBAgent
 
 	managementEndpoints, httpClient, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	require.NoError(t, err)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -183,7 +183,7 @@ func TestCheckPermissionsWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
-	goCBAgent, err := ctx.initializeGoCBHttpClient()
+	goCBAgent, err := ctx.initializeGoCBAgent()
 	require.NoError(t, err)
 	ctx.GoCBAgent = goCBAgent
 
@@ -466,7 +466,7 @@ func TestAdminAuthWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
-	goCBAgent, err := ctx.initializeGoCBHttpClient()
+	goCBAgent, err := ctx.initializeGoCBAgent()
 	require.NoError(t, err)
 	ctx.GoCBAgent = goCBAgent
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -928,12 +928,11 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 	sc := NewServerContext(config, persistentConfig)
 	if !base.ServerIsWalrus(config.Bootstrap.Server) {
-		goCBAgent, goCBHttpClient, err := sc.initializeGoCBHttpClient()
+		goCBAgent, err := sc.initializeGoCBHttpClient()
 		if err != nil {
 			return nil, err
 		}
 		sc.GoCBAgent = goCBAgent
-		sc.GoCBHttpClient = goCBHttpClient
 	}
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.

--- a/rest/config.go
+++ b/rest/config.go
@@ -928,7 +928,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 	sc := NewServerContext(config, persistentConfig)
 	if !base.ServerIsWalrus(config.Bootstrap.Server) {
-		goCBAgent, err := sc.initializeGoCBHttpClient()
+		goCBAgent, err := sc.initializeGoCBAgent()
 		if err != nil {
 			return nil, err
 		}

--- a/rest/config.go
+++ b/rest/config.go
@@ -927,6 +927,14 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 	}
 
 	sc := NewServerContext(config, persistentConfig)
+	if !base.ServerIsWalrus(config.Bootstrap.Server) {
+		goCBAgent, goCBHttpClient, err := sc.initializeGoCBHttpClient()
+		if err != nil {
+			return nil, err
+		}
+		sc.GoCBAgent = goCBAgent
+		sc.GoCBHttpClient = goCBHttpClient
+	}
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
 	if sc.persistentConfig {

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1197,6 +1197,8 @@ func TestSetupServerContext(t *testing.T) {
 		config := DefaultStartupConfig("")
 		config.Bootstrap.Server = base.UnitTestUrl() // Valid config requires server to be explicitly defined
 		config.Bootstrap.UseTLSServer = base.BoolPtr(base.ServerIsTLS(base.UnitTestUrl()))
+		config.Bootstrap.Username = base.TestClusterUsername()
+		config.Bootstrap.Password = base.TestClusterPassword()
 		sc, err := setupServerContext(&config, false)
 		require.NoError(t, err)
 		require.NotNil(t, sc)

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -264,7 +264,7 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
-	goCBAgent, err := ctx.initializeGoCBHttpClient()
+	goCBAgent, err := ctx.initializeGoCBAgent()
 	require.NoError(t, err)
 	ctx.GoCBAgent = goCBAgent
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -264,9 +264,8 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
-	goCBAgent, goCBHttpClient, err := ctx.initializeGoCBHttpClient()
+	goCBAgent, err := ctx.initializeGoCBHttpClient()
 	require.NoError(t, err)
-	ctx.GoCBHttpClient = goCBHttpClient
 	ctx.GoCBAgent = goCBAgent
 
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -264,6 +264,11 @@ func TestObtainManagementEndpointsFromServerContextWithX509(t *testing.T) {
 	}, false)
 	defer ctx.Close()
 
+	goCBAgent, goCBHttpClient, err := ctx.initializeGoCBHttpClient()
+	require.NoError(t, err)
+	ctx.GoCBHttpClient = goCBHttpClient
+	ctx.GoCBAgent = goCBAgent
+
 	eps, _, err := ctx.ObtainManagementEndpointsAndHTTPClient()
 	assert.NoError(t, err)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -147,6 +147,20 @@ func (rt *RestTester) Bucket() base.Bucket {
 
 	rt.RestTesterServerContext = NewServerContext(&sc, false)
 
+	if !base.UnitTestUrlIsWalrus() {
+		// Copy any testbucket cert info into boostrap server config
+		// Required as present for X509 tests there is no way to pass this info to the bootstrap server context with a
+		// RestTester directly - Should hopefully be alleviated by CBG-1460
+		sc.Bootstrap.CACertPath = testBucket.BucketSpec.CACertPath
+		sc.Bootstrap.X509CertPath = testBucket.BucketSpec.Certpath
+		sc.Bootstrap.X509KeyPath = testBucket.BucketSpec.Keypath
+
+		gocbAgent, gocbClient, err := rt.RestTesterServerContext.initializeGoCBHttpClient()
+		require.NoError(rt.tb, err)
+		rt.RestTesterServerContext.GoCBHttpClient = gocbClient
+		rt.RestTesterServerContext.GoCBAgent = gocbAgent
+	}
+
 	// Copy this startup config at this point into initial startup config
 	err := base.DeepCopyInefficient(&rt.RestTesterServerContext.initialStartupConfig, &sc)
 	if err != nil {

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -155,9 +155,8 @@ func (rt *RestTester) Bucket() base.Bucket {
 		sc.Bootstrap.X509CertPath = testBucket.BucketSpec.Certpath
 		sc.Bootstrap.X509KeyPath = testBucket.BucketSpec.Keypath
 
-		gocbAgent, gocbClient, err := rt.RestTesterServerContext.initializeGoCBHttpClient()
+		gocbAgent, err := rt.RestTesterServerContext.initializeGoCBHttpClient()
 		require.NoError(rt.tb, err)
-		rt.RestTesterServerContext.GoCBHttpClient = gocbClient
 		rt.RestTesterServerContext.GoCBAgent = gocbAgent
 	}
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -155,7 +155,7 @@ func (rt *RestTester) Bucket() base.Bucket {
 		sc.Bootstrap.X509CertPath = testBucket.BucketSpec.Certpath
 		sc.Bootstrap.X509KeyPath = testBucket.BucketSpec.Keypath
 
-		gocbAgent, err := rt.RestTesterServerContext.initializeGoCBHttpClient()
+		gocbAgent, err := rt.RestTesterServerContext.initializeGoCBAgent()
 		require.NoError(rt.tb, err)
 		rt.RestTesterServerContext.GoCBAgent = gocbAgent
 	}


### PR DESCRIPTION
CBG-1618

This commit stores both HTTPClients on `ServerContext` and `DatabaseContext` so it can be re-used rather than re-created for each call of `ObtainManagementEndpointsAndHTTPClient`.
Also stores a gocb agent on the `ServerContext`.

This PR requires a couple of test changes:
- Initializing the agent and client on the tests which create their own server context
- Set skip verify on cluster connect
- Copy over certs from bucket (with associated comment describing why)

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1020/
A few failures but look unrelated.
