### PR TITLE
CBG-1606 CBG-1607: Implement sync and import_filter endpoints

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -535,17 +535,88 @@ func (h *handler) handlePutDbConfigSync() error {
 // GET database config import filter function
 func (h *handler) handleGetDbConfigImportFilter() error {
 	h.assertAdminOnly()
-	// TODO: STUB
-	h.writeJSONStatus(http.StatusOK, `function(doc) {
-	// this is a stub import filter function
-}`)
+	var (
+		etagVersion          string
+		importFilterFunction string
+	)
+
+	if h.server.bootstrapContext.connection != nil {
+		found, dbConfig, err := h.server.fetchDatabase(h.db.Name)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return base.HTTPErrorf(http.StatusNotFound, "database config not found")
+		}
+		etagVersion = dbConfig.Version
+		if dbConfig.ImportFilter != nil {
+			importFilterFunction = *dbConfig.ImportFilter
+		}
+	}
+
+	h.response.Header().Set("ETag", etagVersion)
+	h.writeJavascript(importFilterFunction)
 	return nil
 }
 
 // PUT a new database config import filter function
 func (h *handler) handlePutDbConfigImportFilter() error {
 	h.assertAdminOnly()
-	// TODO: STUB
+
+	if !h.server.persistentConfig {
+		return base.HTTPErrorf(http.StatusBadRequest, "endpoint only supports persistent config mode")
+	}
+
+	js, err := h.readJavascript()
+	if err != nil {
+		return err
+	}
+
+	bucket := h.db.Bucket.GetName()
+
+	var updatedDbConfig *DatabaseConfig
+	cas, err := h.server.bootstrapContext.connection.UpdateConfig(
+		bucket, h.server.config.Bootstrap.ConfigGroupID,
+		func(rawBucketConfig []byte) (newConfig []byte, err error) {
+			var bucketDbConfig DatabaseConfig
+			if err := base.JSONUnmarshal(rawBucketConfig, &bucketDbConfig); err != nil {
+				return nil, err
+			}
+
+			headerVersion := h.rq.Header.Get("If-Match")
+			if headerVersion != "" && headerVersion != bucketDbConfig.Version {
+				return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
+			}
+
+			bucketDbConfig.ImportFilter = &js
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			updatedDbConfig = &bucketDbConfig
+			return base.JSONMarshal(bucketDbConfig)
+		})
+	if err != nil {
+		return err
+	}
+	updatedDbConfig.cas = cas
+
+	dbName := h.db.Name
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+		return err
+	}
+
+	h.server.lock.Lock()
+	defer h.server.lock.Unlock()
+	h.server.bucketDbName[bucket] = dbName
+	h.server.dbConfigs[dbName] = updatedDbConfig
+
+	// TODO: Dynamic update instead of reload
+	if _, err := h.server._reloadDatabaseFromConfig(dbName); err != nil {
+		return err
+	}
+
 	return base.HTTPErrorf(http.StatusOK, "updated")
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -602,7 +602,7 @@ func (h *handler) readJSONInto(into interface{}) error {
 // Expands environment variables (if any) referenced in the config.
 func (h *handler) readSanitizeJSON(val interface{}) error {
 	// Performs the Content-Type validation and Content-Encoding check.
-	input, err := processContentEncoding(h.rq.Header, h.requestBody)
+	input, err := processContentEncoding(h.rq.Header, h.requestBody, "application/json")
 	if err != nil {
 		return err
 	}
@@ -636,6 +636,23 @@ func (h *handler) readSanitizeJSON(val interface{}) error {
 		}
 	}
 	return err
+}
+
+// readJavascript reads a javascript function from a request body.
+func (h *handler) readJavascript() (string, error) {
+	// Performs the Content-Type validation and Content-Encoding check.
+	input, err := processContentEncoding(h.rq.Header, h.requestBody, "text/javascript")
+	if err != nil {
+		return "", err
+	}
+
+	defer func() { _ = input.Close() }()
+	jsBytes, err := ioutil.ReadAll(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsBytes), nil
 }
 
 // readSanitizeJSONInto reads and sanitizes a JSON request body and returns DatabaseConfig.

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -783,6 +783,19 @@ func (h *handler) writeJSON(value interface{}) {
 	h.writeJSONStatus(http.StatusOK, value)
 }
 
