### PR TITLE
CBG-1655 Reduce log level for auth failure on config retrieval

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -1055,7 +1055,7 @@ func (sc *ServerContext) fetchDatabase(dbName string) (found bool, dbConfig *Dat
 			continue
 		}
 		if err != nil {
-			base.Errorf("couldn't fetch config in group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			base.Debugf(base.KeyConfig, "unable to fetch config in group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
 			continue
 		}
 
@@ -1111,7 +1111,7 @@ func (sc *ServerContext) fetchConfigs() (dbNameConfigs map[string]DatabaseConfig
 			continue
 		}
 		if err != nil {
-			base.Errorf("couldn't fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
+			base.Debugf(base.KeyConfig, "unable to fetch config for group %q from bucket %q: %v", sc.config.Bootstrap.ConfigGroupID, bucket, err)
 			continue
 		}
 


### PR DESCRIPTION
Avoids error logging for standard case where bootstrap user doesn't have access to non-mobile bucket.


