### PR TITLE
[2.8.3] CBG-1724: Backport CBG-1325 - Replace strict with permissive email validation (#4962)

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -83,7 +83,7 @@ func TestValidateUserEmail(t *testing.T) {
 	bucket := base.GetTestBucket(t)
 	defer bucket.Close()
 	auth := NewAuthenticator(bucket, nil)
-	badEmails := []string{"", "foo", "foo@", "@bar", "foo @bar", "foo@.bar"}
+	badEmails := []string{"", "foo", "foo@", "@bar", "foo@bar@buzz"}
 	for _, e := range badEmails {
 		assert.False(t, IsValidEmail(e))
 	}

--- a/auth/user.go
+++ b/auth/user.go
@@ -42,17 +42,11 @@ type userImplBody struct {
 	OldExplicitRoles_ []string `json:"admin_roles,omitempty"` // obsolete; declared for migration
 }
 
-var kValidEmailRegexp *regexp.Regexp
+// Permissive email validation (accepts ALL valid emails, but does not reject all invalid emails)
+// Regexp in English: Allow one, and only one @ symbol between any two things
+var kValidEmailRegexp = regexp.MustCompile(`^[^@]+@[^@]+$`)
 
 type VBHashFunction func(string) uint32
-
-func init() {
-	var err error
-	kValidEmailRegexp, err = regexp.Compile(`^[-+.\w]+@\w[-.\w]+$`)
-	if err != nil {
-		panic("Bad kValidEmailRegexp")
-	}
-}
 
 func IsValidEmail(email string) bool {
 	return kValidEmailRegexp.MatchString(email)


### PR DESCRIPTION
CBG-1724

Backport of CBG-1325
- Replace strict with permissive email validation (#4962)
