### PR TITLE
CBG-1700 Update golang.org/x/text to 0.3.4

### DIFF
--- a/manifest/default.xml
+++ b/manifest/default.xml
@@ -77,7 +77,7 @@ licenses/APL2.txt.
 
   <project name="fakehttp" path="godeps/src/github.com/tleyden/fakehttp" remote="tleyden" revision="084795c8f01f195a88c0ca4af0d7228a5ef40c83"/>
 
-  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="release-branch.go1.11"/>
+  <project name="text" path="godeps/src/golang.org/x/text" remote="couchbasedeps" revision="refs/tags/v0.3.4"/>
 
   <project name="net" path="godeps/src/golang.org/x/net" remote="couchbasedeps" revision="release-branch.go1.11"/>
 


### PR DESCRIPTION
Version of https://github.com/couchbase/sync_gateway/pull/5255 that should play friendlier with CI.