### PR TITLE
CBG-1672 - Return 422 status for unprocessible deltas instead of 404 to use non-delta retry handling

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -814,17 +814,17 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		//       revisions to malicious actors (in the scenario where that user has write but not read access).
 		deltaSrcRev, err := bh.db.GetRev(docID, deltaSrcRevID, false, nil)
 		if err != nil {
-			return base.HTTPErrorf(http.StatusNotFound, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't fetch doc %s for deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
 		}
 
 		// Receiving a delta to be applied on top of a tombstone is not valid.
 		if deltaSrcRev.Deleted {
-			return base.HTTPErrorf(http.StatusNotFound, "Can't use delta. Found tombstone for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevID)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Can't use delta. Found tombstone for doc %s deltaSrc=%s", base.UD(docID), deltaSrcRevID)
 		}
 
 		deltaSrcBody, err := deltaSrcRev.MutableBody()
 		if err != nil {
-			return base.HTTPErrorf(http.StatusInternalServerError, "Unable to unmarshal mutable body for doc %s deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Unable to unmarshal mutable body for doc %s deltaSrc=%s %v", base.UD(docID), deltaSrcRevID, err)
 		}
 
 		// Stamp attachments so we can patch them
@@ -839,7 +839,7 @@ func (bh *blipHandler) handleRev(rq *blip.Message) (err error) {
 		if err != nil {
 			// Something went wrong in the diffing library. We want to know about this!
 			base.WarnfCtx(bh.loggingCtx, "Error patching deltaSrc %s with %s for doc %s with delta - err: %v", deltaSrcRevID, revID, base.UD(docID), err)
-			return base.HTTPErrorf(http.StatusInternalServerError, "Error patching deltaSrc with delta: %s", err)
+			return base.HTTPErrorf(http.StatusUnprocessableEntity, "Error patching deltaSrc with delta: %s", err)
 		}
 
 		newDoc.UpdateBody(deltaSrcMap)

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -422,9 +422,10 @@ func (bsc *BlipSyncContext) sendRevisionWithProperties(sender *blip.Sender, docI
 						bsc.replicationStats.SendRevErrorConflictCount.Add(1)
 					case "403":
 						bsc.replicationStats.SendRevErrorRejectedCount.Add(1)
-					case "422":
+					case "422", "404":
 						// unprocessable entity, CBL has not been able to use the delta we sent, so we should re-send the revision in full
 						if resendFullRevisionFunc != nil {
+							base.DebugfCtx(bsc.loggingCtx, base.KeySync, "sending full body replication for doc %s/%s due to unprocessable entity", base.UD(docID), revID)
 							if err := resendFullRevisionFunc(); err != nil {
 								base.WarnfCtx(bsc.loggingCtx, "unable to resend revision: %v", err)
 							}

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5747,6 +5747,106 @@ func TestReplicatorDoNotSendDeltaWhenSrcIsTombstone(t *testing.T) {
 	activeRT.waitForReplicationStatus(ar.ID, db.ReplicationStateStopped)
 }
 
+// CBG-1672 - Return 422 status for unprocessible deltas instead of 404 to use non-delta retry handling
+func TestUnprocessibleDeltas(t *testing.T) {
+	if !base.IsEnterpriseEdition() {
+		t.Skipf("Requires EE for some delta sync")
+	}
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	defer db.SuspendSequenceBatching()()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+	// Passive //
+	passiveBucket := base.GetTestBucket(t)
+	passiveRT := NewRestTester(t, &RestTesterConfig{
+		TestBucket: passiveBucket,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CacheConfig: &CacheConfig{
+					RevCacheConfig:     &RevCacheConfig{Size: base.Uint32Ptr(0)},
+					ChannelCacheConfig: &ChannelCacheConfig{MaxNumber: base.IntPtr(0)},
+				},
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: base.BoolPtr(true),
+				},
+			},
+		},
+	})
+	defer passiveRT.Close()
+
+	// Make passive RT listen on an actual HTTP port, so it can receive the blipsync request from the active replicator.
+	srv := httptest.NewServer(passiveRT.TestAdminHandler())
+	defer srv.Close()
+
+	// Active //
+	activeBucket := base.GetTestBucket(t)
+	activeRT := NewRestTester(t, &RestTesterConfig{
+		TestBucket: activeBucket,
+		DatabaseConfig: &DatabaseConfig{
+			DbConfig: DbConfig{
+				CacheConfig: &CacheConfig{
+					RevCacheConfig:     &RevCacheConfig{Size: base.Uint32Ptr(0)},
+					ChannelCacheConfig: &ChannelCacheConfig{MaxNumber: base.IntPtr(0)},
+				},
+				DeltaSync: &DeltaSyncConfig{
+					Enabled: base.BoolPtr(true),
+				},
+			},
+		},
+	})
+	defer activeRT.Close()
+
+	// Create a document //
+	resp := activeRT.SendAdminRequest(http.MethodPut, "/db/test", `{"field1":"f1_1","field2":"f2_1"}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID := respRevID(t, resp)
+	err := activeRT.waitForRev("test", revID)
+	require.NoError(t, err)
+
+	// Set-up replicator //
+	passiveDBURL, err := url.Parse(srv.URL + "/db")
+	require.NoError(t, err)
+
+	ar := db.NewActiveReplicator(&db.ActiveReplicatorConfig{
+		ID:          t.Name(),
+		Direction:   db.ActiveReplicatorTypePush,
+		RemoteDBURL: passiveDBURL,
+		ActiveDB: &db.Database{
+			DatabaseContext: activeRT.GetDatabase(),
+		},
+		Continuous:          false,
+		ChangesBatchSize:    1,
+		DeltasEnabled:       true,
+		ReplicationStatsMap: base.SyncGatewayStats.NewDBStats(t.Name(), true, false, false).DBReplicatorStats(t.Name()),
+	})
+	assert.Equal(t, "", ar.GetStatus().LastSeqPush)
+	assert.NoError(t, ar.Start())
+
+	// Wait for active to replicate to passive
+	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+
+	// Make 2nd revision
+	resp = activeRT.SendAdminRequest(http.MethodPut, "/db/test?rev="+revID, `{"field1":"f1_2","field2":"f2_2"}`)
+	assertStatus(t, resp, http.StatusCreated)
+	revID = respRevID(t, resp)
+	err = activeRT.WaitForPendingChanges()
+	require.NoError(t, err)
+
+	// Delete first revision on active
+	err = activeRT.Bucket().Delete("_sync:rev:test:34:1-dbc7919edc9ec2576d527880186f8e8a")
+	require.NoError(t, err)
+
+	assert.NoError(t, ar.Start())
+	// Wait for active to replicate to passive
+	activeRT.waitForReplicationStatus(t.Name(), db.ReplicationStateStopped)
+	// Check if it managed to replicate
+	err = passiveRT.waitForRev("test", revID)
+	assert.NoError(t, err)
+}
+
 func getTestRevpos(t *testing.T, doc db.Body, attachmentKey string) (revpos int) {
 	attachments := db.GetBodyAttachments(doc)
 	if attachments == nil {


### PR DESCRIPTION
CBG-1672

- HTTP 422 is returned in handleRev when delta sync errors occur
- A test validates that 422 is returned by delta sync in an error case (manually verified by logs)

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1132
