### PR TITLE
CBG-1646 Add a flag to non-active leaf revisions indicating whether they include v2 attachments

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -1339,7 +1339,7 @@ func (doc *Document) updateWinningRevAndSetDocFlags() {
 	}
 }
 
-func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCurrentRev string, newRevID string, newDoc *Document, newDocIncludeV2Att bool) {
+func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCurrentRev string, newRevID string, newDoc *Document, newDocHasAttachments bool) {
 	if doc.HasBody() && doc.CurrentRev != prevCurrentRev && prevCurrentRev != "" {
 		// Store the doc's previous body into the revision tree:
 		oldBodyJson, marshalErr := doc.BodyBytes()
@@ -1348,7 +1348,7 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 		}
 
 		var kvPairs []base.KVPair
-		oldDocIncludeV2Att := false
+		oldDocHasAttachments := false
 
 		// Stamp _attachments into the old body we're about to backup
 		// We need to do a revpos check here because doc actually contains the new attachments
@@ -1369,7 +1369,7 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 
 					version, _ := GetAttachmentVersion(attMetaMap)
 					if version == AttVersion2 {
-						oldDocIncludeV2Att = true
+						oldDocHasAttachments = true
 					}
 				}
 			}
@@ -1387,10 +1387,10 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 		if marshalErr != nil {
 			base.WarnfCtx(db.Ctx, "Unable to marshal document body properties for storage in rev tree: %v", marshalErr)
 		}
-		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, db.AllowExternalRevBodyStorage(), oldDocIncludeV2Att)
+		doc.setNonWinningRevisionBody(prevCurrentRev, oldBodyJson, db.AllowExternalRevBodyStorage(), oldDocHasAttachments)
 	}
 	// Store the new revision body into the doc:
