### PR TITLE
CBG-1693 - Upped expiry time check for assertExpiry to 10 secs

### DIFF
--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -700,9 +700,9 @@ func assertStatus(t testing.TB, response *TestResponse, expectedStatus int) {
 // gocb V2 accepts expiry as a duration and converts to a uint32 epoch time, then does the reverse on retrieval.
 // Sync Gateway's bucket interface uses uint32 expiry. The net result is that expiry values written and then read via SG's
 // bucket API go through a transformation based on time.Now (or time.Until) that can result in inexact matches.
-// assertExpiry validates that the two expiry values are within a 5 second window
+// assertExpiry validates that the two expiry values are within a 10 second window
 func assertExpiry(t testing.TB, expected uint32, actual uint32) {
-	assert.True(t, base.DiffUint32(expected, actual) < 5, fmt.Sprintf("Unexpected difference between expected: %v actual %v", expected, actual))
+	assert.True(t, base.DiffUint32(expected, actual) < 10, fmt.Sprintf("Unexpected difference between expected: %v actual %v", expected, actual))
 }
 
 func NewSlowResponseRecorder(responseDelay time.Duration, responseRecorder *httptest.ResponseRecorder) *SlowResponseRecorder {


### PR DESCRIPTION
CBG-1693

- assertExpiry now checks if the expiry range is within less than 10 seconds
This is to fix multiple failing tests (including TestFeedBasedMigrateWithExpiry) on Jenkins that are failing due to timing issues


## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1200/
