### PR TITLE
CBG-1675: Fix TestUseXattrs to allow explicit false values

### DIFF
--- a/base/util_testing.go
+++ b/base/util_testing.go
@@ -170,15 +170,17 @@ func GetTestBucketForDriver(t testing.TB, driver CouchbaseDriver) *TestBucket {
 
 // Should Sync Gateway use XATTRS functionality when running unit tests?
 func TestUseXattrs() bool {
-	// First check if the SG_TEST_USE_XATTRS env variable is set
-	useXattrs := os.Getenv(TestEnvSyncGatewayUseXattrs)
-	if strings.ToLower(useXattrs) == strings.ToLower(TestEnvSyncGatewayTrue) {
-		return true
+	useXattrs, isSet := os.LookupEnv(TestEnvSyncGatewayUseXattrs)
+	if !isSet {
+		return !UnitTestUrlIsWalrus()
 	}
 
-	// Otherwise fallback to hardcoded default
-	return !UnitTestUrlIsWalrus()
+	val, err := strconv.ParseBool(useXattrs)
+	if err != nil {
+		panic(fmt.Sprintf("unable to parse %q value %q: %v", TestEnvSyncGatewayUseXattrs, useXattrs, err))
+	}
 
+	return val
 }
 
 // Should tests try to drop GSI indexes before flushing buckets?


### PR DESCRIPTION
CBG-1675

This function wasn't allowing explicit `false` values to be used when running with Couchbase Server.
Seems to have been unintentionally introduced in #5123 when we flipped the default xattr value.

Rewritten to be properly checking if the env var was set, and always attempting to use the set value in that case.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
  - known failing xattrs=false tests - addressed in #5227 

## Merge Criteria
 - [x] Test only