### PR TITLE
Skip test if Facebook unreachable

### DIFF
--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -579,7 +579,7 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 	// This is to allow tests to be run offline/without third-party dependencies.
 	if response.Code == http.StatusInternalServerError {
 		respBody := response.Body.String()
-		if strings.Contains(respBody, "io/timeout") || strings.Contains(respBody, "no such host") {
+		if strings.Contains(respBody, "i/o timeout") || strings.Contains(respBody, "no such host") {
 			t.Skipf("WARNING: Facebook host could not be reached: %s", response.Body.String())
 		}
 	}
@@ -621,7 +621,7 @@ func TestNoCORSOriginOnSessionPost(t *testing.T) {
 	// This is to allow tests to be run offline/without third-party dependencies.
 	if response.Code == http.StatusInternalServerError {
 		respBody := response.Body.String()
-		if strings.Contains(respBody, "io/timeout") || strings.Contains(respBody, "no such host") {
+		if strings.Contains(respBody, "i/o timeout") || strings.Contains(respBody, "no such host") {
 			t.Skipf("WARNING: Facebook host could not be reached: %s", response.Body.String())
 		}
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -578,8 +578,8 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 	// Skip test if dial tcp fails with no such host.
 	// This is to allow tests to be run offline/without third-party dependencies.
 	if response.Code == http.StatusInternalServerError {
-		switch response.Body.String() {
-		case "i/o timeout", "no such host":
+		respBody := response.Body.String()
+		if strings.Contains(respBody, "io/timeout") || strings.Contains(respBody, "no such host") {
 			t.Skipf("WARNING: Facebook host could not be reached: %s", response.Body.String())
 		}
 	}
@@ -616,11 +616,12 @@ func TestNoCORSOriginOnSessionPost(t *testing.T) {
 	assertStatus(t, response, 400)
 
 	response = rt.SendRequestWithHeaders("POST", "/db/_facebook", `{"access_token":"true"}`, reqHeaders)
+
 	// Skip test if dial tcp fails with no such host.
 	// This is to allow tests to be run offline/without third-party dependencies.
 	if response.Code == http.StatusInternalServerError {
-		switch response.Body.String() {
-		case "i/o timeout", "no such host":
+		respBody := response.Body.String()
+		if strings.Contains(respBody, "io/timeout") || strings.Contains(respBody, "no such host") {
 			t.Skipf("WARNING: Facebook host could not be reached: %s", response.Body.String())
 		}
 	}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -577,8 +577,11 @@ func TestCORSLoginOriginOnSessionPost(t *testing.T) {
 
 	// Skip test if dial tcp fails with no such host.
 	// This is to allow tests to be run offline/without third-party dependencies.
-	if response.Code == http.StatusInternalServerError && strings.Contains(response.Body.String(), "no such host") {
-		t.Skipf("WARNING: Host could not be reached: %s", response.Body.String())
+	if response.Code == http.StatusInternalServerError {
+		switch response.Body.String() {
+		case "i/o timeout", "no such host":
+			t.Skipf("WARNING: Facebook host could not be reached: %s", response.Body.String())
+		}
 	}
 
 	assertStatus(t, response, 401)
@@ -613,6 +616,15 @@ func TestNoCORSOriginOnSessionPost(t *testing.T) {
 	assertStatus(t, response, 400)
 
 	response = rt.SendRequestWithHeaders("POST", "/db/_facebook", `{"access_token":"true"}`, reqHeaders)
+	// Skip test if dial tcp fails with no such host.
+	// This is to allow tests to be run offline/without third-party dependencies.
+	if response.Code == http.StatusInternalServerError {
+		switch response.Body.String() {
+		case "i/o timeout", "no such host":
+			t.Skipf("WARNING: Facebook host could not be reached: %s", response.Body.String())
+		}
+	}
+
 	assertStatus(t, response, 400)
 }
 


### PR DESCRIPTION
Treat `i/o timeout` like we do `no such host` and just mark the test as skipped in the event that Facebook is unreachable.