### PR TITLE
CBG-1663: Create new temporary connection for Bootstrap ops

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -93,6 +93,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 	// TODO: identify required services and add to WaitUntilReadyOptions
 	err = bucket.WaitUntilReady(30*time.Second, nil)
 	if err != nil {
+		_ = cluster.Close(&gocb.ClusterCloseOptions{})
 		Warnf("Error waiting for bucket to be ready: %v", err)
 		return nil, err
 	}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3506,7 +3506,7 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs(time.Second*30))
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", `{"bucket": "nonExistentBucket"}`)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3488,3 +3488,26 @@ func TestDbConfigDoesNotIncludeCredentials(t *testing.T) {
 	assert.Equal(t, "", dbConfig.KeyPath)
 
 }
+
+func TestCreateDbOnNonExistentBucket(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
+	// Start SG with no databases in bucket(s)
+	config := bootstrapStartupConfigForTest(t)
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+	defer sc.Close()
+
+	serverErr := make(chan error, 0)
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs(time.Second*30))
+
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", `{"bucket": "nonExistentBucket"}`)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/rest/config.go
+++ b/rest/config.go
@@ -948,7 +948,7 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 
 	// Fetch database configs from bucket and start polling for new buckets and config updates.
 	if sc.persistentConfig {
-		couchbaseCluster, err := establishCouchbaseClusterConnection(sc.config)
+		couchbaseCluster, err := createCouchbaseClusterFromStartupConfig(sc.config)
 		if err != nil {
 			return nil, err
 		}

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -82,11 +82,8 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 
 	assert.Equal(t, config, string(writtenBackupFile))
 
-	cbs, err := establishCouchbaseClusterConnection(startupConfig)
+	cbs, err := createCouchbaseClusterFromStartupConfig(startupConfig)
 	require.NoError(t, err)
-	defer func() {
-		_ = cbs.Close()
-	}()
 
 	var dbConfig DbConfig
 	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
@@ -204,11 +201,8 @@ func TestAutomaticConfigUpgradeExistingConfig(t *testing.T) {
 	startupConfig, _, err := automaticConfigUpgrade(updatedConfigPath)
 	require.NoError(t, err)
 
-	cbs, err := establishCouchbaseClusterConnection(startupConfig)
+	cbs, err := createCouchbaseClusterFromStartupConfig(startupConfig)
 	require.NoError(t, err)
-	defer func() {
-		_ = cbs.Close()
-	}()
 
 	var dbConfig DbConfig
 	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -198,12 +198,6 @@ func (sc *ServerContext) Close() {
 	}
 	sc._httpServers = nil
 
-	if c := sc.bootstrapContext.connection; c != nil {
-		if err := c.Close(); err != nil {
-			base.Warnf("Error closing bootstrap cluster connection: %v", err)
-		}
-	}
-
 	if agent := sc.GoCBAgent; agent != nil {
 		if err := agent.Close(); err != nil {
 			base.Warnf("Error closing agent connection: %v", err)


### PR DESCRIPTION
CBG-1663

- Modify `CouchbaseCluster` to store server URL and clusterOptions rather than a cluster connection.
- For each operation start up a connection, perform the operation, and close the connection
- Additional fix to close connection in `GetCouchbaseCollection` on error 

Has a test which ensures that we continue to get the error on a non-existent db. Existing bootstrap tests should ensure this change doesn't affect the other operations.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1070/
Couple unrelated failures