### PR TITLE
CBG-1547: Fixed leaking continuous sub changes feed when not sending changes

### DIFF
--- a/db/changes.go
+++ b/db/changes.go
@@ -678,6 +678,13 @@ func (db *Database) SimpleMultiChangesFeed(chans base.Set, options ChangesOption
 		// This loop is used to re-run the fetch after every database change, in Wait mode
 	outer:
 		for {
+			// Check if feed has been terminated regardless of if any changes have happened
+			select {
+			case <-options.Terminator:
+				return
+			default:
+				// Continue if not terminated
+			}
 
 			// Updates the ChangeWaiter to the current set of available channels
 			if changeWaiter != nil {

--- a/rest/api_test_no_race_test.go
+++ b/rest/api_test_no_race_test.go
@@ -15,11 +15,9 @@ package rest
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"testing"
 
-	"github.com/couchbase/go-blip"
 	"github.com/couchbase/sync_gateway/base"
 	"github.com/couchbase/sync_gateway/channels"
 	"github.com/couchbase/sync_gateway/db"
@@ -284,71 +282,5 @@ func TestSetupAndValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "minimum value for unsupported.stats_log_freq_secs is: 10")
 		assert.Nil(t, config)
 	})
-
-}
-
-// Make sure that a client cannot open multiple subChanges subscriptions on a single blip context (SG #3222)
-//
-// - Open two continuous subChanges feeds, and asserts that it gets an error on the 2nd one.
-// - Open a one-off subChanges request, assert no error
-func TestMultipleOustandingChangesSubscriptions(t *testing.T) {
-
-	// FIXME: CBG-1547: Skipping with race due to data race caused by something in this test
-
-	defer base.SetUpTestLogging(base.LevelInfo, base.KeyHTTP, base.KeySync, base.KeySyncMsg)()
-
-	bt, err := NewBlipTester(t)
-	require.NoError(t, err, "Error creating BlipTester")
-	defer bt.Close()
-
-	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
-		if !request.NoReply() {
-			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
-			response := request.Response()
-			emptyResponseVal := []interface{}{}
-			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
-			assert.NoError(t, err, "Error marshalling response")
-			response.SetBody(emptyResponseValBytes)
-		}
-	}
-
-	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
-	subChangesRequest := blip.NewRequest()
-	subChangesRequest.SetProfile("subChanges")
-	subChangesRequest.Properties["continuous"] = "true"
-	subChangesRequest.SetCompressed(false)
-	sent := bt.sender.Send(subChangesRequest)
-	goassert.True(t, sent)
-	subChangesResponse := subChangesRequest.Response()
-	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
-	errorCode := subChangesResponse.Properties["Error-Code"]
-	log.Printf("errorCode: %v", errorCode)
-	goassert.True(t, errorCode == "")
-
-	// Send a second continuous subchanges request, expect an error
-	subChangesRequest2 := blip.NewRequest()
-	subChangesRequest2.SetProfile("subChanges")
-	subChangesRequest2.Properties["continuous"] = "true"
-	subChangesRequest2.SetCompressed(false)
-	sent2 := bt.sender.Send(subChangesRequest2)
-	goassert.True(t, sent2)
-	subChangesResponse2 := subChangesRequest2.Response()
-	goassert.Equals(t, subChangesResponse2.SerialNumber(), subChangesRequest2.SerialNumber())
-	errorCode2 := subChangesResponse2.Properties["Error-Code"]
-	log.Printf("errorCode2: %v", errorCode2)
-	goassert.True(t, errorCode2 == "500")
-
-	// Send a thirst subChanges request, but this time continuous = false.  Should not return an error
-	subChangesRequest3 := blip.NewRequest()
-	subChangesRequest3.SetProfile("subChanges")
-	subChangesRequest3.Properties["continuous"] = "false"
-	subChangesRequest3.SetCompressed(false)
-	sent3 := bt.sender.Send(subChangesRequest3)
-	goassert.True(t, sent3)
-	subChangesResponse3 := subChangesRequest3.Response()
-	goassert.Equals(t, subChangesResponse3.SerialNumber(), subChangesRequest3.SerialNumber())
-	errorCode3 := subChangesResponse3.Properties["Error-Code"]
-	log.Printf("errorCode: %v", errorCode3)
-	goassert.True(t, errorCode == "")
 
 }

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3672,7 +3672,6 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", errorCode, "resp: %s", respBody)
 
