### PR TITLE
CBG-1695 Bypass channel cache for revocation feed

### DIFF
--- a/db/channel_cache.go
+++ b/db/channel_cache.go
@@ -66,6 +66,9 @@ type ChannelCache interface {
 	// Access to individual channel cache
 	getSingleChannelCache(channelName string) SingleChannelCache
 
+	// Access to individual bypass channel cache
+	getBypassChannelCache(channelName string) SingleChannelCache
+
 	// Stop stops the channel cache and it's background tasks.
 	Stop()
 }
@@ -309,6 +312,14 @@ func (c *channelCacheImpl) getChannelCache(channelName string) SingleChannelCach
 	c.cacheStats.ChannelCacheBypassCount.Add(1)
 	return bypassChannelCache
 
+}
+
+func (c *channelCacheImpl) getBypassChannelCache(channelName string) SingleChannelCache {
+	bypassChannelCache := &bypassChannelCache{
+		channelName:  channelName,
+		queryHandler: c.queryHandler,
+	}
+	return bypassChannelCache
 }
 
 // Converts an RangeSafeCollection value to a singleChannelCacheImpl.  On type

--- a/db/query.go
+++ b/db/query.go
@@ -408,7 +408,7 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	if endSeq == 0 {
 		// If endSeq isn't defined, set to max uint64
 		endSeq = math.MaxUint64
-	} else {
+	} else if endSeq < math.MaxUint64 {
 		// channels query isn't based on inclusive end - add one to ensure complete result set
 		endSeq++
 	}


### PR DESCRIPTION
Bypass the channel cache when building the revocation feed, to avoid scenarios where recently mutated documents aren't mutated because they haven't hit the cache yet. 

- [x] http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/1114/