### PR TITLE
CBG-1629: DELETE /{db} and remove running databases not found in cluster

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -768,9 +768,21 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 	return base.HTTPErrorf(http.StatusOK, "updated")
 }
 
-// "Delete" a database (it doesn't actually do anything to the underlying bucket)
+// handleDeleteDB when running in persistent config mode, deletes a database config from the bucket and removes it from the current node.
+// In non-persistent mode, the endpoint just removes the database from the node.
 func (h *handler) handleDeleteDB() error {
 	h.assertAdminOnly()
+
+	if h.server.persistentConfig {
+		bucket := h.db.Bucket.GetName()
+		_, err := h.server.bootstrapContext.connection.UpdateConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, func(rawBucketConfig []byte) (updatedConfig []byte, err error) {
+			return nil, nil
+		})
+		if err != nil {
+			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't remove database %q from bucket %q: %s", base.MD(h.db.Name), base.MD(bucket), err.Error())
+		}
+	}
+
 	if !h.server.RemoveDatabase(h.db.Name) {
 		return base.HTTPErrorf(http.StatusNotFound, "missing")
 	}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -155,10 +155,10 @@ func (h *handler) handleGetDbConfig() error {
 		h.response.Header().Set("ETag", responseConfig.Version)
 
 		// refresh_config=true forces the config loaded out of the bucket to be applied on the node
-		if h.getBoolQuery("refresh_config") {
+		if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
 			// set cas=0 to force a refresh
 			responseConfig.cas = 0
-			h.server.applyConfigs([]DatabaseConfig{*responseConfig})
+			h.server.applyConfigs(map[string]DatabaseConfig{h.db.Name: *responseConfig})
 		}
 	} else {
 		// non-persistent mode just returns running database config

--- a/rest/config.go
+++ b/rest/config.go
@@ -1108,6 +1108,7 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 		if err == base.ErrNotFound {
 			base.Tracef(base.KeyConfig, "bucket %q did not contain config for group %q", bucket, sc.config.Bootstrap.ConfigGroupID)
 			bucketsNoConfig = append(bucketsNoConfig, bucket)
+			continue
 		}
 		if err != nil {
 			base.Errorf("couldn't fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -926,14 +926,20 @@ func (sc *ServerContext) RemoveDatabase(dbName string) bool {
 }
 
 func (sc *ServerContext) _removeDatabase(dbName string) bool {
-
-	context := sc.databases_[dbName]
-	if context == nil {
+	dbCtx := sc.databases_[dbName]
+	if dbCtx == nil {
 		return false
 	}
-	base.Infof(base.KeyAll, "Closing db /%s (bucket %q)", base.MD(context.Name), base.MD(context.Bucket.GetName()))
-	context.Close()
+
+	base.Infof(base.KeyAll, "Closing db /%s (bucket %q)", base.MD(dbCtx.Name), base.MD(dbCtx.Bucket.GetName()))
+	bucket := dbCtx.Bucket.GetName()
+
+	dbCtx.Close()
+
 	delete(sc.databases_, dbName)
+	delete(sc.dbConfigs, dbName)
+	delete(sc.bucketDbName, bucket)
+
 	return true
 }
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -943,11 +943,12 @@ func (sc *ServerContext) _removeDatabase(dbName string) bool {
 	if dbCtx == nil {
 		return false
 	}
+	bucket := dbCtx.Bucket.GetName()
 	if ok := sc._unloadDatabase(dbName); !ok {
 		return ok
 	}
 	delete(sc.dbConfigs, dbName)
-	delete(sc.bucketDbName, dbCtx.Bucket.GetName())
+	delete(sc.bucketDbName, bucket)
 	return true
 }
 


### PR DESCRIPTION
CBG-1629

- Removes a database config from the bucket, and from the node serving the `DELETE /{db}` request.
- Nodes polling for config updates will remove running databases if they are not found in the server

## Testing (single node)

```
> curl -i http://localhost:4985/db2/_config
HTTP/1.1 200 OK
Content-Length: 207
Content-Type: application/json
Etag: 4-7f1f2e43b6e376ce84fe3baad7d82870
Server: Couchbase Sync Gateway/3.0 branch/ commit/ CE
Date: Mon, 23 Aug 2021 13:05:25 GMT

{"guest":{},"bucket":"b2","username":"Administrator","password":"xxxxx","name":"db2","unsupported":{"user_views":{},"oidc_test_provider":{},"api_endpoints":{},"warning_thresholds":{}},"num_index_replicas":0}%
> curl -i http://localhost:4985/db2/
HTTP/1.1 200 OK
Content-Length: 224
Content-Type: application/json
Server: Couchbase Sync Gateway/3.0 branch/ commit/ CE
Date: Mon, 23 Aug 2021 13:05:33 GMT

{"db_name":"db2","update_seq":3,"committed_update_seq":3,"instance_start_time":1629723883473426,"compact_running":false,"purge_seq":0,"disk_format_version":0,"state":"Online","server_uuid":"8dc94fde8c948d1a9a11fe903d3a5878"}%
```

```
2021-08-23T14:05:25.443+01:00 [INF] HTTP:  #001: GET /db2/_config (as ADMIN)
2021-08-23T14:05:33.575+01:00 [INF] HTTP:  #002: GET /db2/ (as ADMIN)
```

```

> curl -X DELETE -i http://localhost:4985/db2/
HTTP/1.1 200 OK
Server: Couchbase Sync Gateway/3.0 branch/ commit/ CE
Date: Mon, 23 Aug 2021 13:05:39 GMT
Content-Length: 2
Content-Type: text/plain; charset=utf-8

{}%
```

```
2021-08-23T14:05:39.326+01:00 [INF] HTTP:  #003: DELETE /db2/ (as ADMIN)
2021-08-23T14:05:39.328+01:00 [INF] Closing db /db2 (bucket "b2")
```

```
> curl -i http://localhost:4985/db2/_config
HTTP/1.1 404 Not Found
Content-Type: application/json
Server: Couchbase Sync Gateway/3.0 branch/ commit/ CE
Date: Mon, 23 Aug 2021 13:05:42 GMT
Content-Length: 57

{"error":"not_found","reason":"no such database \"db2\""}%
> curl -i http://localhost:4985/db2/
HTTP/1.1 404 Not Found
Content-Type: application/json
Server: Couchbase Sync Gateway/3.0 branch/ commit/ CE
Date: Mon, 23 Aug 2021 13:05:45 GMT
Content-Length: 57

{"error":"not_found","reason":"no such database \"db2\""}%
```

```
2021-08-23T14:05:42.131+01:00 [INF] HTTP:  #004: GET /db2/_config (as ADMIN)
2021-08-23T14:05:42.131+01:00 [INF] HTTP: #004:     --> 404 no such database "db2"  (20.8 ms)
2021-08-23T14:05:45.454+01:00 [INF] HTTP:  #005: GET /db2/ (as ADMIN)
2021-08-23T14:05:45.454+01:00 [INF] HTTP: #005:     --> 404 no such database "db2"  (20.0 ms)
```

## Testing (simulated multi-node - picking up removed config from server)

```
2021-08-23T15:05:59.947+01:00 [INF] Starting metrics server on 127.0.0.1:4986
2021-08-23T15:05:59.947+01:00 [INF] Starting admin server on 127.0.0.1:4985
2021-08-23T15:05:59.947+01:00 [INF] Starting server on :4984 ...
2021-08-23T15:05:59.977+01:00 [INF] CBGoUtilsLogger: Using plain authentication for user <ud>Administrator</ud>


2021-08-23T15:06:19.968+01:00 [INF] Opening db /b2 as bucket "b2", pool "default", server <couchbase://localhost>
2021-08-23T15:06:19.968+01:00 [INF] GoCBv2 Opening Couchbase database b2 on <couchbase://localhost> as user "<ud>Administrator</ud>"
2021-08-23T15:06:19.968+01:00 [INF] Setting query timeouts for bucket b2 to 1m15s
2021-08-23T15:06:20.048+01:00 [INF] Initializing indexes with numReplicas: 0...
2021-08-23T15:06:20.593+01:00 [INF] Verifying index availability for bucket b2...
2021-08-23T15:06:20.601+01:00 [INF] Indexes ready for bucket b2.
2021-08-23T15:06:20.601+01:00 [INF] delta_sync enabled=false with rev_max_age_seconds=86400 for database b2
2021-08-23T15:06:20.602+01:00 [INF] Created background task: "CleanAgedItems" with interval 1m0s
2021-08-23T15:06:20.602+01:00 [INF] Created background task: "InsertPendingEntries" with interval 2.5s
2021-08-23T15:06:20.602+01:00 [INF] Created background task: "CleanSkippedSequenceQueue" with interval 30m0s
2021-08-23T15:06:20.654+01:00 [INF] CBGoUtilsLogger: Using plain authentication for user <ud>Administrator</ud>
2021-08-23T15:06:22.121+01:00 [INF] Using metadata purge interval of 3.00 days for tombstone compaction.
2021-08-23T15:06:22.121+01:00 [WRN] Automatic compaction can only be enabled on nodes running an Import process -- db.NewDatabaseContext() at database.go:516
2021-08-23T15:06:22.132+01:00 [INF] Using default sync function 'channel(doc.channels)' for database "b2"


2021-08-23T15:06:24.413+01:00 [INF] HTTP:  #001: GET /b2/_config (as ADMIN)
Err read tcp [::1]:62139->[::1]:11210: use of closed network connection
2021-08-23T15:06:26.082+01:00 [INF] HTTP:  #002: DELETE /b2/ (as ADMIN)
2021-08-23T15:06:26.083+01:00 [INF] Closing db /b2 (bucket "b2")
2021-08-23T15:06:26.083+01:00 [DBG] Terminating background task: "CleanSkippedSequenceQueue"
2021-08-23T15:06:26.083+01:00 [DBG] Terminating background task: "InsertPendingEntries"
2021-08-23T15:06:26.083+01:00 [DBG] Terminating background task: "CleanAgedItems"
2021-08-23T15:06:26.083+01:00 [WRN] c:b2-SG Error processing DCP stream - will attempt to restart/reconnect if appropriate: pkt.Receive, err: read tcp [::1]:62139->[::1]:11210: use of closed network connection. -- base.(*DCPReceiver).OnError() at dcp_receiver.go:60


2021-08-23T15:06:32.498+01:00 [INF] HTTP:  #003: GET /b2/_config (as ADMIN)
2021-08-23T15:06:32.498+01:00 [INF] HTTP: #003:     --> 404 no such database "b2"  (23.4 ms)
^C2021-08-23T15:06:39.772+01:00 [INF] Handling signal: interrupt
```