-	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
 
 	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
@@ -3690,8 +3689,7 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", errorCode, "resp: %s", respBody)
 
-	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
-	// Might need to expect 0 after CBG-1824
+	// Might need to expect 0 after CBG-1824 depending on fix implementation
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
 
 	// Send a second continuous subchanges request, expect an error
@@ -3707,7 +3705,6 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	log.Printf("errorCode2: %v", errorCode)
 	assert.Equal(t, "500", errorCode)
 
-	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
 
 	// Even a subsequent continuous = false subChanges request should return an error. This isn't restricted to only continuous changes.
@@ -3725,12 +3722,10 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "500", errorCode, "resp: %s", respBody)
 
-	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
 
 	bt.sender.Close() // Close continuous sub changes feed
 
-	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
 	activeContStat, activeContStatIsExpected := base.WaitForStat(pullStats.NumPullReplActiveContinuous.Value, 0)
 	assert.True(t, activeContStatIsExpected, "NumPullReplActiveContinuous=%d instead of expected value of 0", activeContStat)
 

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3628,3 +3628,113 @@ func TestMinRevPosWorkToAvoidUnnecessaryProveAttachment(t *testing.T) {
 	proveAttachmentAfter = btc.pushReplication.replicationStats.ProveAttachment.Value()
 	assert.Equal(t, proveAttachmentBefore, proveAttachmentAfter)
 }
