### PR TITLE
CBG-1773: Fix race condition in attachment compaction stat callback

### DIFF
--- a/base/util.go
+++ b/base/util.go
@@ -1224,6 +1224,35 @@ func (ab *AtomicBool) CASRetry(old bool, new bool) bool {
 	return false
 }
 
+type AtomicInt struct {
+	val int64
+}
+
+func (ai *AtomicInt) Set(value int64) {
+	atomic.StoreInt64(&ai.val, value)
+}
+
+func (ai *AtomicInt) SetIfMax(value int64) {
+	for {
+		cur := atomic.LoadInt64(&ai.val)
+		if cur >= value {
+			return
+		}
+
+		if atomic.CompareAndSwapInt64(&ai.val, cur, value) {
+			return
+		}
+	}
+}
+
+func (ai *AtomicInt) Add(value int64) {
+	atomic.AddInt64(&ai.val, value)
+}
+
+func (ai *AtomicInt) Value() int64 {
+	return atomic.LoadInt64(&ai.val)
+}
+
 func Sha1HashString(str string, salt string) string {
 	h := sha1.New()
 	h.Write([]byte(salt + str))

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -46,9 +46,9 @@ func TestAttachmentMark(t *testing.T) {
 	attKeys = append(attKeys, createDocWithInBodyAttachment(t, "inBodyDoc", []byte(`{}`), "attForInBodyRef", []byte(`{"val": "inBodyAtt"}`), testDb))
 
 	terminator := make(chan struct{})
-	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, func(markedAttachments *int) {})
+	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, base.Uint64Ptr(0))
 	assert.NoError(t, err)
-	assert.Equal(t, 13, attachmentsMarked)
+	assert.Equal(t, uint64(13), attachmentsMarked)
 
 	for _, attDocKey := range attKeys {
 		var attachmentData Body
@@ -102,10 +102,10 @@ func TestAttachmentSweep(t *testing.T) {
 	}
 
 	terminator := make(chan struct{})
-	purged, err := Sweep(testDb, t.Name(), terminator, func(purgedAttachments *int) {})
+	purged, err := Sweep(testDb, t.Name(), terminator, base.Uint64Ptr(0))
 	assert.NoError(t, err)
 
-	assert.Equal(t, 11, purged)
+	assert.Equal(t, uint64(11), purged)
 }
 
 func TestAttachmentCleanup(t *testing.T) {
@@ -242,13 +242,13 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	}
 
 	terminator := make(chan struct{})
-	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, func(markedAttachments *int) {})
+	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, base.Uint64Ptr(0))
 	assert.NoError(t, err)
-	assert.Equal(t, 10, attachmentsMarked)
+	assert.Equal(t, uint64(10), attachmentsMarked)
 
-	attachmentsPurged, err := Sweep(testDb, t.Name(), terminator, func(purgedAttachments *int) {})
+	attachmentsPurged, err := Sweep(testDb, t.Name(), terminator, base.Uint64Ptr(0))
 	assert.NoError(t, err)
