### PR TITLE
Fixes Validate during PUT db config for legacy config

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -479,6 +479,7 @@ func (h *handler) handlePutDbConfig() (err error) {
 		}
 		updatedDbConfig.cas = cas
 	} else {
+		updatedDbConfig = &DatabaseConfig{DbConfig: *dbConfig}
 		err = updatedDbConfig.validate()
 		if err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())


### PR DESCRIPTION
Due to the order in which PRs ended up getting merged we have a couple test failures. PRs are
https://github.com/couchbase/sync_gateway/pull/5217 and https://github.com/couchbase/sync_gateway/pull/5205

The failure essentially is down to the legacy config case not being set anymore meaning that the .validate() change ends with a panic. This change just ensures that value is set as it previously was.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1134/
One known flaky test failing.