+func (h *handler) writeJavascript(js string) {
+	if !h.requestAccepts("text/plain") {
+		base.Warnf("Client won't accept text/plain, only %s", h.rq.Header.Get("Accept"))
+		h.writeStatus(http.StatusNotAcceptable, "only text/plain available")
+		return
+	}
+
+	h.setHeader("Content-Type", "text/javascript charset=utf-8")
+	h.setHeader("Content-Length", fmt.Sprintf("%d", len(js)))
+	h.response.WriteHeader(http.StatusOK)
+	h.response.Write([]byte(js))
+}
+
 // Writes an object to the response in JSON format.
 // If status is nonzero, the header will be written with that status.
 func (h *handler) writeJSONStatus(status int, value interface{}) {

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -53,7 +53,7 @@ func ReadJSONFromMIME(headers http.Header, input io.ReadCloser, into interface{}
 }
 
 func ReadJSONFromMIMERawErr(headers http.Header, input io.ReadCloser, into interface{}) error {
-	input, err := processContentEncoding(headers, input)
+	input, err := processContentEncoding(headers, input, "application/json")
 	if err != nil {
 		return err
 	}
@@ -69,9 +69,9 @@ func ReadJSONFromMIMERawErr(headers http.Header, input io.ReadCloser, into inter
 }
 
 // processContentEncoding performs the Content-Type validation and Content-Encoding check.
-func processContentEncoding(headers http.Header, input io.ReadCloser) (io.ReadCloser, error) {
+func processContentEncoding(headers http.Header, input io.ReadCloser, expectedContentTypeMime string) (io.ReadCloser, error) {
 	contentType := headers.Get("Content-Type")
-	if contentType != "" && !strings.HasPrefix(contentType, "application/json") {
+	if contentType != "" && !strings.HasPrefix(contentType, expectedContentTypeMime) {
 		return input, base.HTTPErrorf(http.StatusUnsupportedMediaType, "Invalid content type %s", contentType)
 	}
 	switch headers.Get("Content-Encoding") {

--- a/rest/multipart.go
+++ b/rest/multipart.go
@@ -72,7 +72,7 @@ func ReadJSONFromMIMERawErr(headers http.Header, input io.ReadCloser, into inter
 func processContentEncoding(headers http.Header, input io.ReadCloser, expectedContentTypeMime string) (io.ReadCloser, error) {
 	contentType := headers.Get("Content-Type")
 	if contentType != "" && !strings.HasPrefix(contentType, expectedContentTypeMime) {
-		return input, base.HTTPErrorf(http.StatusUnsupportedMediaType, "Invalid content type %s", contentType)
+		return input, base.HTTPErrorf(http.StatusUnsupportedMediaType, "Invalid content type %s - expected %s", contentType, expectedContentTypeMime)
 	}
 	switch headers.Get("Content-Encoding") {
 	case "gzip":

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -260,10 +260,14 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigSync)).Methods("GET")
 	dbr.Handle("/_config/sync",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigSync)).Methods("PUT")
+	dbr.Handle("/_config/sync",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleDeleteDbConfigSync)).Methods("DELETE")
 	dbr.Handle("/_config/import_filter",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfigImportFilter)).Methods("GET")
 	dbr.Handle("/_config/import_filter",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePutDbConfigImportFilter)).Methods("PUT")
+	dbr.Handle("/_config/import_filter",
+		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleDeleteDbConfigImportFilter)).Methods("DELETE")
 
 	dbr.Handle("/_resync",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")


### PR DESCRIPTION
CBG-1606 CBG-1607

Allows independent read and write of sync function and import_filter for database configs.

Both PUT endpoint handlers share a lot of code with `handlePutDbConfig` which could potentially be factored out into shared functions.