### PR TITLE
CBG-1666: Fix all_docs with limit when using GSI

### DIFF
--- a/base/collection_n1ql_common.go
+++ b/base/collection_n1ql_common.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/couchbase/gocb/v2"
-
 	sgbucket "github.com/couchbase/sg-bucket"
 	pkgerrors "github.com/pkg/errors"
 )
@@ -492,6 +491,11 @@ func (i *gocbRawIterator) NextBytes() []byte {
 
 // Closes the iterator.  Returns any row-level errors seen during iteration.
 func (i *gocbRawIterator) Close() error {
+	// Have to iterate over any remaining results to clear the reader
+	// Otherwise we get "the result must be closed before accessing the meta-data" on close details on CBG-1666
+	for i.rawResult.NextBytes() != nil {
+		// noop to drain results
+	}
 
 	// check for errors before closing?
 	closeErr := i.rawResult.Close()

--- a/db/database.go
+++ b/db/database.go
@@ -834,7 +834,6 @@ func (db *Database) ForEachDocID(callback ForEachDocIDFunc, resultsOpts ForEachD
 // Iterate over the results of an AllDocs query, performing ForEachDocID handling for each row
 func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit uint64, results sgbucket.QueryResultIterator) error {
 
-	endOfResultsReached := false
 	count := uint64(0)
 	for {
 		var queryRow AllDocsIndexQueryRow
@@ -867,7 +866,6 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 			}
 		}
 		if !found {
-			endOfResultsReached = true
 			break
 		}
 
@@ -883,15 +881,6 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 		}
 
 	}
-
-	// Have to iterate over any remaining results to clear the reader
-	// Otherwise we get "the result must be closed before accessing the meta-data" on close details on CBG-1666
-	if !endOfResultsReached && !db.UseViews() {
-		for results.Next(nil) {
-			// noop to drain results
-		}
-	}
-
 	return nil
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -834,6 +834,7 @@ func (db *Database) ForEachDocID(callback ForEachDocIDFunc, resultsOpts ForEachD
 // Iterate over the results of an AllDocs query, performing ForEachDocID handling for each row
 func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit uint64, results sgbucket.QueryResultIterator) error {
 
+	endOfResultsReached := false
 	count := uint64(0)
 	for {
 		var queryRow AllDocsIndexQueryRow
@@ -866,6 +867,7 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 			}
 		}
 		if !found {
+			endOfResultsReached = true
 			break
 		}
 
@@ -881,6 +883,18 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 		}
 
 	}
+
+	// Have to iterate over any remaining results to clear the reader
+	// Otherwise we get "the result must be closed before accessing the meta-data" on close details on CBG-1666
+	if !endOfResultsReached && !db.UseViews() {
+		for {
+			found := results.Next(nil)
+			if !found {
+				break
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/db/database.go
+++ b/db/database.go
@@ -887,11 +887,8 @@ func (db *Database) processForEachDocIDResults(callback ForEachDocIDFunc, limit 
 	// Have to iterate over any remaining results to clear the reader
 	// Otherwise we get "the result must be closed before accessing the meta-data" on close details on CBG-1666
 	if !endOfResultsReached && !db.UseViews() {
-		for {
-			found := results.Next(nil)
-			if !found {
-				break
-			}
+		for results.Next(nil) {
+			// noop to drain results
 		}
 	}
 

--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -45,8 +45,8 @@ licenses/APL2.txt.
   <project name="go-couchbase" path="godeps/src/github.com/couchbase/go-couchbase" remote="couchbase" revision="74908f5398d1b5e28a4c8873a7c8931076ad81e3"/>
 
   <!-- gocb v2 -->
-  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="7edf8dda70989588940f2649d6ba72b9253aab12" />
-  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="e0632bbd0c3dabf618b8170eb3bffb0862b9ee9a"/>
+  <project name="gocb" path="godeps/src/github.com/couchbase/gocb/v2" remote="couchbase" revision="3fc028aaec8b9dee5d525e98eb92dacdcbb82aba" />
+  <project name="gocbcore" path="godeps/src/github.com/couchbase/gocbcore/v10" remote="couchbase" revision="ed9bb8e33e28683bee2cf609a6c7467b5167b30d"/>
   <project name="golang-snappy"  path="godeps/src/github.com/golang/snappy" remote="couchbasedeps" revision="723cc1e459b8eea2dea4583200fd60757d40097a" />
 
   <!-- gocb v1 -->

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -1998,7 +1998,7 @@ func TestAllDocsAccessControl(t *testing.T) {
 	allDocsResult = allDocsResponse{}
 	err = base.JSONUnmarshal(response.Body.Bytes(), &allDocsResult)
 	assert.NoError(t, err)
-	goassert.Equals(t, len(allDocsResult.Rows), 1)
+	require.Equal(t, 1, len(allDocsResult.Rows))
 	goassert.Equals(t, allDocsResult.Rows[0].ID, "doc3")
 	goassert.DeepEquals(t, allDocsResult.Rows[0].Value.Channels, []string{"Cinemax"})
 


### PR DESCRIPTION
CBG-1666

Calling `results.Close()` on GSI results in gocb v2 requires the results to be exhausted. In the event where we have a limit we are stopping when we hit this limit and not exhausting the rows, resulting in the `the result must be closed before accessing the meta-data` error. 

Fixed by just adding a for loop which iterates through any remaining results and just no-opping on each. This operation is performed when results.Close() is called.

This is already tested by `TestAllDocsAccessControl`, however we only hit this error in the GSI case which is not currently part of our standard integration tests, due to underperforming box.

Additionally made a fix to that existing test just to require on the length. Previously this test would panic due to this problem. 

**Considerations**
1. Considered making all_docs take limit, however, filtering needs to be done locally on SGW for channel access so this isn't possible
2. Considered adding pagination work to again, avoid ending up with un-used results, however, this is involved as it requires using start / end sequences to avoid duplicate results.

In the end the approach in this PR is preferable to the above. Although 2 may work well the work to refactor allDocs to handle this is significant and is not worth it given that this endpoint is being deprecated.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1121/

GSI:
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1136/
