### PR TITLE
CBG-1698 - Fixed defaultLogFilePath not being set by flag when using persistent config

### DIFF
--- a/rest/config_legacy.go
+++ b/rest/config_legacy.go
@@ -484,15 +484,11 @@ func ParseCommandLine(args []string, handling flag.ErrorHandling) (*LegacyServer
 	keypath := flagSet.String("keypath", "", "Client certificate key path")
 
 	// used by service scripts as a way to specify a per-distro defaultLogFilePath
-	defaultLogFilePathFlag := flagSet.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
+	flagSet.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
 
 	_ = flagSet.Parse(args[1:])
 	var config *LegacyServerConfig
 	var err error
-
-	if defaultLogFilePathFlag != nil {
-		defaultLogFilePath = *defaultLogFilePathFlag
-	}
 
 	if flagSet.NArg() > 0 {
 		// Read the configuration file(s), if any:

--- a/rest/main.go
+++ b/rest/main.go
@@ -37,7 +37,7 @@ func serverMain(ctx context.Context, osArgs []string) error {
 	fs := flag.NewFlagSet(osArgs[0], flag.ContinueOnError)
 
 	// used by service scripts as a way to specify a per-distro defaultLogFilePath
-	defaultLogFilePath = *fs.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
+	defaultLogFilePathFlag := fs.String("defaultLogFilePath", "", "Path to log files, if not overridden by --logFilePath, or the config")
 
 	disablePersistentConfigFlag := fs.Bool("disable_persistent_config", false, "Can be set to false to disable persistent config handling, and read all configuration from a legacy config file.")
 
@@ -59,6 +59,8 @@ func serverMain(ctx context.Context, osArgs []string) error {
 		}
 		return err
 	}
+
+	defaultLogFilePath = *defaultLogFilePathFlag
 
 	err = fillConfigWithFlags(fs, configFlags)
 	if err != nil {


### PR DESCRIPTION
CBG-1698

The problem was the flag was being dereferenced into defaultLogFilePath before the flag had been parsed. The same fix has been applied to CBG-1638 as that had the same issue (albeit in a different function).

- `defaultLogFilePath` now gets set after the flags have been parsed instead of before
