### PR TITLE
CBG-1763: Namespaced SG cluster metadata by group ID

### DIFF
--- a/base/constants.go
+++ b/base/constants.go
@@ -198,7 +198,7 @@ func DCPCheckpointPrefixWithGroupID(groupID string) string {
 
 func SGCfgPrefixWithGroupID(groupID string) string {
 	if groupID != "" {
-		return SyncPrefix + groupID + ":cfg:"
+		return SGCfgPrefix + ":" + groupID + ":"
 	}
 	return SGCfgPrefix
 }

--- a/base/constants.go
+++ b/base/constants.go
@@ -114,14 +114,12 @@ const (
 	Att2Prefix             = SyncPrefix + "att2:"
 	BackfillCompletePrefix = SyncPrefix + "backfill:complete:"
 	BackfillPendingPrefix  = SyncPrefix + "backfill:pending:"
-	DCPCheckpointPrefix    = SyncPrefix + "dcp_ck:"
 	RepairBackup           = SyncPrefix + "repair:backup:"
 	RepairDryRun           = SyncPrefix + "repair:dryrun:"
 	RevBodyPrefix          = SyncPrefix + "rb:"
 	RevPrefix              = SyncPrefix + "rev:"
 	RolePrefix             = SyncPrefix + "role:"
 	SessionPrefix          = SyncPrefix + "session:"
-	SGCfgPrefix            = SyncPrefix + "cfg"
 	SyncSeqPrefix          = SyncPrefix + "seq:"
 	UserEmailPrefix        = SyncPrefix + "useremail:"
 	UserPrefix             = SyncPrefix + "user:"
@@ -129,7 +127,6 @@ const (
 	UnusedSeqRangePrefix   = SyncPrefix + "unusedSeqs:"
 
 	DCPBackfillSeqKey = SyncPrefix + "dcp_backfill"
-	SyncDataKey       = SyncPrefix + "syncdata"
 	SyncSeqKey        = SyncPrefix + "seq"
 
 	PersistentConfigPrefix = SyncPrefix + "dbconfig:"
@@ -188,6 +185,27 @@ var (
 	// ErrUnknownField is marked as the cause of the error when trying to decode a JSON snippet with unknown fields
 	ErrUnknownField = errors.New("unrecognized JSON field")
 )
+
+func DCPCheckpointPrefix(groupID string) string {
+	if groupID != "" {
+		return SyncPrefix + groupID + ":dcp_ck:"
+	}
+	return SyncPrefix + "dcp_ck:"
+}
+
+func SGCfgPrefix(groupID string) string {
+	if groupID != "" {
+		return SyncPrefix + groupID + ":cfg:"
+	}
+	return SyncPrefix + "cfg"
+}
+
+func SyncDataKey(groupID string) string {
+	if groupID != "" {
+		return SyncPrefix + groupID + ":syncdata"
+	}
+	return SyncPrefix + "syncdata"
+}
 
 // UnitTestUrl returns the configured test URL.
 func UnitTestUrl() string {

--- a/base/constants.go
+++ b/base/constants.go
@@ -188,7 +188,7 @@ var (
 
 func DCPCheckpointPrefix(groupID string) string {
 	if groupID != "" {
-		return SyncPrefix + groupID + ":dcp_ck:"
+		return SyncPrefix + "dcp_ck:" + groupID + ":"
 	}
 	return SyncPrefix + "dcp_ck:"
 }

--- a/base/constants.go
+++ b/base/constants.go
@@ -121,6 +121,7 @@ const (
 	RevPrefix              = SyncPrefix + "rev:"
 	RolePrefix             = SyncPrefix + "role:"
 	SessionPrefix          = SyncPrefix + "session:"
+	SGCfgPrefix            = SyncPrefix + "cfg"
 	SyncSeqPrefix          = SyncPrefix + "seq:"
 	UserEmailPrefix        = SyncPrefix + "useremail:"
 	UserPrefix             = SyncPrefix + "user:"
@@ -195,11 +196,11 @@ func DCPCheckpointPrefixWithGroupID(groupID string) string {
 	return DCPCheckpointPrefix
 }
 
-func SGCfgPrefix(groupID string) string {
+func SGCfgPrefixWithGroupID(groupID string) string {
 	if groupID != "" {
 		return SyncPrefix + groupID + ":cfg:"
 	}
-	return SyncPrefix + "cfg"
+	return SGCfgPrefix
 }
 
 func SyncDataKeyWithGroupID(groupID string) string {

--- a/base/constants.go
+++ b/base/constants.go
@@ -114,6 +114,7 @@ const (
 	Att2Prefix             = SyncPrefix + "att2:"
 	BackfillCompletePrefix = SyncPrefix + "backfill:complete:"
 	BackfillPendingPrefix  = SyncPrefix + "backfill:pending:"
+	DCPCheckpointPrefix    = SyncPrefix + "dcp_ck:"
 	RepairBackup           = SyncPrefix + "repair:backup:"
 	RepairDryRun           = SyncPrefix + "repair:dryrun:"
 	RevBodyPrefix          = SyncPrefix + "rb:"
@@ -127,6 +128,7 @@ const (
 	UnusedSeqRangePrefix   = SyncPrefix + "unusedSeqs:"
 
 	DCPBackfillSeqKey = SyncPrefix + "dcp_backfill"
+	SyncDataKey       = SyncPrefix + "syncdata"
 	SyncSeqKey        = SyncPrefix + "seq"
 
 	PersistentConfigPrefix = SyncPrefix + "dbconfig:"
@@ -186,11 +188,11 @@ var (
 	ErrUnknownField = errors.New("unrecognized JSON field")
 )
 
-func DCPCheckpointPrefix(groupID string) string {
+func DCPCheckpointPrefixWithGroupID(groupID string) string {
 	if groupID != "" {
-		return SyncPrefix + "dcp_ck:" + groupID + ":"
+		return DCPCheckpointPrefix + groupID + ":"
 	}
-	return SyncPrefix + "dcp_ck:"
+	return DCPCheckpointPrefix
 }
 
 func SGCfgPrefix(groupID string) string {
@@ -200,11 +202,11 @@ func SGCfgPrefix(groupID string) string {
 	return SyncPrefix + "cfg"
 }
 
-func SyncDataKey(groupID string) string {
+func SyncDataKeyWithGroupID(groupID string) string {
 	if groupID != "" {
-		return SyncPrefix + groupID + ":syncdata"
+		return SyncDataKey + ":" + groupID
 	}
-	return SyncPrefix + "syncdata"
+	return SyncDataKey
 }
 
 // UnitTestUrl returns the configured test URL.

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -37,7 +37,7 @@ type DCPClient struct {
 	closeError        error                          // Will be set to a non-nil value for unexpected error
 	closeErrorLock    sync.Mutex                     // Synchronization on close error
 	failOnRollback    bool                           // When true, close when rollback detected
-	groupID           string                         // Used for adding config group ID to keys that use DCPCheckpointPrefix (Mark, Sweep, Cleanup)
+	groupID           string                         // Used for adding config group ID to keys that use DCPCheckpointPrefixWithGroupID (Mark, Sweep, Cleanup)
 }
 
 type DCPClientOptions struct {

--- a/base/dcp_client.go
+++ b/base/dcp_client.go
@@ -37,7 +37,7 @@ type DCPClient struct {
 	closeError        error                          // Will be set to a non-nil value for unexpected error
 	closeErrorLock    sync.Mutex                     // Synchronization on close error
 	failOnRollback    bool                           // When true, close when rollback detected
-	groupID           string                         // Used for adding config group ID to keys that use DCPCheckpointPrefixWithGroupID (Mark, Sweep, Cleanup)
+	checkpointPrefix  string                         // DCP checkpoint key prefix
 }
 
 type DCPClientOptions struct {
@@ -59,15 +59,15 @@ func NewDCPClient(ID string, callback sgbucket.FeedEventCallbackFunc, options DC
 	}
 
 	client := &DCPClient{
-		workers:        make([]*DCPWorker, numWorkers),
-		numVbuckets:    numVbuckets,
-		callback:       callback,
-		ID:             ID,
-		spec:           store.GetSpec(),
-		terminator:     make(chan bool),
-		doneChannel:    make(chan error, 1),
-		failOnRollback: options.FailOnRollback,
-		groupID:        groupID,
+		workers:          make([]*DCPWorker, numWorkers),
+		numVbuckets:      numVbuckets,
+		callback:         callback,
+		ID:               ID,
+		spec:             store.GetSpec(),
+		terminator:       make(chan bool),
+		doneChannel:      make(chan error, 1),
+		failOnRollback:   options.FailOnRollback,
+		checkpointPrefix: DCPCheckpointPrefixWithGroupID(groupID),
 	}
 
 	// Initialize active vbuckets
@@ -251,7 +251,7 @@ func (dc *DCPClient) startWorkers() {
 
 	//
 	for index, _ := range dc.workers {
-		dc.workers[index] = NewDCPWorker(dc.metadata, dc.callback, dc.onStreamEnd, dc.terminator, nil, dc.groupID, nil)
+		dc.workers[index] = NewDCPWorker(dc.metadata, dc.callback, dc.onStreamEnd, dc.terminator, nil, dc.checkpointPrefix, nil)
 		dc.workers[index].Start()
 	}
 }

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -47,7 +47,7 @@ func TestOneShotDCP(t *testing.T) {
 		OneShot: true,
 	}
 
-	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, store)
+	dcpClient, err := NewDCPClient(feedID, counterCallback, clientOptions, store, "")
 	assert.NoError(t, err)
 
 	// Add additional documents in a separate goroutine, to verify afterEndSeq handling
@@ -104,7 +104,7 @@ func TestTerminateDCPFeed(t *testing.T) {
 	assert.True(t, ok)
 	feedID := t.Name()
 
-	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, store)
+	dcpClient, err := NewDCPClient(feedID, counterCallback, DCPClientOptions{}, store, "")
 	assert.NoError(t, err)
 
 	// Add documents in a separate goroutine

--- a/base/dcp_client_test.go
+++ b/base/dcp_client_test.go
@@ -189,7 +189,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 		OneShot:        true,
 		FailOnRollback: true,
 	}
-	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store)
+	dcpClient, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store, "")
 	assert.NoError(t, err)
 
 	doneChan, startErr := dcpClient.Start()
@@ -218,7 +218,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 		FailOnRollback:  true,
 		OneShot:         true,
 	}
-	dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store)
+	dcpClient2, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store, "")
 	assert.NoError(t, err)
 
 	_, startErr2 := dcpClient2.Start()
@@ -231,7 +231,7 @@ func TestDCPClientMultiFeedConsistency(t *testing.T) {
 		FailOnRollback:  false,
 		OneShot:         true,
 	}
-	dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store)
+	dcpClient3, err := NewDCPClient(feedID, counterCallback, dcpClientOpts, store, "")
 	assert.NoError(t, err)
 
 	doneChan3, startErr3 := dcpClient3.Start()

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -33,7 +33,7 @@ type DCPWorkerOptions struct {
 	ignoreDeletes    bool
 }
 
-func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEventCallbackFunc, endCallback endStreamCallbackFunc, terminator chan bool, endSeqNos []uint64, options *DCPWorkerOptions) *DCPWorker {
+func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEventCallbackFunc, endCallback endStreamCallbackFunc, terminator chan bool, endSeqNos []uint64, groupID string, options *DCPWorkerOptions) *DCPWorker {
 
 	// Create a buffered channel for queueing incoming DCP events
 	queueLength := defaultQueueLength
@@ -46,7 +46,7 @@ func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEvent
 		eventFeed:             eventQueue,
 		terminator:            terminator,
 		endSeqNos:             endSeqNos,
-		checkpointPrefixBytes: []byte(DCPCheckpointPrefix),
+		checkpointPrefixBytes: []byte(DCPCheckpointPrefix(groupID)),
 		mutationCallback:      mutationCallback,
 		endStreamCallback:     endCallback,
 		ignoreDeletes:         options != nil && options.ignoreDeletes,

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -33,7 +33,7 @@ type DCPWorkerOptions struct {
 	ignoreDeletes    bool
 }
 
-func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEventCallbackFunc, endCallback endStreamCallbackFunc, terminator chan bool, endSeqNos []uint64, groupID string, options *DCPWorkerOptions) *DCPWorker {
+func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEventCallbackFunc, endCallback endStreamCallbackFunc, terminator chan bool, endSeqNos []uint64, checkpointPrefix string, options *DCPWorkerOptions) *DCPWorker {
 
 	// Create a buffered channel for queueing incoming DCP events
 	queueLength := defaultQueueLength
@@ -46,7 +46,7 @@ func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEvent
 		eventFeed:             eventQueue,
 		terminator:            terminator,
 		endSeqNos:             endSeqNos,
-		checkpointPrefixBytes: []byte(DCPCheckpointPrefixWithGroupID(groupID)),
+		checkpointPrefixBytes: []byte(checkpointPrefix),
 		mutationCallback:      mutationCallback,
 		endStreamCallback:     endCallback,
 		ignoreDeletes:         options != nil && options.ignoreDeletes,

--- a/base/dcp_client_worker.go
+++ b/base/dcp_client_worker.go
@@ -46,7 +46,7 @@ func NewDCPWorker(metadata DCPMetadataStore, mutationCallback sgbucket.FeedEvent
 		eventFeed:             eventQueue,
 		terminator:            terminator,
 		endSeqNos:             endSeqNos,
-		checkpointPrefixBytes: []byte(DCPCheckpointPrefix(groupID)),
+		checkpointPrefixBytes: []byte(DCPCheckpointPrefixWithGroupID(groupID)),
 		mutationCallback:      mutationCallback,
 		endStreamCallback:     endCallback,
 		ignoreDeletes:         options != nil && options.ignoreDeletes,

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -535,7 +535,7 @@ func dcpKeyFilter(key []byte, groupID string) bool {
 		bytes.HasPrefix(key, []byte(UnusedSeqRangePrefix)) ||
 		bytes.HasPrefix(key, []byte(UserPrefix)) ||
 		bytes.HasPrefix(key, []byte(RolePrefix)) ||
-		bytes.HasPrefix(key, []byte(SGCfgPrefix(groupID))) {
+		bytes.HasPrefix(key, []byte(SGCfgPrefixWithGroupID(groupID))) {
 		return true
 	}
 

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -205,7 +205,7 @@ func (c *DCPCommon) incrementCheckpointCount(vbucketId uint16) {
 //   - The ongoing performance overhead of persisting last sequence outweighs the minor performance benefit of not reprocessing a few
 //    sequences in a checkpoint on startup
 func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStartSeq uint64, snapshotEndSeq uint64, err error) {
-	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix(c.groupID), vbNo))
+	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefixWithGroupID(c.groupID), vbNo))
 	if err != nil {
 		// On a key not found error, metadata hasn't been persisted for this vbucket
 		if IsKeyNotFoundError(c.bucket, err) {
@@ -285,7 +285,7 @@ func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 //         - Is a relatively infrequent operation
 func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
 	TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
-	return c.bucket.SetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix(c.groupID), vbNo), 0, value)
+	return c.bucket.SetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefixWithGroupID(c.groupID), vbNo), 0, value)
 }
 
 // This updates the value stored in r.seqs with the given seq number for the given partition

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -79,9 +79,10 @@ type DCPCommon struct {
 	backfill               *backfillStatus                // Backfill state and stats
 	feedID                 string                         // Unique feed ID, used for logging
 	loggingCtx             context.Context                // Logging context, prefixes feedID
+	groupID                string
 }
 
-func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string) *DCPCommon {
+func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, groupID string) *DCPCommon {
 	newBackfillStatus := backfillStatus{}
 
 	c := &DCPCommon{
@@ -97,6 +98,7 @@ func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbN
 		lastCheckpointTime:     make([]time.Time, maxVbNo),
 		backfill:               &newBackfillStatus,
 		feedID:                 feedID,
+		groupID:                groupID,
 	}
 
 	dcpContextID := fmt.Sprintf("%s-%s", MD(bucket.GetName()).Redact(), feedID)
@@ -203,7 +205,7 @@ func (c *DCPCommon) incrementCheckpointCount(vbucketId uint16) {
 //   - The ongoing performance overhead of persisting last sequence outweighs the minor performance benefit of not reprocessing a few
 //    sequences in a checkpoint on startup
 func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStartSeq uint64, snapshotEndSeq uint64, err error) {
-	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix, vbNo))
+	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix(c.groupID), vbNo))
 	if err != nil {
 		// On a key not found error, metadata hasn't been persisted for this vbucket
 		if IsKeyNotFoundError(c.bucket, err) {
@@ -283,7 +285,7 @@ func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 //         - Is a relatively infrequent operation
 func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
 	TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
-	return c.bucket.SetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix, vbNo), 0, value)
+	return c.bucket.SetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefix(c.groupID), vbNo), 0, value)
 }
 
 // This updates the value stored in r.seqs with the given seq number for the given partition
