### PR TITLE
CBG-1769: Database config can be retrieved while db offline

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3750,8 +3750,8 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
-func TestDatabaseOfflineConfig(t *testing.T) {
-	rt := NewRestTester(t, nil)
+func TestDatabaseOfflineConfigLegacy(t *testing.T) {
+	rt := NewRestTester(t, &RestTesterConfig{persistentConfig: false})
 	bucket := rt.Bucket()
 	defer rt.Close()
 
@@ -3777,4 +3777,58 @@ func TestDatabaseOfflineConfig(t *testing.T) {
 	resp = rt.SendAdminRequest("GET", "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Equal(t, dbConfigBeforeOffline, string(resp.BodyBytes()))
+}
+
+func TestDatabaseOfflineConfigPersistent(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
+
+	// Start SG with bootstrap credentials filled
+	config := bootstrapStartupConfigForTest(t)
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
+	serverErr := make(chan error, 0)
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
+	// Get a test bucket, and use it to create the database.
+	tb := base.GetTestBucket(t)
+	defer func() { tb.Close() }()
+
+	dbConfig := `{
+    "bucket": "` + tb.GetName() + `",
+    "name": "db",
+    "sync": "function(doc){ channel(doc.channels); }",
+    "import_docs": true,
+    "offline": false,
+    "enable_shared_bucket_access": true,
+    "num_index_replicas": 0 }`
+	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", dbConfig)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	dbConfigBeforeOffline := DatabaseConfig{}
+	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbConfigBeforeOffline))
+	require.NoError(t, resp.Body.Close())
+
+	resp = bootstrapAdminRequest(t, http.MethodPost, "/db/_offline", "")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	dbConfigAfterOffline := DatabaseConfig{}
+	require.NoError(t, base.JSONDecoder(resp.Body).Decode(&dbConfigAfterOffline))
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, dbConfigBeforeOffline, dbConfigAfterOffline)
 }

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3757,14 +3757,14 @@ func TestDatabaseOfflineConfigLegacy(t *testing.T) {
 	defer rt.Close()
 
 	dbConfig := `{
-    "bucket": "` + bucket.GetName() + `",
-    "name": "db",
-    "sync": "function(doc){ channel(doc.channels); }",
-    "import_docs": false,
-    "offline": false,
-    "enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
+	"bucket": "` + bucket.GetName() + `",
+	"name": "db",
+	"sync": "function(doc){ channel(doc.channels); }",
+	"import_docs": false,
+	"offline": false,
+	"enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
 	"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
-    "num_index_replicas": 0 }`
+	"num_index_replicas": 0 }`
 
 	resp := rt.SendAdminRequest("PUT", "/db/_config", dbConfig)
 	require.Equal(t, http.StatusCreated, resp.Code)
@@ -3807,14 +3807,14 @@ func TestDatabaseOfflineConfigPersistent(t *testing.T) {
 	defer func() { tb.Close() }()
 
 	dbConfig := `{
-    "bucket": "` + tb.GetName() + `",
-    "name": "db",
-    "sync": "function(doc){ channel(doc.channels); }",
-    "import_docs": false,
-    "offline": false,
-    "enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
+	"bucket": "` + tb.GetName() + `",
+	"name": "db",
+	"sync": "function(doc){ channel(doc.channels); }",
+	"import_docs": false,
+	"offline": false,
+	"enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
 	"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
-    "num_index_replicas": 0 }`
+	"num_index_replicas": 0 }`
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", dbConfig)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -3759,9 +3760,10 @@ func TestDatabaseOfflineConfigLegacy(t *testing.T) {
     "bucket": "` + bucket.GetName() + `",
     "name": "db",
     "sync": "function(doc){ channel(doc.channels); }",
-    "import_docs": true,
+    "import_docs": false,
     "offline": false,
-    "enable_shared_bucket_access": true,
+    "enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
+	"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
     "num_index_replicas": 0 }`
 
 	resp := rt.SendAdminRequest("PUT", "/db/_config", dbConfig)
@@ -3808,9 +3810,10 @@ func TestDatabaseOfflineConfigPersistent(t *testing.T) {
     "bucket": "` + tb.GetName() + `",
     "name": "db",
     "sync": "function(doc){ channel(doc.channels); }",
-    "import_docs": true,
+    "import_docs": false,
     "offline": false,
-    "enable_shared_bucket_access": true,
+    "enable_shared_bucket_access": ` + strconv.FormatBool(base.TestUseXattrs()) + `,
+	"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
     "num_index_replicas": 0 }`
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/", dbConfig)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -252,7 +252,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 
 	// Database-relative handlers:
 	dbr.Handle("/_config",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfig)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfig)).Methods("GET")
 	dbr.Handle("/_config",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, (*handler).handlePutDbConfig)).Methods("PUT", "POST")
 


### PR DESCRIPTION
CBG-1769

`GET /db/_config` now works while the database has been taken offline
Unit tested

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1345
