### PR TITLE
CBG-1769: Import filter and sync function can be set and retrieved while db is offline

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3938,7 +3938,7 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 	"use_views": ` + strconv.FormatBool(base.TestsDisableGSI()) + `,
 	"num_index_replicas": 0 }`
 
-	add, err := tb.Add("TestImportDocBeforeOffline", 0, db.Document{ID: "TestImportDocBeforeOffline", RevID: "1-abc"})
+	add, err := tb.Add("TestImportDoc", 0, db.Document{ID: "TestImportDoc", RevID: "1-abc"})
 	require.NoError(t, err)
 	require.Equal(t, true, add)
 
@@ -3990,19 +3990,8 @@ func TestDeleteFunctionsWhileDbOffline(t *testing.T) {
 	resp = bootstrapAdminRequest(t, http.MethodPut, "/db/TestSyncDoc", "{}")
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	add, err = tb.Add("TestImportDocAfterOffline", 0, db.Document{ID: "TestImportDocAfterOffline", RevID: "1-abc"})
-	require.NoError(t, err)
-	require.Equal(t, true, add)
-
-	retryWorker := func() (shouldRetry bool, err error, value interface{}) {
-		resp = bootstrapAdminRequest(t, http.MethodGet, "/db/TestImportDocAfterOffline", "")
-		if resp.StatusCode != http.StatusOK {
-			return true, nil, resp
-		}
-		return false, nil, resp
-	}
-	err, _ = base.RetryLoop("wait for doc import", retryWorker, base.CreateSleeperFunc(10, 100))
-	assert.NoError(t, err)
+	resp = bootstrapAdminRequest(t, http.MethodGet, "/db/TestImportDoc", "")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestSetFunctionsWhileDbOffline(t *testing.T) {

--- a/rest/routing.go
+++ b/rest/routing.go
@@ -257,17 +257,17 @@ func CreateAdminRouter(sc *ServerContext) *mux.Router {
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, []Permission{PermUpdateDb, PermConfigureSyncFn, PermConfigureAuth}, (*handler).handlePutDbConfig)).Methods("PUT", "POST")
 
 	dbr.Handle("/_config/sync",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigSync)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleGetDbConfigSync)).Methods("GET")
 	dbr.Handle("/_config/sync",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigSync)).Methods("PUT")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handlePutDbConfigSync)).Methods("PUT")
 	dbr.Handle("/_config/sync",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleDeleteDbConfigSync)).Methods("DELETE")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb, PermConfigureSyncFn}, nil, (*handler).handleDeleteDbConfigSync)).Methods("DELETE")
 	dbr.Handle("/_config/import_filter",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfigImportFilter)).Methods("GET")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetDbConfigImportFilter)).Methods("GET")
 	dbr.Handle("/_config/import_filter",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePutDbConfigImportFilter)).Methods("PUT")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handlePutDbConfigImportFilter)).Methods("PUT")
 	dbr.Handle("/_config/import_filter",
-		makeHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleDeleteDbConfigImportFilter)).Methods("DELETE")
+		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleDeleteDbConfigImportFilter)).Methods("DELETE")
 
 	dbr.Handle("/_resync",
 		makeOfflineHandler(sc, adminPrivs, []Permission{PermUpdateDb}, nil, (*handler).handleGetResync)).Methods("GET")


### PR DESCRIPTION
CBG-1769
- Made `/{db}/_config/import_filter` and `/{db}/_config/sync` endpoints available while the database is offline for `PUT`, `GET`, and `DELETE` methods
- Made tests to test all these methods on the endpoint while the database is offline

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1​38​7