-	assert.Equal(t, 5, attachmentsPurged)
+	assert.Equal(t, uint64(5), attachmentsPurged)
 
 	for _, attDocKey := range attKeys {
 		var back interface{}

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -46,9 +46,9 @@ func TestAttachmentMark(t *testing.T) {
 	attKeys = append(attKeys, createDocWithInBodyAttachment(t, "inBodyDoc", []byte(`{}`), "attForInBodyRef", []byte(`{"val": "inBodyAtt"}`), testDb))
 
 	terminator := make(chan struct{})
-	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, base.Uint64Ptr(0))
+	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(13), attachmentsMarked)
+	assert.Equal(t, int64(13), attachmentsMarked)
 
 	for _, attDocKey := range attKeys {
 		var attachmentData Body
@@ -102,10 +102,10 @@ func TestAttachmentSweep(t *testing.T) {
 	}
 
 	terminator := make(chan struct{})
-	purged, err := Sweep(testDb, t.Name(), terminator, base.Uint64Ptr(0))
+	purged, err := Sweep(testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
 
-	assert.Equal(t, uint64(11), purged)
+	assert.Equal(t, int64(11), purged)
 }
 
 func TestAttachmentCleanup(t *testing.T) {
@@ -242,13 +242,13 @@ func TestAttachmentMarkAndSweepAndCleanup(t *testing.T) {
 	}
 
 	terminator := make(chan struct{})
-	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, base.Uint64Ptr(0))
+	attachmentsMarked, err := Mark(testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(10), attachmentsMarked)
+	assert.Equal(t, int64(10), attachmentsMarked)
 
-	attachmentsPurged, err := Sweep(testDb, t.Name(), terminator, base.Uint64Ptr(0))
+	attachmentsPurged, err := Sweep(testDb, t.Name(), terminator, &base.AtomicInt{})
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(5), attachmentsPurged)
+	assert.Equal(t, int64(5), attachmentsPurged)
 
 	for _, attDocKey := range attKeys {
 		var back interface{}

--- a/db/background_mgr.go
+++ b/db/background_mgr.go
@@ -288,8 +288,8 @@ func (t *TombstoneCompactionManager) ResetStatus() {
 // =====================================================================
 
 type AttachmentCompactionManager struct {
-	MarkedAttachments uint64
-	PurgedAttachments uint64
+	MarkedAttachments base.AtomicInt
+	PurgedAttachments base.AtomicInt
 	lock              sync.Mutex
 }
 
@@ -325,8 +325,8 @@ func (a *AttachmentCompactionManager) Run(options map[string]interface{}, termin
 
 type AttachmentManagerResponse struct {
 	BackgroundManagerStatus
-	MarkedAttachments uint64 `json:"marked_attachments"`
-	PurgedAttachments uint64 `json:"purged_attachments"`
+	MarkedAttachments int64 `json:"marked_attachments"`
+	PurgedAttachments int64 `json:"purged_attachments"`
 }
 
 func (a *AttachmentCompactionManager) GetProcessStatus(status BackgroundManagerStatus) ([]byte, error) {
@@ -335,8 +335,8 @@ func (a *AttachmentCompactionManager) GetProcessStatus(status BackgroundManagerS
 
 	retStatus := AttachmentManagerResponse{
 		BackgroundManagerStatus: status,
-		MarkedAttachments:       atomic.LoadUint64(&a.MarkedAttachments),
-		PurgedAttachments:       atomic.LoadUint64(&a.PurgedAttachments),
+		MarkedAttachments:       a.MarkedAttachments.Value(),
+		PurgedAttachments:       a.PurgedAttachments.Value(),
 	}
 
 	return base.JSONMarshal(retStatus)
@@ -346,6 +346,6 @@ func (a *AttachmentCompactionManager) ResetStatus() {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	atomic.StoreUint64(&a.MarkedAttachments, 0)
-	atomic.StoreUint64(&a.PurgedAttachments, 0)
+	a.MarkedAttachments.Set(0)
+	a.PurgedAttachments.Set(0)
 }

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -30,8 +30,8 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	err := base.JSONUnmarshal(resp.BodyBytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
-	assert.Equal(t, uint64(0), response.MarkedAttachments)
-	assert.Equal(t, uint64(0), response.PurgedAttachments)
+	assert.Equal(t, int64(0), response.MarkedAttachments)
+	assert.Equal(t, int64(0), response.PurgedAttachments)
 	assert.Empty(t, response.LastErrorMessage)
 
 	// Kick off compact
@@ -104,8 +104,8 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	err = base.JSONUnmarshal(resp.BodyBytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
-	assert.Equal(t, uint64(20), response.MarkedAttachments)
-	assert.Equal(t, uint64(5), response.PurgedAttachments)
+	assert.Equal(t, int64(20), response.MarkedAttachments)
+	assert.Equal(t, int64(5), response.PurgedAttachments)
 	assert.Empty(t, response.LastErrorMessage)
 
 	// Start another run

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -30,8 +30,8 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	err := base.JSONUnmarshal(resp.BodyBytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
-	assert.Equal(t, int64(0), response.MarkedAttachments)
-	assert.Equal(t, int64(0), response.PurgedAttachments)
+	assert.Equal(t, uint64(0), response.MarkedAttachments)
+	assert.Equal(t, uint64(0), response.PurgedAttachments)
 	assert.Empty(t, response.LastErrorMessage)
 
 	// Kick off compact
@@ -104,8 +104,8 @@ func TestAttachmentCompactionAPI(t *testing.T) {
 	err = base.JSONUnmarshal(resp.BodyBytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, db.BackgroundProcessStateStopped, response.State)
-	assert.Equal(t, int64(20), response.MarkedAttachments)
-	assert.Equal(t, int64(5), response.PurgedAttachments)
+	assert.Equal(t, uint64(20), response.MarkedAttachments)
+	assert.Equal(t, uint64(5), response.PurgedAttachments)
 	assert.Empty(t, response.LastErrorMessage)
 
 	// Start another run


### PR DESCRIPTION
CBG-1773

Prior to this change there was a race in the attachment compaction stat callback. We were just sending through a pointer to the stat integer from the Mark / Sweep functions. Due to the fact that the DCP workers run in parallel there was a clear race in mutating this value.

- Added an AtomicInt type for this purpose
- Switched SgwIntStat to embed AtomicInt 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1346/
