### PR TITLE
Fix incorrect config group ID in upgrade log message

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -240,12 +240,12 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 		if err != nil {
 			// If key already exists just continue
 			if errors.Is(err, base.ErrAlreadyExists) {
-				base.Infof(base.KeyAll, "Skipping Couchbase Server persistence for config group %q in %s. Already exists.", startupConfig.Bootstrap.ConfigGroupID, base.UD(dbc.Name))
+				base.Infof(base.KeyAll, "Skipping Couchbase Server persistence for config group %q in %s. Already exists.", configGroupID, base.UD(dbc.Name))
 				continue
 			}
 			return nil, false, err
 		}
-		base.Infof(base.KeyAll, "Persisted database %s config for group %q to Couchbase Server bucket: %s", base.UD(dbc.Name), startupConfig.Bootstrap.ConfigGroupID, base.MD(*dbc.Bucket))
+		base.Infof(base.KeyAll, "Persisted database %s config for group %q to Couchbase Server bucket: %s", base.UD(dbc.Name), configGroupID, base.MD(*dbc.Bucket))
 	}
 
 	// Attempt to backup current config


### PR DESCRIPTION
## Before

```
2021-10-01T13:11:10.020-07:00 [INF] Skipping Couchbase Server persistence for config group "" in <ud>db</ud>. Already exists.
```

## After

```
2021-10-01T13:11:10.020-07:00 [INF] Skipping Couchbase Server persistence for config group "default" in <ud>db</ud>. Already exists.
```