### PR TITLE
CBG-1624: Allow per-database credential overrides from startup config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -68,7 +68,8 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't save database config: %v", err)
 		}
 
-		if err := persistedConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+		dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
+		if err := persistedConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
 			return err
 		}
 
@@ -77,7 +78,7 @@ func (h *handler) handleCreateDB() error {
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't load database: %v", err)
 		}
 	} else {
-		if err := config.setup(dbName, h.server.config.Bootstrap); err != nil {
+		if err := config.setup(dbName, h.server.config.Bootstrap, nil); err != nil {
 			return err
 		}
 
@@ -165,6 +166,13 @@ func (h *handler) handleGetDbConfig() error {
 		}
 
 		responseConfig = &dbConfig.DbConfig
+
+		// Strip out bootstrap credentials that are stamped into the config
+		responseConfig.Username = ""
+		responseConfig.Password = ""
+		responseConfig.CACertPath = ""
+		responseConfig.KeyPath = ""
+		responseConfig.CertPath = ""
 	} else {
 		// non-persistent mode just returns running database config
 		responseConfig = h.server.GetDbConfig(h.db.Name)
@@ -210,13 +218,6 @@ func (h *handler) handleGetDbConfig() error {
 			}
 		}
 	}
-
-	// Strip out credentials that are stamped into the config
-	responseConfig.Username = ""
-	responseConfig.Password = ""
-	responseConfig.CACertPath = ""
-	responseConfig.KeyPath = ""
-	responseConfig.CertPath = ""
 
 	h.writeJSON(responseConfig)
 	return nil
@@ -512,7 +513,8 @@ func (h *handler) handlePutDbConfig() (err error) {
 		}
 	}
 
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
 		return err
 	}
 
@@ -599,7 +601,8 @@ func (h *handler) handleDeleteDbConfigSync() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
 		return err
 	}
 
@@ -665,7 +668,8 @@ func (h *handler) handlePutDbConfigSync() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
 		return err
 	}
 
@@ -748,7 +752,8 @@ func (h *handler) handleDeleteDbConfigImportFilter() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
 		return err
 	}
 
