### PR TITLE
[2.8.3] CBG-1379: Backport CBG-1378 - OIDC client will be initalized until successful (#5097)

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -453,9 +453,9 @@ func (auth *Authenticator) AuthenticateUntrustedJWT(token string, providers OIDC
 	}
 
 	// Get client for issuer
-	client := provider.GetClient(callbackURLFunc)
-	if client == nil {
-		return nil, fmt.Errorf("OIDC client was not initialized")
+	client, err := provider.GetClient(callbackURLFunc)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC initialization error: %w", err)
 	}
 
 	// verifyJWT validates the claims and signature on the JWT

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -165,9 +165,13 @@ type OIDCProvider struct {
 	// use the accessor method GetClient() instead.
 	client *OIDCClient
 
-	// clientOnce synchronises access to the GetClient() and ensures that
-	// the OpenID Connect client only gets initialized exactly once.
-	clientOnce sync.Once
+	// clientInitLock synchronises access to the GetClient() and ensures that
+	// the OpenID Connect client only gets initialized exactly once when
+	// the client has been successfully initialized.
+	clientInitLock sync.Mutex
+
+	// clientInit tracks whether the client has been successfully initialized or not
+	clientInit base.AtomicBool
 
 	// IsDefault indicates whether this OpenID Connect provider (the current
 	// instance of OIDCProvider is explicitly specified as default provider
@@ -240,25 +244,34 @@ func (opm OIDCProviderMap) Stop() {
 	}
 }
 
-func (op *OIDCProvider) GetClient(buildCallbackURLFunc OIDCCallbackURLFunc) *OIDCClient {
-	// Initialize the client on first request. If the callback URL isn't defined for the provider,
-	// uses buildCallbackURLFunc to construct (based on current request)
-	op.clientOnce.Do(func() {
-		var err error
-		// If the redirect URL is not defined for the provider generate it from the
-		// handler request and set it on the provider
-		if op.CallbackURL == nil || *op.CallbackURL == "" {
-			callbackURL := buildCallbackURLFunc(op.Name, op.IsDefault)
-			if callbackURL != "" {
-				op.CallbackURL = &callbackURL
-			}
-		}
-		if err = op.initOIDCClient(); err != nil {
-			base.Errorf("Unable to initialize OIDC client: %v", err)
-		}
-	})
+// GetClient initializes the client on first successful request.
+func (op *OIDCProvider) GetClient(buildCallbackURLFunc OIDCCallbackURLFunc) (*OIDCClient, error) {
+	// If the callback URL isn't defined for the provider, uses buildCallbackURLFunc to construct (based on current request)
 
-	return op.client
+	if op.clientInit.IsTrue() {
+		return op.client, nil
+	}
+	op.clientInitLock.Lock()
+	defer op.clientInitLock.Unlock()
+
+	// Check again to see if the previous lock holder initialized the client
+	if op.clientInit.IsTrue() {
+		return op.client, nil
+	}
+
+	// If the redirect URL is not defined for the provider generate it from the
+	// handler request and set it on the provider
+	if op.CallbackURL == nil || *op.CallbackURL == "" {
+		callbackURL := buildCallbackURLFunc(op.Name, op.IsDefault)
+		if callbackURL != "" {
+			op.CallbackURL = &callbackURL
+		}
+	}
+	if err := op.initOIDCClient(); err != nil {
+		return nil, err
+	}
+	op.clientInit.Set(true)
+	return op.client, nil
 }
 
 // To support multiple providers referencing the same issuer, the user prefix used to build the SG usernames for
@@ -460,7 +473,13 @@ func (op *OIDCProvider) fetchCustomProviderConfig(discoveryURL string) (metadata
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return ProviderMetadata{}, MaxProviderConfigSyncInterval, false, fmt.Errorf("unsuccessful response: %v", err)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			err = fmt.Errorf("unsuccessful response and could not read returned response body: %w", err)
+		} else {
+			err = fmt.Errorf("unsuccessful response: %v", body)
+		}
+		return ProviderMetadata{}, MaxProviderConfigSyncInterval, false, err
 	}
 
 	ttl, _, err = cacheable(resp.Header)

--- a/rest/oidc_api.go
+++ b/rest/oidc_api.go
@@ -96,10 +96,10 @@ func (h *handler) handleOIDCCommon() (redirectURLString string, err error) {
 		return redirectURLString, err
 	}
 
-	client := provider.GetClient(h.getOIDCCallbackURL)
-	if client == nil {
+	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	if err != nil {
 		return redirectURLString, base.HTTPErrorf(
-			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider:%s", providerName))
+			http.StatusInternalServerError, fmt.Sprintf("Unable to obtain client for provider: %s - %v", providerName, err))
 	}
 
 	var redirectURL *url.URL
@@ -169,9 +169,9 @@ func (h *handler) handleOIDCCallback() error {
 		http.SetCookie(h.response, stateCookie)
 	}
 
-	client := provider.GetClient(h.getOIDCCallbackURL)
-	if client == nil {
-		return err
+	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	if err != nil {
+		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
 
 	// Converts the authorization code into a token.
@@ -222,9 +222,9 @@ func (h *handler) handleOIDCRefresh() error {
 		return base.HTTPErrorf(http.StatusBadRequest, "Unable to identify provider for callback request")
 	}
 
-	client := provider.GetClient(h.getOIDCCallbackURL)
-	if client == nil {
-		return err
+	client, err := provider.GetClient(h.getOIDCCallbackURL)
+	if err != nil {
+		return fmt.Errorf("OIDC initialization error: %w", err)
 	}
 
 	context := auth.GetOIDCClientContext(provider.InsecureSkipVerify)

--- a/rest/oidc_api_test.go
+++ b/rest/oidc_api_test.go
@@ -1015,6 +1015,15 @@ func deleteUser(t *testing.T, restTester *RestTester, name string) {
 	assertStatus(t, response, http.StatusNotFound)
 }
 
+// createOIDCRequest creates the request with the sessionEndpoint and token put in.
+// sessionEndpoint should end with "/_session".
+func createOIDCRequest(t *testing.T, sessionEndpoint string, token string) *http.Request {
+	request, err := http.NewRequest(http.MethodPost, sessionEndpoint, strings.NewReader(`{}`))
+	require.NoError(t, err, "Error creating new request")
+	request.Header.Add("Authorization", BearerToken+" "+token)
+	return request
+}
+
 // E2E test that checks OpenID Connect Implicit Flow.
 func TestOpenIDConnectImplicitFlow(t *testing.T) {
 	type test struct {
@@ -1083,9 +1092,7 @@ func TestOpenIDConnectImplicitFlow(t *testing.T) {
 			require.NotEmpty(t, token, "Empty token retrieved from OpenID Connect provider")
 			sessionEndpoint := mockSyncGatewayURL + "/" + restTester.DatabaseConfig.Name + "/_session"
 
-			request, err := http.NewRequest(http.MethodPost, sessionEndpoint, strings.NewReader(`{}`))
-			require.NoError(t, err, "Error creating new request")
-			request.Header.Add("Authorization", BearerToken+" "+token)
+			request := createOIDCRequest(t, sessionEndpoint, token)
 			response, err := http.DefaultClient.Do(request)
 			require.NoError(t, err, "Error sending request with bearer token")
 
@@ -1151,9 +1158,7 @@ func TestOpenIDConnectImplicitFlowEdgeCases(t *testing.T) {
 		require.NoError(t, err, "Error obtaining signed token from OpenID Connect provider")
 		require.NotEmpty(t, token, "Empty token retrieved from OpenID Connect provider")
 		sessionEndpoint := mockSyncGatewayURL + "/" + restTester.DatabaseConfig.Name + "/_session"
-		request, err := http.NewRequest(http.MethodPost, sessionEndpoint, strings.NewReader(`{}`))
-		require.NoError(t, err, "Error creating new request")
-		request.Header.Add("Authorization", BearerToken+" "+token)
+		request := createOIDCRequest(t, sessionEndpoint, token)
 		return http.DefaultClient.Do(request)
 	}
 
@@ -2070,6 +2075,89 @@ func TestOpenIDConnectAuthCodeFlowWithUsernameClaim(t *testing.T) {
 			require.NoError(t, json.NewDecoder(response.Body).Decode(&responseBody))
 			require.NoError(t, response.Body.Close(), "Error closing response body")
 			assert.Equal(t, restTester.DatabaseConfig.Name, responseBody["db_name"])
+		})
+	}
+}
+
+// CBG-1378 - test when OIDC provider is not reachable, and then becomes reachable
+// at a later request
+func TestEventuallyReachableOIDCClient(t *testing.T) {
+	// Modified copy of TestOpenIDConnectImplicitFlow
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	unreachableAddr := "http://0.0.0.0"
+	tests := []struct {
+		name                string
+		providers           auth.OIDCProviderMap
+		defaultProvider     string
+		requireExistingUser bool
+	}{
+		{
+			// Successful new user authentication against single provider
+			// when auto registration is enabled.
+			name: "successful user registration against single provider",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProviderWithRegister("foo"),
+			},
+			defaultProvider: "foo",
+		},
+		{
+			name: "successful registered user authentication against single provider",
+			providers: auth.OIDCProviderMap{
+				"foo": mockProvider("foo"),
+			},
+			defaultProvider:     "foo",
+			requireExistingUser: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockAuthServer, err := newMockAuthServer()
+			require.NoError(t, err, "Error creating mock oauth2 server")
+			mockAuthServer.Start()
+			defer mockAuthServer.Shutdown()
+			mockAuthServer.options.issuer = mockAuthServer.URL + "/" + tc.defaultProvider
+			refreshProviderConfig(tc.providers, unreachableAddr)
+
+			opts := auth.OIDCOptions{Providers: tc.providers, DefaultProvider: &tc.defaultProvider}
+			restTesterConfig := RestTesterConfig{DatabaseConfig: &DbConfig{OIDCConfig: &opts}}
+			restTester := NewRestTester(t, &restTesterConfig)
+			restTester.SetAdminParty(false)
+			defer restTester.Close()
+
+			// Create the user first if the test requires a registered user.
+			if tc.requireExistingUser {
+				createUser(t, restTester, "foo_noah")
+			}
+
+			mockSyncGateway := httptest.NewServer(restTester.TestPublicHandler())
+			defer mockSyncGateway.Close()
+			mockSyncGatewayURL := mockSyncGateway.URL
+
+			token, err := mockAuthServer.makeToken(claimsAuthentic())
+			require.NoError(t, err, "Error obtaining signed token from OpenID Connect provider")
+			require.NotEmpty(t, token, "Empty token retrieved from OpenID Connect provider")
+			sessionEndpoint := mockSyncGatewayURL + "/" + restTester.DatabaseConfig.Name + "/_session"
+
+			// Unreachable
+			request := createOIDCRequest(t, sessionEndpoint, token)
+			response, err := http.DefaultClient.Do(request)
+			require.NoError(t, err, "Error sending request with bearer token")
+			assert.Equal(t, http.StatusUnauthorized, response.StatusCode) // Status code when unreachable
+
+			// Now reachable - success
+			refreshProviderConfig(restTester.DatabaseConfig.OIDCConfig.Providers, mockAuthServer.URL)
+			request = createOIDCRequest(t, sessionEndpoint, token)
+			response, err = http.DefaultClient.Do(request)
+			require.NoError(t, err, "Error sending request with bearer token")
+			checkGoodAuthResponse(t, response, "foo_noah")
+
+			// Unreachable again after being reachable - still success
+			refreshProviderConfig(restTester.DatabaseConfig.OIDCConfig.Providers, unreachableAddr)
+			request = createOIDCRequest(t, sessionEndpoint, token)
+			response, err = http.DefaultClient.Do(request)
+			require.NoError(t, err, "Error sending request with bearer token")
+			checkGoodAuthResponse(t, response, "foo_noah")
 		})
 	}
 }


### PR DESCRIPTION
CBG-1379

Backport of CBG-1378

Test `TestEventuallyReachableOIDCClient` passes

Cherry Picked commit from master with no changes