### PR TITLE
CBG-1710: Update TestDbConfigDoesNotIncludeCredentials to reflect current behaviour

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -146,6 +146,9 @@ const (
 
 	// Increase default gocbv2 op timeout to match the standard SG backoff retry timing used for gocb v1
 	DefaultGocbV2OperationTimeout = 10 * time.Second
+
+	// RedactedStr can be substituted in place of any sensitive data being returned by an API. The 'xxxxx' pattern is the same used by Go's url.Redacted() method.
+	RedactedStr = "xxxxx"
 )
 
 const (

--- a/base/util.go
+++ b/base/util.go
@@ -76,9 +76,9 @@ func RedactBasicAuthURL(urlIn string, passwordOnly bool) (string, error) {
 	if urlParsed.User != nil {
 		user := urlParsed.User.Username()
 		if !passwordOnly {
-			user = "xxxxx"
+			user = RedactedStr
 		}
-		urlParsed.User = url.UserPassword(user, "xxxxx")
+		urlParsed.User = url.UserPassword(user, RedactedStr)
 	}
 
 	return urlParsed.String(), nil

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -334,7 +334,7 @@ func (rc *ReplicationConfig) Equals(compareToCfg *ReplicationConfig) (bool, erro
 func (rc *ReplicationConfig) Redacted() *ReplicationConfig {
 	config := *rc
 	if config.Password != "" {
-		config.Password = "xxxxx"
+		config.Password = base.RedactedStr
 	}
 	config.Remote = base.RedactBasicAuthURLPassword(config.Remote)
 	return &config

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2615,8 +2615,8 @@ func TestConfigRedaction(t *testing.T) {
 	err := json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "xxxxx", unmarshaledConfig.Password)
-	assert.Equal(t, "xxxxx", *unmarshaledConfig.Users["alice"].Password)
+	assert.Equal(t, base.RedactedStr, unmarshaledConfig.Password)
+	assert.Equal(t, base.RedactedStr, *unmarshaledConfig.Users["alice"].Password)
 
 	// Test default db config redaction when redaction disabled
 	response = rt.SendAdminRequest("GET", "/db/_config?include_runtime=true&redact=false", "")
@@ -2632,7 +2632,7 @@ func TestConfigRedaction(t *testing.T) {
 	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
 	require.NoError(t, err)
 
-	assert.Equal(t, "xxxxx", unmarshaledServerConfig.Bootstrap.Password)
+	assert.Equal(t, base.RedactedStr, unmarshaledServerConfig.Bootstrap.Password)
 
 	// Test default server config redaction when redaction disabled
 	unmarshaledServerConfig = StartupConfig{}
@@ -3256,7 +3256,7 @@ func TestInitialStartupConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert value is redacted
-	assert.Equal(t, "xxxxx", initialStartupConfig.Bootstrap.Password)
+	assert.Equal(t, base.RedactedStr, initialStartupConfig.Bootstrap.Password)
 
 	// Assert error logging is nil
 	assert.Nil(t, initialStartupConfig.Logging.Error)
@@ -3344,7 +3344,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
 	require.NoError(t, err)
 
-	assert.Equal(t, "xxxxx", runtimeServerConfigResponse.Bootstrap.Password)
+	assert.Equal(t, base.RedactedStr, runtimeServerConfigResponse.Bootstrap.Password)
 
 	// Setup replication to ensure it is visible in returned config
 	replicationConfig := `{
@@ -3426,7 +3426,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
 }
 
-func TestDbConfigDoesNotIncludeCredentials(t *testing.T) {
+func TestDbConfigCredentials(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
@@ -3460,12 +3460,13 @@ func TestDbConfigDoesNotIncludeCredentials(t *testing.T) {
 	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
 
 	err = base.JSONUnmarshal(body, &dbConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
+	// non-runtime config, we don't expect to see any credentials present
 	assert.Equal(t, "", dbConfig.Username)
 	assert.Equal(t, "", dbConfig.Password)
 	assert.Equal(t, "", dbConfig.CACertPath)
@@ -3475,17 +3476,29 @@ func TestDbConfigDoesNotIncludeCredentials(t *testing.T) {
 	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false&include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
 
 	err = base.JSONUnmarshal(body, &dbConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, "", dbConfig.Username)
-	assert.Equal(t, "", dbConfig.Password)
+	// runtime config, we expect to see the credentials used by the database (either bootstrap or per-db - but in this case, bootstrap)
+	assert.Equal(t, base.TestClusterUsername(), dbConfig.Username)
+	assert.Equal(t, base.TestClusterPassword(), dbConfig.Password)
 	assert.Equal(t, "", dbConfig.CACertPath)
 	assert.Equal(t, "", dbConfig.CertPath)
 	assert.Equal(t, "", dbConfig.KeyPath)
+
+	// try again without disabling redaction to ensure the password is not revealed
+	resp = bootstrapAdminRequest(t, "GET", "/db/_config?include_runtime=true", "")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+
+	err = base.JSONUnmarshal(body, &dbConfig)
+	require.NoError(t, err)
+	assert.Equal(t, base.RedactedStr, dbConfig.Password)
 }
 
 func TestInvalidDBConfig(t *testing.T) {

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -2293,7 +2293,7 @@ func TestHandleDBConfig(t *testing.T) {
 	assert.Equal(t, "Online", respBody["state"].(string))
 
 	// Put database config
-	resource = fmt.Sprintf("/%v/_config?redact=false", bucket)
+	resource = fmt.Sprintf("/%v/_config", bucket)
 
 	// change cache size so we can see the update being reflected in the API response
 	dbConfig := &DbConfig{
@@ -2342,13 +2342,13 @@ func TestHandleDBConfig(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, bucket, gotName)
 
-	un, pw, _ := tb.BucketSpec.Auth.GetCredentials()
+	un, _, _ := tb.BucketSpec.Auth.GetCredentials()
 	gotusername, ok := respBody["username"].(string)
 	require.True(t, ok)
 	assert.Equal(t, un, gotusername)
 	gotpassword, ok := respBody["password"].(string)
 	require.True(t, ok)
-	assert.Equal(t, pw, gotpassword)
+	assert.Equal(t, base.RedactedStr, gotpassword)
 
 	_, ok = respBody["certpath"]
 	require.False(t, ok)
@@ -2618,14 +2618,6 @@ func TestConfigRedaction(t *testing.T) {
 	assert.Equal(t, base.RedactedStr, unmarshaledConfig.Password)
 	assert.Equal(t, base.RedactedStr, *unmarshaledConfig.Users["alice"].Password)
 
-	// Test default db config redaction when redaction disabled
-	response = rt.SendAdminRequest("GET", "/db/_config?include_runtime=true&redact=false", "")
-	err = json.Unmarshal(response.BodyBytes(), &unmarshaledConfig)
-	require.NoError(t, err)
-
-	assert.Equal(t, "password", unmarshaledConfig.Password)
-	assert.Equal(t, "password", *unmarshaledConfig.Users["alice"].Password)
-
 	// Test default server config redaction
 	var unmarshaledServerConfig StartupConfig
 	response = rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
@@ -2633,14 +2625,6 @@ func TestConfigRedaction(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, base.RedactedStr, unmarshaledServerConfig.Bootstrap.Password)
-
-	// Test default server config redaction when redaction disabled
-	unmarshaledServerConfig = StartupConfig{}
-	response = rt.SendAdminRequest("GET", "/_config?include_runtime=true&redact=false", "")
-	err = json.Unmarshal(response.BodyBytes(), &unmarshaledServerConfig)
-	require.NoError(t, err)
-
-	assert.Equal(t, base.TestClusterPassword(), unmarshaledServerConfig.Bootstrap.Password)
 }
 
 // Reproduces panic seen in CBG-1053
@@ -3238,7 +3222,7 @@ func TestInitialStartupConfig(t *testing.T) {
 	defer rt.Close()
 
 	// Get config
-	resp := rt.SendAdminRequest("GET", "/_config?redact=false", "")
+	resp := rt.SendAdminRequest("GET", "/_config", "")
 	assertStatus(t, resp, http.StatusOK)
 
 	var initialStartupConfig StartupConfig
@@ -3247,15 +3231,6 @@ func TestInitialStartupConfig(t *testing.T) {
 
 	// Assert on a couple values to make sure they are set
 	assert.Equal(t, base.TestClusterUsername(), initialStartupConfig.Bootstrap.Username)
-	assert.Equal(t, base.TestClusterPassword(), initialStartupConfig.Bootstrap.Password)
-
-	// Get redacted / default config
-	resp = rt.SendAdminRequest("GET", "/_config", "")
-	assertStatus(t, resp, http.StatusOK)
-	err = json.Unmarshal(resp.BodyBytes(), &initialStartupConfig)
-	require.NoError(t, err)
-
-	// Assert value is redacted
 	assert.Equal(t, base.RedactedStr, initialStartupConfig.Bootstrap.Password)
 
 	// Assert error logging is nil
@@ -3295,7 +3270,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	base.EnableStatsLogger(false)
 
 	// Get config
-	resp := rt.SendAdminRequest("GET", "/_config?include_runtime=true&redact=false", "")
+	resp := rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
 	assertStatus(t, resp, http.StatusOK)
 
 	var runtimeServerConfigResponse RunTimeServerConfigResponse
@@ -3305,7 +3280,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	assert.Contains(t, runtimeServerConfigResponse.Databases, "db")
 	assert.Equal(t, base.UnitTestUrl(), runtimeServerConfigResponse.Bootstrap.Server)
 	assert.Equal(t, base.TestClusterUsername(), runtimeServerConfigResponse.Bootstrap.Username)
-	assert.Equal(t, base.TestClusterPassword(), runtimeServerConfigResponse.Bootstrap.Password)
+	assert.Equal(t, base.RedactedStr, runtimeServerConfigResponse.Bootstrap.Password)
 
 	// Make request to enable error logger
 	resp = rt.SendAdminRequest("PUT", "/_config", `
@@ -3327,7 +3302,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	dbConfig := rt.ServerContext().GetDatabaseConfig("db")
 	dbConfig.RevsLimit = base.Uint32Ptr(100)
 
-	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true&redact=false", "")
+	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
 	assertStatus(t, resp, http.StatusOK)
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
 	require.NoError(t, err)
@@ -3358,7 +3333,7 @@ func TestIncludeRuntimeStartupConfig(t *testing.T) {
 	response := rt.SendAdminRequest("PUT", "/db/_replication/repl", string(replicationConfig))
 	assertStatus(t, response, http.StatusCreated)
 
-	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true&redact=false", "")
+	resp = rt.SendAdminRequest("GET", "/_config?include_runtime=true", "")
 	assertStatus(t, resp, http.StatusOK)
 	err = json.Unmarshal(resp.BodyBytes(), &runtimeServerConfigResponse)
 	require.NoError(t, err)
@@ -3403,7 +3378,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Get config
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false", "")
+	resp = bootstrapAdminRequest(t, "GET", "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	eTag := resp.Header.Get("ETag")
@@ -3417,7 +3392,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	putETag := resp.Header.Get("ETag")
 	assert.NotEqual(t, "", putETag)
 
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false", "")
+	resp = bootstrapAdminRequest(t, "GET", "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	getETag := resp.Header.Get("ETag")
 	assert.Equal(t, putETag, getETag)
@@ -3457,7 +3432,7 @@ func TestDbConfigCredentials(t *testing.T) {
 
 	var dbConfig DatabaseConfig
 
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false", "")
+	resp = bootstrapAdminRequest(t, "GET", "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -3473,7 +3448,7 @@ func TestDbConfigCredentials(t *testing.T) {
 	assert.Equal(t, "", dbConfig.CertPath)
 	assert.Equal(t, "", dbConfig.KeyPath)
 
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?redact=false&include_runtime=true", "")
+	resp = bootstrapAdminRequest(t, "GET", "/db/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -3484,21 +3459,10 @@ func TestDbConfigCredentials(t *testing.T) {
 
 	// runtime config, we expect to see the credentials used by the database (either bootstrap or per-db - but in this case, bootstrap)
 	assert.Equal(t, base.TestClusterUsername(), dbConfig.Username)
-	assert.Equal(t, base.TestClusterPassword(), dbConfig.Password)
+	assert.Equal(t, base.RedactedStr, dbConfig.Password)
 	assert.Equal(t, "", dbConfig.CACertPath)
 	assert.Equal(t, "", dbConfig.CertPath)
 	assert.Equal(t, "", dbConfig.KeyPath)
-
-	// try again without disabling redaction to ensure the password is not revealed
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?include_runtime=true", "")
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	body, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.NoError(t, resp.Body.Close())
-
-	err = base.JSONUnmarshal(body, &dbConfig)
-	require.NoError(t, err)
-	assert.Equal(t, base.RedactedStr, dbConfig.Password)
 }
 
 func TestInvalidDBConfig(t *testing.T) {
@@ -3694,7 +3658,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	assert.Equal(t, db.DefaultCompactInterval, uint32(*dbConfig.CompactIntervalDays))
 
 	var runtimeServerConfigResponse RunTimeServerConfigResponse
-	resp = bootstrapAdminRequest(t, "GET", "/_config?include_runtime=true&redact=false", "")
+	resp = bootstrapAdminRequest(t, "GET", "/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
@@ -3722,7 +3686,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = bootstrapAdminRequest(t, "GET", "/_config?include_runtime=true&redact=false", "")
+	resp = bootstrapAdminRequest(t, "GET", "/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -60,7 +60,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect the config
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config?redact=false", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	var dbConfigResp DatabaseConfig
 	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbConfigResp))
@@ -105,7 +105,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Equal(t, db.RunStateString[db.DBOnline], dbRootResp.State)
 
 	// Inspect config again, and ensure no changes since bootstrap
-	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config?redact=false", ``)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/_config", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	dbConfigResp = DatabaseConfig{}
 	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbConfigResp))

--- a/rest/config.go
+++ b/rest/config.go
@@ -763,12 +763,12 @@ func (dbConfig *DbConfig) Redacted() (*DbConfig, error) {
 func (config *DbConfig) redactInPlace() error {
 
 	if config.Password != "" {
-		config.Password = "xxxxx"
+		config.Password = base.RedactedStr
 	}
 
 	for i := range config.Users {
 		if config.Users[i].Password != nil && *config.Users[i].Password != "" {
-			config.Users[i].Password = base.StringPtr("xxxxx")
+			config.Users[i].Password = base.StringPtr(base.RedactedStr)
 		}
 	}
 

--- a/rest/config_database.go
+++ b/rest/config_database.go
@@ -34,7 +34,7 @@ func (dbc *DatabaseConfig) Redacted() (*DatabaseConfig, error) {
 	}
 
 	if config.Guest != nil && config.Guest.Password != nil && *config.Guest.Password != "" {
-		config.Guest.Password = base.StringPtr("xxxxx")
+		config.Guest.Password = base.StringPtr(base.RedactedStr)
 	}
 
 	return &config, nil

--- a/rest/config_startup.go
+++ b/rest/config_startup.go
@@ -168,12 +168,12 @@ func (sc *StartupConfig) Redacted() (*StartupConfig, error) {
 	}
 
 	if config.Bootstrap.Password != "" {
-		config.Bootstrap.Password = "xxxxx"
+		config.Bootstrap.Password = base.RedactedStr
 	}
 
 	for _, credentialsConfig := range config.DatabaseCredentials {
 		if credentialsConfig != nil && credentialsConfig.Password != "" {
-			credentialsConfig.Password = "xxxxx"
+			credentialsConfig.Password = base.RedactedStr
 		}
 	}
 

--- a/rest/replication_api_test.go
+++ b/rest/replication_api_test.go
@@ -1201,7 +1201,7 @@ func TestReplicationAPIWithAuthCredentials(t *testing.T) {
 		assert.Equal(t, expected.Username, actual.Username, "Couldn't redact username")
 		assert.Equal(t, expected.Password, actual.Password, "Couldn't redact password")
 	}
-	replication1Config.Password = "xxxxx"
+	replication1Config.Password = base.RedactedStr
 	checkReplicationConfig(&replication1Config, &configResponse)
 
 	// Create another replication with auth credentials defined in Remote URL
@@ -1514,7 +1514,7 @@ func TestGetStatusWithReplication(t *testing.T) {
 	// Check replication1 details in cluster response
 	repl, ok := database.SGRCluster.Replications[config1.ID]
 	assert.True(t, ok, "Error getting replication")
-	config1.Password = "xxxxx"
+	config1.Password = base.RedactedStr
 	assertReplication(config1, repl)
 
 	// Check replication2 details in cluster response


### PR DESCRIPTION
CBG-1710

The test has been updated to reflect API changes based on `include_runtime` and per-database credential overrides added in #5236 
  - When `include_runtime` is set, the API returns the currently used credentials (bootstrap or per-db).
  - When `include_runtime` is not set, the behaviour remains the same, and returns the persisted configuration, without any stored credentials.
 - Redaction for passwords is _always_ applied on `/_config` and `/{db}/_config` endpoints and cannot be disabled using the `redact` query parameter any more.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1225/
  - [x] `TestConfigsIncludeDefaults` addressed by changes in #5239
  - [x] `TestUnprocessibleDeltas` CBG-1719 