### PR TITLE
Add a profiler to package tests (SG_TEST_PROFILE_FREQUENCY)

### DIFF
--- a/auth/main_test.go
+++ b/auth/main_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
+	defer base.SetUpGlobalTestHeapProfiling(m)()
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/base/main_test.go
+++ b/base/main_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestMain(m *testing.M) {
 	defer SetUpGlobalTestLogging(m)()
+	defer SetUpGlobalTestHeapProfiling(m)()
 
 	SkipPrometheusStatsRegistration = true
 

--- a/channels/main_test.go
+++ b/channels/main_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
+	defer base.SetUpGlobalTestHeapProfiling(m)()
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
+	defer base.SetUpGlobalTestHeapProfiling(m)()
 
 	base.SkipPrometheusStatsRegistration = true
 

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestMain(m *testing.M) {
 	defer base.SetUpGlobalTestLogging(m)()
+	defer base.SetUpGlobalTestHeapProfiling(m)()
 
 	base.SkipPrometheusStatsRegistration = true
 


### PR DESCRIPTION
Writes a heap profile periodically to the test package directory, if `SG_TEST_PROFILE_FREQUENCY` is set to a valid duration.

E.g:
```
-rw-r--r-- 1 bbrks bbrks  66K Aug 20 16:36 test-pprof-heap-1629473792.pb.gz
-rw-r--r-- 1 bbrks bbrks  94K Aug 20 16:37 test-pprof-heap-1629473852.pb.gz
-rw-r--r-- 1 bbrks bbrks 116K Aug 20 16:38 test-pprof-heap-1629473912.pb.gz
-rw-r--r-- 1 bbrks bbrks 143K Aug 20 16:39 test-pprof-heap-1629473972.pb.gz
-rw-r--r-- 1 bbrks bbrks 162K Aug 20 16:40 test-pprof-heap-1629474032.pb.gz
-rw-r--r-- 1 bbrks bbrks 190K Aug 20 16:41 test-pprof-heap-1629474092.pb.gz
-rw-r--r-- 1 bbrks bbrks 204K Aug 20 16:42 test-pprof-heap-1629474152.pb.gz
```