### PR TITLE
CBG-1299 Implement network connstr flag for cbdatasource alt address shims

### DIFF
--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -295,8 +295,14 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		}
 	}
 
-	// A lookup of host dest to external alternate address hostnames
-	dataSourceOptions.ConnectBucket, dataSourceOptions.Connect, dataSourceOptions.ConnectTLS = alternateAddressShims(loggingCtx, spec.IsTLS(), connSpec.Addresses)
+	networkType := getNetworkTypeFromConnSpec(connSpec)
+	Infof(KeyDCP, "Using network type: %s", networkType)
+
+	// default (aka internal) networking is handled by cbdatasource, so we can avoid the shims altogether in this case, for all other cases we need shims to remap hosts.
+	if networkType != clusterNetworkDefault {
+		// A lookup of host dest to external alternate address hostnames
+		dataSourceOptions.ConnectBucket, dataSourceOptions.Connect, dataSourceOptions.ConnectTLS = alternateAddressShims(loggingCtx, spec.IsTLS(), connSpec.Addresses, networkType)
+	}
 
 	DebugfCtx(loggingCtx, KeyDCP, "Connecting to new bucket datasource.  URLs:%s, pool:%s, bucket:%s", MD(urls), MD(poolName), MD(bucketName))
 

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -144,7 +144,16 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 				return spec.TLSConfig()
 			}
 		}
-		options.ConnectBucket, options.Connect, options.ConnectTLS = alternateAddressShims(c.loggingCtx, spec.IsTLS(), connSpec.Addresses)
+
+		networkType := getNetworkTypeFromConnSpec(connSpec)
+		Infof(KeyDCP, "Using network type: %s", networkType)
+
+		// default (aka internal) networking is handled by cbdatasource, so we can avoid the shims altogether in this case, for all other cases we need shims to remap hosts.
+		if networkType != clusterNetworkDefault {
+			// A lookup of host dest to external alternate address hostnames
+			options.ConnectBucket, options.Connect, options.ConnectTLS = alternateAddressShims(c.loggingCtx, spec.IsTLS(), connSpec.Addresses, networkType)
+		}
+
 		return options
 	})
 


### PR DESCRIPTION
Forward-port from 2.8.x.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1030/
