### PR TITLE
CBG-1638: Added parsing for legacy flags

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -515,10 +515,7 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 		for _, filename := range flagSet.Args() {
 			newConfig, newConfigErr := LoadLegacyServerConfig(filename)
 
-			if pkgerrors.Cause(newConfigErr) == base.ErrUnknownField {
-				// Delay returning this error so we can continue with other setup
-				err = pkgerrors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", filename))
-			} else if newConfigErr != nil {
+			if newConfigErr != nil {
 				return config, pkgerrors.WithMessage(newConfigErr, fmt.Sprintf("Error reading config file %s", filename))
 			}
 

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -718,8 +718,8 @@ func TestParseCommandLineWithBadConfigContent(t *testing.T) {
 
 	args := []string{"sync_gateway", configFile.Name()}
 	config, err := ParseCommandLine(args, flag.ContinueOnError)
-	require.Error(t, err, "Parsing configuration file with an unknown field")
-	assert.NotNil(t, config)
+	assert.Error(t, err, "Parsing configuration file with an unknown field")
+	assert.Nil(t, config)
 }
 
 func TestParseCommandLineWithConfigContent(t *testing.T) {

--- a/rest/main.go
+++ b/rest/main.go
@@ -347,7 +347,7 @@ func parseFlags(args []string) (flagStartupConfig *StartupConfig, fs *flag.FlagS
 	fs = flag.NewFlagSet(args[0], flag.ContinueOnError)
 
 	// used by service scripts as a way to specify a per-distro defaultLogFilePath
-	defaultLogFilePath = *fs.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
+	defaultLogFilePathFlag := fs.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
 
 	disablePersistentConfig = fs.Bool("disable_persistent_config", false, "Can be set to false to disable persistent config handling, and read all configuration from a legacy config file.")
 
@@ -376,6 +376,8 @@ func parseFlags(args []string) (flagStartupConfig *StartupConfig, fs *flag.FlagS
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	defaultLogFilePath = *defaultLogFilePathFlag
 
 	return &legacyStartupConfig, fs, disablePersistentConfig, nil
 }

--- a/rest/main_legacy.go
+++ b/rest/main_legacy.go
@@ -72,22 +72,22 @@ type legacyConfigFlag struct {
 
 func registerLegacyFlags(config *StartupConfig, fs *flag.FlagSet) map[string]legacyConfigFlag {
 	return map[string]legacyConfigFlag{
-		"interface":        {&config.API.PublicInterface, "api.public_interface", fs.String("interface", DefaultPublicInterface, "Address to bind to")},
-		"adminInterface":   {&config.API.AdminInterface, "api.admin_interface", fs.String("adminInterface", DefaultAdminInterface, "Address to bind admin interface to")},
-		"profileInterface": {&config.API.ProfileInterface, "api.profile_interface", fs.String("profileInterface", "", "Address to bind profile interface to")},
-		"pretty":           {&config.API.Pretty, "api.pretty", fs.Bool("pretty", false, "Pretty-print JSON responses")},
-		"verbose":          {&config.Logging.Console.LogLevel, "", fs.Bool("verbose", false, "Log more info about requests")},
-		"url":              {&config.Bootstrap.Server, "bootstrap.server", fs.String("url", "", "Address of Couchbase server")},
-		"certpath":         {&config.API.HTTPS.TLSCertPath, "api.https.tls_cert_path", fs.String("certpath", "", "Client certificate path")},
-		"keypath":          {&config.API.HTTPS.TLSKeyPath, "api.https.tls_key_path", fs.String("keypath", "", "Client certificate key path")},
-		"cacertpath":       {&config.Bootstrap.CACertPath, "bootstrap.ca_cert_path", fs.String("cacertpath", "", "Root CA certificate path")},
-		"log":              {&config.Logging.Console.LogKeys, "logging.console.log_keys", fs.String("log", "", "Log keys, comma separated")},
-		"logFilePath":      {&config.Logging.LogFilePath, "logging.log_file_path", fs.String("logFilePath", "", "Path to log files")},
+		"interface":        {&config.API.PublicInterface, "api.public_interface", fs.String("interface", DefaultPublicInterface, "DEPRECATED: Address to bind to")},
+		"adminInterface":   {&config.API.AdminInterface, "api.admin_interface", fs.String("adminInterface", DefaultAdminInterface, "DEPRECATED: Address to bind admin interface to")},
+		"profileInterface": {&config.API.ProfileInterface, "api.profile_interface", fs.String("profileInterface", "", "DEPRECATED: Address to bind profile interface to")},
+		"pretty":           {&config.API.Pretty, "api.pretty", fs.Bool("pretty", false, "DEPRECATED: Pretty-print JSON responses")},
+		"verbose":          {&config.Logging.Console.LogLevel, "", fs.Bool("verbose", false, "DEPRECATED: Log more info about requests")},
+		"url":              {&config.Bootstrap.Server, "bootstrap.server", fs.String("url", "", "DEPRECATED: Address of Couchbase server")},
+		"certpath":         {&config.API.HTTPS.TLSCertPath, "api.https.tls_cert_path", fs.String("certpath", "", "DEPRECATED: Client certificate path")},
+		"keypath":          {&config.API.HTTPS.TLSKeyPath, "api.https.tls_key_path", fs.String("keypath", "", "DEPRECATED: Client certificate key path")},
+		"cacertpath":       {&config.Bootstrap.CACertPath, "bootstrap.ca_cert_path", fs.String("cacertpath", "", "DEPRECATED: Root CA certificate path")},
+		"log":              {&config.Logging.Console.LogKeys, "logging.console.log_keys", fs.String("log", "", "DEPRECATED: Log keys, comma separated")},
+		"logFilePath":      {&config.Logging.LogFilePath, "logging.log_file_path", fs.String("logFilePath", "", "DEPRECATED: Path to log files")},
 
 		// Removed options
-		"dbname":       {nil, "", fs.String("dbname", "", "Name of Couchbase Server database (defaults to name of bucket)")},
-		"configServer": {nil, "", fs.String("configServer", "", "URL of server that can return database configs")},
-		"deploymentID": {nil, "", fs.String("deploymentID", "", "Customer/project identifier for stats reporting")},
+		"dbname":       {nil, "", fs.String("dbname", "", "REMOVED: Name of Couchbase Server database (defaults to name of bucket)")},
+		"configServer": {nil, "", fs.String("configServer", "", "REMOVED: URL of server that can return database configs")},
+		"deploymentID": {nil, "", fs.String("deploymentID", "", "REMOVED: Customer/project identifier for stats reporting")},
 	}
 }
 

--- a/rest/main_legacy_test.go
+++ b/rest/main_legacy_test.go
@@ -1,0 +1,68 @@
+package rest
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/couchbase/sync_gateway/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test legacy flags using valid values
+func TestLegacyFlagsValid(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	config := NewEmptyStartupConfig()
+
+	flags := registerLegacyFlags(&config, fs)
+
+	err := fs.Parse([]string{
+		"-interface", "12.34.56.78",
+		"-adminInterface", "admin-interface:123",
+		"-profileInterface", "prof",
+		"-pretty",
+		"-verbose",
+		"-url", "server-url.com",
+		"-certpath", "cert",
+		"-keypath", "key",
+		"-cacertpath", "cacert",
+		"-log", "HTTP,DCP,*",
+		"-logFilePath", "test/file",
+		// Should only log warn
+		"-dbname", "dbname",
+		"-deploymentID", "deployment",
+	})
+	require.NoError(t, err)
+
+	err = fillConfigWithLegacyFlags(flags, fs, false)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "12.34.56.78", config.API.PublicInterface)
+	assert.Equal(t, "admin-interface:123", config.API.AdminInterface)
+	assert.Equal(t, "prof", config.API.ProfileInterface)
+	assert.Equal(t, base.BoolPtr(true), config.API.Pretty)
+	assert.Equal(t, base.LogLevelPtr(base.LevelInfo), config.Logging.Console.LogLevel)
+	assert.Equal(t, "server-url.com", config.Bootstrap.Server)
+	assert.Equal(t, "cert", config.API.HTTPS.TLSCertPath)
+	assert.Equal(t, "key", config.API.HTTPS.TLSKeyPath)
+	assert.Equal(t, "cacert", config.Bootstrap.CACertPath)
+	assert.Equal(t, []string{"HTTP", "DCP", "*"}, config.Logging.Console.LogKeys)
+	assert.Equal(t, "test/file", config.Logging.LogFilePath)
+}
+
+func TestLegacyFlagsError(t *testing.T) {
+	errorText := `flag "-configServer" is no longer supported and has been removed`
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	config := NewEmptyStartupConfig()
+
+	flags := registerLegacyFlags(&config, fs)
+
+	err := fs.Parse([]string{
+		"-configServer", "1.2.3.4",
+	})
+	require.NoError(t, err)
+
+	err = fillConfigWithLegacyFlags(flags, fs, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errorText)
+}

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -11,11 +11,14 @@ licenses/APL2.txt.
 package rest
 
 import (
+	"flag"
 	"os"
 	"testing"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -31,4 +34,82 @@ func TestMain(m *testing.M) {
 	base.GTestBucketPool.Close()
 
 	os.Exit(status)
+}
+
+func TestConfigOverwritesLegacyFlags(t *testing.T) {
+	osArgs := []string{
+		"sync_gateway",
+		// Legacy
+		"-verbose",
+		"-url", "1.2.3.4",
+		"-interface", "1.2.3.4",
+		// Persistent config
+		"-logging.console.log_level", "debug",
+		"-bootstrap.server", "localhost",
+		"-bootstrap.username", "test",
+
+		"config.json",
+	}
+	sc, _, _, err := parseFlags(osArgs)
+	assert.NoError(t, err)
+
+	require.NotNil(t, sc)
+	// Overwrote
+	assert.Equal(t, base.LogLevelPtr(base.LevelDebug), sc.Logging.Console.LogLevel)
+	assert.Equal(t, "localhost", sc.Bootstrap.Server)
+	// Not overwrote
+	assert.Equal(t, "1.2.3.4", sc.API.PublicInterface)
+	assert.Equal(t, "test", sc.Bootstrap.Username)
+}
+
+func TestParseFlags(t *testing.T) {
+	osArgsPrefix := []string{"sync_gateway"}
+	testCases := []struct {
+		name                            string
+		osArgs                          []string
+		expectError                     bool
+		expectedError                   error // Leave blank to not check error text
+		expectedDisablePersistentConfig *bool
+	}{
+		{
+			name:                            "Help error returned on -h",
+			osArgs:                          []string{"-h"},
+			expectError:                     true,
+			expectedError:                   flag.ErrHelp,
+			expectedDisablePersistentConfig: nil,
+		},
+		{
+			name:                            "Unknown flag",
+			osArgs:                          []string{"-unknown-flag"},
+			expectError:                     true,
+			expectedError:                   nil,
+			expectedDisablePersistentConfig: nil,
+		},
+		{
+			name:                            "Disable persistent config",
+			osArgs:                          []string{"-disable_persistent_config"},
+			expectError:                     false,
+			expectedError:                   nil,
+			expectedDisablePersistentConfig: base.BoolPtr(true),
+		},
+		{
+			name:                            "Config flag",
+			osArgs:                          []string{"-bootstrap.server", "1.2.3.4"},
+			expectError:                     false,
+			expectedError:                   nil,
+			expectedDisablePersistentConfig: base.BoolPtr(false),
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, disablePersistentConfig, err := parseFlags(append(osArgsPrefix, test.osArgs...))
+			if test.expectError {
+				assert.Error(t, err)
+				if test.expectedError != nil {
+					assert.EqualError(t, test.expectedError, err.Error())
+				}
+			}
+			assert.Equal(t, test.expectedDisablePersistentConfig, disablePersistentConfig)
+		})
+	}
 }


### PR DESCRIPTION
CBG-1638

- Added parsing for the legacy flags with appropriate deprecation/removal notices.
- Added testing for legacy flags

Legacy flags overwrite persistent config flags if both are set.

## Deprecation messages
If deprecated legacy flag used: `[WRN] Flag "-url" is deprecated. Please use "-bootstrap.server" in future.`
`Flag "-verbose" is deprecated. Please use "-logging.console.log_level info" in future.`

If `verbose` flag is used with logging.console.log_level: `Cannot use deprecated flag "-verbose" with flag "-logging.console.log_level". To set Sync Gateway to be verbose, please use flag "-logging.console.log_level info". Ignoring flag...`

If flag `configServer` is used: `flag "-configServer" is no longer supported and has been removed`

If flag `dbname` or `deploymentID` is used: `Flag "-deploymentID" is no longer supported and has been removed`

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1047
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1050
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1171 (flakey test fail)

## Dependencies

- [x] https://github.com/couchbase/sync_gateway/pull/5203

## Merge post-beta
- [x] Merge post-beta