### PR TITLE
Add missing ServerContext close in TestBootstrapDuplicateBucket

### DIFF
--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3760,7 +3760,7 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 
 	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, true)
+	sc, err := setupServerContext(&config, false)
 	require.NoError(t, err)
 	defer func() {
 		sc.Close()

--- a/rest/admin_api_test.go
+++ b/rest/admin_api_test.go
@@ -3361,13 +3361,17 @@ func TestPersistentConfigConcurrency(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
 
-	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
@@ -3418,12 +3422,17 @@ func TestDbConfigCredentials(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
-	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
@@ -3485,13 +3494,17 @@ func TestInvalidDBConfig(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
 
-	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
@@ -3540,13 +3553,17 @@ func TestCreateDbOnNonExistentBucket(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
 
-	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
@@ -3574,12 +3591,17 @@ func TestPutDbConfigChangeName(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
-	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
@@ -3637,12 +3659,17 @@ func TestConfigsIncludeDefaults(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
-	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
@@ -3729,19 +3756,21 @@ func TestLegacyCredentialInheritance(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with bootstrap credentials filled
-	config := bootstrapStartupConfigForTest(t)
-	sc, err := setupServerContext(&config, false)
-	require.NoError(t, err)
 	serverErr := make(chan error, 0)
-	go func() {
-		serverErr <- startServer(&config, sc)
-	}()
-	require.NoError(t, sc.waitForRESTAPIs())
+
+	// Start SG with no databases
+	config := bootstrapStartupConfigForTest(t)
+	sc, err := setupServerContext(&config, true)
+	require.NoError(t, err)
 	defer func() {
 		sc.Close()
 		require.NoError(t, <-serverErr)
 	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
@@ -3814,19 +3843,21 @@ func TestDbOfflineConfigPersistent(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with bootstrap credentials filled
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	serverErr := make(chan error, 0)
-	go func() {
-		serverErr <- startServer(&config, sc)
-	}()
-	require.NoError(t, sc.waitForRESTAPIs())
 	defer func() {
 		sc.Close()
 		require.NoError(t, <-serverErr)
 	}()
+
+	go func() {
+		serverErr <- startServer(&config, sc)
+	}()
+	require.NoError(t, sc.waitForRESTAPIs())
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
@@ -4038,16 +4069,23 @@ func TestEmptyStringJavascriptFunctions(t *testing.T) {
 		t.Skip("This test only works against Couchbase Server")
 	}
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
-	// Start SG with no databases in bucket(s)
+
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
-	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
+
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)
 	defer func() {

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -30,19 +30,13 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	serverErr := make(chan error, 0)
-
 	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
 
-	// defer a function so <-serverErr doesn't block here
-	defer func() {
-		// sc closed later in the test, so don't need to defer it here like the other bootstrap tests
-		require.NoError(t, <-serverErr)
-	}()
-
+	// sc closed and serverErr read later in the test
+	serverErr := make(chan error, 0)
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -148,6 +148,7 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	require.NoError(t, err)
 	serverErr := make(chan error, 0)
 	go func() {
+		sc.Close()
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -148,10 +148,13 @@ func TestBootstrapDuplicateBucket(t *testing.T) {
 	require.NoError(t, err)
 	serverErr := make(chan error, 0)
 	go func() {
-		sc.Close()
 		serverErr <- startServer(&config, sc)
 	}()
 	require.NoError(t, sc.waitForRESTAPIs())
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
 
 	// Get a test bucket, and use it to create the database.
 	tb := base.GetTestBucket(t)

--- a/rest/bootstrap_test.go
+++ b/rest/bootstrap_test.go
@@ -37,8 +37,11 @@ func TestBootstrapRESTAPISetup(t *testing.T) {
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
 
-	// sc closed later in the test, so don't need to defer it here like the other bootstrap tests
-	defer require.NoError(t, <-serverErr)
+	// defer a function so <-serverErr doesn't block here
+	defer func() {
+		// sc closed later in the test, so don't need to defer it here like the other bootstrap tests
+		require.NoError(t, <-serverErr)
+	}()
 
 	go func() {
 		serverErr <- startServer(&config, sc)

--- a/rest/persistent_config_test.go
+++ b/rest/persistent_config_test.go
@@ -291,12 +291,17 @@ func TestImportFilterEndpoint(t *testing.T) {
 
 	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP)()
 
-	// Start SG with no databases in bucket(s)
+	serverErr := make(chan error, 0)
+
+	// Start SG with no databases
 	config := bootstrapStartupConfigForTest(t)
 	sc, err := setupServerContext(&config, true)
 	require.NoError(t, err)
-	defer sc.Close()
-	serverErr := make(chan error, 0)
+	defer func() {
+		sc.Close()
+		require.NoError(t, <-serverErr)
+	}()
+
 	go func() {
 		serverErr <- startServer(&config, sc)
 	}()


### PR DESCRIPTION
The test wasn't closing the server context, which left the ports bound - making the next test using the `bootstrapStartupConfigForTest` not work.

- Made all bootstrap tests use the same setup/teardown code

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [ ] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1397/