### PR TITLE
Preemptive Go 1.17+ test fix: Removes semicolon query parameter separator in test cases

### DIFF
--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -99,7 +99,7 @@ func TestLegacyConfigToStartupConfig(t *testing.T) {
 		{
 			name:     "http:// to couchbase:// with args",
 			base:     StartupConfig{},
-			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://host1,host2:8091?p1=v1&p2=v2;p3=v3")}}}},
+			input:    LegacyServerConfig{Databases: DbConfigMap{"db": &DbConfig{BucketConfig: BucketConfig{Server: base.StringPtr("http://host1,host2:8091?p1=v1&p2=v2&p3=v3")}}}},
 			expected: StartupConfig{Bootstrap: BootstrapConfig{Server: "couchbase://host1,host2?p1=v1&p2=v2&p3=v3"}},
 		},
 	}
@@ -180,8 +180,8 @@ func TestLegacyServerAddressUpgrade(t *testing.T) {
 			expectedPassword: "",
 		},
 		{
-			name:             "Multi params with & and ; separators, alphabetical order",
-			server:           "http://foo:bar@localhost,127.0.0.2?c=3;a=1&b=2",
+			name:             "Multi params with & separators, alphabetical order",
+			server:           "http://foo:bar@localhost,127.0.0.2?c=3&a=1&b=2",
 			expectError:      false,
 			expectedServer:   "couchbase://localhost,127.0.0.2?a=1&b=2&c=3",
 			expectedUsername: "foo",


### PR DESCRIPTION
Semicolon separators in URLs are not supported by default in Go 1.17+ due to security concerns, and is not a common or suggested format for connection strings anyway.

https://golang.org/doc/go1.17#semicolons

Resulted in these two tests failing when run under Go 1.17

```
2021-09-03T10:31:41.601+01:00 [ERR] Error upgrading server address: invalid semicolon separator in query -- rest.(*LegacyServerConfig).ToStartupConfig() at config_legacy.go:109

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -4,3 +4,3 @@
        	            	   ConfigUpdateFrequency: (*base.ConfigDuration)(<nil>),
        	            	-  Server: (string) (len=41) "couchbase://host1,host2?p1=v1&p2=v2&p3=v3",
        	            	+  Server: (string) (len=41) "http://host1,host2:8091?p1=v1&p2=v2;p3=v3",
        	            	   Username: (string) "",
        	Test:       	TestLegacyConfigToStartupConfig/http://_to_couchbase://_with_args

    --- FAIL: TestLegacyConfigToStartupConfig/http://_to_couchbase://_with_args (0.00s)
```

```
        	Test:       	TestLegacyServerAddressUpgrade/Multi_params_with_&_and_;_separators,_alphabetical_order
    config_legacy_test.go:210:
        	Error Trace:	config_legacy_test.go:210
        	Error:      	Received unexpected error:
        	            	invalid semicolon separator in query
        	Test:       	TestLegacyServerAddressUpgrade/Multi_params_with_&_and_;_separators,_alphabetical_order

    --- FAIL: TestLegacyServerAddressUpgrade/Multi_params_with_&_and_;_separators,_alphabetical_order (0.00s)
```


## Merge Criteria
 - [x] Test only