### PR TITLE
[2.8.3] CBG-1362: Remove invalid use of CACertPath in DCP client

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -446,11 +446,6 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
-		// TODO: x.509 not supported for cbgt with cbdatasource until cbAuth supports
-		// a way to use NoPasswordAuthHandler, and custom options.Connect
-		// auth = NoPasswordAuthHandler{Handler: spec.Auth}
-	}
-	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
 	}

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -286,8 +286,6 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
 		auth = NoPasswordAuthHandler{Handler: spec.Auth}
-	}
-	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
 	}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -144,8 +144,6 @@ func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSp
 	if spec.Certpath != "" && spec.Keypath != "" {
 		couchbase.SetCertFile(spec.Certpath)
 		couchbase.SetKeyFile(spec.Keypath)
-	}
-	if spec.CACertPath != "" {
 		couchbase.SetRootFile(spec.CACertPath)
 		couchbase.SetSkipVerify(false)
 	}


### PR DESCRIPTION
CBG-1362
