### PR TITLE
CBG-1785 - Return specific error when multiple databases target same bucket

### DIFF
--- a/rest/admin_api.go
+++ b/rest/admin_api.go
@@ -80,6 +80,8 @@ func (h *handler) handleCreateDB() error {
 		if err != nil {
 			if errors.Is(err, base.ErrAuthError) {
 				return base.HTTPErrorf(http.StatusForbidden, "auth failure accessing provided bucket: %s", bucket)
+			} else if errors.Is(err, base.ErrAlreadyExists) {
+				return base.HTTPErrorf(http.StatusConflict, "couldn't load database: %s", err)
 			}
 			return base.HTTPErrorf(http.StatusInternalServerError, "couldn't load database: %v", err)
 		}

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3379,31 +3379,34 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 		tb.Close()
 	}()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Get config
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	eTag := resp.Header.Get("ETag")
 	assert.NotEqual(t, "", eTag)
 
-	resp = bootstrapAdminRequestWithHeaders(t, "POST", "/db/_config", "{}", map[string]string{"If-Match": eTag})
+	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": eTag})
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = bootstrapAdminRequest(t, "POST", "/db/_config", "{}")
+	resp = bootstrapAdminRequest(t, http.MethodPost, "/db/_config", "{}")
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	putETag := resp.Header.Get("ETag")
 	assert.NotEqual(t, "", putETag)
 
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	getETag := resp.Header.Get("ETag")
 	assert.Equal(t, putETag, getETag)
 
-	resp = bootstrapAdminRequestWithHeaders(t, "POST", "/db/_config", "{}", map[string]string{"If-Match": "x"})
+	resp = bootstrapAdminRequestWithHeaders(t, http.MethodPost, "/db/_config", "{}", map[string]string{"If-Match": "x"})
 	assert.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
 }
 
@@ -3432,13 +3435,16 @@ func TestDbConfigCredentials(t *testing.T) {
 		tb.Close()
 	}()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	var dbConfig DatabaseConfig
 
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -3454,7 +3460,7 @@ func TestDbConfigCredentials(t *testing.T) {
 	assert.Equal(t, "", dbConfig.CertPath)
 	assert.Equal(t, "", dbConfig.KeyPath)
 
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?include_runtime=true", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -3497,26 +3503,29 @@ func TestInvalidDBConfig(t *testing.T) {
 		tb.Close()
 	}()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Put db config with invalid sync fn
-	resp = bootstrapAdminRequest(t, "PUT", "/db/_config", `{"sync": "function(){"}`)
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/_config", `{"sync": "function(){"}`)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(string(body), "invalid javascript syntax"))
 
 	// Put invalid sync fn via sync specific endpoint
-	resp = bootstrapAdminRequest(t, "PUT", "/db/_config/sync", `function(){`)
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/_config/sync", `function(){`)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(string(body), "invalid javascript syntax"))
 
 	// Put invalid import fn via import specific endpoint
-	resp = bootstrapAdminRequest(t, "PUT", "/db/_config/import_filter", `function(){`)
+	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/_config/import_filter", `function(){`)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -3582,7 +3591,10 @@ func TestPutDbConfigChangeName(t *testing.T) {
 		tb.Close()
 	}()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
@@ -3642,12 +3654,15 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 		tb.Close()
 	}()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	var dbConfig DatabaseConfig
