### PR TITLE
CBG-1788: Only allow any bucket to be referenced once

### DIFF
--- a/rest/main.go
+++ b/rest/main.go
@@ -273,7 +273,7 @@ func automaticConfigUpgrade(configPath string) (sc *StartupConfig, disablePersis
 func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 	var databaseServerAddress string
 
-	processedBucketNames := make(map[string]struct{}, len(configMap))
+	processedBucketDbNames := make(map[string]string, len(configMap))
 
 	for dbName, dbConfig := range configMap {
 		if dbConfig.Server == nil || *dbConfig.Server == "" {
@@ -305,12 +305,12 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 		dbConfig.KeyPath = ""
 		dbConfig.CACertPath = ""
 
-		if _, ok := processedBucketNames[*dbConfig.Bucket]; ok {
-			return nil, fmt.Errorf("automatic upgrade to persistent config failed. Only one database can " +
-				"target any given bucket")
+		if dbNameConflicting, ok := processedBucketDbNames[*dbConfig.Bucket]; ok {
+			return nil, fmt.Errorf("automatic upgrade to persistent config failed. Only one database can "+
+				"target any given bucket. %s used by %s and %s", *dbConfig.Bucket, dbName, dbNameConflicting)
 		}
 
-		processedBucketNames[*dbConfig.Bucket] = struct{}{}
+		processedBucketDbNames[*dbConfig.Bucket] = dbName
 
 		// Make sure any updates are written back to the config
 		configMap[dbName] = dbConfig

--- a/rest/main.go
+++ b/rest/main.go
@@ -305,9 +305,6 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 		dbConfig.KeyPath = ""
 		dbConfig.CACertPath = ""
 
-		// Make sure any updates are written back to the config
-		configMap[dbName] = dbConfig
-
 		if _, ok := processedBucketNames[*dbConfig.Bucket]; ok {
 			return nil, fmt.Errorf("automatic upgrade to persistent config failed. Only one database can " +
 				"target any given bucket")
@@ -315,6 +312,8 @@ func sanitizeDbConfigs(configMap DbConfigMap) (DbConfigMap, error) {
 
 		processedBucketNames[*dbConfig.Bucket] = struct{}{}
 
+		// Make sure any updates are written back to the config
+		configMap[dbName] = dbConfig
 	}
 	return configMap, nil
 }

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -161,6 +161,12 @@ func TestSanitizeDbConfigs(t *testing.T) {
 
 			if test.expectedError == "" {
 				assert.NoError(t, err)
+
+				for cfgIdx, dbConfig := range dbConfigMap {
+					assert.Nil(t, dbConfig.Server)
+					assert.Nil(t, test.input[cfgIdx].Server)
+				}
+
 				return
 			}
 

--- a/rest/main_test.go
+++ b/rest/main_test.go
@@ -152,7 +152,8 @@ func TestSanitizeDbConfigs(t *testing.T) {
 					BucketConfig: BucketConfig{Server: base.StringPtr("1.2.3.4"), Bucket: base.StringPtr("bucket")},
 				},
 			},
-			expectedError: "automatic upgrade to persistent config failed. Only one database can target any given bucket",
+			// Cannot specify bucket names exactly due to un-deterministic iteration over map
+			expectedError: "automatic upgrade to persistent config failed. Only one database can target any given bucket. bucket used by",
 		},
 	}
 	for _, test := range testCases {
@@ -172,7 +173,7 @@ func TestSanitizeDbConfigs(t *testing.T) {
 
 			assert.Nil(t, dbConfigMap)
 			require.Error(t, err)
-			assert.EqualError(t, err, test.expectedError)
+			assert.Contains(t, err.Error(), test.expectedError)
 			return
 
 		})


### PR DESCRIPTION
CBG-1788

Adds a simple check to avoid running a persistent config where any bucket is referenced by more than one database.
In the event that this it the case

Logging example:
```
2021-11-15T15:21:29.600Z [ERR] Couldn't start Sync Gateway: automatic upgrade to persistent config failed. Only one database can target any given bucket. x1 used by db2 and db -- rest.ServerMain() at main.go:26
```

Modified existing test to add test case and modify the way that the error string is checked.

Integration test not required. Direct testing of `sanitizeDbConfigs` should be sufficient. Have validated with manual testing to verify.
