### PR TITLE
CBG-1740: Fix create db admin auth when user has access to only provided bucket

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -122,6 +122,24 @@ func (h *handler) handleCreateDB() error {
 	return base.HTTPErrorf(http.StatusCreated, "created")
 }
 
+// getAuthScopeHandleCreateDB is used in the router to supply an auth scope for the admin api auth. Takes the JSON body
+// from the payload, pulls out bucket and returns this as the auth scope.
+func getAuthScopeHandleCreateDB(bodyJSON []byte) (string, error) {
+	var body struct {
+		Bucket string `json:"bucket"`
+	}
+	err := base.JSONUnmarshal(bodyJSON, &body)
+	if err != nil {
+		return "", err
+	}
+
+	if body.Bucket == "" {
+		return "", nil
+	}
+
+	return body.Bucket, nil
+}
+
 // Take a DB online, first reload the DB config
 func (h *handler) handleDbOnline() error {
 	h.assertAdminOnly()

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
@@ -1541,8 +1540,6 @@ func TestCreateDBSpecificBucketPerm(t *testing.T) {
 	mobileSyncGateway := "mobile_sync_gateway"
 	MakeUser(t, httpClient, eps[0], mobileSyncGateway, "password", []string{fmt.Sprintf("%s[%s]", mobileSyncGateway, tb.GetName())})
 	defer DeleteUser(t, httpClient, eps[0], mobileSyncGateway)
-
-	time.Sleep(2 * time.Second)
 
 	resp := rt.SendAdminRequestWithAuth("PUT", "/db2/", `{"bucket": "`+tb.GetName()+`", "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`", "num_index_replicas": 0, "use_views": `+strconv.FormatBool(base.TestsDisableGSI())+`}`, mobileSyncGateway, "password")
 	assertStatus(t, resp, http.StatusCreated)

--- a/rest/admin_api_auth_test.go
+++ b/rest/admin_api_auth_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/stretchr/testify/assert"
@@ -1514,4 +1516,34 @@ func TestNewlyCreateSGWPermissions(t *testing.T) {
 
 	}
 
+}
+
+func TestCreateDBSpecificBucketPerm(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	if base.GTestBucketPool.NumUsableBuckets() < 2 {
+		t.Skipf("test requires at least 2 usable test buckets")
+	}
+
+	rt := NewRestTester(t, &RestTesterConfig{
+		adminInterfaceAuthentication: true,
+	})
+	defer rt.Close()
+
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	eps, httpClient, err := rt.ServerContext().ObtainManagementEndpointsAndHTTPClient()
+	require.NoError(t, err)
+
+	mobileSyncGateway := "mobile_sync_gateway"
+	MakeUser(t, httpClient, eps[0], mobileSyncGateway, "password", []string{fmt.Sprintf("%s[%s]", mobileSyncGateway, tb.GetName())})
+	defer DeleteUser(t, httpClient, eps[0], mobileSyncGateway)
+
+	time.Sleep(2 * time.Second)
+
+	resp := rt.SendAdminRequestWithAuth("PUT", "/db2/", `{"bucket": "`+tb.GetName()+`", "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`", "num_index_replicas": 0, "use_views": `+strconv.FormatBool(base.TestsDisableGSI())+`}`, mobileSyncGateway, "password")
+	assertStatus(t, resp, http.StatusCreated)
 }

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -14,8 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/couchbase/sync_gateway/base"
-	"github.com/couchbase/sync_gateway/db"
 	"github.com/gorilla/mux"
 )
 
@@ -295,18 +293,7 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 	// The routes below are part of the CouchDB REST API but should only be available to admins,
 	// so the handlers are moved to the admin port.
 	r.Handle("/{newdb:"+dbRegex+"}/",
-		makeHandlerSpecificAuthScope(sc, adminPrivs, []Permission{PermCreateDb}, nil, (*handler).handleCreateDB, func(bodyJSON []byte) (string, error) {
-			var body db.Body
-			err := base.JSONUnmarshal(bodyJSON, &body)
-			if err != nil {
-				return "", err
-			}
-			authScope, ok := body["bucket"].(string)
-			if !ok {
-				return "", nil
-			}
-			return authScope, nil
-		})).Methods("PUT")
+		makeHandlerSpecificAuthScope(sc, adminPrivs, []Permission{PermCreateDb}, nil, (*handler).handleCreateDB, getAuthScopeHandleCreateDB)).Methods("PUT")
 	r.Handle("/{db:"+dbRegex+"}/",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermDeleteDb}, nil, (*handler).handleDeleteDB)).Methods("DELETE")
 


### PR DESCRIPTION
CBG-1740

- Make a new `makeHandler` - `makeHandlerSpecificAuthScope` which takes a callback function. This callback will be provided with the payload body and should return the authScope.
- This allows in `handleCreateDB` to be given a function which will open up the payload and provide the supplied bucket as the auth scope.

Currently when reading the payload body this clears the body that the handler may need and therefore we repopulate this with a new `io.ReadCloser`. A future enhancement may be to read this earlier (for all payloads) and save a bytes body on the handler for future use, however, to minimize the scope of this change I opted not to do that. 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1355/
