### PR TITLE
Fix Tombstone Query Leak

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -1079,6 +1079,11 @@ func (db *Database) Compact(skipRunningStateCheck bool, callback compactCallback
 			}
 		}
 
+		err = results.Close()
+		if err != nil {
+			return 0, err
+		}
+
 		// Now purge them from all channel caches
 		count := len(purgedDocs)
 		purgedDocCount += count


### PR DESCRIPTION
The `QueryTombstones` wasn't closing its query results properly.
- This wasn't found in the initial PR adding the `TestTombstoneCompactionStopWithManager` test as it was not based on the latest query op limiting changes
- Unsure as to why this wasn't found in the query op limiting PR itself as there is another test running compact. Will look into this.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1241/
