### PR TITLE
Fix a couple issues with bootstrap tests

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3383,11 +3383,13 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	defer sc.Close()
+
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
@@ -3435,11 +3437,12 @@ func TestDbConfigDoesNotIncludeCredentials(t *testing.T) {
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
+	defer sc.Close()
 	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -68,10 +68,9 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Equal(t, "db1", dbConfigResp.Name)
 	require.NotNil(t, dbConfigResp.Bucket)
 	assert.Equal(t, tb.GetName(), *dbConfigResp.Bucket)
-	require.NotNil(t, dbConfigResp.Server)
-	assert.Equal(t, base.UnitTestUrl(), *dbConfigResp.Server)
-	assert.Equal(t, base.TestClusterUsername(), dbConfigResp.Username)
-	assert.Equal(t, base.TestClusterPassword(), dbConfigResp.Password)
+	assert.Nil(t, dbConfigResp.Server)
+	assert.Empty(t, dbConfigResp.Username)
+	assert.Empty(t, dbConfigResp.Password)
 	require.Nil(t, dbConfigResp.Sync)
 
 	// Sanity check to use the database
@@ -114,10 +113,9 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Equal(t, "db1", dbConfigResp.Name)
 	require.NotNil(t, dbConfigResp.Bucket)
 	assert.Equal(t, tb.GetName(), *dbConfigResp.Bucket)
-	require.NotNil(t, dbConfigResp.Server)
-	assert.Equal(t, base.UnitTestUrl(), *dbConfigResp.Server)
-	assert.Equal(t, base.TestClusterUsername(), dbConfigResp.Username)
-	assert.Equal(t, base.TestClusterPassword(), dbConfigResp.Password)
+	assert.Nil(t, dbConfigResp.Server)
+	assert.Empty(t, dbConfigResp.Username)
+	assert.Empty(t, dbConfigResp.Password)
 	require.Nil(t, dbConfigResp.Sync)
 
 	// Ensure it's _actually_ the same bucket

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/db"
@@ -39,7 +38,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
@@ -91,7 +90,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
-	require.NoError(t, sc.waitForRESTAPIs(time.Second*5))
+	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
 		sc.Close()
 		require.NoError(t, <-serverErr)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -129,7 +129,8 @@ func NewServerContext(config *StartupConfig, persistentConfig bool) *ServerConte
 	return sc
 }
 
-func (sc *ServerContext) waitForRESTAPIs(timeout time.Duration) error {
+func (sc *ServerContext) waitForRESTAPIs() error {
+	timeout := 30 * time.Second
 	interval := time.Millisecond * 100
 	numAttempts := int(timeout / interval)
 	timeoutCtx, cancelFn := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
Fixes a couple issues with bootstrap config tests.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1064/
Unrelated failed tests.

## Merge criteria
- [x] Test only changes