### PR TITLE
CBG-1678: Support non-default config group IDs in automatic config upgrade

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -57,7 +58,13 @@ type LegacyServerConfig struct {
 	AdminInterfaceAuthentication              *bool                          `json:"admin_interface_authentication,omitempty" help:"Whether the admin API requires authentication"`
 	MetricsInterfaceAuthentication            *bool                          `json:"metrics_interface_authentication,omitempty" help:"Whether the metrics API requires authentication"`
 	EnableAdminAuthenticationPermissionsCheck *bool                          `json:"enable_advanced_auth_dp,omitempty" help:"Whether to enable the permissions check feature of admin auth"`
-	Replications                              interface{}                    `json:"replications,omitempty"` // Functionality removed. Used to log message to user to switch to ISGR
+	ConfigUpgradeGroupID                      string                         `json:"config_upgrade_group_id,omitempty"` // If set, determines the config group ID used when this legacy config is upgraded to a persistent config.
+	RemovedLegacyServerConfig
+}
+
+// RemovedLegacyServerConfig are fields that used to be deprecated in a legacy config, but are now only present to log information about their removal.
+type RemovedLegacyServerConfig struct {
+	Replications interface{} `json:"replications,omitempty"` // Functionality removed. Used to log message to user to switch to ISGR
 }
 
 type FacebookConfigLegacy struct {
@@ -126,6 +133,13 @@ func (lc *LegacyServerConfig) ToStartupConfig() (*StartupConfig, DbConfigMap, er
 			UseTLSServer:        lc.UseTLSServer,
 		}
 		break
+	}
+
+	if lc.ConfigUpgradeGroupID != "" {
+		if !base.IsEnterpriseEdition() {
+			return nil, nil, errors.New("customization of config_upgrade_group_id is only supported in enterprise edition")
+		}
+		bsc.ConfigGroupID = lc.ConfigUpgradeGroupID
 	}
 
 	sc := StartupConfig{

--- a/rest/main.go
+++ b/rest/main.go
@@ -233,7 +233,12 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 			return nil, false, err
 		}
 
-		_, err = cluster.InsertConfig(*dbc.Bucket, startupConfig.Bootstrap.ConfigGroupID, dbc)
+		configGroupID := persistentConfigDefaultGroupID
+		if startupConfig.Bootstrap.ConfigGroupID != "" {
+			configGroupID = startupConfig.Bootstrap.ConfigGroupID
+		}
+
+		_, err = cluster.InsertConfig(*dbc.Bucket, configGroupID, dbc)
 		if err != nil {
 			// If key already exists just continue
 			if errors.Is(err, base.ErrAlreadyExists) {

--- a/rest/main.go
+++ b/rest/main.go
@@ -233,16 +233,16 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 			return nil, false, err
 		}
 
-		_, err = cluster.InsertConfig(*dbc.Bucket, persistentConfigDefaultGroupID, dbc)
+		_, err = cluster.InsertConfig(*dbc.Bucket, startupConfig.Bootstrap.ConfigGroupID, dbc)
 		if err != nil {
 			// If key already exists just continue
 			if errors.Is(err, base.ErrAlreadyExists) {
-				base.Infof(base.KeyAll, "Skipping Couchbase Server persistence for %s. Already exists.", base.UD(dbc.Name))
+				base.Infof(base.KeyAll, "Skipping Couchbase Server persistence for config group %q in %s. Already exists.", startupConfig.Bootstrap.ConfigGroupID, base.UD(dbc.Name))
 				continue
 			}
 			return nil, false, err
 		}
-		base.Infof(base.KeyAll, "Persisted database %s config to Couchbase Server bucket: %s", base.UD(dbc.Name), base.MD(*dbc.Bucket))
+		base.Infof(base.KeyAll, "Persisted database %s config for group %q to Couchbase Server bucket: %s", base.UD(dbc.Name), startupConfig.Bootstrap.ConfigGroupID, base.MD(*dbc.Bucket))
 	}
 
 	// Attempt to backup current config

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -48,6 +48,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	startupConfig, _, err := automaticConfigUpgrade(configPath)
 	require.NoError(t, err)
 
