### PR TITLE
CBG-1779: Warning logged if root pool cannot be retrieved instead of erroring

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -150,7 +150,7 @@ func getRootCAs(caCertPath string) (*x509.CertPool, error) {
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
 		rootCAs = x509.NewCertPool()
-		Errorf("Error getting root CAs: %v", err)
+		Warnf("Could not retrieve root CAs: %v", err)
 	}
 	return rootCAs, nil
 }


### PR DESCRIPTION
CBG-1779

- Error changes to warning when system root pool cannot be retrieved. 
- Log text changes from `Error getting root CAs` to `Could not retrieve root CAs`
