### PR TITLE
Avoid panic in RestTester SetAdminParty

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1033,7 +1033,7 @@ func TestFlush(t *testing.T) {
 
 	log.Printf("Flushing db...")
 	assertStatus(t, rt.SendAdminRequest("POST", "/db/_flush", ""), 200)
-	rt.SetAdminParty(true) // needs to be re-enabled after flush since guest user got wiped
+	require.NoError(t, rt.SetAdminParty(true)) // needs to be re-enabled after flush since guest user got wiped
 
 	// After the flush, the db exists but the documents are gone:
 	assertStatus(t, rt.SendAdminRequest("GET", "/db/", ""), 200)

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -887,7 +887,7 @@ func TestOpenIDConnectAuthCodeFlow(t *testing.T) {
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			restTester.SetAdminParty(false)
+			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.
@@ -1092,7 +1092,7 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			restTester.SetAdminParty(false)
+			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.
@@ -1162,7 +1162,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 	opts := auth.OIDCOptions{Providers: providers, DefaultProvider: &defaultProvider}
 	restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 	restTester := NewRestTester(t, &restTesterConfig)
-	restTester.SetAdminParty(false)
+	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -1807,7 +1807,7 @@ func TestCallbackStateClientCookies(t *testing.T) {
 		}},
 	}
 	restTester := NewRestTester(t, &restTesterConfig)
-	restTester.SetAdminParty(false)
+	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 
 	mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
@@ -2043,7 +2043,7 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 				}},
 			}
 			restTester := NewRestTester(t, &restTesterConfig)
-			restTester.SetAdminParty(false)
+			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.
@@ -2139,7 +2139,7 @@ func TestEventuallyReachableOIDCClient(t *testing.T) {
 			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
 			restTesterConfig := RestTesterConfig{DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{OIDCConfig: &opts}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			restTester.SetAdminParty(false)
+			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			// Create the user first if the test requires a registered user.

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -157,7 +157,7 @@ func TestProviderOIDCAuthWithTlsSkipVerifyEnabled(t *testing.T) {
 	restTesterConfig := restTesterConfigWithTestProviderEnabled()
 	restTesterConfig.DatabaseConfig.Unsupported.OidcTlsSkipVerify = true
 	restTester := NewRestTester(t, &restTesterConfig)
-	restTester.SetAdminParty(false)
+	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	mockSyncGateway := httptest.NewTLSServer(restTester.TestPublicHandler())
 	defer mockSyncGateway.Close()
@@ -211,7 +211,7 @@ func TestProviderOIDCAuthWithTlsSkipVerifyDisabled(t *testing.T) {
 	restTesterConfig := restTesterConfigWithTestProviderEnabled()
 	restTesterConfig.DatabaseConfig.Unsupported.OidcTlsSkipVerify = false
 	restTester := NewRestTester(t, &restTesterConfig)
-	restTester.SetAdminParty(false)
+	require.NoError(t, restTester.SetAdminParty(false))
 	defer restTester.Close()
 	mockSyncGateway := httptest.NewTLSServer(restTester.TestPublicHandler())
 	defer mockSyncGateway.Close()
@@ -302,7 +302,7 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 					},
 				}}}
 			restTester := NewRestTester(t, &restTesterConfig)
-			restTester.SetAdminParty(false)
+			require.NoError(t, restTester.SetAdminParty(false))
 			defer restTester.Close()
 
 			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())


### PR DESCRIPTION
`rt.SetAdminParty` has the potential to panic if the query/view for the underlying `GetUser` fails - this change prevents tests from panicing by doing additional assertions on this error.

## Merge Criteria
 - [x] Test only