-	resp = bootstrapAdminRequest(t, "GET", "/db/_config?include_runtime=true", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
@@ -3664,7 +3679,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	assert.Equal(t, db.DefaultCompactInterval, uint32(*dbConfig.CompactIntervalDays))
 
 	var runtimeServerConfigResponse RunTimeServerConfigResponse
-	resp = bootstrapAdminRequest(t, "GET", "/_config?include_runtime=true", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
@@ -3692,7 +3707,7 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	resp = bootstrapAdminRequest(t, "GET", "/_config?include_runtime=true", "")
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/_config?include_runtime=true", "")
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err = ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)
@@ -3733,19 +3748,25 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 
 	// No credentials should fail
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	// Wrong credentials should fail
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db2/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0, "username": "test", "password": "invalid_password"}`,
+		`{"bucket": "`+tb.GetName()+`", "username": "test", "password": "invalid_password"}`,
 	)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	// Proper credentials should pass
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db3/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0, "username": "`+base.TestClusterUsername()+`", "password": "`+base.TestClusterPassword()+`"}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t, "username": "%s", "password": "%s"}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(), base.TestClusterUsername(), base.TestClusterPassword(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -47,7 +47,10 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 		tb.Close()
 	}()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
@@ -153,13 +156,19 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer func() { tb.Close() }()
 	resp := bootstrapAdminRequest(t, http.MethodPut, "/db1/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	// Create db2 using the same bucket and expect it to fail
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db2/",
-		`{"bucket": "`+tb.GetName()+`", "num_index_replicas": 0}`,
+		fmt.Sprintf(
+			`{"bucket": "%s", "num_index_replicas": 0, "enable_shared_bucket_access": %t, "use_views": %t}`,
+			tb.GetName(), base.TestUseXattrs(), base.TestsDisableGSI(),
+		),
 	)
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 

--- a/rest/config.go
+++ b/rest/config.go
@@ -1217,6 +1217,11 @@ func (sc *ServerContext) _applyConfig(cnf DatabaseConfig, failFast bool) (applie
 	// skip if we already have this config loaded, and we've got a cas value to compare with
 	foundDbName, ok := sc.bucketDbName[*cnf.Bucket]
 	if ok {
+		// Somebody is trying to create a new database with a duplicate bucket. Changing db name is not supported and is rejected earlier in the update handler.
+		if foundDbName != cnf.Name {
+			return false, fmt.Errorf("%w: Bucket %q already in use by database %q", base.ErrAlreadyExists, *cnf.Bucket, foundDbName)
+		}
+
 		if cnf.cas == 0 {
 			// force an update when the new config's cas was set to zero prior to load
 			base.Infof(base.KeyConfig, "Forcing update of config for database %q bucket %q", cnf.Name, *cnf.Bucket)

--- a/rest/config_legacy_test.go
+++ b/rest/config_legacy_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -289,28 +288,31 @@ func TestLegacyGuestUserMigration(t *testing.T) {
 	tb := base.GetTestBucket(t)
 	defer tb.Close()
 
-	config := `
-	{
-		"server_tls_skip_verify": ` + strconv.FormatBool(base.TestTLSSkipVerify()) + `,
-		"interface": ":4444",
-		"adminInterface": ":4445",
-		"databases": {
-			"db": {
-				"server": "%s",
-				"username": "%s",
-				"password": "%s",
-				"bucket": "%s",
-				"users": {
-					"GUEST": {
-						"disabled": false,
-						"admin_channels": ["*"]
-					}
+	config := fmt.Sprintf(`{
+	"server_tls_skip_verify": %t,
+	"interface": ":4444",
+	"adminInterface": ":4445",
+	"databases": {
+		"db": {
+			"server": "%s",
+			"username": "%s",
+			"password": "%s",
+			"bucket": "%s",
+			"users": {
+				"GUEST": {
+					"disabled": false,
+					"admin_channels": ["*"]
 				}
 			}
 		}
-	}`
-
-	config = fmt.Sprintf(config, base.UnitTestUrl(), base.TestClusterUsername(), base.TestClusterPassword(), tb.GetName())
+	}
+}`,
+		base.TestTLSSkipVerify(),
+		base.UnitTestUrl(),
+		base.TestClusterUsername(),
+		base.TestClusterPassword(),
+		tb.GetName(),
+	)
 
 	tmpDir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
CBG-1785

When creating databases, we should check that the bucket is not used by any other databases first, and return a specific error when we encounter this unsupported scenario, instead of a generic/misleading error message.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1374/