### PR TITLE
CBG-1596: Wait for pending changes after writing doc in TestConflictResolveMergeWithMutatedRev

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5318,9 +5318,11 @@ func TestConflictResolveMergeWithMutatedRev(t *testing.T) {
 
 	resp := rt2.SendAdminRequest("PUT", "/db/doc", "{}")
 	assertStatus(t, resp, http.StatusCreated)
+	require.NoError(t, rt2.WaitForPendingChanges())
 
 	resp = rt1.SendAdminRequest("PUT", "/db/doc", `{"some_val": "val"}`)
 	assertStatus(t, resp, http.StatusCreated)
+	require.NoError(t, rt1.WaitForPendingChanges())
 
 	require.NoError(t, ar.Start())
 


### PR DESCRIPTION
CBG-1596

Wait for pending changes after writing doc in TestConflictResolveMergeWithMutatedRev

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1023/

