### PR TITLE
CBG-1749: Add attachment compaction dry run support

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -304,11 +304,11 @@ func Sweep(db *Database, compactionID string, dryRun bool, terminator chan struc
 				return true
 			}
 			base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Purged attachment %s", compactionLoggingID, base.UD(docID))
+		} else {
+			base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Would have purged attachment %s (not purged, running with dry run)", compactionLoggingID, base.UD(docID))
 		}
 
-		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Would have purged attachment %s (not purged, running with dry run)", compactionLoggingID, base.UD(docID))
 		purgedAttachmentCount.Add(1)
-
 		return true
 	}
 

--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -252,7 +252,7 @@ func handleAttachments(attachmentKeyMap map[string]string, docKey string, attach
 	}
 }
 
-func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAttachmentCount *base.AtomicInt) (int64, error) {
+func Sweep(db *Database, compactionID string, dryRun bool, terminator chan struct{}, purgedAttachmentCount *base.AtomicInt) (int64, error) {
 	base.InfofCtx(db.Ctx, base.KeyAll, "Starting second phase of attachment compaction (sweep phase) with compactionID: %q", compactionID)
 	compactionLoggingID := "Compaction Sweep: " + compactionID
 
@@ -296,14 +296,17 @@ func Sweep(db *Database, compactionID string, terminator chan struct{}, purgedAt
 		// - Has no compactionID set in its xattr
 		// - Has a compactionID set in its xattr but it is from a previous run and therefore is not equal to the passed
 		// in compactionID
-		// Therefore, we want to purge the doc
-		_, err := db.Bucket.Remove(docID, event.Cas)
-		if err != nil {
-			base.WarnfCtx(db.Ctx, "[%s] Unable to purge attachment %s: %v", compactionLoggingID, base.UD(docID), err)
-			return true
+		// Therefore, we want to purge the doc (unless running as dryRun mode)
+		if !dryRun {
+			_, err := db.Bucket.Remove(docID, event.Cas)
+			if err != nil {
+				base.WarnfCtx(db.Ctx, "[%s] Unable to purge attachment %s: %v", compactionLoggingID, base.UD(docID), err)
+				return true
+			}
+			base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Purged attachment %s", compactionLoggingID, base.UD(docID))
 		}
 
-		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Purged attachment %s", compactionLoggingID, base.UD(docID))
+		base.DebugfCtx(db.Ctx, base.KeyAll, "[%s] Would have purged attachment %s (not purged, running with dry run)", compactionLoggingID, base.UD(docID))
 		purgedAttachmentCount.Add(1)
 
 		return true

--- a/db/attachment_compaction_test.go
+++ b/db/attachment_compaction_test.go
@@ -325,7 +325,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		rawStatus, err := testDB2.AttachmentCompactionManager.GetStatus()
 		assert.NoError(t, err)
 		err = base.JSONUnmarshal(rawStatus, &status)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if status.State == BackgroundProcessStateStopped {
 			return true
@@ -339,7 +339,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	testRawStatus, err := testDB2.AttachmentCompactionManager.GetStatus()
 	assert.NoError(t, err)
 	err = base.JSONUnmarshal(testRawStatus, &testStatus)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, testStatus.DryRun)
 
 	err = testDB2.AttachmentCompactionManager.Start(map[string]interface{}{"database": testDB2, "dryRun": false})
@@ -350,7 +350,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		rawStatus, err := testDB2.AttachmentCompactionManager.GetStatus()
 		assert.NoError(t, err)
 		err = base.JSONUnmarshal(rawStatus, &status)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if status.State == BackgroundProcessStateCompleted {
 			return true
@@ -363,7 +363,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	testRawStatus, err = testDB2.AttachmentCompactionManager.GetStatus()
 	assert.NoError(t, err)
 	err = base.JSONUnmarshal(testRawStatus, &testStatus)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, testStatus.DryRun)
 
 	// Trigger start with immediate stop (stopped from db2)
@@ -376,7 +376,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus()
 		assert.NoError(t, err)
 		err = base.JSONUnmarshal(rawStatus, &status)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if status.State == BackgroundProcessStateStopped {
 			return true
@@ -395,7 +395,7 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 		rawStatus, err := testDB1.AttachmentCompactionManager.GetStatus()
 		assert.NoError(t, err)
 		err = base.JSONUnmarshal(rawStatus, &status)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		if status.State == BackgroundProcessStateCompleted {
 			return true
@@ -414,9 +414,9 @@ func TestAttachmentCompactionRunTwice(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = base.JSONUnmarshal(testDB1RawStatus, &testDB1Status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = base.JSONUnmarshal(testDB2RawStatus, &testDB2Status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, BackgroundProcessStateCompleted, testDB1Status.State)
 	assert.Equal(t, BackgroundProcessStateCompleted, testDB2Status.State)

--- a/rest/api.go
+++ b/rest/api.go
@@ -159,6 +159,7 @@ func (h *handler) handleCompact() error {
 			err := h.db.AttachmentCompactionManager.Start(map[string]interface{}{
 				"database": h.db,
 				"reset":    h.getBoolQuery("reset"),
+				"dryRun":   h.getBoolQuery("dry_run"),
 			})
 			if err != nil {
 				return err

--- a/rest/attachment_compaction_api_test.go
+++ b/rest/attachment_compaction_api_test.go
@@ -195,6 +195,51 @@ func TestAttachmentCompactionPersistence(t *testing.T) {
 	_ = rt1.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
 }
 
+func TestAttachmentCompactionDryRun(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("This test only works against Couchbase Server")
+	}
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	// Create some 'unmarked' attachments
+	makeUnmarkedDoc := func(docid string) {
+		err := rt.GetDatabase().Bucket.SetRaw(docid, 0, []byte("{}"))
+		assert.NoError(t, err)
+	}
+
+	attachmentKeys := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		docID := fmt.Sprintf("%s%s%d", base.AttPrefix, "unmarked", i)
+		makeUnmarkedDoc(docID)
+		attachmentKeys = append(attachmentKeys, docID)
+	}
+
+	resp := rt.SendAdminRequest("POST", "/db/_compact?type=attachment&dry_run=true", "")
+	assertStatus(t, resp, http.StatusOK)
+	status := rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	assert.True(t, status.DryRun)
+	assert.Equal(t, int64(5), status.PurgedAttachments)
+
+	for _, docID := range attachmentKeys {
+		_, _, err := rt.GetDatabase().Bucket.GetRaw(docID)
+		assert.NoError(t, err)
+	}
+
+	resp = rt.SendAdminRequest("POST", "/db/_compact?type=attachment", "")
+	assertStatus(t, resp, http.StatusOK)
+	status = rt.WaitForAttachmentCompactionStatus(t, db.BackgroundProcessStateCompleted)
+	assert.False(t, status.DryRun)
+	assert.Equal(t, int64(5), status.PurgedAttachments)
+
+	for _, docID := range attachmentKeys {
+		_, _, err := rt.GetDatabase().Bucket.GetRaw(docID)
+		assert.Error(t, err)
+		assert.True(t, base.IsDocNotFoundError(err))
+	}
+}
+
 func TestAttachmentCompactionReset(t *testing.T) {
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
@@ -242,7 +287,7 @@ func (rt *RestTester) WaitForAttachmentCompactionStatus(t *testing.T, state db.B
 		assert.NoError(t, err)
 
 		return response.State == state
-	}, 30, 1000)
+	}, 90, 1000)
 	assert.NoError(t, err)
 
 	return response


### PR DESCRIPTION
CBG-1749

Adds the option for attachment compaction to be ran with a dry run option. This just runs the full attachment compaction process but skips the actual purge part.

Based on CBG-1750 --> That PR included some changes which were used here. Technically this PR could be done separately but would cause a lot of conflicts when the two get merged

## Dependencies 
- [x] https://github.com/couchbase/sync_gateway/pull/5317

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1381/
