### PR TITLE
CBG-1656 - DB Unsupported config is a pointer as well as inner structs

### DIFF
--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -318,7 +318,7 @@ func (c *changeCache) CleanSkippedSequenceQueue(ctx context.Context) error {
 	var foundEntries []*LogEntry
 	var pendingRemovals []uint64
 
-	if c.context.Options.UnsupportedOptions.DisableCleanSkippedQuery == true {
+	if c.context.Options.UnsupportedOptions != nil && c.context.Options.UnsupportedOptions.DisableCleanSkippedQuery {
 		pendingRemovals = append(pendingRemovals, oldSkippedSequences...)
 		oldSkippedSequences = nil
 	}

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -477,13 +477,18 @@ func (m *sgReplicateManager) StartReplications() error {
 
 // NewActiveReplicatorConfig converts an incoming ReplicationCfg to an ActiveReplicatorConfig
 func (m *sgReplicateManager) NewActiveReplicatorConfig(config *ReplicationCfg) (rc *ActiveReplicatorConfig, err error) {
+	insecureSkipVerify := false
+	if m.dbContext.Options.UnsupportedOptions != nil {
+		insecureSkipVerify = m.dbContext.Options.UnsupportedOptions.SgrTlsSkipVerify
+	}
+
 	rc = &ActiveReplicatorConfig{
 		ID:                 config.ID,
 		Continuous:         config.Continuous,
 		ActiveDB:           &Database{DatabaseContext: m.dbContext}, // sg-replicate interacts with local as admin
 		PurgeOnRemoval:     config.PurgeOnRemoval,
 		DeltasEnabled:      config.DeltaSyncEnabled,
-		InsecureSkipVerify: m.dbContext.Options.UnsupportedOptions.SgrTlsSkipVerify,
+		InsecureSkipVerify: insecureSkipVerify,
 		CheckpointInterval: m.CheckpointInterval,
 	}
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2932,15 +2932,15 @@ func TestChannelNameSizeWarningBoundaries(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			var thresholdConfig db.WarningThresholds
+			var thresholdConfig *db.WarningThresholds
 			// If threshold is not default then configure it
 			if test.warnThresholdLength != base.DefaultWarnThresholdChannelNameSize {
-				thresholdConfig = db.WarningThresholds{ChannelNameSize: &test.warnThresholdLength}
+				thresholdConfig = &db.WarningThresholds{ChannelNameSize: &test.warnThresholdLength}
 			}
 			rt = NewRestTester(t, &RestTesterConfig{
 				SyncFn: syncFn,
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
-					Unsupported: db.UnsupportedOptions{
+					Unsupported: &db.UnsupportedOptions{
 						WarningThresholds: thresholdConfig,
 					}},
 				},

--- a/rest/config.go
+++ b/rest/config.go
@@ -127,7 +127,7 @@ type DbConfig struct {
 	CacheConfig                      *CacheConfig                     `json:"cache,omitempty"`                                // Cache settings
 	DeprecatedRevCacheSize           *uint32                          `json:"rev_cache_size,omitempty"`                       // Maximum number of revisions to store in the revision cache (deprecated, CBG-356)
 	StartOffline                     *bool                            `json:"offline,omitempty"`                              // start the DB in the offline state, defaults to false
-	Unsupported                      db.UnsupportedOptions            `json:"unsupported,omitempty"`                          // Config for unsupported features
+	Unsupported                      *db.UnsupportedOptions           `json:"unsupported,omitempty"`                          // Config for unsupported features
 	OIDCConfig                       *auth.OIDCOptions                `json:"oidc,omitempty"`                                 // Config properties for OpenID Connect authentication
 	OldRevExpirySeconds              *uint32                          `json:"old_rev_expiry_seconds,omitempty"`               // The number of seconds before old revs are removed from CBS bucket
 	ViewQueryTimeoutSecs             *uint32                          `json:"view_query_timeout_secs,omitempty"`              // The view query timeout in seconds
@@ -278,9 +278,14 @@ func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig) 
 		}
 	}
 
+	insecureSkipVerify := false
+	if dbConfig.Unsupported != nil {
+		insecureSkipVerify = dbConfig.Unsupported.RemoteConfigTlsSkipVerify
+	}
+
 	// Load Sync Function.
 	if dbConfig.Sync != nil {
-		sync, err := loadJavaScript(*dbConfig.Sync, dbConfig.Unsupported.RemoteConfigTlsSkipVerify)
+		sync, err := loadJavaScript(*dbConfig.Sync, insecureSkipVerify)
 		if err != nil {
 			return &JavaScriptLoadError{
 				JSLoadType: SyncFunction,
@@ -293,7 +298,7 @@ func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig) 
 
 	// Load Import Filter Function.
 	if dbConfig.ImportFilter != nil {
-		importFilter, err := loadJavaScript(*dbConfig.ImportFilter, dbConfig.Unsupported.RemoteConfigTlsSkipVerify)
+		importFilter, err := loadJavaScript(*dbConfig.ImportFilter, insecureSkipVerify)
 		if err != nil {
 			return &JavaScriptLoadError{
 				JSLoadType: ImportFilter,
@@ -307,7 +312,7 @@ func (dbConfig *DbConfig) setup(dbName string, bootstrapConfig BootstrapConfig) 
 	// Load Conflict Resolution Function.
 	for _, rc := range dbConfig.Replications {
 		if rc.ConflictResolutionFn != "" {
-			conflictResolutionFn, err := loadJavaScript(rc.ConflictResolutionFn, dbConfig.Unsupported.RemoteConfigTlsSkipVerify)
+			conflictResolutionFn, err := loadJavaScript(rc.ConflictResolutionFn, insecureSkipVerify)
 			if err != nil {
 				return &JavaScriptLoadError{
 					JSLoadType: ConflictResolver,

--- a/rest/config_test.go
+++ b/rest/config_test.go
@@ -1581,7 +1581,7 @@ func TestSetupDbConfigWithSyncFunction(t *testing.T) {
 				Sync: base.StringPtr(sync),
 			}
 			if test.insecureSkipVerify {
-				dbConfig.Unsupported = db.UnsupportedOptions{
+				dbConfig.Unsupported = &db.UnsupportedOptions{
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
@@ -1681,7 +1681,7 @@ func TestSetupDbConfigWithImportFilterFunction(t *testing.T) {
 				ImportFilter: base.StringPtr(importFilter),
 			}
 			if test.insecureSkipVerify {
-				dbConfig.Unsupported = db.UnsupportedOptions{
+				dbConfig.Unsupported = &db.UnsupportedOptions{
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
@@ -1793,7 +1793,7 @@ func TestSetupDbConfigWithConflictResolutionFunction(t *testing.T) {
 				},
 			}
 			if test.insecureSkipVerify {
-				dbConfig.Unsupported = db.UnsupportedOptions{
+				dbConfig.Unsupported = &db.UnsupportedOptions{
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}
@@ -1897,7 +1897,7 @@ func TestWebhookFilterFunctionLoad(t *testing.T) {
 				},
 			}
 			if test.insecureSkipVerify {
-				dbConfig.Unsupported = db.UnsupportedOptions{
+				dbConfig.Unsupported = &db.UnsupportedOptions{
 					RemoteConfigTlsSkipVerify: true,
 				}
 			}

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -390,7 +390,8 @@ func (h *handler) checkAuth(context *db.DatabaseContext) (err error) {
 		* and the username and password match those in the oidc default provider config
 		* then authorize this request
 		 */
-		if context.Options.UnsupportedOptions.OidcTestProvider.Enabled && strings.HasSuffix(h.rq.URL.Path, "/_oidc_testing/token") {
+		if strings.HasSuffix(h.rq.URL.Path, "/_oidc_testing/token") && context.Options.UnsupportedOptions != nil &&
+			context.Options.UnsupportedOptions.OidcTestProvider != nil && context.Options.UnsupportedOptions.OidcTestProvider.Enabled {
 			if username, password := h.getBasicAuth(); username != "" && password != "" {
 				provider := context.Options.OIDCOptions.Providers.GetProviderForIssuer(issuerUrlForDB(h, context.Name), testProviderAudiences)
 				if provider != nil && provider.ValidationKey != nil {

--- a/rest/oidc_test_provider.go
+++ b/rest/oidc_test_provider.go
@@ -148,7 +148,8 @@ var authCodeTokenMap = make(map[string]AuthState)
  * Returns the OpenID provider configuration info
  */
 func (h *handler) handleOidcProviderConfiguration() error {
-	if !h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider != nil &&
+		!h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
@@ -190,7 +191,8 @@ type AuthorizeParameters struct {
  * which is part of an internal authentication flow
  */
 func (h *handler) handleOidcTestProviderAuthorize() error {
-	if !h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider != nil &&
+		!h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
@@ -252,7 +254,8 @@ type OidcTokenResponse struct {
  * Return tokens for Auth code flow
  */
 func (h *handler) handleOidcTestProviderToken() error {
-	if !h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider != nil &&
+		!h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
@@ -274,7 +277,8 @@ func (h *handler) handleOidcTestProviderToken() error {
  * Return public certificates for signing keys
  */
 func (h *handler) handleOidcTestProviderCerts() error {
-	if !h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider != nil &&
+		!h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 
@@ -309,7 +313,8 @@ func (h *handler) handleOidcTestProviderCerts() error {
  * Return an OAuth 2.0 Authorization Response
  */
 func (h *handler) handleOidcTestProviderAuthenticate() error {
-	if !h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
+	if h.db.DatabaseContext.Options.UnsupportedOptions != nil && h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider != nil &&
+		!h.db.DatabaseContext.Options.UnsupportedOptions.OidcTestProvider.Enabled {
 		return base.HTTPErrorf(http.StatusForbidden, "OIDC test provider is not enabled")
 	}
 

--- a/rest/oidc_test_provider_test.go
+++ b/rest/oidc_test_provider_test.go
@@ -143,8 +143,8 @@ func restTesterConfigWithTestProviderEnabled() RestTesterConfig {
 	restTesterConfig := RestTesterConfig{
 		DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 			OIDCConfig: &opts,
-			Unsupported: db.UnsupportedOptions{
-				OidcTestProvider: db.OidcTestProviderOptions{
+			Unsupported: &db.UnsupportedOptions{
+				OidcTestProvider: &db.OidcTestProviderOptions{
 					Enabled: true,
 				},
 			},
@@ -295,8 +295,8 @@ func TestOpenIDConnectTestProviderWithRealWorldToken(t *testing.T) {
 			restTesterConfig := RestTesterConfig{
 				DatabaseConfig: &DatabaseConfig{DbConfig: DbConfig{
 					OIDCConfig: &opts,
-					Unsupported: db.UnsupportedOptions{
-						OidcTestProvider: db.OidcTestProviderOptions{
+					Unsupported: &db.UnsupportedOptions{
+						OidcTestProvider: &db.OidcTestProviderOptions{
 							Enabled: true,
 						},
 					},


### PR DESCRIPTION
CBG-1656

- Unsupported struct changed to pointer
- Inner structs in UnsupportedOptions change to pointer
- Added lots of nil checks including chained nil checks when checking a variable in a struct, thats in a struct. EG: `if UnsupportedOptions != nil && UnsupportedOptions.OidcTestProvider != nil && !UnsupportedOptions.OidcTestProvider.Enabled {`

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1080/
  - 1 failure unrelated to changes

Tested manually with new bucket and config to make sure `/db/_config` endpoint does not show UnsupportedOptions. `/db/_config?include_runtime=true` does include UnsupportedOptions with WarningThresholds only as intended.
