### PR TITLE
CBG-1764: Creating a new legacy database does not inherit credentials from a static database

### DIFF
--- a/base/collection.go
+++ b/base/collection.go
@@ -79,6 +79,7 @@ func GetCouchbaseCollection(spec BucketSpec) (*Collection, error) {
 		RetryStrategy: &goCBv2FailFastRetryStrategy{},
 	})
 	if err != nil {
+		_ = cluster.Close(nil)
 		if errors.Is(err, gocb.ErrAuthenticationFailure) {
 			return nil, ErrAuthError
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -105,7 +105,7 @@ func (h *handler) handleCreateDB() error {
 		// store the cas in the loaded config after a successful insert
 		h.server.dbConfigs[dbName].cas = cas
 	} else {
-		// Intentionally do not pass bootstrap config in so it's credentials or server is not inherited (CBG-1764)
+		// Intentionally pass in an empty BootstrapConfig to avoid inheriting any credentials or server when running with a legacy config (CBG-1764)
 		if err := config.setup(dbName, BootstrapConfig{}, nil); err != nil {
 			return err
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -40,11 +40,6 @@ func (h *handler) handleCreateDB() error {
 	}
 	config.Name = dbName
 
-	bucket := dbName
-	if config.Bucket != nil {
-		bucket = *config.Bucket
-	}
-
 	if h.server.persistentConfig {
 		if err := config.validatePersistentDbConfig(); err != nil {
 			return base.HTTPErrorf(http.StatusBadRequest, err.Error())
@@ -57,6 +52,11 @@ func (h *handler) handleCreateDB() error {
 		version, err := GenerateDatabaseConfigVersionID("", config)
 		if err != nil {
 			return err
+		}
+
+		bucket := dbName
+		if config.Bucket != nil {
+			bucket = *config.Bucket
 		}
 
 		// copy config before setup to persist the raw config the user supplied
@@ -112,7 +112,7 @@ func (h *handler) handleCreateDB() error {
 		// load database in-memory for non-persistent nodes
 		if _, err := h.server.AddDatabaseFromConfigFailFast(DatabaseConfig{DbConfig: *config}); err != nil {
 			if errors.Is(err, base.ErrAuthError) {
-				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket using database credentials: %s", base.Metadata(bucket))
+				return base.HTTPErrorf(http.StatusForbidden, "auth failure using provided bucket credentials for database %s", base.Metadata(config.Name))
 			}
 			return err
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -105,10 +105,6 @@ func (h *handler) handleCreateDB() error {
 		// store the cas in the loaded config after a successful insert
 		h.server.dbConfigs[dbName].cas = cas
 	} else {
-		if config.BucketConfig.Username == "" || config.BucketConfig.Password == "" {
-			return fmt.Errorf("bucket credentials must be provided")
-		}
-
 		// Check credentials are correct
 		_, err := db.ConnectToBucket(config.MakeBucketSpec())
 		if err != nil {

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -105,7 +105,17 @@ func (h *handler) handleCreateDB() error {
 		// store the cas in the loaded config after a successful insert
 		h.server.dbConfigs[dbName].cas = cas
 	} else {
-		if err := config.setup(dbName, h.server.config.Bootstrap, nil); err != nil {
+		if config.BucketConfig.Username == "" || config.BucketConfig.Password == "" {
+			return fmt.Errorf("bucket credentials must be provided")
+		}
+
+		// Check credentials are correct
+		_, err := db.ConnectToBucket(config.MakeBucketSpec())
+		if err != nil {
+			return err
+		}
+
+		if err := config.setup(dbName, BootstrapConfig{}, nil); err != nil {
 			return err
 		}
 

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -112,7 +112,7 @@ func (h *handler) handleCreateDB() error {
 		// load database in-memory for non-persistent nodes
 		if _, err := h.server.AddDatabaseFromConfigFailFast(DatabaseConfig{DbConfig: *config}); err != nil {
 			if errors.Is(err, base.ErrAuthError) {
-				return base.HTTPErrorf(http.StatusForbidden, "auth failure using provided bucket credentials for database %s", base.Metadata(config.Name))
+				return base.HTTPErrorf(http.StatusForbidden, "auth failure using provided bucket credentials for database %s", base.MD(config.Name))
 			}
 			return err
 		}

--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -105,6 +105,7 @@ func (h *handler) handleCreateDB() error {
 		// store the cas in the loaded config after a successful insert
 		h.server.dbConfigs[dbName].cas = cas
 	} else {
+		// Intentionally do not pass bootstrap config in so it's credentials or server is not inherited (CBG-1764)
 		if err := config.setup(dbName, BootstrapConfig{}, nil); err != nil {
 			return err
 		}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3710,7 +3710,6 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
 	// Start SG with bootstrap credentials filled
 	config := bootstrapStartupConfigForTest(t)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3711,6 +3711,8 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
 	// Start SG with bootstrap credentials filled
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, false)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3727,20 +3727,20 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 	defer func() { tb.Close() }()
 
 	// No credentials should fail
-	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
 		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
 	)
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	// Wrong credentials should fail
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/",
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db2/",
 		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0, "username": "test", "password": "invalid_password"}`,
 	)
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	// Proper credentials should pass
-	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0, "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterUsername()+`"}`,
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db3/",
+		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0, "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`"}`,
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3722,6 +3722,10 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -28,6 +28,8 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 		t.Skip("Bootstrap works with Couchbase Server only")
 	}
 
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
 	// Start SG with no databases in bucket(s)
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -28,8 +28,6 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 		t.Skip("Bootstrap works with Couchbase Server only")
 	}
 
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
-
 	// Start SG with no databases in bucket(s)
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -330,10 +330,10 @@ func (sc *ServerContext) ReloadDatabaseFromConfig(reloadDbName string) (*db.Data
 // Adds a database to the ServerContext.  Attempts a read after it gets the write
 // lock to see if it's already been added by another process. If so, returns either the
 // existing DatabaseContext or an error based on the useExisting flag.
-func (sc *ServerContext) getOrAddDatabaseFromConfig(config DatabaseConfig, useExisting bool) (*db.DatabaseContext, error) {
+func (sc *ServerContext) getOrAddDatabaseFromConfig(config DatabaseConfig, useExisting bool, failFast bool) (*db.DatabaseContext, error) {
 	// Obtain write lock during add database, to avoid race condition when creating based on ConfigServer
 	sc.lock.Lock()
-	dbContext, err := sc._getOrAddDatabaseFromConfig(config, useExisting, false)
+	dbContext, err := sc._getOrAddDatabaseFromConfig(config, useExisting, failFast)
 	sc.lock.Unlock()
 
 	return dbContext, err
@@ -920,7 +920,13 @@ func (sc *ServerContext) initEventHandlers(dbcontext *db.DatabaseContext, config
 // Adds a database to the ServerContext given its configuration.  If an existing config is found
 // for the name, returns an error.
 func (sc *ServerContext) AddDatabaseFromConfig(config DatabaseConfig) (*db.DatabaseContext, error) {
-	return sc.getOrAddDatabaseFromConfig(config, false)
+	return sc.getOrAddDatabaseFromConfig(config, false, false)
+}
+
+// AddDatabaseFromConfigFailFast adds a database to the ServerContext given its configuration and fails fast.
+// If an existing config is found for the name, returns an error.
+func (sc *ServerContext) AddDatabaseFromConfigFailFast(config DatabaseConfig) (*db.DatabaseContext, error) {
+	return sc.getOrAddDatabaseFromConfig(config, false, true)
 }
 
 func (sc *ServerContext) processEventHandlersForEvent(events []*EventConfig, eventType db.EventType, dbcontext *db.DatabaseContext) error {


### PR DESCRIPTION
CBG-1764

- Credentials no longer inherited from any static databases
- unit test to test this behaviour
- cluster is closed on error to stop constant warning logs due to authentication failure
- adding database fails fast

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​344
