### PR TITLE
CBG-1699: Include ca cert in inheritFromBootstrap

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -237,6 +237,9 @@ func (dbc *DbConfig) inheritFromBootstrap(b BootstrapConfig) {
 	if dbc.Password == "" {
 		dbc.Password = b.Password
 	}
+	if dbc.CACertPath == "" {
+		dbc.CACertPath = b.CACertPath
+	}
 	if dbc.CertPath == "" {
 		dbc.CertPath = b.X509CertPath
 	}


### PR DESCRIPTION
CBG-1699

Pass through CA Cert as part of `inheritFromBootstrap` ensures that when creating databases through the REST API we have a cert properly attached to the db config for use in the connection.