### PR TITLE
CBG-1667 Backport CBG-1622 to 2.8.3 - Avoid using sourceParams to pass credentials between SG and cbgt

### DIFF
--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -7,14 +7,10 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 
 	"github.com/couchbase/cbgt"
-	"github.com/couchbase/go-couchbase"
-	"github.com/couchbase/go-couchbase/cbdatasource"
 	"github.com/couchbase/gomemcached"
 	sgbucket "github.com/couchbase/sg-bucket"
-	pkgerrors "github.com/pkg/errors"
 )
 
 // vbucketIdStrings is a memorized array of 1024 entries for fast
@@ -246,6 +242,9 @@ func vbNoToPartition(vbNo uint16) string {
 	return vbucketIdStrings[vbNo]
 }
 
+/* Not in use, retaining as reference for future enhancement
+  TODO: remove auth from feedParams and use cbgtFeedParams before re-enabling
+
 // This starts a cbdatasource powered DCP Feed using an entirely separate connection to Couchbase Server than anything the existing
 // bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
 func StartCbgtDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, callback sgbucket.FeedEventCallbackFunc, dbStats *expvar.Map) error {
@@ -272,10 +271,7 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 		return err
 	}
 
-	feedParams, err := cbgtFeedParams(spec)
-	if err != nil {
-		return err
-	}
+	feedParams := cbgt.NewDCPFeedParams()
 
 	bucketUUID, err := bucket.UUID()
 	if err != nil {
@@ -356,6 +352,7 @@ func StartCbgtGocbFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArgumen
 	return nil
 
 }
+
 
 // This starts a cbdatasource powered DCP Feed using an entirely separate connection to Couchbase Server than anything the existing
 // bucket is using, and it uses the go-couchbase cbdatasource DCP abstraction layer
@@ -502,6 +499,7 @@ func StartCbgtCbdatasourceFeed(bucket Bucket, spec BucketSpec, args sgbucket.Fee
 	return nil
 
 }
+*/
 
 func makeFeedEventForDest(key []byte, val []byte, cas uint64, vbNo uint16, expiry uint32, dataType uint8, opcode sgbucket.FeedOpcode) sgbucket.FeedEvent {
 	return makeFeedEvent(key, val, dataType, cas, expiry, vbNo, opcode)

--- a/base/dcp_feed_type.go
+++ b/base/dcp_feed_type.go
@@ -1,0 +1,183 @@
+package base
+
+import (
+	"sync"
+
+	"github.com/couchbase/cbgt"
+)
+
+// cbgtCredentials are global map of dbname to basic auth creds.  Updated on cbgt manager creation, required
+// for couchbase-dcp-sg feed type to retrieve per-db credentials without requiring server context handle
+// Cannot use the serverContext to retrieve this information, as the cbgt manager for a database is initialized
+// before the database is added to the server context's set of databases
+var cbgtCredentials map[string]cbgtCreds
+var cbgtCredentialsLock sync.Mutex
+
+type cbgtCreds struct {
+	username string
+	password string
+}
+
+const SOURCE_GOCOUCHBASE_DCP_SG = "couchbase-dcp-sg"
+
+// When SG isn't using x.509 authentication, it's necessary to pass bucket credentials
+// to cbgt for use when setting up the DCP feed.  These need to be passed as AuthUser and
+// AuthPassword in the DCP source parameters.
+// The dbname is stored in the cfg, and the credentials for that db retrieved from databaseCredentials.
+// The SOURCE_GOCOUCHBASE_DCP_SG feed type is a wrapper for SOURCE_GOCOUCHBASE_DCP that adds
+// the credential information to the DCP parameters before calling the underlying method.
+func init() {
+	cbgtCredentials = make(map[string]cbgtCreds)
+	cbgt.RegisterFeedType(SOURCE_GOCOUCHBASE_DCP_SG, &cbgt.FeedType{
+		Start:           SGFeedStartDCPFeed,
+		Partitions:      SGFeedPartitions,
+		PartitionSeqs:   SGFeedPartitionSeqs,
+		Stats:           SGFeedStats,
+		PartitionLookUp: cbgt.CouchbaseSourceVBucketLookUp,
+		//SourceUUIDLookUp: SGFeedSourceUUIDLookUp,     // TODO: cbgt 1.2.0
+		Public: false, // Won't be listed in /api/managerMeta output.
+		Description: "general/" + SOURCE_GOCOUCHBASE_DCP_SG +
+			" - a Couchbase Server bucket will be the data source," +
+			" via DCP protocol",
+		StartSample: cbgt.NewDCPFeedParams(),
+	})
+}
+
+type SGFeedSourceParams struct {
+	// Used to specify whether the applications are interested
+	// in receiving the xattrs information in a dcp stream.
+	IncludeXAttrs bool `json:"includeXAttrs,omitempty"`
+
+	// Used to pass the SG database name to SGFeed* shims
+	DbName string `json:"sg_dbname,omitempty"`
+}
+
+// cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
+// Used to pass basic auth credentials and xattr flag to cbgt.
+func cbgtFeedParams(spec BucketSpec, dbName string) (string, error) {
+	feedParams := &SGFeedSourceParams{}
+	feedParams.DbName = dbName
+
+	if spec.UseXattrs {
+		feedParams.IncludeXAttrs = true
+	}
+
+	paramBytes, err := JSONMarshal(feedParams)
+	if err != nil {
+		return "", err
+	}
+	return string(paramBytes), nil
+}
+
+// SGFeed* functions add credentials to sourceParams before calling the underlying
+// cbgt function
+func SGFeedStartDCPFeed(mgr *cbgt.Manager, feedName, indexName, indexUUID,
+	sourceType, sourceName, bucketUUID, params string,
+	dests map[string]cbgt.Dest) error {
+
+	paramsWithAuth := addCbgtAuthToDCPParams(params)
+	return cbgt.StartDCPFeed(mgr, feedName, indexName, indexUUID, sourceType, sourceName, bucketUUID,
+		paramsWithAuth, dests)
+}
+
+func SGFeedPartitions(sourceType, sourceName, sourceUUID, sourceParams,
+	serverIn string, options map[string]string) (partitions []string, err error) {
+
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbasePartitions(sourceType, sourceName, sourceUUID, sourceParamsWithAuth,
+		serverIn, options)
+}
+
+func SGFeedPartitionSeqs(sourceType, sourceName, sourceUUID,
+	sourceParams, serverIn string, options map[string]string) (map[string]cbgt.UUIDSeq, error) {
+
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbasePartitionSeqs(sourceType, sourceName, sourceUUID, sourceParamsWithAuth,
+		serverIn, options)
+}
+
+func SGFeedStats(sourceType, sourceName, sourceUUID, sourceParams, serverIn string, options map[string]string,
+	statsKind string) (map[string]interface{}, error) {
+
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbaseStats(sourceType, sourceName, sourceUUID,
+		sourceParamsWithAuth, serverIn, options, statsKind)
+}
+
+/*  TODO: enable when moving to cbgt 1.2.0
+func SGFeedSourceUUIDLookUp(sourceName, sourceParams, serverIn string, options map[string]string) (string, error) {
+	sourceParamsWithAuth := addCbgtAuthToDCPParams(sourceParams)
+	return cbgt.CouchbaseSourceUUIDLookUp(sourceName, sourceParamsWithAuth, serverIn, options)
+}
+
+*/
+
+// addCbgtAuthToDCPParams gets the dbName from the incoming dcpParams, and checks for credentials
+// stored in databaseCredentials.  If found, adds those to the params as authUser/authPassword.
+// If dbname is present,
+func addCbgtAuthToDCPParams(dcpParams string) string {
+
+	var sgSourceParams SGFeedSourceParams
+
+	unmarshalErr := JSONUnmarshal([]byte(dcpParams), &sgSourceParams)
+	if unmarshalErr != nil {
+		Warnf("Unable to unmarshal params provided by cbgt as sgSourceParams: %v", unmarshalErr)
+		return dcpParams
+	}
+
+	if sgSourceParams.DbName == "" {
+		Infof(KeyImport, "Database name not specified in dcp params, feed credentials not added")
+		return dcpParams
+	}
+
+	username, password, ok := getCbgtCredentials(sgSourceParams.DbName)
+	if !ok {
+		// no stored credentials includes the valid x.509 auth case
+		Infof(KeyImport, "No feed credentials stored for db from sourceParams: %s", MD(sgSourceParams.DbName))
+		return dcpParams
+	}
+
+	var feedParamsWithAuth cbgt.DCPFeedParams
+	unmarshalDCPErr := JSONUnmarshal([]byte(dcpParams), &feedParamsWithAuth)
+	if unmarshalDCPErr != nil {
+		Warnf("Unable to unmarshal params provided by cbgt as dcpFeedParams: %v", unmarshalDCPErr)
+	}
+
+	// Add creds to params
+	feedParamsWithAuth.AuthUser = username
+	feedParamsWithAuth.AuthPassword = password
+
+	marshalledParamsWithAuth, marshalErr := JSONMarshal(feedParamsWithAuth)
+	if marshalErr != nil {
+		Warnf("Unable to marshal updated cbgt dcp params: %v", marshalErr)
+		return dcpParams
+	}
+
+	return string(marshalledParamsWithAuth)
+}
+
+func addCbgtCredentials(dbName, username, password string) {
+	cbgtCredentialsLock.Lock()
+	cbgtCredentials[dbName] = cbgtCreds{
+		username: username,
+		password: password,
+	}
+	cbgtCredentialsLock.Unlock()
+}
+
+func removeCbgtCredentials(dbName string) {
+	cbgtCredentialsLock.Lock()
+	delete(cbgtCredentials, dbName)
+	cbgtCredentialsLock.Unlock()
+}
+
+func getCbgtCredentials(dbName string) (username, password string, ok bool) {
+	cbgtCredentialsLock.Lock()
+	creds, found := cbgtCredentials[dbName]
+	if found {
+		username = creds.username
+		password = creds.password
+	}
+	cbgtCredentialsLock.Unlock()
+	return username, password, found
+}

--- a/base/dcp_sharded.go
+++ b/base/dcp_sharded.go
@@ -29,7 +29,8 @@ type CbgtContext struct {
 // dbName is used to define a unique path name for local file storage of pindex files
 func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bucket *CouchbaseBucketGoCB, numPartitions uint16, cfg cbgt.Cfg) (*CbgtContext, error) {
 
-	cbgtContext, err := initCBGTManager(bucket, bucket.Spec, cfg, uuid)
+	cbgtContext, err := initCBGTManager(bucket, bucket.Spec, cfg, uuid, dbName)
+
 	if err != nil {
 		return nil, err
 	}
@@ -58,30 +59,6 @@ func StartShardedDCPFeed(dbName string, uuid string, heartbeater Heartbeater, bu
 	return cbgtContext, nil
 }
 
-// cbgtFeedParams returns marshalled cbgt.DCPFeedParams as string, to be passed as feedparams during cbgt.Manager init.
-// Used to pass basic auth credentials and xattr flag to cbgt.
-func cbgtFeedParams(spec BucketSpec) (string, error) {
-	feedParams := cbgt.NewDCPFeedParams()
-
-	// check for basic auth
-	if spec.Certpath == "" && spec.Auth != nil {
-		username, password, _ := spec.Auth.GetCredentials()
-		feedParams.AuthUser = username
-		feedParams.AuthPassword = password
-	}
-
-	if spec.UseXattrs {
-		// TODO: This is always being set in NewGocbDCPFeed, review whether we actually need ability to run w/ false
-		feedParams.IncludeXAttrs = true
-	}
-
-	paramBytes, err := JSONMarshal(feedParams)
-	if err != nil {
-		return "", err
-	}
-	return string(paramBytes), nil
-}
-
 // Given a dbName, generate a unique and length-constrained index name for CBGT to use as part of their DCP name.
 func GenerateIndexName(dbName string) string {
 	// Index names *must* start with a letter, so we'll prepend 'db' before the per-database checksum (which starts with '0x')
@@ -97,24 +74,16 @@ func GenerateLegacyIndexName(dbName string) string {
 // to the manager's cbgt cfg.  Nodes that have registered for this indexType with the manager via
 // RegisterPIndexImplType (see importListener.RegisterImportPindexImpl)
 // will receive PIndexImpl callbacks (New, Open) for assigned PIndex to initiate DCP processing.
-// TODO: If the index definition already exists in the cfg, it appears like this step can be bypassed,
-//       as we don't currently have a scenario where we want to update an existing index def.  Needs
-//       additional testing to validate.
 func createCBGTIndex(c *CbgtContext, dbName string, bucket Bucket, spec BucketSpec, numPartitions uint16) error {
 
-	// sourceType is based on cbgt.source_gocouchbase non-public constant.
-	// TODO: Request that cbgt make this and source_gocb public.
-	sourceType := "gocb"
-	if feedType == cbgtFeedType_cbdatasource {
-		sourceType = "couchbase"
-	}
+	sourceType := SOURCE_GOCOUCHBASE_DCP_SG
 
 	bucketUUID, err := bucket.UUID()
 	if err != nil {
 		return err
 	}
 
-	sourceParams, err := cbgtFeedParams(spec)
+	sourceParams, err := cbgtFeedParams(spec, dbName)
 	if err != nil {
 		return err
 	}
@@ -249,7 +218,7 @@ func getCBGTIndexUUID(manager *cbgt.Manager, indexName string) (exists bool, pre
 // createCBGTManager creates a new manager for a given bucket and bucketSpec
 // Inline comments below provide additional detail on how cbgt uses each manager
 // parameter, and the implications for SG
-func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string) (*CbgtContext, error) {
+func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID string, dbName string) (*CbgtContext, error) {
 
 	// uuid: Unique identifier for the node. Used to identify the node in the config.
 	//       Without UUID persistence across SG restarts, a restarted SG node relies on heartbeater to remove
@@ -342,6 +311,12 @@ func initCBGTManager(bucket Bucket, spec BucketSpec, cfgSG cbgt.Cfg, dbUUID stri
 		Manager: mgr,
 		Cfg:     cfgSG,
 	}
+
+	if spec.Auth != nil && spec.Certpath == "" {
+		username, password, _ := spec.Auth.GetCredentials()
+		addCbgtCredentials(dbName, username, password)
+	}
+
 	return cbgtContext, nil
 }
 
@@ -372,6 +347,10 @@ func (c *CbgtContext) StopHeartbeatListener() {
 		c.heartbeater.UnregisterListener(c.heartbeatListener.Name())
 		c.heartbeatListener.Stop()
 	}
+}
+
+func (c *CbgtContext) RemoveFeedCredentials(dbName string) {
+	removeCbgtCredentials(dbName)
 }
 
 func initCfgCB(bucket Bucket, spec BucketSpec) (*cbgt.CfgCB, error) {

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -149,6 +149,7 @@ func (il *importListener) Stop() {
 			}
 			// ClosePIndex calls are synchronous, so can stop manager once they've completed
 			il.cbgtContext.Manager.Stop()
+			il.cbgtContext.RemoveFeedCredentials(il.database.Name)
 
 			// TODO: Shut down the cfg (when cfg supports)
 		}


### PR DESCRIPTION

CBG-1667

Wraps cbgt go-couchbase feed definition and supports retrieval of SG db-scoped metadata.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1250/
