### PR TITLE
CBG-1590: Retrieve existing doc metadata prior to calling downloadOrVerifyAttachments

### DIFF
--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3572,7 +3572,7 @@ func TestBlipPushPullNewAttachmentNoCommonAncestor(t *testing.T) {
 	assert.Equal(t, int64(0), btc.pushReplication.replicationStats.ProveAttachment.Value())
 }
 
-func TestMinRevPosThing(t *testing.T) {
+func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
 	rt := NewRestTester(t, &RestTesterConfig{
 		guestEnabled: true,
@@ -3590,6 +3590,8 @@ func TestMinRevPosThing(t *testing.T) {
 
 	// Push an initial rev with attachment data
 	initialRevID := rt.createDocReturnRev(t, "doc", "", map[string]interface{}{"_attachments": map[string]interface{}{"hello.txt": map[string]interface{}{"data": "aGVsbG8gd29ybGQ="}}})
+	err = rt.WaitForPendingChanges()
+	assert.NoError(t, err)
 
 	// Replicate data to client and ensure doc arrives
 	err = btc.StartOneshotPull()

--- a/rest/doc_api.go
+++ b/rest/doc_api.go
@@ -457,7 +457,7 @@ func (h *handler) handlePutDocReplicator2(docid string, roundTrip bool) (err err
 		newDoc.UpdateBody(body)
 	}
 
-	doc, rev, err := h.db.PutExistingRev(newDoc, history, true, false)
+	doc, rev, err := h.db.PutExistingRev(newDoc, history, true, false, nil)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
CBG-1590

- Gets document metadata prior to calling downloadOrVerifyAttachments to set the minrevpos - avoids calling proveAttachment / getAttachment unnecessarily 
- Passed retrieved document down to avoid an additional KV get later on

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1146/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1147/
