### PR TITLE
CBG-1750: Implement bucket persistence of attachment compaction

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -119,7 +119,8 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 	}
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
-	dcpClient, err := base.NewDCPClient(compactionID, callback, clientOptions, cbStore)
+	dcpFeedKey := compactionID + "_mark"
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
 	if err != nil {
 		return 0, err
 	}
@@ -318,7 +319,8 @@ func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAt
 	}
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for sweep phase of attachment compaction", compactionLoggingID)
-	dcpClient, err := base.NewDCPClient(compactionID, callback, clientOptions, cbStore)
+	dcpFeedKey := compactionID + "_sweep"
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
 	if err != nil {
 		return 0, err
 	}
@@ -434,7 +436,8 @@ func Cleanup(db *Database, compactionID string, terminator chan struct{}) error 
 	}
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
-	dcpClient, err := base.NewDCPClient(compactionID, callback, clientOptions, cbStore)
+	dcpFeedKey := compactionID + "_cleanup"
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
 	if err != nil {
 		return err
 	}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -320,7 +320,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		err = base.JSONUnmarshal(rawStatus, &status)
 		assert.NoError(t, err)
 
-		if status.State == BackgroundProcessStateStopped {
+		if status.State == BackgroundProcessStateCompleted {
 			return true
 		}
 
@@ -341,8 +341,8 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	err = base.JSONUnmarshal(testDB2RawStatus, &testDB2Status)
 	assert.NoError(t, err)
 
-	assert.Equal(t, BackgroundProcessStateStopped, testDB1Status.State)
-	assert.Equal(t, BackgroundProcessStateStopped, testDB2Status.State)
+	assert.Equal(t, BackgroundProcessStateCompleted, testDB1Status.State)
+	assert.Equal(t, BackgroundProcessStateCompleted, testDB2Status.State)
 	assert.Equal(t, testDB1Status.CompactID, testDB2Status.CompactID)
 
 }

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -280,6 +280,90 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	}
 }
 
+func TestAttachmentCompactionRunTwice(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	b := base.GetTestBucket(t).LeakyBucketClone(base.LeakyBucketConfig{})
+	defer b.Close()
+
+	testDB1 := setupTestDBForBucket(t, b)
+	defer testDB1.Close()
+
+	testDB2 := setupTestDBForBucket(t, b.NoCloseClone())
+	defer testDB2.Close()
+
+	var err error
+
+	leakyBucket, ok := base.AsLeakyBucket(testDB1.Bucket)
+	require.True(t, ok)
+
+	triggerCallback := false
+	leakyBucket.SetGetRawCallback(func(s string) {
+		if triggerCallback {
+			err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "Process already running")
+			triggerCallback = false
+		}
+	})
+
+	triggerCallback = true
+	err = testDB1.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB1})
+	assert.NoError(t, err)
+
+	err = WaitForConditionWithOptions(func() bool {
+		var status AttachmentManagerResponse
+		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus()
+		assert.NoError(t, err)
+		err = base.JSONUnmarshal(rawStatus, &status)
+		assert.NoError(t, err)
+
+		if status.State == BackgroundProcessStateStopped {
+			return true
+		}
+
+		return false
+	}, 200, 1000)
+	assert.NoError(t, err)
+
+	var testDB1Status AttachmentManagerResponse
+	var testDB2Status AttachmentManagerResponse
+
+	testDB1RawStatus, err := testDB1.AttachmentCompactionManager.GetStatus()
+	assert.NoError(t, err)
+	testDB2RawStatus, err := testDB2.AttachmentCompactionManager.GetStatus()
+	assert.NoError(t, err)
+
+	err = base.JSONUnmarshal(testDB1RawStatus, &testDB1Status)
+	assert.NoError(t, err)
+	err = base.JSONUnmarshal(testDB2RawStatus, &testDB2Status)
+	assert.NoError(t, err)
+
+	assert.Equal(t, BackgroundProcessStateStopped, testDB1Status.State)
+	assert.Equal(t, BackgroundProcessStateStopped, testDB2Status.State)
+	assert.Equal(t, testDB1Status.CompactID, testDB2Status.CompactID)
+
+}
+
+func WaitForConditionWithOptions(successFunc func() bool, maxNumAttempts, timeToSleepMs int) error {
+	waitForSuccess := func() (shouldRetry bool, err error, value interface{}) {
+		if successFunc() {
+			return false, nil, nil
+		}
+		return true, nil, nil
+	}
+
+	sleeper := base.CreateSleeperFunc(maxNumAttempts, timeToSleepMs)
+	err, _ := base.RetryLoop("Wait for condition options", waitForSuccess, sleeper)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func CreateLegacyAttachmentDoc(t *testing.T, db *Database, docID string, body []byte, attID string, attBody []byte) string {
 	if !base.TestUseXattrs() {
 		t.Skip("Requires xattrs")

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -131,13 +131,13 @@ func (b *BackgroundManager) Start(options map[string]interface{}) error {
 			b.SetError(err)
 		}
 
+		b.Terminate()
+
 		if b.GetRunState() == BackgroundProcessStateStopping {
 			b.setRunState(BackgroundProcessStateStopped)
 		} else if b.GetRunState() != BackgroundProcessStateError {
 			b.setRunState(BackgroundProcessStateCompleted)
 		}
-
-		b.Terminate()
 
 		// Once our background process run has completed we should update the completed status and delete the heartbeat
 		// doc

--- a/db/database.go
+++ b/db/database.go
@@ -578,7 +578,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 
 	dbContext.ResyncManager = NewResyncManager()
 	dbContext.TombstoneCompactionManager = NewTombstoneCompactionManager()
-	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager()
+	dbContext.AttachmentCompactionManager = NewAttachmentCompactionManager(bucket)
 
 	return dbContext, nil
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1570,7 +1570,7 @@ func TestResyncStop(t *testing.T) {
 		var resyncManagerStatus ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
 		assert.NoError(t, err)
-		return resyncManagerStatus.Status == db.BackgroundProcessStateStopped
+		return resyncManagerStatus.Status == db.BackgroundProcessStateAborted
 	})
 	assert.NoError(t, err)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -1231,7 +1231,7 @@ func TestDBOfflinePostResync(t *testing.T) {
 		var status db.ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &status)
 		assert.NoError(t, err)
-		return status.State == db.BackgroundProcessStateStopped
+		return status.State == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
 }
@@ -1281,7 +1281,7 @@ func TestDBOfflineSingleResync(t *testing.T) {
 		var status db.ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &status)
 		assert.NoError(t, err)
-		return status.State == db.BackgroundProcessStateStopped
+		return status.State == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
 
@@ -1361,7 +1361,7 @@ func TestResync(t *testing.T) {
 				response := rt.SendAdminRequest("GET", "/db/_resync", "")
 				err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
 				assert.NoError(t, err)
-				return resyncManagerStatus.State == db.BackgroundProcessStateStopped
+				return resyncManagerStatus.State == db.BackgroundProcessStateCompleted
 			})
 			assert.NoError(t, err)
 
