### PR TITLE
CBG-1142 Align gocbv2 default timeout with previous timeout

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -143,6 +143,9 @@ const (
 
 	// Replication filter constants
 	ByChannelFilter = "sync_gateway/bychannel"
+
+	// Increase default gocbv2 op timeout to match the standard SG backoff retry timing used for gocb v1
+	DefaultGocbV2OperationTimeout = 10 * time.Second
 )
 
 const (

--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -46,10 +46,16 @@ func GoCBv2AuthenticatorConfig(username, password, certPath, keyPath string) (a 
 
 // GoCBv2TimeoutsConfig returns a gocb.TimeoutsConfig to use when connecting.
 func GoCBv2TimeoutsConfig(bucketOpTimeout, viewQueryTimeout *time.Duration) (tc gocb.TimeoutsConfig) {
+
+	opTimeout := DefaultGocbV2OperationTimeout
 	if bucketOpTimeout != nil {
-		tc.KVTimeout = *bucketOpTimeout
-		tc.ManagementTimeout = *bucketOpTimeout
-		tc.ConnectTimeout = *bucketOpTimeout
+		opTimeout = *bucketOpTimeout
+	}
+
+	if bucketOpTimeout != nil {
+		tc.KVTimeout = opTimeout
+		tc.ManagementTimeout = opTimeout
+		tc.ConnectTimeout = opTimeout
 	}
 	if viewQueryTimeout != nil {
 		tc.QueryTimeout = *viewQueryTimeout


### PR DESCRIPTION
Increase default gocb v2 op timeout to match SG's gocb v1 retry handling for recoverable errors.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/view/Build/job/sync-gateway-integration/1159/
