### PR TITLE
Avoid server address upgrade attempt with Walrus addresses

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -261,6 +261,10 @@ func (dbc *DbConfig) ToDatabaseConfig() *DatabaseConfig {
 }
 
 func legacyServerAddressUpgrade(server string) (newServer, username, password string, err error) {
+	if base.ServerIsWalrus(server) {
+		return server, "", "", nil
+	}
+
 	connSpec, err := connstr.Parse(server)
 	if err != nil {
 		return "", "", "", err


### PR DESCRIPTION
PR avoids attempting to perform `legacyServerAddressUpgrade` in the event that the server is a Walrus address. The function was converting a 'walrus:' address to a 'walrus' host and attempting to connect to that with gocb.

This has the result of fixing the failing litecore tests.