### PR TITLE
CBG-1757 Include attachments in non-winning revision body backup

### DIFF
--- a/db/crud.go
+++ b/db/crud.go
@@ -910,7 +910,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		}
 
 		// move _attachment metadata to syncdata of doc after rev-id generation
-		//doc.SyncData.Attachments = newDoc.DocAttachments
 		newDoc.RevID = newRev
 		newDoc.Deleted = deleted
 
@@ -1029,7 +1028,6 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 			return nil, nil, false, nil, err
 		}
 
-		//doc.SyncData.Attachments = newDoc.DocAttachments
 		newDoc.RevID = newRev
 
 		return newDoc, newAttachments, false, nil, nil

--- a/db/crud.go
+++ b/db/crud.go
@@ -910,7 +910,7 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 		}
 
 		// move _attachment metadata to syncdata of doc after rev-id generation
-		doc.SyncData.Attachments = newDoc.DocAttachments
+		//doc.SyncData.Attachments = newDoc.DocAttachments
 		newDoc.RevID = newRev
 		newDoc.Deleted = deleted
 
@@ -1029,7 +1029,7 @@ func (db *Database) PutExistingRevWithConflictResolution(newDoc *Document, docHi
 			return nil, nil, false, nil, err
 		}
 
-		doc.SyncData.Attachments = newDoc.DocAttachments
+		//doc.SyncData.Attachments = newDoc.DocAttachments
 		newDoc.RevID = newRev
 
 		return newDoc, newAttachments, false, nil, nil
@@ -1405,6 +1405,7 @@ func (db *Database) storeOldBodyInRevTreeAndUpdateCurrent(doc *Document, prevCur
 	}
 	// Store the new revision body into the doc:
 	doc.setRevisionBody(newRevID, newDoc, db.AllowExternalRevBodyStorage(), newDocHasAttachments)
+	doc.SyncData.Attachments = newDoc.DocAttachments
 
 	if doc.CurrentRev == newRevID {
 		doc.NewestRev = ""

--- a/db/crud.go
+++ b/db/crud.go
@@ -909,7 +909,6 @@ func (db *Database) Put(docid string, body Body) (newRevID string, doc *Document
 			return nil, nil, false, nil, base.ErrRevTreeAddRevFailure
 		}
 
-		// move _attachment metadata to syncdata of doc after rev-id generation
 		newDoc.RevID = newRev
 		newDoc.Deleted = deleted
 

--- a/db/import.go
+++ b/db/import.go
@@ -320,6 +320,8 @@ func (db *Database) importDoc(docid string, body Body, isDelete bool, existingDo
 		// to ensure obsolete attachments are removed from the bucket.
 		if isDelete {
 			doc.SyncData.Attachments = nil
+		} else {
+			newDoc.DocAttachments = doc.SyncData.Attachments
 		}
 
 		return newDoc, nil, !shouldGenerateNewRev, updatedExpiry, nil


### PR DESCRIPTION
CBG-1757

Copy attachments into the new document at the same time the body is updated, to ensure the previous attachments are still on the previous document when conflict revisions are copied.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1388/

(one integration test failure is unrelated to the changes in this PR)