### PR TITLE
CBG-1700, use v0.3.4 for couchbasedeps text per Adam.

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -77,7 +77,7 @@ licenses/APL2.txt.
 
   <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="release-branch.go1.11"/>
+  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
 
   <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 


### PR DESCRIPTION
CBG-1700

Describe your PR here...
update couchbasedeps text repo to use tag v0.3.4

-Ming Ho
## Pre-review checklist (remove once done)
- Removed debug logging (`fmt.Print`, `log.Print`, ...)
- Logging sensitive data? Make sure it's tagged (e.g. `base.UD(docID)`, `base.MD(dbName)`)

## Dependencies (if applicable)
- [ ] Link upstream PRs
- [ ] Bump manifest once merged

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
- [ ] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/???/
