### PR TITLE
CBG-1427 - Full Body replication is sent when delta source is tombstone

### DIFF
--- a/base/error.go
+++ b/base/error.go
@@ -54,9 +54,9 @@ var (
 	// ErrEmptyDocument is returned when trying to insert a document with a null body.
 	ErrEmptyDocument = &sgError{"Document body is empty"}
 
-	// ErrFromRevIsTombstone is returned to indicate delta sync should do a full body replication due to the
+	// ErrDeltaSourceIsTombstone is returned to indicate delta sync should do a full body replication due to the
 	// delta source being a tombstone (therefore having an empty body)
-	ErrFromRevIsTombstone = &sgError{"From rev is a tombstone"}
+	ErrDeltaSourceIsTombstone = &sgError{"From rev is a tombstone"}
 )
 
 func (e *sgError) Error() string {

--- a/base/error.go
+++ b/base/error.go
@@ -53,6 +53,10 @@ var (
 
 	// ErrEmptyDocument is returned when trying to insert a document with a null body.
 	ErrEmptyDocument = &sgError{"Document body is empty"}
+
+	// ErrFromRevIsTombstone is returned to indicate delta sync should do a full body replication due to the
+	// delta source being a tombstone (therefore having an empty body)
+	ErrFromRevIsTombstone = &sgError{"From rev is a tombstone"}
 )
 
 func (e *sgError) Error() string {

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -683,6 +683,9 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, de
 		// Something went wrong in the diffing library. We want to know about this!
 		base.WarnfCtx(bsc.loggingCtx, "Falling back to full body replication. Error generating delta from %s to %s for key %s - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
 		return bsc.sendRevision(sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseDb)
+	} else if err == base.ErrFromRevIsTombstone {
+		base.TracefCtx(bsc.loggingCtx, base.KeySync, "Falling back to full body replication. Delta source %s is tombstone and delta %s is resurrection for key %s", deltaSrcRevID, revID, base.UD(docID))
+		return bsc.sendRevision(sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseDb)
 	} else if err != nil {
 		base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Falling back to full body replication. Couldn't get delta from %s to %s for key %s - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
 		return bsc.sendRevision(sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseDb)

--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -683,8 +683,8 @@ func (bsc *BlipSyncContext) sendRevAsDelta(sender *blip.Sender, docID, revID, de
 		// Something went wrong in the diffing library. We want to know about this!
 		base.WarnfCtx(bsc.loggingCtx, "Falling back to full body replication. Error generating delta from %s to %s for key %s - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
 		return bsc.sendRevision(sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseDb)
-	} else if err == base.ErrFromRevIsTombstone {
-		base.TracefCtx(bsc.loggingCtx, base.KeySync, "Falling back to full body replication. Delta source %s is tombstone and delta %s is resurrection for key %s", deltaSrcRevID, revID, base.UD(docID))
+	} else if err == base.ErrDeltaSourceIsTombstone {
+		base.TracefCtx(bsc.loggingCtx, base.KeySync, "Falling back to full body replication. Delta source %s is tombstone. Unable to generate delta to %s for key %s", deltaSrcRevID, revID, base.UD(docID))
 		return bsc.sendRevision(sender, docID, revID, seq, knownRevs, maxHistory, handleChangesResponseDb)
 	} else if err != nil {
 		base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Falling back to full body replication. Couldn't get delta from %s to %s for key %s - err: %v", deltaSrcRevID, revID, base.UD(docID), err)

--- a/db/crud.go
+++ b/db/crud.go
@@ -312,7 +312,7 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 
 	// If the fromRevision was a tombstone, then return error to tell delta sync to send full body replication
 	if fromRevision.Deleted {
-		return nil, nil, base.ErrFromRevIsTombstone
+		return nil, nil, base.ErrDeltaSourceIsTombstone
 	}
 
 	// If both body and delta are not available for fromRevId, the delta can't be generated

--- a/db/crud.go
+++ b/db/crud.go
@@ -310,6 +310,11 @@ func (db *Database) GetDelta(docID, fromRevID, toRevID string) (delta *RevisionD
 		return nil, nil, base.HTTPErrorf(404, "missing")
 	}
 
+	// If the fromRevision was a tombstone, then return error to tell delta sync to send full body replication
+	if fromRevision.Deleted {
+		return nil, nil, base.ErrFromRevIsTombstone
+	}
+
 	// If both body and delta are not available for fromRevId, the delta can't be generated
 	if fromRevision.BodyBytes == nil && fromRevision.Delta == nil {
 		return nil, nil, err

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5651,6 +5651,102 @@ func TestReplicatorSwitchPurgeNoReset(t *testing.T) {
 	rt1.waitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 }
 
+// CBG-1427 - ISGR should not try sending a delta when deltaSrc is a tombstone
+func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("Requires EE for some delta sync")
+	}
+	defer db.SuspendSequenceBatching()()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+	// Passive //
+	passiveBucket := base.GetTestBucket(t)
+	passiveRT := NewRestTester(t, &RestTesterConfig{
+		TestBucket: passiveBucket,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: base.BoolPtr(true),
+				},
+			},
+		},
+	})
+	defer passiveRT.Close()
+
+	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator.
+	srv := httptest.NewServer(passiveRT.TestAdminHandler())
+	defer srv.Close()
+
+	// Active //
+	activeBucket := base.GetTestBucket(t)
+	activeRT := NewRestTester(t, &RestTesterConfig{
+		TestBucket: activeBucket,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: base.BoolPtr(true),
+				},
+			},
+		},
+	})
+	defer activeRT.Close()
+
+	// Create a document //
+	resp := activeRT.SendAdminRequest(http.MethodPut, "/db/test", `{"field1":"f1_1","field2":"f2_1"}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID := respRevID(t, resp)
+	err := activeRT.waitForRev("test", revID)
+	require.NoError(t, err)
+
+	// Set-up replicator //
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: activeRT.GetDatabase(),
+		},
+		ChangesBatchSize:    200,
+		DeltasEnabled:       true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false).DBReplicatorStats(t.Name()),
+	})
+	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
+
+	// Wait for active to replicate to passive
+	assert.NoError(t, ar.Start())
+	err = passiveRT.waitForRev("test", revID)
+	require.NoError(t, err)
+	assert.NoError(t, ar.Stop())
+
+	// Delete active document
+	resp = activeRT.SendAdminRequest(http.MethodDelete, "/db/test?rev="+revID, "")
+	assertStatus(t, resp, http.StatusOK)
+	revID = respRevID(t, resp)
+
+	// Replicate tombstone to passive
+	assert.NoError(t, ar.Start())
+	err = passiveRT.WaitForCondition(func() bool {
+		rawResponse := passiveRT.SendAdminRequest("GET", "/db/test", "")
+		return rawResponse.Code == 404
+	})
+	require.NoError(t, err)
+	assert.NoError(t, ar.Stop())
+
+	// Resurrect tombstoned document
+	resp = activeRT.SendAdminRequest(http.MethodPut, "/db/test?rev="+revID, `{"field2":"f2_2"}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID = respRevID(t, resp)
+
+	// Replicate resurrection to passive
+	assert.NoError(t, ar.Start())
+	err = passiveRT.waitForRev("test", revID)
+	assert.NoError(t, err) // If error, problem not fixed
+	assert.NoError(t, ar.Stop())
+}
+
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {
 	attachments := db.GetBodyAttachments(doc)
 	if attachments == nil {


### PR DESCRIPTION
CBG-1427

- Added new error `ErrFromRevIsTombstone`
- When getting the delta, if the from revision is marked as deleted then this error is returned. Then sendRevAsDelta falls back to full body replication so then a successful resurrection is done.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1113
