### PR TITLE
CBG-1626: Fix incorrect JSON marshalling of RedactionLevel in some cases

### DIFF
--- a/base/redactor.go
+++ b/base/redactor.go
@@ -11,7 +11,6 @@ licenses/APL2.txt.
 package base
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -128,10 +127,7 @@ func (l RedactionLevel) String() string {
 }
 
 // MarshalText marshals the RedactionLevel to text.
-func (l *RedactionLevel) MarshalText() ([]byte, error) {
-	if l == nil {
-		return nil, errors.New("can't marshal a nil *RedactionLevel to text")
-	}
+func (l RedactionLevel) MarshalText() ([]byte, error) {
 	return []byte(l.String()), nil
 }
 


### PR DESCRIPTION
CBG-1626

Fixes incorrect JSON marshalling of RedactionLevel into a non-string value in some cases, and also follows the recommended non-pointer reciever signature for `MarshalText` here: https://pkg.go.dev/encoding/json#example-package-TextMarshalJSON


## Test Config
```
{
  "bootstrap": {
    "server": "couchbases://localhost",
     "username": "Administrator",
    "password": "password",
    "server_tls_skip_verify": true
  },
  "logging": {
    "redaction_level": "none"
  }
}
```

## Before

```
> go build && ./sync_gateway cnf_bootstrap.json
2021-08-21T12:36:52.595+01:00 ==== Couchbase Sync Gateway/() CE ====
2021-08-21T12:36:52.595+01:00 [INF] Loading content from [cnf_bootstrap.json] ...
2021-08-21T12:36:52.596+01:00 [ERR] Couldn't start Sync Gateway: Unable to unmarshal into dst: json: cannot unmarshal number into Go struct field LoggingConfig.logging.redaction_level of type base.RedactionLevel -- rest.ServerMain() at main.go:25
```

## After

```
> go build && ./sync_gateway cnf_bootstrap.json
2021-08-21T12:37:44.477+01:00 ==== Couchbase Sync Gateway/() CE ====
2021-08-21T12:37:44.477+01:00 [INF] Loading content from [cnf_bootstrap.json] ...
2021-08-21T12:37:44.478+01:00 [INF] Config: Starting in persistent mode using config group "default"
2021-08-21T12:37:44.478+01:00 [INF] Logging: Console to stderr
2021-08-21T12:37:44.478+01:00 [INF] Logging: Files to /tmp/sglog
2021-08-21T12:37:44.479+01:00 [INF] Logging: Console level: debug
2021-08-21T12:37:44.479+01:00 [INF] Logging: Console keys: [HTTP]
2021-08-21T12:37:44.479+01:00 [INF] Logging: Redaction level: none
2021-08-21T12:37:44.479+01:00 [INF] Configured process to allow 5000 open file descriptors
2021-08-21T12:37:44.479+01:00 [INF] Logging stats with frequency: &{1m0s}
^C2021-08-21T12:37:46.101+01:00 [INF] Handling signal: interrupt
```