### PR TITLE
CBG-1633: Added retry loop to initializeGoCBAgent

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -356,7 +356,7 @@ func establishCouchbaseClusterConnection(config *StartupConfig) (*base.Couchbase
 		}
 
 		return false, nil, cluster
-	}, base.CreateSleeperFunc(27, 1000)) // ~2 mins total - 5 second gocb WaitForReady timeout and 1 second interval
+	}, base.CreateSleeperFunc(27, 1000)) // ~2 mins total - 5 second gocb WaitUntilReady timeout and 1 second interval
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CBG-1633

Added retry loop to initializeGoCBAgent

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1038
