### PR TITLE
CBG-1615: Don't flush to disabled log files

### DIFF
--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -117,10 +117,12 @@ func (l *FileLogger) FlushBufferToLog() {
 	// Need to clear hanging new line to avoid empty line
 	logString := strings.TrimSuffix(l.buffer.String(), "\n")
 
+	// Clear buffer as we no longer need it
+	l.buffer.Reset()
+
 	if l.Enabled.IsTrue() {
 		l.logf(logString)
 	}
-
 }
 
 // Rotate will rotate the active log file.

--- a/base/logger_file.go
+++ b/base/logger_file.go
@@ -116,7 +116,11 @@ func NewFileLogger(config *FileLoggerConfig, level LogLevel, name string, logFil
 func (l *FileLogger) FlushBufferToLog() {
 	// Need to clear hanging new line to avoid empty line
 	logString := strings.TrimSuffix(l.buffer.String(), "\n")
-	l.logf(logString)
+
+	if l.Enabled.IsTrue() {
+		l.logf(logString)
+	}
+
 }
 
 // Rotate will rotate the active log file.

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -602,8 +602,8 @@ func TestLogFlush(t *testing.T) {
 			// Flush memory loggers
 			base.FlushLoggerBuffers()
 
-			// Add a minor sleep to allow the files to complete writing
-			time.Sleep(1 * time.Second)
+			// Flush collation buffers to ensure the files that will be built do get written
+			base.FlushLogBuffers()
 
 			// Check that the expected number of log files are created
 			worker := func() (shouldRetry bool, err error, value interface{}) {

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -521,4 +523,114 @@ func TestUseTLSServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogFlush(t *testing.T) {
+	testCases := []struct {
+		Name                 string
+		ExpectedLogFileCount int
+		EnableFunc           func(config StartupConfig) StartupConfig
+	}{
+		{
+			"Default",
+			4,
+			func(config StartupConfig) StartupConfig {
+				return config
+			},
+		},
+		{
+			"Add trace",
+			5,
+			func(config StartupConfig) StartupConfig {
+				config.Logging.Trace = &base.FileLoggerConfig{
+					Enabled: base.BoolPtr(true),
+				}
+				return config
+			},
+		},
+		{
+			"Add debug and trace",
+			6,
+			func(config StartupConfig) StartupConfig {
+				config.Logging.Debug = &base.FileLoggerConfig{
+					Enabled: base.BoolPtr(true),
+				}
+				config.Logging.Trace = &base.FileLoggerConfig{
+					Enabled: base.BoolPtr(true),
+				}
+				return config
+			},
+		},
+		{
+			"Disable error",
+			3,
+			func(config StartupConfig) StartupConfig {
+				config.Logging.Error = &base.FileLoggerConfig{
+					Enabled: base.BoolPtr(false),
+				}
+				return config
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+			// Setup memory logging
+			base.InitializeMemoryLoggers()
+
+			// Log some stuff (which will go into the memory loggers)
+			base.Errorf("error")
+			base.Warnf("warn")
+			base.Infof(base.KeyAll, "info")
+			base.Debugf(base.KeyAll, "debug")
+			base.Tracef(base.KeyAll, "trace")
+			base.RecordStats("{}")
+
+			// Add temp dir to save log files to
+			tempPath, err := ioutil.TempDir("", "logs"+testCase.Name)
+			require.NoError(t, err)
+
+			config := DefaultStartupConfig(tempPath)
+			config = testCase.EnableFunc(config)
+
+			// Setup logging
+			err = config.SetupAndValidateLogging()
+			assert.NoError(t, err)
+
+			// Flush memory loggers
+			base.FlushLoggerBuffers()
+
+			// Add a minor sleep to allow the files to complete writing
+			time.Sleep(1 * time.Second)
+
+			// Check that the expected number of log files are created
+			worker := func() (shouldRetry bool, err error, value interface{}) {
+				var files []string
+				err = filepath.Walk(tempPath, func(path string, info os.FileInfo, err error) error {
+					if tempPath != path {
+						files = append(files, filepath.Base(path))
+					}
+					return nil
+				})
+
+				if err != nil {
+					return false, err, nil
+				}
+
+				if testCase.ExpectedLogFileCount == len(files) {
+					return false, nil, nil
+				}
+
+				return true, nil, nil
+			}
+
+			sleeper := base.CreateSleeperFunc(200, 100)
+			err, _ = base.RetryLoop("Wait for log files", worker, sleeper)
+			require.NoError(t, err)
+
+		})
+	}
+
 }


### PR DESCRIPTION
CBG-1615

Adds a basic enabled check to `FlushBufferToLog`. 
Previously even if a log level was not enabled we would flush the initial in-memory log lines to that level. 

This has been tested with an additional unit test.
Integration test should not be necessary for this as log file changes can be adequately tested with basic unit tests.