### PR TITLE
CBG-1816: Handle errors in Mark Phase and test

### DIFF
--- a/base/leaky_bucket.go
+++ b/base/leaky_bucket.go
@@ -68,6 +68,8 @@ type LeakyBucketConfig struct {
 
 	PostUpdateCallback func(key string)
 
+	SetXattrCallback func(key string) error
+
 	// WriteWithXattrCallback is ran before WriteWithXattr is called. This can be used to trigger a CAS retry
 	WriteWithXattrCallback func(key string)
 
@@ -248,6 +250,11 @@ func (b *LeakyBucket) WriteUpdateWithXattr(k string, xattr string, userXattrKey 
 }
 
 func (b *LeakyBucket) SetXattr(k string, xattrKey string, xv []byte) (casOut uint64, err error) {
+	if b.config.SetXattrCallback != nil {
+		if err := b.config.SetXattrCallback(k); err != nil {
+			return 0, err
+		}
+	}
 	return b.bucket.SetXattr(k, xattrKey, xv)
 }
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -2425,7 +2425,7 @@ func TestResyncUpdateAllDocChannels(t *testing.T) {
 		return state == DBOffline
 	})
 
-	_, err = db.UpdateAllDocChannels(false, func(docsProcessed, docsChanged *int) {}, nil)
+	_, err = db.UpdateAllDocChannels(false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
 	assert.NoError(t, err)
 
 	syncFnCount := int(db.DbStats.CBLReplicationPush().SyncFunctionCount.Value())

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -2310,7 +2310,7 @@ func TestChannelAccessChanges(t *testing.T) {
 	changed, err := database.UpdateSyncFun(`function(doc) {access("alice", "beta");channel("beta");}`)
 	assert.NoError(t, err)
 	assert.True(t, changed)
-	changeCount, err := database.UpdateAllDocChannels(false, func(docsProcessed, docsChanged *int) {}, nil)
+	changeCount, err := database.UpdateAllDocChannels(false, func(docsProcessed, docsChanged *int) {}, base.NewSafeTerminator())
 	assert.NoError(t, err)
 	assert.Equal(t, 9, changeCount)
 


### PR DESCRIPTION
CBG-1816

When an error occurs in mark phase we close the terminator channel. However the background manager also ends up closing the terminator channel.

This results in a double close and hence a panic. There is protection around a double close in the background manager but this atomic check is not passed to the attachment compaction processing. 

Therefore created a new type `SafeTerminator` which essentially pushes down both the terminator channel and the atomic bool check into into a singular type. Switched background manager and associated processes to use this.

Added test to ensure this is working as intended.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1396/
