### PR TITLE
SGCollect: Ensure sg_url is always set to avoid later Exception

### DIFF
--- a/tools/sgcollect_info
+++ b/tools/sgcollect_info
@@ -625,6 +625,11 @@ def main():
         sg_url_http = "http://" + root_url
         print("Trying Sync Gateway URL: {0}".format(sg_url_http))
 
+        # Set sg_url to sg_url_http at this point
+        # If we're unable to determine which URL to use this is our best
+        # attempt. Avoids having this is 'None' later
+        sg_url = sg_url_http
+
         try:
             response = urllib.request.urlopen(sg_url_http)
             json.load(response)
@@ -641,8 +646,6 @@ def main():
                       "Will attempt to continue anyway.".format(e))
             else:
                 sg_url = sg_url_https
-        else:
-            sg_url = sg_url_http
 
     # Build path to zip directory, make sure it exists
     zip_filename = args[0]

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -589,7 +589,7 @@ def make_os_tasks(processes):
         UnixTask("ntp time",
                  "ntpdate -q pool.ntp.org || "
                  "nc time.nist.gov 13 || "
-                 "netcat time.nist.gov 13"),
+                 "netcat time.nist.gov 13", timeout=60),
         UnixTask("ntp peers", "ntpq -p"),
         UnixTask("raw /etc/sysconfig/clock", "cat /etc/sysconfig/clock"),
         UnixTask("raw /etc/timezone", "cat /etc/timezone"),


### PR DESCRIPTION
- Added timeout to `ntp`. Saw this command occasionally hanging in my local testing and the cbcollect version has a timeout.
- Ensures an sg_url is always set.

In the event of a 401 on the initial connection attempt sg_url can end up being `None` which causes later Exceptions which aren't caught. 
Currently only url exceptions are caught on a failed connection attempt but not this 'None' ValueError. 

This currently only occurs for the `_all_dbs` call as this is ran immediately rather than as a 'task' and tasks catch all exceptions.
The other option would be to catch the exception on the `_all_dbs` call but this seemed a better approach. 
