### PR TITLE
[2.8.3] CBG-1665: Backport CBG-1564: Apply query limit to N1QL and allow configuration (#5125)

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -98,6 +98,7 @@ type BucketSpec struct {
 	InitialRetrySleepTimeMS                int            // the initial time to sleep in between retry attempts (in millisecond), which will double each retry
 	UseXattrs                              bool           // Whether to use xattrs to store _sync metadata.  Used during view initialization
 	ViewQueryTimeoutSecs                   *uint32        // the view query timeout in seconds (default: 75 seconds)
+	MaxConcurrentQueryOps                  int            // maximum number of concurrent query operations (default: DefaultMaxConcurrentQueryOps)
 	BucketOpTimeout                        *time.Duration // How long bucket ops should block returning "operation timed out". If nil, uses GoCB default.  GoCB buckets only.
 	KvPoolSize                             int            // gocb kv_pool_size - number of pipelines per node. Initialized on GetGoCBConnString
 }

--- a/rest/config.go
+++ b/rest/config.go
@@ -105,15 +105,16 @@ type ServerConfig struct {
 
 // Bucket configuration elements - used by db, index
 type BucketConfig struct {
-	Server     *string `json:"server,omitempty"`      // Couchbase server URL
-	Pool       *string `json:"pool,omitempty"`        // Couchbase pool name, default "default"
-	Bucket     *string `json:"bucket,omitempty"`      // Bucket name
-	Username   string  `json:"username,omitempty"`    // Username for authenticating to server
-	Password   string  `json:"password,omitempty"`    // Password for authenticating to server
-	CertPath   string  `json:"certpath,omitempty"`    // Cert path (public key) for X.509 bucket auth
-	KeyPath    string  `json:"keypath,omitempty"`     // Key path (private key) for X.509 bucket auth
-	CACertPath string  `json:"cacertpath,omitempty"`  // Root CA cert path for X.509 bucket auth
-	KvTLSPort  int     `json:"kv_tls_port,omitempty"` // Memcached TLS port, if not default (11207)
+	Server                *string `json:"server,omitempty"`                   // Couchbase server URL
+	Pool                  *string `json:"pool,omitempty"`                     // Couchbase pool name, default "default"
+	Bucket                *string `json:"bucket,omitempty"`                   // Bucket name
+	Username              string  `json:"username,omitempty"`                 // Username for authenticating to server
+	Password              string  `json:"password,omitempty"`                 // Password for authenticating to server
+	CertPath              string  `json:"certpath,omitempty"`                 // Cert path (public key) for X.509 bucket auth
+	KeyPath               string  `json:"keypath,omitempty"`                  // Key path (private key) for X.509 bucket auth
+	CACertPath            string  `json:"cacertpath,omitempty"`               // Root CA cert path for X.509 bucket auth
+	KvTLSPort             int     `json:"kv_tls_port,omitempty"`              // Memcached TLS port, if not default (11207)
+	MaxConcurrentQueryOps *int    `json:"max_concurrent_query_ops,omitempty"` // Max concurrent query ops
 }
 
 func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
@@ -137,15 +138,21 @@ func (bc *BucketConfig) MakeBucketSpec() base.BucketSpec {
 		tlsPort = bc.KvTLSPort
 	}
 
+	maxConcurrentQueryOps := base.MaxConcurrentQueryOps
+	if bc.MaxConcurrentQueryOps != nil {
+		maxConcurrentQueryOps = *bc.MaxConcurrentQueryOps
+	}
+
 	return base.BucketSpec{
-		Server:     server,
-		PoolName:   pool,
-		BucketName: bucketName,
-		Keypath:    bc.KeyPath,
-		Certpath:   bc.CertPath,
-		CACertPath: bc.CACertPath,
-		KvTLSPort:  tlsPort,
-		Auth:       bc,
+		Server:                server,
+		PoolName:              pool,
+		BucketName:            bucketName,
+		Keypath:               bc.KeyPath,
+		Certpath:              bc.CertPath,
+		CACertPath:            bc.CACertPath,
+		KvTLSPort:             tlsPort,
+		Auth:                  bc,
+		MaxConcurrentQueryOps: maxConcurrentQueryOps,
 	}
 }
 

--- a/rest/server_context_test.go
+++ b/rest/server_context_test.go
@@ -272,3 +272,32 @@ func TestGetOrAddDatabaseFromConfig(t *testing.T) {
 	assert.Equal(t, server, dbContext.BucketSpec.Server)
 	assert.Equal(t, bucketName, dbContext.BucketSpec.BucketName)
 }
+
+func TestViewQueryBucketOptionsOnBucketSpec(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		OperationsPerNode *int
+		ExpectedValue     int
+	}{
+		{
+			Name:              "Set Value",
+			OperationsPerNode: base.IntPtr(10),
+			ExpectedValue:     10,
+		},
+		{
+			Name:              "Set Nil",
+			OperationsPerNode: nil,
+			ExpectedValue:     base.MaxConcurrentQueryOps,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			dbConfig := &DbConfig{BucketConfig: BucketConfig{MaxConcurrentQueryOps: testCase.OperationsPerNode}}
+			spec, err := GetBucketSpec(dbConfig)
+			assert.NoError(t, err)
+
+			assert.Equal(t, testCase.ExpectedValue, spec.MaxConcurrentQueryOps)
+		})
+	}
+}


### PR DESCRIPTION
CBG-1665

- Backport of CBG-1564 which includes the fix also done in CBG-1697.
- Due to the differences introduced in Lithium this change was not a direct cherry-pick and was separately implemented.
- Manually ran a test which stressed the query connections and it was indeed limited to 1000.