### PR TITLE
CBG-1676: Fix incorrect usages of AddRaw/SetRaw for JSON docs causing "binary datatype is not supported by RawJSONTranscoder"

### DIFF
--- a/db/attachment_test.go
+++ b/db/attachment_test.go
@@ -845,7 +845,7 @@ func TestMigrateBodyAttachments(t *testing.T) {
 		} else {
 			newBody, err := base.InjectJSONPropertiesFromBytes([]byte(bodyPre25), base.KVPairBytes{Key: base.SyncPropertyName, Val: []byte(syncData)})
 			assert.NoError(t, err)
-			ok, err := bucket.AddRaw(docKey, 0, newBody)
+			ok, err := bucket.Add(docKey, 0, newBody)
 			assert.NoError(t, err)
 			assert.True(t, ok)
 		}
@@ -1144,7 +1144,7 @@ func TestMigrateBodyAttachmentsMerge(t *testing.T) {
 	} else {
 		newBody, err := base.InjectJSONPropertiesFromBytes([]byte(bodyPre25), base.KVPairBytes{Key: base.SyncPropertyName, Val: []byte(syncData)})
 		assert.NoError(t, err)
-		ok, err := bucket.AddRaw(docKey, 0, newBody)
+		ok, err := bucket.Add(docKey, 0, newBody)
 		assert.NoError(t, err)
 		assert.True(t, ok)
 	}
@@ -1330,7 +1330,7 @@ func TestMigrateBodyAttachmentsMergeConflicting(t *testing.T) {
 	} else {
 		newBody, err := base.InjectJSONPropertiesFromBytes([]byte(bodyPre25), base.KVPairBytes{Key: base.SyncPropertyName, Val: []byte(syncData)})
 		assert.NoError(t, err)
-		ok, err := bucket.AddRaw(docKey, 0, newBody)
+		ok, err := bucket.Add(docKey, 0, newBody)
 		assert.NoError(t, err)
 		assert.True(t, ok)
 	}

--- a/db/crud_test.go
+++ b/db/crud_test.go
@@ -796,7 +796,7 @@ func TestMalformedRevisionStorageRecovery(t *testing.T) {
 	//  |
 	// 6-a
 	log.Printf("Add doc1 w/ malformed body for rev 2-b included in revision tree")
-	ok, addErr := db.Bucket.AddRaw("doc1", 0, []byte(rawDocMalformedRevisionStorage))
+	ok, addErr := db.Bucket.Add("doc1", 0, []byte(rawDocMalformedRevisionStorage))
 	goassert.True(t, ok)
 	assert.NoError(t, addErr, "Error writing raw document")
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -40,7 +40,7 @@ licenses/APL2.txt.
 
   <project name="sync_gateway_admin_ui" path="godeps/src/github.com/couchbaselabs/sync_gateway_admin_ui" revision="93c74bac9ddc2979ab895a37087c225c998b03bf" remote="couchbaselabs"/>
 
-  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="aac9eb5d3047d4a74d3e87db231a36e231446dad"/>
+  <project name="walrus" path="godeps/src/github.com/couchbaselabs/walrus" remote="couchbaselabs" revision="2594ed1ddc60c95a30b7e3fc76cfeda2cc74b1fd"/>
 
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -4288,7 +4288,7 @@ func TestAttachmentRevposPre25Metadata(t *testing.T) {
 	rt := NewRestTester(t, nil)
 	defer rt.Close()
 
-	ok, err := rt.GetDatabase().Bucket.AddRaw("doc1", 0, []byte(`{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_sync":{"rev":"1-6e5a9ed9e2e8637d495ac5dd2fa90479","sequence":2,"recent_sequences":[2],"history":{"revs":["1-6e5a9ed9e2e8637d495ac5dd2fa90479"],"parents":[-1],"channels":[null]},"cas":"","time_saved":"2019-12-06T20:02:25.523013Z"},"test":true}`))
+	ok, err := rt.GetDatabase().Bucket.Add("doc1", 0, []byte(`{"_attachments":{"hello.txt":{"digest":"sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=","length":11,"revpos":1,"stub":true}},"_sync":{"rev":"1-6e5a9ed9e2e8637d495ac5dd2fa90479","sequence":2,"recent_sequences":[2],"history":{"revs":["1-6e5a9ed9e2e8637d495ac5dd2fa90479"],"parents":[-1],"channels":[null]},"cas":"","time_saved":"2019-12-06T20:02:25.523013Z"},"test":true}`))
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -6318,7 +6318,7 @@ func TestChannelHistoryLegacyDoc(t *testing.T) {
 	}`
 
 	// Insert raw 'legacy' doc with no channel history info
-	err := rt.GetDatabase().Bucket.SetRaw("doc1", 0, []byte(docData))
+	err := rt.GetDatabase().Bucket.Set("doc1", 0, []byte(docData))
 	assert.NoError(t, err)
 
 	var body db.Body
@@ -8657,6 +8657,11 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		if base.UnitTestUrlIsWalrus() {
 			t.Skip("This import test won't work under walrus")
 		}
+
+		if !base.TestUseXattrs() {
+			t.Skip("Test requires xattrs")
+		}
+
 		// Create a document with inline attachment.
 		docID := "foo10"
 		attName := "foo.txt"
@@ -8705,6 +8710,11 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		if base.UnitTestUrlIsWalrus() {
 			t.Skip("This import test won't work under walrus")
 		}
+
+		if !base.TestUseXattrs() {
+			t.Skip("Test requires xattrs")
+		}
+
 		// Create a document with inline attachment.
 		docID := "foo11"
 		attName := "foo.txt"


### PR DESCRIPTION
CBG-1676

Several tests were using the `Raw()` variants to write JSON documents to the bucket, which ended up having a binary flag set on the document. This meant that on subsequent reads, the `RawJSONTranscoder` failed to decode the document.

These failures could be seen when running integration tests with xattrs=false after the TestUseXattrs fix

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​08​4/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​08​5/

## Merge Criteria
 - [x] Test/walrus only