@@ -814,7 +819,8 @@ func (h *handler) handlePutDbConfigImportFilter() error {
 	updatedDbConfig.cas = cas
 
 	dbName := h.db.Name
-	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap); err != nil {
+	dbCreds, _ := h.server.config.DatabaseCredentials[dbName]
+	if err := updatedDbConfig.setup(dbName, h.server.config.Bootstrap, dbCreds); err != nil {
 		return err
 	}
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2615,7 +2615,7 @@ func TestConfigRedaction(t *testing.T) {
 	err := json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "", unmarshaledConfig.Password)
+	assert.Equal(t, "xxxxx", unmarshaledConfig.Password)
 	assert.Equal(t, "xxxxx", *unmarshaledConfig.Users["alice"].Password)
 
 	// Test default db config redaction when redaction disabled
@@ -2623,7 +2623,7 @@ func TestConfigRedaction(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "", unmarshaledConfig.Password)
+	assert.Equal(t, "password", unmarshaledConfig.Password)
 	assert.Equal(t, "password", *unmarshaledConfig.Users["alice"].Password)
 
 	// Test default server config redaction

--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -386,7 +386,7 @@ func setupServerConfig(args []string) (config *LegacyServerConfig, err error) {
 
 func setupAndValidateDatabases(databases DbConfigMap) error {
 	for name, dbConfig := range databases {
-		if err := dbConfig.setup(name, BootstrapConfig{}); err != nil {
+		if err := dbConfig.setup(name, BootstrapConfig{}, nil); err != nil {
 			return err
 		}
 		if err := dbConfig.validateSgDbConfig(); err != nil {

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -67,6 +67,8 @@ type StartupConfig struct {
 	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
 	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
 
+	DatabaseCredentials map[string]*DatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones."`
+
 	MaxFileDescriptors uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 
 	DeprecatedConfig *DeprecatedConfig `json:"-,omitempty" help:"Deprecated options that can be set from a legacy config upgrade, but cannot be set from a 3.0 config."`
@@ -143,6 +145,13 @@ type HTTP2Config struct {
 	Enabled *bool `json:"enabled,omitempty" help:"Whether HTTP2 support is enabled"`
 }
 
+type DatabaseCredentialsConfig struct {
+	Username     string `json:"username,omitempty"       help:"Username for authenticating to the bucket"`
+	Password     string `json:"password,omitempty"       help:"Password for authenticating to the bucket"`
+	X509CertPath string `json:"x509_cert_path,omitempty" help:"Cert path (public key) for X.509 bucket auth"`
+	X509KeyPath  string `json:"x509_key_path,omitempty"  help:"Key path (private key) for X.509 bucket auth"`
+}
+
 type DeprecatedConfig struct {
 	Facebook *FacebookConfigLegacy `json:"-" help:""`
 	Google   *GoogleConfigLegacy   `json:"-" help:""`
@@ -157,6 +166,10 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 	}
 
 	config.Bootstrap.Password = "xxxxx"
+
+	for _, credentialsConfig := range config.DatabaseCredentials {
+		credentialsConfig.Password = "xxxxx"
+	}
 
 	return &config, nil
 }

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -67,7 +67,7 @@ type StartupConfig struct {
 	Replicator  ReplicatorConfig   `json:"replicator,omitempty"`
 	Unsupported UnsupportedConfig  `json:"unsupported,omitempty"`
 
-	DatabaseCredentials map[string]*DatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones."`
+	DatabaseCredentials PerDatabaseCredentialsConfig `json:"database_credentials,omitempty" help:"A map of database name to credentials, that can be used instead of the bootstrap ones."`
 
 	MaxFileDescriptors uint64 `json:"max_file_descriptors,omitempty" help:"Max # of open file descriptors (RLIMIT_NOFILE)"`
 
@@ -145,6 +145,8 @@ type HTTP2Config struct {
 	Enabled *bool `json:"enabled,omitempty" help:"Whether HTTP2 support is enabled"`
 }
 
+type PerDatabaseCredentialsConfig map[string]*DatabaseCredentialsConfig
+
 type DatabaseCredentialsConfig struct {
 	Username     string `json:"username,omitempty"       help:"Username for authenticating to the bucket"`
 	Password     string `json:"password,omitempty"       help:"Password for authenticating to the bucket"`
@@ -165,10 +167,14 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 		return nil, err
 	}
 
-	config.Bootstrap.Password = "xxxxx"
+	if config.Bootstrap.Password != "" {
+		config.Bootstrap.Password = "xxxxx"
+	}
 
 	for _, credentialsConfig := range config.DatabaseCredentials {
-		credentialsConfig.Password = "xxxxx"
+		if credentialsConfig != nil && credentialsConfig.Password != "" {
+			credentialsConfig.Password = "xxxxx"
+		}
 	}
 
 	return &config, nil


### PR DESCRIPTION
CBG-1624

Allows per-database credentials to be set that override the bootstrap credentials.

### Config example:
```
{
  "bootstrap": {
    "username": "bob",
    "password": "secret"
  },
  "database_credentials": {
    "db1": {
      "username": "alice",
      "password": "hunter2"
    },
    "db2": {
      "x509_cert_path": "/tmp/foo",
      "x509_key_path": "/tmp/bar"
    }
  }
}
```

In this case, bootstrap to retrieve dbconfigs happens as bob, but then whenever we create or open a database matching the name in the config, we will use those credentials instead of the bootstrap ones.

## REST API Changes
- `GET /_config` now returns the `database_credentials` section of the config to reflect the config file on disk.
- `GET /_config?include_runtime=true` now shows per-database credentials inside each running database config to reflect the running state of each database.
- `GET /{db}/_config?include_runtime=false` has no change (the dbconfig stored in the bucket remains unchanged with per-db overrides)
- `GET /{db}/_config?include_runtime=true` now shows per-database credentials when set
- Redaction is applied to passwords on all of the above scenarios.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1094/