+	assert.Equal(t, "", startupConfig.Bootstrap.ConfigGroupID)
 	assert.Equal(t, base.UnitTestUrl(), startupConfig.Bootstrap.Server)
 	assert.Equal(t, base.TestClusterUsername(), startupConfig.Bootstrap.Username)
 	assert.Equal(t, base.TestClusterPassword(), startupConfig.Bootstrap.Password)
@@ -61,6 +62,7 @@ func TestAutomaticConfigUpgrade(t *testing.T) {
 	err = json.Unmarshal(writtenNewFile, &writtenFileStartupConfig)
 	require.NoError(t, err)
 
+	assert.Equal(t, "", startupConfig.Bootstrap.ConfigGroupID)
 	assert.Equal(t, base.UnitTestUrl(), writtenFileStartupConfig.Bootstrap.Server)
 	assert.Equal(t, base.TestClusterUsername(), writtenFileStartupConfig.Bootstrap.Username)
 	assert.Equal(t, base.TestClusterPassword(), writtenFileStartupConfig.Bootstrap.Password)
@@ -150,7 +152,7 @@ func TestAutomaticConfigUpgradeError(t *testing.T) {
 	}
 }
 
-func TestAutomaticConfigUpgradeExistingConfig(t *testing.T) {
+func TestAutomaticConfigUpgradeExistingConfigAndNewGroup(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("CBS required")
 	}
@@ -211,10 +213,56 @@ func TestAutomaticConfigUpgradeExistingConfig(t *testing.T) {
 	}()
 
 	var dbConfig DbConfig
-	_, err = cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+	originalDefaultDbConfigCAS, err := cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
 	assert.NoError(t, err)
 
 	// Ensure that revs limit hasn't actually been set
 	assert.Nil(t, dbConfig.RevsLimit)
 
+	// Now attempt an upgrade for a non-default group ID, and ensure it's written correctly, and separately from the default group.
+	const configUpgradeGroupID = "import"
+
+	importConfigRaw := `
+	{
+		"config_upgrade_group_id": "%s",
+		"databases": {
+			"db": {
+				"enable_shared_bucket_access": true,
+				"import_docs": true,
+				"server": "%s",
+				"username": "%s",
+				"password": "%s",
+				"bucket": "%s"
+			}
+		}
+	}`
+
+	importConfig := fmt.Sprintf(importConfigRaw, configUpgradeGroupID, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+	importConfigPath := filepath.Join(tmpDir, "config-import.json")
+	err = ioutil.WriteFile(importConfigPath, []byte(importConfig), os.FileMode(0644))
+	require.NoError(t, err)
+
+	startupConfig, _, err = automaticConfigUpgrade(importConfigPath)
+	// only supported in EE
+	if base.IsEnterpriseEdition() {
+		require.NoError(t, err)
+
+		// Ensure that startupConfig group ID has been set
+		assert.Equal(t, configUpgradeGroupID, startupConfig.Bootstrap.ConfigGroupID)
+
+		// Ensure dbConfig is saved as the specified config group ID
+		var dbConfig DbConfig
+		_, err = cbs.GetConfig(tb.GetName(), configUpgradeGroupID, &dbConfig)
+		assert.NoError(t, err)
+
+		// Ensure default has not changed
+		dbConfig = DbConfig{}
+		defaultDbConfigCAS, err := cbs.GetConfig(tb.GetName(), persistentConfigDefaultGroupID, &dbConfig)
+		assert.NoError(t, err)
+		assert.Equal(t, originalDefaultDbConfigCAS, defaultDbConfigCAS)
+	} else {
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "only supported in enterprise edition")
+		assert.Nil(t, startupConfig)
+	}
 }


### PR DESCRIPTION
CBG-1678

- Allows `config_upgrade_group_id` to be specified in a legacy config prior to automatic persistent config migration to set a non-default config group ID.
  - Persists the database configs under the custom group ID doc key, separate from default configs.
  - Persists the bootstrap config with the custom group ID, and starts up SG using this group.
- Moved `Replications` field to new embedded `RemovedLegacyServerConfig` struct for clarity.


## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1092/
