### PR TITLE
CBG-1628: Differentiate between PrincipalConfig.disabled=false and unset value

### DIFF
--- a/db/users.go
+++ b/db/users.go
@@ -28,7 +28,7 @@ type PrincipalConfig struct {
 	Channels         base.Set `json:"all_channels,omitempty"`
 	// Fields below only apply to Users, not Roles:
 	Email             string   `json:"email,omitempty"`
-	Disabled          bool     `json:"disabled,omitempty"`
+	Disabled          *bool    `json:"disabled,omitempty"`
 	Password          *string  `json:"password,omitempty"`
 	ExplicitRoleNames []string `json:"admin_roles,omitempty"`
 	RoleNames         []string `json:"roles,omitempty"`
@@ -84,7 +84,7 @@ func (dbc *DatabaseContext) GetPrincipal(name string, isUser bool) (info *Princi
 	if user, ok := princ.(auth.User); ok {
 		info.Channels = user.InheritedChannels().AsSet()
 		info.Email = user.Email()
-		info.Disabled = user.Disabled()
+		info.Disabled = base.BoolPtr(user.Disabled())
 		info.ExplicitRoleNames = user.ExplicitRoles().AllKeys()
 		info.RoleNames = user.RoleNames().AllKeys()
 	} else {
@@ -185,8 +185,8 @@ func (dbc *DatabaseContext) UpdatePrincipal(newInfo PrincipalConfig, isUser bool
 				user.SetPassword(*newInfo.Password)
 				changed = true
 			}
-			if newInfo.Disabled != user.Disabled() {
-				user.SetDisabled(newInfo.Disabled)
+			if newInfo.Disabled != nil && *newInfo.Disabled != user.Disabled() {
+				user.SetDisabled(*newInfo.Disabled)
 				changed = true
 			}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -1052,7 +1052,7 @@ func marshalPrincipal(princ auth.Principal, includeDynamicGrantInfo bool) ([]byt
 	}
 	if user, ok := princ.(auth.User); ok {
 		info.Email = user.Email()
-		info.Disabled = user.Disabled()
+		info.Disabled = base.BoolPtr(user.Disabled())
 		info.ExplicitRoleNames = user.ExplicitRoles().AllKeys()
 		if includeDynamicGrantInfo {
 			info.Channels = user.InheritedChannels().AsSet()

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -582,7 +582,7 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 					},
 					Users: map[string]*db.PrincipalConfig{
 						base.GuestUsername: {
-							Disabled:         false,
+							Disabled:         base.BoolPtr(false),
 							ExplicitChannels: base.SetFromArray([]string{"*"}),
 						},
 					},

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -792,7 +792,8 @@ func TestParseCommandLineWithConfigContent(t *testing.T) {
 	assert.Equal(t, "/etc/ssl/certs/key.pem", db1.BucketConfig.KeyPath)
 
 	guest := db1.Users["GUEST"]
-	assert.False(t, guest.Disabled)
+	require.NotNil(t, guest.Disabled)
+	assert.False(t, *guest.Disabled)
 	assert.Equal(t, base.SetFromArray([]string{"*"}), guest.ExplicitChannels)
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -541,8 +541,16 @@ func (sc *ServerContext) _getOrAddDatabaseFromConfig(config DatabaseConfig, useE
 	// Create default users & roles:
 	if err := sc.installPrincipals(dbcontext, config.Roles, "role"); err != nil {
 		return nil, err
-	} else if err := sc.installPrincipals(dbcontext, config.Users, "user"); err != nil {
+	}
+	if err := sc.installPrincipals(dbcontext, config.Users, "user"); err != nil {
 		return nil, err
+	}
+
+	if config.Guest != nil {
+		guest := map[string]*db.PrincipalConfig{base.GuestUsername: config.Guest}
+		if err := sc.installPrincipals(dbcontext, guest, "user"); err != nil {
+			return nil, err
+		}
 	}
 
 	// Initialize event handlers


### PR DESCRIPTION
CBG-1628

- Allows for `"guest":{"disabled":false}` to enable the guest user on a database as expected.
- Adds missing "installPrincipal" case for new 3.x Guest database config option

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1036/