### PR TITLE
CBG-1766: Limit max concurrent query ops to be inline with max idle conns per host

### DIFF
--- a/base/bucket.go
+++ b/base/bucket.go
@@ -228,7 +228,7 @@ func (spec *BucketSpec) GetGoCBConnString() (string, error) {
 
 // addGoCBv2ConnValues adds URL values for GoCBv2 based on the bucket spec and default SG values.
 func addGoCBv2ConnValues(spec *BucketSpec, connValues *url.Values) {
-	connValues.Set("max_perhost_idle_http_connections", DefaultHttpMaxIdleConnsPerHost)
+	connValues.Set("max_perhost_idle_http_connections", strconv.Itoa(DefaultHttpMaxIdleConnsPerHost))
 	connValues.Set("max_idle_http_connections", DefaultHttpMaxIdleConns)
 	connValues.Set("idle_http_connection_timeout", DefaultHttpIdleConnTimeoutMilliseconds)
 
@@ -239,7 +239,7 @@ func addGoCBv2ConnValues(spec *BucketSpec, connValues *url.Values) {
 
 // addGoCBv1ConnValues adds URL values for GoCBv1 based on the bucket spec and default SG values.
 func addGoCBv1ConnValues(spec *BucketSpec, connValues *url.Values) {
-	connValues.Set("http_max_idle_conns_per_host", DefaultHttpMaxIdleConnsPerHost)
+	connValues.Set("http_max_idle_conns_per_host", strconv.Itoa(DefaultHttpMaxIdleConnsPerHost))
 	connValues.Set("http_max_idle_conns", DefaultHttpMaxIdleConns)
 	connValues.Set("http_idle_conn_timeout", DefaultHttpIdleConnTimeoutMilliseconds)
 

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -186,7 +186,7 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 
 	if maxConcurrentQueryOps > DefaultHttpMaxIdleConnsPerHost*queryNodeCount {
 		maxConcurrentQueryOps = DefaultHttpMaxIdleConnsPerHost * queryNodeCount
-		Warnf("Limited max concurrent query ops to %d to be in line with number of query nodes", maxConcurrentQueryOps)
+		Infof(KeyAll, "Setting max_concurrent_query_ops to %d based on query node count (%d)", maxConcurrentQueryOps, queryNodeCount)
 	}
 
 	viewOpsQueue := make(chan struct{}, maxConcurrentQueryOps)

--- a/base/bucket_gocb.go
+++ b/base/bucket_gocb.go
@@ -179,6 +179,16 @@ func GetCouchbaseBucketGoCBFromAuthenticatedCluster(cluster *gocb.Cluster, spec 
 		maxConcurrentQueryOps = *spec.MaxConcurrentQueryOps
 	}
 
+	queryNodeCount := len(goCBBucket.IoRouter().N1qlEps())
+	if queryNodeCount == 0 {
+		queryNodeCount = 1
+	}
+
+	if maxConcurrentQueryOps > DefaultHttpMaxIdleConnsPerHost*queryNodeCount {
+		maxConcurrentQueryOps = DefaultHttpMaxIdleConnsPerHost * queryNodeCount
+		Warnf("Limited max concurrent query ops to %d to be in line with number of query nodes", maxConcurrentQueryOps)
+	}
+
 	viewOpsQueue := make(chan struct{}, maxConcurrentQueryOps)
 
 	bucket = &CouchbaseBucketGoCB{

--- a/base/collection.go
+++ b/base/collection.go
@@ -123,7 +123,7 @@ func GetCollectionFromCluster(cluster *gocb.Cluster, spec BucketSpec, waitUntilR
 
 	if maxConcurrentQueryOps > DefaultHttpMaxIdleConnsPerHost*queryNodeCount {
 		maxConcurrentQueryOps = DefaultHttpMaxIdleConnsPerHost * queryNodeCount
-		Warnf("Limited max concurrent query ops to %d to be in line with number of query nodes", maxConcurrentQueryOps)
+		Infof(KeyAll, "Setting max_concurrent_query_ops to %d based on query node count (%d)", maxConcurrentQueryOps, queryNodeCount)
 	}
 
 	collection.queryOps = make(chan struct{}, maxConcurrentQueryOps)

--- a/base/constants.go
+++ b/base/constants.go
@@ -92,7 +92,7 @@ const (
 	// a high number of connections to end up in the TIME_WAIT state and exhaust system resources.  Since
 	// GoCB is only connecting to a fixed set of Couchbase nodes, this number can be set relatively high and
 	// still stay within a reasonable value.
-	DefaultHttpMaxIdleConnsPerHost = "256"
+	DefaultHttpMaxIdleConnsPerHost = 256
 
 	// This primarily depends on MaxIdleConnsPerHost as the limiting factor, but sets some upper limit just to avoid
 	// being completely unlimited


### PR DESCRIPTION
CBG-1766

Changed max concurrent query ops to be limited to query node count * DefaultHttpMaxIdleConnsPerHost.
This ensures that we can properly handle a large number of concurrent query ops without having to constantly open new connections. 

Opted to limit node count to 1 if we either can't get the count or if the count is 0. Means we can still handle queries if for whatever there is an issue getting the node count or if they are still in startup for example. 

Given the low level operations here it's difficult to write a test for. However, I did manual testing for both collections and buckets and ensured that the setting was correctly limiting the max concurrent query ops in line with the number of nodes. Tested with 1, 2, 3 and 4 nodes.