### PR TITLE
CBG-1709: Add support for PUT and POST on /{db}/_config endpoints

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -448,8 +448,14 @@ func (h *handler) handlePutDbConfig() (err error) {
 					return nil, base.HTTPErrorf(http.StatusPreconditionFailed, "Provided If-Match header does not match current config version")
 				}
 
-				if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
-					return nil, err
+				if h.rq.Method == http.MethodPost {
+					base.TracefCtx(h.rq.Context(), base.KeyConfig, "merging upserted config into bucket config")
+					if err := base.ConfigMerge(&bucketDbConfig.DbConfig, dbConfig); err != nil {
+						return nil, err
+					}
+				} else {
+					base.TracefCtx(h.rq.Context(), base.KeyConfig, "using config as-is without merge")
+					bucketDbConfig.DbConfig = *dbConfig
 				}
 
 				// TODO: CBG-1619 We're validating but we're not actually starting up the database before we persist the update!

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3390,10 +3390,10 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	eTag := resp.Header.Get("ETag")
 	assert.NotEqual(t, "", eTag)
 
-	resp = bootstrapAdminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": eTag})
+	resp = bootstrapAdminRequestWithHeaders(t, "POST", "/db/_config", "{}", map[string]string{"If-Match": eTag})
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = bootstrapAdminRequest(t, "PUT", "/db/_config", "{}")
+	resp = bootstrapAdminRequest(t, "POST", "/db/_config", "{}")
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	putETag := resp.Header.Get("ETag")
 	assert.NotEqual(t, "", putETag)
@@ -3403,7 +3403,7 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 	getETag := resp.Header.Get("ETag")
 	assert.Equal(t, putETag, getETag)
 
-	resp = bootstrapAdminRequestWithHeaders(t, "PUT", "/db/_config", "{}", map[string]string{"If-Match": "x"})
+	resp = bootstrapAdminRequestWithHeaders(t, "POST", "/db/_config", "{}", map[string]string{"If-Match": "x"})
 	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
 }
 

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -51,6 +51,12 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
+	// upsert 1 config field
+	resp = bootstrapAdminRequest(t, http.MethodPost, "/db1/_config",
+		`{"cache": {"rev_cache":{"size":1234}}}`,
+	)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/", ``)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	var dbRootResp DatabaseRoot
@@ -72,6 +78,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Empty(t, dbConfigResp.Username)
 	assert.Empty(t, dbConfigResp.Password)
 	require.Nil(t, dbConfigResp.Sync)
+	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.Size)
 
 	// Sanity check to use the database
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db1/doc1", `{"foo":"bar"}`)
@@ -117,6 +124,7 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	assert.Empty(t, dbConfigResp.Username)
 	assert.Empty(t, dbConfigResp.Password)
 	require.Nil(t, dbConfigResp.Sync)
+	require.Equal(t, uint32(1234), *dbConfigResp.CacheConfig.RevCacheConfig.Size)
 
 	// Ensure it's _actually_ the same bucket
 	resp = bootstrapAdminRequest(t, http.MethodGet, "/db1/doc1", ``)

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -254,7 +254,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	dbr.Handle("/_config",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfig)).Methods("GET")
 	dbr.Handle("/_config",
-		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, (*handler).handlePutDbConfig)).Methods("PUT")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, (*handler).handlePutDbConfig)).Methods("PUT", "POST")
 
 	dbr.Handle("/_config/sync",
 		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigSync)).Methods("GET")


### PR DESCRIPTION
CBG-1709

Add support for `PUT` and `POST` on /{db}/_config endpoints:
- `PUT` replaces the whole config
- `POST` does an upsert
- Covered in existing test by expanding `TestBootstrapRESTAPISetup`

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1242/
  - `TestTombstoneCompactionStopWithManager` fixed by #5278 
  - `TestUnprocessibleDeltas` CBG-1719