### PR TITLE
CBG-1632 - Fixed registerLegacyFlags always filling adminInterface and publicInterface with default address if flag not set

### DIFF
--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -86,10 +86,7 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 			X509KeyPath:  *keyPath,
 		},
 		API: APIConfig{
-			PublicInterface:  *publicInterface,
-			AdminInterface:   *adminInterface,
 			ProfileInterface: *profileInterface,
-			Pretty:           pretty,
 		},
 		Logging: base.LoggingConfig{
 			LogFilePath: *logFilePath,
@@ -98,6 +95,17 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 				LogKeys:  strings.Split(*log, ","),
 			},
 		},
+	}
+
+	// Set if user modified default value. fs.Set could be used in future.
+	if *publicInterface != DefaultPublicInterface {
+		sc.API.PublicInterface = *publicInterface
+	}
+	if *adminInterface != DefaultAdminInterface {
+		sc.API.AdminInterface = *adminInterface
+	}
+	if !*pretty {
+		sc.API.Pretty = pretty
 	}
 
 	// removed options

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -73,11 +73,6 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 	log := fs.String("log", "", "Log keys, comma separated")
 	logFilePath := fs.String("logFilePath", "", "Path to log files")
 
-	var logLevel *base.LogLevel
-	if *verbose {
-		logLevel = base.LogLevelPtr(base.LevelInfo)
-	}
-
 	sc := StartupConfig{
 		Bootstrap: BootstrapConfig{
 			Server:       *url,
@@ -90,10 +85,7 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 		},
 		Logging: base.LoggingConfig{
 			LogFilePath: *logFilePath,
-			Console: &base.ConsoleLoggerConfig{
-				LogLevel: logLevel,
-				LogKeys:  strings.Split(*log, ","),
-			},
+			Console:     &base.ConsoleLoggerConfig{},
 		},
 	}
 
@@ -106,6 +98,12 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 	}
 	if !*pretty {
 		sc.API.Pretty = pretty
+	}
+	if *verbose {
+		sc.Logging.Console.LogLevel = base.LogLevelPtr(base.LevelInfo)
+	}
+	if *log != "" {
+		sc.Logging.Console.LogKeys = strings.Split(*log, ",")
 	}
 
 	// removed options

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -97,7 +97,7 @@ func registerLegacyFlags(fs *flag.FlagSet) *StartupConfig {
 		},
 	}
 
-	// Set if user modified default value. fs.Set could be used in future.
+	// Set if user modified default value
 	if *publicInterface != DefaultPublicInterface {
 		sc.API.PublicInterface = *publicInterface
 	}


### PR DESCRIPTION
CBG-1632

- registerLegacyFlags only sets startup config fields `PublicInterface, AdminInterface, and Pretty` if the flag is set to something different then the default value. This way the default value does not override user set values.

