### PR TITLE
CBG-1716: norev uses "sequence" property name except for protocol version 2 and ISGR

### DIFF
--- a/db/blip_handler.go
+++ b/db/blip_handler.go
@@ -722,7 +722,11 @@ func (bh *blipHandler) handleNoRev(rq *blip.Message) error {
 		rq.String(), base.UD(rq.Properties[NorevMessageId]), rq.Properties[NorevMessageRev], rq.Properties[NorevMessageError], rq.Properties[NorevMessageReason])
 
 	if bh.sgr2PullProcessedSeqCallback != nil {
-		bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+		if bh.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bh.clientType == BLIPClientTypeSGR2 {
+			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSeq], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+		} else {
+			bh.sgr2PullProcessedSeqCallback(rq.Properties[NorevMessageSequence], IDAndRev{DocID: rq.Properties[NorevMessageId], RevID: rq.Properties[NorevMessageRev]})
+		}
 	}
 
 	// Couchbase Lite always sends noreply=true for norev profiles

--- a/db/blip_sync_context.go
+++ b/db/blip_sync_context.go
@@ -518,13 +518,16 @@ func (bsc *BlipSyncContext) sendBLIPMessage(sender *blip.Sender, msg *blip.Messa
 }
 
 func (bsc *BlipSyncContext) sendNoRev(sender *blip.Sender, docID, revID string, seq SequenceID, err error) error {
-
 	base.DebugfCtx(bsc.loggingCtx, base.KeySync, "Sending norev %q %s due to unavailable revision: %v", base.UD(docID), revID, err)
 
 	noRevRq := NewNoRevMessage()
 	noRevRq.SetId(docID)
 	noRevRq.SetRev(revID)
-	noRevRq.SetSeq(seq)
+	if bsc.blipContext.ActiveSubprotocol() == BlipCBMobileReplicationV2 && bsc.clientType == BLIPClientTypeSGR2 {
+		noRevRq.SetSeq(seq)
+	} else {
+		noRevRq.SetSequence(seq)
+	}
 
 	status, reason := base.ErrorAsHTTPStatus(err)
 	noRevRq.SetError(strconv.Itoa(status))

--- a/db/blip_sync_messages.go
+++ b/db/blip_sync_messages.go
@@ -71,11 +71,12 @@ const (
 	RevMessageDeltaSrc    = "deltaSrc"
 
 	// norev message properties
-	NorevMessageId     = "id"
-	NorevMessageRev    = "rev"
-	NorevMessageSeq    = "seq"
-	NorevMessageError  = "error"
-	NorevMessageReason = "reason"
+	NorevMessageId       = "id"
+	NorevMessageRev      = "rev"
+	NorevMessageSeq      = "seq" // Use when protocol version 2 with client type ISGR
+	NorevMessageSequence = "sequence"
+	NorevMessageError    = "error"
+	NorevMessageReason   = "reason"
 
 	// changes message properties
 	ChangesMessageIgnoreNoConflicts = "ignoreNoConflicts"
@@ -415,6 +416,10 @@ func (nrm *noRevMessage) SetRev(rev string) {
 
 func (nrm *noRevMessage) SetSeq(seq SequenceID) {
 	nrm.Properties[NorevMessageSeq] = seq.String()
+}
+
+func (nrm *noRevMessage) SetSequence(sequence SequenceID) {
+	nrm.Properties[NorevMessageSequence] = sequence.String()
 }
 
 func (nrm *noRevMessage) SetReason(reason string) {

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -2770,6 +2770,7 @@ func TestBlipNorev(t *testing.T) {
 	norevMsg := db.NewNoRevMessage()
 	norevMsg.SetId("docid")
 	norevMsg.SetRev("1-a")
+	norevMsg.SetSequence(db.SequenceID{Seq: 50})
 	norevMsg.SetError("404")
 	norevMsg.SetReason("couldn't send xyz")
 
@@ -2786,6 +2787,20 @@ func TestBlipNorev(t *testing.T) {
 	resp := norevMsg.Response()
 	assert.NotNil(t, resp)
 	assert.Equal(t, "handleNoRev", resp.Properties[db.SGHandler])
+}
+
+// TestNoRevSetSeq makes sure the correct string is used with the corresponding function
+func TestNoRevSetSeq(t *testing.T) {
+	norevMsg := db.NewNoRevMessage()
+	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSeq])
+	assert.Equal(t, "", norevMsg.Properties[db.NorevMessageSequence])
+
+	norevMsg.SetSequence(db.SequenceID{Seq: 50})
+	assert.Equal(t, "50", norevMsg.Properties[db.NorevMessageSequence])
+
+	norevMsg.SetSeq(db.SequenceID{Seq: 60})
+	assert.Equal(t, "60", norevMsg.Properties[db.NorevMessageSeq])
+
 }
 
 // TestBlipDeltaSyncPushAttachment tests updating a doc that has an attachment with a delta that doesn't modify the attachment.


### PR DESCRIPTION
CBG-1716

norev uses the "seq" property name to store or read the sequence number on the norev message if the client type is ISGR, and the active subprotocol on BLIP is version 2 to maintain backwards compatibility. Otherwise "sequence" is used as the property name.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1247/
