### PR TITLE
CBG-1658: Updating db with name via PUT is rejected

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -437,7 +437,14 @@ func (h *handler) handlePutDbConfig() (err error) {
 
 	// Set dbName based on path value (since db doesn't necessarily exist), and update in incoming config in case of insert
 	dbName := h.PathVar("db")
-	dbConfig.Name = dbName
+	if dbConfig.Name != "" && dbName != dbConfig.Name {
+		return base.HTTPErrorf(http.StatusBadRequest, "Cannot update database name. "+
+			"This requires removing and re-creating the database with a new name")
+	}
+
+	if dbConfig.Name == "" {
+		dbConfig.Name = dbName
+	}
 
 	var updatedDbConfig *DatabaseConfig
 	if h.server.persistentConfig {


### PR DESCRIPTION
CBG-1658

Reject database updates which specify a different db name to the current one.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1076/
