### PR TITLE
CBG-1631: Don't remove in-memory database on failed new database config insert

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -60,8 +60,6 @@ func (h *handler) handleCreateDB() error {
 
 		config.cas, err = h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, config)
 		if err != nil {
-			// remove database if we can't persist to avoid inconsistent cluster state
-			h.server.RemoveDatabase(dbName)
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't save database config: %v", err)
 		}
 


### PR DESCRIPTION
CBG-1631

There was outdated logic to remove an in-memory database when the bucket insert op fails. This isn't nessesary any more, and actually causes problems when a database already exists.

```
2021-08-21T13:09:13.306+01:00 [INF] HTTP:  #002: GET /db2/_config (as ADMIN)
Err read tcp [::1]:58526->[::1]:11210: use of closed network connection
2021-08-21T13:09:16.621+01:00 [INF] HTTP:  #003: PUT /db2/ (as ADMIN)
2021-08-21T13:09:16.621+01:00 [INF] Closing db /db2 (bucket "b2")
2021-08-21T13:09:16.621+01:00 [DBG] Terminating background task: "CleanSkippedSequenceQueue"
2021-08-21T13:09:16.621+01:00 [DBG] Terminating background task: "InsertPendingEntries"
2021-08-21T13:09:16.621+01:00 [DBG] Terminating background task: "CleanAgedItems"
2021-08-21T13:09:16.621+01:00 [WRN] c:b2-SG Error processing DCP stream - will attempt to restart/reconnect if appropriate: pkt.Receive, err: read tcp [::1]:58526->[::1]:11210: use of closed network connection. -- base.(*DCPReceiver).OnError() at dcp_receiver.go:60
2021-08-21T13:09:16.622+01:00 [ERR] #003: 500 couldn't save database config: Already exists -- rest.(*handler).writeError() at handler.go:954
2021-08-21T13:09:16.622+01:00 [INF] HTTP: #003:     --> 500 couldn't save database config: Already exists  (0.8 ms)
2021-08-21T13:09:24.869+01:00 [INF] HTTP:  #004: PUT /db2/_config (as ADMIN)
2021-08-21T13:09:24.869+01:00 [INF] HTTP: #004:     --> 404 no such database "db2"  (14.1 ms)
```