### PR TITLE
[2.8.3] CBG-1725: Backport CBG-1591: Order expectedSeqs when calculating checkpoint (#5143)

### DIFF
--- a/db/active_replicator_checkpointer.go
+++ b/db/active_replicator_checkpointer.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -270,6 +271,13 @@ func (c *Checkpointer) _updateCheckpointLists() (safeSeq string) {
 // Returns -1 if no sequence in the list is able to be checkpointed.
 func (c *Checkpointer) _calculateSafeExpectedSeqsIdx() int {
 	safeIdx := -1
+
+	sort.Slice(c.expectedSeqs, func(i, j int) bool {
+		seqI, _ := parseIntegerSequenceID(c.expectedSeqs[i])
+		seqJ, _ := parseIntegerSequenceID(c.expectedSeqs[j])
+
+		return seqI.Before(seqJ)
+	})
 
 	// iterates over each (ordered) expected sequence and stops when we find the first sequence we've yet to process a rev message for
 	for i, seq := range c.expectedSeqs {

--- a/db/active_replicator_checkpointer_test.go
+++ b/db/active_replicator_checkpointer_test.go
@@ -81,6 +81,17 @@ func TestCheckpointerSafeSeq(t *testing.T) {
 			expectedExpectedSeqs:    []string{},
 			expectedProcessedSeqs:   map[string]struct{}{"4": {}, "5": {}},
 		},
+		{
+			name: "out of order expected seqs",
+			c: &Checkpointer{
+				expectedSeqs:  []string{"3", "2", "1"},
+				processedSeqs: map[string]struct{}{"1": {}, "2": {}, "3": {}},
+			},
+			expectedSafeSeq:         "3",
+			expectedExpectedSeqsIdx: 2,
+			expectedExpectedSeqs:    []string{},
+			expectedProcessedSeqs:   map[string]struct{}{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/db/sequence_id.go
+++ b/db/sequence_id.go
@@ -146,23 +146,12 @@ func (s SequenceID) IsNonZero() bool {
 
 // Equality of sequences, based on seq, triggered by and low hash
 func (s SequenceID) Equals(s2 SequenceID) bool {
-	return s.intEquals(s2)
-}
-
-func (s SequenceID) intEquals(s2 SequenceID) bool {
 	return s.SafeSequence() == s2.SafeSequence() && s.TriggeredBy == s2.TriggeredBy
 }
 
 // The most significant value is TriggeredBy, unless it's zero, in which case use Seq.
 // The tricky part is that "n" sorts after "n:m" for any nonzero m
 func (s SequenceID) Before(s2 SequenceID) bool {
-	return s.intBefore(s2)
-}
-
-// The most significant value is TriggeredBy, unless it's zero, in which case use Seq.
-// The tricky part is that "n" sorts after "n:m" for any nonzero m
-func (s SequenceID) intBefore(s2 SequenceID) bool {
-
 	// using SafeSequence for comparison, which takes the lower of LowSeq and Seq
 	if s.TriggeredBy == s2.TriggeredBy {
 		return s.SafeSequence() < s2.SafeSequence() // the simple case: untriggered, or triggered by same sequence


### PR DESCRIPTION
CBG-1725

Backport of CBG-1591
Was able to use cherry-pick here.

---

* CBG-1591: Order expectedSeqs when calculating checkpoint

* Switch to .Before() and cleanup