@@ -516,7 +518,7 @@ func (b *backfillStatus) purgeBackfillSequences(bucket Bucket) error {
 // Only a subset of Sync Gateway's internal documents need to be included during DCP processing: user, role, and
 // unused sequence documents.  Any other documents with the leading '_sync' prefix can be ignored.
 // dcpKeyFilter returns true for documents that should be processed, false for those that do not need processing.
-func dcpKeyFilter(key []byte) bool {
+func dcpKeyFilter(key []byte, groupID string) bool {
 
 	// If it's a _txn doc, don't process
 	if bytes.HasPrefix(key, []byte(TxnPrefix)) {
@@ -533,7 +535,7 @@ func dcpKeyFilter(key []byte) bool {
 		bytes.HasPrefix(key, []byte(UnusedSeqRangePrefix)) ||
 		bytes.HasPrefix(key, []byte(UserPrefix)) ||
 		bytes.HasPrefix(key, []byte(RolePrefix)) ||
-		bytes.HasPrefix(key, []byte(SGCfgPrefix)) {
+		bytes.HasPrefix(key, []byte(SGCfgPrefix(groupID))) {
 		return true
 	}
 

--- a/base/dcp_common.go
+++ b/base/dcp_common.go
@@ -79,7 +79,8 @@ type DCPCommon struct {
 	backfill               *backfillStatus                // Backfill state and stats
 	feedID                 string                         // Unique feed ID, used for logging
 	loggingCtx             context.Context                // Logging context, prefixes feedID
-	groupID                string
+	sgCfgPrefix            string                         // Prefix for SG Cfg doc keys
+	checkpointPrefix       string                         // DCP checkpoint key prefix
 }
 
 func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, groupID string) *DCPCommon {
@@ -98,7 +99,8 @@ func NewDCPCommon(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbN
 		lastCheckpointTime:     make([]time.Time, maxVbNo),
 		backfill:               &newBackfillStatus,
 		feedID:                 feedID,
-		groupID:                groupID,
+		checkpointPrefix:       DCPCheckpointPrefixWithGroupID(groupID),
+		sgCfgPrefix:            SGCfgPrefixWithGroupID(groupID),
 	}
 
 	dcpContextID := fmt.Sprintf("%s-%s", MD(bucket.GetName()).Redact(), feedID)
@@ -205,7 +207,7 @@ func (c *DCPCommon) incrementCheckpointCount(vbucketId uint16) {
 //   - The ongoing performance overhead of persisting last sequence outweighs the minor performance benefit of not reprocessing a few
 //    sequences in a checkpoint on startup
 func (c *DCPCommon) loadCheckpoint(vbNo uint16) (vbMetadata []byte, snapshotStartSeq uint64, snapshotEndSeq uint64, err error) {
-	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefixWithGroupID(c.groupID), vbNo))
+	rawValue, _, err := c.bucket.GetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo))
 	if err != nil {
 		// On a key not found error, metadata hasn't been persisted for this vbucket
 		if IsKeyNotFoundError(c.bucket, err) {
@@ -285,7 +287,7 @@ func (c *DCPCommon) initMetadata(maxVbNo uint16) {
 //         - Is a relatively infrequent operation
 func (c *DCPCommon) persistCheckpoint(vbNo uint16, value []byte) error {
 	TracefCtx(c.loggingCtx, KeyDCP, "Persisting checkpoint for vbno %d", vbNo)
-	return c.bucket.SetRaw(fmt.Sprintf("%s%d", DCPCheckpointPrefixWithGroupID(c.groupID), vbNo), 0, value)
+	return c.bucket.SetRaw(fmt.Sprintf("%s%d", c.checkpointPrefix, vbNo), 0, value)
 }
 
 // This updates the value stored in r.seqs with the given seq number for the given partition
@@ -518,7 +520,8 @@ func (b *backfillStatus) purgeBackfillSequences(bucket Bucket) error {
 // Only a subset of Sync Gateway's internal documents need to be included during DCP processing: user, role, and
 // unused sequence documents.  Any other documents with the leading '_sync' prefix can be ignored.
 // dcpKeyFilter returns true for documents that should be processed, false for those that do not need processing.
-func dcpKeyFilter(key []byte, groupID string) bool {
+// c is used to get the SG Cfg prefix
+func (c *DCPCommon) dcpKeyFilter(key []byte) bool { // group id
 
 	// If it's a _txn doc, don't process
 	if bytes.HasPrefix(key, []byte(TxnPrefix)) {
@@ -535,7 +538,7 @@ func dcpKeyFilter(key []byte, groupID string) bool {
 		bytes.HasPrefix(key, []byte(UnusedSeqRangePrefix)) ||
 		bytes.HasPrefix(key, []byte(UserPrefix)) ||
 		bytes.HasPrefix(key, []byte(RolePrefix)) ||
-		bytes.HasPrefix(key, []byte(SGCfgPrefixWithGroupID(groupID))) {
+		bytes.HasPrefix(key, []byte(c.sgCfgPrefix)) { //	bytes.HasPrefix(key, []byte(SGCfgPrefixWithGroupID(groupID))) {
 		return true
 	}
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -68,9 +68,9 @@ type DCPDest struct {
 	metaInitComplete   []bool      // Whether metadata initialization has been completed, per vbNo
 }
 
-func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, groupID string) (SGDest, context.Context) {
+func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, checkpointPrefix, sgCfgPrefix string) (SGDest, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, groupID)
+	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, checkpointPrefix, sgCfgPrefix)
 
 	d := &DCPDest{
 		DCPCommon:          dcpCommon,

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -105,7 +105,7 @@ func (d *DCPDest) Close() error {
 func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 	val []byte, cas uint64, extrasType cbgt.DestExtrasType, extras []byte) error {
 
-	if !dcpKeyFilter(key, d.groupID) {
+	if !d.dcpKeyFilter(key) {
 		return nil
 	}
 	event := makeFeedEventForDest(key, val, cas, partitionToVbNo(partition), 0, 0, sgbucket.FeedOpMutation)
@@ -116,7 +116,7 @@ func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []byte,
 	cas uint64, extrasType cbgt.DestExtrasType, req interface{}) error {
 
-	if !dcpKeyFilter(key, d.groupID) {
+	if !d.dcpKeyFilter(key) {
 		return nil
 	}
 
@@ -143,7 +143,7 @@ func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []b
 func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 	cas uint64,
 	extrasType cbgt.DestExtrasType, extras []byte) error {
-	if !dcpKeyFilter(key, d.groupID) {
+	if !d.dcpKeyFilter(key) {
 		return nil
 	}
 
@@ -154,7 +154,7 @@ func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 
 func (d *DCPDest) DataDeleteEx(partition string, key []byte, seq uint64,
 	cas uint64, extrasType cbgt.DestExtrasType, req interface{}) error {
-	if !dcpKeyFilter(key, d.groupID) {
+	if !d.dcpKeyFilter(key) {
 		return nil
 	}
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -68,9 +68,9 @@ type DCPDest struct {
 	metaInitComplete   []bool      // Whether metadata initialization has been completed, per vbNo
 }
 
-func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat) (SGDest, context.Context) {
+func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, groupID string) (SGDest, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID)
+	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, groupID)
 
 	d := &DCPDest{
 		DCPCommon:          dcpCommon,
@@ -105,7 +105,7 @@ func (d *DCPDest) Close() error {
 func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 	val []byte, cas uint64, extrasType cbgt.DestExtrasType, extras []byte) error {
 
-	if !dcpKeyFilter(key) {
+	if !dcpKeyFilter(key, d.groupID) {
 		return nil
 	}
 	event := makeFeedEventForDest(key, val, cas, partitionToVbNo(partition), 0, 0, sgbucket.FeedOpMutation)
@@ -116,7 +116,7 @@ func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []byte,
 	cas uint64, extrasType cbgt.DestExtrasType, req interface{}) error {
 
-	if !dcpKeyFilter(key) {
+	if !dcpKeyFilter(key, d.groupID) {
 		return nil
 	}
 
@@ -143,7 +143,7 @@ func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []b
 func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 	cas uint64,
 	extrasType cbgt.DestExtrasType, extras []byte) error {
-	if !dcpKeyFilter(key) {
+	if !dcpKeyFilter(key, d.groupID) {
 		return nil
 	}
 
@@ -154,7 +154,7 @@ func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 
 func (d *DCPDest) DataDeleteEx(partition string, key []byte, seq uint64,
 	cas uint64, extrasType cbgt.DestExtrasType, req interface{}) error {
-	if !dcpKeyFilter(key) {
+	if !dcpKeyFilter(key, d.groupID) {
 		return nil
 	}
 

--- a/base/dcp_dest.go
+++ b/base/dcp_dest.go
@@ -68,9 +68,9 @@ type DCPDest struct {
 	metaInitComplete   []bool      // Whether metadata initialization has been completed, per vbNo
 }
 
-func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, checkpointPrefix, sgCfgPrefix string) (SGDest, context.Context) {
+func NewDCPDest(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dcpStats *expvar.Map, feedID string, importPartitionStat *SgwIntStat, checkpointPrefix string) (SGDest, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, checkpointPrefix, sgCfgPrefix)
+	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dcpStats, feedID, checkpointPrefix)
 
 	d := &DCPDest{
 		DCPCommon:          dcpCommon,
@@ -105,7 +105,7 @@ func (d *DCPDest) Close() error {
 func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 	val []byte, cas uint64, extrasType cbgt.DestExtrasType, extras []byte) error {
 
-	if !d.dcpKeyFilter(key) {
+	if !dcpKeyFilter(key) {
 		return nil
 	}
 	event := makeFeedEventForDest(key, val, cas, partitionToVbNo(partition), 0, 0, sgbucket.FeedOpMutation)
@@ -116,7 +116,7 @@ func (d *DCPDest) DataUpdate(partition string, key []byte, seq uint64,
 func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []byte,
 	cas uint64, extrasType cbgt.DestExtrasType, req interface{}) error {
 
-	if !d.dcpKeyFilter(key) {
+	if !dcpKeyFilter(key) {
 		return nil
 	}
 
@@ -143,7 +143,7 @@ func (d *DCPDest) DataUpdateEx(partition string, key []byte, seq uint64, val []b
 func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 	cas uint64,
 	extrasType cbgt.DestExtrasType, extras []byte) error {
-	if !d.dcpKeyFilter(key) {
+	if !dcpKeyFilter(key) {
 		return nil
 	}
 
@@ -154,7 +154,7 @@ func (d *DCPDest) DataDelete(partition string, key []byte, seq uint64,
 
 func (d *DCPDest) DataDeleteEx(partition string, key []byte, seq uint64,
 	cas uint64, extrasType cbgt.DestExtrasType, req interface{}) error {
-	if !d.dcpKeyFilter(key) {
+	if !dcpKeyFilter(key) {
 		return nil
 	}
 

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -40,9 +40,9 @@ type DCPReceiver struct {
 	*DCPCommon
 }
 
-func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, checkpointPrefix, sgCfgPrefix string) (cbdatasource.Receiver, context.Context) {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, checkpointPrefix string) (cbdatasource.Receiver, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, checkpointPrefix, sgCfgPrefix)
+	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, checkpointPrefix)
 	r := &DCPReceiver{
 		DCPCommon: dcpCommon,
 	}
@@ -74,7 +74,7 @@ func (r *DCPReceiver) OnError(err error) {
 
 func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
-	if !r.dcpKeyFilter(key) {
+	if !dcpKeyFilter(key) {
 		return nil
 	}
 	event := makeFeedEventForMCRequest(req, sgbucket.FeedOpMutation)
@@ -84,7 +84,7 @@ func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 
 func (r *DCPReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
-	if !r.dcpKeyFilter(key) {
+	if !dcpKeyFilter(key) {
 		return nil
 	}
 	event := makeFeedEventForMCRequest(req, sgbucket.FeedOpDeletion)
@@ -242,7 +242,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		Infof(KeyDCP, "DCP feed started without feedID specified - defaulting to %s", DCPCachingFeedID)
 		feedID = DCPCachingFeedID
 	}
-	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID, args.CheckpointPrefix, args.SGCfgPrefix)
+	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID, args.CheckpointPrefix)
 
 	var dcpReceiver *DCPReceiver
 	switch v := receiver.(type) {

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -40,9 +40,9 @@ type DCPReceiver struct {
 	*DCPCommon
 }
 
-func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string) (cbdatasource.Receiver, context.Context) {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, groupID string) (cbdatasource.Receiver, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID)
+	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, groupID)
 	r := &DCPReceiver{
 		DCPCommon: dcpCommon,
 	}
@@ -74,7 +74,7 @@ func (r *DCPReceiver) OnError(err error) {
 
 func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
-	if !dcpKeyFilter(key) {
+	if !dcpKeyFilter(key, r.groupID) {
 		return nil
 	}
 	event := makeFeedEventForMCRequest(req, sgbucket.FeedOpMutation)
@@ -84,7 +84,7 @@ func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 
 func (r *DCPReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
-	if !dcpKeyFilter(key) {
+	if !dcpKeyFilter(key, r.groupID) {
 		return nil
 	}
 	event := makeFeedEventForMCRequest(req, sgbucket.FeedOpDeletion)
@@ -242,7 +242,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		Infof(KeyDCP, "DCP feed started without feedID specified - defaulting to %s", DCPCachingFeedID)
 		feedID = DCPCachingFeedID
 	}
-	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID)
+	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID, args.GroupID)
 
 	var dcpReceiver *DCPReceiver
 	switch v := receiver.(type) {

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -74,7 +74,7 @@ func (r *DCPReceiver) OnError(err error) {
 
 func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
-	if !dcpKeyFilter(key, r.groupID) {
+	if !r.dcpKeyFilter(key) {
 		return nil
 	}
 	event := makeFeedEventForMCRequest(req, sgbucket.FeedOpMutation)
@@ -84,7 +84,7 @@ func (r *DCPReceiver) DataUpdate(vbucketId uint16, key []byte, seq uint64,
 
 func (r *DCPReceiver) DataDelete(vbucketId uint16, key []byte, seq uint64,
 	req *gomemcached.MCRequest) error {
-	if !dcpKeyFilter(key, r.groupID) {
+	if !r.dcpKeyFilter(key) {
 		return nil
 	}
 	event := makeFeedEventForMCRequest(req, sgbucket.FeedOpDeletion)

--- a/base/dcp_receiver.go
+++ b/base/dcp_receiver.go
@@ -40,9 +40,9 @@ type DCPReceiver struct {
 	*DCPCommon
 }
 
-func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, groupID string) (cbdatasource.Receiver, context.Context) {
+func NewDCPReceiver(callback sgbucket.FeedEventCallbackFunc, bucket Bucket, maxVbNo uint16, persistCheckpoints bool, dbStats *expvar.Map, feedID string, checkpointPrefix, sgCfgPrefix string) (cbdatasource.Receiver, context.Context) {
 
-	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, groupID)
+	dcpCommon := NewDCPCommon(callback, bucket, maxVbNo, persistCheckpoints, dbStats, feedID, checkpointPrefix, sgCfgPrefix)
 	r := &DCPReceiver{
 		DCPCommon: dcpCommon,
 	}
@@ -242,7 +242,7 @@ func StartDCPFeed(bucket Bucket, spec BucketSpec, args sgbucket.FeedArguments, c
 		Infof(KeyDCP, "DCP feed started without feedID specified - defaulting to %s", DCPCachingFeedID)
 		feedID = DCPCachingFeedID
 	}
-	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID, args.GroupID)
+	receiver, loggingCtx := NewDCPReceiver(callback, bucket, maxVbno, persistCheckpoints, dbStats, feedID, args.CheckpointPrefix, args.SGCfgPrefix)
 
 	var dcpReceiver *DCPReceiver
 	switch v := receiver.(type) {

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -59,17 +59,23 @@ func TestTransformBucketCredentials(t *testing.T) {
 }
 
 func TestDCPKeyFilter(t *testing.T) {
+	assert.True(t, dcpKeyFilter([]byte("doc123"), ""))
+	assert.True(t, dcpKeyFilter([]byte(UserPrefix+"user1"), ""))
+	assert.True(t, dcpKeyFilter([]byte(RolePrefix+"role2"), ""))
+	assert.True(t, dcpKeyFilter([]byte(UnusedSeqPrefix+"1234"), ""))
+	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefix("")), ""))
+	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefix("group")), "group"))
 
-	assert.True(t, dcpKeyFilter([]byte("doc123")))
-	assert.True(t, dcpKeyFilter([]byte(UserPrefix+"user1")))
-	assert.True(t, dcpKeyFilter([]byte(RolePrefix+"role2")))
-	assert.True(t, dcpKeyFilter([]byte(UnusedSeqPrefix+"1234")))
-
-	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey)))
-	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq")))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKey)))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
-	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData")))
+	assert.False(t, dcpKeyFilter([]byte(SGCfgPrefix("group1")), "group2"))
+	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey), ""))
+	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq"), ""))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKey("")), ""))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKey("group")), "group"))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKey("group1")), "group2"))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix("")+"12"), ""))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix("group")+"12"), "group"))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix("group1")+"12"), "group2"))
+	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData"), ""))
 }
 
 func TestCBGTIndexCreation(t *testing.T) {
@@ -394,7 +400,7 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 	testDBName := "testDB"
 
 	// Use an bucket-backed cfg
-	cfg, err := NewCfgSG(bucket, nil)
+	cfg, err := NewCfgSG(bucket, "")
 	require.NoError(t, err)
 
 	// Define index type for db name

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -59,31 +59,19 @@ func TestTransformBucketCredentials(t *testing.T) {
 }
 
 func TestDCPKeyFilter(t *testing.T) {
-	c := DCPCommon{
-		checkpointPrefix: DCPCheckpointPrefix,
-		sgCfgPrefix:      SGCfgPrefix,
-	}
-	assert.True(t, c.dcpKeyFilter([]byte("doc123")))
-	assert.True(t, c.dcpKeyFilter([]byte(UserPrefix+"user1")))
-	assert.True(t, c.dcpKeyFilter([]byte(RolePrefix+"role2")))
-	assert.True(t, c.dcpKeyFilter([]byte(UnusedSeqPrefix+"1234")))
-	assert.True(t, c.dcpKeyFilter([]byte(SGCfgPrefixWithGroupID(""))))
+	assert.True(t, dcpKeyFilter([]byte("doc123")))
+	assert.True(t, dcpKeyFilter([]byte(UserPrefix+"user1")))
+	assert.True(t, dcpKeyFilter([]byte(RolePrefix+"role2")))
+	assert.True(t, dcpKeyFilter([]byte(UnusedSeqPrefix+"1234")))
+	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("")+"123")))
+	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group")+"123")))
 
-	assert.False(t, c.dcpKeyFilter([]byte(SyncSeqKey)))
-	assert.False(t, c.dcpKeyFilter([]byte(SyncPrefix+"unusualSeq")))
-	assert.False(t, c.dcpKeyFilter([]byte(SyncDataKey)))
-	assert.False(t, c.dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
-	assert.False(t, c.dcpKeyFilter([]byte(TxnPrefix+"atrData")))
-
-	c = DCPCommon{
-		checkpointPrefix: DCPCheckpointPrefixWithGroupID("group"),
-		sgCfgPrefix:      SGCfgPrefixWithGroupID("group"),
-	}
-	assert.True(t, c.dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group"))))
-
-	assert.False(t, c.dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group1"))))
-	assert.False(t, c.dcpKeyFilter([]byte(SyncDataKeyWithGroupID("group"))))
-	assert.False(t, c.dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12")))
+	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey)))
+	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq")))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKey)))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
+	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData")))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12")))
 
 }
 

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -59,23 +59,32 @@ func TestTransformBucketCredentials(t *testing.T) {
 }
 
 func TestDCPKeyFilter(t *testing.T) {
-	assert.True(t, dcpKeyFilter([]byte("doc123"), ""))
-	assert.True(t, dcpKeyFilter([]byte(UserPrefix+"user1"), ""))
-	assert.True(t, dcpKeyFilter([]byte(RolePrefix+"role2"), ""))
-	assert.True(t, dcpKeyFilter([]byte(UnusedSeqPrefix+"1234"), ""))
-	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("")), ""))
-	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group")), "group"))
+	c := DCPCommon{
+		checkpointPrefix: DCPCheckpointPrefix,
+		sgCfgPrefix:      SGCfgPrefix,
+	}
+	assert.True(t, c.dcpKeyFilter([]byte("doc123")))
+	assert.True(t, c.dcpKeyFilter([]byte(UserPrefix+"user1")))
+	assert.True(t, c.dcpKeyFilter([]byte(RolePrefix+"role2")))
+	assert.True(t, c.dcpKeyFilter([]byte(UnusedSeqPrefix+"1234")))
+	assert.True(t, c.dcpKeyFilter([]byte(SGCfgPrefixWithGroupID(""))))
 
-	assert.False(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group1")), "group2"))
-	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey), ""))
-	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq"), ""))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("")), ""))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("group")), "group"))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("group1")), "group2"))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("")+"12"), ""))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12"), "group"))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group1")+"12"), "group2"))
-	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData"), ""))
+	assert.False(t, c.dcpKeyFilter([]byte(SyncSeqKey)))
+	assert.False(t, c.dcpKeyFilter([]byte(SyncPrefix+"unusualSeq")))
+	assert.False(t, c.dcpKeyFilter([]byte(SyncDataKey)))
+	assert.False(t, c.dcpKeyFilter([]byte(DCPCheckpointPrefix+"12")))
+	assert.False(t, c.dcpKeyFilter([]byte(TxnPrefix+"atrData")))
+
+	c = DCPCommon{
+		checkpointPrefix: DCPCheckpointPrefixWithGroupID("group"),
+		sgCfgPrefix:      SGCfgPrefixWithGroupID("group"),
+	}
+	assert.True(t, c.dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group"))))
+
+	assert.False(t, c.dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group1"))))
+	assert.False(t, c.dcpKeyFilter([]byte(SyncDataKeyWithGroupID("group"))))
+	assert.False(t, c.dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12")))
+
 }
 
 func TestCBGTIndexCreation(t *testing.T) {

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -394,7 +394,7 @@ func TestConcurrentCBGTIndexCreation(t *testing.T) {
 	testDBName := "testDB"
 
 	// Use an bucket-backed cfg
-	cfg, err := NewCfgSG(bucket)
+	cfg, err := NewCfgSG(bucket, nil)
 	require.NoError(t, err)
 
 	// Define index type for db name

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -63,10 +63,10 @@ func TestDCPKeyFilter(t *testing.T) {
 	assert.True(t, dcpKeyFilter([]byte(UserPrefix+"user1"), ""))
 	assert.True(t, dcpKeyFilter([]byte(RolePrefix+"role2"), ""))
 	assert.True(t, dcpKeyFilter([]byte(UnusedSeqPrefix+"1234"), ""))
-	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefix("")), ""))
-	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefix("group")), "group"))
+	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("")), ""))
+	assert.True(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group")), "group"))
 
-	assert.False(t, dcpKeyFilter([]byte(SGCfgPrefix("group1")), "group2"))
+	assert.False(t, dcpKeyFilter([]byte(SGCfgPrefixWithGroupID("group1")), "group2"))
 	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey), ""))
 	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq"), ""))
 	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("")), ""))

--- a/base/dcp_test.go
+++ b/base/dcp_test.go
@@ -69,12 +69,12 @@ func TestDCPKeyFilter(t *testing.T) {
 	assert.False(t, dcpKeyFilter([]byte(SGCfgPrefix("group1")), "group2"))
 	assert.False(t, dcpKeyFilter([]byte(SyncSeqKey), ""))
 	assert.False(t, dcpKeyFilter([]byte(SyncPrefix+"unusualSeq"), ""))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKey("")), ""))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKey("group")), "group"))