+
+// Make sure that a client cannot open multiple subChanges subscriptions on a single blip context (SG #3222)
+//
+// - Open a one-off subChanges request, ensure it works.
+// - Open a subsequent continuous request, and ensure it works.
+// - Open another continuous subChanges, and asserts that it gets an error on the 2nd one, because the first is still running.
+// - Open another one-off subChanges request, assert we still get an error.
+func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
+	defer base.SetUpTestLogging(base.LevelInfo, base.KeyAll)()
+
+	bt, err := NewBlipTester(t)
+	require.NoError(t, err, "Error creating BlipTester")
+	defer bt.Close()
+
+	bt.blipContext.HandlerForProfile["changes"] = func(request *blip.Message) {
+		if !request.NoReply() {
+			// Send an empty response to avoid the Sync: Invalid response to 'changes' message
+			response := request.Response()
+			emptyResponseVal := []interface{}{}
+			emptyResponseValBytes, err := base.JSONMarshal(emptyResponseVal)
+			assert.NoError(t, err, "Error marshalling response")
+			response.SetBody(emptyResponseValBytes)
+		}
+	}
+
+	pullStats := bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
+	assert.EqualValues(t, 0, pullStats.NumPullReplActiveContinuous.Value())
+	assert.EqualValues(t, 0, pullStats.NumPullReplActiveOneShot.Value())
+
+	// Open an initial continuous = false subChanges request, which we'd expect to release the lock after it's "caught up".
+	subChangesRequest := blip.NewRequest()
+	subChangesRequest.SetProfile("subChanges")
+	subChangesRequest.Properties["continuous"] = "false"
+	subChangesRequest.SetCompressed(false)
+	sent := bt.sender.Send(subChangesRequest)
+	goassert.True(t, sent)
+	subChangesResponse := subChangesRequest.Response()
+	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	errorCode := subChangesResponse.Properties["Error-Code"]
+	log.Printf("errorCode: %v", errorCode)
+	respBody, err := subChangesResponse.Body()
+	require.NoError(t, err)
+	assert.Equal(t, "", errorCode, "resp: %s", respBody)
+
+	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
+	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
+
+	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
+	subChangesRequest = blip.NewRequest()
+	subChangesRequest.SetProfile("subChanges")
+	subChangesRequest.Properties["continuous"] = "true"
+	subChangesRequest.SetCompressed(false)
+	sent = bt.sender.Send(subChangesRequest)
+	goassert.True(t, sent)
+	subChangesResponse = subChangesRequest.Response()
+	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	errorCode = subChangesResponse.Properties["Error-Code"]
+	log.Printf("errorCode: %v", errorCode)
+	respBody, err = subChangesResponse.Body()
+	require.NoError(t, err)
+	assert.Equal(t, "", errorCode, "resp: %s", respBody)
+
+	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
+	// Might need to expect 0 after CBG-1824
+	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
+
+	// Send a second continuous subchanges request, expect an error
+	subChangesRequest = blip.NewRequest()
+	subChangesRequest.SetProfile("subChanges")
+	subChangesRequest.Properties["continuous"] = "true"
+	subChangesRequest.SetCompressed(false)
+	sent = bt.sender.Send(subChangesRequest)
+	goassert.True(t, sent)
+	subChangesResponse = subChangesRequest.Response()
+	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	errorCode = subChangesResponse.Properties["Error-Code"]
+	log.Printf("errorCode2: %v", errorCode)
+	assert.Equal(t, "500", errorCode)
+
+	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
+	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
+
+	// Even a subsequent continuous = false subChanges request should return an error. This isn't restricted to only continuous changes.
+	subChangesRequest = blip.NewRequest()
+	subChangesRequest.SetProfile("subChanges")
+	subChangesRequest.Properties["continuous"] = "false"
+	subChangesRequest.SetCompressed(false)
+	sent = bt.sender.Send(subChangesRequest)
+	goassert.True(t, sent)
+	subChangesResponse = subChangesRequest.Response()
+	goassert.Equals(t, subChangesResponse.SerialNumber(), subChangesRequest.SerialNumber())
+	errorCode = subChangesResponse.Properties["Error-Code"]
+	log.Printf("errorCode: %v", errorCode)
+	respBody, err = subChangesResponse.Body()
+	require.NoError(t, err)
+	assert.Equal(t, "500", errorCode, "resp: %s", respBody)
+
+	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
+	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
+
+	bt.sender.Close() // Close continuous sub changes feed
+
+	pullStats = bt.restTester.GetDatabase().DbStats.CBLReplicationPull()
+	activeContStat, activeContStatIsExpected := base.WaitForStat(pullStats.NumPullReplActiveContinuous.Value, 0)
+	assert.True(t, activeContStatIsExpected, "NumPullReplActiveContinuous=%d instead of expected value of 0", activeContStat)
+
+	// Skipping assertions on one shot stat due to stat not being decremented after one shot has completed - CBG-1824
+	// activeOneShotStat, activeOneShotStatIsExpected := base.WaitForStat(pullStats.NumPullReplActiveOneShot.Value, 0)
+	// assert.True(t, activeOneShotStatIsExpected, "NumPullReplActiveOneShot=%d instead of expected value of 0", activeOneShotStat)
+}

--- a/rest/blip_api_test.go
+++ b/rest/blip_api_test.go
@@ -3672,6 +3672,7 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", errorCode, "resp: %s", respBody)
 
+	// Might need to expect 0 after CBG-1824 depending on fix implementation
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveOneShot.Value())
 
 	// Send continous subChanges to subscribe to changes, which will cause the "changes" profile handler above to be called back
@@ -3689,7 +3690,6 @@ func TestMultipleOutstandingChangesSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "", errorCode, "resp: %s", respBody)
 
-	// Might need to expect 0 after CBG-1824 depending on fix implementation
 	assert.EqualValues(t, 1, pullStats.NumPullReplActiveContinuous.Value())
 
 	// Send a second continuous subchanges request, expect an error


### PR DESCRIPTION
CBG-1547

- Added terminator check at the start of the database changes fetch to terminate the sub-changes feed regardless of if there are any changes to be sent
- `TestMultipleOutstandingChangesSubscriptions` is moved to `blip_api_test.go` so it can be race tested
- Changed test to assert stats and applied test fixes from branch [`cbg1547-prereq`](https://github.com/couchbase/sync_gateway/compare/CBG-1547...cbg1547-prereq)

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1415 (flaky test failures)
