### PR TITLE
CBG-1708 Handle concurrent update race during index creation

### DIFF
--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -344,6 +344,8 @@ func (c *CbgtContext) StartManager(dbName string, bucket Bucket, spec BucketSpec
 	if err != nil {
 		if strings.Contains(err.Error(), "an index with the same name already exists") {
 			Infof(KeyCluster, "Duplicate cbgt index detected during index creation (concurrent creation), using existing")
+		} else if strings.Contains(err.Error(), "concurrent index definition update") {
+			Infof(KeyCluster, "Index update failed due to concurrent update, using existing")
 		} else {
 			Errorf("cbgt index creation failed: %v", err)
 			return err

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -430,7 +430,7 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 			case <-terminatorChan:
 				context.Manager.Stop()
 			case <-time.After(20 * time.Second):
-				t.Fatalf("manager goroutine not terminated")
+				assert.Fail(t, "manager goroutine not terminated: %v", managerUUID)
 			}
 
 		}(i, terminator)


### PR DESCRIPTION
Existing handling only covered the case where multiple nodes attempted to create a CBGT index concurrently.  In the case where the index already exists, Sync Gateway nodes will attempt to update the index to the same value concurrently - in this case we receive a concurrent update error from cbgt.  Adds a check for that error message, and skips index update in that scenario (since all SG nodes will be attempting to create/update the same index definition).

CBG-1708

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1239/
