### PR TITLE
Get bucket name from dbName, unless specified in config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -50,7 +50,12 @@ func (h *handler) handleCreateDB() error {
 			return err
 		}
 
-		config.cas, err = h.server.bootstrapContext.connection.InsertConfig(*config.Bucket, h.server.config.Bootstrap.ConfigGroupID, config)
+		bucket := dbName
+		if config.Bucket != nil {
+			bucket = *config.Bucket
+		}
+
+		config.cas, err = h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, config)
 		if err != nil {
 			// remove database if we can't persist to avoid inconsistent cluster state
 			h.server.RemoveDatabase(dbName)


### PR DESCRIPTION
Fixes panic on `PUT /{db}/` when there is no explicit bucket name specified in the config. This was caused by an change in the last few commits of #5155 to move `dbConfig.Setup()` 

## Manual testing

### Before
```
> curl -X PUT http://localhost:4985/db1/ -H 'Content-Type: application/json' -d '{"num_index_replicas":0}'
curl: (52) Empty reply from server

2021/08/20 16:10:19 http: panic serving 127.0.0.1:57758: runtime error: invalid memory address or nil pointer dereference
goroutine 46 [running]:
net/http.(*conn).serve.func1(0xc004368320)
	/usr/local/Cellar/go/1.16.5/libexec/src/net/http/server.go:1824 +0x153
panic(0x4b3af80, 0x54d61f0)
	/usr/local/Cellar/go/1.16.5/libexec/src/runtime/panic.go:971 +0x499
github.com/couchbase/sync_gateway/rest.(*handler).handleCreateDB(0xc0043ce000, 0x4c909cf, 0x2)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/admin_api.go:53 +0x34b
github.com/couchbase/sync_gateway/rest.(*handler).invoke(0xc0043ce000, 0x4ce6af0, 0xc00027d848, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/handler.go:302 +0x3be
github.com/couchbase/sync_gateway/rest.makeHandler.func1(0x4e0abd0, 0xc00436a8c0, 0xc00420d700)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/handler.go:120 +0xc6
net/http.HandlerFunc.ServeHTTP(0xc004335180, 0x4e0abd0, 0xc00436a8c0, 0xc00420d700)
	/usr/local/Cellar/go/1.16.5/libexec/src/net/http/server.go:2069 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000146000, 0x4e0abd0, 0xc00436a8c0, 0xc00420d500)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/gorilla/mux/mux.go:114 +0xf8
github.com/couchbase/sync_gateway/rest.wrapRouter.func1(0x4e0abd0, 0xc00436a8c0, 0xc00420d500)
	/Users/benbrooks/dev/sync_gateway/master-new/godeps/src/github.com/couchbase/sync_gateway/rest/routing.go:340 +0x945
net/http.HandlerFunc.ServeHTTP(0xc004305f80, 0x4e0abd0, 0xc00436a8c0, 0xc00420d500)
	/usr/local/Cellar/go/1.16.5/libexec/src/net/http/server.go:2069 +0x44
net/http.serverHandler.ServeHTTP(0xc00436a000, 0x4e0abd0, 0xc00436a8c0, 0xc00420d500)
	/usr/local/Cellar/go/1.16.5/libexec/src/net/http/server.go:2887 +0xa3
net/http.(*conn).serve(0xc004368320, 0x4e0f298, 0xc00434ba80)
	/usr/local/Cellar/go/1.16.5/libexec/src/net/http/server.go:1952 +0x8cd
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.16.5/libexec/src/net/http/server.go:3013 +0x39b
2021-08-20T16:10:19.886+01:00 [INF] HTTP:  #001: PUT /db1/ (as ADMIN)
```

### After
```
> curl -X PUT http://localhost:4985/db1/ -H 'Content-Type: application/json' -d '{"num_index_replicas":0}'

2021-08-20T16:05:29.047+01:00 [INF] HTTP:  #001: PUT /db1/ (as ADMIN)
2021-08-20T16:05:29.048+01:00 [INF] Opening db /db1 as bucket "db1", pool "default", server <couchbase://localhost>
2021-08-20T16:05:29.048+01:00 [INF] GoCBv2 Opening Couchbase database db1 on <couchbase://localhost> as user "<ud>Administrator</ud>"
2021-08-20T16:05:29.048+01:00 [INF] Setting query timeouts for bucket db1 to 1m15s
2021-08-20T16:05:30.012+01:00 [INF] Initializing indexes with numReplicas: 0...
```