### PR TITLE
CBG-1821: Handle purge for attachment deletion

### DIFF
--- a/db/attachment_compaction.go
+++ b/db/attachment_compaction.go
@@ -48,11 +48,6 @@ func Mark(db *Database, compactionID string, terminator *base.SafeTerminator, ma
 			return true
 		}
 
-		// // Skip any binary docs
-		// if event.DataType == base.MemcachedDataTypeRaw {
-		// 	return true
-		// }
-
 		// We need to mark attachments in every leaf revision of the current doc
 		// We will build up a list of attachment names which map to attachment doc IDs. Avoids doing multiple KV ops
 		// when marking if multiple leaves are referencing the same attachment.

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -9288,3 +9288,77 @@ func TestAttachmentsMissingNoBody(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 	assert.Contains(t, string(resp.BodyBytes()), "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
 }
+
+func TestAttachmentDeleteOnPurge(t *testing.T) {
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	// Create doc with attachment
+	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello": {"data": "aGVsbG8gd29ybGQ="}}}`)
+	assertStatus(t, resp, http.StatusCreated)
+	err := rt.WaitForPendingChanges()
+	assert.NoError(t, err)
+
+	// Ensure attachment is uploaded and key the attachment doc key
+	resp = rt.SendAdminRequest("GET", "/db/"+t.Name()+"/hello?meta=true", "")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body db.Body
+	err = base.JSONUnmarshal(resp.BodyBytes(), &body)
+	require.NoError(t, err)
+
+	key, ok := body["key"].(string)
+	assert.True(t, ok)
+
+	// Ensure we can get the attachment doc
+	_, _, err = rt.GetDatabase().Bucket.GetRaw(key)
+	assert.NoError(t, err)
+
+	// Purge the document
+	resp = rt.SendAdminRequest("POST", "/db/_purge", `{"`+t.Name()+`": ["*"]}`)
+	assertStatus(t, resp, http.StatusOK)
+
+	// Ensure that the attachment has now been deleted
+	_, _, err = rt.GetDatabase().Bucket.GetRaw(key)
+	assert.Error(t, err)
+	assert.True(t, base.IsDocNotFoundError(err))
+}
+
+func TestAttachmentDeleteOnExpiry(t *testing.T) {
+	if base.UnitTestUrlIsWalrus() {
+		t.Skip("Expiry only supported by Couchbase Server")
+	}
+
+	rt := NewRestTester(t, nil)
+	defer rt.Close()
+
+	// Create doc with attachment and expiry
+	resp := rt.SendAdminRequest("PUT", "/db/"+t.Name(), `{"_attachments": {"hello.txt": {"data": "aGVsbG8gd29ybGQ="}}, "_exp": 2}`)
+	assertStatus(t, resp, http.StatusCreated)
+	err := rt.WaitForPendingChanges()
+	assert.NoError(t, err)
+
+	// Wait for document to be expired - this bucket get should also trigger the expiry purge interval
+	err = rt.WaitForCondition(func() bool {
+		_, _, err = rt.GetDatabase().Bucket.GetRaw(t.Name())
+		return base.IsDocNotFoundError(err)
+	})
+	assert.NoError(t, err)
+
+	// Trigger OnDemand Import for that doc to trigger tombstone
+	resp = rt.SendAdminRequest("GET", "/db/"+t.Name(), "")
+	assertStatus(t, resp, http.StatusNotFound)
+
+	att2Key := db.MakeAttachmentKey(db.AttVersion2, t.Name(), "sha1-Kq5sNclPz7QV2+lfQIuc6R7oRu0=")
+
+	// With xattrs doc will be imported and will be captured as tombstone and therefore purge attachments
+	// Otherwise attachment will not be purged
+	_, _, err = rt.GetDatabase().Bucket.GetRaw(att2Key)
+	if base.TestUseXattrs() {
+		assert.Error(t, err)
+		assert.True(t, base.IsDocNotFoundError(err))
+	} else {
+		assert.NoError(t, err)
+	}
+
+}

--- a/rest/api_test.go
+++ b/rest/api_test.go
@@ -8911,7 +8911,6 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(attKey)
 		rt.purgeDoc(docID)
 	})
 
@@ -8955,7 +8954,6 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(attKey)
 		rt.purgeDoc(docID1)
 		rt.purgeDoc(docID2)
 	})
@@ -8986,7 +8984,6 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(attKey)
 		rt.purgeDoc(docID)
 	})
 
@@ -9032,7 +9029,6 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 		requireAttachmentFound(attKey, attBody)
 
 		// Perform cleanup after the test ends.
-		rt.purgeDoc(attKey)
 		rt.purgeDoc(docID1)
 		rt.purgeDoc(docID2)
 	})
@@ -9060,9 +9056,6 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
-
-		// Perform cleanup after the test ends.
-		rt.purgeDoc(attKey)
 	})
 
 	t.Run("legacy attachment persistence upon doc purge (multiple docs referencing same attachment)", func(t *testing.T) {
@@ -9103,9 +9096,6 @@ func TestBasicAttachmentRemoval(t *testing.T) {
 
 		// Check whether legacy attachment is still persisted in the bucket.
 		requireAttachmentFound(attKey, attBody)
-
-		// Perform cleanup after the test ends.
-		rt.purgeDoc(attKey)
 	})
 }
 


### PR DESCRIPTION
CBG-1821

 - Adds a basic operation to delete all associated attachments when a purge operation is carried out. Re-uses existing `getAttachmentIDsForLeafRevisions` as used in the `updateAndReturnDoc` flow. 
 - Opted to marshal the document so we can re-use the above function easily. 

Note: Also noticed a minor cleanup I could do in attachment cleanup by just removing a bit of code that was commented out and somehow snuck in.

PR adds both a test for purge operation as well as expiry.

## [Integration Tests](http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/build?delay=0sec)
- [x] `xattrs=true` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1420/
- [x] `xattrs=false` http://uberjenkins.sc.couchbase.com:8080/job/sync-gateway-integration/1421/
