### PR TITLE
Unpin 2.8(.3) build repo

### DIFF
--- a/manifest/2.8.xml
+++ b/manifest/2.8.xml
@@ -24,7 +24,7 @@ licenses/APL2.txt.
 
     <!-- Build Scripts (required on CI servers) -->
     <project name="product-texts" path="product-texts" remote="couchbase"/>
-    <project name="build" path="cbbuild" remote="couchbase" revision="5547da1aeb276479ba3adc9cd25bf9795640d976">
+    <project name="build" path="cbbuild" remote="couchbase">
         <annotation name="VERSION" value="2.8.3"     keep="true"/>
         <annotation name="BLD_NUM" value="@BLD_NUM@" keep="true"/>
         <annotation name="RELEASE" value="@RELEASE@" keep="true"/>


### PR DESCRIPTION
Unpinning 2.8(.3) build repo as there are updates in there that are required to build sync gateway. Can pin it again once the build ships.