### PR TITLE
CBG-1817: Filter out invalid docs from attachment cleanup

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -37,6 +37,12 @@ func Mark(db *Database, compactionID string, terminator chan struct{}, markedAtt
 			return false
 		}
 
+		// Don't want to process raw binary docs
+		// The binary check should suffice but for additional safety also check for empty bodies
+		if event.DataType == base.MemcachedDataTypeRaw || len(event.Value) == 0 {
+			return true
+		}
+
 		// We only want to process full docs. Not any sync docs.
 		if strings.HasPrefix(docID, base.SyncPrefix) {
 			return true


### PR DESCRIPTION
CBG-1817

Just filters out invalid documents that cannot be processed by our attachment compaction. Uses the data type supplied over the DCP feed and for additional safety checks for empty bodies.

Have written test which test both deleted documents and binary documents. 

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1399/
