### PR TITLE
[2.8.3] CBG-1696: Backport CBG-1695: buildChannelsQuery checks for boundary condition when incrementing endSeq (#5242)

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -399,7 +399,7 @@ func (context *DatabaseContext) buildChannelsQuery(channelName string, startSeq 
 	if endSeq == 0 {
 		// If endSeq isn't defined, set to max uint64
 		endSeq = math.MaxUint64
-	} else {
+	} else if endSeq < math.MaxUint64 {
 		// channels query isn't based on inclusive end - add one to ensure complete result set
 		endSeq++
 	}


### PR DESCRIPTION
CBG-1696

Backport of boundary checking from CBG-1695
