### PR TITLE
CBG-1619: Wait for successful db startup before persisting config on db create

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -369,10 +369,6 @@ func GetBucket(spec BucketSpec) (bucket Bucket, err error) {
 		}
 
 		if err != nil {
-			if pkgerrors.Cause(err) == ErrAuthError {
-				Warnf("Unable to authenticate as user %q: %v", UD(username), err)
-				return nil, ErrFatalBucketConnection
-			}
 			return nil, err
 		}
 

--- a/base/bucket_gocb_test.go
+++ b/base/bucket_gocb_test.go
@@ -2084,7 +2084,7 @@ func TestCouchbaseServerIncorrectLogin(t *testing.T) {
 
 	// Attempt to open the bucket again using invalid creds. We should expect an error.
 	bucket, err := GetBucket(testBucket.BucketSpec)
-	assert.Equal(t, ErrFatalBucketConnection, err)
+	assert.Equal(t, ErrAuthError, err)
 	assert.Nil(t, bucket)
 }
 

--- a/base/collection.go
+++ b/base/collection.go
@@ -96,9 +96,15 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
-	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, nil)
+	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
+		DesiredState:  gocb.ClusterStateOnline,
+		RetryStrategy: &goCBv2FailFastRetryStrategy{},
+	})
 	if err != nil {
 		_ = cluster.Close(&gocb.ClusterCloseOptions{})
+		if errors.Is(err, gocb.ErrAuthenticationFailure) {
+			return nil, ErrAuthError
+		}
 		Warnf("Error waiting for bucket to be ready: %v", err)
 		return nil, err
 	}

--- a/base/collection.go
+++ b/base/collection.go
@@ -97,7 +97,6 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 	// Connect to bucket
 	bucket := cluster.Bucket(spec.BucketName)
 	err := bucket.WaitUntilReady(time.Duration(waitUntilReadySeconds)*time.Second, &gocb.WaitUntilReadyOptions{
-		DesiredState:  gocb.ClusterStateOnline,
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},
 	})
 	if err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/couchbase/sync_gateway/db"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	pkgerrors "github.com/pkg/errors"
 )
 
 const kDefaultDBOnlineDelay = 0
@@ -341,7 +342,7 @@ func (h *handler) handlePutConfig() error {
 	var config ServerPutConfig
 	err := base.WrapJSONUnknownFieldErr(ReadJSONFromMIMERawErr(h.rq.Header, h.requestBody, &config))
 	if err != nil {
-		if errors.Is(err, base.ErrUnknownField) {
+		if pkgerrors.Cause(err) == base.ErrUnknownField {
 			return base.HTTPErrorf(http.StatusBadRequest, "Unable to configure given options at runtime: %v", err)
 		}
 		return err

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3542,19 +3542,19 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
 
-	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", `{"bucket": "nonExistentBucket"}`)
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", `{"bucket": "nonexistentbucket"}`)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Contains(t, string(body), "auth failure accessing provided bucket using bootstrap credentials: nonExistentBucket")
+	assert.Contains(t, string(body), "auth failure accessing provided bucket: nonexistentbucket")
 
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/nonExistentBucket/", `{}`)
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/nonexistentbucket/", `{}`)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Contains(t, string(body), "auth failure accessing provided bucket using bootstrap credentials: nonExistentBucket")
+	assert.Contains(t, string(body), "auth failure accessing provided bucket: nonexistentbucket")
 }
 
 func TestPutDbConfigChangeName(t *testing.T) {

--- a/rest/config.go
+++ b/rest/config.go
@@ -1051,13 +1051,13 @@ func setupServerContext(config *StartupConfig, persistentConfig bool) (*ServerCo
 // fetchAndLoadConfigs retrieves all database configs from the ServerContext's bootstrapConnection, and loads them into the ServerContext.
 // It will remove any databases currently running that are not found in the bucket.
 func (sc *ServerContext) fetchAndLoadConfigs() (count int, err error) {
+	sc.lock.Lock()
+	defer sc.lock.Unlock()
+
 	fetchedConfigs, bucketsNoConfig, err := sc.fetchConfigs()
 	if err != nil {
 		return 0, err
 	}
-
-	sc.lock.Lock()
-	defer sc.lock.Unlock()
 
 	for _, bucket := range bucketsNoConfig {
 		dbName, ok := sc.bucketDbName[bucket]

--- a/rest/config.go
+++ b/rest/config.go
@@ -1246,6 +1246,9 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig) (applied bool, err err
 
 	// TODO: Dynamic update instead of reload
 	if _, err := sc._reloadDatabaseFromConfig(cnf.Name); err != nil {
+		// remove these entries we just created above if the database hasn't loaded properly
+		delete(sc.dbConfigs, cnf.Name)
+		delete(sc.bucketDbName, *cnf.Bucket)
 		return false, fmt.Errorf("couldn't reload database: %w", err)
 	}
 


### PR DESCRIPTION
CBG-1619

Ensures that the supplied per-database credentials in the startup config are valid by loading the database first, before persisting to the cluster.
- Unloads the database on a failed write to prevent cluster inconsistencies.
- Promoted locking up a level in handleCreateDB to avoid races between background config loop and a failed database creation/removal.

We don't need to validate per-database credentials on update because we know the database has already started up successfully, and must be already using the per-database credentials, if they're set.

## Dependencies
- [x] #5236 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1254/