### PR TITLE
Omit `version` from `/{db}/_config` response body

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -173,6 +173,9 @@ func (h *handler) handleGetDbConfig() error {
 		responseConfig = bucketDbConfig
 	}
 
+	// FIXME: CBG-1630 Use better approach for this (like wrapping in a PersistedDatabaseConfig struct)
+	responseConfig.Version = ""
+
 	// redaction to sensitive config fields
 	redact, _ := h.getOptBoolQuery("redact", true)
 	if redact {


### PR DESCRIPTION
Temporary fix for CBG-1630 until a cleaner approach is implemented

- Omits `version` from the `/{db}/_config` response body