### PR TITLE
Fix TestCreateDbOnNonExistentBucket assertion

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3564,14 +3564,14 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Contains(t, string(body), "auth failure accessing provided bucket nonExistentBucket")
+	assert.Contains(t, string(body), "auth failure accessing provided bucket using bootstrap credentials: nonExistentBucket")
 
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/nonExistentBucket/", `{}`)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
-	assert.Contains(t, string(body), "auth failure accessing provided bucket nonExistentBucket")
+	assert.Contains(t, string(body), "auth failure accessing provided bucket using bootstrap credentials: nonExistentBucket")
 }
 
 func TestPutDbConfigChangeName(t *testing.T) {


### PR DESCRIPTION
Minor test assertion fix broken in https://github.com/couchbase/sync_gateway/pull/5221

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1161/
One unrelated failure