@@ -1462,7 +1462,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 		var status db.ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &status)
 		assert.NoError(t, err)
-		return status.State == db.BackgroundProcessStateStopped
+		return status.State == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
 
@@ -1481,7 +1481,7 @@ func TestResyncErrorScenarios(t *testing.T) {
 		var status db.ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &status)
 		assert.NoError(t, err)
-		return status.State == db.BackgroundProcessStateStopped
+		return status.State == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
 
@@ -1570,7 +1570,7 @@ func TestResyncStop(t *testing.T) {
 		var resyncManagerStatus ResyncManagerResponse
 		err := json.Unmarshal(response.BodyBytes(), &resyncManagerStatus)
 		assert.NoError(t, err)
-		return resyncManagerStatus.Status == db.BackgroundProcessStateAborted
+		return resyncManagerStatus.Status == db.BackgroundProcessStateStopped
 	})
 	assert.NoError(t, err)
 
@@ -1688,7 +1688,7 @@ func TestResyncRegenerateSequences(t *testing.T) {
 	assertStatus(t, response, http.StatusOK)
 
 	err = rt.WaitForCondition(func() bool {
-		return rt.GetDatabase().ResyncManager.GetRunState() == db.BackgroundProcessStateStopped
+		return rt.GetDatabase().ResyncManager.GetRunState() == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
 

--- a/rest/api.go
+++ b/rest/api.go
@@ -158,6 +158,7 @@ func (h *handler) handleCompact() error {
 		if action == string(db.BackgroundProcessActionStart) {
 			err := h.db.AttachmentCompactionManager.Start(map[string]interface{}{
 				"database": h.db,
+				"reset":    h.getBoolQuery("reset"),
 			})
 			if err != nil {
 				return err

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -9203,7 +9203,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	err := base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
 	assert.NoError(t, err)
 
-	assert.Equal(t, db.BackgroundProcessStateStopped, tombstoneCompactionStatus.State)
+	assert.Equal(t, db.BackgroundProcessStateCompleted, tombstoneCompactionStatus.State)
 	assert.Empty(t, tombstoneCompactionStatus.LastErrorMessage)
 	assert.Equal(t, 0, int(tombstoneCompactionStatus.DocsPurged))
 
@@ -9217,7 +9217,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 		err = base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
 		assert.NoError(t, err)
 
-		return tombstoneCompactionStatus.State == db.BackgroundProcessStateStopped
+		return tombstoneCompactionStatus.State == db.BackgroundProcessStateCompleted
 	})
 	assert.NoError(t, err)
 
@@ -9226,7 +9226,7 @@ func TestTombstoneCompactionAPI(t *testing.T) {
 	err = base.JSONUnmarshal(resp.BodyBytes(), &tombstoneCompactionStatus)
 	assert.NoError(t, err)
 
-	assert.Equal(t, db.BackgroundProcessStateStopped, tombstoneCompactionStatus.State)
+	assert.Equal(t, db.BackgroundProcessStateCompleted, tombstoneCompactionStatus.State)
 	assert.Empty(t, tombstoneCompactionStatus.LastErrorMessage)
 
 	if base.TestUseXattrs() {

--- a/rest/changes_api_test.go
+++ b/rest/changes_api_test.go
@@ -3893,7 +3893,7 @@ func TestTombstoneCompaction(t *testing.T) {
 
 		err := rt.WaitForCondition(func() bool {
 			time.Sleep(1 * time.Second)
-			return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateStopped
+			return rt.GetDatabase().TombstoneCompactionManager.GetRunState() == db.BackgroundProcessStateCompleted
 		})
 		assert.NoError(t, err)
 

--- a/rest/utilities_testing.go
+++ b/rest/utilities_testing.go
@@ -444,7 +444,10 @@ func (rt *RestTester) WaitForChanges(numChangesExpected int, changesUrl, usernam
 // WaitForCondition runs a retry loop that evaluates the provided function, and terminates
 // when the function returns true.
 func (rt *RestTester) WaitForCondition(successFunc func() bool) error {
+	return rt.WaitForConditionWithOptions(successFunc, 200, 100)
+}
 
+func (rt *RestTester) WaitForConditionWithOptions(successFunc func() bool, maxNumAttempts, timeToSleepMs int) error {
 	waitForSuccess := func() (shouldRetry bool, err error, value interface{}) {
 		if successFunc() {
 			return false, nil, nil
@@ -452,15 +455,13 @@ func (rt *RestTester) WaitForCondition(successFunc func() bool) error {
 		return true, nil, nil
 	}
 
-	sleeper := base.CreateSleeperFunc(200, 100)
-
-	err, _ := base.RetryLoop("Wait for condition", waitForSuccess, sleeper)
+	sleeper := base.CreateSleeperFunc(maxNumAttempts, timeToSleepMs)
+	err, _ := base.RetryLoop("Wait for condition options", waitForSuccess, sleeper)
 	if err != nil {
 		return err
 	}
 
 	return nil
-
 }
 
 func (rt *RestTester) SendAdminRequest(method, resource string, body string) *TestResponse {


### PR DESCRIPTION
CBG-1750

For the attachment compaction work we want to support two new things:
 - Only allow the process to run one instance of compaction at a time
 - Allow GET to be called from other nodes so that all nodes can access the current run status
 - Make the process resumable

We want to make this as generic as possible so that this can be implemented for other features. In the resumable case this is attachment compaction specific but the ability to store status in the cluster as well as maintaining heartbeat docs to limit the process to one running instance can easily be applied to other processes, such as resync.

---
**Changes**
- New state -- Completed -- Signifies that a process has completed. Previous 'stopped' now signifies that the process either crashed or was manually stopped prior to completion. 
 - When attempting to mark start - create a heartbeat document
 		- If document already exists, fail out and error 
 		- If document is successfully created kick off a heartbeat go routine which will maintain that document for the lifetime of the process
 - Check if a process status document exists in the bucket
 		- If one exists in a 'stopped' state we can just continue - new compactID
 		- If one exists but is not in a 'stopped' state then we need to resume the previous run - use old compactID and start at correct phase
 - Kick off a goroutine which updates the status
 		- This polls the 'local' status for the process and updates the cluster status
 - GetStatus will now return the cluster status document if it exists. If the cluster status document exists and a heartbeat doesn't then we need to do a check. Basically if the cluster status state isn't 'stopped' / 'errored' / 'aborted' then this processed crashed, but it'd be weird to return the status to the user as 'running'. Therefore if no heartbeat and it isn't in one of the aforementioned states we set it to 'aborted' as we know it must have failed.
 - Once process completes:
 		- Stop goroutines
 		- Delete heartbeat doc
 		- Set status doc to stopped
---

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1382/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1385/