-	doc.setRevisionBody(newRevID, newDoc, db.AllowExternalRevBodyStorage(), newDocIncludeV2Att)
+	doc.setRevisionBody(newRevID, newDoc, db.AllowExternalRevBodyStorage(), newDocHasAttachments)
 
 	if doc.CurrentRev == newRevID {
 		doc.NewestRev = ""
@@ -1643,8 +1643,8 @@ func (db *Database) documentUpdateFunc(docExists bool, doc *Document, allowImpor
 	newRevID := newDoc.RevID
 	prevCurrentRev := doc.CurrentRev
 	doc.updateWinningRevAndSetDocFlags()
-	newDocIncludeV2Att := len(newAttachments) > 0
-	db.storeOldBodyInRevTreeAndUpdateCurrent(doc, prevCurrentRev, newRevID, newDoc, newDocIncludeV2Att)
+	newDocHasAttachments := len(newAttachments) > 0
+	db.storeOldBodyInRevTreeAndUpdateCurrent(doc, prevCurrentRev, newRevID, newDoc, newDocHasAttachments)
 
 	syncFnBody[BodyId] = doc.ID
 	syncFnBody[BodyRev] = newRevID

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -102,7 +102,7 @@ func TestRevisionCacheLoad(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestIncludeV2Att(t *testing.T) {
+func TestHasAttachmentsFlag(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	db := setupTestDB(t)
 	defer db.Close()
@@ -164,7 +164,7 @@ func TestIncludeV2Att(t *testing.T) {
 	assert.NoError(t, err, "Couldn't get revtree for raw document")
 	assert.Equal(t, 0, len(revTree.BodyMap))
 	assert.Equal(t, 1, len(revTree.BodyKeyMap))
-	assert.Equal(t, 1, len(revTree.Attachments))
+	assert.Equal(t, 1, len(revTree.HasAttachments))
 }
 
 // TestRevisionStorageConflictAndTombstones

--- a/db/document.go
+++ b/db/document.go
@@ -722,24 +722,24 @@ func (doc *Document) pruneRevisions(maxDepth uint32, keepRev string) int {
 }
 
 // Adds a revision body (as Body) to a document.  Removes special properties first.
-func (doc *Document) setRevisionBody(revid string, newDoc *Document, storeInline, includeV2Att bool) {
+func (doc *Document) setRevisionBody(revid string, newDoc *Document, storeInline, hasAttachments bool) {
 	if revid == doc.CurrentRev {
 		doc._body = newDoc._body
 		doc._rawBody = newDoc._rawBody
 	} else {
 		bodyBytes, _ := newDoc.BodyBytes()
-		doc.setNonWinningRevisionBody(revid, bodyBytes, storeInline, includeV2Att)
+		doc.setNonWinningRevisionBody(revid, bodyBytes, storeInline, hasAttachments)
 	}
 }
 
 // Adds a revision body (as []byte) to a document.  Flags for external storage when appropriate
-func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool, includeV2Att bool) {
+func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool, hasAttachments bool) {
 	revBodyKey := ""
 	if !storeInline && len(body) > MaximumInlineBodySize {
 		revBodyKey = generateRevBodyKey(doc.ID, revid)
 		doc.addedRevisionBodies = append(doc.addedRevisionBodies, revid)
 	}
-	doc.History.setRevisionBody(revid, body, revBodyKey, includeV2Att)
+	doc.History.setRevisionBody(revid, body, revBodyKey, hasAttachments)
 }
 
 // persistModifiedRevisionBodies writes new non-inline revisions to the bucket.

--- a/db/document.go
+++ b/db/document.go
@@ -722,24 +722,24 @@ func (doc *Document) pruneRevisions(maxDepth uint32, keepRev string) int {
 }
 
 // Adds a revision body (as Body) to a document.  Removes special properties first.
-func (doc *Document) setRevisionBody(revid string, newDoc *Document, storeInline bool) {
+func (doc *Document) setRevisionBody(revid string, newDoc *Document, storeInline, includeV2Att bool) {
 	if revid == doc.CurrentRev {
 		doc._body = newDoc._body
 		doc._rawBody = newDoc._rawBody
 	} else {
 		bodyBytes, _ := newDoc.BodyBytes()
-		doc.setNonWinningRevisionBody(revid, bodyBytes, storeInline)
+		doc.setNonWinningRevisionBody(revid, bodyBytes, storeInline, includeV2Att)
 	}
 }
 
 // Adds a revision body (as []byte) to a document.  Flags for external storage when appropriate
-func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool) {
+func (doc *Document) setNonWinningRevisionBody(revid string, body []byte, storeInline bool, includeV2Att bool) {
 	revBodyKey := ""
 	if !storeInline && len(body) > MaximumInlineBodySize {
 		revBodyKey = generateRevBodyKey(doc.ID, revid)
 		doc.addedRevisionBodies = append(doc.addedRevisionBodies, revid)
 	}
-	doc.History.setRevisionBody(revid, body, revBodyKey)
+	doc.History.setRevisionBody(revid, body, revBodyKey, includeV2Att)
 }
 
 // persistModifiedRevisionBodies writes new non-inline revisions to the bucket.

--- a/db/revtree.go
+++ b/db/revtree.go
@@ -22,14 +22,14 @@ type RevKey string
 
 // Information about a single revision.
 type RevInfo struct {
-	ID           string
-	Parent       string
-	BodyKey      string // Used when revision body stored externally (doc key used for external storage)
-	Deleted      bool
-	depth        uint32
-	Body         []byte // Used when revision body stored inline (stores bodies)
-	Channels     base.Set
-	IncludeV2Att bool
+	ID             string
+	Parent         string
+	BodyKey        string // Used when revision body stored externally (doc key used for external storage)
+	Deleted        bool
+	depth          uint32
+	Body           []byte // Used when revision body stored inline (stores bodies)
+	Channels       base.Set
+	HasAttachments bool
 }
 
 func (rev RevInfo) IsRoot() bool {
@@ -43,14 +43,14 @@ type RevTree map[string]*RevInfo
 // rev IDs, with a parallel array of parent indexes. Ordering in the arrays doesn't matter.
 // So the parent of Revs[i] is Revs[Parents[i]] (unless Parents[i] == -1, which denotes a root.)
 type revTreeList struct {
-	Revs        []string          `json:"revs"`                 // The revision IDs
-	Parents     []int             `json:"parents"`              // Index of parent of each revision (-1 if root)
-	Deleted     []int             `json:"deleted,omitempty"`    // Indexes of revisions that are deletions
-	Bodies_Old  []string          `json:"bodies,omitempty"`     // JSON of each revision (legacy)
-	BodyMap     map[string]string `json:"bodymap,omitempty"`    // JSON of each revision
-	BodyKeyMap  map[string]string `json:"bodyKeyMap,omitempty"` // Keys of revision bodies stored in external documents
-	Channels    []base.Set        `json:"channels"`
-	Attachments []int             `json:"attachments,omitempty"` // Indexes of revisions that has attachments
+	Revs           []string          `json:"revs"`                 // The revision IDs
+	Parents        []int             `json:"parents"`              // Index of parent of each revision (-1 if root)
+	Deleted        []int             `json:"deleted,omitempty"`    // Indexes of revisions that are deletions
+	Bodies_Old     []string          `json:"bodies,omitempty"`     // JSON of each revision (legacy)
+	BodyMap        map[string]string `json:"bodymap,omitempty"`    // JSON of each revision
+	BodyKeyMap     map[string]string `json:"bodyKeyMap,omitempty"` // Keys of revision bodies stored in external documents
+	Channels       []base.Set        `json:"channels"`
+	HasAttachments []int             `json:"hasAttachments,omitempty"` // Indexes of revisions that has attachments
 }
 
 func (tree RevTree) MarshalJSON() ([]byte, error) {
@@ -87,11 +87,11 @@ func (tree RevTree) MarshalJSON() ([]byte, error) {
 			}
 			rep.Deleted = append(rep.Deleted, i)
 		}
-		if info.IncludeV2Att {
-			if rep.Attachments == nil {
-				rep.Attachments = make([]int, 0, 1)
+		if info.HasAttachments {
+			if rep.HasAttachments == nil {
+				rep.HasAttachments = make([]int, 0, 1)
 			}
-			rep.Attachments = append(rep.Attachments, i)
+			rep.HasAttachments = append(rep.HasAttachments, i)
 		}
 		i++
 	}
@@ -164,10 +164,10 @@ func (tree *RevTree) UnmarshalJSON(inputjson []byte) (err error) {
 			(*tree)[rep.Revs[i]] = info
 		}
 	}
-	if rep.Attachments != nil {
-		for _, i := range rep.Attachments {
+	if rep.HasAttachments != nil {
+		for _, i := range rep.HasAttachments {
 			info := (*tree)[rep.Revs[i]]
-			info.IncludeV2Att = true
+			info.HasAttachments = true
 			(*tree)[rep.Revs[i]] = info
 		}
 	}
@@ -403,7 +403,7 @@ func (tree RevTree) getRevisionBody(revid string, loader RevLoaderFunc) ([]byte,
 	return info.Body, true
 }
 
-func (tree RevTree) setRevisionBody(revid string, body []byte, bodyKey string, includeV2Att bool) {
+func (tree RevTree) setRevisionBody(revid string, body []byte, bodyKey string, hasAttachments bool) {
 	if revid == "" {
 		panic("Illegal empty revision ID")
 	}
@@ -414,7 +414,7 @@ func (tree RevTree) setRevisionBody(revid string, body []byte, bodyKey string, i
 
 	info.BodyKey = bodyKey
 	info.Body = body
-	info.IncludeV2Att = includeV2Att
+	info.HasAttachments = hasAttachments
 }
 
 func (tree RevTree) removeRevisionBody(revid string) (deletedBodyKey string) {
@@ -426,7 +426,7 @@ func (tree RevTree) removeRevisionBody(revid string) (deletedBodyKey string) {
 	deletedBodyKey = info.BodyKey
 	info.BodyKey = ""
 	info.Body = nil
-	info.IncludeV2Att = false
+	info.HasAttachments = false
 	return deletedBodyKey
 }
 


### PR DESCRIPTION
Changest to include a flag to non-active leaf revisions indicating whether they include v2 attachments.
