### PR TITLE
CBG-1713 - Bcrypt cost is validate on startup and set

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -144,6 +144,7 @@ type DatabaseContextOptions struct {
 	QueryPaginationLimit      int    // Limit used for pagination of queries. If not set defaults to DefaultQueryPaginationLimit
 	UserXattrKey              string // Key of user xattr that will be accessible from the Sync Function. If empty the feature will be disabled.
 	ClientPartitionWindow     time.Duration
+	BcryptCost                int
 }
 
 type SGReplicateOptions struct {
@@ -760,6 +761,7 @@ func (context *DatabaseContext) Authenticator() *auth.Authenticator {
 		ClientPartitionWindow:    context.Options.ClientPartitionWindow,
 		ChannelsWarningThreshold: channelsWarningThreshold,
 		SessionCookieName:        sessionCookieName,
+		BcryptCost:               context.Options.BcryptCost,
 	})
 
 	return authenticator

--- a/rest/config.go
+++ b/rest/config.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/crypto/bcrypt"
+
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/hashicorp/go-multierror"
 
@@ -937,6 +939,10 @@ func (sc *StartupConfig) validate() (errorMessages error) {
 	// Make sure if a SSL key or cert is provided, they are both provided
 	if (sc.API.HTTPS.TLSKeyPath != "" || sc.API.HTTPS.TLSCertPath != "") && (sc.API.HTTPS.TLSKeyPath == "" || sc.API.HTTPS.TLSCertPath == "") {
 		errorMessages = multierror.Append(errorMessages, fmt.Errorf("both TLS Key Path and TLS Cert Path must be provided when using client TLS. Disable client TLS by not providing either of these options"))
+	}
+
+	if sc.Auth.BcryptCost > 0 && (sc.Auth.BcryptCost < auth.DefaultBcryptCost || sc.Auth.BcryptCost > bcrypt.MaxCost) {
+		errorMessages = multierror.Append(errorMessages, fmt.Errorf("%v: %d outside allowed range: %d-%d", auth.ErrInvalidBcryptCost, sc.Auth.BcryptCost, auth.DefaultBcryptCost, bcrypt.MaxCost))
 	}
 
 	// EE only features

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -786,6 +786,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		// FIXME?
 		// SlowQueryWarningThreshold: time.Duration(*sc.config.SlowQueryWarningThreshold) * time.Millisecond,
 		ClientPartitionWindow: clientPartitionWindow,
+		BcryptCost:            sc.config.Auth.BcryptCost,
 	}
 
 	return contextOptions, nil

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -25,6 +25,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/couchbase/sync_gateway/auth"
+
 	"github.com/couchbase/gocbcore/v10"
 	sgbucket "github.com/couchbase/sg-bucket"
 	"github.com/couchbase/sync_gateway/base"
@@ -759,6 +761,11 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		clientPartitionWindow = time.Duration(*config.ClientPartitionWindowSecs) * time.Second
 	}
 
+	bcryptCost := sc.config.Auth.BcryptCost
+	if bcryptCost <= 0 {
+		bcryptCost = auth.DefaultBcryptCost
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		RevisionCacheOptions:      revCacheOptions,
@@ -786,7 +793,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		// FIXME?
 		// SlowQueryWarningThreshold: time.Duration(*sc.config.SlowQueryWarningThreshold) * time.Millisecond,
 		ClientPartitionWindow: clientPartitionWindow,
-		BcryptCost:            sc.config.Auth.BcryptCost,
+		BcryptCost:            bcryptCost,
 	}
 
 	return contextOptions, nil


### PR DESCRIPTION
CBG-1713

- Validation done on startup config to make sure bcrypt cost is set within allowed range
- Bcrypt cost is set on the authenticator when it is made
- Bcrypt cost added to database context and set to default if cost is 0 or less

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​19​6
