### PR TITLE
CBG-1686: Cleanup perms and Read Only fix

### DIFF
--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -943,7 +943,7 @@ func TestAdminAPIAuth(t *testing.T) {
 					assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
 				} else {
 					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "ROAdminUser", "password")
-					if endPoint.Method == http.MethodGet || endPoint.Method == http.MethodHead {
+					if endPoint.Method == http.MethodGet || endPoint.Method == http.MethodHead || endPoint.Method == http.MethodOptions {
 						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
 					} else {
 						assertStatus(t, resp, http.StatusForbidden)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -324,6 +324,7 @@ func TestAdminAuth(t *testing.T) {
 		Name                string
 		Username            string
 		Password            string
+		Operation           string
 		CheckPermissions    []Permission
 		ResponsePermissions []Permission
 		ExpectedStatusCode  int
@@ -386,6 +387,7 @@ func TestAdminAuth(t *testing.T) {
 			Name:               "MissingPermissionHasRole",
 			Username:           "MissingPermissionHasRole",
 			Password:           "password",
+			Operation:          "GET",
 			CheckPermissions:   []Permission{clusterAdminPermission},
 			ExpectedStatusCode: http.StatusOK,
 			CreateUser:         "MissingPermissionHasRole",
@@ -437,7 +439,7 @@ func TestAdminAuth(t *testing.T) {
 				defer DeleteUser(t, managementEndpoints[0], testCase.CreateUser)
 			}
 
-			permResults, statusCode, err := checkAdminAuth(testCase.BucketName, testCase.Username, testCase.Password, "", httpClient, managementEndpoints, true, testCase.CheckPermissions, testCase.ResponsePermissions)
+			permResults, statusCode, err := checkAdminAuth(testCase.BucketName, testCase.Username, testCase.Password, testCase.Operation, httpClient, managementEndpoints, true, testCase.CheckPermissions, testCase.ResponsePermissions)
 
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.ExpectedStatusCode, statusCode)
@@ -941,10 +943,10 @@ func TestAdminAPIAuth(t *testing.T) {
 					assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
 				} else {
 					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "ROAdminUser", "password")
-					if endPoint.Method == http.MethodPut || endPoint.Method == http.MethodPost {
-						assertStatus(t, resp, http.StatusForbidden)
-					} else {
+					if endPoint.Method == http.MethodGet || endPoint.Method == http.MethodHead {
 						assert.True(t, resp.Code != http.StatusUnauthorized && resp.Code != http.StatusForbidden)
+					} else {
+						assertStatus(t, resp, http.StatusForbidden)
 					}
 
 					resp = rt.SendAdminRequestWithAuth(endPoint.Method, formattedEndpoint, body, "ClusterAdminUser", "password")

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -477,10 +477,10 @@ func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, att
 	if bucketName != "" {
 		requestRoles = BucketScopedEndpointRoles
 	} else {
-		if attemptedHTTPOperation == http.MethodPut || attemptedHTTPOperation == http.MethodPost {
-			requestRoles = ClusterScopedEndpointRolesWrite
-		} else {
+		if attemptedHTTPOperation == http.MethodGet || attemptedHTTPOperation == http.MethodHead {
 			requestRoles = ClusterScopedEndpointRolesRead
+		} else {
+			requestRoles = ClusterScopedEndpointRolesWrite
 		}
 	}
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -477,7 +477,7 @@ func checkAdminAuth(bucketName, basicAuthUsername, basicAuthPassword string, att
 	if bucketName != "" {
 		requestRoles = BucketScopedEndpointRoles
 	} else {
-		if attemptedHTTPOperation == http.MethodGet || attemptedHTTPOperation == http.MethodHead {
+		if attemptedHTTPOperation == http.MethodGet || attemptedHTTPOperation == http.MethodHead || attemptedHTTPOperation == http.MethodOptions {
 			requestRoles = ClusterScopedEndpointRolesRead
 		} else {
 			requestRoles = ClusterScopedEndpointRolesWrite

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -151,7 +151,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermReadAppData}, nil, (*handler).handleGetRevTree)).Methods("GET")
 
 	dbr.Handle("/_user/",
-		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, []Permission{PermReadPrincipal}, (*handler).getUsers)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, nil, (*handler).getUsers)).Methods("GET", "HEAD")
 	dbr.Handle("/_user/",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putUser)).Methods("POST")
 	dbr.Handle("/_user/{name}",
@@ -167,7 +167,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).deleteUserSession)).Methods("DELETE")
 
 	dbr.Handle("/_role/",
-		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, []Permission{PermReadPrincipal}, (*handler).getRoles)).Methods("GET", "HEAD")
+		makeHandler(sc, adminPrivs, []Permission{PermReadPrincipal}, nil, (*handler).getRoles)).Methods("GET", "HEAD")
 	dbr.Handle("/_role/",
 		makeHandler(sc, adminPrivs, []Permission{PermWritePrincipal}, nil, (*handler).putRole)).Methods("POST")
 	dbr.Handle("/_role/{name}",


### PR DESCRIPTION
CBG-1686

Removed some unnecessary response permissions as these were left from changed perms
 - Note this doesn't affect functionality anything but might as well clean up

Fixed a Read / Write issue. We explicitly checked for PUT / POST previously, however, this didn't include DELETE. Flipped this around to check for GET / HEAD too as this seems safer.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1081/
