### PR TITLE
CBG-1183: Fixed race condition with TestDefaultConflictResolverWithTombstoneRemote

### DIFF
--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4572,6 +4572,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			rt1RevID := rt1RevIDCreated
 			for _, bodyValue := range test.localBodyValues {
 				rt1RevID = createOrUpdateDoc(t, rt1, docID, rt1RevID, bodyValue)
+				require.NoError(tt, rt1.waitForRev(docID, rt1RevID))
 			}
 
 			// Start replication.

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4448,7 +4448,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 	if !base.TestUseXattrs() {
 		t.Skip("This test only works with XATTRS enabled")
 	}
-	defer base.SetUpTestLogging(base.LevelDebug, base.KeyAll)()
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
 
 	defaultConflictResolverWithTombstoneTests := []struct {
 		name            string   // A unique name to identify the unit test.

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -5956,6 +5956,7 @@ func createOrUpdateDoc(t *testing.T, rt *RestTester, docID, revID, bodyValue str
 // waitForTombstone waits until the specified tombstone revision is available
 // in the bucket backed by the specified RestTester instance.
 func waitForTombstone(t *testing.T, rt *RestTester, docID string) {
+	require.NoError(t, rt.WaitForPendingChanges())
 	require.NoError(t, rt.WaitForCondition(func() bool {
 		doc, _ := rt.GetDatabase().GetDocument(docID, db.DocUnmarshalAll)
 		return doc.IsDeleted() && len(doc.Body()) == 0

--- a/rest/replicator_test.go
+++ b/rest/replicator_test.go
@@ -4490,7 +4490,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 	}
 
 	for _, test := range defaultConflictResolverWithTombstoneTests {
-		t.Run(test.name, func(tt *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			// Passive
 			rt2 := NewRestTester(t, &RestTesterConfig{
 				TestBucket: base.GetTestBucket(t),
@@ -4537,7 +4537,7 @@ func TestDefaultConflictResolverWithTombstoneRemote(t *testing.T) {
 			}
 
 			// Create the first revision of the document on rt2.
-			docID := t.Name() + "foo"
+			docID := test.name + "foo"
 			rt2RevIDCreated := createOrUpdateDoc(t, rt2, docID, "", "foo")
 
 			// Create active replicator and start replication.


### PR DESCRIPTION
CBG-1183

- Added wait for all revs to be wrote to the bucket before starting replication
- Set log level to info

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true, TestDefaultConflictResolverWithTombstoneRemote only, 25 times run, debug logs` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1405
