### PR TITLE
CBG-1790: Panic handling added to NewImportPIndexImpl and unit test to repro bug

### DIFF
--- a/db/import_pindex.go
+++ b/db/import_pindex.go
@@ -38,7 +38,7 @@ func (il *importListener) RegisterImportPindexImpl() {
 // NewImportPIndexImpl is called when the node is first added to the cbgt cfg.  On a node restart,
 // OpenImportPindexImpl is called, and indexParams aren't included.
 func (il *importListener) NewImportPIndexImpl(indexType, indexParams, path string, restart func()) (cbgt.PIndexImpl, cbgt.Dest, error) {
-
+	defer base.FatalPanicHandler()
 	importDest, err := il.NewImportDest()
 	if err != nil {
 		base.Errorf("Error creating NewImportDest during NewImportPIndexImpl: %v", err)

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3940,6 +3940,9 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 
 // CBG-1790: Deleting a database that targets the same bucket as another causes a panic in legacy
 func TestDeleteDatabasePointingAtSameBucket(t *testing.T) {
+	// Panic found in CBG-1741
+	t.Skip("CBG-1790: skipping due to not being a supported use case")
+
 	if base.UnitTestUrlIsWalrus() {
 		t.Skip("This test only works against Couchbase Server")
 	}


### PR DESCRIPTION
CBG-1790

- Added unit test to reproduce panic that happens when deleting a database that targets the same bucket as another when import_docs is true in legacy. This is skipped for now.
- Added panic handling function so the panic caught and logged before SG exits