### PR TITLE
CBG-1664: Validate Javascript syntax in validate()

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -478,6 +478,11 @@ func (h *handler) handlePutDbConfig() (err error) {
 			return err
 		}
 		updatedDbConfig.cas = cas
+	} else {
+		err = updatedDbConfig.validate()
+		if err != nil {
+			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
+		}
 	}
 
 	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
@@ -613,7 +618,13 @@ func (h *handler) handlePutDbConfigSync() error {
 			}
 
 			bucketDbConfig.Sync = &js
+
+			if err := bucketDbConfig.validate(); err != nil {
+				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+			}
+
 			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
+
 			if err != nil {
 				return nil, err
 			}
@@ -757,6 +768,11 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 			}
 
 			bucketDbConfig.ImportFilter = &js
+
+			if err := bucketDbConfig.validate(); err != nil {
+				return nil, base.HTTPErrorf(http.StatusBadRequest, err.Error())
+			}
+
 			bucketDbConfig.Version, err = GenerateDatabaseConfigVersionID(bucketDbConfig.Version, &bucketDbConfig.DbConfig)
 			if err != nil {
 				return nil, err

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3486,7 +3486,56 @@ func TestDbConfigDoesNotIncludeCredentials(t *testing.T) {
 	assert.Equal(t, "", dbConfig.CACertPath)
 	assert.Equal(t, "", dbConfig.CertPath)
 	assert.Equal(t, "", dbConfig.KeyPath)
+}
 
+func TestInvalidDBConfig(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
+	// Start SG with no databases in bucket(s)
+	config := bootstrapStartupConfigForTest(t)
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+	serverErr := make(chan error, 0)
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() {
+		fmt.Println("closing test bucket")
+		tb.Close()
+	}()
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
+		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+	)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// Put db config with invalid sync fn
+	resp = bootstrapAdminRequest(t, "PUT", "/db/_config", `{"sync": "function(){"}`)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(body), "invalid javascript syntax"))
+
+	// Put invalid sync fn via sync specific endpoint
+	resp = bootstrapAdminRequest(t, "PUT", "/db/_config/sync", `function(){`)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(body), "invalid javascript syntax"))
+
+	// Put invalid import fn via import specific endpoint
+	resp = bootstrapAdminRequest(t, "PUT", "/db/_config/import_filter", `function(){`)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(body), "invalid javascript syntax"))
 }
 
 func TestCreateDbOnNonExistentBucket(t *testing.T) {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3499,11 +3499,13 @@ func TestInvalidDBConfig(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	defer sc.Close()
+
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)

--- a/rest/config.go
+++ b/rest/config.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/couchbase/sync_gateway/auth"
@@ -593,6 +594,20 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 
 	if dbConfig.DeprecatedPool != nil {
 		base.Warnf(`"pool" config option is not supported. The pool will be set to "default". The option should be removed from config file.`)
+	}
+
+	if dbConfig.Sync != nil {
+		_, err = sgbucket.NewJSRunner(*dbConfig.Sync)
+		if err != nil {
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function contains invalid javascript syntax: %v", err))
+		}
+	}
+
+	if dbConfig.ImportFilter != nil {
+		_, err = sgbucket.NewJSRunner(*dbConfig.ImportFilter)
+		if err != nil {
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function contains invalid javascript syntax: %v", err))
+		}
 	}
 
 	return errorMessages


### PR DESCRIPTION
CBG-1664

- Adds Javascript validation as part of the dbConfig validate method
- Adds validate to be ran in the non-persistent config path too

Tested with a couple unit tests: function directly and one small one testing that this is flagged on db config endpoint.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1069/