### PR TITLE
Set gocbv2 operation timeouts when DefaultGocbV2OperationTimeout bein…

### DIFF
--- a/base/gocb_utils.go
+++ b/base/gocb_utils.go
@@ -51,12 +51,10 @@ func GoCBv2TimeoutsConfig(bucketOpTimeout, viewQueryTimeout *time.Duration) (tc 
 	if bucketOpTimeout != nil {
 		opTimeout = *bucketOpTimeout
 	}
+	tc.KVTimeout = opTimeout
+	tc.ManagementTimeout = opTimeout
+	tc.ConnectTimeout = opTimeout
 
-	if bucketOpTimeout != nil {
-		tc.KVTimeout = opTimeout
-		tc.ManagementTimeout = opTimeout
-		tc.ConnectTimeout = opTimeout
-	}
 	if viewQueryTimeout != nil {
 		tc.QueryTimeout = *viewQueryTimeout
 		tc.ViewTimeout = *viewQueryTimeout


### PR DESCRIPTION
gocbv2 timeouts weren't being set unless explicitly specified in the config.

