### PR TITLE
CBG-1635 Close gocbv2 collections per test

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -130,7 +130,9 @@ func (c *Collection) UUID() (string, error) {
 }
 
 func (c *Collection) Close() {
-	// No close handling for collection
+	if c.cluster != nil {
+		c.cluster.Close(nil)
+	}
 	return
 }
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -131,7 +131,9 @@ func (c *Collection) UUID() (string, error) {
 
 func (c *Collection) Close() {
 	if c.cluster != nil {
-		c.cluster.Close(nil)
+		if err := c.cluster.Close(nil); err != nil {
+			Warnf("Error closing collection cluster: %v", err)
+		}
 	}
 	return
 }

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -146,7 +146,6 @@ func (c *tbpClusterV1) close() error {
 
 // tbpClusterV2 implements the tbpCluster interface for a gocb v2 cluster
 type tbpClusterV2 struct {
-	//cluster *gocb.Cluster
 	logger clusterLogFunc
 	server string
 }
@@ -155,13 +154,12 @@ var _ tbpCluster = &tbpClusterV2{}
 
 func newTestClusterV2(server string, logger clusterLogFunc) *tbpClusterV2 {
 	tbpCluster := &tbpClusterV2{}
-	//tbpCluster.cluster = initV2Cluster(server)
 	tbpCluster.logger = logger
 	tbpCluster.server = server
 	return tbpCluster
 }
 
-// tbpCluster validates cluster connectivity
+// getCluster makes cluster connection.  Callers must close.
 func getCluster(server string) *gocb.Cluster {
 	spec := BucketSpec{
 		Server:        server,
@@ -269,14 +267,6 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 }
 
 func (c *tbpClusterV2) close() error {
-	/*
-		if c.cluster != nil {
-			if err := c.cluster.Close(nil); err != nil {
-				c.logger(context.Background(), "Couldn't close cluster connection: %v", err)
-				return err
-			}
-		}
-
-	*/
+	// no close operations needed
 	return nil
 }

--- a/base/main_test_cluster.go
+++ b/base/main_test_cluster.go
@@ -204,7 +204,7 @@ func getCluster(server string) *gocb.Cluster {
 func (c *tbpClusterV2) getBucketNames() ([]string, error) {
 
 	cluster := getCluster(c.server)
-	defer cluster.Close(nil)
+	defer c.closeCluster(cluster)
 
 	manager := cluster.Buckets()
 
@@ -224,7 +224,7 @@ func (c *tbpClusterV2) getBucketNames() ([]string, error) {
 func (c *tbpClusterV2) insertBucket(name string, quotaMB int) error {
 
 	cluster := getCluster(c.server)
-	defer cluster.Close(nil)
+	defer c.closeCluster(cluster)
 	settings := gocb.CreateBucketSettings{
 		BucketSettings: gocb.BucketSettings{
 			Name:         name,
@@ -239,7 +239,7 @@ func (c *tbpClusterV2) insertBucket(name string, quotaMB int) error {
 
 func (c *tbpClusterV2) removeBucket(name string) error {
 	cluster := getCluster(c.server)
-	defer cluster.Close(nil)
+	defer c.closeCluster(cluster)
 
 	return cluster.Buckets().DropBucket(name, nil)
 }
@@ -269,4 +269,10 @@ func (c *tbpClusterV2) openTestBucket(testBucketName tbpBucketName, waitUntilRea
 func (c *tbpClusterV2) close() error {
 	// no close operations needed
 	return nil
+}
+
+func (c *tbpClusterV2) closeCluster(cluster *gocb.Cluster) {
+	if err := cluster.Close(nil); err != nil {
+		c.logger(context.Background(), "Couldn't close cluster connection: %v", err)
+	}
 }

--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -131,7 +131,6 @@ func GetTestBucketForDriver(t testing.TB, driver CouchbaseDriver) *TestBucket {
 	// If the spec being used by the test bucket pool matches the requested, use that
 	if spec.CouchbaseDriver == driver {
 		closeAll := func() {
-			bucket.Close()
 			closeFn()
 		}
 		return &TestBucket{
@@ -528,6 +527,7 @@ func ForAllDataStores(t *testing.T, testCallback func(*testing.T, sgbucket.DataS
 			driver: GoCBv2,
 		})
 	}
+
 	dataStores = append(dataStores, dataStore{
 		name:   "gocb.v1",
 		driver: GoCBCustomSGTranscoder,


### PR DESCRIPTION
Have testBucketPool use a single cluster instance per collection, instead of sharing across test runs, as gocbv2 only closes bucket/collection pipelines on cluster close.
## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/1044/
