### PR TITLE
CBG-1545/CBG-1598: Fix TestRevocationResumeAndLowSeqCheck & TestRevocationResumeSameRoleAndLowSeqCheck

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -6460,7 +6460,11 @@ func (tester *ChannelRevocationTester) fillToSeq(seq uint64) {
 func (tester *ChannelRevocationTester) getChanges(sinceSeq interface{}, expectedLength int) changesResults {
 	var changes changesResults
 
-	err := tester.restTester.WaitForCondition(func() bool {
+	// Ensure any previous mutations have caught up before issuing changes request
+	err := tester.restTester.WaitForPendingChanges()
+	assert.NoError(tester.test, err)
+
+	err = tester.restTester.WaitForCondition(func() bool {
 		resp := tester.restTester.SendUserRequestWithHeaders("GET", fmt.Sprintf("/db/_changes?since=%v&revocations=true", sinceSeq), "", nil, "user", "test")
 		require.Equal(tester.test, http.StatusOK, resp.Code)
 		err := json.Unmarshal(resp.BodyBytes(), &changes)


### PR DESCRIPTION
CBG-1545 / CBG-1598

This PR aims to fix the flaky-ness seen in `TestRevocationResumeAndLowSeqCheck` and `TestRevocationResumeSameRoleAndLowSeqCheck`. 
I believe the issue was in a few cases getChanges ended up getting called before the document mutation went through. Due to the fact that these weren't 'new' docs in the channel but mutations the standard getChanges loop didn't catch them. 
I've tested this by running each test literally thousands of times with a `-count` flag and although far from reliable I was able to get it to fail a few times without this fix and was unable to reproduce it with the fix. 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1087/
One unrelated fail
