### PR TITLE
CBG-1630: Move Guest field down into DbConfig and tidy up comments in DatabaseConfig

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -48,7 +48,7 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
 		}
 
-		config.Version, err = GenerateDatabaseConfigVersionID("", config)
+		version, err := GenerateDatabaseConfigVersionID("", config)
 		if err != nil {
 			return err
 		}
@@ -58,16 +58,18 @@ func (h *handler) handleCreateDB() error {
 			bucket = *config.Bucket
 		}
 
-		config.cas, err = h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, config)
+		persistedConfig := DatabaseConfig{Version: version, DbConfig: *config}
+
+		persistedConfig.cas, err = h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't save database config: %v", err)
 		}
 
-		if err := config.setup(dbName, h.server.config.Bootstrap); err != nil {
+		if err := persistedConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
 			return err
 		}
 
-		_, err := h.server.applyConfig(*config)
+		_, err = h.server.applyConfig(persistedConfig)
 		if err != nil {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't load database: %v", err)
 		}
@@ -77,7 +79,7 @@ func (h *handler) handleCreateDB() error {
 		}
 
 		// load database in-memory for non-persistent nodes
-		if _, err := h.server.AddDatabaseFromConfig(*config); err != nil {
+		if _, err := h.server.AddDatabaseFromConfig(DatabaseConfig{DbConfig: *config}); err != nil {
 			return err
 		}
 	}
