### PR TITLE
CBG-1782: Disallow empty strings for import_filter and sync function

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -629,12 +629,20 @@ func (dbConfig *DbConfig) validateVersion(isEnterpriseEdition bool) (errorMessag
 		if err != nil {
 			errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function contains invalid javascript syntax: %v", err))
 		}
+
+		if *dbConfig.Sync == "" {
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("sync function cannot be empty string"))
+		}
 	}
 
 	if dbConfig.ImportFilter != nil {
 		_, err = sgbucket.NewJSRunner(*dbConfig.ImportFilter)
 		if err != nil {
 			errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function contains invalid javascript syntax: %v", err))
+		}
+
+		if *dbConfig.ImportFilter == "" {
+			errorMessages = multierror.Append(errorMessages, fmt.Errorf("import filter function cannot be empty string"))
 		}
 	}
 


### PR DESCRIPTION
CBG-1782

Error on validation when attempting to set sync function or import filter function to empty string.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1377/
