### PR TITLE
CBG-1670: Improve error message for PUT db failure

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -63,7 +63,7 @@ func (h *handler) handleCreateDB() error {
 		persistedConfig.cas, err = h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
 			if errors.Cause(err) == base.ErrAuthError {
-				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket %s", bucket)
+				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket using bootstrap credentials: %s", bucket)
 			}
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't save database config: %v", err)
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -62,6 +62,9 @@ func (h *handler) handleCreateDB() error {
 
 		persistedConfig.cas, err = h.server.bootstrapContext.connection.InsertConfig(bucket, h.server.config.Bootstrap.ConfigGroupID, persistedConfig)
 		if err != nil {
+			if errors.Cause(err) == base.ErrAuthError {
+				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket %s", bucket)
+			}
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't save database config: %v", err)
 		}
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3560,7 +3560,18 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	require.NoError(t, sc.waitForRESTAPIs())
 
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", `{"bucket": "nonExistentBucket"}`)
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Contains(t, string(body), "auth failure accessing provided bucket nonExistentBucket")
+
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/nonExistentBucket/", `{}`)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Contains(t, string(body), "auth failure accessing provided bucket nonExistentBucket")
 }
 
 func TestPutDbConfigChangeName(t *testing.T) {


### PR DESCRIPTION
CBG-1670

 - Change getBucket in bootstrap to use the fail fast retry - meaning an auth error will immediately return rather than doing the 10 second wait.
 - If the error returned from creating bucket connection is auth error return `ErrAuthError`
 - Check for this error when `InsertConfig` is run in `handleCreateDB` and if we get this return 403

Returned error looks like:
```
{
    "error": "Forbidden",
    "reason": "auth failure accessing provided bucket dbx"
}
```

Tested by modifying existing test to check for `403` instead of `500` and also assert on the error message itself.

## Dependencies
- [x] Merge https://github.com/couchbase/sync_gateway/pull/5218

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1141/