@@ -139,40 +141,42 @@ func (h *handler) handleGetDbConfig() error {
 	// - Populate an up to date ETag header
 	// - Applying if refresh_config is set
 	// - Returning if include_runtime=false
-	var responseConfig *DatabaseConfig
+	var responseConfig *DbConfig
 	if h.server.bootstrapContext.connection != nil {
-		var found bool
-		var err error
-		found, responseConfig, err = h.server.fetchDatabase(h.db.Name)
+		found, dbConfig, err := h.server.fetchDatabase(h.db.Name)
 		if err != nil {
 			return err
 		}
 
-		if !found {
+		if !found || dbConfig == nil {
 			return base.HTTPErrorf(http.StatusNotFound, "database config not found")
 		}
 
-		h.response.Header().Set("ETag", responseConfig.Version)
+		h.response.Header().Set("ETag", dbConfig.Version)
 
 		// refresh_config=true forces the config loaded out of the bucket to be applied on the node
 		if h.getBoolQuery("refresh_config") && h.server.bootstrapContext.connection != nil {
 			// set cas=0 to force a refresh
-			responseConfig.cas = 0
-			h.server.applyConfigs(map[string]DatabaseConfig{h.db.Name: *responseConfig})
+			dbConfig.cas = 0
+			h.server.applyConfigs(map[string]DatabaseConfig{h.db.Name: *dbConfig})
 		}
+
+		responseConfig = &dbConfig.DbConfig
 	} else {
 		// non-persistent mode just returns running database config
-		responseConfig = h.server.GetDatabaseConfig(h.db.Name)
+		responseConfig = h.server.GetDbConfig(h.db.Name)
 	}
 
 	// include_runtime controls whether to return the raw bucketDbConfig, or the runtime version populated with default values, etc.
 	includeRuntime, _ := h.getOptBoolQuery("include_runtime", false)
 	if includeRuntime {
-		responseConfig = h.server.GetDatabaseConfig(h.db.Name)
+		responseConfig = h.server.GetDbConfig(h.db.Name)
 	}
 
-	// FIXME: CBG-1630 Use better approach for this (like wrapping in a PersistedDatabaseConfig struct)
-	responseConfig.Version = ""
+	// defensive check - there could've been an in-flight request to remove the database between entering the handler and getting the config above.
+	if responseConfig == nil {
+		return base.HTTPErrorf(http.StatusNotFound, "database config not found")
+	}
 
 	// redaction to sensitive config fields
 	redact, _ := h.getOptBoolQuery("redact", true)
@@ -224,7 +228,13 @@ func (h *handler) handleGetConfig() error {
 			}
 
 			for _, dbName := range allDbNames {
-				databaseMap[dbName], err = h.server.GetDatabaseConfig(dbName).DbConfig.Redacted()
+				// defensive check - in-flight requests could've removed this database since we got the name of it
+				dbConfig := h.server.GetDbConfig(dbName)
+				if dbConfig == nil {
+					continue
+				}
+
+				databaseMap[dbName], err = dbConfig.Redacted()
 				if err != nil {
 					return err
 				}
@@ -232,9 +242,15 @@ func (h *handler) handleGetConfig() error {
 		} else {
 			cfg.StartupConfig = h.server.config
 			for _, dbName := range allDbNames {
+				// defensive check - in-flight requests could've removed this database since we got the name of it
+				dbConfig := h.server.GetDbConfig(dbName)
+				if dbConfig == nil {
+					continue
+				}
+
 				// Copying struct here to avoid mutating the running dbconfig later on
 				var dbConfigCopy DbConfig
-				err = base.DeepCopyInefficient(&dbConfigCopy, h.server.GetDatabaseConfig(dbName).DbConfig)
+				err = base.DeepCopyInefficient(&dbConfigCopy, dbConfig)
 				if err != nil {
 					return err
 				}
@@ -364,7 +380,7 @@ func (h *handler) handlePutConfig() error {
 func (h *handler) handlePutDbConfig() (err error) {
 	h.assertAdminOnly()
 
-	var dbConfig *DatabaseConfig
+	var dbConfig *DbConfig
 
 	if h.permissionsResults[PermUpdateDb.PermissionName] {
 		// user authorized to change all fields
@@ -410,16 +426,11 @@ func (h *handler) handlePutDbConfig() (err error) {
 		bucket = *dbConfig.Bucket
 	}
 
-	if dbConfig.Version != "" {
-		return base.HTTPErrorf(http.StatusBadRequest, "version cannot be specified in the config body. If "+
-			"concurrency protection is required use the If-Match header to supply config version")
-	}
-
 	// Set dbName based on path value (since db doesn't necessarily exist), and update in incoming config in case of insert
 	dbName := h.PathVar("db")
 	dbConfig.Name = dbName
 
-	updatedDbConfig := dbConfig
+	var updatedDbConfig *DatabaseConfig
 	if h.server.persistentConfig {
 		cas, err := h.server.bootstrapContext.connection.UpdateConfig(
 			bucket, h.server.config.Bootstrap.ConfigGroupID,
@@ -434,7 +445,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 				}
 
-				if err := base.ConfigMerge(&bucketDbConfig, dbConfig); err != nil {
+				if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
 					return nil, err
 				}
 
@@ -446,7 +457,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 					return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
 				}
 
-				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig)
+				bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 				if err != nil {
 					return nil, err
 				}
@@ -533,7 +544,7 @@ func (h *handler) handleDeleteDbConfigSync() error {
 			}
 
 			bucketDbConfig.Sync = nil
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig)
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -593,7 +604,7 @@ func (h *handler) handlePutDbConfigSync() error {
 			}
 
 			bucketDbConfig.Sync = &js
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig)
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -676,7 +687,7 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 			}
 
 			bucketDbConfig.ImportFilter = nil
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig)
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -737,7 +748,7 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 			}
 
 			bucketDbConfig.ImportFilter = &js
-			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig)
+			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/rest/config.go
+++ b/rest/config.go
@@ -150,6 +150,7 @@ type DbConfig struct {
 	QueryPaginationLimit             *int                             `json:"query_pagination_limit,omitempty"`               // Query limit to be used during pagination of large queries
 	UserXattrKey                     string                           `json:"user_xattr_key,omitempty"`                       // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 	ClientPartitionWindowSecs        *int                             `json:"client_partition_window_secs,omitempty"`         // How long clients can remain offline for without losing replication metadata. Default 30 days (in seconds)
+	Guest                            *db.PrincipalConfig              `json:"guest,omitempty"`                                // Guest user settings
 }
 
 type DeltaSyncConfig struct {

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -39,10 +39,8 @@ func (dbc *DatabaseConfig) Redacted() (*DatabaseConfig, error) {
 	return &config, nil
 }
 
-func GenerateDatabaseConfigVersionID(previousRevID string, databaseConfig *DatabaseConfig) (string, error) {
-	databaseConfig.Version = ""
-
-	encodedBody, err := base.JSONMarshalCanonical(databaseConfig)
+func GenerateDatabaseConfigVersionID(previousRevID string, dbConfig *DbConfig) (string, error) {
+	encodedBody, err := base.JSONMarshalCanonical(dbConfig)
 	if err != nil {
 		return "", err
 	}

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -5,17 +5,17 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 )
 
-// DatabaseConfig is a 3.x/persisted database config.
-// TODO: Review whether DatabaseConfig should maintain its own list of valid config options, or should just continue inheriting them from DbConfig
+// DatabaseConfig is a 3.x/persisted database config that represents a config stored in the bucket.
 type DatabaseConfig struct {
 	// cas is the Couchbase Server CAS of the database config in the bucket
-	// value is used to skip applying configs to SG nodes that already have
-	// an up to date config. This value can be explicitly set to 0 before applyConfig to force a reload.
+	// used to skip applying configs to SG nodes that already have an up-to-date config.
+	// This value can be explicitly set to 0 before applyConfig to force reload.
 	cas uint64
 
-	Guest *db.PrincipalConfig `json:"guest,omitempty"`
-
+	// Version is a generated Rev ID used for optimistic concurrency control using ETags/If-Match headers.
 	Version string `json:"version,omitempty"`
+
+	// DbConfig embeds database config properties
 	DbConfig
 }
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -668,10 +668,10 @@ func (h *handler) readJavascript() (string, error) {
 	return string(jsBytes), nil
 }
 
-// readSanitizeJSONInto reads and sanitizes a JSON request body and returns DatabaseConfig.
+// readSanitizeJSONInto reads and sanitizes a JSON request body and returns DbConfig.
 // Expands environment variables (if any) referenced in the config.
-func (h *handler) readSanitizeDbConfigJSON() (*DatabaseConfig, error) {
-	var config DatabaseConfig
+func (h *handler) readSanitizeDbConfigJSON() (*DbConfig, error) {
+	var config DbConfig
 	err := h.readSanitizeJSON(&config)
 	if err != nil {
 		if errors.Cause(base.WrapJSONUnknownFieldErr(err)) == base.ErrUnknownField {

--- a/rest/main.go
+++ b/rest/main.go
@@ -228,7 +228,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 	for _, dbConfig := range dbConfigs {
 		dbc := dbConfig.ToDatabaseConfig()
 
-		dbc.Version, err = GenerateDatabaseConfigVersionID("", dbc)
+		dbc.Version, err = GenerateDatabaseConfigVersionID("", &dbc.DbConfig)
 		if err != nil {
 			return nil, false, err
 		}

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -239,6 +239,13 @@ func (sc *ServerContext) GetDatabase(name string) (*db.DatabaseContext, error) {
 	return nil, base.HTTPErrorf(http.StatusNotFound, "no such database %q", name)
 }
 
+func (sc *ServerContext) GetDbConfig(name string) *DbConfig {
+	if dbConfig := sc.GetDatabaseConfig(name); dbConfig != nil {
+		return &dbConfig.DbConfig
+	}
+	return nil
+}
+
 func (sc *ServerContext) GetDatabaseConfig(name string) *DatabaseConfig {
 	sc.lock.RLock()
 	config, ok := sc.dbConfigs[name]


### PR DESCRIPTION
CBG-1630

Makes `DatabaseConfig` struct represent the persisted database config, and keep `DbConfig` use for REST APIs

## Merge post-beta
- [ ] Merge post-beta