-	assert.False(t, dcpKeyFilter([]byte(SyncDataKey("group1")), "group2"))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix("")+"12"), ""))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix("group")+"12"), "group"))
-	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefix("group1")+"12"), "group2"))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("")), ""))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("group")), "group"))
+	assert.False(t, dcpKeyFilter([]byte(SyncDataKeyWithGroupID("group1")), "group2"))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("")+"12"), ""))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group")+"12"), "group"))
+	assert.False(t, dcpKeyFilter([]byte(DCPCheckpointPrefixWithGroupID("group1")+"12"), "group2"))
 	assert.False(t, dcpKeyFilter([]byte(TxnPrefix+"atrData"), ""))
 }
 

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -66,7 +66,7 @@ type HeartbeatListener interface {
 type couchbaseHeartBeater struct {
 	bucket                  Bucket
 	keyPrefix               string
-	groupID                 *string
+	groupID                 string
 	nodeUUID                string
 	heartbeatSendInterval   time.Duration                // Heartbeat send interval
 	heartbeatExpirySeconds  uint32                       // Heartbeat expiry time (seconds)
@@ -84,7 +84,7 @@ type couchbaseHeartBeater struct {
 // the keyPrefix which will be prepended to the heartbeat doc keys,
 // and the nodeUUID, which is an opaque identifier for the "thing" that is using this
 // library.  nodeUUID will be passed to listeners on stale node detection.
-func NewCouchbaseHeartbeater(bucket Bucket, keyPrefix, nodeUUID string, groupID *string) (heartbeater *couchbaseHeartBeater, err error) {
+func NewCouchbaseHeartbeater(bucket Bucket, keyPrefix, nodeUUID, groupID string) (heartbeater *couchbaseHeartBeater, err error) {
 
 	heartbeater = &couchbaseHeartBeater{
 		bucket:                 bucket,
@@ -301,9 +301,9 @@ func (h *couchbaseHeartBeater) checkStaleHeartbeats() error {
 	return nil
 }
 
-func heartbeatTimeoutDocID(nodeUuid, keyPrefix string, groupID *string) string {
-	if groupID != nil {
-		return keyPrefix + "heartbeat_timeout:" + *groupID + ":" + nodeUuid
+func heartbeatTimeoutDocID(nodeUuid, keyPrefix, groupID string) string {
+	if groupID != "" {
+		return keyPrefix + groupID + ":heartbeat_timeout:" + nodeUuid
 	}
 	return keyPrefix + "heartbeat_timeout:" + nodeUuid
 }

--- a/base/heartbeat.go
+++ b/base/heartbeat.go
@@ -65,9 +65,9 @@ type HeartbeatListener interface {
 //       e.g  Default for a 4 node cluster: 12 ops/second
 type couchbaseHeartBeater struct {
 	bucket                  Bucket
+	nodeUUID                string
 	keyPrefix               string
 	groupID                 string
-	nodeUUID                string
 	heartbeatSendInterval   time.Duration                // Heartbeat send interval
 	heartbeatExpirySeconds  uint32                       // Heartbeat expiry time (seconds)
 	heartbeatPollInterval   time.Duration                // Frequency of polling for other nodes' heartbeat documents

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -115,7 +115,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 	listeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, nil)
+		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, "")
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -194,7 +194,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 	sgrListeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, nil)
+		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, "")
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -309,11 +309,11 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create three heartbeaters (representing three nodes)
-	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", nil)
+	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", "")
 	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", nil)
+	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", "")
 	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", nil)
+	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", "")
 	assert.NoError(t, err)
 
 	assert.NoError(t, node1.SetExpirySeconds(2))

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -115,7 +115,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 	listeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID)
+		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, nil)
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -194,7 +194,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 	sgrListeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID)
+		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, nil)
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -309,11 +309,11 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create three heartbeaters (representing three nodes)
-	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1")
+	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", nil)
 	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2")
+	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", nil)
 	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3")
+	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", nil)
 	assert.NoError(t, err)
 
 	assert.NoError(t, node1.SetExpirySeconds(2))

--- a/base/heartbeat_test.go
+++ b/base/heartbeat_test.go
@@ -115,7 +115,7 @@ func TestCouchbaseHeartbeaters(t *testing.T) {
 	listeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, "")
+		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID)
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -194,7 +194,7 @@ func TestCouchbaseHeartbeatersMultipleListeners(t *testing.T) {
 	sgrListeners := make([]*documentBackedListener, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		nodeUUID := fmt.Sprintf("node%d", i)
-		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID, "")
+		node, err := NewCouchbaseHeartbeater(testBucket, keyprefix, nodeUUID)
 		assert.NoError(t, err)
 
 		// Lower heartbeat expiry to avoid long-running test
@@ -309,11 +309,11 @@ func TestCBGTManagerHeartbeater(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create three heartbeaters (representing three nodes)
-	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1", "")
+	node1, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node1")
 	assert.NoError(t, err)
-	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2", "")
+	node2, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node2")
 	assert.NoError(t, err)
-	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3", "")
+	node3, err := NewCouchbaseHeartbeater(testBucket, keyprefix, "node3")
 	assert.NoError(t, err)
 
 	assert.NoError(t, node1.SetExpirySeconds(2))

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -12,6 +12,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -84,7 +85,10 @@ func (c *CfgSG) Get(cfgKey string, cas uint64) (
 func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Set, key: %s, cas: %d", cfgKey, cas)
-	var err error
+	if strings.HasPrefix(cfgKey, ":") {
+		return 0, fmt.Errorf("cfg_sg: key cannot start with a colon")
+	}
+
 	bucketKey := c.sgCfgBucketKey(cfgKey)
 
 	casOut, err := c.bucket.WriteCas(bucketKey, 0, 0, cas, val, 0)

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -28,6 +28,7 @@ type CfgSG struct {
 	loggingCtx    context.Context
 	subscriptions map[string][]chan<- cbgt.CfgEvent // Keyed by key
 	lock          sync.Mutex                        // mutex for subscriptions
+	groupID       *string
 }
 
 type CfgEventNotifyFunc func(docID string, cas uint64, err error)
@@ -40,7 +41,7 @@ var ErrCfgCasError = &cbgt.CfgCASError{}
 //
 // urlStr: single URL or multiple URLs delimited by ';'
 // bucket: couchbase bucket name
-func NewCfgSG(bucket Bucket) (*CfgSG, error) {
+func NewCfgSG(bucket Bucket, groupID *string) (*CfgSG, error) {
 
 	cfgContextID := MD(bucket.GetName()).Redact() + "-cfgSG"
 	loggingCtx := context.WithValue(context.Background(), LogContextKey{},
@@ -51,11 +52,15 @@ func NewCfgSG(bucket Bucket) (*CfgSG, error) {
 		bucket:        bucket,
 		loggingCtx:    loggingCtx,
 		subscriptions: make(map[string][]chan<- cbgt.CfgEvent),
+		groupID:       groupID,
 	}
 	return c, nil
 }
 
-func sgCfgBucketKey(cfgKey string) string {
+func (c *CfgSG) sgCfgBucketKey(cfgKey string) string {
+	if c.groupID != nil {
+		return SGCfgPrefix + ":" + *c.groupID + ":" + cfgKey
+	}
 	return SGCfgPrefix + cfgKey
 }
 
@@ -63,7 +68,7 @@ func (c *CfgSG) Get(cfgKey string, cas uint64) (
 	[]byte, uint64, error) {
 
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Get, key: %s, cas: %d", cfgKey, cas)
-	bucketKey := sgCfgBucketKey(cfgKey)
+	bucketKey := c.sgCfgBucketKey(cfgKey)
 	var value []byte
 	casOut, err := c.bucket.Get(bucketKey, &value)
 	if err != nil && !IsKeyNotFoundError(c.bucket, err) {
@@ -83,7 +88,7 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Set, key: %s, cas: %d", cfgKey, cas)
 	var err error
-	bucketKey := sgCfgBucketKey(cfgKey)
+	bucketKey := c.sgCfgBucketKey(cfgKey)
 
 	casOut, err := c.bucket.WriteCas(bucketKey, 0, 0, cas, val, 0)
 
@@ -101,7 +106,7 @@ func (c *CfgSG) Set(cfgKey string, val []byte, cas uint64) (uint64, error) {
 func (c *CfgSG) Del(cfgKey string, cas uint64) error {
 
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: Del, key: %s, cas: %d", cfgKey, cas)
-	bucketKey := sgCfgBucketKey(cfgKey)
+	bucketKey := c.sgCfgBucketKey(cfgKey)
 	_, err := c.bucket.Remove(bucketKey, cas)
 	if IsCasMismatch(err) {
 		return ErrCfgCasError
@@ -128,7 +133,10 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 }
 
 func (c *CfgSG) FireEvent(docID string, cas uint64, err error) {
-
+	if c.groupID != nil {
+		// Remove first instance of group ID
+		docID = strings.Replace(docID, *c.groupID, "", 1)
+	}
 	cfgKey := strings.TrimPrefix(docID, SGCfgPrefix)
 	c.lock.Lock()
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: FireEvent, key: %s, cas %d", cfgKey, cas)

--- a/base/sg_cluster_cfg.go
+++ b/base/sg_cluster_cfg.go
@@ -59,7 +59,7 @@ func NewCfgSG(bucket Bucket, groupID string) (*CfgSG, error) {
 }
 
 func (c *CfgSG) sgCfgBucketKey(cfgKey string) string {
-	return SGCfgPrefix(c.groupID) + cfgKey
+	return SGCfgPrefixWithGroupID(c.groupID) + cfgKey
 }
 
 func (c *CfgSG) Get(cfgKey string, cas uint64) (
@@ -133,9 +133,8 @@ func (c *CfgSG) Subscribe(cfgKey string, ch chan cbgt.CfgEvent) error {
 	return nil
 }
 
-// TODO: Write test targetting FireEvent to check colon is being removed correctly
 func (c *CfgSG) FireEvent(docID string, cas uint64, err error) {
-	cfgKey := strings.TrimPrefix(docID, SGCfgPrefix(c.groupID))
+	cfgKey := strings.TrimPrefix(docID, SGCfgPrefixWithGroupID(c.groupID))
 	c.lock.Lock()
 	DebugfCtx(c.loggingCtx, KeyCluster, "cfg_sg: FireEvent, key: %s, cas %d", cfgKey, cas)
 	for _, ch := range c.subscriptions[cfgKey] {

--- a/db/active_replicator_common.go
+++ b/db/active_replicator_common.go
@@ -66,7 +66,7 @@ func newActiveReplicatorCommon(config *ActiveReplicatorConfig, direction ActiveR
 		config:           config,
 		state:            ReplicationStateStopped,
 		replicationStats: replicationStats,
-		CheckpointID:     checkpointID,
+		CheckpointID:     config.checkpointPrefix + checkpointID,
 	}
 }
 

--- a/db/active_replicator_config.go
+++ b/db/active_replicator_config.go
@@ -90,6 +90,9 @@ type ActiveReplicatorConfig struct {
 	// Callback to be invoked on replication completion
 	onComplete OnCompleteFunc
 
+	// checkpointPrefix is the prefix for checkpoint ID on activeReplicatorCommon which is used for replication checkpoints
+	checkpointPrefix string
+
 	// Map corresponding to db.replications.[replicationID] in Sync Gateway's expvars.  Populated with
 	// replication stats in blip_sync_stats.go
 	ReplicationStatsMap *base.DbReplicatorStats

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -127,7 +127,7 @@ func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, ma
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for mark phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_mark"
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore, db.Options.GroupID)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -333,7 +333,7 @@ func Sweep(db *Database, compactionID string, vbUUIDs []uint64, dryRun bool, ter
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for sweep phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_sweep"
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore, db.Options.GroupID)
 	if err != nil {
 		return 0, err
 	}
@@ -452,7 +452,7 @@ func Cleanup(db *Database, compactionID string, vbUUIDs []uint64, terminator *ba
 
 	base.InfofCtx(db.Ctx, base.KeyAll, "[%s] Starting DCP feed for cleanup phase of attachment compaction", compactionLoggingID)
 	dcpFeedKey := compactionID + "_cleanup"
-	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore)
+	dcpClient, err := base.NewDCPClient(dcpFeedKey, callback, clientOptions, cbStore, db.Options.GroupID)
 	if err != nil {
 		return err
 	}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -422,7 +422,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		return
 	}
 
-	if strings.HasPrefix(docID, base.SGCfgPrefix) {
+	if strings.HasPrefix(docID, base.SGCfgPrefix(c.context.Options.GroupID)) {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -422,7 +422,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		return
 	}
 
-	if strings.HasPrefix(docID, base.SGCfgPrefix(c.context.Options.GroupID)) {
+	if strings.HasPrefix(docID, base.SGCfgPrefixWithGroupID(c.context.Options.GroupID)) {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}

--- a/db/change_cache.go
+++ b/db/change_cache.go
@@ -67,6 +67,7 @@ type changeCache struct {
 	lastAddPendingTime int64                   // The most recent time _addPendingLogs was run, as epoch time
 	internalStats      changeCacheStats        // Running stats for the change cache.  Only applied to expvars on a call to changeCache.updateStats
 	cfgEventCallback   base.CfgEventNotifyFunc // Callback for Cfg updates recieved over the caching feed
+	sgCfgPrefix        string                  // Prefix for SG Cfg doc keys
 }
 
 type changeCacheStats struct {
@@ -164,6 +165,7 @@ func (c *changeCache) Init(dbcontext *DatabaseContext, notifyChange func(base.Se
 	c.initTime = time.Now()
 	c.skippedSeqs = NewSkippedSequenceList()
 	c.lastAddPendingTime = time.Now().UnixNano()
+	c.sgCfgPrefix = base.SGCfgPrefixWithGroupID(dbcontext.Options.GroupID)
 
 	// init cache options
 	if options != nil {
@@ -422,7 +424,7 @@ func (c *changeCache) DocChanged(event sgbucket.FeedEvent) {
 		return
 	}
 
-	if strings.HasPrefix(docID, base.SGCfgPrefixWithGroupID(c.context.Options.GroupID)) {
+	if strings.HasPrefix(docID, c.sgCfgPrefix) {
 		if c.cfgEventCallback != nil {
 			c.cfgEventCallback(docID, event.Cas, nil)
 		}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -36,16 +36,18 @@ type changeListener struct {
 	keyCounts             map[string]uint64      // Latest count at which each doc key was updated
 	OnDocChanged          DocChangedFunc         // Called when change arrives on feed
 	terminator            chan bool              // Signal to cause cbdatasource bucketdatasource.Close() to be called, which removes dcp receiver
+	groupID               string
 }
 
 type DocChangedFunc func(event sgbucket.FeedEvent)
 
-func (listener *changeListener) Init(name string) {
+func (listener *changeListener) Init(name string, groupID string) {
 	listener.bucketName = name
 	listener.counter = 1
 	listener.terminateCheckCounter = 0
 	listener.keyCounts = map[string]uint64{}
 	listener.tapNotifier = sync.NewCond(&sync.Mutex{})
+	listener.groupID = groupID
 }
 
 // Starts a changeListener on a given Bucket.
@@ -59,6 +61,7 @@ func (listener *changeListener) Start(bucket base.Bucket, dbStats *expvar.Map) e
 		Backfill:   sgbucket.FeedNoBackfill,
 		Terminator: listener.terminator,
 		DoneChan:   make(chan struct{}),
+		GroupID:    listener.groupID,
 	}
 
 	return listener.StartMutationFeed(bucket, dbStats)
@@ -120,13 +123,13 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
-		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix) { // SG DCP checkpoint docs
+		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix(listener.groupID)) { // SG DCP checkpoint docs
 			// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
 			// we'll end up in a feedback loop for their vbucket if persistence is enabled
 			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place
 			// defensively.
 			requiresCheckpointPersistence = false
-		} else if strings.HasPrefix(key, base.SGCfgPrefix) {
+		} else if strings.HasPrefix(key, base.SGCfgPrefix(listener.groupID)) {
 			if listener.OnDocChanged != nil {
 				listener.OnDocChanged(event)
 			}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -123,7 +123,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
-		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix(listener.groupID)) { // SG DCP checkpoint docs
+		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix("")) { // SG DCP checkpoint docs (including other config group IDs)
 			// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
 			// we'll end up in a feedback loop for their vbucket if persistence is enabled
 			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -132,7 +132,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place
 			// defensively.
 			requiresCheckpointPersistence = false
-		} else if strings.HasPrefix(key, listener.checkpointPrefix) {
+		} else if strings.HasPrefix(key, listener.sgCfgPrefix) {
 			if listener.OnDocChanged != nil {
 				listener.OnDocChanged(event)
 			}

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -123,7 +123,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			if listener.OnDocChanged != nil && event.Opcode == sgbucket.FeedOpMutation {
 				listener.OnDocChanged(event)
 			}
-		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix("")) { // SG DCP checkpoint docs (including other config group IDs)
+		} else if strings.HasPrefix(key, base.DCPCheckpointPrefix) { // SG DCP checkpoint docs (including other config group IDs)
 			// Do not require checkpoint persistence when DCP checkpoint docs come back over DCP - otherwise
 			// we'll end up in a feedback loop for their vbucket if persistence is enabled
 			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -64,7 +64,6 @@ func (listener *changeListener) Start(bucket base.Bucket, dbStats *expvar.Map) e
 		Terminator:       listener.terminator,
 		DoneChan:         make(chan struct{}),
 		CheckpointPrefix: listener.checkpointPrefix,
-		SGCfgPrefix:      listener.sgCfgPrefix,
 	}
 
 	return listener.StartMutationFeed(bucket, dbStats)

--- a/db/change_listener.go
+++ b/db/change_listener.go
@@ -129,7 +129,7 @@ func (listener *changeListener) ProcessFeedEvent(event sgbucket.FeedEvent) bool 
 			// NOTE: checkpoint persistence is disabled altogether for the caching feed.  Leaving this check in place
 			// defensively.
 			requiresCheckpointPersistence = false
-		} else if strings.HasPrefix(key, base.SGCfgPrefix(listener.groupID)) {
+		} else if strings.HasPrefix(key, base.SGCfgPrefixWithGroupID(listener.groupID)) {
 			if listener.OnDocChanged != nil {
 				listener.OnDocChanged(event)
 			}

--- a/db/database.go
+++ b/db/database.go
@@ -461,7 +461,7 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	// If this is an xattr import node, start import feed.  Must be started after the caching DCP feed, as import cfg
 	// subscription relies on the caching feed.
 	if importEnabled {
-		dbContext.ImportListener = NewImportListener()
+		dbContext.ImportListener = NewImportListener(dbContext.Options.GroupID)
 		if importFeedErr := dbContext.ImportListener.StartImportFeed(bucket, dbContext.DbStats, dbContext); importFeedErr != nil {
 			return nil, importFeedErr
 		}

--- a/db/database.go
+++ b/db/database.go
@@ -1161,7 +1161,7 @@ func (context *DatabaseContext) UpdateSyncFun(syncFun string) (changed bool, err
 		Sync string
 	}
 
-	_, err = context.Bucket.Update(base.SyncDataKey(context.Options.GroupID), 0, func(currentValue []byte) ([]byte, *uint32, bool, error) {
+	_, err = context.Bucket.Update(base.SyncDataKeyWithGroupID(context.Options.GroupID), 0, func(currentValue []byte) ([]byte, *uint32, bool, error) {
 		// The first time opening a new db, currentValue will be nil. Don't treat this as a change.
 		if currentValue != nil {
 			parseErr := base.JSONUnmarshal(currentValue, &syncData)

--- a/db/database.go
+++ b/db/database.go
@@ -397,7 +397,11 @@ func NewDatabaseContext(dbName string, bucket base.Bucket, autoImport bool, opti
 	// sending heartbeats before registering itself to the cfg, to avoid triggering immediate removal by other active nodes.
 	if base.IsEnterpriseEdition() && (importEnabled || sgReplicateEnabled) {
 		// Create heartbeater
-		heartbeater, err := base.NewCouchbaseHeartbeater(bucket, base.SyncPrefix, dbContext.UUID, dbContext.Options.GroupID)
+		heartbeaterPrefix := base.SyncPrefix
+		if dbContext.Options.GroupID != "" {
+			heartbeaterPrefix = heartbeaterPrefix + dbContext.Options.GroupID + ":"
+		}
+		heartbeater, err := base.NewCouchbaseHeartbeater(bucket, heartbeaterPrefix, dbContext.UUID)
 		if err != nil {
 			return nil, pkgerrors.Wrapf(err, "Error starting heartbeater for bucket %s", base.MD(bucket.GetName()).Redact())
 		}

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -46,10 +46,11 @@ func (il *importListener) StartImportFeed(bucket base.Bucket, dbStats *base.DbSt
 	il.database = Database{DatabaseContext: dbContext, user: nil}
 	il.stats = dbStats.Database()
 	feedArgs := sgbucket.FeedArguments{
-		ID:         base.DCPImportFeedID,
-		Backfill:   sgbucket.FeedResume,
-		Terminator: il.terminator,
-		DoneChan:   make(chan struct{}),
+		ID:               base.DCPImportFeedID,
+		Backfill:         sgbucket.FeedResume,
+		Terminator:       il.terminator,
+		DoneChan:         make(chan struct{}),
+		CheckpointPrefix: il.checkpointPrefix,
 	}
 
 	importFeedStatsMap := dbContext.DbStats.Database().ImportFeedMapStats

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -20,16 +20,20 @@ import (
 // ImportListener manages the import DCP feed.  ProcessFeedEvent is triggered for each feed events,
 // and invokes ImportFeedEvent for any event that's eligible for import handling.
 type importListener struct {
-	bucketName  string              // Used for logging
-	terminator  chan bool           // Signal to cause cbdatasource bucketdatasource.Close() to be called, which removes dcp receiver
-	database    Database            // Admin database instance to be used for import
-	stats       *base.DatabaseStats // Database stats group
-	cbgtContext *base.CbgtContext   // Handle to cbgt manager,cfg
+	bucketName       string              // Used for logging
+	terminator       chan bool           // Signal to cause cbdatasource bucketdatasource.Close() to be called, which removes dcp receiver
+	database         Database            // Admin database instance to be used for import
+	stats            *base.DatabaseStats // Database stats group
+	cbgtContext      *base.CbgtContext   // Handle to cbgt manager,cfg
+	checkpointPrefix string              // DCP checkpoint key prefix
+	sgCfgPrefix      string              // SG config key prefix
 }
 
-func NewImportListener() *importListener {
+func NewImportListener(groupID string) *importListener {
 	importListener := &importListener{
-		terminator: make(chan bool),
+		terminator:       make(chan bool),
+		checkpointPrefix: base.DCPCheckpointPrefixWithGroupID(groupID),
+		sgCfgPrefix:      base.SGCfgPrefixWithGroupID(groupID),
 	}
 	return importListener
 }

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -83,7 +83,8 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 	// Ignore internal documents
 	if strings.HasPrefix(key, base.SyncPrefix) {
-		if strings.HasPrefix(key, base.DCPCheckpointPrefix(il.database.Options.GroupID)) {
+		// Ignore all DCP checkpoints no matter config group ID
+		if strings.HasPrefix(key, base.DCPCheckpointPrefix("")) {
 			return false
 		}
 		return true

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -84,7 +84,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 	// Ignore internal documents
 	if strings.HasPrefix(key, base.SyncPrefix) {
 		// Ignore all DCP checkpoints no matter config group ID
-		if strings.HasPrefix(key, base.DCPCheckpointPrefix("")) {
+		if strings.HasPrefix(key, base.DCPCheckpointPrefix) {
 			return false
 		}
 		return true

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -83,7 +83,7 @@ func (il *importListener) ProcessFeedEvent(event sgbucket.FeedEvent) (shouldPers
 
 	// Ignore internal documents
 	if strings.HasPrefix(key, base.SyncPrefix) {
-		if strings.HasPrefix(key, base.DCPCheckpointPrefix) {
+		if strings.HasPrefix(key, base.DCPCheckpointPrefix(il.database.Options.GroupID)) {
 			return false
 		}
 		return true

--- a/db/import_listener.go
+++ b/db/import_listener.go
@@ -26,14 +26,12 @@ type importListener struct {
 	stats            *base.DatabaseStats // Database stats group
 	cbgtContext      *base.CbgtContext   // Handle to cbgt manager,cfg
 	checkpointPrefix string              // DCP checkpoint key prefix
-	sgCfgPrefix      string              // SG config key prefix
 }
 
 func NewImportListener(groupID string) *importListener {
 	importListener := &importListener{
 		terminator:       make(chan bool),
 		checkpointPrefix: base.DCPCheckpointPrefixWithGroupID(groupID),
-		sgCfgPrefix:      base.SGCfgPrefixWithGroupID(groupID),
 	}
 	return importListener
 }

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -72,6 +72,6 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.database.DbStats.Database().ImportFeedMapStats
 	importPartitionStat := il.database.DbStats.SharedBucketImport().ImportPartitions
 
-	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix, il.sgCfgPrefix)
+	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix)
 	return importDest, nil
 }

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -72,6 +72,6 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.database.DbStats.Database().ImportFeedMapStats
 	importPartitionStat := il.database.DbStats.SharedBucketImport().ImportPartitions
 
-	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat)
+	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.database.Options.GroupID)
 	return importDest, nil
 }

--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -72,6 +72,6 @@ func (il *importListener) NewImportDest() (cbgt.Dest, error) {
 	importFeedStatsMap := il.database.DbStats.Database().ImportFeedMapStats
 	importPartitionStat := il.database.DbStats.SharedBucketImport().ImportPartitions
 
-	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.database.Options.GroupID)
+	importDest, _ := base.NewDCPDest(callback, bucket, maxVbNo, true, importFeedStatsMap.Map, base.DCPImportFeedID, importPartitionStat, il.checkpointPrefix, il.sgCfgPrefix)
 	return importDest, nil
 }

--- a/db/sg_replicate_cfg.go
+++ b/db/sg_replicate_cfg.go
@@ -579,6 +579,10 @@ func (m *sgReplicateManager) InitializeReplication(config *ReplicationCfg) (repl
 		return nil, cfgErr
 	}
 
+	if m.dbContext.Options.GroupID != "" {
+		rc.checkpointPrefix = m.dbContext.Options.GroupID + ":"
+	}
+
 	// Retrieve or create an entry in db.replications expvar for this replication
 	allReplicationsStatsMap := m.dbContext.DbStats.DBReplicatorStats(rc.ID)
 	rc.ReplicationStatsMap = allReplicationsStatsMap

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -652,7 +652,7 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	require.NoError(t, err)
 	err = managerDefault.AddReplication(&ReplicationCfg{
 		ReplicationConfig: ReplicationConfig{
-			ID:           "replicator",
+			ID:           "repl",
 			InitialState: ReplicationStateStopped,
 		},
 	})
@@ -666,7 +666,7 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	require.NoError(t, err)
 	err = managerGroupA.AddReplication(&ReplicationCfg{
 		ReplicationConfig: ReplicationConfig{
-			ID:           "replicatorGroupA",
+			ID:           "repl",
 			InitialState: ReplicationStateStopped,
 		},
 	})
@@ -680,7 +680,7 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	require.NoError(t, err)
 	err = managerGroupB.AddReplication(&ReplicationCfg{
 		ReplicationConfig: ReplicationConfig{
-			ID:           "replicatorGroupB",
+			ID:           "repl",
 			InitialState: ReplicationStateStopped,
 		},
 	})
@@ -690,21 +690,21 @@ func TestReplicateGroupIDAssignedNodes(t *testing.T) {
 	replications, err := managerDefault.GetReplications()
 	require.NoError(t, err)
 	assert.Len(t, replications, 1)
-	cfg, exists := replications["replicator"]
+	cfg, exists := replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeDefault", cfg.AssignedNode)
 
 	replications, err = managerGroupA.GetReplications()
 	require.NoError(t, err)
 	assert.Len(t, replications, 1)
-	cfg, exists = replications["replicatorGroupA"]
+	cfg, exists = replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeGroupA", cfg.AssignedNode)
 
 	replications, err = managerGroupB.GetReplications()
 	require.NoError(t, err)
 	assert.Len(t, replications, 1)
-	cfg, exists = replications["replicatorGroupB"]
+	cfg, exists = replications["repl"]
 	require.True(t, exists, "Replicator not found")
 	assert.Equal(t, "nodeGroupB", cfg.AssignedNode)
 }

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -626,3 +626,85 @@ func TestIsCfgChanged(t *testing.T) {
 	}
 
 }
+
+// Test replicators assigned nodes with different group IDs
+func TestReplicateGroupIDAssignedNodes(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+	tb := base.GetTestBucket(t)
+	defer tb.Close()
+
+	// Set up SG Configs
+	cfgDefault, err := base.NewCfgSG(tb, "")
+	require.NoError(t, err)
+
+	cfgGroupA, err := base.NewCfgSG(tb, "GroupA")
+	require.NoError(t, err)
+
+	cfgGGroupB, err := base.NewCfgSG(tb, "GroupB")
+	require.NoError(t, err)
+
+	// Set up replicators
+	dbDefault, err := NewDatabaseContext("default", tb, false, DatabaseContextOptions{GroupID: ""})
+	require.NoError(t, err)
+	managerDefault, err := NewSGReplicateManager(dbDefault, cfgDefault)
+	require.NoError(t, err)
+	err = managerDefault.RegisterNode("nodeDefault")
+	require.NoError(t, err)
+	err = managerDefault.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:           "replicator",
+			InitialState: ReplicationStateStopped,
+		},
+	})
+	require.NoError(t, err)
+
+	dbGroupA, err := NewDatabaseContext("groupa", tb, false, DatabaseContextOptions{GroupID: "GroupA"})
+	require.NoError(t, err)
+	managerGroupA, err := NewSGReplicateManager(dbGroupA, cfgGroupA)
+	require.NoError(t, err)
+	err = managerGroupA.RegisterNode("nodeGroupA")
+	require.NoError(t, err)
+	err = managerGroupA.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:           "replicatorGroupA",
+			InitialState: ReplicationStateStopped,
+		},
+	})
+	require.NoError(t, err)
+
+	dbGroupB, err := NewDatabaseContext("groupb", tb, false, DatabaseContextOptions{GroupID: "GroupB"})
+	require.NoError(t, err)
+	managerGroupB, err := NewSGReplicateManager(dbGroupB, cfgGGroupB)
+	require.NoError(t, err)
+	err = managerGroupB.RegisterNode("nodeGroupB")
+	require.NoError(t, err)
+	err = managerGroupB.AddReplication(&ReplicationCfg{
+		ReplicationConfig: ReplicationConfig{
+			ID:           "replicatorGroupB",
+			InitialState: ReplicationStateStopped,
+		},
+	})
+	require.NoError(t, err)
+
+	// Check replications are assigned to correct nodes
+	replications, err := managerDefault.GetReplications()
+	require.NoError(t, err)
+	assert.Len(t, replications, 1)
+	cfg, exists := replications["replicator"]
+	require.True(t, exists, "Replicator not found")
+	assert.Equal(t, "nodeDefault", cfg.AssignedNode)
+
+	replications, err = managerGroupA.GetReplications()
+	require.NoError(t, err)
+	assert.Len(t, replications, 1)
+	cfg, exists = replications["replicatorGroupA"]
+	require.True(t, exists, "Replicator not found")
+	assert.Equal(t, "nodeGroupA", cfg.AssignedNode)
+
+	replications, err = managerGroupB.GetReplications()
+	require.NoError(t, err)
+	assert.Len(t, replications, 1)
+	cfg, exists = replications["replicatorGroupB"]
+	require.True(t, exists, "Replicator not found")
+	assert.Equal(t, "nodeGroupB", cfg.AssignedNode)
+}

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -27,7 +27,7 @@ func TestReplicateManagerReplications(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket)
+	testCfg, err := base.NewCfgSG(testBucket, nil)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
@@ -89,7 +89,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket)
+	testCfg, err := base.NewCfgSG(testBucket, nil)
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
@@ -143,7 +143,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket)
+	testCfg, err := base.NewCfgSG(testBucket, nil)
 	require.NoError(t, err)
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket)
+	testCfg, err := base.NewCfgSG(testBucket, nil)
 	require.NoError(t, err)
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
@@ -606,7 +606,7 @@ func TestIsCfgChanged(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket)
+	testCfg, err := base.NewCfgSG(testBucket, nil)
 	require.NoError(t, err)
 
 	mgr, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)

--- a/db/sg_replicate_cfg_test.go
+++ b/db/sg_replicate_cfg_test.go
@@ -27,7 +27,7 @@ func TestReplicateManagerReplications(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket, nil)
+	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
@@ -89,7 +89,7 @@ func TestReplicateManagerNodes(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket, nil)
+	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
@@ -143,7 +143,7 @@ func TestReplicateManagerConcurrentNodeOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket, nil)
+	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestReplicateManagerConcurrentReplicationOperations(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket, nil)
+	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 	manager, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)
 	require.NoError(t, err)
@@ -606,7 +606,7 @@ func TestIsCfgChanged(t *testing.T) {
 	testBucket := base.GetTestBucket(t)
 	defer testBucket.Close()
 
-	testCfg, err := base.NewCfgSG(testBucket, nil)
+	testCfg, err := base.NewCfgSG(testBucket, "")
 	require.NoError(t, err)
 
 	mgr, err := NewSGReplicateManager(&DatabaseContext{Name: "test"}, testCfg)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -292,6 +292,19 @@ func bootstrapAdminRequest(t *testing.T, method, path, body string) *http.Respon
 	return resp
 }
 
+func bootstrapAdminRequestCustomHost(t *testing.T, method, host, path, body string) *http.Response {
+	url := host + path
+
+	buf := bytes.NewBufferString(body)
+	req, err := http.NewRequest(method, url, buf)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	return resp
+}
+
 func bootstrapAdminRequestWithHeaders(t *testing.T, method, path, body string, headers map[string]string) *http.Response {
 	url := "http://localhost:" + strconv.FormatInt(4985+bootstrapTestPortOffset, 10) + path
 

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -765,9 +765,9 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		slowQueryWarningThreshold = time.Duration(*config.SlowQueryWarningThresholdMs) * time.Millisecond
 	}
 
-	groupID := base.StringPtr(sc.config.Bootstrap.ConfigGroupID)
-	if *groupID == persistentConfigDefaultGroupID {
-		groupID = nil
+	groupID := sc.config.Bootstrap.ConfigGroupID
+	if groupID == persistentConfigDefaultGroupID {
+		groupID = ""
 	}
 
 	contextOptions := db.DatabaseContextOptions{

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -765,6 +765,11 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		slowQueryWarningThreshold = time.Duration(*config.SlowQueryWarningThresholdMs) * time.Millisecond
 	}
 
+	groupID := base.StringPtr(sc.config.Bootstrap.ConfigGroupID)
+	if *groupID == persistentConfigDefaultGroupID {
+		groupID = nil
+	}
+
 	contextOptions := db.DatabaseContextOptions{
 		CacheOptions:              &cacheOptions,
 		RevisionCacheOptions:      revCacheOptions,
@@ -792,6 +797,7 @@ func dbcOptionsFromConfig(sc *ServerContext, config *DbConfig, dbName string) (d
 		SlowQueryWarningThreshold: slowQueryWarningThreshold,
 		ClientPartitionWindow:     clientPartitionWindow,
 		BcryptCost:                bcryptCost,
+		GroupID:                   groupID,
 	}
 
 	return contextOptions, nil


### PR DESCRIPTION
CBG-1763

- If Group ID is set, it is used to namespace anything that uses `CfgSG` to store config settings (such as SG Replicate), namespace the sync function, namespace the heartbeat documents, and namespaced DCP Checkpoints for the import feed
- If group ID is not set, then the old document names are used (IE. not putting `default` in the doc names)
- Modified tests to account for these changed

## Dependencies 
- [x] https://github.com/couchbase/sg-bucket/pull/68
- [x] Add commit hash to manifest

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1460
