### PR TITLE
Minor fix to attachment compaction Mark phase logging

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -25,7 +25,7 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 	failProcess := func(err error, format string, args ...interface{}) bool {
 		markProcessFailureErr = err
 		close(terminator)
-		base.WarnfCtx(db.Ctx, format, args)
+		base.WarnfCtx(db.Ctx, format, args...)
 		return false
 	}
 


### PR DESCRIPTION
Just a small fix to the logging for the Mark phase errors. Should be fairly self explanatory.
